### PR TITLE
[@types/koa-router]: Parameterize `Router`

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -43,7 +43,7 @@ declare namespace Router {
         strict?: boolean;
     }
 
-    export interface IRouterContext extends Koa.Context {
+    export interface IRouterContext<StateT = any, CustomT = {}> {
         /**
          * url params
          */
@@ -51,11 +51,14 @@ declare namespace Router {
         /**
          * the router instance
          */
-        router: Router;
+        router: Router<StateT, CustomT>;
     }
 
-    export interface IMiddleware {
-        (ctx: Koa.ParameterizedContext<{}, IRouterContext>, next: () => Promise<any>): any;
+    export interface IMiddleware<StateT = any, CustomT = {}> {
+        (
+            ctx: Koa.ParameterizedContext<StateT, IRouterContext<StateT, CustomT> & CustomT>,
+            next: () => Promise<void>
+        ): void;
     }
 
     export interface IParamMiddleware {
@@ -148,7 +151,7 @@ declare namespace Router {
     }
 }
 
-declare class Router {
+declare class Router<StateT = any, CustomT = {}> {
     params: Object;
     stack: Array<Router.Layer>;
 
@@ -164,109 +167,195 @@ declare class Router {
      * sequentially, requests start at the first middleware and work their way
      * "down" the middleware stack.
      */
-    use(...middleware: Array<Router.IMiddleware>): Router;
-    use(path: string | string[] | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+    use(...middleware: Array<Router.IMiddleware<StateT, CustomT>>): Router<StateT, CustomT>;
+    use(
+        path: string | string[] | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP get method
      */
-    get(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    get(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    get(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    get(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP post method
      */
-    post(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    post(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    post(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    post(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP put method
      */
-    put(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    put(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    put(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    put(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP link method
      */
-    link(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    link(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    link(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    link(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP unlink method
      */
-    unlink(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    unlink(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
-
+    unlink(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    unlink(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP delete method
      */
-    delete(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    delete(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    delete(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    delete(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * Alias for `router.delete()` because delete is a reserved word
      */
-    del(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    del(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    del(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    del(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP head method
      */
-    head(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    head(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    head(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    head(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP options method
      */
-    options(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    options(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    options(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    options(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * HTTP path method
      */
-    patch(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    patch(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    patch(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    patch(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * Register route with all methods.
      */
-    all(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
-    all(path: string | RegExp | (string | RegExp)[], ...middleware: Array<Router.IMiddleware>): Router;
+    all(
+        name: string,
+        path: string | RegExp,
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
+    all(
+        path: string | RegExp | (string | RegExp)[],
+        ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
+    ): Router<StateT, CustomT>;
 
     /**
      * Set the path prefix for a Router instance that was already initialized.
      */
-    prefix(prefix: string): Router;
+    prefix(prefix: string): Router<StateT, CustomT>;
 
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    routes(): Koa.Middleware;
+    routes(): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
 
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    middleware(): Koa.Middleware;
+    middleware(): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
 
     /**
      * Returns separate middleware for responding to `OPTIONS` requests with
      * an `Allow` header containing the allowed methods, as well as responding
      * with `405 Method Not Allowed` and `501 Not Implemented` as appropriate.
      */
-    allowedMethods(options?: Router.IRouterAllowedMethodsOptions): Koa.Middleware;
+    allowedMethods(
+        options?: Router.IRouterAllowedMethodsOptions
+    ): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
 
     /**
      * Redirect `source` to `destination` URL with optional 30x status `code`.
      *
      * Both `source` and `destination` can be route names.
      */
-    redirect(source: string, destination: string, code?: number): Router;
+    redirect(source: string, destination: string, code?: number): Router<StateT, CustomT>;
 
     /**
      * Create and register a route.
      */
-    register(path: string | RegExp, methods: string[], middleware: Router.IMiddleware, opts?: Object): Router.Layer;
+    register(
+        path: string | RegExp,
+        methods: string[],
+        middleware: Router.IMiddleware<StateT, CustomT>,
+        opts?: Object
+    ): Router.Layer;
 
     /**
      * Lookup route with given `name`.
@@ -304,7 +393,7 @@ declare class Router {
     /**
      * Run middleware for named route parameters. Useful for auto-loading or validation.
      */
-    param(param: string, middleware: Router.IParamMiddleware): Router;
+    param(param: string, middleware: Router.IParamMiddleware): Router<StateT, CustomT>;
 
     /**
      * Generate URL from url pattern and given `params`.

--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -58,15 +58,14 @@ declare namespace Router {
         router: Router<StateT, CustomT>;
     }
 
+    export type RouterContext<T = any, U = {}> = Koa.ParameterizedContext<T, IRouterParamContext<T, U> & U>;
+
     export interface IMiddleware<StateT = any, CustomT = {}> {
-        (
-            ctx: Koa.ParameterizedContext<StateT, IRouterParamContext<StateT, CustomT> & CustomT>,
-            next: () => Promise<void>
-        ): void;
+        (ctx: RouterContext<StateT, CustomT>, next: () => Promise<void>): void;
     }
 
     export interface IParamMiddleware {
-        (param: string, ctx: Koa.ParameterizedContext<{}, IRouterParamContext>, next: () => Promise<any>): any;
+        (param: string, ctx: RouterContext, next: () => Promise<any>): any;
     }
 
     export interface IRouterAllowedMethodsOptions {

--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -44,15 +44,7 @@ declare namespace Router {
     }
 
     // Deprecated - please use IRouterParamContext
-    export interface IRouterContext extends Koa.ParameterizedContext {
-        /**
-         * url params
-         */
-        params: any;
-        /**
-         * the router instance
-         */
-        router: Router;
+    export interface IRouterContext extends Koa.ParameterizedContext<any, IRouterParamContext> {
     }
 
     export interface IRouterParamContext<StateT = any, CustomT = {}> {

--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -43,7 +43,19 @@ declare namespace Router {
         strict?: boolean;
     }
 
-    export interface IRouterContext<StateT = any, CustomT = {}> {
+    // Deprecated - please use IRouterParamContext
+    export interface IRouterContext extends Koa.ParameterizedContext {
+        /**
+         * url params
+         */
+        params: any;
+        /**
+         * the router instance
+         */
+        router: Router;
+    }
+
+    export interface IRouterParamContext<StateT = any, CustomT = {}> {
         /**
          * url params
          */
@@ -56,13 +68,13 @@ declare namespace Router {
 
     export interface IMiddleware<StateT = any, CustomT = {}> {
         (
-            ctx: Koa.ParameterizedContext<StateT, IRouterContext<StateT, CustomT> & CustomT>,
+            ctx: Koa.ParameterizedContext<StateT, IRouterParamContext<StateT, CustomT> & CustomT>,
             next: () => Promise<void>
         ): void;
     }
 
     export interface IParamMiddleware {
-        (param: string, ctx: Koa.ParameterizedContext<{}, IRouterContext>, next: () => Promise<any>): any;
+        (param: string, ctx: Koa.ParameterizedContext<{}, IRouterParamContext>, next: () => Promise<any>): any;
     }
 
     export interface IRouterAllowedMethodsOptions {
@@ -324,12 +336,12 @@ declare class Router<StateT = any, CustomT = {}> {
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    routes(): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
+    routes(): Koa.Middleware<StateT, CustomT & Router.IRouterParamContext<StateT, CustomT>>;
 
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    middleware(): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
+    middleware(): Koa.Middleware<StateT, CustomT & Router.IRouterParamContext<StateT, CustomT>>;
 
     /**
      * Returns separate middleware for responding to `OPTIONS` requests with
@@ -338,7 +350,7 @@ declare class Router<StateT = any, CustomT = {}> {
      */
     allowedMethods(
         options?: Router.IRouterAllowedMethodsOptions
-    ): Koa.Middleware<StateT, CustomT & Router.IRouterContext<StateT, CustomT>>;
+    ): Koa.Middleware<StateT, CustomT & Router.IRouterParamContext<StateT, CustomT>>;
 
     /**
      * Redirect `source` to `destination` URL with optional 30x status `code`.

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -56,7 +56,11 @@ const match = router.match('/users/:id', 'GET');
 let layer: Router.Layer
 let layerOptions: Router.ILayerOptions
 
-const mw: Router.IMiddleware = (ctx: Koa.ParameterizedContext<any, Router.IRouterContext>, next: () => Promise<any>) => {
+const mw: Router.IMiddleware = (ctx: Koa.ParameterizedContext<any, Router.IRouterParamContext>, next: () => Promise<any>) => {
+  ctx.body = "Ok";
+};
+
+const mw2: Router.IMiddleware = (ctx: Router.IRouterContext, next: () => Promise<any>) => {
   ctx.body = "Ok";
 };
 
@@ -78,6 +82,9 @@ router3.get('/', (ctx) => {
     console.log(ctx.router.params);
     ctx.body = "Hello World!";
 });
+router3.get('/foo', (ctx: Router.IRouterContext) => {
+    ctx.body = "Yup";
+})
 new Koa()
     .use(async (ctx, next) => next())
     .use(router3.routes())

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -1,9 +1,15 @@
 import Koa = require("koa");
+import { Context } from "koa";
+import compose = require("koa-compose");
+import etag = require("koa-etag");
 import Router = require("koa-router");
+
+type MyState = {foo: string}
+type MyContext = {bar: string}
 
 const app = new Koa<{}, {}>();
 
-const router = new Router({
+const router = new Router<MyState, MyContext>({
     prefix: "/users"
 });
 
@@ -31,9 +37,10 @@ router
         }
     })
     .post('/users', function (ctx, next) {
-        // ...
+        ctx.state.foo = 'foo';
     })
     .put('/users/:id', function (ctx, next) {
+        ctx.bar = 'bar';
         ctx.body = ctx.params.id;
     })
     .del('/users/:id', function () {
@@ -49,11 +56,65 @@ const match = router.match('/users/:id', 'GET');
 let layer: Router.Layer
 let layerOptions: Router.ILayerOptions
 
-const mw: Router.IMiddleware = (ctx: Router.IRouterContext, next: () => Promise<any>) => {
+const mw: Router.IMiddleware = (ctx: Koa.ParameterizedContext<any, Router.IRouterContext>, next: () => Promise<any>) => {
   ctx.body = "Ok";
 };
 
-app.use(router.routes());
-app.use(router.allowedMethods());
+app.use(async (ctx: Koa.ParameterizedContext<MyState, MyContext>, next) => {
+        ctx.state.foo = 'foo';
+        await next();
+    })
+    .use(router.routes())
+    .use(router.allowedMethods())
+    .use(async (ctx, next) => {
+        ctx.state.foo = '3';
+        await next();
+    })
+    .listen(3000);
 
-app.listen(3000);
+const router3 = new Router();
+router3.get('/', (ctx) => {
+    ctx.foo = "bar";
+    console.log(ctx.router.params);
+    ctx.body = "Hello World!";
+});
+new Koa()
+    .use(async (ctx, next) => next())
+    .use(router3.routes())
+    .use(router.allowedMethods())
+    .listen(3001);
+
+// It's from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31704#issuecomment-451075919,
+// to make sure we don't break it again
+
+declare module "koa" {
+    interface Context {
+        name: string;
+    }
+}
+
+const app2 = new Koa();
+
+const conditional = async (ctx: Context, next: any) => {
+    await next();
+    if (ctx.fresh) {
+        ctx.status = 304;
+        ctx.body = null;
+    }
+};
+
+const router2 = compose([conditional, etag()]);
+
+app2.use(router2);
+
+app2.use(async (ctx: Context, next: any) => {
+    ctx.name = "hello world";
+    await next();
+});
+
+app2.use((ctx: Context, next: any) => {
+    console.log(ctx.name);
+    ctx.body = ctx.name;
+});
+
+app2.listen(8000);


### PR DESCRIPTION
After #31704 it would be useful to specify what is `Context.State` and
`Context` inside the `Router`'s handlers. For that, we could provide
a way to parameterize `Router` (also fallbacking to default `any` and
`{}` in case the generic type params are omitted).

So it would work like that:

```ts
type MyState = {foo: string}
type MyContext = {bar: string}

const app = new Koa<{}, {}>();
const router = new Router<MyState, MyContext>();
router.get('/', (ctx, next) => {
    // ctx here is Koa.ParameterizedContext<MyState, MyContext & IRouterContext<MyState, MyContext>>
    console.log(ctx.state.foo);
    ctx.body = 'Hello World!';
});
app.use<MyState, MyContext>(async (ctx, next) => {
        ctx.state.foo = "foo"
        ctx.bar = "bar";
        await next();
    })
    .use(router.routes())
    .use(router.allowedMethods())
    .use(async (ctx, next) => {
        // ctx here is Koa.ParameterizedContext<MyState, MyContext & IRouterContext<MyState, MyContext>>
        console.log(ctx.router);
        console.log(ctx.bar);
        await next();
    })
    .listen(3000);
```

But if we don't parameterize `Router`, it will work as before:

```ts
const app = new Koa();
const router = new Router();
router.get('/', (ctx, next) => {
    // ctx here is Koa.ParameterizedContext<any, IRouterContext>
    ctx.body = 'Hello World!';
});
app.use(async (ctx, next) => {
        ctx.state.foo = "foo"
        ctx.bar = "bar";
        await next();
    })
    .use(router.routes())
    .use(router.allowedMethods())
    .listen(3000);
```

What do you think?