### PR TITLE
Add definition for mediaType() in @types/accept

### DIFF
--- a/types/accept/accept-tests.ts
+++ b/types/accept/accept-tests.ts
@@ -14,6 +14,8 @@ accept.language("en;q=0.7, en-GB;q=0.8", ["en-gb"]); // language === "en-GB"
 const languages = accept.languages("da, en;q=0.7, en-GB;q=0.8"); // languages === ["da", "en-GB", "en"]
 languages.lastIndexOf('');
 
+accept.mediaType("text/plain, application/json;q=0.5, text/html, */*;q=0.1");
+accept.mediaType("text/plain, application/json;q=0.5, text/html, */*;q=0.1", ["application/json", "text/html"]);
 const mediaTypes = accept.mediaTypes("text/plain, application/json;q=0.5, text/html, */*;q=0.1");
 // mediaTypes === ["text/plain", "text/html", "application/json", "*/*"]
 mediaTypes.lastIndexOf('');

--- a/types/accept/index.d.ts
+++ b/types/accept/index.d.ts
@@ -10,6 +10,7 @@ export function encoding(encodingHeader?: string, preferences?: string[]): strin
 export function encodings(encodingHeader?: string): string[];
 export function language(languageHeader?: string, preferences?: string[]): string;
 export function languages(languageHeader?: string): string[];
+export function mediaType(mediaTypeHeader?: string, preferences?: string[]): string;
 export function mediaTypes(mediaTypeHeader?: string): string[];
 export function parseAll(
     headers: Record<string, string | string[] | undefined>


### PR DESCRIPTION
Adding definition for mediaType() added in https://github.com/hapijs/accept/pull/28 and available since 3.1.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Documentation pending in pull request https://github.com/hapijs/accept/pull/35
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
