### PR TITLE
attempt to type yargs/yargs

### DIFF
--- a/types/yargs/tsconfig.json
+++ b/types/yargs/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "yargs.d.ts",
         "yargs-tests.ts"
     ]
 }

--- a/types/yargs/yargs.d.ts
+++ b/types/yargs/yargs.d.ts
@@ -1,0 +1,9 @@
+import { Argv } from "./index";
+
+declare function yargs(
+  args?: ReadonlyArray<string>,
+  cwd?: string,
+  require?: any
+): Argv;
+
+export = yargs;


### PR DESCRIPTION
Admittedly, I'm not sure how to type this file successfully to have both the primary module `yargs` and the less public [`yargs/yargs`](https://github.com/yargs/yargs/blob/master/yargs.js).