### PR TITLE
[@types/react] Fix to WeakValidationMap optional type breaking react type extensions 

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2551,7 +2551,7 @@ declare namespace React {
     type ValidationMap<T> = PropTypes.ValidationMap<T>;
 
     type WeakValidationMap<T> = {
-        [K in keyof T]?: null extends T[K]
+        [K in keyof T]-?: null extends T[K]
             ? Validator<T[K] | null | undefined>
             : undefined extends T[K]
             ? Validator<T[K] | null | undefined>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

The PR aims to solve (at least temporary) the inability of users, who use the latest `@types/react` package to compile.

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31734
