### PR TITLE
[@mapbox/geo-viewport] add allowFloat parameter added in 0.4

### DIFF
--- a/types/mapbox__geo-viewport/index.d.ts
+++ b/types/mapbox__geo-viewport/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @mapbox/geo-viewport 0.3
+// Type definitions for @mapbox/geo-viewport 0.4
 // Project: https://github.com/mapbox/geo-viewport
 // Definitions by: Fabio Berta <https://github.com/fnberta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,6 +10,6 @@ export interface GeoViewport {
 
 export type BoundingBox = [number, number, number, number];
 
-export function viewport(bounds: BoundingBox, dimensions: [number, number], minzoom?: number, maxzoom?: number, tileSize?: number): GeoViewport;
+export function viewport(bounds: BoundingBox, dimensions: [number, number], minzoom?: number, maxzoom?: number, tileSize?: number, allowFloat?: boolean): GeoViewport;
 
 export function bounds(viewport: { lon: number; lat: number } | [number, number], zoom: number, dimensions: [number, number], tileSize?: number): BoundingBox;


### PR DESCRIPTION
Parameter `allowFloat` was added in 0.4 of the package, see https://github.com/mapbox/geo-viewport/blob/master/CHANGELOG.md. This PR brings the types up to date.