### PR TITLE
[stripe] Update Accounts and Transfers type definitions

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -14,6 +14,7 @@
 //                 Troy Zarger <https://github.com/tzarger>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 Simon Schick <https://github.com/SimonSchick>
+//                 Slava Yultyyev Schick <https://github.com/yultyyev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -461,6 +462,16 @@ declare namespace Stripe {
              * "terms_of_service", or "other".
              */
             reason: "fraud" | "terms_of_service" | "other" ;
+        }
+
+        interface ILoginLink {
+            object: "login_link";
+            created: number;
+
+            /**
+             * A single-use login link for an Express account to access their Stripe dashboard.
+             */
+            url: string;
         }
     }
 
@@ -2352,6 +2363,7 @@ declare namespace Stripe {
             end: number;
         }
     }
+
     namespace invoiceItems {
         interface InvoiceItem extends IResourceObject {
             /**
@@ -5517,6 +5529,14 @@ declare namespace Stripe {
              */
             listExternalAccounts(accId: string, data: accounts.ICardListOptions, options: HeaderOptions, response?: IResponseFn<IList<cards.ICard>>): Promise<IList<cards.ICard>>;
             listExternalAccounts(accId: string, data: accounts.ICardListOptions, response?: IResponseFn<IList<cards.ICard>>): Promise<IList<cards.ICard>>;
+
+            /**
+             * Creates a single-use login link for an Express account to access their Stripe dashboard.
+             * You may only create login links for Express accounts connected to your platform.
+             * Returns a login link object if the call succeeded.
+             */
+            createLoginLink(accId: string, response?: IResponseFn<accounts.ILoginLink>): Promise<accounts.ILoginLink>;
+            createLoginLink(accId: string, redirectUrl?: string, response?: IResponseFn<accounts.ILoginLink>): Promise<accounts.ILoginLink>;
         }
 
         class ApplicationFees extends StripeResource {
@@ -7518,6 +7538,7 @@ declare namespace Stripe {
          */
         starting_after?: string;
     }
+
     interface IListOptionsCreated extends IListOptions {
         /**
          * A filter on the list based on the object created field. The value can be a string with an integer Unix timestamp, or it can

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4000,16 +4000,9 @@ declare namespace Stripe {
             destination?: string;
 
             /**
-             * Only return transfers for the recipient specified by this
-             * recipient ID.
+             * Only return transfers with the specified transfer group.
              */
-            recipient?: string;
-
-            /**
-             * Only return transfers that have the given status:
-             * pending, paid, failed, in_transit, or canceled.
-             */
-            status: Statuses;
+            transfer_group?: string | null;
         }
 
         type SourceTypes = "alipay_account" | "bank_account" | "bitcoin_receiver" | "card";

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -725,6 +725,20 @@ stripe.accounts.retrieve("acct_17wV8KBoqMA9o2xk").then(
         const payouts_enabled: boolean = accounts.payouts_enabled;
     }
 );
+stripe.accounts.createLoginLink("acct_17wV8KBoqMA9o2xk").then(
+    (loginLink) => {
+        const object: string = loginLink.object;
+        const created: number = loginLink.created;
+        const url: string = loginLink.url;
+    }
+);
+stripe.accounts.createLoginLink("acct_17wV8KBoqMA9o2xk", "http://localhost:3000").then(
+    (loginLink) => {
+        const object: string = loginLink.object;
+        const created: number = loginLink.created;
+        const url: string = loginLink.url;
+    }
+);
 //#endregion
 
 //#region Application Fee Refunds tests


### PR DESCRIPTION
Add missing `createLoginLink` method to Accounts type definitions.
Ref: https://stripe.com/docs/api/account/login_link?lang=node

Update Transfers list method type definitions.
Ref: https://stripe.com/docs/api/transfers/list?lang=node