### PR TITLE
[@types/jwplayer] Add setCaptions, getVisualQuality

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -5,6 +5,7 @@
 //                 Philipp Gürtler <https://github.com/philippguertler>
 //                 Daniel McGraw <https://github.com/danielmcgraw>
 //                 Benjamin Dobson <https://github.com/bpdsw>
+//                 Be Birchall <https://gitnub.com/bebebebebe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -241,6 +242,18 @@ interface Region {
     height: number;
 }
 
+interface CaptionOptions {
+    color: string;
+    fontSize: number;
+    fontFamily: string;
+    fontOpacity: number;
+    backgroundColor: string;
+    backgroundOpacity: number;
+    edgeStyle: string;
+    windowColor: string;
+    windowOpacity: number;
+}
+
 interface JWPlayer {
 	addButton(icon: string, label: string, handler: () => void, id: string): void;
 	getAudioTracks(): any[];
@@ -469,6 +482,7 @@ interface JWPlayer {
 	setMute(state?: boolean): void;
 	setup(options: any): JWPlayer;
 	setVolume(volume: number): void;
+    setCaptions(options: CaptionOptions): void;
 	stop(): void;
 }
 

--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -254,6 +254,19 @@ interface CaptionOptions {
     windowOpacity: number;
 }
 
+interface Level {
+    bitrate: number;
+    height: number;
+    width: number;
+    label: string;
+}
+
+interface QualityLevel {
+    mode: 'auto' | 'manual';
+    level: Level;
+    reason: 'auto' | 'api' | 'initial choice';
+}
+
 interface JWPlayer {
 	addButton(icon: string, label: string, handler: () => void, id: string): void;
 	getAudioTracks(): any[];
@@ -279,6 +292,7 @@ interface JWPlayer {
 	getContainer(): HTMLElement;
 	getEnvironment(): Environment;
 	getWidth(): number;
+    getVisualQuality(): QualityLevel | undefined;
 	load(playlist: any[]): void;
 	load(playlist: string): void;
 	on(event: 'adClick', callback: EventCallback<AdProgressParam>): void;


### PR DESCRIPTION
This adds to existing types, per jwplayer docs (https://developer.jwplayer.com/jw-player/docs/javascript-api-reference). We have been using the addition as an extension in our code already.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.jwplayer.com/jw-player/docs/javascript-api-reference
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
