### PR TITLE
[onesignal-cordova-plugin] [cordova-plugin-x-socialsharing] Make Cord…

### DIFF
--- a/types/cordova-plugin-x-socialsharing/index.d.ts
+++ b/types/cordova-plugin-x-socialsharing/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for SocialSharing-PhoneGap-Plugin v5.1.8
+// Type definitions for SocialSharing-PhoneGap-Plugin v5.1.9
 // Project: https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin
 // Definitions by: Markus Wagner <https://github.com/Ritzlgrmft>, Larry Bahr <https://github.com/larrybahr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Window {
-    plugins: Plugins;
+    plugins: CordovaPlugins;
 }
 
-interface Plugins {
+interface CordovaPlugins {
 	socialsharing: SocialSharingPlugin.SocialSharing;
 }
 

--- a/types/onesignal-cordova-plugin/index.d.ts
+++ b/types/onesignal-cordova-plugin/index.d.ts
@@ -1,10 +1,14 @@
-// Type definitions for onesignal-cordova-plugin 2.2
+// Type definitions for onesignal-cordova-plugin 2.2.1
 // Project: https://github.com/onesignal/OneSignal-Cordova-SDK#readme
 // Definitions by: David Broder-Rodgers <https://github.com/broder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Window {
-    plugins: { OneSignal: OneSignalCordovaPlugin.OneSignalCordovaPlugin };
+    plugins: CordovaPlugins;
+}
+
+interface CordovaPlugins {
+    OneSignal: OneSignalCordovaPlugin.OneSignalCordovaPlugin;
 }
 
 declare namespace OneSignalCordovaPlugin {

--- a/types/onesignal-cordova-plugin/index.d.ts
+++ b/types/onesignal-cordova-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for onesignal-cordova-plugin 2.2.1
+// Type definitions for onesignal-cordova-plugin 2.2
 // Project: https://github.com/onesignal/OneSignal-Cordova-SDK#readme
 // Definitions by: David Broder-Rodgers <https://github.com/broder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
…ova plugins compatible with each other

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
I don't think there are any tests to add
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Added a description of the problem below
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The current definitions give the following error when using both definitions at once.
```
ERROR` in .../node_modules/@types/onesignal-cordova-plugin/index.d.ts(7,5):
TS2717: Subsequent property declarations must have the same type.  Property 'plugins' must be of type 'Plugins', but here has type '{ OneSignal: OneSignalCordovaPlugin; }'.
```


I've renamed Plugins to CordovaPlugins to be consistent with types/cordova.

