### PR TITLE
[react-loadable] Ability to import Bundle, Manifest and ReactLoadablePluginOptions

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-loadable 5.4
+// Type definitions for react-loadable 5.5
 // Project: https://github.com/thejameskyle/react-loadable#readme
 // Definitions by: Jessica Franco <https://github.com/Kovensky>
 //                 Oden S. <https://github.com/odensc>

--- a/types/react-loadable/test/webpack.ts
+++ b/types/react-loadable/test/webpack.ts
@@ -13,7 +13,7 @@ const config: webpack.Configuration = {
 const manifest = {
   react: [
     {
-      id: 0,
+      id: './node_modules/react/index.js',
       name: './node_modules/react/index.js',
       file: 'main.js',
       publicPath: 'http://127.0.0.1/main.js'

--- a/types/react-loadable/webpack.d.ts
+++ b/types/react-loadable/webpack.d.ts
@@ -2,7 +2,7 @@ import webpack = require('webpack');
 
 export interface Bundle {
     id: string;
-    name: string;
+    name: string | null;
     file: string;
     publicPath: string;
 }

--- a/types/react-loadable/webpack.d.ts
+++ b/types/react-loadable/webpack.d.ts
@@ -1,31 +1,22 @@
-import webpack = require("webpack");
+import webpack = require('webpack');
 
-declare namespace LoadableExport {
-  interface Options {
-    filename: string;
-  }
-
-  class ReactLoadablePlugin extends webpack.Plugin {
-    constructor(opts?: Options);
-  }
-
-  interface Bundle {
+export interface Bundle {
     id: number;
     name: string;
     file: string;
     publicPath: string;
-  }
-
-  interface Manifest {
-    [moduleId: string]: Bundle[];
-  }
-
-  function getBundles(manifest: Manifest, moduleIds: string[]): Bundle[];
 }
 
-declare const exports: {
-  getBundles: typeof LoadableExport.getBundles;
-  ReactLoadablePlugin: typeof LoadableExport.ReactLoadablePlugin;
-};
+export interface Manifest {
+    [moduleId: string]: Bundle[];
+}
 
-export = exports;
+export interface ReactLoadablePluginOptions {
+    filename: string;
+}
+
+export class ReactLoadablePlugin extends webpack.Plugin {
+    constructor(opts?: ReactLoadablePluginOptions);
+}
+
+export function getBundles(manifest: Manifest, moduleIds: string[]): Bundle[];

--- a/types/react-loadable/webpack.d.ts
+++ b/types/react-loadable/webpack.d.ts
@@ -1,7 +1,7 @@
 import webpack = require('webpack');
 
 export interface Bundle {
-    id: number;
+    id: string;
     name: string;
     file: string;
     publicPath: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

1. Now it is possible to do this
```ts
import { Bundle, getBundles } from 'react-loadable/webpack';
import stats from './react-loadable.json';

const bundles: Array<Bundle> = getBundles(stats, modules);
```
or this
```ts
import { Bundle, Manifest getBundles } from 'react-loadable/webpack';

const { default: stats }: { default: Manifest } = await import('./react-loadable.json');
const bundles: Array<Bundle> = getBundles(stats, modules);
```
2. Changed `id` type in `Bundle` interface. See https://github.com/jamiebuilds/react-loadable/blob/master/src/webpack.js#L13 and https://webpack.js.org/api/module-variables/#module-id-commonjs-. `require.resolve` returns `string` (https://nodejs.org/api/modules.html#modules_require_resolve_request_options).
3. Changed `name` type in `Bundle` interface. See https://github.com/jamiebuilds/react-loadable/blob/master/src/webpack.js#L14.