### PR TITLE
[expo] Add types for SecureStore keychain item accessibility constants

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -47,6 +47,7 @@ import {
     Region,
     registerRootComponent,
     ScreenOrientation,
+    SecureStore,
     Svg,
     Updates
 } from 'expo';
@@ -483,6 +484,19 @@ async () => {
     isString(path2);
     isString(queryParams2['y'] || '');
 };
+
+// #region securestore
+async () => {
+    await SecureStore.setItemAsync('some-key', 'some-val', {
+        keychainAccessible: SecureStore.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY,
+    });
+    const result = await SecureStore.getItemAsync('some-key');
+    if (result != null) {
+        result.slice() === 'some-val';
+    }
+    await SecureStore.deleteItemAsync('some-key');
+};
+// #endregion
 
 () => (
     <Svg width={100} height={50}>

--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -488,14 +488,25 @@ async () => {
 // #region securestore
 async () => {
     await SecureStore.setItemAsync('some-key', 'some-val', {
+        keychainService: "some-service",
         keychainAccessible: SecureStore.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY,
     });
-    const result = await SecureStore.getItemAsync('some-key');
+    const result = await SecureStore.getItemAsync('some-key', { keychainService: "some-service" });
     if (result != null) {
         result.slice() === 'some-val';
     }
-    await SecureStore.deleteItemAsync('some-key');
+    await SecureStore.deleteItemAsync('some-key', { keychainService: "some-service" });
 };
+
+const allSecureStoreKeychainAccessibleValues: number[] = [
+    SecureStore.WHEN_UNLOCKED,
+    SecureStore.AFTER_FIRST_UNLOCK,
+    SecureStore.ALWAYS,
+    SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    SecureStore.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY,
+    SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+    SecureStore.ALWAYS_THIS_DEVICE_ONLY,
+];
 // #endregion
 
 () => (

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -14,6 +14,7 @@
 //                 Levan Basharuli <https://github.com/levansuper>
 //                 Pavel Ihm <https://github.com/ihmpavel>
 //                 Bartosz Dotryw <https://github.com/burtek>
+//                 Jason Killian <https://github.com/jkillian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -2307,6 +2308,14 @@ export namespace SecureStore {
     function setItemAsync(key: string, value: string, options?: SecureStoreOptions): Promise<void>;
     function getItemAsync(key: string, options?: SecureStoreOptions): Promise<string | null>;
     function deleteItemAsync(key: string, options?: SecureStoreOptions): Promise<void>;
+
+    const WHEN_UNLOCKED: number;
+    const AFTER_FIRST_UNLOCK: number;
+    const ALWAYS: number;
+    const WHEN_UNLOCKED_THIS_DEVICE_ONLY: number;
+    const WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: number;
+    const AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: number;
+    const ALWAYS_THIS_DEVICE_ONLY: number;
 }
 
 /**

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2302,10 +2302,13 @@ export namespace ScreenOrientation {
 export namespace SecureStore {
     interface SecureStoreOptions {
         keychainService?: string;
+    }
+
+    interface SecureStoreSetOptions extends SecureStoreOptions {
         keychainAccessible?: number;
     }
 
-    function setItemAsync(key: string, value: string, options?: SecureStoreOptions): Promise<void>;
+    function setItemAsync(key: string, value: string, options?: SecureStoreSetOptions): Promise<void>;
     function getItemAsync(key: string, options?: SecureStoreOptions): Promise<string | null>;
     function deleteItemAsync(key: string, options?: SecureStoreOptions): Promise<void>;
 


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/securestore#exposecurestoresetitemasynckey-value-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

