### PR TITLE
[graphql] Predicates can be now used as type guards

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -16,6 +16,7 @@
 //                 Brad Zacher <https://github.com/bradzacher>
 //                 Curtis Layne <https://github.com/clayne11>
 //                 Jonathan Cardoso <https://github.com/JCMais>
+//                 Pavel Lang <https://github.com/langpavel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/graphql/language/predicates.d.ts
+++ b/types/graphql/language/predicates.d.ts
@@ -1,19 +1,30 @@
-import { ASTNode } from "./ast";
+import {
+    ASTNode,
+    DefinitionNode,
+    ExecutableDefinitionNode,
+    SelectionNode,
+    ValueNode,
+    TypeNode,
+    TypeSystemDefinitionNode,
+    TypeDefinitionNode,
+    TypeSystemExtensionNode,
+    TypeExtensionNode,
+} from "./ast";
 
-export function isDefinitionNode(node: ASTNode): boolean;
+export function isDefinitionNode(node: ASTNode): node is DefinitionNode;
 
-export function isExecutableDefinitionNode(node: ASTNode): boolean;
+export function isExecutableDefinitionNode(node: ASTNode): node is ExecutableDefinitionNode;
 
-export function isSelectionNode(node: ASTNode): boolean;
+export function isSelectionNode(node: ASTNode): node is SelectionNode;
 
-export function isValueNode(node: ASTNode): boolean;
+export function isValueNode(node: ASTNode): node is ValueNode;
 
-export function isTypeNode(node: ASTNode): boolean;
+export function isTypeNode(node: ASTNode): node is TypeNode;
 
-export function isTypeSystemDefinitionNode(node: ASTNode): boolean;
+export function isTypeSystemDefinitionNode(node: ASTNode): node is TypeSystemDefinitionNode;
 
-export function isTypeDefinitionNode(node: ASTNode): boolean;
+export function isTypeDefinitionNode(node: ASTNode): node is TypeDefinitionNode;
 
-export function isTypeSystemExtensionNode(node: ASTNode): boolean;
+export function isTypeSystemExtensionNode(node: ASTNode): node is TypeSystemExtensionNode;
 
-export function isTypeExtensionNode(node: ASTNode): boolean;
+export function isTypeExtensionNode(node: ASTNode): node is TypeExtensionNode;


### PR DESCRIPTION
Predicates in `graphql/language/predicates` are used in Flow as type guards.
Now they can be used in TS too:

* isDefinitionNode
* isExecutableDefinitionNode
* isSelectionNode
* isValueNode
* isTypeNode
* isTypeSystemDefinitionNode
* isTypeDefinitionNode
* isTypeSystemExtensionNode
* isTypeExtensionNode

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/blob/master/src/language/predicates.js
