### PR TITLE
[node] Add null type to net.createServer#address

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3656,7 +3656,7 @@ declare module "net" {
         listen(handle: any, backlog?: number, listeningListener?: Function): this;
         listen(handle: any, listeningListener?: Function): this;
         close(callback?: Function): this;
-        address(): AddressInfo | string;
+        address(): AddressInfo | string | null;
         getConnections(cb: (error: Error | null, count: number) => void): void;
         ref(): this;
         unref(): this;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3462,7 +3462,7 @@ import * as p from "process";
         server = server.close((...args: any[]) => { });
 
         // test the types of the address object fields
-        const address: net.AddressInfo | string = server.address();
+        const address: net.AddressInfo | string | null = server.address();
     }
 
     {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3461,7 +3461,7 @@ import * as p from "process";
         // specified, so any callback function is permissible.
         server = server.close((...args: any[]) => { });
 
-        // test the types of the address object fields
+        // test the types of the address
         const address: net.AddressInfo | string | null = server.address();
     }
 

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -2242,7 +2242,8 @@ declare module "net" {
         setTimeout(timeout: number, callback?: Function): this;
         setNoDelay(noDelay?: boolean): this;
         setKeepAlive(enable?: boolean, initialDelay?: number): this;
-        address(): { port: number; family: string; address: string; };
+        // (new net.Socket()).address() produces {}
+        address(): { port: number; family: string; address: string; } | {};
         unref(): void;
         ref(): void;
 
@@ -2358,7 +2359,8 @@ declare module "net" {
         listen(handle: any, backlog?: number, listeningListener?: Function): Server;
         listen(handle: any, listeningListener?: Function): Server;
         close(callback?: Function): Server;
-        address(): { port: number; family: string; address: string; };
+        // (net.createServer()).address() produces null
+        address(): { port: number; family: string; address: string; } | null;
         getConnections(cb: (error: Error, count: number) => void): void;
         ref(): Server;
         unref(): Server;
@@ -2459,7 +2461,8 @@ declare module "dgram" {
         bind(port?: number, address?: string, callback?: () => void): void;
         bind(options: BindOptions, callback?: Function): void;
         close(callback?: () => void): void;
-        address(): AddressInfo;
+        // (new net.Socket()).address() produces {}
+        address(): AddressInfo | {};
         setBroadcast(flag: boolean): void;
         setTTL(ttl: number): void;
         setMulticastTTL(ttl: number): void;
@@ -3300,7 +3303,7 @@ declare module "tls" {
          * the operating system.
          * @returns An object with three properties, e.g. { port: 12346, family: 'IPv4', address: '127.0.0.1' }.
          */
-        address(): { port: number; family: string; address: string };
+        address(): { port: number; family: string; address: string } | null;
         /**
          * A boolean that is true if the peer certificate was signed by one of the specified CAs, otherwise false.
          */
@@ -3474,7 +3477,8 @@ declare module "tls" {
 
     export interface Server extends net.Server {
         close(callback?: Function): Server;
-        address(): { port: number; family: string; address: string; };
+        // (tls.createServer()).address() produces null
+        address(): { port: number; family: string; address: string; } | null;
         addContext(hostName: string, credentials: {
             key: string;
             cert: string;

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -2735,6 +2735,12 @@ declare module "net" {
 
     type LookupFunction = (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
 
+    interface AddressInfo {
+      address: string;
+      family: string;
+      port: number;
+    }
+
     export interface SocketConstructorOpts {
         fd?: number;
         allowHalfOpen?: boolean;
@@ -2898,7 +2904,7 @@ declare module "net" {
         listen(handle: any, backlog?: number, listeningListener?: Function): this;
         listen(handle: any, listeningListener?: Function): this;
         close(callback?: Function): this;
-        address(): { port: number; family: string; address: string; };
+        address(): AddressInfo | string | null;
         getConnections(cb: (error: Error | null, count: number) => void): void;
         ref(): this;
         unref(): this;
@@ -2974,16 +2980,11 @@ declare module "net" {
 }
 
 declare module "dgram" {
+    import { AddressInfo } from "net";
     import * as events from "events";
     import * as dns from "dns";
 
     interface RemoteInfo {
-        address: string;
-        family: string;
-        port: number;
-    }
-
-    interface AddressInfo {
         address: string;
         family: string;
         port: number;

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -2736,9 +2736,9 @@ declare module "net" {
     type LookupFunction = (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
 
     interface AddressInfo {
-      address: string;
-      family: string;
-      port: number;
+        address: string;
+        family: string;
+        port: number;
     }
 
     export interface SocketConstructorOpts {

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -1561,7 +1561,7 @@ namespace dgram_tests {
         ds.bind(4123, 'localhost', () => { });
         ds.bind(4123, () => { });
         ds.bind(() => { });
-        var ai: dgram.AddressInfo = ds.address();
+        var ai: net.AddressInfo = ds.address();
         ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
         });
         ds.send(new Buffer("hello"), 5000, "127.0.0.1");
@@ -1574,7 +1574,7 @@ namespace dgram_tests {
         let _boolean: boolean;
         let _err: Error;
         let _str: string;
-        let _rinfo: dgram.AddressInfo;
+        let _rinfo: net.AddressInfo;
         /**
          * events.EventEmitter
          * 1. close
@@ -1590,7 +1590,7 @@ namespace dgram_tests {
         _socket = _socket.addListener("listening", () => { });
         _socket = _socket.addListener("message", (msg, rinfo) => {
             let _msg: Buffer = msg;
-            let _rinfo: dgram.AddressInfo = rinfo;
+            let _rinfo: net.AddressInfo = rinfo;
         });
 
         _boolean = _socket.emit("close");
@@ -1605,7 +1605,7 @@ namespace dgram_tests {
         _socket = _socket.on("listening", () => { });
         _socket = _socket.on("message", (msg, rinfo) => {
             let _msg: Buffer = msg;
-            let _rinfo: dgram.AddressInfo = rinfo;
+            let _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.once("close", () => { });
@@ -1615,7 +1615,7 @@ namespace dgram_tests {
         _socket = _socket.once("listening", () => { });
         _socket = _socket.once("message", (msg, rinfo) => {
             let _msg: Buffer = msg;
-            let _rinfo: dgram.AddressInfo = rinfo;
+            let _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.prependListener("close", () => { });
@@ -1625,7 +1625,7 @@ namespace dgram_tests {
         _socket = _socket.prependListener("listening", () => { });
         _socket = _socket.prependListener("message", (msg, rinfo) => {
             let _msg: Buffer = msg;
-            let _rinfo: dgram.AddressInfo = rinfo;
+            let _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.prependOnceListener("close", () => { });
@@ -1635,7 +1635,7 @@ namespace dgram_tests {
         _socket = _socket.prependOnceListener("listening", () => { });
         _socket = _socket.prependOnceListener("message", (msg, rinfo) => {
             let _msg: Buffer = msg;
-            let _rinfo: dgram.AddressInfo = rinfo;
+            let _rinfo: net.AddressInfo = rinfo;
         });
     }
 
@@ -2783,11 +2783,8 @@ namespace net_tests {
         // specified, so any callback function is permissible.
         server = server.close((...args: any[]) => { });
 
-        // test the types of the address object fields
-        let address = server.address();
-        address.port = 1234;
-        address.family = "ipv4";
-        address.address = "127.0.0.1";
+        // test the types of the address
+        let address: net.AddressInfo | string | null = server.address();
     }
 
     {

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -3313,7 +3313,7 @@ declare module "net" {
         listen(handle: any, backlog?: number, listeningListener?: Function): this;
         listen(handle: any, listeningListener?: Function): this;
         close(callback?: Function): this;
-        address(): AddressInfo | string;
+        address(): AddressInfo | string | null;
         getConnections(cb: (error: Error | null, count: number) => void): void;
         ref(): this;
         unref(): this;

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -2821,8 +2821,8 @@ namespace net_tests {
         // specified, so any callback function is permissible.
         server = server.close((...args: any[]) => { });
 
-        // test the types of the address object fields
-        let address: net.AddressInfo | string = server.address();
+        // test the types of the address
+        let address: net.AddressInfo | string | null = server.address();
     }
 
     {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31955#issue-396742996
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I was not able to do `npm run test` locally because it fails on unrelated packages.

This behaviour:
```
const net = require('net');
const server = net.createServer();
server.address() === null // => true
```
is consistent for all the `node` versions (although `require('net')` is not needed for `node` version 4 and below, it's already in scope), so I guess the change should be applied to all versions. But before I'll  dig into it, I'd love someone to have a look at my approach with v8.