### PR TITLE
mongoose-paginate-v2: fix export causing errors.

### DIFF
--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -57,4 +57,5 @@ declare module 'mongoose' {
 }
 
 import mongoose = require('mongoose');
-export function _(schema: mongoose.Schema): void;
+declare function _(schema: mongoose.Schema): void;
+export = _;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The recent addition (by me) of this declaration contained an issue causing error in some setups but not others, hence it did not surface when I tested the declaration in my own code and unfortunately `npm test` does not detect this kind of errors. This PR should fix the issue.

For completeness sake, a snippet like the following triggered the error:
```typescript
import mongoose from 'mongoose';
import mongoosePaginate from 'mongoose-paginate-v2';

mongoose.plugin(mongoosePaginate);  // this line caused the error
```

And the error was as follows:
```
Argument of type 'typeof import(".../node_modules/@types/mongoose-paginate-v2/index")' is not assignable to parameter of type 'Function'.
  Type 'typeof import(".../node_modules/@types/mongoose-paginate-v2/index")' is missing the following properties from type 'Function': apply, call, bind, prototype, and 5 more.
```