### PR TITLE
[react-redux] use the new forwardRef option

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -314,6 +314,13 @@ export interface Options<State = {}, TStateProps = {}, TOwnProps = {}, TMergedPr
      * @default shallowEqual
      */
     areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;
+
+    /**
+     * If true, use React's forwardRef to expose a ref of the wrapped component
+     *
+     * @default false
+     */
+    forwardRef?: boolean;
 }
 
 /**
@@ -383,7 +390,7 @@ export interface ConnectOptions {
      */
     storeKey?: string;
     /**
-     * If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+     * @deprecated Use forwardRef
      *
      * @default false
      */


### PR DESCRIPTION
Add the new `forwardRef` option and deprecate the old `withRef`
https://github.com/reduxjs/react-redux/releases/tag/v6.0.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
