### PR TITLE
next-server: dynamic() can be passed a AsyncComponentLoader

### DIFF
--- a/types/next-server/dynamic.d.ts
+++ b/types/next-server/dynamic.d.ts
@@ -31,7 +31,7 @@ type DynamicComponent<P> = React.ComponentType<P> & LoadableComponent;
  * https://github.com/zeit/next.js/blob/7.0.0/lib/dynamic.js#L55
  */
 declare function dynamic<P = {}>(
-    options: AsyncComponent<P> | NextDynamicOptions<P>
+    options: AsyncComponentLoader<P> | AsyncComponent<P> | NextDynamicOptions<P>
 ): DynamicComponent<P>;
 declare function dynamic<P = {}>(
     asyncModule: AsyncComponent<P>,

--- a/types/next-server/test/next-server-dynamic-tests.tsx
+++ b/types/next-server/test/next-server-dynamic-tests.tsx
@@ -20,6 +20,10 @@ const LoadingComponent: React.StatelessComponent<LoadingComponentProps> = ({
 const DynamicComponent = dynamic(asyncComponent);
 const dynamicComponentJSX = <DynamicComponent foo="bar" />;
 
+// 1.1 Basic Usage (Loader function)
+const DynamicComponent2 = dynamic(() => asyncComponent);
+const dynamicComponent2JSX = <DynamicComponent2 foo="bar" />;
+
 // 2. With Custom Loading Component
 const DynamicComponentWithCustomLoading = dynamic(asyncComponent, {
     loading: LoadingComponent


### PR DESCRIPTION
This is actually the preferred form of the basic usage according to the next.js documentation.

See https://nextjs.org/docs/#dynamic-import.
