### PR TITLE
[stripe] fix incorrect spelling: UsageRecordSummarys -> UsageRecordSummaries

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5331,7 +5331,7 @@ declare namespace Stripe {
          * starting after summary starting_after. Each entry in the array is a separate summary object.
          * If no more summaries are available, the resulting array is empty.
          */
-        interface IUsageRecordSummaries extends IList<IUsageRecordSummariesItem>{
+        interface IUsageRecordSummaries extends IList<IUsageRecordSummariesItem> {
             object: 'list'
         }
 
@@ -5345,7 +5345,7 @@ declare namespace Stripe {
             total_usage: number;
         }
 
-        interface IUsageRecordSummariesListOptions extends IListOptions{
+        interface IUsageRecordSummariesListOptions extends IListOptions {
             /**
              * Only summary items for the given subscription item.
              */

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -15,6 +15,7 @@
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 Simon Schick <https://github.com/SimonSchick>
 //                 Slava Yultyyev Schick <https://github.com/yultyyev>
+//                 Corey Psoinos <https://github.com/cpsoinos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -76,7 +77,7 @@ declare class Stripe {
     webhooks: Stripe.resources.WebHooks;
     ephemeralKeys: Stripe.resources.EphemeralKeys;
     usageRecords: Stripe.resources.UsageRecords;
-    usageRecordSummarys: Stripe.resources.UsageRecordSummarys;
+    usageRecordSummaries: Stripe.resources.UsageRecordSummaries;
 
     setHost(host: string): void;
     setHost(host: string, port: string|number): void;
@@ -5324,17 +5325,17 @@ declare namespace Stripe {
         }
     }
 
-    namespace usageRecordSummarys {
+    namespace usageRecordSummaries {
         /**
          * A object with a data property that contains an array of up to limit summaries,
          * starting after summary starting_after. Each entry in the array is a separate summary object.
          * If no more summaries are available, the resulting array is empty.
          */
-        interface IUsageRecordSummarys extends IList<IUsageRecordSummarysItem> {
-            object: 'list';
+        interface IUsageRecordSummaries extends IList<IUsageRecordSummariesItem>{
+            object: 'list'
         }
 
-        interface IUsageRecordSummarysItem {
+        interface IUsageRecordSummariesItem {
             id: string;
             object: string;
             invoice: string;
@@ -5344,7 +5345,7 @@ declare namespace Stripe {
             total_usage: number;
         }
 
-        interface IUsageRecordSummarysListOptions extends IListOptions {
+        interface IUsageRecordSummariesListOptions extends IListOptions{
             /**
              * Only summary items for the given subscription item.
              */
@@ -5371,12 +5372,12 @@ declare namespace Stripe {
             create(subscription: string, data: usageRecords.IUsageRecordCreationOptions, response?: IResponseFn<usageRecords.IUsageRecord>): Promise<usageRecords.IUsageRecord>;
         }
 
-        class UsageRecordSummarys extends StripeResource {
+        class UsageRecordSummaries extends StripeResource {
             /**
              * Creates a usage record for a specified subscription item and date, and fills it with a quantity.
              */
-            list(data: usageRecordSummarys.IUsageRecordSummarysListOptions, options: HeaderOptions, response?: IResponseFn<usageRecordSummarys.IUsageRecordSummarys>): Promise<usageRecordSummarys.IUsageRecordSummarys>;
-            list(data: usageRecordSummarys.IUsageRecordSummarysListOptions, response?: IResponseFn<usageRecordSummarys.IUsageRecordSummarys>): Promise<usageRecordSummarys.IUsageRecordSummarys>;
+            list(data: usageRecordSummaries.IUsageRecordSummariesListOptions, options: HeaderOptions, response?: IResponseFn<usageRecordSummaries.IUsageRecordSummaries>): Promise<usageRecordSummaries.IUsageRecordSummaries>;
+            list(data: usageRecordSummaries.IUsageRecordSummariesListOptions, response?: IResponseFn<usageRecordSummaries.IUsageRecordSummaries>): Promise<usageRecordSummaries.IUsageRecordSummaries>;
         }
 
         class Accounts extends StripeResource {

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5332,7 +5332,7 @@ declare namespace Stripe {
          * If no more summaries are available, the resulting array is empty.
          */
         interface IUsageRecordSummaries extends IList<IUsageRecordSummariesItem> {
-            object: 'list'
+            object: 'list';
         }
 
         interface IUsageRecordSummariesItem {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1332,8 +1332,8 @@ stripe.ephemeralKeys.create({ customer: "cus_5rfJKDJkuxzh5Q" }, { stripe_version
 stripe.usageRecords.create('sub_8QwCiwZ9tmMSpt', { action: 'set', quantity: 10000, timestamp: 1537006853 }).then((usageRecord: Stripe.usageRecords.IUsageRecord) => {});
 stripe.usageRecords.create('sub_8QwCiwZ9tmMSpt', { action: 'set', quantity: 10000, timestamp: 1537006853 }, (err, usageRecord: Stripe.usageRecords.IUsageRecord) => {});
 
-stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }).then((usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => { });
-stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }, (err, usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => { });
+stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }).then((usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => {});
+stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }, (err, usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => {});
 
 //#region Errors
 // ##################################################################################

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1332,8 +1332,8 @@ stripe.ephemeralKeys.create({ customer: "cus_5rfJKDJkuxzh5Q" }, { stripe_version
 stripe.usageRecords.create('sub_8QwCiwZ9tmMSpt', { action: 'set', quantity: 10000, timestamp: 1537006853 }).then((usageRecord: Stripe.usageRecords.IUsageRecord) => {});
 stripe.usageRecords.create('sub_8QwCiwZ9tmMSpt', { action: 'set', quantity: 10000, timestamp: 1537006853 }, (err, usageRecord: Stripe.usageRecords.IUsageRecord) => {});
 
-stripe.usageRecordSummarys.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }).then((usageRecordSummarys: Stripe.usageRecordSummarys.IUsageRecordSummarys) => {});
-stripe.usageRecordSummarys.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }, (err, usageRecordSummarys: Stripe.usageRecordSummarys.IUsageRecordSummarys) => {});
+stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }).then((usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => { });
+stripe.usageRecordSummaries.list({ subscription_item: 'si_C9gimdd2l9qvCU', limit: 10 }, (err, usageRecordSummaries: Stripe.usageRecordSummaries.IUsageRecordSummaries) => { });
 
 //#region Errors
 // ##################################################################################


### PR DESCRIPTION
Changes the spelling of UsageRecordSummarys to UsageRecordSummaries

ref: https://github.com/stripe/stripe-node/issues/503
docs: https://stripe.com/docs/api/usage_records/subscription_item_summary_list

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [stripe-node source code](https://github.com/stripe/stripe-node/blob/master/lib/stripe.js#L74)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.