### PR TITLE
h2o2: fix response toolkit decoration

### DIFF
--- a/types/h2o2/h2o2-tests.ts
+++ b/types/h2o2/h2o2-tests.ts
@@ -140,6 +140,18 @@ const badProtocolDemo: hapi.ServerRoute = {
     }
 };
 
+const replyViaToolkit: hapi.ServerRoute = {
+    method: 'GET',
+    path: '/',
+    async handler(req, h): Promise<hapi.ResponseObject> {
+        return h.proxy({
+            host: '10.33.33.1',
+            port: '443',
+            protocol: 'https'
+        });
+    }
+};
+
 if (!module.parent) {
     main().then(() => console.log('done'), err => console.error(err.stack));
 }

--- a/types/h2o2/index.d.ts
+++ b/types/h2o2/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for h2o2 8.1
 // Project: https://github.com/hapijs/h2o2
-// Definitions by: Jason Swearingen <https://github.com/jasonswearingen>, AJP <https://github.com/AJamesPhillips>
+// Definitions by: Jason Swearingen <https://github.com/jasonswearingen>, AJP <https://github.com/AJamesPhillips>, Garth Kidd <https://github.com/garthk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -83,13 +83,17 @@ declare namespace h2o2 {
 
 declare module 'hapi' {
     interface HandlerDecorations {
-        /** Proxies the request to an upstream endpoint */
+        /**
+         * Proxies the request to an upstream endpoint.
+         */
         proxy?: h2o2.ProxyHandlerOptions;
     }
 
     interface ResponseToolkit {
-        /** Proxies the request to an upstream endpoint */
-        proxy(options: h2o2.ProxyHandlerOptions): void;
+        /**
+         * Proxies the request to an upstream endpoint. `async`, so you'll need to `await` the `ResponseObject` to work on it before returning it.
+         */
+        proxy(options: h2o2.ProxyHandlerOptions): Promise<ResponseObject>;
     }
 }
 


### PR DESCRIPTION
`h.proxy` returns a `Promise<ResponseObject>`, not `undefined`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/h2o2/blob/master/lib/index.js#L85
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, ~consider adding~ _note someone else added_ a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
