### PR TITLE
[weixin-app] Add type-safe behavior

### DIFF
--- a/types/weixin-app/index.d.ts
+++ b/types/weixin-app/index.d.ts
@@ -4,7 +4,7 @@
 //                 AlexStacker <https://github.com/AlexStacker>
 //                 Jimexist <https://github.com/Jimexist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 declare namespace wx {
 	// #region 基本参数
@@ -3729,13 +3729,44 @@ declare namespace wx {
 
 	type DefaultProps = object | Record<string, any>;
 
+	type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((
+		k: infer I,
+	) => void)
+		? I
+		: never;
+
+	type ArrayType<T extends any[]> = T extends Array<infer R> ? R : never;
+
+	interface Behavior<Data, Props, Methods> {
+		__DO_NOT_USE_INTERNAL_FIELD_DATA: Data;
+		__DO_NOT_USE_INTERNAL_FIELD_PROPS: Props;
+		__DO_NOT_USE_INTERNAL_FIELD_METHODS: Methods;
+	}
+
+  type UnboxBehaviorData<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_DATA'] : {};
+  type UnboxBehaviorProps<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_PROPS'] : {};
+	type UnboxBehaviorMethod<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_METHODS'] : {};
+
+  type UnboxBehaviorsMethods<
+    Behaviors extends Array<Behavior<{}, {}, {}> | string>
+	> = UnionToIntersection<UnboxBehaviorMethod<ArrayType<Behaviors>>>;
+
+  type UnboxBehaviorsData<
+    Behaviors extends Array<Behavior<{}, {}, {}> | string>
+	> = UnionToIntersection<UnboxBehaviorData<ArrayType<Behaviors>>>;
+
+  type UnboxBehaviorsProps<
+    Behaviors extends Array<Behavior<{}, {}, {}> | string>
+	> = UnionToIntersection<UnboxBehaviorProps<ArrayType<Behaviors>>>;
+
 	// CombinedInstance models the `this`, i.e. instance type for (user defined) component
 	type CombinedInstance<
-		Instance extends Component<Data, Props>,
+		Instance extends Component<Data, Props, Behaviors>,
 		Data,
 		Methods,
-		Props
-	> = Methods & Instance;
+		Props,
+    Behaviors extends Array<Behavior<{}, {}, {}> | string>
+	> = Methods & Instance & UnboxBehaviorsMethods<Behaviors>;
 
 	type Prop<T> = (() => T) | { new (...args: any[]): T & object };
 
@@ -3773,13 +3804,14 @@ declare namespace wx {
 		unlinked?: (target: Component<D, P>) => void;
 	}
 	type ThisTypedComponentOptionsWithRecordProps<
-		V extends Component<Data, Props>,
+		V extends Component<Data, Props, Behaviors>,
 		Data,
 		Methods,
-		Props
+		Props,
+    Behaviors extends Array<Behavior<{}, {}, {}> | string>
 	> = object &
-		ComponentOptions<V, Data, Methods, Props> &
-		ThisType<CombinedInstance<V, Data, Methods, Readonly<Props>>>;
+		ComponentOptions<V, Data, Methods, Props, Behaviors> &
+		ThisType<CombinedInstance<V, Data, Methods, Readonly<Props>, Behaviors>>;
 
 	interface ComponentRelation<D = any, P = any> {
 		/** 目标组件的相对关系，可选的值为 parent 、 child 、 ancestor 、 descendant */
@@ -3836,10 +3868,11 @@ declare namespace wx {
 	 * Component组件参数
 	 */
 	interface ComponentOptions<
-		Instance extends Component<Data, Props>,
+		Instance extends Component<Data, Props, Behaviors>,
 		Data = DefaultData<Instance>,
 		Methods = DefaultMethods<Instance>,
-		Props = PropsDefinition<DefaultProps>
+		Props = PropsDefinition<DefaultProps>,
+    Behaviors extends Array<Behavior<{}, {}, {}> | string> = []
 	> extends Partial<Lifetimes> {
 		/**
 		 * 组件的对外属性，是属性名到属性设置的映射表
@@ -3892,7 +3925,7 @@ declare namespace wx {
 		 * 类似于mixins和traits的组件间代码复用机制
 		 * 参见 [behaviors](https://mp.weixin.qq.com/debug/wxadoc/dev/framework/custom-component/behaviors.html)
 		 */
-		behaviors?: string[];
+    behaviors?: Behaviors;
 
 		/**
 		 * 组件生命周期声明对象，组件的生命周期：created、attached、ready、moved、detached将收归到lifetimes字段内进行声明，
@@ -3932,7 +3965,7 @@ declare namespace wx {
 	/**
 	 * Component实例方法
 	 */
-	interface Component<D, P> {
+	interface Component<D, P, B extends Array<Behavior<{}, {}, {}> | string> = []> {
 		/**
 		 * 组件的文件路径
 		 */
@@ -3948,12 +3981,20 @@ declare namespace wx {
 		/**
 		 * 组件数据，包括内部数据和属性值
 		 */
-		data: D & { [key in keyof P]: PropValueType<P[key]> };
+    data: D & UnboxBehaviorsData<B> & {
+      [key in keyof (P & UnboxBehaviorsProps<B>)]: PropValueType<
+        (P & UnboxBehaviorsProps<B>)[key]
+      >
+    };
 
 		/**
 		 * 组件数据，包括内部数据和属性值（与 data 一致）
 		 */
-		properties: D & { [key in keyof P]: PropValueType<P[key]> };
+    properties: D & UnboxBehaviorsData<B> & {
+      [key in keyof (P & UnboxBehaviorsProps<B>)]: PropValueType<
+        (P & UnboxBehaviorsProps<B>)[key]
+      >
+    };
 		/**
 		 * 将数据从逻辑层发送到视图层，同时改变对应的 this.data 的值
 		 * 1. 直接修改 this.data 而不调用 this.setData 是无法改变页面的状态的，还会造成数据不一致。
@@ -4356,12 +4397,13 @@ declare function App<T extends wx.AppOptions>(
 declare function getApp(): wx.App;
 // #endregion
 // #region Compontent组件
-declare function Component<D, M, P>(
+declare function Component<D, M, P, B extends Array<wx.Behavior<{}, {}, {}> | string> = []>(
 	options?: wx.ThisTypedComponentOptionsWithRecordProps<
-		wx.Component<D, P>,
+		wx.Component<D, P, B>,
 		D,
 		M,
-		P
+		P,
+		B
 	>
 ): string;
 /**
@@ -4372,14 +4414,15 @@ declare function Component<D, M, P>(
  * 每个组件可以引用多个 behavior
  * behavior 也可以引用其他 behavior
  */
-declare function Behavior<D, M, P>(
+declare function Behavior<D, M, P, B extends Array<wx.Behavior<{}, {}, {}> | string> = []>(
 	options?: wx.ThisTypedComponentOptionsWithRecordProps<
-		wx.Component<D, P>,
+		wx.Component<D, P, B>,
 		D,
 		M,
-		P
+		P,
+		B
 	>
-): string;
+): wx.Behavior<D & wx.UnboxBehaviorsData<B>, P & wx.UnboxBehaviorsProps<B>, M & wx.UnboxBehaviorsMethods<B>>;
 // #endregion
 // #region Page
 /**

--- a/types/weixin-app/weixin-app-tests.ts
+++ b/types/weixin-app/weixin-app-tests.ts
@@ -8,8 +8,25 @@ interface MyOwnEvent
 		}
 	> {}
 
-let behavior = Behavior({
-	behaviors: [],
+const parentBehavior = Behavior({
+	behaviors: ["wx://form-field"],
+	properties: {
+		myParentBehaviorProperty: {
+			type: String
+		}
+	},
+	data: {
+		myParentBehaviorData: "",
+	},
+	methods: {
+		myParentBehaviorMethod(input: number) {
+			const s: string = this.data.myParentBehaviorData;
+		}
+	}
+});
+
+const behavior = Behavior({
+	behaviors: [parentBehavior, "wx://form-field"],
 	properties: {
 		myBehaviorProperty: {
 			type: String
@@ -20,7 +37,7 @@ let behavior = Behavior({
 	},
 	attached() {},
 	methods: {
-		myBehaviorMethod() {
+		myBehaviorMethod(input: number) {
 			const s: string = this.data.myBehaviorData;
 		}
 	}
@@ -102,6 +119,14 @@ Component({
 	detached() {},
 
 	methods: {
+		testBehaviors() {
+			console.log(this.data.myBehaviorData);
+			console.log(this.data.myBehaviorProperty);
+			this.myBehaviorMethod(123);
+			console.log(this.data.myParentBehaviorData);
+			console.log(this.data.myParentBehaviorProperty);
+			this.myParentBehaviorMethod(456);
+		},
 		readMyDataAndMyProps() {
 			const stringValue1: string = this.data.myProperty;
 			const stringValue2: string = this.data.myProperty2;


### PR DESCRIPTION
# What

The type-safe behavior means TS can automatically infer component's `data` / `methods` / `properties` from its [behaviors](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/behaviors.html).

For example:

```ts
const behavior = Behavior({
  properties: {
    myBehaviorProperty: {
      type: String
    }
  },
  data: {
    myBehaviorData: ""
  },
  attached() {},
  methods: {
    myBehaviorMethod(input: number) {
      const s: string = this.data.myBehaviorData;
    }
  }
});

Component({
  behaviors: [behavior, "wx://form-field"],
  methods: {
    run() {
      console.log(this.data.myBehaviorData); // infer from behaviors' data
      console.log(this.data.myBehaviorProperty); // infer from behaviors' properties
      this.myBehaviorMethod(123); // infer from behaviors' methods
    }
  }
});
```

# Why

A use case is that if you use Redux in WeChat Mini Program with a `connect` behavior like this:

```ts
Component({
  behavior: [connect(store)(mapStateToProps, mapDispatchToProps)],
  methods: {
    onXxxClick() {
      console.log(this.data.myFieldFromReudxStore);
    },
  },
});
```

The `mapStateToProps` and `mapDispatchToProps` will add some fields / methods to `data` / `properties`. 

# How

Although function `Behavior` return `string` in runtime ( see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31965 ) it is an internal type that user should not relay on. So it is possible to implement an alternative internal `wx.Behavior` type to solve this issue.

For more detail, function `Behavior` return a new type `wx.Behavior<Data, Props, Methods>` and `behaviors` in `ComponentOptions` can accept `Array<wx.Behavior<{}, {}, {}> | string>` ( to support [internal behaviors](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/behaviors.html#%E5%86%85%E7%BD%AE-behaviors) ) so that `Component` could infer `this` type for its methods / lifecycles / observer and so on .

# Dependencies

This PR should be merge after these merged:

* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31960
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31965

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
