### PR TITLE
[chroma-js] add an `alpha` channel field to `.hsl()`

### DIFF
--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -11,7 +11,7 @@ declare namespace chroma {
     interface ColorSpaces {
         rgb: [number, number, number];
         rgba: [number, number, number, number];
-        hsl: [number, number, number];
+        hsl: [number, number, number, number?];
         hsv: [number, number, number];
         hsi: [number, number, number];
         lab: [number, number, number];


### PR DESCRIPTION
`color.hsl()` actually returns a HSLa array when there is alpha channel information available:

https://github.com/gka/chroma.js/blob/master/src/io/hsl/rgb2hsl.js#L38-L39

This is noted in the docs in this same file at line 335–336: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ba83f54a74011bd5395459ac66b6e45b0abb7433/types/chroma-js/index.d.ts#L335-L336

---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (linked above)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.