### PR TITLE
Knockout: Fix issue with computeds and KnockoutObservable<infer T> (reopened)

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -140,7 +140,7 @@ interface KnockoutSubscribableStatic {
 
 interface KnockoutSubscription {
     /**
-     * Terminates a subscription 
+     * Terminates a subscription
      */
     dispose(): void;
 }
@@ -213,9 +213,6 @@ interface KnockoutReadonlyComputed<T> extends KnockoutReadonlyObservable<T> {
 interface KnockoutComputed<T> extends KnockoutReadonlyComputed<T>, KnockoutObservable<T>, KnockoutComputedFunctions<T> {
     fn: KnockoutComputedFunctions<any>;
 
-    // It's possible for 'a' to be undefined, since the equalityComparer is run on the initial
-    // computation with undefined as the first argument. This is user-relevant for deferred computeds.
-    equalityComparer(a: T | undefined, b: T): boolean;
     /**
      * Manually disposes the computed observable, clearing all subscriptions to dependencies.
      * This function is useful if you want to stop a computed observable from being updated or want to clean up memory for a


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


With TS 3.2, I'm having issues using infer to get the contents of a KnockoutComputed, a KnockoutComputed<T> infers as if it were a KnockoutObservable<T | undefined>, apparently due to the conflict between the definition of equalityComparer - the first argument to the computed version of equalityComparer can be undefined, but it can't be for an observable.

I think in this case the cure is worse than the disease: while the typings for equalityComparer which includes undefined is likely more accurate than the version without, this fix seems to be more trouble than its worth, and it's probably a bug that should be fixed in Knockout, anyway.

---

This is a reopen of #31572, which closed due to inactivity over the holidays.  The original version added a test to verify the behavior, but since the bug requires TS2.8 syntax, I don't think I can add a test that doesn't break with older versions: (unless there's a way to add test code that only runs for specific versions of Typescript)