### PR TITLE
React components cannot render undefined

### DIFF
--- a/types/lingui__macro/ReactSelect.d.ts
+++ b/types/lingui__macro/ReactSelect.d.ts
@@ -11,14 +11,14 @@ export interface PluralPropsWithoutI18n extends RenderProps {
     few?: ReactNode;
     many?: ReactNode;
     other: ReactNode;
-    [exact: string]: ReactNode;
+    [exact: string]: ReactNode | undefined;
 }
 
 export interface SelectPropsWithoutI18n extends RenderProps {
     id?: string;
     value: string;
     other: ReactNode;
-    [exact: string]: ReactNode;
+    [exact: string]: ReactNode | undefined;
 }
 
 export class Select extends Component<SelectPropsWithoutI18n> { }

--- a/types/lingui__react/Select.d.ts
+++ b/types/lingui__react/Select.d.ts
@@ -11,14 +11,14 @@ export interface PluralPropsWithoutI18n extends RenderProps {
     few?: ReactNode;
     many?: ReactNode;
     other: ReactNode;
-    [exact: string]: ReactNode;
+    [exact: string]: ReactNode | undefined;
 }
 
 export interface SelectPropsWithoutI18n extends RenderProps {
     id?: string;
     value: string;
     other: ReactNode;
-    [exact: string]: ReactNode;
+    [exact: string]: ReactNode | undefined;
 }
 
 export class Select extends Component<SelectPropsWithoutI18n> { }

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -29,7 +29,7 @@ export interface ReactDatePickerProps {
 	autoComplete?: string;
 	autoFocus?: boolean;
 	calendarClassName?: string;
-	calendarContainer?(props: { children: React.ReactNode[] }): React.ReactNode;
+	calendarContainer?(props: { children: React.ReactNode }): React.ReactNode;
 	children?: React.ReactNode;
 	className?: string;
 	clearButtonTitle?: string;
@@ -81,7 +81,7 @@ export interface ReactDatePickerProps {
 	peekNextMonth?: boolean;
 	placeholderText?: string;
 	popperClassName?: string;
-	popperContainer?(props: { children: React.ReactNode[] }): React.ReactNode;
+	popperContainer?(props: { children: React.ReactNode }): React.ReactNode;
 	popperModifiers?: Popper.Modifiers;
 	popperPlacement?: string;
 	popperProps?: {};

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 // All events need to be lowercase so they don't collide with React.DOMAttributes<T>
 // which already declares things with some of the same names
 
-export type Children = React.ReactNode | React.ReactNode[];
+export type Children = React.ReactNode;
 
 export interface MapEvents {
     onclick?(event: Leaflet.LeafletMouseEvent): void;

--- a/types/react-native-dialog/index.d.ts
+++ b/types/react-native-dialog/index.d.ts
@@ -34,7 +34,7 @@ interface ButtonProps {
 
 interface ContainerProps {
     blurComponentIOS?: ReactNode;
-    children: React.ReactNode[];
+    children: React.ReactNode;
     /**
      * default: false
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -348,7 +348,7 @@ export interface NativeMethodsMixinStatic {
 export function createElement<P>(
     type: React.ReactType,
     props?: P,
-    ...children: React.ReactNode[]
+    ...children: React.ReactNodeArray
 ): React.ReactElement<P>;
 
 export type Runnable = (appParameters: any) => void;

--- a/types/react-router-navigation-core/index.d.ts
+++ b/types/react-router-navigation-core/index.d.ts
@@ -60,7 +60,7 @@ export type TabsRendererProps = {
 };
 
 export type CardStackProps = {
-    children?: ReactNode[];
+    children?: ReactNode;
     render: (props: CardsRendererProps) => ReactNode;
 };
 
@@ -86,7 +86,7 @@ export class CardStack extends PureComponent<
 }
 
 export type TabStackProps = {
-    children?: ReactNode[];
+    children?: ReactNode;
     render: (props: TabsRendererProps) => ReactNode;
     lazy?: boolean;
     forceSync?: boolean;

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -104,7 +104,7 @@ export interface Tab extends TabProps {
 
 // High-level wrappers
 export interface BottomNavigationProps extends TabBarProps {
-    children?: ReactNode[];
+    children?: ReactNode;
     lazy?: boolean;
     style?: StyleProp<ViewStyle>;
 }

--- a/types/react-virtualized/dist/es/Collection.d.ts
+++ b/types/react-virtualized/dist/es/Collection.d.ts
@@ -26,7 +26,7 @@ export type CollectionCellGroupRendererParams = {
 };
 export type CollectionCellGroupRenderer = (
     params: CollectionCellGroupRendererParams
-) => React.ReactNode[];
+) => React.ReactNodeArray;
 export type CollectionCellRendererParams = {
     index: number;
     isScrolling: boolean;
@@ -181,5 +181,5 @@ export class Collection extends PureComponent<CollectionProps> {
         params: {
             isScrolling: boolean;
         } & SizeInfo
-    ): React.ReactNode[];
+    ): React.ReactNodeArray;
 }

--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -153,7 +153,7 @@ export type GridCellRangeProps = {
 };
 export type GridCellRangeRenderer = (
     params: GridCellRangeProps
-) => React.ReactNode[];
+) => React.ReactNodeArray;
 
 export type GridCoreProps = {
     "aria-label"?: string;

--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -73,7 +73,7 @@ export type TableHeaderProps = {
 };
 export type TableHeaderRowProps = {
     className: string;
-    columns: React.ReactNode[];
+    columns: React.ReactNodeArray;
     style: React.CSSProperties;
     scrollbarWidth: number;
     height: number;

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -1196,7 +1196,7 @@ export class GridExample3 extends PureComponent<{}, any> {
 
     _renderBodyCell(params: GridCellProps) {
         if (params.columnIndex < 1) {
-            return;
+            return null;
         }
 
         return this._renderLeftSideCell(params);
@@ -1204,7 +1204,7 @@ export class GridExample3 extends PureComponent<{}, any> {
 
     _renderHeaderCell(params: GridCellProps) {
         if (params.columnIndex < 1) {
-            return;
+            return null;
         }
 
         return this._renderLeftHeaderCell(params);

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -1627,8 +1627,8 @@ export class GridCellRangeRendererExample extends PureComponent<{}, any> {
         parent,
         visibleColumnIndices,
         visibleRowIndices
-    }: GridCellRangeProps): React.ReactNode[] {
-        const renderedCells: React.ReactNode[] = [];
+    }: GridCellRangeProps): React.ReactNodeArray {
+        const renderedCells: React.ReactNodeArray = [];
         const style: React.CSSProperties = {};
 
         for (

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -167,7 +167,7 @@ declare namespace React {
     type ReactText = string | number;
     type ReactChild = ReactElement<any> | ReactText;
 
-    interface ReactNodeArray extends Array<ReactNode> {}
+    interface ReactNodeArray extends Array<ReactNode | undefined> {}
     type ReactFragment = {} | ReactNodeArray;
     type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -169,7 +169,7 @@ declare namespace React {
 
     interface ReactNodeArray extends Array<ReactNode> {}
     type ReactFragment = {} | ReactNodeArray;
-    type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
+    type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null;
 
     //
     // Top Level API

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -130,33 +130,33 @@ declare namespace React {
     // Factories
     // ----------------------------------------------------------------------
 
-    type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
+    type Factory<P> = (props?: Attributes & P, ...children: ReactNodeArray) => ReactElement<P>;
 
     /**
      * @deprecated Please use `FunctionComponentFactory`
      */
     type SFCFactory<P> = FunctionComponentFactory<P>;
 
-    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
+    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNodeArray) => FunctionComponentElement<P>;
 
     type ComponentFactory<P, T extends Component<P, ComponentState>> =
-        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
+        (props?: ClassAttributes<T> & P, ...children: ReactNodeArray) => CElement<P, T>;
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
-        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNodeArray) => DOMElement<P, T>;
 
     // tslint:disable-next-line:no-empty-interface
     interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
 
     interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
-        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNodeArray): DetailedReactHTMLElement<P, T>;
     }
 
     interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
-        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
+        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNodeArray): ReactSVGElement;
     }
 
     //
