### PR TITLE
d3-dsv and d3-fetch: Improve typing with generics

### DIFF
--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -15,19 +15,39 @@
 
 /**
  * An object representing a DSV parsed row with values represented as strings.
+ * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
-export interface DSVRowString {
-    [key: string]: string | undefined;
-}
+export type DSVRowString<Columns extends string = string> = {
+    [key in Columns]: string | undefined;
+};
+
+/**
+ * An object in raw format before parsing, that is with only string values.
+ * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
+ */
+export type DSVRaw<T extends object> = {
+    [key in keyof T]: string | undefined;
+};
 
 /**
  * An object representing a DSV parsed row with values represented as an arbitrary datatype, depending
  * on the performed parsed row mapping.
  *
- * @deprecated
+ * @deprecated Use `object` instead.
  */
 export interface DSVRowAny {
     [key: string]: any;
+}
+
+/**
+ * An array object representing all deserialized rows. The array is enhanced with a property listing
+ * the names of the parsed columns.
+ */
+export interface DSVRowArray<Columns extends string = string> extends Array<DSVRowString<Columns>> {
+    /**
+     * List of column names.
+     */
+    columns: Columns[];
 }
 
 /**
@@ -38,7 +58,7 @@ export interface DSVParsedArray<T> extends Array<T> {
     /**
      * List of column names.
      */
-    columns: string[];
+    columns: Array<keyof T>;
 }
 
 // ------------------------------------------------------------------------------------------
