### PR TITLE
[chrome] add missing type and event to omnibox

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4587,6 +4587,8 @@ declare namespace chrome.omnibox {
 
     export interface OmniboxInputCancelledEvent extends chrome.events.Event<() => void> { }
 
+    export interface OmniboxSuggestionDeletedEvent extends chrome.events.Event<(text: string) => void> { }
+
     /**
      * Sets the description and styling for the default suggestion. The default suggestion is the text that is displayed in the first suggestion row underneath the URL bar.
      * @param suggestion A partial SuggestResult object, without the 'content' parameter.
@@ -4601,6 +4603,11 @@ declare namespace chrome.omnibox {
     export var onInputStarted: OmniboxInputStartedEvent;
     /** User has ended the keyword input session without accepting the input. */
     export var onInputCancelled: OmniboxInputCancelledEvent;
+     /**
+     * User has deleted a suggested result
+     * @since Chrome 63.
+     */
+    export var onDeleteSuggestion: OmniboxSuggestionDeletedEvent;
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4576,7 +4576,10 @@ declare namespace chrome.omnibox {
         description: string;
     }
 
-    export interface OmniboxInputEnteredEvent extends chrome.events.Event<(text: string) => void> { }
+    /** The window disposition for the omnibox query. This is the recommended context to display results. */
+    export type OnInputEnteredDisposition = 'currentTab' | 'newForegroundTab' | 'newBackgroundTab';
+
+    export interface OmniboxInputEnteredEvent extends chrome.events.Event<(text: string, disposition: OnInputEnteredDisposition) => void> { }
 
     export interface OmniboxInputChangedEvent extends chrome.events.Event<(text: string, suggest: (suggestResults: SuggestResult[]) => void) => void> { }
 


### PR DESCRIPTION
Documentation: 

* [OnInputEnteredDisposition](https://developer.chrome.com/extensions/omnibox#type-OnInputEnteredDisposition)
* [onDeleteSuggestion](https://developer.chrome.com/extensions/omnibox#event-onDeleteSuggestion)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.