### PR TITLE
[dialogflow] Add WebhookState enum to Intent interface

### DIFF
--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for dialogflow 0.6
 // Project: https://github.com/dialogflow/dialogflow-nodejs-client-v2#readme
 // Definitions by: Daniel Dyla <https://github.com/dyladan>
+//                 Joseph Thibeault <https://github.com/jrthib>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -840,10 +841,16 @@ export enum IntentView {
     INTENT_VIEW_FULL = "INTENT_VIEW_FULL"
 }
 
+export enum WebhookState {
+    WEBHOOK_STATE_UNSPECIFIED = "WEBHOOK_STATE_UNSPECIFIED",
+    WEBHOOK_STATE_ENABLED = "WEBHOOK_STATE_ENABLED",
+    WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING = "WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING"
+}
+
 export interface Intent {
     name: string;
     displayName: string;
-    webhookState: string;
+    webhookState: WebhookState;
     priority?: number;
     isFallback?: boolean;
     mlEnabled?: boolean;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - <https://dialogflow.com/docs/reference/api-v2/rest/Shared.Types/WebhookState> 
  - <https://dialogflow.com/docs/reference/api-v2/rest/Shared.Types/Intent>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
