### PR TITLE
[forever-monitor] Fix typo in option name

### DIFF
--- a/types/forever-monitor/index.d.ts
+++ b/types/forever-monitor/index.d.ts
@@ -25,7 +25,7 @@ export interface Options {
     sourceDir?: string;
     watch?: boolean;
     watchIgnoreDotFiles?: boolean;
-    watchIgnorePatters?: string[];
+    watchIgnorePatterns?: string[];
     watchDirectory?: string;
     spawnWith?: SpawnWith;
     env?: NodeJS.ProcessEnv;


### PR DESCRIPTION
Replace "watchIgnorePatters" with "watchIgnorePatterns" in Options interface.
[forever-monitor readme](https://github.com/foreverjs/forever-monitor#options-available-when-using-forever-in-nodejs)
