### PR TITLE
Fix to `typography` package - export `BaseLine` to fix `cannot be named ts4023`

### DIFF
--- a/types/typography/index.d.ts
+++ b/types/typography/index.d.ts
@@ -2,10 +2,11 @@
 // Project: https://github.com/KyleAMathews/typography.js
 // Definitions by: Boye <https://github.com/boyeborg>
 //                 Krzysztof Żuraw <https://github.com/krzysztofzuraw>
+//                 Dominic Fallows <https://github.com/dominicfallows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-interface BaseLine {
+export interface BaseLine {
     fontSize: string;
     lineHeight: string;
 }


### PR DESCRIPTION
Export the `BaseLine` interface to fix TS `cannot be named errors`, for example: 

```bash
Exported variable 'scale' has or is using name 'BaseLine' from external module 
"node_modules/@types/typography/index" but cannot be named.ts(4023)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The problem has been discussed on various GitHub issues from TypeScript, for example https://github.com/Microsoft/TypeScript/issues/5711
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
