### PR TITLE
[ramda] add tuple support to head and nth

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -26,7 +26,7 @@
 //                 Drew Wyatt <https://github.com/drewwyatt>
 //                 John Ottenlips <https://github.com/jottenlips>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference path="./es/add.d.ts" />
 /// <reference path="./es/addIndex.d.ts" />
@@ -1108,6 +1108,7 @@ declare namespace R {
          * Returns the first element in a list.
          * In some libraries this function is named `first`.
          */
+        head<T>(list: [T, ...T[]]): T;
         head<T>(list: ReadonlyArray<T>): T | undefined;
         head(list: string): string;
 
@@ -1583,6 +1584,12 @@ declare namespace R {
         /**
          * Returns the nth element in a list.
          */
+        nth<T>(n: 0, list: [T, ...T[]]): T;
+        nth<T>(n: 1, list: [T, T, ...T[]]): T;
+        nth<T>(n: 2, list: [T, T, T, ...T[]]): T;
+        nth<T>(n: 3, list: [T, T, T, T, ...T[]]): T;
+        nth<T>(n: 4, list: [T, T, T, T, T, ...T[]]): T;
+        nth<T>(n: 5, list: [T, T, T, T, T, T, ...T[]]): T;
         nth<T>(n: number, list: ReadonlyArray<T>): T | undefined;
         nth(n: number): <T>(list: ReadonlyArray<T>) => T | undefined;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1108,7 +1108,7 @@ declare namespace R {
          * Returns the first element in a list.
          * In some libraries this function is named `first`.
          */
-        head<T>(list: [T, ...T[]]): T;
+        head<T>(list: [T, ...any[]]): T;
         head<T>(list: ReadonlyArray<T>): T | undefined;
         head(list: string): string;
 
@@ -1584,12 +1584,12 @@ declare namespace R {
         /**
          * Returns the nth element in a list.
          */
-        nth<T>(n: 0, list: [T, ...T[]]): T;
-        nth<T>(n: 1, list: [T, T, ...T[]]): T;
-        nth<T>(n: 2, list: [T, T, T, ...T[]]): T;
-        nth<T>(n: 3, list: [T, T, T, T, ...T[]]): T;
-        nth<T>(n: 4, list: [T, T, T, T, T, ...T[]]): T;
-        nth<T>(n: 5, list: [T, T, T, T, T, T, ...T[]]): T;
+        nth<T>(n: 0, list: [T, ...any[]]): T;
+        nth<T>(n: 1, list: [any, T, ...any[]]): T;
+        nth<T>(n: 2, list: [any, any, T, ...any[]]): T;
+        nth<T>(n: 3, list: [any, any, any, T, ...any[]]): T;
+        nth<T>(n: 4, list: [any, any, any, any, T, ...any[]]): T;
+        nth<T>(n: 5, list: [any, any, any, any, any, T, ...any[]]): T;
         nth<T>(n: number, list: ReadonlyArray<T>): T | undefined;
         nth(n: number): <T>(list: ReadonlyArray<T>) => T | undefined;
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1135,12 +1135,12 @@ interface Obj {
     R.nth(0, [0]); // $ExpectType number
     const numbers: number[] = [0]; // array instead of tuple
     R.nth(0, numbers); // $ExpectType number | undefined
-    R.nth(1, [0, 1]); // $ExpectType number
-    R.nth(2, [0, 1, 2]); // $ExpectType number
-    R.nth(3, [0, 1, 2, 3]); // $ExpectType number
-    R.nth(4, [0, 1, 2, 3, 4]); // $ExpectType number
-    R.nth(5, [0, 1, 2, 3, 4, 5]); // $ExpectType number
-    R.nth(6, [0, 1, 2, 3, 4, 5, 6]); // $ExpectType number | undefined
+    R.nth(1, ['a', 1]); // $ExpectType number
+    R.nth(2, ['a', 'b', 2]); // $ExpectType number
+    R.nth(3, ['a', 'b', 'c', 3]); // $ExpectType number
+    R.nth(4, ['a', 'b', 'c', 'd', 4]); // $ExpectType number
+    R.nth(5, ['a', 'b', 'c', 'd', 'e', 5]); // $ExpectType number
+    R.nth(6, ['a', 'b', 'c', 'd', 'e', 'f', 6]); // $ExpectType string | number | undefined
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -951,6 +951,10 @@ interface Obj {
     R.head(["10", 10]); // => '10'
     R.head("abc"); // => 'a'
     R.head(""); // => ''
+
+    const numbers: number[] = [1]; // array instead of tuple
+    R.head(numbers); // $ExpectType number | undefined
+    R.head([]); // $ExpectType undefined
 };
 
 (() => {
@@ -1127,6 +1131,16 @@ interface Obj {
     R.nth(-1, list); // => 'quux'
     R.nth(-99, list); // => undefined
     R.nth(-99)(list); // => undefined
+
+    R.nth(0, [0]); // $ExpectType number
+    const numbers: number[] = [0]; // array instead of tuple
+    R.nth(0, numbers); // $ExpectType number | undefined
+    R.nth(1, [0, 1]); // $ExpectType number
+    R.nth(2, [0, 1, 2]); // $ExpectType number
+    R.nth(3, [0, 1, 2, 3]); // $ExpectType number
+    R.nth(4, [0, 1, 2, 3, 4]); // $ExpectType number
+    R.nth(5, [0, 1, 2, 3, 4, 5]); // $ExpectType number
+    R.nth(6, [0, 1, 2, 3, 4, 5, 6]); // $ExpectType number | undefined
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`nth` covers just few basic cases