### PR TITLE
Activate strict function types

### DIFF
--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -161,8 +161,9 @@ accessorArcDatumNumberOrNull = svgArc.padRadius();
 
 // centroid(...) ---------------------------------------------------------------------
 
-const centroid: [number, number] = svgArc.centroid(arcDatum);
-// centroid = svgArc.centroid(arcDefaultDatum); // fails, wrong datum type
+let centroid: [number, number] = svgArc.centroid(arcDatum);
+// $ExpectError
+centroid = svgArc.centroid(arcDefaultDatum); // fails, wrong datum type
 
 // generate arc ----------------------------------------------------------------------
 
@@ -176,10 +177,13 @@ const wrongArc1: Selection<SVGCircleElement, ArcDatum, any, any> = select<SVGCir
 const wrongArc2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.arc-paths'); // mock
 
 pArc.attr('d', svgArc);
-// wrongArc1.attr('d', svgArc); // fails, incompatible this contexts
-// wrongArc2.attr('d', svgArc); // fails, incompatible datum types
+// $ExpectError
+wrongArc1.attr('d', svgArc); // fails, incompatible this contexts
+// $ExpectError
+wrongArc2.attr('d', svgArc); // fails, incompatible datum types
 
-// pathStringMaybe = svgArc(arcDatum); // fails, wrong this type for invocation
+// $ExpectError
+pathStringMaybe = svgArc(arcDatum); // fails, wrong this type for invocation
 
 // Use with custom object
 
@@ -270,13 +274,13 @@ let pie: d3Shape.Pie<any, PieDatum> = d3Shape.pie<PieDatum>();
 
 // value(...) -------------------------------------------------------------------------
 
-let defaultPieValueAccessor: (d: number | { valueOf(): number }, i?: number, data?: Array<number | { valueOf(): number }>) => number;
+let defaultPieValueAccessor: (d: number | { valueOf(): number }, i: number, data: Array<number | { valueOf(): number }>) => number;
 
 defaultPie = defaultPie.value(10);
 
 defaultPieValueAccessor = defaultPie.value();
 
