### PR TITLE
Fix typo on "readOnly" props for react-draft-wysiwyg

### DIFF
--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -1,11 +1,12 @@
 // Type definitions for react-draft-wysiwyg 1.12
 // Project: https://github.com/jpuri/react-draft-wysiwyg#readme
 // Definitions by: imechZhangLY <https://github.com/imechZhangLY>
+//                 brunoMaurice <https://github.com/brunoMaurice>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from 'react';
-import * as Draft from 'draft-js';
+import * as React from "react";
+import * as Draft from "draft-js";
 
 export type SyntheticKeyboardEvent = React.KeyboardEvent<{}>;
 export type SyntheticEvent = React.SyntheticEvent<{}>;
@@ -51,7 +52,7 @@ export interface EditorProps {
     mention?: object;
     hashtag?: object;
     textAlignment?: string;
-    readonly?: boolean;
+    readOnly?: boolean;
     tabIndex?: number;
     placeholder?: string;
     ariaLabel?: string;
@@ -65,7 +66,12 @@ export interface EditorProps {
     wrapperId?: number;
     customDecorators?: object[];
     editorRef?(ref: object): void;
-    handlePastedText?(text: string, html: string, editorState: EditorState, onChange: (editorState: EditorState) => void): boolean;
+    handlePastedText?(
+        text: string,
+        html: string,
+        editorState: EditorState,
+        onChange: (editorState: EditorState) => void
+    ): boolean;
 }
 
 export class Editor extends React.Component<EditorProps> {

--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -5,8 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import * as Draft from "draft-js";
+import * as React from 'react';
+import * as Draft from 'draft-js';
 
 export type SyntheticKeyboardEvent = React.KeyboardEvent<{}>;
 export type SyntheticEvent = React.SyntheticEvent<{}>;
@@ -66,12 +66,7 @@ export interface EditorProps {
     wrapperId?: number;
     customDecorators?: object[];
     editorRef?(ref: object): void;
-    handlePastedText?(
-        text: string,
-        html: string,
-        editorState: EditorState,
-        onChange: (editorState: EditorState) => void
-    ): boolean;
+    handlePastedText?(text: string, html: string, editorState: EditorState, onChange: (editorState: EditorState) => void): boolean;
 }
 
 export class Editor extends React.Component<EditorProps> {


### PR DESCRIPTION
A little fix for a props named "readonly" instead of "readOnly"

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with npm test.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run npm run lint package-name (or tsc if no tslint.json is present).
Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://draftjs.org/docs/api-reference-editor.html#readonly
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }.