### PR TITLE
Correct metadata types for react-filepond

### DIFF
--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 type FilePondOrigin = 'limbo' | 'local';
 
-export interface FilePondFileProps {
+export interface FileProps {
     src: string;
     name?: string;
     size?: number;
@@ -20,11 +20,15 @@ export interface FilePondFileProps {
     metadata?: {[key: string]: any};
 }
 
-export class FilePondFile extends React.Component<FilePondFileProps> { }
-export { FilePondFile as File };
+export class File extends React.Component<FileProps> { }
 
 export interface FilePondItem {
-    file: File;
+    // Note that this duplicates the JS File type declaration, but is necessary
+    // to avoid duplicating the name 'File' in this module
+    // see: https://developer.mozilla.org/en-US/docs/Web/API/File
+    // see: https://github.com/Microsoft/dtslint/issues/173
+    // see: https://stackoverflow.com/q/53876793/2517147
+    file: Blob & {readonly lastModified: number; readonly name: string};
     fileSize: number;
     fileType: string;
     filename: string;
@@ -115,7 +119,7 @@ interface FilePondHookProps {
 }
 
 interface FilePondBaseProps {
-    children?: React.ReactElement<FilePondFile> | Array<React.ReactElement<FilePondFile>>;
+    children?: React.ReactElement<File> | Array<React.ReactElement<File>>;
     id?: string;
     name?: string;
     className?: string;

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -232,4 +232,22 @@ export class FilePond extends React.Component<FilePondProps> {
     context: () => void;
 }
 
+/** Creates a new FilePond instance */
+export function create(element?: any, options?: FilePondProps): void;
+/** Destroys the FilePond instance attached to the supplied element */
+export function destroy(element: any): void;
+/** Returns the FilePond instance attached to the supplied element */
+export function find(element: any): FilePond;
+/**
+ * Parses a given section of the DOM tree for elements with class
+ * .filepond and turns them into FilePond elements.
+ */
+export function parse(context: any): void;
+/** Registers a FilePond plugin for later use */
 export function registerPlugin(...plugins: any[]): void;
+/** Sets page level default options for all FilePond instances */
+export function setOptions(options: FilePondProps): void;
+/** Returns the current default options */
+export function getOptions(): FilePondProps;
+/** Determines whether or not the browser supports FilePond */
+export function supported(): boolean;

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -97,33 +97,74 @@ interface FilePondServerConfigProps {
 }
 
 interface FilePondDragDropProps {
+    /** FilePond will catch all files dropped on the webpage */
     dropOnPage?: boolean;
+    /** Require drop on the FilePond element itself to catch the file. */
     dropOnElement?: boolean;
+    /**
+     * When enabled, files are validated before they are dropped.
+     * A file is not added when it’s invalid.
+     */
     dropValidation?: boolean;
+    /**
+     * Ignored file names when handling dropped directories.
+     * Dropping directories is not supported on all browsers.
+     */
     ignoredFiles?: string[];
 }
 
 interface FilePondLabelProps {
+    /**
+     * The decimal separator used to render numbers.
+     * By default this is determined automatically.
+     */
     labelDecimalSeparator?: string;
+    /**
+     * The thousands separator used to render numbers.
+     * By default this is determined automatically.
+     */
     labelThousandsSeparator?: string;
+    /**
+     * Default label shown to indicate this is a drop area.
+     * FilePond will automatically bind browse file events to
+     * the element with CSS class .filepond--label-action
+     */
     labelIdle?: string;
+    /** Label used while waiting for file size information */
     labelFileWaitingForSize?: string;
+    /** Label used when no file size information was received */
     labelFileSizeNotAvailable?: string;
+    /** Label used while loading a file */
     labelFileLoading?: string;
+    /** Label used when file load failed */
     labelFileLoadError?: string;
+    /** Label used when uploading a file */
     labelFileProcessing?: string;
+    /** Label used when file upload has completed */
     labelFileProcessingComplete?: string;
+    /** Label used when upload was cancelled */
     labelFileProcessingAborted?: string;
+    /** Label used when something went wrong during file upload */
     labelFileProcessingError?: string;
+    /** Label used to indicate to the user that an action can be cancelled. */
     labelTapToCancel?: string;
+    /** Label used to indicate to the user that an action can be retried. */
     labelTapToRetry?: string;
+    /** Label used to indicate to the user that an action can be undone. */
     labelTapToUndo?: string;
+    /** Label used for remove button */
     labelButtonRemoveItem?: string;
+    /** Label used for abort load button */
     labelButtonAbortItemLoad?: string;
+    /** Label used for retry load button */
     labelButtonRetryItemLoad?: string;
+    /** Label used for abort upload button */
     labelButtonAbortItemProcessing?: string;
+    /** Label used for undo upload button */
     labelButtonUndoItemProcessing?: string;
+    /** Label used for retry upload button */
     labelButtonRetryItemProcessing?: string;
+    /** Label used for upload button */
     labelButtonProcessItem?: string;
 }
 
@@ -196,15 +237,29 @@ interface FilePondBaseProps {
     id?: string;
     name?: string;
     className?: string;
+    /** Sets the required attribute to the output field */
     required?: boolean;
+    /** Sets the given value to the capture attribute */
     captureMethod?: any;
+    /** Enable or disable drag n’ drop */
     allowDrop?: boolean;
+    /** Enable or disable file browser */
     allowBrowse?: boolean;
+    /**
+     * Enable or disable pasting of files. Pasting files is not
+     * supported on all browsers.
+     */
     allowPaste?: boolean;
+    /** Enable or disable adding multiple files */
     allowMultiple?: boolean;
+    /** Allow drop to replace a file, only works when allowMultiple is false */
     allowReplace?: boolean;
+    /** Allows the user to undo file upload */
     allowRevert?: boolean;
+    /** The maximum number of files that the pond can handle */
     maxFiles?: number;
+    /** The maximum number of files that can be uploaded in parallel */
+    maxParallelUploads?: number;
     acceptedFileTypes?: string[];
     metadata?: {[key: string]: any};
 }

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -9,6 +9,12 @@
 
 import * as React from 'react';
 
+// This line shuts off automatic exporting for this module
+// I want to do this so that I can have internal types to this module that make
+// understanding the type definition more clear, while at the same time only
+// exporting the API that react-filepond exports.
+export {};
+
 type FilePondOrigin = 'limbo' | 'local';
 
 export interface FileProps {

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -40,8 +40,8 @@ export interface FilePondItem {
     archived: boolean;
     abortLoad: () => void;
     abortProcessing: () => void;
-    getMetadata: (key: any) => any;
-    setMetadata: (key: any, value: any, silent: boolean) => void;
+    getMetadata: (key?: any) => any;
+    setMetadata: (key: any, value: any, silent?: boolean) => void;
 }
 
 interface FilePondDragDropProps {

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -48,6 +48,40 @@ export interface FilePondItem {
     abortProcessing: () => void;
     getMetadata: (key?: any) => any;
     setMetadata: (key: any, value: any, silent?: boolean) => void;
+
+interface ServerUrl {
+    url: string;
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+    withCredentials?: boolean;
+    headers?: {[key: string]: string|boolean|number};
+    timeout?: number;
+
+    /**
+     * Called when server response is received, useful for getting
+     * the unique file id from the server response
+     */
+    onload?: () => any;
+    /**
+     * Called when server error is received, receives the response
+     * body, useful to select the relevant error data
+     */
+    onerror?: (responseBody: any) => any;
+    /**
+     * Called with the formdata object right before it is sent,
+     * return extended formdata object to make changes
+     */
+    ondata?: (data: any) => any;
+}
+
+interface FilePondServerConfigProps {
+    instantUpload?: boolean;
+    server?: string | {
+        process: string | ServerUrl;
+        revert: string | ServerUrl;
+        restore: string | ServerUrl;
+        load: string | ServerUrl;
+        fetch: string | ServerUrl;
+    };
 }
 
 interface FilePondDragDropProps {
@@ -55,11 +89,6 @@ interface FilePondDragDropProps {
     dropOnElement?: boolean;
     dropValidation?: boolean;
     ignoredFiles?: string[];
-}
-
-interface FilePondServerConfigProps {
-    server?: string;
-    instantUpload?: boolean;
 }
 
 interface FilePondLabelProps {

--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -17,6 +17,7 @@ export interface FilePondFileProps {
     size?: number;
     type?: string;
     origin?: FilePondOrigin;
+    metadata?: {[key: string]: any};
 }
 
 export class FilePondFile extends React.Component<FilePondFileProps> { }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - The location of the metadata parameter was extracted from [here](https://github.com/pqina/react-filepond/blob/master/lib/index.js)
  - The documentation for the various filepond pieces can be found [here](https://pqina.nl/filepond/docs/patterns/api/filepond-instance/)
  - The parameter list of the metadata methods were taken from [these docs](https://pqina.nl/filepond/docs/patterns/api/file/#methods)
- [x] Increase the version number in the header if appropriate.
  - Not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - Making minor tweaks