### PR TITLE
[@types/koa]: Parameterize `Context` and `Application`.

### DIFF
--- a/types/koa-useragent/koa-useragent-tests.ts
+++ b/types/koa-useragent/koa-useragent-tests.ts
@@ -5,7 +5,7 @@ const app = new Koa();
 
 app.use(userAgent);
 
-app.use((ctx, next) => {
+app.use((ctx: Koa.Context, next) => {
     ctx.userAgent.isAuthoritative; // $ExpectType boolean
     ctx.userAgent.isMobile; // $ExpectType boolean
     ctx.userAgent.isTablet; // $ExpectType boolean

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -702,7 +702,7 @@ declare namespace Application {
         respond?: boolean;
     } & CustomT;
 
-    interface Context extends ParameterizedContext<any, {}> {}
+    interface Context extends ParameterizedContext {}
 }
 
 export = Application;

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -431,12 +431,12 @@ declare interface ContextDelegatedResponse {
     flushHeaders(): void;
 }
 
-declare class Application extends EventEmitter {
+declare class Application<StateT = any, CustomT = {}> extends EventEmitter {
     proxy: boolean;
-    middleware: Application.Middleware[];
+    middleware: Application.Middleware<StateT, CustomT>[];
     subdomainOffset: number;
     env: string;
-    context: Application.BaseContext;
+    context: Application.BaseContext & CustomT;
     request: Application.BaseRequest;
     response: Application.BaseResponse;
     silent: boolean;
@@ -497,7 +497,9 @@ declare class Application extends EventEmitter {
      *
      * Old-style middleware will be converted.
      */
-    use(middleware: Application.Middleware): this;
+    use<NewStateT = {}, NewCustomT = {}>(
+        middleware: Application.Middleware<StateT & NewStateT, CustomT & NewCustomT>,
+    ): Application<StateT & NewStateT, CustomT & NewCustomT>;
 
     /**
      * Return a request handler callback
@@ -510,10 +512,10 @@ declare class Application extends EventEmitter {
      *
      * @api private
      */
-    createContext(
+    createContext<StateT = any>(
         req: IncomingMessage,
         res: ServerResponse,
-    ): Application.Context;
+    ): Application.Context<StateT>;
 
     /**
      * Default error handler.
@@ -524,7 +526,7 @@ declare class Application extends EventEmitter {
 }
 
 declare namespace Application {
-    type Middleware = compose.Middleware<Context>;
+    type Middleware<StateT = any, CustomT = {}> = compose.Middleware<Context<StateT, CustomT>>;
 
     interface BaseRequest extends ContextDelegatedRequest {
         /**
@@ -684,7 +686,7 @@ declare namespace Application {
         request: Request;
     }
 
-    interface Context extends BaseContext {
+    type Context<StateT = any, CustomT = {}> = BaseContext & {
         app: Application;
         request: Request;
         response: Response;
@@ -693,12 +695,12 @@ declare namespace Application {
         originalUrl: string;
         cookies: Cookies;
         accept: accepts.Accepts;
-        state: any;
+        state: StateT;
         /**
          * To bypass Koa's built-in response handling, you may explicitly set `ctx.respond = false;`
          */
         respond?: boolean;
-    }
+    } & CustomT;
 }
 
 export = Application;

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -515,7 +515,7 @@ declare class Application<StateT = any, CustomT = {}> extends EventEmitter {
     createContext<StateT = any>(
         req: IncomingMessage,
         res: ServerResponse,
-    ): Application.Context<StateT>;
+    ): Application.ParameterizedContext<StateT>;
 
     /**
      * Default error handler.
@@ -526,7 +526,7 @@ declare class Application<StateT = any, CustomT = {}> extends EventEmitter {
 }
 
 declare namespace Application {
-    type Middleware<StateT = any, CustomT = {}> = compose.Middleware<Context<StateT, CustomT>>;
+    type Middleware<StateT = any, CustomT = {}> = compose.Middleware<ParameterizedContext<StateT, CustomT>>;
 
     interface BaseRequest extends ContextDelegatedRequest {
         /**
@@ -671,7 +671,7 @@ declare namespace Application {
         app: Application;
         req: IncomingMessage;
         res: ServerResponse;
-        ctx: Context;
+        ctx: ParameterizedContext;
         response: Response;
         originalUrl: string;
         ip: string;
@@ -682,11 +682,11 @@ declare namespace Application {
         app: Application;
         req: IncomingMessage;
         res: ServerResponse;
-        ctx: Context;
+        ctx: ParameterizedContext;
         request: Request;
     }
 
-    type Context<StateT = any, CustomT = {}> = BaseContext & {
+    type ParameterizedContext<StateT = any, CustomT = {}> = BaseContext & {
         app: Application;
         request: Request;
         response: Response;
@@ -701,6 +701,8 @@ declare namespace Application {
          */
         respond?: boolean;
     } & CustomT;
+
+    interface Context extends ParameterizedContext<any, {}> {}
 }
 
 export = Application;

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -671,7 +671,7 @@ declare namespace Application {
         app: Application;
         req: IncomingMessage;
         res: ServerResponse;
-        ctx: ParameterizedContext;
+        ctx: Context;
         response: Response;
         originalUrl: string;
         ip: string;
@@ -682,7 +682,7 @@ declare namespace Application {
         app: Application;
         req: IncomingMessage;
         res: ServerResponse;
-        ctx: ParameterizedContext;
+        ctx: Context;
         request: Request;
     }
 

--- a/types/koa/koa-tests.ts
+++ b/types/koa/koa-tests.ts
@@ -1,19 +1,18 @@
 import Koa = require("koa");
 
-declare module 'koa' {
-    export interface BaseContext {
-        db(): void;
-    }
-    export interface Context {
-        user: {};
-    }
+interface DbBaseContext {
+    db(): void;
 }
 
-const app = new Koa();
+interface UserContext {
+    user: {};
+}
+
+const app = new Koa<{}, DbBaseContext>();
 
 app.context.db = () => {};
 
-app.use(async ctx => {
+app.use<{}, UserContext>(async ctx => {
     console.log(ctx.db);
     ctx.user = {};
 });


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/koa/blob/a007198fa23c19902b1f3ffb81498629e0e9c875/docs/api/context.md#ctxstate

Currently, `ctx.state` is `any`, and `ctx` itself allows any fields to
be inside `Context`. That's essentially 2 places where developers can
add their custom properties, and would be great to opt-in into more
typesafe approach than it's currently is.

What if we parameterize `Context` and `Application` with 2 types - one
will define `ctx.state`, and another - fields in `Context`? Then, if you
chain `use`, TypeScript will infer the types properly for your
middlewares. Like:

```typescript
interface NewContext {
  orgh: string;
}

interface FooState {
  foo: string;
}

interface BarState {
  bar: string;
}

async function fooMiddleware(
  ctx: Koa.Context<FooState>,
  next: () => Promise<void>
): Promise<void> {
  ctx.state.foo = "foo";
  await next();
}

async function barMiddleware(
  ctx: Koa.Context<BarState>,
  next: () => Promise<void>
): Promise<void> {
  ctx.state.bar = "bar";
  await next();
}

const app = new Koa<{}, {}>()
  .use(fooMiddleware)
  .use(barMiddleware)
  .use<{}, NewContext>(async (ctx, next) => {
    // Here ctx is inferred as Koa.Context<FooState & BarState, NewContext>
    ctx.orgh = "bazinga";
    await next();
  })
  .use(async (ctx, next) => {
    // Here ctx is inferred as Koa.Context<FooState & BarState, NewContext>
    await next();
  });
// `app` here is `Koa<FooState & BarState, NewContext>`

app.listen(3000);
```

So, if you define `const app = new Koa<{}, {}>()`, then you'll opt-in
into "typesafe" Koa Context. But if you do just `const app = new Koa()`,
you still will have `ctx.state: any`, like before. So, it should be
backwards-compatible.

But even in this case you can specify what the `ctx` is inside
the middlewares, like:

```typescript
const app2 = new Koa();
app2.use(fooMiddleware);
app2.use(async (ctx, next) => {
  // `ctx.state` here is inferred as `any`
  ctx.state.prop = "Some Prop";
  await next();
});
app2.use(async (ctx: Koa.Context<{}, NewContext>, next) => {
  ctx.orgh = "oh yeah";
  await next();
});
app2.use(async (ctx: Koa.Context<FooState>, next) => {
  ctx.state.foo = "Yay";
  await next();
});
```

What do you think?