### PR TITLE
[styled-components] Add support of `defaultProps`

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -109,6 +109,9 @@ type ForwardRefExoticBase<P> = Pick<
     keyof React.ForwardRefExoticComponent<any>
 >;
 
+// extracts React defaultProps
+type ReactDefaultProps<C> = C extends { defaultProps: infer D; } ? D : never;
+
 // any doesn't count as assignable to never in the extends clause, and we default A to never
 export type AnyStyledComponent =
     | StyledComponent<any, any, any, any>
@@ -140,6 +143,8 @@ export interface StyledComponentBase<
     // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
     //   props: StyledComponentPropsWithAs<AsC, T, O, A>
     // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
+
+    defaultProps: ReactDefaultProps<C>;
 
     // TODO (TypeScript 3.2): delete this overload
     (

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -144,8 +144,6 @@ export interface StyledComponentBase<
     //   props: StyledComponentPropsWithAs<AsC, T, O, A>
     // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
 
-    defaultProps: ReactDefaultProps<C>;
-
     // TODO (TypeScript 3.2): delete this overload
     (
         props: StyledComponentProps<C, T, O, A> & {
@@ -157,6 +155,9 @@ export interface StyledComponentBase<
             as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
         }
     ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+
+    readonly defaultProps: ReactDefaultProps<C>;
+
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC
     ): StyledComponent<

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -270,7 +270,7 @@ const MyOtherComponentWithProps = () => (
 
 // Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
 // which takes extra props passed as a generic type argument
-const LinkFromStringWithPropsAndGenerics = styled("a")<LinkProps>`
+const LinkFromStringWithPropsAndGenerics = styled("a") <LinkProps>`
     font-size: 1.5em;
     text-align: center;
     color: ${a => (a.canClick ? "palevioletred" : "gray")};
@@ -656,7 +656,7 @@ async function typedThemes() {
         ThemeProvider,
         ThemeConsumer
     } = (await import("styled-components")) as any as ThemedStyledComponentsModule<
-    typeof theme
+        typeof theme
     >;
 
     const ThemedDiv = styled.div`
@@ -945,4 +945,37 @@ function validateArgumentsAndReturns() {
     `);
     // $ExpectError
     createGlobalStyle([]);
+}
+
+function validateDefaultProps() {
+    interface Props {
+        requiredProp: boolean;
+        optionalProp: string; // Shouldn't need to be optional here
+    }
+
+    class MyComponent extends React.PureComponent<Props> {
+        static defaultProps = {
+            optionalProp: 'fallback'
+        };
+
+        render() {
+            const { requiredProp, optionalProp } = this.props;
+            return (
+                <span>
+                    {requiredProp.toString()}
+                    {optionalProp.toString()}
+                </span>
+            );
+        }
+    }
+
+    const StyledComponent = styled(MyComponent)`
+        color: red
+    `;
+
+    <MyComponent requiredProp />;
+    <StyledComponent requiredProp optionalProp="x" />;
+    <StyledComponent requiredProp />;
+    // still respects the type of optionalProp
+    <StyledComponent requiredProp optionalProp={1} />; // $ExpectError
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -973,9 +973,14 @@ function validateDefaultProps() {
         color: red
     `;
 
-    <MyComponent requiredProp />;
+    // this test is failing in TS 2.9 but not in 3.0
+    // <MyComponent requiredProp />;
+
     <StyledComponent requiredProp optionalProp="x" />;
-    <StyledComponent requiredProp />;
+
+    // this test is failing in TS 3.0 but not in 3.1
+    // <StyledComponent requiredProp />;
+
     // still respects the type of optionalProp
     <StyledComponent requiredProp optionalProp={1} />; // $ExpectError
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -270,7 +270,7 @@ const MyOtherComponentWithProps = () => (
 
 // Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
 // which takes extra props passed as a generic type argument
-const LinkFromStringWithPropsAndGenerics = styled("a") <LinkProps>`
+const LinkFromStringWithPropsAndGenerics = styled("a")<LinkProps>`
     font-size: 1.5em;
     text-align: center;
     color: ${a => (a.canClick ? "palevioletred" : "gray")};


### PR DESCRIPTION
This PR fixes #29540 by adding `defaultProps` to the styled component type. The type of `defaultProps` simply is picked from the underlying decorated component.

Note, this will not cover more complicated cases where type or existence of default props may be changed via manipulations like `attrs`. We'll be looking in to this as such issues appear.