### PR TITLE
[stripe] Fix constructEvent return type

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stripe 6.18
+// Type definitions for stripe 6.19
 // Project: https://github.com/stripe/stripe-node/
 // Definitions by: William Johnston <https://github.com/wjohnsto>
 //                 Peter Harris <https://github.com/codeanimal>
@@ -3683,25 +3683,6 @@ declare namespace Stripe {
         interface ISkuAttributes {}
     }
 
-    namespace webhooks {
-        interface StripeWebhookEvent<T> {
-            id: string;
-            object: string;
-            api_version: string;
-            created: number;
-            data: {
-              object: T;
-            };
-            livemode: boolean;
-            pending_webhooks: number;
-            /**
-             * One of https://stripe.com/docs/api#event_types
-             * E.g. account.updated
-             */
-            type: string;
-        }
-    }
-
     namespace ephemeralKeys {
         interface IStripeVersion {
             /**
@@ -7345,7 +7326,7 @@ declare namespace Stripe {
         }
 
         class WebHooks {
-            constructEvent(requestBody: any, signature: string | string[], endpointSecret: string, tolerance?: number): webhooks.StripeWebhookEvent<any>;
+            constructEvent(requestBody: any, signature: string | string[], endpointSecret: string, tolerance?: number): events.IEvent;
         }
 
         class EphemeralKeys {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -829,11 +829,11 @@ const webhookRequest = {
 };
 const webhookSecret = '';
 
-const event = stripe.webhooks.constructEvent(
+const event: Stripe.events.IEvent = stripe.webhooks.constructEvent(
   webhookRequest.rawBody,
   webhookRequest.headers['stripe-signature'],
   webhookSecret
-) as Stripe.webhooks.StripeWebhookEvent<Stripe.subscriptions.ISubscription>;
+);
 
 //#endregion
 


### PR DESCRIPTION
`constructEvent` was returning a redundant type `StripeWebhookEvent`,
which should have identical fields with `IEvent`.  As a result it
was out of date, missing the `data.previous_attributes` field.

Workaround: Cast result of `constructEvent` to `IEvent` if you want to use `data.previous_attributes`.

Fix: Change `constructEvent` to return `IEvent`
