### PR TITLE
React Native - added missing property for SectionList

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3994,6 +3994,9 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
      */
     keyExtractor?: (item: ItemT, index: number) => string;
 
+    /**
+     * Uses legacy MetroListView instead of default VirtualizedSectionList
+     */
     legacyImplementation?: boolean;
 
     /**
@@ -4269,7 +4272,10 @@ export interface SectionListProps<ItemT> extends VirtualizedListWithoutRenderIte
      * Only enabled by default on iOS because that is the platform standard there.
      */
     stickySectionHeadersEnabled?: boolean;
-    
+
+    /**
+     * Uses legacy MetroListView instead of default VirtualizedSectionList
+     */
     legacyImplementation?: boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4269,6 +4269,8 @@ export interface SectionListProps<ItemT> extends VirtualizedListWithoutRenderIte
      * Only enabled by default on iOS because that is the platform standard there.
      */
     stickySectionHeadersEnabled?: boolean;
+    
+    legacyImplementation?: boolean;
 }
 
 export interface SectionListScrollParams {


### PR DESCRIPTION
Added missing `legacyImplementation` property for `SectionList` ([docs](https://facebook.github.io/react-native/docs/sectionlist#legacyimplementation))
