### PR TITLE
react-router fix

### DIFF
--- a/types/react-router/v3/index.d.ts
+++ b/types/react-router/v3/index.d.ts
@@ -53,7 +53,7 @@ export { default as Route } from "react-router/lib/Route";
 export { createRoutes } from "react-router/lib/RouteUtils";
 export { default as RouterContext } from "react-router/lib/RouterContext";
 export { routerShape, locationShape } from "react-router/lib/PropTypes";
-export { default as match } from "react-router/lib/match";
+export { default as match, MatchHistoryArgs, MatchLocationArgs, MatchCallback } from "react-router/lib/match";
 export { default as useRouterHistory } from "react-router/lib/useRouterHistory";
 export { formatPattern } from "react-router/lib/PatternUtils";
 export { default as applyRouterMiddleware } from "react-router/lib/applyRouterMiddleware";

--- a/types/react-router/v3/lib/match.d.ts
+++ b/types/react-router/v3/lib/match.d.ts
@@ -1,4 +1,4 @@
-import { Basename, History, LocationDescriptor } from "history";
+import { Basename, History, Location, LocationDescriptor } from "history";
 import { ParseQueryString, RouteConfig, StringifyQuery } from "react-router";
 
 export interface MatchArgs {


### PR DESCRIPTION
- [`redirectLocation`](https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#match-routes-location-history-options--cb) from `MatchCallback` is not a DOM Location. In fact, one of `match`'s use cases is server-side rendering, where DOM Location type doesn't exist.
- Export types of the arguments of `match`. Users should not import them from `react-router/lib/match`