### PR TITLE
react-youtube: refactor interfaces

### DIFF
--- a/types/react-youtube/index.d.ts
+++ b/types/react-youtube/index.d.ts
@@ -7,32 +7,32 @@
 import * as React from "react";
 
 export interface PlayerVars {
-    autoplay?: 0 | 1,
-    cc_load_policy?: 1,
-    color?: 'red' | 'white',
-    controls?: 0 | 1 | 2,
-    disablekb?: 0 | 1,
-    enablejsapi?: 0 | 1,
-    end?: number,
-    fs?: 0 | 1,
-    hl?: string,
-    iv_load_policy?: 1 | 3,
-    list?: string,
-    listType?: 'playlist' | 'search' | 'user_uploads',
-    loop?: 0 | 1,
-    modestbranding?: 1,
-    origin?: string,
-    playlist?: string,
-    playsinline?: 0 | 1,
-    rel?: 0 | 1,
-    showinfo?: 0 | 1,
-    start?: number
+    autoplay?: 0 | 1;
+    cc_load_policy?: 1;
+    color?: 'red' | 'white';
+    controls?: 0 | 1 | 2;
+    disablekb?: 0 | 1;
+    enablejsapi?: 0 | 1;
+    end?: number;
+    fs?: 0 | 1;
+    hl?: string;
+    iv_load_policy?: 1 | 3;
+    list?: string;
+    listType?: 'playlist' | 'search' | 'user_uploads';
+    loop?: 0 | 1;
+    modestbranding?: 1;
+    origin?: string;
+    playlist?: string;
+    playsinline?: 0 | 1;
+    rel?: 0 | 1;
+    showinfo?: 0 | 1;
+    start?: number;
 }
 
 export interface Options {
-    height?: string,
-    width?: string,
-    playerVars?: PlayerVars,
+    height?: string;
+    width?: string;
+    playerVars?: PlayerVars;
 }
 
 export default class YouTube extends React.Component<{

--- a/types/react-youtube/index.d.ts
+++ b/types/react-youtube/index.d.ts
@@ -5,36 +5,41 @@
 // TypeScript Version: 2.8
 
 import * as React from "react";
+
+export interface PlayerVars {
+    autoplay?: 0 | 1,
+    cc_load_policy?: 1,
+    color?: 'red' | 'white',
+    controls?: 0 | 1 | 2,
+    disablekb?: 0 | 1,
+    enablejsapi?: 0 | 1,
+    end?: number,
+    fs?: 0 | 1,
+    hl?: string,
+    iv_load_policy?: 1 | 3,
+    list?: string,
+    listType?: 'playlist' | 'search' | 'user_uploads',
+    loop?: 0 | 1,
+    modestbranding?: 1,
+    origin?: string,
+    playlist?: string,
+    playsinline?: 0 | 1,
+    rel?: 0 | 1,
+    showinfo?: 0 | 1,
+    start?: number
+}
+
+export interface Options {
+    height?: string,
+    width?: string,
+    playerVars?: PlayerVars,
+}
+
 export default class YouTube extends React.Component<{
     videoId?: string,
     id?: string,
     className?: string,
-    opts?: {
-        height?: string,
-        width?: string,
-        playerVars?: {
-            autoplay?: 0 | 1,
-            cc_load_policy?: 1,
-            color?: 'red' | 'white',
-            controls?: 0 | 1 | 2,
-            disablekb?: 0 | 1,
-            enablejsapi?: 0 | 1,
-            end?: number,
-            fs?: 0 | 1,
-            hl?: string,
-            iv_load_policy?: 1 | 3,
-            list?: string,
-            listType?: 'playlist' | 'search' | 'user_uploads',
-            loop?: 0 | 1,
-            modestbranding?: 1,
-            origin?: string,
-            playlist?: string,
-            playsinline?: 0 | 1,
-            rel?: 0 | 1,
-            showinfo?: 0 | 1,
-            start?: number
-        }
-    },
+    opts?: Options,
     onReady?(event: { target: any }): void,
     onError?(event: { target: any, data: number }): void,
     onPlay?(event: { target: any, data: number }): void,


### PR DESCRIPTION
Until now the definition for the `playerVars` was hidden within the definition of the `YouTube` component. I pulled it out into separate interfaces, which one can import, such that one can define `playerVars` in his own code as a separate object while still having Intellisense available.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.