### PR TITLE
[nedb] Nedb class should extend EventEmitter

### DIFF
--- a/types/nedb/index.d.ts
+++ b/types/nedb/index.d.ts
@@ -5,10 +5,14 @@
 //                 Alejandro Fernandez Haro <https://github.com/afharo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+
 export = Nedb;
 export as namespace Nedb;
 
-declare class Nedb {
+declare class Nedb extends EventEmitter {
     constructor(pathOrOptions?: string | Nedb.DataStoreOptions);
 
     persistence: Nedb.Persistence;
@@ -153,6 +157,17 @@ declare class Nedb {
      */
     remove(query: any, options: Nedb.RemoveOptions, cb?: (err: Error, n: number) => void): void;
     remove(query: any, cb?: (err: Error, n: number) => void): void;
+
+    addListener(event: 'compaction.done', listener: () => void): this;
+    on(event: 'compaction.done', listener: () => void): this;
+    once(event: 'compaction.done', listener: () => void): this;
+    prependListener(event: 'compaction.done', listener: () => void): this;
+    prependOnceListener(event: 'compaction.done', listener: () => void): this;
+    removeListener(event: 'compaction.done', listener: () => void): this;
+    off(event: 'compaction.done', listener: () => void): this;
+    listeners(event: 'compaction.done'): Array<() => void>;
+    rawListeners(event: 'compaction.done'): Array<() => void>;
+    listenerCount(type: 'compaction.done'): number;
 }
 
 declare namespace Nedb {

--- a/types/nedb/nedb-tests.ts
+++ b/types/nedb/nedb-tests.ts
@@ -514,3 +514,14 @@ db.insert({ somefield: 'nedb' }, (err: Error) => {
 // Remove index on field somefield
 db.removeIndex('somefield', (err: Error) => {
 });
+
+db.addListener("compaction.done", () => {});
+db.on("compaction.done", () => {});
+db.once("compaction.done", () => {});
+db.prependListener("compaction.done", () => {});
+db.prependOnceListener("compaction.done", () => {});
+db.removeListener("compaction.done", () => {});
+db.off("compaction.done", () => {});
+db.listeners("compaction.done"); // $ExpectType (() => void)[]
+db.rawListeners("compaction.done"); // $ExpectType (() => void)[]
+db.listenerCount("compaction.done"); // $ExpectType number


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L81
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes #31539.