### PR TITLE
dateformat - Add back static interface type.

### DIFF
--- a/types/dateformat/index.d.ts
+++ b/types/dateformat/index.d.ts
@@ -83,4 +83,21 @@ declare namespace dateFormat {
         monthNames: string[];
         timeNames: string[];
     }
+
+    /**
+     * dateFormat()
+     *
+     * Accepts a date, a mask, or a date and a mask.
+     * Returns a formatted version of the given date.
+     * The date defaults to the current date/time.
+     * The mask defaults to dateFormat.masks.default.
+     *
+     * https://github.com/felixge/node-dateformat/blob/master/lib/dateformat.js#L18
+     */
+    interface DateFormatStatic {
+        (date?: Date | string | number, mask?: string, utc?: boolean, gmt?: boolean): string;
+        (mask?: string, utc?: boolean, gmt?: boolean): string;
+        masks: DateFormatMasks;
+        i18n: DateFormatI18n;
+    }
 }


### PR DESCRIPTION
This type is used in our codebase as follows: `private _dateTime: DateFormatStatic = dateTime as DateFormatStatic;`. The function itself should also probably be exported under the namespace or it won't be accessible. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
