### PR TITLE
Fix the type of source for the argument to the copy() method.

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -453,7 +453,7 @@ export class Camera extends Object3D {
 
     isCamera: true;
 
-    copy(source: this, recursive?: boolean): this;
+    copy(source: Camera, recursive?: boolean): this;
 
     getWorldDirection(target: Vector3): Vector3;
 


### PR DESCRIPTION
Fix the type of source for the argument to the copy() method.