### PR TITLE
[randomcolor] support for setting hue from a hex color

### DIFF
--- a/types/randomcolor/index.d.ts
+++ b/types/randomcolor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for randomColor 0.5.0
+// Type definitions for randomColor 0.5.2
 // Project: https://github.com/davidmerfield/randomColor
 // Definitions by: Mathias Feitzinger <https://github.com/feitzi>, Brady Liles <https://github.com/BradyLiles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 declare function randomColor(options?: RandomColorOptions): string;
 
 interface RandomColorOptions {
-	hue?: number | "red" | "orange" | "yellow" | "green" | "blue" | "purple" | "pink" | "monochrome" | "random";
+	hue?: number | string;
 	luminosity?: "bright" | "light" | "dark" | "random";
 	count?: number;
 	seed?: number | string;

--- a/types/randomcolor/randomcolor-tests.ts
+++ b/types/randomcolor/randomcolor-tests.ts
@@ -36,3 +36,15 @@ randomColor({
     luminosity: 'light',
     format: 'hsla' // e.g. 'hsla(27, 88.99%, 81.83%, 0.6450211517512798)'
 });
+
+// Returns a dark RGB color with specified alpha
+randomColor({
+    luminosity: 'dark',
+    format: 'rgba',
+    alpha: 0.5 // e.g. 'rgba(9, 1, 107, 0.5)',
+});
+
+// Support for setting hue from a hex color
+randomColor({
+    hue: "#00FFFF"
+});


### PR DESCRIPTION
support for setting hue from a hex color (https://github.com/davidmerfield/randomColor/pull/90), however since typescript didn't support validate string pattern (https://github.com/Microsoft/TypeScript/issues/6579) yet, so need to drop those string unions

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
