### PR TITLE
@types/chromecast-caf-receiver - breaks, breakClips, metadata, tracks have too strict types

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1419,7 +1419,7 @@ export interface MediaInformation {
     /**
      * The media metadata.
      */
-    metadata: 
+    metadata?: 
     | MediaMetadata 
     | GenericMediaMetadata 
     | MovieMediaMetadata 

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1,7 +1,13 @@
 import { Event, DetailedErrorCode } from "./cast.framework.events";
 
-export as namespace messages;
-export type UserAction = "LIKE" | "DISLIKE" | "FOLLOW" | "UNFOLLOW" | "FLAG" | "SKIP_AD";
+export as namespace messages
+export type UserAction =
+    | "LIKE"
+    | "DISLIKE"
+    | "FOLLOW"
+    | "UNFOLLOW"
+    | "FLAG"
+    | "SKIP_AD";
 
 export type UserActionContext =
     | "UNKNOWN_CONTEXT"
@@ -16,7 +22,12 @@ export type UserActionContext =
     | "PLAYER"
     | "COACH";
 
-export type TextTrackType = "SUBTITLES" | "CAPTIONS" | "DESCRIPTIONS" | "CHAPTERS" | "METADATA";
+export type TextTrackType =
+    | "SUBTITLES"
+    | "CAPTIONS"
+    | "DESCRIPTIONS"
+    | "CHAPTERS"
+    | "METADATA";
 
 export type TextTrackWindowType = "NONE" | "NORMAL" | "ROUNDED_CORNERS";
 
@@ -33,7 +44,12 @@ export type TextTrackFontGenericFamily =
 
 export type TextTrackFontStyle = "NORMAL" | "BOLD" | "BOLD_ITALIC" | "ITALIC";
 
-export type TextTrackEdgeType = "NONE" | "OUTLINE" | "DROP_SHADOW" | "RAISED" | "DEPRESSED";
+export type TextTrackEdgeType =
+    | "NONE"
+    | "OUTLINE"
+    | "DROP_SHADOW"
+    | "RAISED"
+    | "DEPRESSED";
 
 export type Command =
     | "PAUSE"
@@ -48,7 +64,11 @@ export type Command =
 
 export type SeekResumeState = "PLAYBACK_START" | "PLAYBACK_PAUSE";
 
-export type StreamingProtocolType = "UNKNOWN" | "MPEG_DASH" | "HLS" | "SMOOTH_STREAMING";
+export type StreamingProtocolType =
+    | "UNKNOWN"
+    | "MPEG_DASH"
+    | "HLS"
+    | "SMOOTH_STREAMING";
 
 export type StreamType = "BUFFERED" | "LIVE" | "NONE";
 
@@ -81,7 +101,11 @@ export type ErrorReason =
     | "INVALID_REQUEST"
     | "GENERIC_LOAD_ERROR";
 
-export type RepeatMode = "REPEAT_OFF" | "REPEAT_ALL" | "REPEAT_SINGLE" | "REPEAT_ALL_AND_SHUFFLE";
+export type RepeatMode =
+    | "REPEAT_OFF"
+    | "REPEAT_ALL"
+    | "REPEAT_SINGLE"
+    | "REPEAT_ALL_AND_SHUFFLE";
 
 export type IdleReason = "CANCELLED" | "INTERRUPTED" | "FINISHED" | "ERROR";
 
@@ -136,7 +160,12 @@ export type MessageType =
 
 export type PlayerState = "IDLE" | "PLAYING" | "PAUSED" | "BUFFERING";
 
-export type QueueChangeType = "INSERT" | "REMOVE" | "ITEMS_CHANGE" | "UPDATE" | "NO_CHANGE";
+export type QueueChangeType =
+    | "INSERT"
+    | "REMOVE"
+    | "ITEMS_CHANGE"
+    | "UPDATE"
+    | "NO_CHANGE";
 
 export type QueueType =
     | "ALBUM"
@@ -149,7 +178,12 @@ export type QueueType =
     | "LIVE_TV"
     | "MOVIE";
 
-export type MetadataType = "GENERIC" | "MOVIE" | "TV_SHOW" | "MUSIC_TRACK" | "PHOTO";
+export type MetadataType =
+    | "GENERIC"
+    | "MOVIE"
+    | "TV_SHOW"
+    | "MUSIC_TRACK"
+    | "PHOTO";
 
 /**
  * RefreshCredentials request data.
@@ -1385,13 +1419,13 @@ export interface MediaInformation {
     /**
      * The media metadata.
      */
-    metadata?:
-        | MediaMetadata
-        | GenericMediaMetadata
-        | MovieMediaMetadata
-        | MusicTrackMediaMetadata
-        | PhotoMediaMetadata
-        | TvShowMediaMetadata;
+    metadata: 
+    | MediaMetadata 
+    | GenericMediaMetadata 
+    | MovieMediaMetadata 
+    | MusicTrackMediaMetadata 
+    | PhotoMediaMetadata 
+    | PhotoMediaMetadata;
 
     /**
      * The stream type.
@@ -1487,7 +1521,12 @@ export interface LoadByEntityRequestData {
  * attributes.
  */
 export class LiveSeekableRange {
-    constructor(start?: number, end?: number, isMovingWindow?: boolean, isLiveDone?: boolean);
+    constructor(
+        start?: number,
+        end?: number,
+        isMovingWindow?: boolean,
+        isLiveDone?: boolean
+    );
 
     /**
      * A boolean value indicates whether a live stream is ended. If it is done;
@@ -1626,7 +1665,10 @@ export class FetchItemsRequestData extends RequestData {
  * Extended media status information
  */
 export class ExtendedMediaStatus {
-    constructor(playerState: MediaInformation, opt_media?: MediaInformation);
+    constructor(
+        playerState: MediaInformation,
+        opt_media?: MediaInformation
+    );
 
     media: MediaInformation;
 

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1,13 +1,7 @@
 import { Event, DetailedErrorCode } from "./cast.framework.events";
 
-export as namespace messages
-export type UserAction =
-    | "LIKE"
-    | "DISLIKE"
-    | "FOLLOW"
-    | "UNFOLLOW"
-    | "FLAG"
-    | "SKIP_AD";
+export as namespace messages;
+export type UserAction = "LIKE" | "DISLIKE" | "FOLLOW" | "UNFOLLOW" | "FLAG" | "SKIP_AD";
 
 export type UserActionContext =
     | "UNKNOWN_CONTEXT"
@@ -22,12 +16,7 @@ export type UserActionContext =
     | "PLAYER"
     | "COACH";
 
-export type TextTrackType =
-    | "SUBTITLES"
-    | "CAPTIONS"
-    | "DESCRIPTIONS"
-    | "CHAPTERS"
-    | "METADATA";
+export type TextTrackType = "SUBTITLES" | "CAPTIONS" | "DESCRIPTIONS" | "CHAPTERS" | "METADATA";
 
 export type TextTrackWindowType = "NONE" | "NORMAL" | "ROUNDED_CORNERS";
 
@@ -44,12 +33,7 @@ export type TextTrackFontGenericFamily =
 
 export type TextTrackFontStyle = "NORMAL" | "BOLD" | "BOLD_ITALIC" | "ITALIC";
 
-export type TextTrackEdgeType =
-    | "NONE"
-    | "OUTLINE"
-    | "DROP_SHADOW"
-    | "RAISED"
-    | "DEPRESSED";
+export type TextTrackEdgeType = "NONE" | "OUTLINE" | "DROP_SHADOW" | "RAISED" | "DEPRESSED";
 
 export type Command =
     | "PAUSE"
@@ -64,11 +48,7 @@ export type Command =
 
 export type SeekResumeState = "PLAYBACK_START" | "PLAYBACK_PAUSE";
 
-export type StreamingProtocolType =
-    | "UNKNOWN"
-    | "MPEG_DASH"
-    | "HLS"
-    | "SMOOTH_STREAMING";
+export type StreamingProtocolType = "UNKNOWN" | "MPEG_DASH" | "HLS" | "SMOOTH_STREAMING";
 
 export type StreamType = "BUFFERED" | "LIVE" | "NONE";
 
@@ -101,11 +81,7 @@ export type ErrorReason =
     | "INVALID_REQUEST"
     | "GENERIC_LOAD_ERROR";
 
-export type RepeatMode =
-    | "REPEAT_OFF"
-    | "REPEAT_ALL"
-    | "REPEAT_SINGLE"
-    | "REPEAT_ALL_AND_SHUFFLE";
+export type RepeatMode = "REPEAT_OFF" | "REPEAT_ALL" | "REPEAT_SINGLE" | "REPEAT_ALL_AND_SHUFFLE";
 
 export type IdleReason = "CANCELLED" | "INTERRUPTED" | "FINISHED" | "ERROR";
 
@@ -160,12 +136,7 @@ export type MessageType =
 
 export type PlayerState = "IDLE" | "PLAYING" | "PAUSED" | "BUFFERING";
 
-export type QueueChangeType =
-    | "INSERT"
-    | "REMOVE"
-    | "ITEMS_CHANGE"
-    | "UPDATE"
-    | "NO_CHANGE";
+export type QueueChangeType = "INSERT" | "REMOVE" | "ITEMS_CHANGE" | "UPDATE" | "NO_CHANGE";
 
 export type QueueType =
     | "ALBUM"
@@ -178,12 +149,7 @@ export type QueueType =
     | "LIVE_TV"
     | "MOVIE";
 
-export type MetadataType =
-    | "GENERIC"
-    | "MOVIE"
-    | "TV_SHOW"
-    | "MUSIC_TRACK"
-    | "PHOTO";
+export type MetadataType = "GENERIC" | "MOVIE" | "TV_SHOW" | "MUSIC_TRACK" | "PHOTO";
 
 /**
  * RefreshCredentials request data.
@@ -1372,12 +1338,12 @@ export interface MediaInformation {
      * is playing or ones that receiver will play shortly after; instead of sending
      * whole list of clips. This is to avoid overflow of MediaStatus message.
      */
-    breakClips: BreakClip[];
+    breakClips?: BreakClip[];
 
     /**
      * List of breaks.
      */
-    breaks: Break[];
+    breaks?: Break[];
 
     /**
      * Typically the url of the media.
@@ -1414,12 +1380,18 @@ export interface MediaInformation {
     /**
      * The format of the HLS media segment.
      */
-    hlsSegmentFormat: HlsSegmentFormat;
+    hlsSegmentFormat?: HlsSegmentFormat;
 
     /**
      * The media metadata.
      */
-    metadata: MediaMetadata;
+    metadata?:
+        | MediaMetadata
+        | GenericMediaMetadata
+        | MovieMediaMetadata
+        | MusicTrackMediaMetadata
+        | PhotoMediaMetadata
+        | TvShowMediaMetadata;
 
     /**
      * The stream type.
@@ -1429,12 +1401,12 @@ export interface MediaInformation {
     /**
      * The style of text track.
      */
-    textTrackStyle: TextTrackStyle;
+    textTrackStyle?: TextTrackStyle;
 
     /**
      * The media tracks.
      */
-    tracks: Track[];
+    tracks?: Track[];
 }
 
 /**
@@ -1515,12 +1487,7 @@ export interface LoadByEntityRequestData {
  * attributes.
  */
 export class LiveSeekableRange {
-    constructor(
-        start?: number,
-        end?: number,
-        isMovingWindow?: boolean,
-        isLiveDone?: boolean
-    );
+    constructor(start?: number, end?: number, isMovingWindow?: boolean, isLiveDone?: boolean);
 
     /**
      * A boolean value indicates whether a live stream is ended. If it is done;
@@ -1659,10 +1626,7 @@ export class FetchItemsRequestData extends RequestData {
  * Extended media status information
  */
 export class ExtendedMediaStatus {
-    constructor(
-        playerState: MediaInformation,
-        opt_media?: MediaInformation
-    );
+    constructor(playerState: MediaInformation, opt_media?: MediaInformation);
 
     media: MediaInformation;
 

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1419,11 +1419,11 @@ export interface MediaInformation {
     /**
      * The media metadata.
      */
-    metadata?: 
-    | MediaMetadata 
-    | GenericMediaMetadata 
-    | MovieMediaMetadata 
-    | MusicTrackMediaMetadata 
+    metadata?:
+    | MediaMetadata
+    | GenericMediaMetadata
+    | MovieMediaMetadata
+    | MusicTrackMediaMetadata
     | PhotoMediaMetadata
     | TvShowMediaMetadata;
 

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1424,8 +1424,8 @@ export interface MediaInformation {
     | GenericMediaMetadata 
     | MovieMediaMetadata 
     | MusicTrackMediaMetadata 
-    | PhotoMediaMetadata 
-    | PhotoMediaMetadata;
+    | PhotoMediaMetadata
+    | TvShowMediaMetadata;
 
     /**
      * The stream type.


### PR DESCRIPTION
These values have too strict definitions, they are defined in https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.MediaInformation#metadata as undefined.

Also metadata can be any one of these metadatas listed.

Cloning this repo is pain.

CC. @craigrbruce

P.S. I'm using this package to make types for `castv2-client` npm package. Which is is breeze because this is so finely typed already!