### PR TITLE
Allow dynamic CSS values based on component props in react-jss

### DIFF
--- a/types/react-jss/index.d.ts
+++ b/types/react-jss/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-jss 8.6
 // Project: https://github.com/cssinjs/react-jss#readme
 // Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
+//                 James Lawrence <https://github.com/jlaw90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { createGenerateClassName, JSS, SheetsRegistry } from "jss";

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -53,26 +53,35 @@ export type PropsOf<C> = C extends new (props: infer P) => React.Component
  */
 export type PropInjector<InjectedProps, AdditionalProps = {}> = <
   C extends React.ComponentType<ConsistentWith<PropsOf<C>, InjectedProps>>
->(
+  >(
   component: C
 ) => React.ComponentType<
   Omit<JSX.LibraryManagedAttributes<C, PropsOf<C>>, keyof InjectedProps> &
-    AdditionalProps
->;
+  AdditionalProps
+  >;
 
-export interface CSSProperties extends CSS.Properties<number | string> {
+type cssNumberOrString = CSS.Properties<number | string>
+
+// Allow functions that take the properties of the component and return a CSS value
+export type CssRule<Props> = {
+  [K in keyof cssNumberOrString]:
+  | (cssNumberOrString[K])
+  | ((props: Props) => cssNumberOrString[K])
+}[keyof CSS.Properties]
+
+export interface CSSProperties<Props> {
   // Allow pseudo selectors and media queries
   [k: string]:
-    | CSS.Properties<number | string>[keyof CSS.Properties]
-    | CSSProperties;
+    | CssRule<Props>
+    | CSSProperties<Props>;
 }
-export type Styles<ClassKey extends string = string> = Record<
+export type Styles<ClassKey extends string = string, Props = {}> = Record<
   ClassKey,
-  CSSProperties
->;
-export type StyleCreator<C extends string = string, T extends {} = {}> = (
+  CSSProperties<Props>
+  >;
+export type StyleCreator<C extends string = string, T extends {} = {}, Props = {}> = (
   theme: T
-) => Styles<C>;
+) => Styles<C, Props>;
 
 export interface Theming {
   channel: string;
@@ -89,15 +98,16 @@ export interface InjectOptions extends CreateStyleSheetOptions {
 export type ClassNameMap<C extends string> = Record<C, string>;
 export type WithSheet<
   S extends string | Styles | StyleCreator<string, any>,
-  GivenTheme = undefined
-> = {
+  GivenTheme = undefined,
+  Props = {}
+  > = {
   classes: ClassNameMap<
     S extends string
       ? S
-      : S extends StyleCreator<infer C, any>
-        ? C
-        : S extends Styles<infer C> ? C : never
-  >;
+      : S extends StyleCreator<infer C, any, Props>
+      ? C
+      : S extends Styles<infer C, Props> ? C : never
+    >;
 } & WithTheme<S extends StyleCreator<string, infer T> ? T : GivenTheme>;
 
 export interface WithTheme<T> {
@@ -110,7 +120,7 @@ export interface StyledComponentProps<ClassKey extends string = string> {
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function injectSheet<C extends string, T extends object>(
-  stylesOrCreator: Styles<C> | StyleCreator<C, T>,
+export default function injectSheet<C extends string, T extends object, Props = {}>(
+  stylesOrCreator: Styles<C, Props> | StyleCreator<C, T, Props>,
   options?: InjectOptions
-): PropInjector<WithSheet<C, T>, StyledComponentProps<C>>;
+): PropInjector<WithSheet<C, T, Props>, StyledComponentProps<C>>;

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -60,14 +60,12 @@ export type PropInjector<InjectedProps, AdditionalProps = {}> = <
   AdditionalProps
   >;
 
-type cssNumberOrString = CSS.Properties<number | string>
-
 // Allow functions that take the properties of the component and return a CSS value
 export type CssRule<Props> = {
-  [K in keyof cssNumberOrString]:
-  | (cssNumberOrString[K])
-  | ((props: Props) => cssNumberOrString[K])
-}[keyof CSS.Properties]
+  [K in keyof CSS.Properties<number | string>]:
+  | (CSS.Properties<number | string>[K])
+  | ((props: Props) => CSS.Properties<number | string>[K])
+}[keyof CSS.Properties];
 
 export interface CSSProperties<Props> {
   // Allow pseudo selectors and media queries

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -61,16 +61,16 @@ export type PropInjector<InjectedProps, AdditionalProps = {}> = <
   >;
 
 // Allow functions that take the properties of the component and return a CSS value
-export type CssRule<Props> = {
+export type DynamicCSSRule<Props> = {
   [K in keyof CSS.Properties<number | string>]:
-  | (CSS.Properties<number | string>[K])
+  | CSS.Properties<number | string>[K]
   | ((props: Props) => CSS.Properties<number | string>[K])
 }[keyof CSS.Properties];
 
 export interface CSSProperties<Props> {
   // Allow pseudo selectors and media queries
   [k: string]:
-    | CssRule<Props>
+    | DynamicCSSRule<Props>
     | CSSProperties<Props>;
 }
 export type Styles<ClassKey extends string = string, Props = {}> = Record<

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -21,7 +21,6 @@ function createStyles<Props = {}, C extends string = string>(styles: Styles<C, P
   return styles;
 }
 
-
 interface ButtonProps {
   label: string;
   active?: boolean;
@@ -29,7 +28,7 @@ interface ButtonProps {
 
 const styles = (theme: MyTheme) => createStyles({
   myButton: {
-    color: (props: ButtonProps) => props.active ? 'red': theme.color.primary,
+    color: (props: ButtonProps) => props.active ? 'red' : theme.color.primary,
     margin: 1,
     "& span": {
       fontWeight: "revert"

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -17,42 +17,44 @@ interface MyTheme {
 /**
  * helper function to counter typescripts type widening
  */
-function createStyles<C extends string>(styles: Styles<C>): Styles<C> {
+function createStyles<Props = {}, C extends string = string>(styles: Styles<C, Props>): Styles<C, Props> {
   return styles;
 }
 
-const styles = (theme: MyTheme) =>
-  createStyles({
-    myButton: {
-      color: theme.color.primary,
-      margin: 1,
-      "& span": {
-        fontWeight: "revert"
-      }
-    },
-    myLabel: {
-      fontStyle: "italic"
-    }
-  });
 
-interface ButtonProps extends WithSheet<typeof styles> {
+interface ButtonProps {
   label: string;
+  active?: boolean;
 }
 
-const Button: React.SFC<ButtonProps> = ({ classes, children }) => {
+const styles = (theme: MyTheme) => createStyles({
+  myButton: {
+    color: (props: ButtonProps) => props.active ? 'red': theme.color.primary,
+    margin: 1,
+    "& span": {
+      fontWeight: "revert"
+    }
+  },
+  myLabel: {
+    fontStyle: "italic"
+  }
+});
+const Button: React.SFC<ButtonProps & WithSheet<typeof styles>> = ({active, classes, children}) => {
   return (
-    <button className={classes.myButton}>
-      <span className={classes.myLabel}>{children}</span>
-    </button>
+    <>
+      <button className={classes.myButton}>
+        <span className={classes.myLabel}>{children}</span>
+      </button>
+    </>
   );
 };
 
 const ManuallyStyles = () => {
   return (
     <Button
-      classes={{ myButton: "my-button", myLabel: "my-label" }}
+      classes={{myButton: "my-button", myLabel: "my-label"}}
       label="Hello, World!"
-      theme={{ color: { primary: "red", secondary: "blue" } }}
+      theme={{color: {primary: "red", secondary: "blue"}}}
     />
   );
 };
@@ -67,7 +69,10 @@ const darkTheme: MyTheme = {
 };
 const App = () => (
   <ThemeProvider theme={darkTheme}>
-    <StyledButton label="I'm dark" />
+    <>
+      <StyledButton label="I'm dark"/>
+      <StyledButton label="I'm active" active/>
+    </>
   </ThemeProvider>
 );
 
@@ -77,7 +82,7 @@ function ssrRender(req: any, res: { send: (text: string) => any }) {
 
   const body = mockedRenderToString(
     <JssProvider classNamePrefix="dt-" registry={sheets}>
-      <StyledButton label="I come from the server" />
+      <StyledButton label="I come from the server"/>
     </JssProvider>
   );
 
@@ -87,10 +92,10 @@ function ssrRender(req: any, res: { send: (text: string) => any }) {
   return res.send(
     mockedRenderToString(
       <html>
-        <head>
-          <style type="text/css">{sheets.toString()}</style>
-        </head>
-        <body>{body}</body>
+      <head>
+        <style type="text/css">{sheets.toString()}</style>
+      </head>
+      <body>{body}</body>
       </html>
     )
   );

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -17,6 +17,7 @@ interface MyTheme {
 /**
  * helper function to counter typescripts type widening
  */
+// tslint:disable-next-line:no-unnecessary-generics
 function createStyles<Props = {}, C extends string = string>(styles: Styles<C, Props>): Styles<C> {
   return styles as Styles<C>;
 }

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -17,8 +17,8 @@ interface MyTheme {
 /**
  * helper function to counter typescripts type widening
  */
-function createStyles<Props = {}, C extends string = string>(styles: Styles<C, Props>): Styles<C, Props> {
-  return styles;
+function createStyles<Props = {}, C extends string = string>(styles: Styles<C, Props>): Styles<C> {
+  return styles as Styles<C>;
 }
 
 interface ButtonProps {

--- a/types/react-jss/tsconfig.json
+++ b/types/react-jss/tsconfig.json
@@ -15,7 +15,7 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
-        "strictFunctionTypes": false
+        "strictFunctionTypes": true
     },
     "files": [
         "index.d.ts",

--- a/types/react-jss/tsconfig.json
+++ b/types/react-jss/tsconfig.json
@@ -15,7 +15,7 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
-        "strictFunctionTypes": true
+        "strictFunctionTypes": false
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
This PR is to add typings for part of the dynamic values functionality in react-jss.

A few things I'm not happy with:
* I can't work out how to define typings for the other part of the spec (className: props => {color: 'red', etc...})
* I had to disable strict function checking in tsconfig.json to get tsc to pass with the changes made to the test file.

Would be glad if anyone has pointers or wants to look at these parts.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/cssinjs/react-jss#dynamic-values>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.