### PR TITLE
@types/solr-client : Fix for a typo in deleteByID method name that breaks usage

### DIFF
--- a/types/solr-client/index.d.ts
+++ b/types/solr-client/index.d.ts
@@ -147,7 +147,7 @@ export interface Client {
     softCommit(callback?: (err: Error, data: object) => void): ClientRequest;
     delete(field: string, text: string, options?: Options, callback?: (err: Error, data: object) => void): ClientRequest;
     deleteByRange(field: string, start: string | Date, stop: string | Date, options?: object, callback?: (err: Error, data: object) => void): ClientRequest;
-    deleteById(id: string | number, options?: Options, callback?: (err: Error, data: object) => void): ClientRequest;
+    deleteByID(id: string | number, options?: Options, callback?: (err: Error, data: object) => void): ClientRequest;
     deleteByQuery(query: string, options?: Options, callback?: (err: Error, data: object) => void): ClientRequest;
     deleteAll(options?: Options, callback?: (err: Error, data: object) => void): ClientRequest;
     optimize(options: object, callback?: (err: Error, data: object) => void): ClientRequest;


### PR DESCRIPTION
In code is deleteByID, in definition was deleteById.
Reference to package source code
https://github.com/lbdremy/solr-node-client/blob/master/lib/solr.js
