### PR TITLE
[pubnub] Added "history" method with required interfaces

### DIFF
--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for pubnub 4.0
 // Project: https://github.com/pubnub/javascript
-// Definitions by: bitbankinc <https://github.com/bitbankinc>, rollymaduk <https://github.com/rollymaduk>, vitosamson <https://github.com/vitosamson>, FlorianDr <https://github.com/FlorianDr>
+// Definitions by:  bitbankinc <https://github.com/bitbankinc>,
+//                  rollymaduk <https://github.com/rollymaduk>,
+//                  vitosamson <https://github.com/vitosamson>,
+//                  FlorianDr <https://github.com/FlorianDr>,
+//                  danduh <https://github.com/danduh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // @see https://www.pubnub.com/docs/web-javascript/api-reference-configuration
 // TypeScript Version: 2.2
@@ -41,6 +45,11 @@ declare class Pubnub {
   fire(
     params: Pubnub.FireParameters
   ): Promise<Pubnub.PublishResponse>;
+
+  history(
+    params: Pubnub.HistoryParameters,
+    callback: (status: Pubnub.HistoryStatus, response: Pubnub.HistoryResponse) => void
+  ): void;
 
   subscribe(params: Pubnub.SubscribeParameters): void;
 
@@ -193,6 +202,34 @@ declare namespace Pubnub {
     timetoken: number;
   }
 
+  interface HistoryParameters {
+    channel: string;
+    count: number;
+    stringifiedTimeToken?: boolean;
+    includeTimetoken?: boolean;
+    reverse?: boolean;
+    start?: number; // timetoken
+    end?: number; // timetoken
+  }
+
+  interface HistoryMessage {
+    entry: any;
+    timetoken?: string | number;
+  }
+
+  interface HistoryResponse {
+    endTimeToken?: number;
+    startTimeToken?: number;
+    messages: HistoryMessage[];
+  }
+
+  interface HistoryStatus {
+    error: boolean;
+    errorData?: Error;
+    operation: string; // see Pubnub.Operations
+    statusCode?: number;
+  }
+
   interface PublishStatus {
     operation: string; // see Pubnub.Operations
     category: string; // see Pubnub.Categories;
@@ -225,7 +262,9 @@ declare namespace Pubnub {
   // addListener
   interface ListenerParameters {
     status?(statusEvent: StatusEvent): void;
+
     message?(messageEvent: MessageEvent): void;
+
     presence?(presenceEvent: PresenceEvent): void;
   }
 

--- a/types/pubnub/pubnub-tests.ts
+++ b/types/pubnub/pubnub-tests.ts
@@ -87,6 +87,11 @@ pubnub.setState({ channels: [] }).then(res => {
   console.log(res.state);
 });
 
+pubnub.history({channel: 'channel-1', count: 2}, (status, res) => {
+  console.log(status);
+  console.log(res);
+});
+
 const cryptoOptions = {
   encryptKey: true,
   keyEncoding: 'utf8',


### PR DESCRIPTION
New method `Pubnub.history()`.
Required interfaces: `HistoryParameters, HistoryMessage, HistoryResponse, HistoryStatus`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Pubnub History](https://www.pubnub.com/docs/web-javascript/storage-and-history)
- [  ] Increase the version number in the header if appropriate.

