### PR TITLE
[socketcluster-server] Fixes

### DIFF
--- a/types/socketcluster-server/index.d.ts
+++ b/types/socketcluster-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for socketcluster-server 13.1
+// Type definitions for socketcluster-server 14.2
 // Project: https://github.com/SocketCluster/socketcluster-server
 // Definitions by: Daniel Rose <https://github.com/DanielRose>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/socketcluster-server/scserver.d.ts
+++ b/types/socketcluster-server/scserver.d.ts
@@ -34,7 +34,7 @@ declare class SCServer extends EventEmitter {
 
     on(event: "connection", listener: SCServer.connectionListenerFunction): this;
     on(event: "ready", listener: () => void): this;
-    on(event: "error", listener: (error: Error) => void): this;
+    on(event: "warning" | "error", listener: (error: Error) => void): this;
     on(event: "disconnection" | "connectionAbort" | "closure", listener: SCServer.disconnectionListenerFunction): this;
     on(event: "subscription", listener: SCServer.subscriptionListenerFunction): this;
     on(event: "unsubscription", listener: SCServer.unsubscriptionListenerFunction): this;
@@ -323,7 +323,7 @@ declare namespace SCServer {
     type connectionListenerFunction = (scSocket: SCServerSocket, serverSocketStatus: SCServerSocketStatus) => void;
     type disconnectionListenerFunction = (scSocket: SCServerSocket, code: number, data: any) => void;
     type subscriptionListenerFunction = (scSocket: SCServerSocket, name: string, options: {channel: string}) => void;
-    type unsubscriptionListenerFunction = (scSocket: SCServerSocket, name: string, channel: string) => void;
+    type unsubscriptionListenerFunction = (scSocket: SCServerSocket, channel: string) => void;
     type handshakeListenerFunction = (scSocket: SCServerSocket) => void;
     type badSocketAuthTokenListenerFunction = (scSocket: SCServerSocket, status: badAuthStatus) => void;
 

--- a/types/socketcluster-server/scserver.d.ts
+++ b/types/socketcluster-server/scserver.d.ts
@@ -33,6 +33,13 @@ declare class SCServer extends EventEmitter {
     constructor(options?: SCServer.SCServerOptions);
 
     on(event: "connection", listener: SCServer.connectionListenerFunction): this;
+    on(event: "ready", listener: () => void): this;
+    on(event: "error", listener: (error: Error) => void): this;
+    on(event: "disconnection" | "connectionAbort" | "closure", listener: SCServer.disconnectionListenerFunction): this;
+    on(event: "subscription", listener: SCServer.subscriptionListenerFunction): this;
+    on(event: "unsubscription", listener: SCServer.unsubscriptionListenerFunction): this;
+    on(event: "handshake", listener: SCServer.handshakeListenerFunction): this;
+    on(event: "badSocketAuthToken", listener: SCServer.badSocketAuthTokenListenerFunction): this;
 
     addMiddleware(type: "handshakeWS", middlewareFn: (req: IncomingMessage, next: SCServer.nextMiddlewareFunction) => void): void;
     addMiddleware(type: "handshakeSC", middlewareFn: (req: SCServer.HandshakeSCRequest, next: SCServer.nextHandshakeSCMiddlewareFunction) => void): void;
@@ -305,10 +312,20 @@ declare namespace SCServer {
         data?: any;
     }
 
+    interface badAuthStatus {
+        authError: Error;
+        signedAuthToken: string;
+    }
+
     type nextMiddlewareFunction = (error?: true | string | Error) => void;
     type nextHandshakeSCMiddlewareFunction = (error?: true | string | Error | null, statusCode?: number) => void;
     type nextAuthenticateMiddlewareFunction = (error?: true | string | Error | null, isBadToken?: boolean) => void;
     type connectionListenerFunction = (scSocket: SCServerSocket, serverSocketStatus: SCServerSocketStatus) => void;
+    type disconnectionListenerFunction = (scSocket: SCServerSocket, code: number, data: any) => void;
+    type subscriptionListenerFunction = (scSocket: SCServerSocket, name: string, options: {channel: string}) => void;
+    type unsubscriptionListenerFunction = (scSocket: SCServerSocket, name: string, channel: string) => void;
+    type handshakeListenerFunction = (scSocket: SCServerSocket) => void;
+    type badSocketAuthTokenListenerFunction = (scSocket: SCServerSocket, status: badAuthStatus) => void;
 
     interface SCCodecEngine {
         decode: (input: any) => any;

--- a/types/socketcluster-server/scserver.d.ts
+++ b/types/socketcluster-server/scserver.d.ts
@@ -83,7 +83,7 @@ declare namespace SCServer {
         // This can be the name of an npm module or a path to a Node.js module
         // to use as the WebSocket server engine.
         // You can now set this to 'sc-uws' for a massive speedup of at least 2x!
-        wsEngine?: string;
+        wsEngine?: any;
 
         // An ID to associate with this specific instance of SC
         // this may be useful if you are running an SC app on multiple


### PR DESCRIPTION
## Changing an existing definition (Based on [Source](https://github.com/SocketCluster/socketcluster-server/blob/master/scserver.js))

Changes:

- fix(SCServer): add missing events
    - ready
    - error
    - disconnection
    - subscription
    - unsubscription
    - handshake
    - badSocketAuthToken
    - connectionAbort
    - closure
- fix(SCServer): any wsEngine to handle modules
    Example: `wsEngine: require('ws')`

Outstanding problems noticed:

- fix(SCServer): add auth events
    [Docs](https://socketcluster.io/#!/docs/api-scserver) mention "authentication", "deauthentication" and "authenticationStateChange" but I didn't found them in source to understand their types.