### PR TITLE
superagent: cookie related headers has special types

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -100,6 +100,7 @@ declare namespace request {
         files: any;
         forbidden: boolean;
         get(header: string): string;
+        get(header: 'Set-Cookie'): string[];
         header: any;
         info: boolean;
         links: object;
@@ -148,6 +149,7 @@ declare namespace request {
         serialize(serializer: Serializer): this;
         set(field: object): this;
         set(field: string, val: string): this;
+        set(field: 'Cookie', val: string[]): this;
         timeout(ms: number | { deadline?: number, response?: number }): this;
         type(val: string): this;
         unset(field: string): this;

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -83,6 +83,12 @@ request
     .set({ 'API-Key': 'foobar', Accept: 'application/json' })
     .end(callback);
 
+// Setting cookie header
+request
+    .get('/search')
+    .set('Cookie', ['name1=value1; Domain=.test.com; Path=/', 'name2=value2; Domain=.test.com; Path=/'])
+    .end(callback);
+
 // GET requests
 request
     .get('/search')
@@ -196,6 +202,12 @@ request('/search')
         const contentLength = res.header['content-length'];
         const contentType: string = res.type;
         const charset: string = res.charset;
+    });
+
+// Getting response 'Set-Cookie'
+request('/search')
+    .end((res: request.Response) => {
+      const setCookie: string[] = res.get('Set-Cookie');
     });
 
 // Custom parsers


### PR DESCRIPTION
I found "cookie" related types in the typing file are not followed the real values, it should be `string[]`, not `string`. 

I made a demo to represent this: https://github.com/freewind-demos/typescript-superagent-cookies-demo, and also fixed the typings here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/freewind-demos/typescript-superagent-cookies-demo>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