-let pieValueAccessor: (d: PieDatum, i?: number, data?: PieDatum[]) => number;
+let pieValueAccessor: (d: PieDatum, i: number, data: PieDatum[]) => number;
 
 pie = pie.value((d, i, data) => {
     console.log(data.length > 0 ? data[0].val : 'no data'); // data type is Array<PieDatum>
@@ -364,8 +368,8 @@ interface LineDatum {
     missing: boolean;
 }
 
-let lineXYAccessorFn: (d: LineDatum, index?: number, data?: LineDatum[]) => number;
-let lineDefAccessorFn: (d: LineDatum, index?: number, data?: LineDatum[]) => boolean;
+let lineXYAccessorFn: (d: LineDatum, index: number, data: LineDatum[]) => number;
+let lineDefAccessorFn: (d: LineDatum, index: number, data: LineDatum[]) => boolean;
 
 interface LineRadialDatum {
     angle: number;
@@ -373,8 +377,8 @@ interface LineRadialDatum {
     missing: boolean;
 }
 
-let lineRadialAngRAccessorFn: (d: LineRadialDatum, index?: number, data?: LineRadialDatum[]) => number;
-let lineRadialDefAccessorFn: (d: LineRadialDatum, index?: number, data?: LineRadialDatum[]) => boolean;
+let lineRadialAngRAccessorFn: (d: LineRadialDatum, index: number, data: LineRadialDatum[]) => number;
+let lineRadialDefAccessorFn: (d: LineRadialDatum, index: number, data: LineRadialDatum[]) => boolean;
 
 // line(...) create Line generator =====================================================
 
@@ -541,9 +545,9 @@ interface AreaDatum {
     missing: boolean;
 }
 
-let areaXYAccessorFn: (d: AreaDatum, index?: number, data?: AreaDatum[]) => number;
-let areaXYAccessorFnMaybe: null | ((d: AreaDatum, index?: number, data?: AreaDatum[]) => number);
-let areaDefAccessorFn: (d: AreaDatum, index?: number, data?: AreaDatum[]) => boolean;
+let areaXYAccessorFn: (d: AreaDatum, index: number, data: AreaDatum[]) => number;
+let areaXYAccessorFnMaybe: null | ((d: AreaDatum, index: number, data: AreaDatum[]) => number);
+let areaDefAccessorFn: (d: AreaDatum, index: number, data: AreaDatum[]) => boolean;
 
 interface AreaRadialDatum {
     startAngle: number;
@@ -553,9 +557,9 @@ interface AreaRadialDatum {
     missing: boolean;
 }
 
-let areaRadialAngRAccessorFn: (d: AreaRadialDatum, index?: number, data?: AreaRadialDatum[]) => number;
-let areaRadialAngRAccessorFnMaybe: null | ((d: AreaRadialDatum, index?: number, data?: AreaRadialDatum[]) => number);
-let areaRadialDefAccessorFn: (d: AreaRadialDatum, index?: number, data?: AreaRadialDatum[]) => boolean;
+let areaRadialAngRAccessorFn: (d: AreaRadialDatum, index: number, data: AreaRadialDatum[]) => number;
+let areaRadialAngRAccessorFnMaybe: null | ((d: AreaRadialDatum, index: number, data: AreaRadialDatum[]) => number);
+let areaRadialDefAccessorFn: (d: AreaRadialDatum, index: number, data: AreaRadialDatum[]) => boolean;
 
 // area(...) create Area generator =====================================================
 
@@ -662,7 +666,8 @@ areaDefAccessorFn = area.defined();
 defaultArea = defaultArea.curve(d3Shape.curveLinear);
 
 area = area.curve(d3Shape.curveCardinal.tension(0.5));
-// area = area.curve(d3Shape.curveBundle.beta(0.5)); // fails, as curveBundle-based line generator does not support area-related methods
+// $ExpectError
+area = area.curve(d3Shape.curveBundle.beta(0.5)); // fails, as curveBundle-based line generator does not support area-related methods
 
 currentCurveFactory = area.curve();
 
@@ -800,7 +805,8 @@ areaRadialDefAccessorFn = areaRadial.defined();
 defaultAreaRadial = defaultAreaRadial.curve(d3Shape.curveLinear);
 
 areaRadial = areaRadial.curve(d3Shape.curveCardinal.tension(0.5));
-// areaRadial = areaRadial.curve(d3Shape.curveBundle.beta(0.5)); // fails, as curveBundle-based line generator does not support area-related methods
+// $ExpectError
+areaRadial = areaRadial.curve(d3Shape.curveBundle.beta(0.5)); // fails, as curveBundle-based line generator does not support area-related methods
 
 currentCurveFactory = areaRadial.curve();
 
@@ -868,7 +874,8 @@ curveBundleFactory = d3Shape.curveBundle.beta(0.5);
 
 lineOnlyGenerator = d3Shape.curveBundle.beta(0.5)(context!);  // force context to be non-null with post-fix for mock
 lineOnlyGenerator = d3Shape.curveBundle.beta(0.5)(path());
-// curveGenerator = d3Shape.curveBundle.beta(0.5)(context); // fails, no area related methods
+// $ExpectError
+curveGenerator = d3Shape.curveBundle.beta(0.5)(context); // fails, no area related methods
 
 let curveCardinalFactory: d3Shape.CurveCardinalFactory;
 
@@ -1153,22 +1160,28 @@ defaultLinkRadial(defaultLinkDatum);
 // vertical/horizontal
 
 pLink.attr('d', svgLink);
-// wrongLink1.attr('d', svgLink); // fails, incompatible this contexts
-// wrongLink2.attr('d', svgLink); // fails, incompatible datum types
+// $ExpectError
+wrongLink1.attr('d', svgLink); // fails, incompatible this contexts
+// $ExpectError
+wrongLink2.attr('d', svgLink); // fails, incompatible datum types
 
 pathStringMaybe = link(linkDatum);
 
-// pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
+// $ExpectError
+pathStringMaybe = svgLink(linkDatum); // fails, wrong this type for invocation
 
 // radial
 
 pLink.attr('d', svgLinkRadial);
-// wrongLink1.attr('d', svgLinkRadial); // fails, incompatible this contexts
-// wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
+// $ExpectError
+wrongLink1.attr('d', svgLinkRadial); // fails, incompatible this contexts
+// $ExpectError
+wrongLink2.attr('d', svgLinkRadial); // fails, incompatible datum types
 
 pathStringMaybe = radialLink(linkDatum);
 
-// pathStringMaybe = svgLinkRadial(linkDatum); // fails, wrong this type for invocation
+// $ExpectError
+pathStringMaybe = svgLinkRadial(linkDatum); // fails, wrong this type for invocation
 
 // -----------------------------------------------------------------------------------
 // Test Symbols
@@ -1259,10 +1272,13 @@ const wrongSymbol1: Selection<SVGCircleElement, SymbolDatum, any, any> = select<
 const wrongSymbol2: Selection<SVGPathElement, { test: string }, any, any> = select<SVGPathElement, { test: string }>('.symbol-path'); // mock
 
 pSymbol.attr('d', svgSymbol);
-// wrongSymbol1.attr('d', svgSymbol); // fails, incompatible this contexts
-// wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
+// $ExpectError
+wrongSymbol1.attr('d', svgSymbol); // fails, incompatible this contexts
+// $ExpectError
+wrongSymbol2.attr('d', svgSymbol); // fails, incompatible datum types
 
-// pathStringMaybe = svgSymbol(symbolDatum); // fails, wrong this type for invocation
+// $ExpectError
+pathStringMaybe = svgSymbol(symbolDatum); // fails, wrong this type for invocation
 
 // Use with custom object
 
@@ -1390,11 +1406,11 @@ keysAccessor = overlyComplicatedStack.keys();
 
 defaultStack = defaultStack.value(30);
 
-overlyComplicatedStack = overlyComplicatedStack.value((d, key, j, data) => {
+overlyComplicatedStack = overlyComplicatedStack.value((d, key, i, data) => {
     return d.values[key.name];
 });
 
-let valueAccessorFn: (this: any, d: StackDatum, key: StackKey, j?: number, data?: StackDatum[]) => number;
+let valueAccessorFn: (d: StackDatum, key: StackKey, i: number, data: StackDatum[]) => number;
 valueAccessorFn = overlyComplicatedStack.value();
 
 // order(...) ----------------------------------------------------------------------

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-shape module 1.2
 // Project: https://github.com/d3/d3-shape/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -38,7 +41,7 @@ export interface CanvasPath_D3Shape {
 // -----------------------------------------------------------------------------------
 
 /**
- * Interface corresponding to the minimum data type assumed by the accessor functions of the Arc generator
+ * Interface corresponding to the minimum data type assumed by the accessor functions of the Arc generator.
  */
 export interface DefaultArcObject {
     /**
@@ -385,7 +388,7 @@ export function arc<This, Datum>(): Arc<This, Datum>;
  */
 export interface PieArcDatum<T> {
     /**
-     * The input datum; the corresponding element in the input data array of the Pie generator
+     * The input datum; the corresponding element in the input data array of the Pie generator.
      */
     data: T;
     /**
@@ -439,7 +442,6 @@ export interface Pie<This, Datum> {
     /**
      * Returns the current value accessor, which defaults to a function returning the first argument passed into it.
      * The default value accessor assumes that the input data are numbers, or that they are coercible to numbers using valueOf.
-     *
      */
     value(): (d: Datum, i: number, data: Datum[]) => number;
     /**
@@ -454,7 +456,6 @@ export interface Pie<This, Datum> {
      * When a pie is generated, the value accessor will be invoked for each element in the input data array.
      * The default value accessor assumes that the input data are numbers, or that they are coercible to numbers using valueOf.
      * If your data are not simply numbers, then you should specify an accessor that returns the corresponding numeric value for a given datum.
-     *
      *
      * @param value A value accessor function, which is invoked for each element in the input data array, being passed the element d, the index i, and the array data as three arguments.
      * It returns a numeric value.
@@ -506,7 +507,6 @@ export interface Pie<This, Datum> {
      * @param comparator The value comparator takes two arguments a and b which are values derived from the input data array using the value accessor, not the data elements.
      * If the arc for a should be before the arc for b, then the comparator must return a number less than zero;
      * if the arc for a should be after the arc for b, then the comparator must return a number greater than zero; returning zero means that the relative order of a and b is unspecified.
-     *
      */
     sortValues(comparator: (a: number, b: number) => number): this;
     /**
@@ -737,7 +737,7 @@ export interface Line<Datum> {
      * Note that if a line segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
      * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
-     * @param defined A boolean constant
+     * @param defined A boolean constant.
      */
     defined(defined: boolean): this;
     /**
@@ -912,7 +912,7 @@ export interface LineRadial<Datum> {
      * Note that if a radial line segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
      * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
-     * @param defined A boolean constant
+     * @param defined A boolean constant.
      */
     defined(defined: boolean): this;
     /**
@@ -1166,7 +1166,6 @@ export interface Area<Datum> {
      * two-element array of numbers.
      *
      * If the y1 accessor is null, the previously-computed y0 value is reused for the y1 value.
-     *
      */
     y1(): ((d: Datum, index: number, data: Datum[]) => number) | null;
     /**
@@ -1209,9 +1208,9 @@ export interface Area<Datum> {
      * As a result, the generated area may have several discrete segments.
      *
      * Note that if an area segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
-     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points
+     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
-     * @param defined A boolean constant
+     * @param defined A boolean constant.
      */
     defined(defined: boolean): this;
     /**
@@ -1228,7 +1227,7 @@ export interface Area<Datum> {
      * As a result, the generated area may have several discrete segments.
      *
      * Note that if an area segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
-     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points
+     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
      * @param defined An accessor function which returns a boolean value. The accessor will be invoked for each defined element in the input data array,
      * being passed the element d, the index i, and the array data as three arguments.
@@ -1247,7 +1246,6 @@ export interface Area<Datum> {
     curve<C extends CurveFactory>(): C;
     /**
      * Sets the curve factory and returns this area generator.
-     *
      *
      * @param curve A valid curve factory.
      */
@@ -1470,7 +1468,6 @@ export interface AreaRadial<Datum> {
      * two-element array of numbers.
      *
      * If the outerRadius accessor is null, the previously-computed innerRadius value is reused for the outerRadius value.
-     *
      */
     outerRadius(): ((d: Datum, index: number, data: Datum[]) => number) | null;
     /**
@@ -1515,9 +1512,9 @@ export interface AreaRadial<Datum> {
      * As a result, the generated area may have several discrete segments.
      *
      * Note that if an area segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
-     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points
+     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
-     * @param defined A boolean constant
+     * @param defined A boolean constant.
      */
     defined(defined: boolean): this;
     /**
@@ -1533,7 +1530,7 @@ export interface AreaRadial<Datum> {
      * As a result, the generated area may have several discrete segments.
      *
      * Note that if an area segment consists of only a single point, it may appear invisible unless rendered with rounded or square line caps.
-     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points
+     * In addition, some curves such as curveCardinalOpen only render a visible segment if it contains multiple points.
      *
      * @param defined An accessor function which returns a boolean value. The accessor will be invoked for each defined element in the input data array,
      * being passed the element d, the index i, and the array data as three arguments.
@@ -1668,16 +1665,13 @@ export interface CurveGeneratorLineOnly {
 /**
  * A factory for curve generators addressing only lines, but not areas.
  */
-// This is a base interface to be extended, hence the suppression of the warning
-// tslint:disable-next-line:callable-types
-export interface CurveFactoryLineOnly {
+export type CurveFactoryLineOnly =
     /**
      * Returns a "lines only" curve generator which renders to the specified context.
      *
-     * @param context A rendering context
+     * @param context A rendering context.
      */
-    (context: CanvasRenderingContext2D | Path): CurveGeneratorLineOnly;
-}
+    (context: CanvasRenderingContext2D | Path) => CurveGeneratorLineOnly;
 
 /**
  * A minimal interface for a curve generator which supports the rendering of lines and areas.
@@ -1704,16 +1698,13 @@ export interface CurveGenerator extends CurveGeneratorLineOnly {
 /**
  * A factory for curve generators addressing both lines and areas.
  */
-// This is a base interface to be extended, hence the suppression of the warning
-// tslint:disable-next-line:callable-types
-export interface CurveFactory {
+export type CurveFactory =
     /**
      * Returns a curve generator which renders to the specified context.
      *
-     * @param context A rendering context
+     * @param context A rendering context.
      */
-    (context: CanvasRenderingContext2D | Path): CurveGenerator;
-}
+    (context: CanvasRenderingContext2D | Path) => CurveGenerator;
 
 /**
  * A curve factory for cubic basis spline generators.
@@ -1924,7 +1915,7 @@ export const curveStepBefore: CurveFactory;
 
 /**
  * An interface describing the default Link Data structure expected
- * by the Link and LinkRadial generators
+ * by the Link and LinkRadial generators.
  */
 export interface DefaultLinkObject {
     /**
@@ -2077,7 +2068,7 @@ export function linkHorizontal(): Link<any, DefaultLinkObject, [number, number]>
  *
  * The first generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The second generic corresponds to the datum type of the source/target node contained in the link object
+ * The second generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkHorizontal<LinkDatum, NodeDatum>(): Link<any, LinkDatum, NodeDatum>;
 /**
@@ -2091,7 +2082,7 @@ export function linkHorizontal<LinkDatum, NodeDatum>(): Link<any, LinkDatum, Nod
  *
  * The second generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The third generic corresponds to the datum type of the source/target node contained in the link object
+ * The third generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkHorizontal<This, LinkDatum, NodeDatum>(): Link<This, LinkDatum, NodeDatum>;
 
@@ -2111,7 +2102,7 @@ export function linkVertical(): Link<any, DefaultLinkObject, [number, number]>;
  *
  * The first generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The second generic corresponds to the datum type of the source/target node contained in the link object
+ * The second generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkVertical<LinkDatum, NodeDatum>(): Link<any, LinkDatum, NodeDatum>;
 /**
@@ -2125,7 +2116,7 @@ export function linkVertical<LinkDatum, NodeDatum>(): Link<any, LinkDatum, NodeD
  *
  * The second generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The third generic corresponds to the datum type of the source/target node contained in the link object
+ * The third generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkVertical<This, LinkDatum, NodeDatum>(): Link<This, LinkDatum, NodeDatum>;
 
@@ -2262,7 +2253,7 @@ export function linkRadial(): LinkRadial<any, DefaultLinkObject, [number, number
  *
  * The first generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The second generic corresponds to the datum type of the source/target node contained in the link object
+ * The second generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkRadial<LinkDatum, NodeDatum>(): LinkRadial<any, LinkDatum, NodeDatum>;
 /**
@@ -2276,7 +2267,7 @@ export function linkRadial<LinkDatum, NodeDatum>(): LinkRadial<any, LinkDatum, N
  *
  * The second generic corresponds to the datum type of the link object for which the link is to be generated.
  *
- * The third generic corresponds to the datum type of the source/target node contained in the link object
+ * The third generic corresponds to the datum type of the source/target node contained in the link object.
  */
 export function linkRadial<This, LinkDatum, NodeDatum>(): LinkRadial<This, LinkDatum, NodeDatum>;
 
@@ -2289,7 +2280,7 @@ export function linkRadial<This, LinkDatum, NodeDatum>(): LinkRadial<This, LinkD
  *
  * Symbol types are typically not used directly, instead being passed to symbol.type.
  * However, you can define your own symbol type implementation should none of the built-in types satisfy your needs using the following interface.
- * You can also use this low-level interface with a built-in symbol type as an alternative to the symbol generator
+ * You can also use this low-level interface with a built-in symbol type as an alternative to the symbol generator.
  */
 export interface SymbolType {
     /**
@@ -2367,7 +2358,6 @@ export interface Symbol<This, Datum> {
     type(): (this: This, d: Datum, ...args: any[]) => SymbolType;
     /**
      * Sets the symbol type to the specified symbol type and returns this symbol generator.
-     *
      *
      * @param type A constant symbol type.
      */
@@ -2485,7 +2475,7 @@ export function pointRadial(angle: number, radius: number): [number, number];
  * the difference between y0 and y1 corresponds to the computed value for this point.
  *
  * SeriesPoint is a [number, number] two-element Array with added data and index properties
- * related to the data element which formed the basis for theSeriesPoint
+ * related to the data element which formed the basis for theSeriesPoint.
  */
 export interface SeriesPoint<Datum> extends Array<number> {
     /**
@@ -2510,11 +2500,11 @@ export interface SeriesPoint<Datum> extends Array<number> {
  */
 export interface Series<Datum, Key> extends Array<SeriesPoint<Datum>> {
     /**
-     * Key of the series
+     * Key of the series.
      */
     key: Key;
     /**
-     * Index of the series in the series array returned by stack generator
+     * Index of the series in the series array returned by stack generator.
      */
     index: number;
 }
@@ -2578,7 +2568,7 @@ export interface Stack<This, Datum, Key> {
      *
      * Thus, by default the stack generator assumes that the input data is an array of objects, with each object exposing named properties with numeric values; see stack for an example.
      */
-    value(): (d: Datum, key: Key, j: number, data: Datum[]) => number;
+    value(): (d: Datum, key: Key, i: number, data: Datum[]) => number;
     /**
      * Sets the value accessor to the specified number and returns this stack generator.
      *
@@ -2591,7 +2581,7 @@ export interface Stack<This, Datum, Key> {
      * @param value A value accessor function which returns the numeric value for a given data element and key combination. The accessor function is invoked for each data element and key being passed
      * the datum, the key, index of the data element in the input data array, and the complete data array.
      */
-    value(value: (d: Datum, key: Key, j: number, data: Datum[]) => number): this;
+    value(value: (d: Datum, key: Key, i: number, data: Datum[]) => number): this;
 
     /**
      * Returns the current order accessor, which defaults to stackOrderNone; this uses the order given by the key accessor.
@@ -2683,14 +2673,14 @@ export function stack<This, Datum, Key>(): Stack<This, Datum, Key>;
 /**
  * Returns a series order such that the smallest series (according to the sum of values) is at the bottom.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  */
 export function stackOrderAscending(series: Series<any, any>): number[];
 
 /**
  * Returns a series order such that the largest series (according to the sum of values) is at the bottom.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  */
 export function stackOrderDescending(series: Series<any, any>): number[];
 
@@ -2698,28 +2688,28 @@ export function stackOrderDescending(series: Series<any, any>): number[];
  * Returns a series order such that the larger series (according to the sum of values) are on the inside and the smaller series are on the outside.
  * This order is recommended for streamgraphs in conjunction with the wiggle offset. See Stacked Graphs—Geometry & Aesthetics by Byron & Wattenberg for more information.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  */
 export function stackOrderInsideOut(series: Series<any, any>): number[];
 
 /**
  * Returns the given series order [0, 1, … n - 1] where n is the number of elements in series. Thus, the stack order is given by the key accessor.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  */
 export function stackOrderNone(series: Series<any, any>): number[];
 
 /**
  * Returns the reverse of the given series order [n - 1, n - 2, … 0] where n is the number of elements in series. Thus, the stack order is given by the reverse of the key accessor.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  */
 export function stackOrderReverse(series: Series<any, any>): number[];
 
 /**
  * Applies a zero baseline and normalizes the values for each point such that the topline is always one.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  * @param order An array of numeric indexes representing the stack order.
  */
 export function stackOffsetExpand(series: Series<any, any>, order: number[]): void;
@@ -2727,7 +2717,7 @@ export function stackOffsetExpand(series: Series<any, any>, order: number[]): vo
 /**
  * Positive values are stacked above zero, while negative values are stacked below zero.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  * @param order An array of numeric indexes representing the stack order.
  */
 export function stackOffsetDiverging(series: Series<any, any>, order: number[]): void;
@@ -2735,7 +2725,7 @@ export function stackOffsetDiverging(series: Series<any, any>, order: number[]):
 /**
  * Applies a zero baseline.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  * @param order An array of numeric indexes representing the stack order.
  */
 export function stackOffsetNone(series: Series<any, any>, order: number[]): void;
@@ -2743,7 +2733,7 @@ export function stackOffsetNone(series: Series<any, any>, order: number[]): void
 /**
  * Shifts the baseline down such that the center of the streamgraph is always at zero.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  * @param order An array of numeric indexes representing the stack order.
  */
 export function stackOffsetSilhouette(series: Series<any, any>, order: number[]): void;
@@ -2752,7 +2742,7 @@ export function stackOffsetSilhouette(series: Series<any, any>, order: number[])
  * Shifts the baseline so as to minimize the weighted wiggle of layers. This offset is recommended for streamgraphs in conjunction with the inside-out order.
  * See Stacked Graphs—Geometry & Aesthetics by Bryon & Wattenberg for more information.
  *
- * @param series A series generated by a stack generator
+ * @param series A series generated by a stack generator.
  * @param order An array of numeric indexes representing the stack order.
  */
 export function stackOffsetWiggle(series: Series<any, any>, order: number[]): void;

--- a/types/d3-shape/tsconfig.json
+++ b/types/d3-shape/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/d3-shape/tslint.json
+++ b/types/d3-shape/tslint.json
@@ -1,10 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        // TODO
-        "no-this-assignment": false,
         "unified-signatures": false,
-        "callable-types": false,
         "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
Activate strict function types. `CurveFactory` and `CurveFactoryLineOnly` may still cause some problems for `strictFunctionTypes`. But it should not in practice. So I keep it like that. It can always be changed later.

Some linting. CurveFactory and CurveFactoryLineOnly are now types (TS 2.2).
Use `$ExpectError`.

Related #23611.
