### PR TITLE
[koa-router] fix IRouterContext

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -43,7 +43,7 @@ declare namespace Router {
         strict?: boolean;
     }
 
-    export interface IRouterContext {
+    export interface IRouterContext extends Koa.Context {
         /**
          * url params
          */

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -49,6 +49,10 @@ const match = router.match('/users/:id', 'GET');
 let layer: Router.Layer
 let layerOptions: Router.ILayerOptions
 
+const mw: Router.IMiddleware = (ctx: Router.IRouterContext, next: () => Promise<any>) => {
+  ctx.body = "Ok";
+};
+
 app.use(router.routes());
 app.use(router.allowedMethods());
 


### PR DESCRIPTION
Quick fix related to PR #31838 @dolezel 
IRouterContext should extend Koa.Context.
It would be better if it could be parametrized like Koa, but I don't know how to do it. 