@@ -196,74 +196,74 @@ declare namespace React {
     function createElement(
         type: "input",
         props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
-        ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+        ...children: ReactNodeArray): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
     function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         type: keyof ReactHTML,
         props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        ...children: ReactNodeArray): DetailedReactHTMLElement<P, T>;
     function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
         type: keyof ReactSVG,
         props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): ReactSVGElement;
+        ...children: ReactNodeArray): ReactSVGElement;
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
         props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        ...children: ReactNodeArray): DOMElement<P, T>;
 
     // Custom components
 
     function createElement<P extends {}>(
         type: FunctionComponent<P>,
         props?: Attributes & P | null,
-        ...children: ReactNode[]): FunctionComponentElement<P>;
+        ...children: ReactNodeArray): FunctionComponentElement<P>;
     function createElement<P extends {}>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
         props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
-        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
+        ...children: ReactNodeArray): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
         props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): CElement<P, T>;
+        ...children: ReactNodeArray): CElement<P, T>;
     function createElement<P extends {}>(
         type: FunctionComponent<P> | ComponentClass<P> | string,
         props?: Attributes & P | null,
-        ...children: ReactNode[]): ReactElement<P>;
+        ...children: ReactNodeArray): ReactElement<P>;
 
     // DOM Elements
     // ReactHTMLElement
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: DetailedReactHTMLElement<P, T>,
         props?: P,
-        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        ...children: ReactNodeArray): DetailedReactHTMLElement<P, T>;
     // ReactHTMLElement, less specific
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: ReactHTMLElement<T>,
         props?: P,
-        ...children: ReactNode[]): ReactHTMLElement<T>;
+        ...children: ReactNodeArray): ReactHTMLElement<T>;
     // SVGElement
     function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
         element: ReactSVGElement,
         props?: P,
