### PR TITLE
[ember-qunit] Add `options` parameter to `setupTest` and friends

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -139,4 +139,11 @@ module('foo service', function(hooks) {
     setupTest(hooks);
 });
 
+// RFC-232 equivalent of https://github.com/ember-engines/ember-engines#unitintegration-testing-for-in-repo-engines
+module('engine foo component', function(hooks) {
+    setupTest(hooks, {
+        resolver: Ember.Resolver.create()
+    });
+});
+
 start();

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Mike North <https://github.com/mike-north>
 //                 Steve Calvert <https://github.com/scalvert>
+//                 Dan Freeman <https://github.com/dfreeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -46,6 +47,13 @@ declare module 'ember-qunit' {
      */
     export function setResolver(resolver: Ember.Resolver): void;
 
+    interface SetupTestOptions {
+        /**
+         * The resolver to use when instantiating container-managed entities in the test.
+         */
+        resolver?: Ember.Resolver;
+    }
+
     /**
      * Sets up acceptance tests.
      *
@@ -58,7 +66,7 @@ declare module 'ember-qunit' {
      * * `this.pauseTest` and `this.resumeTest` - allow easy pausing/resuming of tests.
      * * `this.element` which returns the DOM element representing the application's root element.
      */
-    export function setupApplicationTest(hooks: NestedHooks): void;
+    export function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions): void;
 
     /**
      * Sets up tests that need to render snippets of templates.
@@ -79,7 +87,7 @@ declare module 'ember-qunit' {
      * * this.$(...) - When jQuery is present, executes a jQuery selector with
      * the current this.element as its root
      */
-    export function setupRenderingTest(hooks: NestedHooks): void;
+    export function setupRenderingTest(hooks: NestedHooks, options?: SetupTestOptions): void;
 
     /**
      * Sets up tests that do not need to render snippets of templates.
@@ -94,7 +102,7 @@ declare module 'ember-qunit' {
      * * this.set / this.setProperties - Allows setting values on the test context.
      * * this.get / this.getProperties - Retrieves values from the test context.
      */
-    export function setupTest(hooks: NestedHooks): void;
+    export function setupTest(hooks: NestedHooks, options?: SetupTestOptions): void;
 
     export class QUnitAdapter extends Ember.Test.Adapter { }
 


### PR DESCRIPTION
This adds support for the optional `options` hash that `setupTest`, `setupRenderingTest` and `setupApplicationTest` accept.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Engines documentation: https://github.com/ember-engines/ember-engines#unitintegration-testing-for-in-repo-engines
  - RFC-232 implementation that's delegated to: https://github.com/emberjs/ember-test-helpers/blob/7e0ab3927d0f4c081937fc6e5a86432272b2bc68/addon-test-support/%40ember/test-helpers/setup-context.ts#L154-L157