### PR TITLE
[iobroker] Fix return type of getForeignObjectsAsync

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1125,9 +1125,9 @@ declare global {
             getForeignObjects(pattern: string, type: ObjectType, enums: EnumList, options: unknown, callback: GetObjectsCallback): void;
             // tslint:enable:unified-signatures
             /** Get foreign objects by pattern, by specific type and resolve their enums. */
-            getForeignObjectsAsync(pattern: string, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectCallback>>;
-            getForeignObjectsAsync(pattern: string, type: ObjectType, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectCallback>>;
-            getForeignObjectsAsync(pattern: string, type: ObjectType, enums: EnumList, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectCallback>>;
+            getForeignObjectsAsync(pattern: string, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
+            getForeignObjectsAsync(pattern: string, type: ObjectType, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
+            getForeignObjectsAsync(pattern: string, type: ObjectType, enums: EnumList, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
             setForeignObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObject(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -170,6 +170,9 @@ adapter.getForeignObject("obj.id", (err, obj) => { });
 adapter.getObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
 adapter.getForeignObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
 
+adapter.getForeignObjects("*", (err, objs) => { objs["foo"]._id.toLowerCase(); })
+adapter.getForeignObjectsAsync("*").then(objs => objs["foo"]._id.toLowerCase());
+
 adapter.subscribeObjects("*");
 adapter.subscribeStates("*");
 adapter.subscribeForeignObjects("*");

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -170,7 +170,7 @@ adapter.getForeignObject("obj.id", (err, obj) => { });
 adapter.getObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
 adapter.getForeignObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
 
-adapter.getForeignObjects("*", (err, objs) => { objs["foo"]._id.toLowerCase(); })
+adapter.getForeignObjects("*", (err, objs) => objs["foo"]._id.toLowerCase());
 adapter.getForeignObjectsAsync("*").then(objs => objs["foo"]._id.toLowerCase());
 
 adapter.subscribeObjects("*");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **I forgot an `s` in the type definition of the method, which lead to the wrong return type**
- [ ] Increase the version number in the header if appropriate. **There is none**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **no substantial changes**

## This PR fixes the following bug:
`getForeignObjectsAsync` returned a `Promise<ioBroker.Object>` when it should be `Promise<Record<string, ioBroker.Object>>`