### PR TITLE
yargs: Fix typing of return value when passing an argument list

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -33,7 +33,7 @@ declare namespace yargs {
     // Arguments<T> to simplify the inferred type signature in client code.
     interface Argv<T = {}> {
         (): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        (args: ReadonlyArray<string>, cwd?: string): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        (args: ReadonlyArray<string>, cwd?: string): Argv<T>;
 
         // Aliases for previously declared options can inherit the types of those options.
         alias<K1 extends keyof T, K2 extends string>(shortName: K1, longName: K2 | ReadonlyArray<K2>): Argv<T & { [key in K2]: T[K1] }>;
@@ -167,8 +167,8 @@ declare namespace yargs {
         options<K extends string, O extends Options>(key: K, options: O): Argv<T & { [key in K]: InferredOptionType<O> }>;
         options<O extends { [key: string]: Options }>(options: O): Argv<Omit<T, keyof O> & InferredOptionTypes<O>>;
 
-        parse(): Arguments<T>;
-        parse(arg: string | ReadonlyArray<string>, context?: object, parseCallback?: ParseCallback<T>): Arguments<T>;
+        parse(): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context?: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
 
         pkgConf(key: string | ReadonlyArray<string>, cwd?: string): Argv<T>;
 

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -73,6 +73,7 @@ function default_singles() {
         ;
     console.log(argv.x + argv.y);
 }
+
 function default_hash() {
     const argv = yargs
         .default({ x: 10, y: 10 })
@@ -90,6 +91,7 @@ function boolean_single() {
     console.dir(argv.v);
     console.dir(argv._);
 }
+
 function boolean_double() {
     const argv = yargs
         .boolean(['x', 'y', 'z'])
@@ -120,11 +122,30 @@ function Argv$argv() {
     console.log("command: " + argv._[1]);
 }
 
-function Argv_parsing() {
+function Argv$parsing() {
     const argv1 = yargs.parse();
-    const argv2 = yargs(['-x', '1', '-y', '2']);
+    const argv2 = yargs(['-x', '1', '-y', '2']).argv;
     const argv3 = yargs.parse(['-x', '1', '-y', '2']);
-    console.log(argv1.x, argv2.x, argv3.x);
+    const argv4 = yargs();
+    console.log(argv1.x, argv2.x, argv3.x, argv4.x);
+
+    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    yargs.parse();
+
+    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    yargs([]).argv;
+
+    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    yargs.argv;
+
+    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    yargs();
+
+    // $ExpectType { [x: string]: unknown; update: boolean | undefined; extern: boolean | undefined; _: string[]; $0: string; }
+    yargs(['--update'])
+        .boolean('update')
+        .boolean('extern')
+        .argv;
 }
 
 function Argv$options() {


### PR DESCRIPTION
Fix for issue #31785.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31785
- [X] (n/a) Increase the version number in the header if appropriate.
- [X] (n/a) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
