### PR TITLE
react-intl: change the FormattedMessage tagName prop to accept any ReactType

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -146,7 +146,7 @@ declare namespace ReactIntl {
 
         interface Props extends MessageDescriptor {
             values?: {[key: string]: MessageValue | JSX.Element};
-            tagName?: string;
+            tagName?: React.ReactType;
             children?: (...formattedMessage: Array<string | JSX.Element>) => React.ReactNode;
         }
     }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -159,6 +159,13 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
             <FormattedMessage
                 id="test"
                 description="Test"
+                defaultMessage="Hi {blank} and {empty}!"
+                values={{ blank: null, empty: undefined }}
+                tagName={({ children }) => <div>{children}</div>} />
+
+            <FormattedMessage
+                id="test"
+                description="Test"
             >
                 {(text) => <div className="messageDiv">{text}</div>}
             </FormattedMessage>


### PR DESCRIPTION
In the react-intl source the prop is defined as follows:

    tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.element])

But it's actually passed straight to React.createElement(tagName, …),
so any type that is accepted by createElement should be allowed here.

It is useful to allow passing custom components to FormattedMessage,
for example when you use styled components, eg.

    const FancyHeading = styled('h1')`font-size: 32px`;
    <FormattedMessage … tagName={FancyHeading} />

References:
 - https://github.com/yahoo/react-intl/blob/32c791ff8ed66529fc6602b26b1cc83bbeda89f4/src/components/message.js#L40-L45
 - https://github.com/yahoo/react-intl/blob/32c791ff8ed66529fc6602b26b1cc83bbeda89f4/src/components/message.js#L155 (Component ~ tagName)
