### PR TITLE
[@types/snapsvg] Exposed interface for Snap.set()

### DIFF
--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -35,7 +35,7 @@ declare namespace Snap {
     export function plugin(f:Function):void;
     export function select(query:string):Snap.Element;
     export function selectAll(query:string):any;
-    export function set(...args:Snap.Element[]): Snap.Set;
+    export function set(...els:Snap.Element[]):Snap.Set;
     export function snapTo(values:Array<number>|number,value:number,tolerance?:number):number;
 
     export function animate(from:number|number[],to:number|number[],updater:(n:number)=>void,duration:number,easing?:(num:number)=>number,callback?:()=>void):mina.MinaAnimation;
@@ -306,19 +306,21 @@ declare namespace Snap {
     export interface Set {
         animate(attrs:{[attr:string]:string|number|boolean|any},duration:number,easing?:(num:number)=>number,callback?:()=>void):Snap.Set;
         animate(...params:Array<{attrs:any,duration:number,easing:(num:number)=>number,callback?:()=>void}>):Snap.Set;
-        attr(params: {[attr:string]:string|number|boolean|BBox|any}): Snap.Set;
-        attr(param: "viewBox"): BBox;
-        attr(param: string): string;
-        bind(attr: string, callback: Function): Snap.Set;
+        attr(params:{[attr:string]:string|number|boolean|BBox|any}):Snap.Set;
+        attr(param:"viewBox"):Snap.Set;
+        attr(param:string):Snap.Set;
+        bind(attr:string,callback:Function):Snap.Set;
         bind(attr:string,element:Snap.Element):Snap.Set;
         bind(attr:string,element:Snap.Element,eattr:string):Snap.Set;
-        clear():Snap.Set;
-        exclude(element:Snap.Element):boolean;
+        clear():void;
+        exclude(el:Snap.Element):boolean;
         forEach(callback:(el:Snap.Element,index?:number)=>void|boolean,thisArg?:Object):Snap.Set;
+        getBBox():BBox;
+        insertAfter():Snap.Set;
         pop():Snap.Element;
         push(el:Snap.Element):Snap.Set;
         push(...els:Snap.Element[]):Snap.Set;
-        remove(): Snap.Set;
+        remove():Snap.Set;
         splice(index:number,count:number,...insertion:Snap.Element[]):Snap.Set;
     }
 

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -313,10 +313,10 @@ declare namespace Snap {
         bind(attr:string,element:Snap.Element,eattr:string):Snap.Set;
         clear():Snap.Set;
         exclude(element:Snap.Element):boolean;
-        forEach(callback:Function,thisArg?:Object):Snap.Set;
+        forEach(callback:(el:Snap.Element,index?:number)=>void|boolean),thisArg?:Object):Snap.Set;
         pop():Snap.Element;
         push(el:Snap.Element):Snap.Set;
-        push(...els:Snap.element[]):Snap.Set;
+        push(...els:Snap.Element[]):Snap.Set;
         remove(): Snap.Set;
         splice(index:number,count:number,...insertion:Snap.Element[]):Snap.Set;
     }

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -5,6 +5,7 @@
 //                 Andrey Kurdyumov <https://github.com/kant2002>,
 //                 Terry Mun <https://github.com/terrymun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 /// <reference types="mina" />
 
 export = Snap;

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -313,7 +313,7 @@ declare namespace Snap {
         bind(attr:string,element:Snap.Element,eattr:string):Snap.Set;
         clear():Snap.Set;
         exclude(element:Snap.Element):boolean;
-        forEach(callback:(el:Snap.Element,index?:number)=>void|boolean),thisArg?:Object):Snap.Set;
+        forEach(callback:(el:Snap.Element,index?:number)=>void|boolean,thisArg?:Object):Snap.Set;
         pop():Snap.Element;
         push(el:Snap.Element):Snap.Set;
         push(...els:Snap.Element[]):Snap.Set;

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for Snap-SVG 0.4.1
 // Project: https://github.com/adobe-webplatform/Snap.svg
-// Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>, Andrey Kurdyumov <https://github.com/kant2002>
+// Definitions by: Lars Klein <https://github.com/lhk>,
+//                 Mattanja Kern <https://github.com/mattanja>,
+//                 Andrey Kurdyumov <https://github.com/kant2002>,
+//                 Terry Mun <https://github.com/terrymun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="mina" />
 
@@ -31,6 +34,7 @@ declare namespace Snap {
     export function plugin(f:Function):void;
     export function select(query:string):Snap.Element;
     export function selectAll(query:string):any;
+    export function set(...args:Snap.Element[]): Snap.Set;
     export function snapTo(values:Array<number>|number,value:number,tolerance?:number):number;
 
     export function animate(from:number|number[],to:number|number[],updater:(n:number)=>void,duration:number,easing?:(num:number)=>number,callback?:()=>void):mina.MinaAnimation;

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -5,7 +5,7 @@
 //                 Andrey Kurdyumov <https://github.com/kant2002>,
 //                 Terry Mun <https://github.com/terrymun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.0
 /// <reference types="mina" />
 
 export = Snap;
@@ -305,7 +305,7 @@ declare namespace Snap {
 
     export interface Set {
         animate(attrs:{[attr:string]:string|number|boolean|any},duration:number,easing?:(num:number)=>number,callback?:()=>void):Snap.Set;
-        animate(...params:Array<{attrs:any,duration:number,easing:(num:number)=>number,callback?:()=>void}>):Snap.Set;
+        animate(...attrs:[{[attr:string]:string|number|boolean|any},number?,((num:number)=>number)?,(()=>void)?][]):Snap.Element;
         attr(params:{[attr:string]:string|number|boolean|BBox|any}):Snap.Set;
         attr(param:"viewBox"):Snap.Set;
         attr(param:string):Snap.Set;

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -303,9 +303,9 @@ declare namespace Snap {
     }
 
     export interface Set {
-        animate(attrs:{[attr:string]:string|number|boolean|any},duration:number,easing?:(num:number)=>number,callback?:()=>void):Snap.Element;
-        animate(...params:Array<{attrs:any,duration:number,easing:(num:number)=>number,callback?:()=>void}>):Snap.Element;
-        attr(params: {[attr:string]:string|number|boolean|BBox|any}): Snap.Element;
+        animate(attrs:{[attr:string]:string|number|boolean|any},duration:number,easing?:(num:number)=>number,callback?:()=>void):Snap.Set;
+        animate(...params:Array<{attrs:any,duration:number,easing:(num:number)=>number,callback?:()=>void}>):Snap.Set;
+        attr(params: {[attr:string]:string|number|boolean|BBox|any}): Snap.Set;
         attr(param: "viewBox"): BBox;
         attr(param: string): string;
         bind(attr: string, callback: Function): Snap.Set;
@@ -315,10 +315,10 @@ declare namespace Snap {
         exclude(element:Snap.Element):boolean;
         forEach(callback:Function,thisArg?:Object):Snap.Set;
         pop():Snap.Element;
-        push(el:Snap.Element):Snap.Element;
-        push(els:Snap.Element[]):Snap.Element;
+        push(el:Snap.Element):Snap.Set;
+        push(...els:Snap.element[]):Snap.Set;
         remove(): Snap.Set;
-        splice(index:number,count:number,insertion?:Object[]):Snap.Element[];
+        splice(index:number,count:number,...insertion:Snap.Element[]):Snap.Set;
     }
 
     interface Filter {

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Snap-SVG 0.4.1
+// Type definitions for Snap-SVG 0.5.1
 // Project: https://github.com/adobe-webplatform/Snap.svg
 // Definitions by: Lars Klein <https://github.com/lhk>,
 //                 Mattanja Kern <https://github.com/mattanja>,

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -34,7 +34,7 @@
     function forEachTest() {
         const colors = ['red', 'green', 'blue'];
         return new Promise(resolve => {
-        rectSet.forEach((element, idx) => element.attr({ fill: colors[idx] || '#aaa' }));
+        rectSet.forEach((element,idx) => element.attr({ fill: colors[idx] || '#aaa' }));
         resolve();
       });
     }

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -1,94 +1,108 @@
 (() => {
-    // Tests by Terry Mun
-    // Checks that Snap.set() is properly typed
+  // Tests by Terry Mun
+  // Checks that Snap.set() is properly typed
 
-    const s = Snap(200, 500);
-    s.attr({
-        viewBox: '0 0 200 500'
+  const s = Snap(200, 500);
+  s.attr({
+    viewBox: '0 0 200 500'
+  });
+
+  // Create multiple elements to be added to set
+  const rect1 = s.rect(0, 0, 50, 50);
+  const rect2 = s.rect(0, 100, 50, 50);
+  const rect3 = s.rect(0, 200, 50, 50);
+  const rect4 = s.rect(0, 300, 50, 50);
+  let rect5: Snap.Element;
+
+  // Create new set
+  const rectSet = Snap.set(rect1, rect2);
+
+  // Add missing rectangles to set
+  rectSet.push(rect3, rect4);
+
+  // Set all attributes
+  rectSet.attr({
+    fill: 'steelblue'
+  });
+
+  // Animate all elements in set
+  function animateTest() {
+    return new Promise(resolve => {
+      rectSet.animate({
+        x: 50
+      }, 500, mina.bounce, resolve);
+    });
+  }
+
+  // Animate elements individually
+  function forEachTest() {
+    const colors = ['red', 'green', 'blue'];
+    return new Promise(resolve => {
+      rectSet.forEach((element, idx) => { 
+        element.attr({
+          fill: colors[idx] || '#aaa'
+        });
+      });
+      resolve();
+    });
+  }
+
+  // Exclude rect4 from set
+  function excludeTest() {
+    return new Promise(resolve => {
+      rectSet.exclude(rect4);
+      rectSet.animate({
+        x: 100
+      }, 500, mina.bounce, resolve);
+    });
+  }
+
+  // Remove rect2 from set (it has index of 1)
+  // Add new rect5 to set
+  async function spliceTest() {
+    rectSet.splice(1, 1);
+    rectSet.attr({
+      fill: '#000'
     });
 
-    // Create multiple elements to be added to set
-    const rect1 = s.rect(0,0,50,50);
-    const rect2 = s.rect(0,100,50,50);
-    const rect3 = s.rect(0,200,50,50);
-    const rect4 = s.rect(0,300,50,50);
-    let rect5: Snap.Element;
+    rect5 = s.rect(100, 400, 50, 50);
+    rectSet.splice(1, 0, rect5);
+    return;
+  }
 
-    // Create new set
-    const rectSet = Snap.set(rect1, rect2);
+  // Clear set. Rectangles should not go back to x=0
+  function clearTest() {
+    return new Promise(resolve => {
+      rectSet.clear();
 
-    // Add missing rectangles to set
-    rectSet.push(rect3, rect4);
+      // SHOULD NOT WORK
+      rectSet.animate({
+        x: 0
+      }, 500, mina.bounce, resolve);
 
-    // Set all attributes
-    rectSet.attr({ fill: 'steelblue' });
+      // Re-add rects to set
+      rectSet.push(rect1, rect2, rect3, rect4, rect5);
+      resolve();
+    });
+  }
 
-    // Animate all elements in set
-    function animateTest() {
-        return new Promise(resolve => {
-        rectSet.animate({ x: 50 }, 500, mina.bounce, resolve);
-      });
-    }
+  // Remove all elements from DOM that are present in set
+  async function removeTest() {
+    rectSet.remove();
+    return;
+  }
 
-    // Animate elements individually
-    function forEachTest() {
-        const colors = ['red', 'green', 'blue'];
-        return new Promise(resolve => {
-        rectSet.forEach((element,idx) => element.attr({ fill: colors[idx] || '#aaa' }));
-        resolve();
-      });
-    }
+  // Start test
+  async function startTest() {
+    await animateTest();
+    await forEachTest();
+    await excludeTest();
+    await spliceTest();
+    await clearTest();
+    await removeTest();
 
-    // Exclude rect4 from set
-    function excludeTest() {
-        return new Promise(resolve => {
-        rectSet.exclude(rect4);
-        rectSet.animate({ x: 100 }, 500, mina.bounce, resolve);
-      });
-    }
+    return;
+  }
 
-    // Remove rect2 from set (it has index of 1)
-    // Add new rect5 to set
-    async function spliceTest() {
-        rectSet.splice(1, 1);
-      rectSet.attr({ fill: '#000' });
-      
-      rect5 = s.rect(100, 400, 50, 50);
-      rectSet.splice(1, 0, rect5);
-        return;
-    }
-
-    // Clear set. Rectangles should not go back to x=0
-    function clearTest() {
-        return new Promise(resolve => {
-        rectSet.clear();
-        
-        // SHOULD NOT WORK
-        rectSet.animate({ x: 0 }, 500, mina.bounce, resolve);
-        
-        // Re-add rects to set
-        rectSet.push(rect1, rect2, rect3, rect4, rect5);
-        resolve();
-      });
-    }
-
-    // Remove all elements from DOM that are present in set
-    async function removeTest() {
-        rectSet.remove();
-      return;
-    }
-
-    // Start test
-    async function startTest() {
-        await animateTest();
-      await forEachTest();
-      await excludeTest();
-      await spliceTest();
-      await clearTest();
-      await removeTest();
-      
-      return;
-    }
-
-    startTest();
+  startTest();
 })();

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -1,92 +1,94 @@
-// Tests by Terry Mun
-// Checks that Snap.set() is properly typed
+(() => {
+    // Tests by Terry Mun
+    // Checks that Snap.set() is properly typed
 
-const s = Snap(200, 500);
-s.attr({
-    viewBox: '0 0 200 500'
-});
+    const s = Snap(200, 500);
+    s.attr({
+        viewBox: '0 0 200 500'
+    });
 
-// Create multiple elements to be added to set
-const rect1 = s.rect(0,0,50,50);
-const rect2 = s.rect(0,100,50,50);
-const rect3 = s.rect(0,200,50,50);
-const rect4 = s.rect(0,300,50,50);
-let rect5 = null;
+    // Create multiple elements to be added to set
+    const rect1 = s.rect(0,0,50,50);
+    const rect2 = s.rect(0,100,50,50);
+    const rect3 = s.rect(0,200,50,50);
+    const rect4 = s.rect(0,300,50,50);
+    let rect5: Snap.Element;
 
-// Create new set
-const rectSet = Snap.set(rect1, rect2);
+    // Create new set
+    const rectSet = Snap.set(rect1, rect2);
 
-// Add missing rectangles to set
-rectSet.push(rect3, rect4);
+    // Add missing rectangles to set
+    rectSet.push(rect3, rect4);
 
-// Set all attributes
-rectSet.attr({ fill: 'steelblue' });
+    // Set all attributes
+    rectSet.attr({ fill: 'steelblue' });
 
-// Animate all elements in set
-function animateTest() {
-    return new Promise(resolve => {
-    rectSet.animate({ x: 50 }, 500, mina.bounce, resolve);
-  });
-}
+    // Animate all elements in set
+    function animateTest() {
+        return new Promise(resolve => {
+        rectSet.animate({ x: 50 }, 500, mina.bounce, resolve);
+      });
+    }
 
-// Animate elements individually
-function forEachTest() {
-    const colors = ['red', 'green', 'blue'];
-    return new Promise(resolve => {
-    rectSet.forEach((element, idx) => element.attr({ fill: colors[idx] || '#aaa' }));
-    resolve();
-  });
-}
+    // Animate elements individually
+    function forEachTest() {
+        const colors = ['red', 'green', 'blue'];
+        return new Promise(resolve => {
+        rectSet.forEach((element, idx) => element.attr({ fill: colors[idx] || '#aaa' }));
+        resolve();
+      });
+    }
 
-// Exclude rect4 from set
-function excludeTest() {
-    return new Promise(resolve => {
-    rectSet.exclude(rect4);
-    rectSet.animate({ x: 100 }, 500, mina.bounce, resolve);
-  });
-}
+    // Exclude rect4 from set
+    function excludeTest() {
+        return new Promise(resolve => {
+        rectSet.exclude(rect4);
+        rectSet.animate({ x: 100 }, 500, mina.bounce, resolve);
+      });
+    }
 
-// Remove rect2 from set (it has index of 1)
-// Add new rect5 to set
-async function spliceTest() {
-    rectSet.splice(1, 1);
-  rectSet.attr({ fill: '#000' });
-  
-  rect5 = s.rect(100, 400, 50, 50);
-  rectSet.splice(1, 0, rect5);
-    return;
-}
+    // Remove rect2 from set (it has index of 1)
+    // Add new rect5 to set
+    async function spliceTest() {
+        rectSet.splice(1, 1);
+      rectSet.attr({ fill: '#000' });
+      
+      rect5 = s.rect(100, 400, 50, 50);
+      rectSet.splice(1, 0, rect5);
+        return;
+    }
 
-// Clear set. Rectangles should not go back to x=0
-function clearTest() {
-    return new Promise(resolve => {
-    rectSet.clear();
-    
-    // SHOULD NOT WORK
-    rectSet.animate({ x: 0 }, 500, mina.bounce, resolve);
-    
-    // Re-add rects to set
-    rectSet.push(rect1, rect2, rect3, rect4, rect5);
-    resolve();
-  });
-}
+    // Clear set. Rectangles should not go back to x=0
+    function clearTest() {
+        return new Promise(resolve => {
+        rectSet.clear();
+        
+        // SHOULD NOT WORK
+        rectSet.animate({ x: 0 }, 500, mina.bounce, resolve);
+        
+        // Re-add rects to set
+        rectSet.push(rect1, rect2, rect3, rect4, rect5);
+        resolve();
+      });
+    }
 
-// Remove all elements from DOM that are present in set
-async function removeTest() {
-    rectSet.remove();
-  return;
-}
+    // Remove all elements from DOM that are present in set
+    async function removeTest() {
+        rectSet.remove();
+      return;
+    }
 
-// Start test
-async function startTest() {
-    await animateTest();
-  await forEachTest();
-  await excludeTest();
-  await spliceTest();
-  await clearTest();
-  await removeTest();
-  
-  return;
-}
+    // Start test
+    async function startTest() {
+        await animateTest();
+      await forEachTest();
+      await excludeTest();
+      await spliceTest();
+      await clearTest();
+      await removeTest();
+      
+      return;
+    }
 
-startTest();
+    startTest();
+})();

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -2,7 +2,7 @@
   // Tests by Terry Mun
   // Checks that Snap.set() is properly typed
 
-  const s = Snap(200, 500);
+  const s = Snap(300, 500);
   s.attr({
     viewBox: '0 0 200 500'
   });
@@ -35,6 +35,18 @@
   }
 
   // Animate elements individually
+  function animateMultipleTest() {
+    return new Promise(resolve => {
+      rectSet.animate(
+        [{ x: 100 }, 500, mina.linear],
+        [{ x: 100 }, 1000, mina.linear],
+        [{ x: 100 }, 1500, mina.linear],
+        [{ x: 100 }, 2000, mina.linear, resolve]
+      );
+    });
+  }
+
+  // Animate elements individually
   function forEachTest() {
     const colors = ['red', 'green', 'blue'];
     return new Promise(resolve => {
@@ -52,7 +64,7 @@
     return new Promise(resolve => {
       rectSet.exclude(rect4);
       rectSet.animate({
-        x: 100
+        x: 150
       }, 500, mina.bounce, resolve);
     });
   }
@@ -95,6 +107,7 @@
   // Start test
   async function startTest() {
     await animateTest();
+    await animateMultipleTest();
     await forEachTest();
     await excludeTest();
     await spliceTest();

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -1,0 +1,92 @@
+// Tests by Terry Mun
+// Checks that Snap.set() is properly typed
+
+const s = Snap(200, 500);
+s.attr({
+    viewBox: '0 0 200 500'
+});
+
+// Create multiple elements to be added to set
+const rect1 = s.rect(0,0,50,50);
+const rect2 = s.rect(0,100,50,50);
+const rect3 = s.rect(0,200,50,50);
+const rect4 = s.rect(0,300,50,50);
+let rect5 = null;
+
+// Create new set
+const rectSet = Snap.set(rect1, rect2);
+
+// Add missing rectangles to set
+rectSet.push(rect3, rect4);
+
+// Set all attributes
+rectSet.attr({ fill: 'steelblue' });
+
+// Animate all elements in set
+function animateTest() {
+    return new Promise(resolve => {
+    rectSet.animate({ x: 50 }, 500, mina.bounce, resolve);
+  });
+}
+
+// Animate elements individually
+function forEachTest() {
+    const colors = ['red', 'green', 'blue'];
+    return new Promise(resolve => {
+    rectSet.forEach((element, idx) => element.attr({ fill: colors[idx] || '#aaa' }));
+    resolve();
+  });
+}
+
+// Exclude rect4 from set
+function excludeTest() {
+    return new Promise(resolve => {
+    rectSet.exclude(rect4);
+    rectSet.animate({ x: 100 }, 500, mina.bounce, resolve);
+  });
+}
+
+// Remove rect2 from set (it has index of 1)
+// Add new rect5 to set
+async function spliceTest() {
+    rectSet.splice(1, 1);
+  rectSet.attr({ fill: '#000' });
+  
+  rect5 = s.rect(100, 400, 50, 50);
+  rectSet.splice(1, 0, rect5);
+    return;
+}
+
+// Clear set. Rectangles should not go back to x=0
+function clearTest() {
+    return new Promise(resolve => {
+    rectSet.clear();
+    
+    // SHOULD NOT WORK
+    rectSet.animate({ x: 0 }, 500, mina.bounce, resolve);
+    
+    // Re-add rects to set
+    rectSet.push(rect1, rect2, rect3, rect4, rect5);
+    resolve();
+  });
+}
+
+// Remove all elements from DOM that are present in set
+async function removeTest() {
+    rectSet.remove();
+  return;
+}
+
+// Start test
+async function startTest() {
+    await animateTest();
+  await forEachTest();
+  await excludeTest();
+  await spliceTest();
+  await clearTest();
+  await removeTest();
+  
+  return;
+}
+
+startTest();

--- a/types/snapsvg/tsconfig.json
+++ b/types/snapsvg/tsconfig.json
@@ -21,6 +21,7 @@
         "index.d.ts",
         "test/1.ts",
         "test/2.ts",
-        "test/3.ts"
+        "test/3.ts",
+        "test/4.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://snapsvg.io/docs/#Snap.set
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
    *PR author's note: no substantial changes were made.*

***

A quick overview of what I have changed in this PR:

* `Snap.set()` is not exposed and therefore no typing is available. In fact, when attempting to use `Snap.set()` results in a compilation error. This is easily fixed by exposing the interface.
* Created new tests (in `test/4.ts`) which checks for the documented API for `Snap.set()`: http://snapsvg.io/docs/#Snap.set
* Incremented version of snapsvg from 0.4.1 to 0.5.1
* Added my name to the contributors list