-        ...children: ReactNode[]): ReactSVGElement;
+        ...children: ReactNodeArray): ReactSVGElement;
     // DOM Element (has to be the last, because type checking stops at first overload that fits)
     function cloneElement<P extends DOMAttributes<T>, T extends Element>(
         element: DOMElement<P, T>,
         props?: DOMAttributes<T> & P,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        ...children: ReactNodeArray): DOMElement<P, T>;
 
     // Custom components
     function cloneElement<P>(
         element: FunctionComponentElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]): FunctionComponentElement<P>;
+        ...children: ReactNodeArray): FunctionComponentElement<P>;
     function cloneElement<P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
         props?: Partial<P> & ClassAttributes<T>,
-        ...children: ReactNode[]): CElement<P, T>;
+        ...children: ReactNodeArray): CElement<P, T>;
     function cloneElement<P>(
         element: ReactElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]): ReactElement<P>;
+        ...children: ReactNodeArray): ReactElement<P>;
 
     // Context via RenderProps
     interface ProviderProps<T> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -218,7 +218,7 @@ namespace FunctionComponent {
 
 const FunctionComponent2: React.FunctionComponent<SCProps> =
     // props is contextually typed
-    props => DOM.div(null, props.foo);
+    props => DOM.div(null, props.foo != null ? props.foo : null);
 FunctionComponent2.displayName = "FunctionComponent2";
 FunctionComponent2.defaultProps = {
     foo: 42
@@ -226,7 +226,7 @@ FunctionComponent2.defaultProps = {
 
 const LegacyStatelessComponent2: React.SFC<SCProps> =
     // props is contextually typed
-    props => DOM.div(null, props.foo);
+    props => DOM.div(null, props.foo != null ? props.foo : null);
 LegacyStatelessComponent2.displayName = "LegacyStatelessComponent2";
 LegacyStatelessComponent2.defaultProps = {
     foo: 42
@@ -235,12 +235,12 @@ LegacyStatelessComponent2.defaultProps = {
 const FunctionComponent3: React.FunctionComponent<SCProps> =
     // allows usage of props.children
     // allows null return
-    props => props.foo ? DOM.div(null, props.foo, props.children) : null;
+    props => props.foo ? DOM.div(null, props.foo, props.children ? props.children : null) : null;
 
 const LegacyStatelessComponent3: React.SFC<SCProps> =
     // allows usage of props.children
     // allows null return
-    props => props.foo ? DOM.div(null, props.foo, props.children) : null;
+    props => props.foo ? DOM.div(null, props.foo, props.children ? props.children : null) : null;
 
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -303,6 +303,7 @@ const clonedElement: React.CElement<Props, ModernComponent> = React.cloneElement
 
 React.cloneElement(element, {});
 React.cloneElement(element, {}, null);
+React.cloneElement(element, {}, undefined);
 
 const clonedElement2: React.CElement<Props, ModernComponent> =
     React.cloneElement(element, {

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -99,7 +99,7 @@ export interface CategoricalChartWrapper<L = LayoutType> {
     maxBarSize?: number;
     style?: object;
     className?: string;
-    children?: React.ReactNode | React.ReactNode[];
+    children?: React.ReactNode;
     onClick?: RechartsFunction;
     onMouseLeave?: RechartsFunction;
     onMouseEnter?: RechartsFunction;
@@ -841,7 +841,7 @@ export interface TreemapProps extends EventAttributes, Animatable {
     className?: string;
     nameKey?: string | number | RechartsFunction;
     dataKey?: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    children?: React.ReactNode[] | React.ReactNode;
+    children?: React.ReactNode;
 }
 
 export class Treemap extends React.Component<TreemapProps> { }
@@ -855,7 +855,7 @@ export interface LabelProps extends Partial<PresentationAttributes> {
     value?: number | string;
     offset?: number;
     position?: PositionType;
-    children?: React.ReactNode[] | React.ReactNode;
+    children?: React.ReactNode;
     className?: string;
     content?: React.ReactElement<any> | ContentRenderer<any>;
 }
@@ -864,7 +864,7 @@ export class LabelList extends React.Component<LabelListProps> { }
 
 export interface LabelListProps {
     angle?: number;
-    children?: React.ReactNode[] | React.ReactNode;
+    children?: React.ReactNode;
     className?: string;
     clockWise?: boolean;
     content?: React.ReactElement<any> | ContentRenderer<LabelProps>;

--- a/types/rmc-drawer/index.d.ts
+++ b/types/rmc-drawer/index.d.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 interface DrawerProps {
     className?: string;
     prefixCls?: string;
-    children?: React.ReactNode | React.ReactNode[];
+    children?: React.ReactNode;
     style?: React.CSSProperties;
     sidebarStyle?: React.CSSProperties;
     contentStyle?: React.CSSProperties;


### PR DESCRIPTION
React does not allow components to render `undefined`, only `null` is permitted.  Returning `undefined` from the render method results in the error:

> **Invariant Violation**
> ComponentName(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.

See also the discussion at https://github.com/facebook/react/issues/3738.

This PR is a continuation of #25546 by @elongl.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/issues/3738
- [x] Increase the version number in the header if appropriate. **(n/a)**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **(n/a)**
