### PR TITLE
Refactor GeoJSON to make Geometry = GeometryObject

### DIFF
--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -58,10 +58,11 @@ featureCollection.features[0].type;  // $ExpectType "Feature"
 featureCollection.features[0].geometry;  // $ExpectType Geometry
 featureCollection.features[0].geometry.type;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
 
-function testLiteralTypes(geojsonTypes: GeoJsonTypes, geometryTypes: GeoJsonGeometryTypes) {
-    geometryTypes; // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
-    geojsonTypes; // $ExpectType "FeatureCollection" | "Feature" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
-}
+declare let geometryTypes: GeoJsonGeometryTypes;
+geometryTypes; // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+
+declare let geojsonTypes: GeoJsonTypes;
+geojsonTypes; // $ExpectType "FeatureCollection" | "Feature" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
 
 const featureWithPolygon: Feature<Polygon> = {
     type: "Feature",

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -58,8 +58,10 @@ featureCollection.features[0].type;  // $ExpectType "Feature"
 featureCollection.features[0].geometry;  // $ExpectType Geometry
 featureCollection.features[0].geometry.type;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
 
-declare let tg: GeoJsonGeometryTypes;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
-declare let t: GeoJsonTypes;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection" | "Feature" | "FeatureCollection"
+function testLiteralTypes(geojsonTypes: GeoJsonTypes, geometryTypes: GeoJsonGeometryTypes) {
+    geometryTypes; // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+    geojsonTypes; // $ExpectType "FeatureCollection" | "Feature" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+}
 
 const featureWithPolygon: Feature<Polygon> = {
     type: "Feature",

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -1,10 +1,11 @@
 import {
     BBox,
-    Feature, FeatureCollection, GeometryCollection, LineString,
-    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, GeometryObject
+    Feature, FeatureCollection, Geometry, GeometryCollection, LineString,
+    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, GeoJsonGeometryTypes,
+    GeometryObject, GeoJsonProperties
 } from "geojson";
 
-let featureCollection: FeatureCollection<Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon | GeometryCollection> = {
+let featureCollection: FeatureCollection = {
     type: "FeatureCollection",
     features: [
         {
@@ -53,6 +54,11 @@ let featureCollection: FeatureCollection<Point | LineString | Polygon | MultiPoi
     ]
 };
 
+featureCollection.type;  // $ExpectType "FeatureCollection"
+featureCollection.features[0].type;  // $ExpectType "Feature"
+featureCollection.features[0].geometry;  // $ExpectType Geometry
+featureCollection.features[0].geometry.type;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+
 const featureWithPolygon: Feature<Polygon> = {
     type: "Feature",
     bbox: [-180.0, -90.0, 180.0, 90.0],
@@ -64,6 +70,11 @@ const featureWithPolygon: Feature<Polygon> = {
     },
     properties: null
 };
+
+featureWithPolygon.type;  // $ExpectType "Feature"
+featureWithPolygon.geometry;  // $ExpectType Polygon
+featureWithPolygon.geometry.type;  // $ExpectType "Polygon"
+featureWithPolygon.geometry.coordinates;  // $ExpectType number[][][]
 
 const point: Point = {
     type: "Point",
@@ -134,6 +145,8 @@ let feature: Feature<GeometryObject> = {
     geometry: lineString,
     properties: null
 };
+
+feature.properties;  // $ExpectType GeoJsonProperties
 
 feature = {
     type: "Feature",
@@ -275,11 +288,15 @@ const featureGeometryNull: Feature<null, TestProperty> = {
     geometry: null
 };
 
+featureGeometryNull.properties.foo;  // $ExpectType "bar" | "baz"
+
 const featureNoNull: Feature<Point, TestProperty> = {
     type: "Feature",
     properties: testProps,
     geometry: point
 };
+
+featureNoNull.geometry.type;  // $ExpectType "Point"
 
 const collectionAllNull: FeatureCollection<null, null> = {
     type: "FeatureCollection",
@@ -301,6 +318,8 @@ const collectionGeometryMaybeNull: FeatureCollection<Point | null, TestProperty>
     features: [featureGeometryNull, featureNoNull],
 };
 
+collectionGeometryMaybeNull.features[0].geometry;  // $ExpectType Point | null
+
 const collectionNoNull: FeatureCollection<Point, TestProperty> = {
     type: "FeatureCollection",
     features: [featureNoNull],
@@ -310,6 +329,9 @@ const collectionDefault: FeatureCollection = {
     type: "FeatureCollection",
     features: []
 };
+
+collectionDefault.features[0].geometry;  // $ExpectType Geometry
+collectionDefault.features[0].properties!.foo;  // $ExpectType any
 
 isNull = featureAllNull.geometry;
 isPoint = featurePropertyNull.geometry;

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -1,8 +1,7 @@
 import {
-    BBox,
-    Feature, FeatureCollection, Geometry, GeometryCollection, LineString,
+    Feature, FeatureCollection, GeometryCollection, LineString,
     MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, GeoJsonGeometryTypes,
-    GeometryObject, GeoJsonProperties
+    GeoJsonTypes, GeometryObject
 } from "geojson";
 
 let featureCollection: FeatureCollection = {
@@ -58,6 +57,9 @@ featureCollection.type;  // $ExpectType "FeatureCollection"
 featureCollection.features[0].type;  // $ExpectType "Feature"
 featureCollection.features[0].geometry;  // $ExpectType Geometry
 featureCollection.features[0].geometry.type;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+
+declare let tg: GeoJsonGeometryTypes;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection"
+declare let t: GeoJsonTypes;  // $ExpectType "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection" | "Feature" | "FeatureCollection"
 
 const featureWithPolygon: Feature<Polygon> = {
     type: "Feature",

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -4,6 +4,7 @@
 //                 Arne Schubert <https://github.com/atd-schubert>
 //                 Jeff Jacobson <https://github.com/JeffJacobson>
 //                 Ilia Choly <https://github.com/icholy>
+//                 Dan Vanderkam <https://github.com/danvk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -16,14 +17,13 @@ export as namespace GeoJSON;
  * The valid values for the "type" property of GeoJSON geometry objects.
  * https://tools.ietf.org/html/rfc7946#section-1.4
  */
-export type GeoJsonGeometryTypes = "Point" | "LineString" | "MultiPoint" | "Polygon" | "MultiLineString" |
-    "MultiPolygon" | "GeometryCollection";
+export type GeoJsonGeometryTypes = Geometry['type'];
 
 /**
  * The value values for the "type" property of GeoJSON Objects.
  * https://tools.ietf.org/html/rfc7946#section-1.4
  */
-export type GeoJsonTypes = "FeatureCollection" | "Feature" | GeoJsonGeometryTypes;
+export type GeoJsonTypes = GeoJSON['type'];
 
 /**
  * Bounding box
@@ -58,6 +58,10 @@ export interface GeoJsonObject {
     type: GeoJsonTypes;
     /**
      * Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections.
+     * The value of the bbox member is an array of length 2*n where n is the number of dimensions
+     * represented in the contained geometries, with all axes of the most southwesterly point
+     * followed by all axes of the more northeasterly point.
+     * The axes order of a bbox follows the axes order of geometries.
      * https://tools.ietf.org/html/rfc7946#section-5
      */
     bbox?: BBox;
@@ -69,24 +73,17 @@ export interface GeoJsonObject {
 export type GeoJSON = Geometry | Feature | FeatureCollection;
 
 /**
- * A geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3
- */
-export interface GeometryObject extends GeoJsonObject {
-    type: GeoJsonGeometryTypes;
-}
-
-/**
- * Union of geometry objects.
+ * Geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3
  */
 export type Geometry = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | GeometryCollection;
+export type GeometryObject = Geometry;
 
 /**
  * Point geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.2
  */
-export interface Point extends GeometryObject {
+export interface Point extends GeoJsonObject {
     type: "Point";
     coordinates: Position;
 }
@@ -95,7 +92,7 @@ export interface Point extends GeometryObject {
  * MultiPoint geometry object.
  *  https://tools.ietf.org/html/rfc7946#section-3.1.3
  */
-export interface MultiPoint extends GeometryObject {
+export interface MultiPoint extends GeoJsonObject {
     type: "MultiPoint";
     coordinates: Position[];
 }
@@ -104,7 +101,7 @@ export interface MultiPoint extends GeometryObject {
  * LineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.4
  */
-export interface LineString extends GeometryObject {
+export interface LineString extends GeoJsonObject {
     type: "LineString";
     coordinates: Position[];
 }
@@ -113,7 +110,7 @@ export interface LineString extends GeometryObject {
  * MultiLineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.5
  */
-export interface MultiLineString extends GeometryObject {
+export interface MultiLineString extends GeoJsonObject {
     type: "MultiLineString";
     coordinates: Position[][];
 }
@@ -122,7 +119,7 @@ export interface MultiLineString extends GeometryObject {
  * Polygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.6
  */
-export interface Polygon extends GeometryObject {
+export interface Polygon extends GeoJsonObject {
     type: "Polygon";
     coordinates: Position[][];
 }
@@ -131,7 +128,7 @@ export interface Polygon extends GeometryObject {
  * MultiPolygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.7
  */
-export interface MultiPolygon extends GeometryObject {
+export interface MultiPolygon extends GeoJsonObject {
     type: "MultiPolygon";
     coordinates: Position[][][];
 }
@@ -140,7 +137,7 @@ export interface MultiPolygon extends GeometryObject {
  * Geometry Collection
  * https://tools.ietf.org/html/rfc7946#section-3.1.8
  */
-export interface GeometryCollection extends GeometryObject {
+export interface GeometryCollection extends GeoJsonObject {
     type: "GeometryCollection";
     geometries: Geometry[];
 }
@@ -151,7 +148,7 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
+export interface Feature<G extends Geometry | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
     type: "Feature";
     /**
      * The feature's geometry
@@ -172,7 +169,7 @@ export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJson
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
+export interface FeatureCollection<G extends Geometry | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }


### PR DESCRIPTION
So far as I can tell the distinction between `Geometry` and `GeometryObject` in these typings does not exist [in the RFC](https://tools.ietf.org/html/rfc7946#section-3):

> 3.1.  Geometry Object
>
>   A Geometry object represents points, curves, and surfaces in coordinate space.  Every Geometry object is a GeoJSON object no matter where it occurs in a GeoJSON text.
>
>   o  The value of a Geometry object's "type" member MUST be one of the seven geometry types (see Section 1.4).
>
>   o  A GeoJSON Geometry object of any type other than "GeometryCollection" has a member with the name "coordinates". The value of the "coordinates" member is an array.  The structure of the elements in this array is determined by the type of geometry.  GeoJSON processors MAY interpret Geometry objects with empty "coordinates" arrays as null objects.

This PR eliminates that distinction while keeping both symbols to avoid breaking existing code. 

Additionally it:
- adds some dtslint-style tests
- reduces some duplication in the declarations
- pulls in more descriptive text from the spec for the bbox property

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
