### PR TITLE
[parse] Update cloud code definitions for Parse server 3.X

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -7,6 +7,7 @@
 //                  Wes Grimes <https://github.com/wesleygrimes>
 //                  Otherwise SAS <https://github.com/owsas>
 //                  Andrew Goldis <https://github.com/agoldis>
+//                  Alexandre Hétu Rivard <https://github.com/AlexandreHetu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -490,7 +491,7 @@ declare namespace Parse {
 
     /**
      * Represents a LiveQuery Subscription.
-     * 
+     *
      * @see https://docs.parseplatform.org/js/guide/#live-queries
      * @see NodeJS.EventEmitter
      *
@@ -556,7 +557,7 @@ subscription.on('close', () => {});
     class LiveQuerySubscription extends NodeJS.EventEmitter {
         /**
          * Creates an instance of LiveQuerySubscription.
-         * 
+         *
          * @param {string} id
          * @param {string} query
          * @param {string} [sessionToken]
@@ -692,12 +693,7 @@ subscription.on('close', () => {});
 
         interface JobRequest {
             params: any;
-        }
-
-        interface JobStatus {
-            error?: (response: any) => void;
             message?: (response: any) => void;
-            success?: (response: any) => void;
         }
 
         interface FunctionRequest {
@@ -705,12 +701,6 @@ subscription.on('close', () => {});
             master?: boolean;
             params?: any;
             user?: User;
-        }
-
-        interface FunctionResponse {
-            success: (response: any) => void;
-            error (code: number, response: any): void;
-            error (response: any): void;
         }
 
         interface Cookie {
@@ -734,11 +724,7 @@ subscription.on('close', () => {});
         interface AfterSaveRequest extends TriggerRequest { }
         interface AfterDeleteRequest extends TriggerRequest { }
         interface BeforeDeleteRequest extends TriggerRequest { }
-        interface BeforeDeleteResponse extends FunctionResponse { }
         interface BeforeSaveRequest extends TriggerRequest { }
-        interface BeforeSaveResponse extends FunctionResponse {
-            success: () => void;
-        }
 
         // Read preference describes how MongoDB driver route read operations to the members of a replica set.
         enum ReadPreferenceOption {
@@ -760,19 +746,16 @@ subscription.on('close', () => {});
             objects: Object[]
         }
 
-        interface AfterFindResponse extends FunctionResponse {
-            success: (objects: Object[]) => void;
-        }
-
-        function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => void): void;
-        function afterSave(arg1: any, func?: (request: AfterSaveRequest) => void): void;
-        function beforeDelete(arg1: any, func?: (request: BeforeDeleteRequest, response: BeforeDeleteResponse) => void): void;
-        function beforeSave(arg1: any, func?: (request: BeforeSaveRequest, response: BeforeSaveResponse) => void): void;
-        function beforeFind(arg1: any, func?: (request: BeforeFindRequest) => void): void;
-        function afterFind(arg1: any, func?: (request: AfterFindRequest, response: AfterFindResponse) => void): void;
-        function define(name: string, func?: (request: FunctionRequest, response: FunctionResponse) => void): void;
+        function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => Promise<void> | void): void;
+        function afterSave(arg1: any, func?: (request: AfterSaveRequest) => Promise<void> | void): void;
+        function beforeDelete(arg1: any, func?: (request: BeforeDeleteRequest) => Promise<void> | void): void;
+        function beforeSave(arg1: any, func?: (request: BeforeSaveRequest) => Promise<void> | void): void;
+        function beforeFind(arg1: any, func?: (request: BeforeFindRequest) => Promise<void> | void): void;
+        function beforeFind(arg1: any, func?: (request: BeforeFindRequest) => Promise<Query> | Query): void;
+        function afterFind(arg1: any, func?: (request: AfterFindRequest) => Promise<any> | any): void;
+        function define(name: string, func?: (request: FunctionRequest) => Promise<any> | any): void;
         function httpRequest(options: HTTPOptions): Promise<HttpResponse>;
-        function job(name: string, func?: (request: JobRequest, status: JobStatus) => void): HttpResponse;
+        function job(name: string, func?: (request: JobRequest) => Promise<void> | void): HttpResponse;
         function run(name: string, data?: any, options?: RunOptions): Promise<any>;
         function useMasterKey(): void;
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse 2.1.0
+// Type definitions for parse 2.1.0 and parse-server 3.1.3
 // Project: https://parseplatform.org/
 // Definitions by:  Ullisen Media Group <http://ullisenmedia.com>
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>
@@ -693,7 +693,7 @@ subscription.on('close', () => {});
 
         interface JobRequest {
             params: any;
-            message?: (response: any) => void;
+            message: (response: any) => void;
         }
 
         interface FunctionRequest {

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse 2.1.0 and parse-server 3.1.3
+// Type definitions for parse 2.1.0
 // Project: https://parseplatform.org/
 // Definitions by:  Ullisen Media Group <http://ullisenmedia.com>
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -389,17 +389,29 @@ function test_cloud_functions() {
         request.readPreference = Parse.Cloud.ReadPreferenceOption.Nearest
     });
 
-  Parse.Cloud.beforeFind('MyCustomClass', (request: Parse.Cloud.BeforeFindRequest) => {
-    let query = request.query; // the Parse.Query
+    Parse.Cloud.beforeFind('MyCustomClass', (request: Parse.Cloud.BeforeFindRequest) => {
+        let query = request.query; // the Parse.Query
 
-    return new Parse.Query("QueryMe!");
-  });
+        return new Parse.Query("QueryMe!");
+    });
 
-  Parse.Cloud.beforeFind('MyCustomClass', async (request: Parse.Cloud.BeforeFindRequest) => {
-    let query = request.query; // the Parse.Query
+    Parse.Cloud.beforeFind('MyCustomClass', async (request: Parse.Cloud.BeforeFindRequest) => {
+        let query = request.query; // the Parse.Query
 
-    return new Parse.Query("QueryMe, IN THE FUTURE!");
-  });
+        return new Parse.Query("QueryMe, IN THE FUTURE!");
+    });
+
+    Parse.Cloud.afterFind('MyCustomClass', async (request: Parse.Cloud.AfterFindRequest) => {
+        return new Parse.Object('MyCustomClass');
+    });
+
+    Parse.Cloud.define('AFunc', (request: Parse.Cloud.FunctionRequest) => {
+        return 'Some result';
+    });
+
+    Parse.Cloud.job('AJob', (request: Parse.Cloud.JobRequest) => {
+        request.message('Message to associate with this job run');
+    });
 }
 
 class PlaceObject extends Parse.Object { }

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -126,7 +126,7 @@ function test_query() {
     // Find objects with distinct key
     query.distinct('name');
 
-    const testQuery = Parse.Query.or(query, query);   
+    const testQuery = Parse.Query.or(query, query);
 }
 
 async function test_query_promise() {
@@ -348,30 +348,30 @@ function test_cloud_functions() {
         // result
     });
 
-    Parse.Cloud.beforeDelete('MyCustomClass', (request: Parse.Cloud.BeforeDeleteRequest,
-        response: Parse.Cloud.BeforeDeleteResponse) => {
+    Parse.Cloud.beforeDelete('MyCustomClass', (request: Parse.Cloud.BeforeDeleteRequest) => {
+        // result
+    });
+
+    Parse.Cloud.beforeDelete('MyCustomClass', async (request: Parse.Cloud.BeforeDeleteRequest) => {
         // result
     });
 
     const CUSTOM_ERROR_INVALID_CONDITION = 1001
     const CUSTOM_ERROR_IMMUTABLE_FIELD = 1002
 
-    Parse.Cloud.beforeSave('MyCustomClass', (request: Parse.Cloud.BeforeSaveRequest,
-        response: Parse.Cloud.BeforeSaveResponse) => {
-
+    Parse.Cloud.beforeSave('MyCustomClass', async (request: Parse.Cloud.BeforeSaveRequest) => {
             if (request.object.isNew()) {
-                if (!request.object.has('immutable')) return response.error('Field immutable is required')
+                if (!request.object.has('immutable')) throw new Error('Field immutable is required')
             } else {
                 const original = request.original;
                 if (original == null) { // When the object is not new, request.original must be defined
-                    return response.error(CUSTOM_ERROR_INVALID_CONDITION, 'Original must me defined for an existing object')
+                    throw new Parse.Error(CUSTOM_ERROR_INVALID_CONDITION, 'Original must me defined for an existing object')
                 }
 
                 if (original.get('immutable') !== request.object.get('immutable')) {
-                    return response.error(CUSTOM_ERROR_IMMUTABLE_FIELD, 'This field cannot be changed')
+                    throw new Parse.Error(CUSTOM_ERROR_IMMUTABLE_FIELD, 'This field cannot be changed')
                 }
             }
-            response.success()
     });
 
     Parse.Cloud.beforeFind('MyCustomClass', (request: Parse.Cloud.BeforeFindRequest) => {
@@ -388,6 +388,18 @@ function test_cloud_functions() {
         request.readPreference = Parse.Cloud.ReadPreferenceOption.SecondaryPreferred
         request.readPreference = Parse.Cloud.ReadPreferenceOption.Nearest
     });
+
+  Parse.Cloud.beforeFind('MyCustomClass', (request: Parse.Cloud.BeforeFindRequest) => {
+    let query = request.query; // the Parse.Query
+
+    return new Parse.Query("QueryMe!");
+  });
+
+  Parse.Cloud.beforeFind('MyCustomClass', async (request: Parse.Cloud.BeforeFindRequest) => {
+    let query = request.query; // the Parse.Query
+
+    return new Parse.Query("QueryMe, IN THE FUTURE!");
+  });
 }
 
 class PlaceObject extends Parse.Object { }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://parseplatform.org/parse-server/api/master/Parse.Cloud.html
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The cloud code definitions in the JS SDK project do not correspond to the actual code in Parse-Server. Since Parse Server 3.X, only Promises or raw returns are supported by cloud functions. This PR makes sure that the definitions match the Parse Server cloud code documentation.