### PR TITLE
Lodash: Make PropertyPath elements optional

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -216,7 +216,7 @@ declare module "../index" {
     type Comparator<T> = (a: T, b: T) => boolean;
     type Comparator2<T1, T2> = (a: T1, b: T2) => boolean;
 
-    type PropertyName = string | number | symbol;
+    type PropertyName = string | number | symbol | null | undefined;
     type PropertyPath = Many<PropertyName>;
 
     type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never })[keyof T]>;

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -8,7 +8,8 @@
 //                 e-cloud <https://github.com/e-cloud>,
 //                 Georgii Dolzhykov <https://github.com/thorn0>,
 //                 Jack Moore <https://github.com/jtmthf>,
-//                 Dominique Rau <https://github.com/DomiR>
+//                 Dominique Rau <https://github.com/DomiR>,
+//                 Steven Langbroek <https://github.com/StevenLangbroek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4064,7 +4064,7 @@ fp.now(); // $ExpectType number
 
 // _.isEqualWith
 {
-    const customizer = (value: any, other: any, indexOrKey: number|string|symbol|undefined, parent: any, otherParent: any, stack: any) => true;
+    const customizer = (value: any, other: any, indexOrKey: number|string|symbol|null|undefined, parent: any, otherParent: any, stack: any) => true;
 
     _.isEqualWith(anything, anything, customizer); // $ExpectType boolean
     _(anything).isEqualWith(anything, customizer); // $ExpectType boolean
@@ -4205,14 +4205,14 @@ fp.now(); // $ExpectType number
 
 // _.isMatchWith
 {
-    const testIsMatchCustiomizerFn = (value: any, other: any, indexOrKey: number|string|symbol, object: object, source: object) => true;
+    const testIsMatchCustomizerFn = (value: any, other: any, indexOrKey: number|string|symbol|null|undefined, object: object, source: object) => true;
 
-    _.isMatchWith({}, {}, testIsMatchCustiomizerFn); // $ExpectType boolean
-    _({}).isMatchWith({}, testIsMatchCustiomizerFn); // $ExpectType boolean
-    _.chain({}).isMatchWith({}, testIsMatchCustiomizerFn); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.isMatchWith({}, {}, testIsMatchCustomizerFn); // $ExpectType boolean
+    _({}).isMatchWith({}, testIsMatchCustomizerFn); // $ExpectType boolean
+    _.chain({}).isMatchWith({}, testIsMatchCustomizerFn); // $ExpectType LoDashExplicitWrapper<boolean>
 
-    fp.isMatchWith(testIsMatchCustiomizerFn, {}, {}); // $ExpectType boolean
-    fp.isMatchWith(testIsMatchCustiomizerFn)({})({}); // $ExpectType boolean
+    fp.isMatchWith(testIsMatchCustomizerFn, {}, {}); // $ExpectType boolean
+    fp.isMatchWith(testIsMatchCustomizerFn)({})({}); // $ExpectType boolean
 }
 
 // _.isNaN


### PR DESCRIPTION
I ran into an issue when `strictNullChecks` was enabled using `lodash/fp/prop`: though perfectly valid `lodash`, TypeScript told me individual elements could not be null (this came from an optional property on an interface). The behavior in `lodash` is that it aborts and returns the `defaultValue` (`undefined` in the case of `fp/prop`) if it cannot find any of the intermediary path elements on the object you're accessing. I'd say having this not throw and gracefully returning `undefined` is a primary use-case here. 

I took a look at internals, and it's [cast to string](https://github.com/lodash/lodash/blob/a7e0428889f7c26fba5c6e7127cbb36a99e0eb44/.internal/toKey.js#L17), so it'll try to access `"undefined"`, which will fail gracefully. I think this makes the type closer to the library intent...

If this leads to undesired behavior or the way I've fixed it isn't correct, I'd love to hear it. This is my first time contributing to external type definitions and I'm here to learn ✌️.

Thanks!

---

### Todo:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.11#get
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
- [x] Add temporarily removed `null` back