### PR TITLE
Adds definition of ContentState.getEntityMap()

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -315,6 +315,7 @@ ReactDOM.render(
 
 const editorState = EditorState.createEmpty();
 const contentState = editorState.getCurrentContent();
+const entityMap = contentState.getEntityMap();
 const rawContentState: RawDraftContentState = convertToRaw(contentState);
 
 rawContentState.blocks.forEach((block: RawDraftContentBlock) => {

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -9,6 +9,7 @@
 //                 Santiago Vilar <https://github.com/smvilar>
 //                 Ulf Schwekendiek <https://github.com/sulf>
 //                 Pablo Varela <https://github.com/pablopunk>
+//                 Claudio Procida <https://github.com/claudiopro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -754,6 +755,7 @@ declare namespace Draft {
 
                 createEntity(type: DraftEntityType, mutability: DraftEntityMutability, data?: Object): ContentState;
                 getEntity(key: string): EntityInstance;
+                getEntityMap(): any;
                 getLastCreatedEntityKey(): string;
                 mergeEntityData(key: string, toMerge: { [key: string]: any }): ContentState;
                 replaceEntityData(key: string, toMerge: { [key: string]: any }): ContentState;


### PR DESCRIPTION
This PR adds the definition for the `ContentState.getEntityMap()` method of the Draft.js library. Addresses https://github.com/facebook/draft-js/issues/1925.

**Checklist**
If changing an existing definition:
- [✅] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/draft-js/blob/master/src/model/immutable/ContentState.js#L51
- [❌] Increase the version number in the header if appropriate: not needed
- [☑️ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: already existing

**Test plan**
Before:

```
→ yarn run lint draft-js
Using globally installed version of Yarn
yarn run v1.12.1
$ dtslint types draft-js
Error: /Users/procidac/Development/gh/claudiopro/DefinitelyTyped/types/draft-js/draft-js-tests.tsx:318:32
ERROR: 318:32  expect  TypeScript@next compile error:
Property 'getEntityMap' does not exist on type 'ContentState'.

    at /Users/procidac/Development/gh/claudiopro/DefinitelyTyped/node_modules/dtslint/bin/index.js:163:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/procidac/Development/gh/claudiopro/DefinitelyTyped/node_modules/dtslint/bin/index.js:5:58)
    at <anonymous>
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:

```
→ yarn run lint draft-js
Using globally installed version of Yarn
yarn run v1.12.1
$ dtslint types draft-js
✨  Done in 9.57s.
```