### PR TITLE
Make FormSection in redux-form a generic type over its component's props.

### DIFF
--- a/types/redux-form/lib/FormSection.d.ts
+++ b/types/redux-form/lib/FormSection.d.ts
@@ -1,12 +1,10 @@
 import { Component, ComponentType } from "react";
 
-export type GenericFormSection<P> = Component<P & FormSectionProps<P>>;
-
-export interface FormSectionProps<P = {}> {
+export interface FormSectionProps<P> {
     name: string;
-    component?: string | ComponentType<P>;
+    component?: ComponentType<P>;
 }
 
-export declare class FormSection extends Component<FormSectionProps> {}
+export declare class FormSection<P = {}> extends Component<FormSectionProps<P> & P> {}
 
 export default FormSection;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -252,7 +252,11 @@ const Test = reduxForm<TestFormData>({
             return (
                 <div>
                     <FormCustom onSubmit={ handleSubmit(this.handleSubmitForm) }>
-                        <FormSection<MyFormSectionProps> name="my-section" component={MyFormSection} foo="hello" />;
+                        <FormSection<MyFormSectionProps>
+                            name="my-section"
+                            component={MyFormSection}
+                            foo="hello"
+                        />
 
                         <FormSection name="test2">
                             <Field

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -7,7 +7,6 @@ import {
     FormName,
     GenericForm,
     FormSection,
-    GenericFormSection,
     formValues,
     formValueSelector,
     Field,
@@ -101,8 +100,8 @@ const ItemListObj = formValues({ fooBar : "foo" })(
 interface MyFormSectionProps {
     foo: string;
 }
-const MyFormSection: React.StatelessComponent<MyFormSectionProps> = ({ children }) => null;
-const FormSectionCustom = FormSection as new () => GenericFormSection<MyFormSectionProps>;
+
+const MyFormSection: React.StatelessComponent<MyFormSectionProps> = ({ children, foo }) => null;
 
 /* Custom Field */
 
@@ -253,11 +252,7 @@ const Test = reduxForm<TestFormData>({
             return (
                 <div>
                     <FormCustom onSubmit={ handleSubmit(this.handleSubmitForm) }>
-                        <FormSectionCustom
-                            name="test1"
-                            component={ MyFormSection }
-                            foo="bar"
-                        />
+                        <FormSection<MyFormSectionProps> name="my-section" component={MyFormSection} foo="hello" />;
 
                         <FormSection name="test2">
                             <Field


### PR DESCRIPTION
This PR fixes the type definition of the `FormSection` component in `redux-form` to correctly accept a number of arguments passed to it which depend on the type of the `component` prop which may or may not be passed to the `FormSection` instance.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-form.com/7.4.2/docs/api/formsection.md/ ("Note that any additional props (e.g. 'className', 'style') that you pass to FormSection will be passed along to the wrapper component.")