### PR TITLE
[redux-form] Fix signature of `blur` and `change` actions

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -11,6 +11,7 @@
 //                 Tim de Koning <https://github.com/reggino>
 //                 Maddi Joyce <https://github.com/maddijoyce>
 //                 Kamil Wojcik <https://github.com/smifun>
+//                 Mohamed Shaaban <https://github.com/mshaaban088>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 import {

--- a/types/redux-form/lib/actions.d.ts
+++ b/types/redux-form/lib/actions.d.ts
@@ -18,8 +18,8 @@ export declare function arraySplice(form: string, field: string, index: number, 
 export declare function arraySwap(form: string, field: string, indexA: number, indexB: number): FormAction;
 export declare function arrayUnshift(form: string, field: string, value: any): FormAction;
 export declare function autofill(form: string, field: string, value: any): FormAction;
-export declare function blur(form: string, field: string, value: any): FormAction;
-export declare function change(form: string, field: string, value: any): FormAction;
+export declare function blur(form: string, field: string, value: any, touch?: boolean): FormAction;
+export declare function change(form: string, field: string, value: any, touch?: boolean, persistentSubmitErrors?: boolean): FormAction;
 export declare function destroy(...form: string[]): FormAction;
 export declare function focus(form: string, field: string): FormAction;
 

--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for redux-form 6.6
 // Project: https://github.com/erikras/redux-form
-// Definitions by: Carson Full <https://github.com/carsonf>, Daniel Lytkin <https://github.com/aikoven>, Karol Janyst <https://github.com/LKay>, Luka Zakrajsek <https://github.com/bancek>
+// Definitions by: Carson Full <https://github.com/carsonf>
+//                 Daniel Lytkin <https://github.com/aikoven>
+//                 Karol Janyst <https://github.com/LKay>
+//                 Luka Zakrajsek <https://github.com/bancek>
+//                 Mohamed Shaaban <https://github.com/mshaaban088>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/redux-form/v6/lib/actions.d.ts
+++ b/types/redux-form/v6/lib/actions.d.ts
@@ -66,12 +66,12 @@ export function autofill(form: string, field: string, value: any): FormAction;
 /**
  * Saves the value to the field
  */
-export function blur(form: string, field: string, value: any): FormAction;
+export function blur(form: string, field: string, value: any, touch?: boolean): FormAction;
 
 /**
  * Saves the value to the field
  */
-export function change(form: string, field: string, value: any): FormAction;
+export function change(form: string, field: string, value: any, touch?: boolean, persistentSubmitErrors?: boolean): FormAction;
 
 /**
  * Destroys the form, removing all it's state


### PR DESCRIPTION
Type definitions for redux-form actions, both `blur` and `change` were not correct
 - `blur` was missing `touch` parameter
 - `change` was missing both `touch` and `persistentSubmitErrors` parameters

v6 -> https://github.com/erikras/redux-form/blob/v6.6.0/src/actions.js#L59-L63
v7 -> https://github.com/erikras/redux-form/blob/master/src/actions.js#L226-L247

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/erikras/redux-form/blob/v6.6.0/src/actions.js#L59-L63 and https://github.com/erikras/redux-form/blob/master/src/actions.js#L226-L247
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

