### PR TITLE
[got] Add errorCodes to RetryOptions

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -265,8 +265,27 @@ got('https://todomvc.com', { rejectUnauthorized: false });
 got('/examples/angularjs', { baseUrl: 'http://todomvc.com' });
 got('http://todomvc.com', { headers: { foo: 'bar'} });
 got('http://todomvc.com', { cookieJar: new tough.CookieJar() });
+
+// Test retry options.
 got('http://todomvc.com', { retry: 2 });
-got('http://todomvc.com', { retry: { retries: 2, methods: ['GET'], statusCodes: [408, 504], maxRetryAfter: 1 } });
+got('http://todomvc.com', {
+    retry: {
+        retries: 2,
+        methods: ['GET'],
+        statusCodes: [408, 504],
+        maxRetryAfter: 1,
+        errorCodes: ['ETIMEDOUT']
+    }
+});
+// Test custom retry error code. See https://github.com/sindresorhus/got/blob/9f3a09948ff80057b12af0af60846cc5b8f0372d/test/retry.js#L155
+got('http://todomvc.com', {
+    retry: {
+        retries: 1,
+        methods: ['GET'],
+        errorCodes: ['OH_SNAP']
+    }
+});
+
 got('http://todomvc.com', { throwHttpErrors: false });
 got('http://todomvc.com', { hooks: { beforeRequest: [ () => 'foo']} });
 

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for got 9.3
+// Type definitions for got 9.4
 // Project: https://github.com/sindresorhus/got#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Linus Unnebäck <https://github.com/LinusU>
@@ -226,6 +226,10 @@ declare namespace got {
         methods?: Array<'GET' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
         statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
         maxRetryAfter?: number;
+        /**
+         * Allowed error codes.
+         */
+        errorCodes?: string[];
     }
 
     interface AgentOptions {


### PR DESCRIPTION
Add property `errorCodes` to `RetryOptions`.

This property was added in `got` [`v9.4.0`](https://github.com/sindresorhus/got/releases/tag/v9.4.0)

***

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got/blob/9f3a09948ff80057b12af0af60846cc5b8f0372d/readme.md#retry
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.