### PR TITLE
Change middleware type

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -55,11 +55,11 @@ declare namespace Router {
     }
 
     export interface IMiddleware {
-        (ctx: Koa.ParameterizedContext<{}, IRouterContext>, next: () => Promise<any>): any;
+        (ctx: Koa.ParameterizedContext<any, IRouterContext>, next: () => Promise<any>): any;
     }
 
     export interface IParamMiddleware {
-        (param: string, ctx: Koa.ParameterizedContext<{}, IRouterContext>, next: () => Promise<any>): any;
+        (param: string, ctx: Koa.ParameterizedContext<any, IRouterContext>, next: () => Promise<any>): any;
     }
 
     export interface IRouterAllowedMethodsOptions {


### PR DESCRIPTION
The parameterized context state should not be `{}` but `any`, so a custom state can be used with the given middleware. 

A better solution would be to add a template type to `Router` for the whole context, like Koa did with `Application`. This should be sufficient for now, though.