### PR TITLE
[react-bootstrap-table] Correct TableHeaderColumnProps.autovalue property

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -1291,7 +1291,7 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 	 * generated automatically after a row insertion. If a function given, you can customize the value by yourself and
 	 * remember to return the value for the cell from the function.
 	 */
-	autovalue?: boolean | (() => any);
+	autoValue?: boolean | (() => any);
 	/**
 	 * False to disable search functionality on column, default is true.
 	 */

--- a/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -1222,7 +1222,7 @@ class HideOnInsertTable extends React.Component {
     };
     return (
       <BootstrapTable data={jobs} insertRow={true} options={options}>
-        <TableHeaderColumn dataField='id' isKey={true} autovalue>Job ID</TableHeaderColumn>
+        <TableHeaderColumn dataField='id' isKey={true} autoValue>Job ID</TableHeaderColumn>
         <TableHeaderColumn dataField='name' hiddenOnInsert>Job Name</TableHeaderColumn>
         <TableHeaderColumn dataField='type' editable={{ type: 'select', options: { values: jobTypes }, readOnly: true }}>Job Type</TableHeaderColumn>
         <TableHeaderColumn dataField='active' editable={{ type: 'checkbox', options: { values: 'Y:N' } }}>Active</TableHeaderColumn>


### PR DESCRIPTION
[react-bootstrap-table] Correct TableHeaderColumnProps.autovalue property

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://allenfang.github.io/react-bootstrap-table/docs.html#autoValue>>

This PR fixes an incorrect property name.  The property name should be camelCased.


