### PR TITLE
[jest] Add missing types for requireActual and requireMock

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -39,11 +39,15 @@ interface NodeRequire {
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.
+     *
+     * @deprecated Use `jest.requireActual` instead.
      */
     requireActual(moduleName: string): any;
     /**
      * Returns a mock module instead of the actual module, bypassing all checks
      * on whether the module should be required normally or not.
+     *
+     * @deprecated Use `jest.requireMock`instead.
      */
     requireMock(moduleName: string): any;
 }
@@ -127,6 +131,16 @@ declare namespace jest {
      * Mocks a module with an auto-mocked version when it is being required.
      */
     function mock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
+    /**
+     * Returns the actual module instead of a mock, bypassing all checks on
+     * whether the module should receive a mock implementation or not.
+     */
+    function requireActual(moduleName: string): any;
+    /**
+     * Returns a mock module instead of the actual module, bypassing all checks
+     * on whether the module should be required normally or not.
+     */
+    function requireMock(moduleName: string): any;
     /**
      * Resets the module registry - the cache of all required modules. This is
      * useful to isolate modules where local state might conflict between tests.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -251,6 +251,12 @@ jest
     .useFakeTimers()
     .useRealTimers();
 
+// https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
+jest.requireActual("./thisReturnsTheActualModule");
+
+// https://jestjs.io/docs/en/jest-object#jestrequiremockmodulename
+jest.requireMock("./thisAlwaysReturnsTheMock");
+
 /* Mocks and spies */
 
 const mock1: jest.Mock = jest.fn();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Documentation for the added methods
https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
https://jestjs.io/docs/en/jest-object#jestrequiremockmodulename

PR that introduced the changed the jest documentation to prefer the methods on the `jest` object instead of the `require` ones.
https://github.com/facebook/jest/pull/7210

- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

