### PR TITLE
Add missing "ensure" to @types/xmlpoke's API interface

### DIFF
--- a/types/xmlpoke/index.d.ts
+++ b/types/xmlpoke/index.d.ts
@@ -25,6 +25,7 @@ declare module XmlPoke { // ghost module
 		withBasePath(xpath: string): API;
 		addNamespace(prefix: string, uri: string): API;
 		errorOnNoMatches(): API;
+        ensure(xpath: string): API;
 	}
 	interface CDataValue {
 		value: string;

--- a/types/xmlpoke/xmlpoke-tests.ts
+++ b/types/xmlpoke/xmlpoke-tests.ts
@@ -76,3 +76,7 @@ result = xmlpoke('<test><x><![CDATA[hello]]></x></test>', xml =>
             return 'y';
        }));
 assert.equal(result, '<test><x>y</x></test>');
+
+// ensure
+result = xmlpoke('</a>', xml => xml.ensure('a/b'));
+assert.equal(result, '<a><b/></a>');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mikeobrien/node-xmlpoke/blob/097693bfa42964af71c73a2bb79c019adee15d0a/src/document.js#L158-L161
- [x] ~Increase the version number in the header if appropriate.~ N/A
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`~ N/A