### PR TITLE
[styled-components] Add set 'children' prop on StyledComponentProps

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ihor Chulinda <https://github.com/Igmat>
 //                 Adam Lavin <https://github.com/lavoaster>
 //                 Jessica Franco <https://github.com/Kovensky>
+//                 Mike Deverell <https://github.com/devrelm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -41,10 +42,12 @@ export type StyledComponentProps<
     O extends object,
     // The props that are made optional by .attrs
     A extends keyof any
-> = WithOptionalTheme<
-    Omit<React.ComponentPropsWithRef<C> & O, A> &
-        Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
-    T
+> = WithChildren<
+    WithOptionalTheme<
+        Omit<React.ComponentPropsWithRef<C> & O, A> &
+            Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+        T
+    >
 >;
 
 type StyledComponentPropsWithAs<
@@ -307,6 +310,10 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type WithChildren<P extends object> =
+    P extends { children: any }
+        ? P
+        : P & { children?: React.ReactNode };
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -25,6 +25,67 @@ import {} from "styled-components/cssprop";
  * general usage
  */
 
+interface AllOptionalProps {
+    text?: boolean;
+    altText?: boolean;
+}
+
+const AllOptionalPropComponent: React.SFC<AllOptionalProps> =
+    ({ text, altText, children }) => (
+        <div>
+            {text || altText || 'Hello World'}
+            {children}
+        </div>
+    );
+
+const StyledAllOptionalPropComponent = styled(AllOptionalPropComponent)`
+    max-width: 100px;
+`;
+
+// Check that passing no props to a component with only optional props works.
+// If we aren't explicitly setting a `children` prop, then this would produce
+// a "no properties in common" error.
+const UseStyledAllOptionalPropComponent: React.SFC = () => (
+    <StyledAllOptionalPropComponent>
+        blah
+    </StyledAllOptionalPropComponent>
+);
+
+interface CustomChildrenProps {
+    children?: (enabled: boolean) => JSX.Element;
+}
+
+const CustomChildrenComponent: React.SFC<CustomChildrenProps> = ({ children }) =>
+    children
+        ? children(Math.random() > 0.5)
+        : null;
+
+const StyledCustomChildrenComponent = styled(CustomChildrenComponent)``;
+
+// Check that we don't override the `children` prop if someone explicitly
+// declared it with a custom type.
+const UseStyledCustomChildrenComponent = () => (
+    <>
+        <CustomChildrenComponent>
+            {
+                (enabled) => (
+                    enabled
+                        ? <div>is on</div>
+                        : <div>is off</div>
+                )
+            }
+        </CustomChildrenComponent>
+        <CustomChildrenComponent // $ExpectError
+        >
+            Blah Blah Blah
+        </CustomChildrenComponent>
+        <CustomChildrenComponent // $ExpectError
+        >
+            <div>Blah Blah Blah</div>
+        </CustomChildrenComponent>
+    </>
+);
+
 // Create a <Title> react component that renders an <h1> which is
 // centered, palevioletred and sized at 1.5em
 const Title = styled.h1`


### PR DESCRIPTION
I had trouble when trying to use a component that had been styled whose props were all optional. I tracked it down to `children` not being added as a prop anywhere.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] N/A ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [ ] N/A ~Increase the version number in the header if appropriate.~
- [ ] N/A ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
