### PR TITLE
[@types/google-apps-script] Removed unused List interface from Slides_v1

### DIFF
--- a/types/google-apps-script/apis/slides/v1.d.ts
+++ b/types/google-apps-script/apis/slides/v1.d.ts
@@ -1717,18 +1717,6 @@ declare namespace GoogleAppsScript {
       bullet: Bullet
     }
 
-    // A List describes the look and feel of bullets belonging to paragraphs
-    // associated with a list. A paragraph that is part of a list has an implicit
-    // reference to that list's ID.
-    interface List {
-      // The ID of the list.
-      list_id: string
-      // A map of nesting levels to the properties of bullets at the associated
-      // level. A list has at most nine levels of nesting, so the possible values
-      // for the keys of this map are 0 through 8, inclusive.
-      nesting_level: Map<number, NestingLevel>
-    }
-
     // Describes the bullet of a paragraph.
     interface Bullet {
       // The ID of the list this paragraph belongs to.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

The Map inside the interface requires that I put `"lib": ["ES2015"]` in my `tsconfig.json`. It's not exported and not used in the file so it seems like its removal won't cause any issues.
