### PR TITLE
[@types/jest] Update `jest.fail` return type from `void` to `never`.

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -221,7 +221,7 @@ declare namespace jest {
 
     interface DoneCallback {
         (...args: any[]): any;
-        fail(error?: string | { message: string }): any;
+        fail(error?: string | { message: string }): never;
     }
 
     type ProvidesCallback = (cb: DoneCallback) => any;
@@ -981,7 +981,7 @@ declare function pending(reason?: string): void;
 /**
  * Fails a test when called within one.
  */
-declare function fail(error?: any): void;
+declare function fail(error?: any): never;
 declare namespace jasmine {
     let DEFAULT_TIMEOUT_INTERVAL: number;
     function clock(): Clock;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -221,7 +221,7 @@ declare namespace jest {
 
     interface DoneCallback {
         (...args: any[]): any;
-        fail(error?: string | { message: string }): never;
+        fail(error?: string | { message: string }): any;
     }
 
     type ProvidesCallback = (cb: DoneCallback) => any;


### PR DESCRIPTION
This should never return, right?