@@ -55,11 +75,12 @@ export interface DSVParsedArray<T> extends Array<T> {
  *
  * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
  *
- * Equivalent to dsvFormat(",").parse.
+ * Equivalent to `dsvFormat(",").parse`.
  *
  * @param csvString A string, which must be in the comma-separated values format.
  */
-export function csvParse(csvString: string): DSVParsedArray<DSVRowString>;
+// tslint:disable-next-line:no-unnecessary-generics
+export function csvParse<Columns extends string>(csvString: string): DSVRowArray<Columns>;
 /**
  * Parses the specified string, which must be in the comma-separated values format, returning an array of objects representing the parsed rows.
  *
@@ -68,7 +89,7 @@ export function csvParse(csvString: string): DSVParsedArray<DSVRowString>;
  *
  * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
  *
- * Equivalent to dsvFormat(",").parse.
+ * Equivalent to `dsvFormat(",").parse`.
  *
  * @param csvString A string, which must be in the comma-separated values format.
  * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
@@ -76,9 +97,9 @@ export function csvParse(csvString: string): DSVParsedArray<DSVRowString>;
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csvParse<ParsedRow extends object>(
+export function csvParse<ParsedRow extends object, Columns extends string>(
     csvString: string,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): DSVParsedArray<ParsedRow>;
 
 // csvParseRows(...) ========================================================================
@@ -92,7 +113,7 @@ export function csvParse<ParsedRow extends object>(
  * If a row conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types.
  * In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the + operator), but better is to specify a row conversion function.
  *
- * Equivalent to dsvFormat(",").parseRows.
+ * Equivalent to `dsvFormat(",").parseRows`.
  *
  * @param csvString A string, which must be in the comma-separated values format.
  */
@@ -103,7 +124,7 @@ export function csvParseRows(csvString: string): string[][];
  * Unlike csvParse, this method treats the header line as a standard row, and should be used whenever CSV content does not contain a header.
  * Each row is represented as an array rather than an object. Rows may have variable length.
  *
- * Equivalent to dsvFormat(",").parseRows.
+ * Equivalent to `dsvFormat(",").parseRows`.
  *
  * @param csvString A string, which must be in the comma-separated values format.
  * @param row A row conversion function which is invoked for each row, being passed an array representing the current row (d), the index (i)
@@ -127,7 +148,7 @@ export function csvParseRows<ParsedRow extends object>(
  * If columns is not specified, the list of column names that forms the header row is determined by the union of all properties on all objects in rows;
  * the order of columns is nondeterministic.
  *
- * Equivalent to dsvFormat(",").format.
+ * Equivalent to `dsvFormat(",").format`.
  *
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
@@ -145,7 +166,7 @@ export function csvFormat<T extends object>(rows: T[], columns?: Array<keyof T>)
  * To convert an array of objects to an array of arrays while explicitly specifying the columns, use array.map.
  * If you like, you can also array.concat this result with an array of column names to generate the first row.
  *
- * Equivalent to dsvFormat(",").formatRows.
+ * Equivalent to `dsvFormat(",").formatRows`.
  *
  * @param rows An array of array of string rows.
  */
@@ -165,11 +186,12 @@ export function csvFormatRows(rows: string[][]): string;
  *
  * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
  *
- * Equivalent to dsvFormat("\t").parse.
+ * Equivalent to `dsvFormat("\t").parse`.
  *
  * @param tsvString A string, which must be in the tab-separated values format.
  */
-export function tsvParse(tsvString: string): DSVParsedArray<DSVRowString>;
+// tslint:disable-next-line:no-unnecessary-generics
+export function tsvParse<Columns extends string>(tsvString: string): DSVRowArray<Columns>;
 /**
  * Parses the specified string, which must be in the tab-separated values format, returning an array of objects representing the parsed rows.
  *
@@ -178,7 +200,7 @@ export function tsvParse(tsvString: string): DSVParsedArray<DSVRowString>;
  *
  * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
  *
- * Equivalent to dsvFormat("\t").parse.
+ * Equivalent to `dsvFormat("\t").parse`.
  *
  * @param tsvString A string, which must be in the tab-separated values format.
  * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
@@ -186,10 +208,10 @@ export function tsvParse(tsvString: string): DSVParsedArray<DSVRowString>;
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsvParse<MappedRow extends object>(
+export function tsvParse<ParsedRow extends object, Columns extends string>(
     tsvString: string,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => MappedRow | undefined | null
-): DSVParsedArray<MappedRow>;
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): DSVParsedArray<ParsedRow>;
 
 // tsvParseRows(...) ========================================================================
 
@@ -202,7 +224,7 @@ export function tsvParse<MappedRow extends object>(
  * If a row conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types.
  * In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the + operator), but better is to specify a row conversion function.
  *
- * Equivalent to dsvFormat("\t").parseRows.
+ * Equivalent to `dsvFormat("\t").parseRows`.
  *
  * @param tsvString A string, which must be in the tab-separated values format.
  */
@@ -213,7 +235,7 @@ export function tsvParseRows(tsvString: string): string[][];
  * Unlike tsvParse, this method treats the header line as a standard row, and should be used whenever TSV content does not contain a header.
  * Each row is represented as an array rather than an object. Rows may have variable length.
  *
- * Equivalent to dsvFormat("\t").parseRows.
+ * Equivalent to `dsvFormat("\t").parseRows`.
  *
  * @param tsvString A string, which must be in the tab-separated values format.
  * @param row A row conversion function which is invoked for each row, being passed an array representing the current row (d), the index (i)
@@ -221,10 +243,10 @@ export function tsvParseRows(tsvString: string): string[][];
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsvParseRows<MappedRow extends object>(
+export function tsvParseRows<ParsedRow extends object>(
     tsvString: string,
-    row: (rawRow: string[], index: number) => MappedRow | undefined | null
-): MappedRow[];
+    row: (rawRow: string[], index: number) => ParsedRow | undefined | null
+): ParsedRow[];
 
 // tsvFormat(...) ============================================================================
 
@@ -237,7 +259,7 @@ export function tsvParseRows<MappedRow extends object>(
  * If columns is not specified, the list of column names that forms the header row is determined by the union of all properties on all objects in rows;
  * the order of columns is nondeterministic.
  *
- * Equivalent to dsvFormat("\t").format.
+ * Equivalent to `dsvFormat("\t").format`.
  *
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
@@ -255,7 +277,7 @@ export function tsvFormat<T extends object>(rows: T[], columns?: Array<keyof T>)
  * To convert an array of objects to an array of arrays while explicitly specifying the columns, use array.map.
  * If you like, you can also array.concat this result with an array of column names to generate the first row.
  *
- * Equivalent to dsvFormat("\t").formatRows.
+ * Equivalent to `dsvFormat("\t").formatRows`.
  *
  * @param rows An array of array of string rows.
  */
@@ -279,7 +301,8 @@ export interface DSV {
      *
      * @param dsvString A string, which must be in the delimiter-separated values format with the appropriate delimiter.
      */
-    parse(dsvString: string): DSVParsedArray<DSVRowString>;
+    // tslint:disable-next-line:no-unnecessary-generics
+    parse<Columns extends string>(dsvString: string): DSVRowArray<Columns>;
     /**
      * Parses the specified string, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of objects representing the parsed rows.
      *
@@ -294,9 +317,9 @@ export interface DSV {
      * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
      * In effect, row is similar to applying a map and filter operator to the returned rows.
      */
-    parse<ParsedRow extends object>(
+    parse<ParsedRow extends object, Columns extends string>(
         dsvString: string,
-        row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+        row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
     ): DSVParsedArray<ParsedRow>;
 
     /**

--- a/types/d3-fetch/d3-fetch-tests.ts
+++ b/types/d3-fetch/d3-fetch-tests.ts
@@ -35,16 +35,20 @@ const parseRow = (rawRow: DSVRowString, index: number, columns: string[]): (MyTy
     const myType: MyType | null = rawRow['foo'] ? { foo: rawRow['foo'] + '+ bar' } : null;
     return myType;
 };
+
 let promise1: Promise<DSVParsedArray<DSVRowString>>;
 let promise2: Promise<DSVParsedArray<MyType>>;
+
 promise1 = d3Fetch.csv(url);
 promise1 = d3Fetch.csv(url, init);
 promise2 = d3Fetch.csv<MyType>(url, parseRow);
 promise2 = d3Fetch.csv<MyType>(url, init, parseRow);
+
 promise1 = d3Fetch.dsv(';', url);
 promise1 = d3Fetch.dsv(';', url, init);
 promise2 = d3Fetch.dsv<MyType>(';', url, parseRow);
 promise2 = d3Fetch.dsv<MyType>(';', url, init, parseRow);
+
 promise1 = d3Fetch.tsv(url);
 promise1 = d3Fetch.tsv(url, init);
 promise2 = d3Fetch.tsv<MyType>(url, parseRow);

--- a/types/d3-fetch/d3-fetch-tests.ts
+++ b/types/d3-fetch/d3-fetch-tests.ts
@@ -1,66 +1,158 @@
 import * as d3Fetch from 'd3-fetch';
-import { DSVParsedArray, DSVRowString } from 'd3-dsv';
+import { DSVParsedArray, DSVRaw, DSVRowString } from 'd3-dsv';
 
-interface MyType {
-    foo: string;
+// ----------------------------------------------------------------------------
+// Preparatory Steps
+// ----------------------------------------------------------------------------
+
+type Headers = "Year" | "Make" | "Model" | "Length";
+
+interface Car {
+    year: Date;
+    make: string;
+    model: string;
+    length: number;
 }
 
-const url = 'foo.bar';
-
-const init: RequestInit = {};
-
-let p1: Promise<Blob> = d3Fetch.blob(url);
-p1 = d3Fetch.blob(url, init);
-
-let p2: Promise<ArrayBuffer> = d3Fetch.buffer(url);
-p2 = d3Fetch.buffer(url, init);
-
-let p3: Promise<HTMLImageElement> = d3Fetch.image(url);
-const imageProperties = {
-    width: '300px',
-    height: '500px'
-};
-p3 = d3Fetch.image(url, imageProperties);
-
-let p4: Promise<any> = d3Fetch.json(url);
-p4 = d3Fetch.json(url, init);
-let p5: Promise<MyType> = d3Fetch.json<MyType>(url);
-p5 = d3Fetch.json<MyType>(url, init);
-
-let myString: Promise<string>;
-myString = d3Fetch.text(url);
-myString = d3Fetch.text(url, init);
-
-const parseRow = (rawRow: DSVRowString, index: number, columns: string[]): (MyType | undefined | null) => {
-    const myType: MyType | null = rawRow['foo'] ? { foo: rawRow['foo'] + '+ bar' } : null;
-    return myType;
-};
-
-let promise1: Promise<DSVParsedArray<DSVRowString>>;
-let promise2: Promise<DSVParsedArray<MyType>>;
-
-promise1 = d3Fetch.csv(url);
-promise1 = d3Fetch.csv(url, init);
-promise2 = d3Fetch.csv<MyType>(url, parseRow);
-promise2 = d3Fetch.csv<MyType>(url, init, parseRow);
-
-promise1 = d3Fetch.dsv(';', url);
-promise1 = d3Fetch.dsv(';', url, init);
-promise2 = d3Fetch.dsv<MyType>(';', url, parseRow);
-promise2 = d3Fetch.dsv<MyType>(';', url, init, parseRow);
-
-promise1 = d3Fetch.tsv(url);
-promise1 = d3Fetch.tsv(url, init);
-promise2 = d3Fetch.tsv<MyType>(url, parseRow);
-promise2 = d3Fetch.tsv<MyType>(url, init, parseRow);
-
+let anyPromise: Promise<any>;
+let arrayPromise: Promise<ArrayBuffer>;
+let blobPromise: Promise<Blob>;
 let docPromise: Promise<Document>;
+let imagePromise: Promise<HTMLImageElement>;
+let carPromise: Promise<Car>;
+let stringPromise: Promise<string>;
+let xmlDocPromise: Promise<XMLDocument>;
+
+const url = 'example.org';
+const init: RequestInit = {};
+const map = new Map<string, number>();
+
+const imageProperties = {
+    width: 300,
+    height: 500,
+    crossOrigin: "anonymous",
+};
+
+// ----------------------------------------------------------------------------
+// Non DSV file format
+// ----------------------------------------------------------------------------
+
+blobPromise = d3Fetch.blob(url);
+blobPromise = d3Fetch.blob(url, init);
+
+arrayPromise = d3Fetch.buffer(url);
+arrayPromise = d3Fetch.buffer(url, init);
+
+imagePromise = d3Fetch.image(url);
+imagePromise = d3Fetch.image(url, imageProperties);
+// $ExpectError
+imagePromise = d3Fetch.image(url, {width: "500px"}); // fails, string not assignable to number | undefined
+
+anyPromise = d3Fetch.json(url);
+anyPromise = d3Fetch.json(url, init);
+
+carPromise = d3Fetch.json<Car>(url);
+carPromise = d3Fetch.json<Car>(url, init);
+
+stringPromise = d3Fetch.text(url);
+stringPromise = d3Fetch.text(url, init);
+
 docPromise = d3Fetch.html(url);
 docPromise = d3Fetch.html(url, init);
 
 docPromise = d3Fetch.svg(url);
 docPromise = d3Fetch.svg(url, init);
 
-let xmlDocPromise: Promise<XMLDocument>;
 xmlDocPromise = d3Fetch.xml(url);
 xmlDocPromise = d3Fetch.xml(url, init);
+
+// ----------------------------------------------------------------------------
+// DSV file format
+// ----------------------------------------------------------------------------
+
+let rawPromise: Promise<DSVParsedArray<DSVRowString>>;
+let rawPromiseHeader: Promise<DSVParsedArray<DSVRowString<Headers>>>;
+let parsedPromise: Promise<DSVParsedArray<Car>>;
+
+declare const parseRowString: (rawRow: DSVRowString, index: number, columns: string[]) => Car | undefined | null;
+
+const parseRow = (d: DSVRowString<Headers>, index: number, columns: Headers[]): Car | undefined | null => {
+    const item: string | undefined = d[columns[0]];
+    const car = d.Make === 'Ford' ? null :
+        {
+            year: new Date(+d.Make!, 0, 1),
+            make: d.Make!,
+            model: d.Model!,
+            length: +d.Length!,
+        };
+    return index % 2 === 0 ? undefined : car;
+};
+
+const parseRowSimple = (d: DSVRaw<Car>) => {
+    return {
+        year: new Date(+d.make!, 0, 1),
+        make: d.make!,
+        model: d.model!,
+        length: +d.length!,
+    };
+};
+
+// CSV
+
+rawPromise = d3Fetch.csv(url);
+rawPromise = d3Fetch.csv(url, init);
+
+rawPromiseHeader = d3Fetch.csv<Headers>(url);
+rawPromiseHeader = d3Fetch.csv<Headers>(url, init);
+
+parsedPromise = d3Fetch.csv<Car>(url, parseRowString);
+parsedPromise = d3Fetch.csv<Car>(url, init, parseRowString);
+
+parsedPromise = d3Fetch.csv<Car, Headers>(url, parseRow);
+parsedPromise = d3Fetch.csv<Car, Headers>(url, init, parseRow);
+
+parsedPromise = d3Fetch.csv(url, parseRow);
+parsedPromise = d3Fetch.csv(url, init, parseRow);
+parsedPromise = d3Fetch.csv(url, parseRowSimple);
+
+anyPromise = d3Fetch.csv(url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));
+
+// DSV
+
+rawPromise = d3Fetch.dsv("|", url);
+rawPromise = d3Fetch.dsv("|", url, init);
+
+rawPromiseHeader = d3Fetch.dsv<Headers>("|", url);
+rawPromiseHeader = d3Fetch.dsv<Headers>("|", url, init);
+
+parsedPromise = d3Fetch.dsv<Car>("|", url, parseRowString);
+parsedPromise = d3Fetch.dsv<Car>("|", url, init, parseRowString);
+
+parsedPromise = d3Fetch.dsv<Car, Headers>("|", url, parseRow);
+parsedPromise = d3Fetch.dsv<Car, Headers>("|", url, init, parseRow);
+
+parsedPromise = d3Fetch.dsv("|", url, parseRow);
+parsedPromise = d3Fetch.dsv("|", url, init, parseRow);
+parsedPromise = d3Fetch.dsv("|", url, parseRowSimple);
+
+anyPromise = d3Fetch.dsv("|", url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));
+
+// TSV
+
+rawPromise = d3Fetch.tsv(url);
+rawPromise = d3Fetch.tsv(url, init);
+
+rawPromiseHeader = d3Fetch.tsv<Headers>(url);
+rawPromiseHeader = d3Fetch.tsv<Headers>(url, init);
+
+parsedPromise = d3Fetch.tsv<Car>(url, parseRowString);
+parsedPromise = d3Fetch.tsv<Car>(url, init, parseRowString);
+
+parsedPromise = d3Fetch.tsv<Car, Headers>(url, parseRow);
+parsedPromise = d3Fetch.tsv<Car, Headers>(url, init, parseRow);
+
+parsedPromise = d3Fetch.tsv(url, parseRow);
+parsedPromise = d3Fetch.tsv(url, init, parseRow);
+parsedPromise = d3Fetch.tsv(url, parseRowSimple);
+
+anyPromise = d3Fetch.csv(url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));

--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -173,7 +173,7 @@ export function html(url: string, init?: RequestInit): Promise<Document>;
  * @param url A valid URL string.
  * @param init An optional object of image properties to set.
  */
-export function image(url: string, init?: {[key: string]: any}): Promise<HTMLImageElement>;
+export function image(url: string, init?: Partial<HTMLImageElement>): Promise<HTMLImageElement>;
 
 /**
  * Fetches the json file at the specified input URL and returns it as a Promise of a parsed JSON object.

--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -1,12 +1,13 @@
 // Type definitions for d3-fetch 1.1
 // Project: https://d3js.org/d3-fetch/
 // Definitions by: Hugues Stefanski <https://github.com/ledragon>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1.0
 
-import { DSVParsedArray, DSVRowString } from 'd3-dsv';
+import { DSVParsedArray, DSVRowArray, DSVRowString } from "d3-dsv";
 
 /**
  * Fetches the binary file at the specified input URL and returns it as a Promise of a Blob.
@@ -33,13 +34,15 @@ export function buffer(url: string, init?: RequestInit): Promise<ArrayBuffer>;
  *
  * If init is specified, it is passed along to the underlying call to fetch.
  *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
  * @param url A valid URL string.
  * @param init An optional request initialization object.
  */
-export function csv(
+export function csv<Columns extends string>(
     url: string,
-    init?: RequestInit,
-): Promise<DSVParsedArray<DSVRowString>>;
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
 /**
  * Fetches the CSV file at the specified input URL and returns
  * a promise of an array of objects representing the parsed rows.
@@ -47,7 +50,8 @@ export function csv(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.csvParse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param url A valid URL string.
  * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
@@ -55,9 +59,9 @@ export function csv(
  * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csv<ParsedRow extends object>(
+export function csv<ParsedRow extends object, Columns extends string = string>(
     url: string,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 /**
  * Fetches the CSV file at the specified input URL and returns
@@ -68,7 +72,8 @@ export function csv<ParsedRow extends object>(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.csvParse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param url A valid URL string.
  * @param init An request initialization object.
@@ -77,10 +82,10 @@ export function csv<ParsedRow extends object>(
  * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csv<ParsedRow extends object>(
+export function csv<ParsedRow extends object, Columns extends string = string>(
     url: string,
     init: RequestInit,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 
 /**
@@ -90,15 +95,17 @@ export function csv<ParsedRow extends object>(
  *
  * If init is specified, it is passed along to the underlying call to fetch.
  *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
  * @param delimiter The delimiter character used in the DSV file to be fetched.
  * @param url A valid URL string.
  * @param init An optional request initialization object.
  */
-export function dsv(
+export function dsv<Columns extends string>(
     delimiter: string,
     url: string,
-    init?: RequestInit,
-): Promise<DSVParsedArray<DSVRowString>>;
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
 /**
  * Fetches the DSV file with the specified delimiter character at the specified input URL and returns
  * a promise of an array of objects representing the parsed rows.
@@ -106,7 +113,8 @@ export function dsv(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.parse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param delimiter The delimiter character used in the DSV file to be fetched.
  * @param url A valid URL string.
@@ -115,10 +123,10 @@ export function dsv(
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function dsv<ParsedRow extends object>(
+export function dsv<ParsedRow extends object, Columns extends string = string>(
     delimiter: string,
     url: string,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 /**
  * Fetches the DSV file with the specified delimiter character at the specified input URL and returns
@@ -129,7 +137,8 @@ export function dsv<ParsedRow extends object>(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.parse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param delimiter The delimiter character used in the DSV file to be fetched.
  * @param url A valid URL string.
@@ -139,11 +148,11 @@ export function dsv<ParsedRow extends object>(
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function dsv<ParsedRow extends object>(
+export function dsv<ParsedRow extends object, Columns extends string = string>(
     delimiter: string,
     url: string,
     init: RequestInit,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 
 /**
@@ -204,13 +213,15 @@ export function text(url: string, init?: RequestInit): Promise<string>;
  *
  * If init is specified, it is passed along to the underlying call to fetch.
  *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
  * @param url A valid URL string.
  * @param init An optional request initialization object.
  */
-export function tsv(
+export function tsv<Columns extends string>(
     url: string,
-    init?: RequestInit,
-): Promise<DSVParsedArray<DSVRowString>>;
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
 /**
  * Fetches the TSV file at the specified input URL and returns
  * a promise of an array of objects representing the parsed rows. The values of the properties of the parsed row
@@ -219,7 +230,8 @@ export function tsv(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.tsvParse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param url A valid URL string.
  * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
@@ -227,9 +239,9 @@ export function tsv(
  * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsv<ParsedRow extends object>(
+export function tsv<ParsedRow extends object, Columns extends string = string>(
     url: string,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 /**
  * Fetches the TSV file at the specified input URL and returns
@@ -240,7 +252,8 @@ export function tsv<ParsedRow extends object>(
  * The specified row conversion function is used to map and filter row objects to a more-specific representation;
  * see dsv.tsvParse for details.
  *
- * The generic parameter describes the type of the object representation of a parsed row.
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
  *
  * @param url A valid URL string.
  * @param init An request initialization object.
@@ -249,10 +262,10 @@ export function tsv<ParsedRow extends object>(
  * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsv<ParsedRow extends object>(
+export function tsv<ParsedRow extends object, Columns extends string = string>(
     url: string,
     init: RequestInit,
-    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
 
 /**


### PR DESCRIPTION
This PR Improve typing for d3-dsv and d3-fetch, see below. Those changes are backward compatible with old code as it has defaults generics. I also improved typing for `d3.image` parameter `init`.

You can know use a union of string literal to improve typing d3-dsv and d3-fetch. For example,

```typescript
type Headers = "Year" | "Make";
const p = d3.csvParse<Headers>("Year,Make\n1997,Ford\n2000,Mercury");

p[0].Year; // Ok
p[0].Unknown; // Compile error
```

You still need to keep your types in "sync" with your file structure. But now, if you change your file content, you just change your types and see the compiler find the places where changes are needed. Before you should have reviewed all your code.

A more practical example.

```typescript
interface Temperatures {
    low: string | undefined;
    high: string | undefined;
}

interface TempDiff {
    value: number;
}

d3.csv("temperatures.csv", type).then((data) => {});
// inferred as csv<TempDiff, "low" | "high">
// first generic is parsed row
// second generic is csv headers (raw object keys)

function type(d: Temperatures): TempDiff {
    return {
        value: +d.high! - +d.low!,
    };
}
```

If the _csv_ content is not well-structured and some columns are missing, d3 use `undefined` values. So all properties in the _raw_ interface are `| undefined`.

As it is common to have your raw and parsed object that only differs on types (raw being always `string | undefined`), a type `DSVRaw` has been added to _convert_ your parsed type to raw type. For example:

```typescript
interface Population {
    age: string;
    population: number;
}

function type(d: d3.DSVRaw<Population>): Population {
    return {
        age: d.age!,
        population: +d.population!,
    };
}

d3.csv("population.csv", type).then((data) => {});
// inferred as csv<Population, "age" | "population">
```

In the above code, `d3.DSVRaw<Population>` is same as
```typescript
interface PopulationRaw {
    age: string | undefined;
    population: string | undefined;
}
```

Inlining the function works too:

```typescript
interface Diamond {
    carat: number;
    price: number;
}

d3.tsv("diamonds.tsv", (d: d3.DSVRaw<Diamond>) => {
    return {
        carat: +d.carat!,
        price: +d.price!,
    };
}).then((diamonds) => {});
```

Related #30466 and #23611.
