### PR TITLE
[@pollyjs/adapter-node-http] Add types for initial 1.4 release

### DIFF
--- a/types/pollyjs__adapter-node-http/index.d.ts
+++ b/types/pollyjs__adapter-node-http/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @pollyjs/adapter-node-http 1.4
+// Project: https://github.com/netflix/pollyjs/tree/master/packages/@pollyjs/adapter-node-http
+// Definitions by: jlmessenger <https://github.com/jlmessenger>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import Adapter from '@pollyjs/adapter';
+
+export default class HttpAdapter extends Adapter {}

--- a/types/pollyjs__adapter-node-http/pollyjs__adapter-node-http-tests.ts
+++ b/types/pollyjs__adapter-node-http/pollyjs__adapter-node-http-tests.ts
@@ -1,0 +1,8 @@
+import HttpAdapter from '@pollyjs/adapter-node-http';
+import { Polly } from '@pollyjs/core';
+
+Polly.register(HttpAdapter);
+
+new Polly('<recording>', {
+	adapters: ['node-http', HttpAdapter]
+});

--- a/types/pollyjs__adapter-node-http/tsconfig.json
+++ b/types/pollyjs__adapter-node-http/tsconfig.json
@@ -1,0 +1,40 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true,
+		"paths": {
+			"@pollyjs/core": [
+				"pollyjs__core"
+			],
+			"@pollyjs/adapter": [
+				"pollyjs__adapter"
+			],
+			"@pollyjs/adapter-node-http": [
+				"pollyjs__adapter-node-http"
+			],
+			"@pollyjs/persister": [
+				"pollyjs__persister"
+			],
+			"@pollyjs/utils": [
+				"pollyjs__utils"
+			]
+		}
+	},
+	"files": [
+		"index.d.ts",
+		"pollyjs__adapter-node-http-tests.ts"
+	]
+}

--- a/types/pollyjs__adapter-node-http/tslint.json
+++ b/types/pollyjs__adapter-node-http/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Based on solution of sister project [@types/pollyjs__adapter-fetch](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/pollyjs__adapter-fetch)