### PR TITLE
[match-sorter] Update to 2.3 and fix issues with selecting keys

### DIFF
--- a/types/match-sorter/index.d.ts
+++ b/types/match-sorter/index.d.ts
@@ -20,8 +20,8 @@ declare namespace matchSorter {
 }
 
 type ExtendedKeyOptions<T> = { key: string | ((item: T) => string) } & (
-    | { minRanking: number; threshold?: number }
-    | { maxRanking: number; threshold?: number }
+    | { minRanking: number }
+    | { maxRanking: number }
     | { threshold: number });
 
 interface Options<T> {

--- a/types/match-sorter/index.d.ts
+++ b/types/match-sorter/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Claas Ahlrichs <https://github.com/claasahl>
 //                 Christian Ruigrok <https://github.com/chrisru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare namespace matchSorter {
     namespace rankings {

--- a/types/match-sorter/index.d.ts
+++ b/types/match-sorter/index.d.ts
@@ -19,12 +19,10 @@ declare namespace matchSorter {
     }
 }
 
-interface ExtendedKeyOptions<T> {
-    minRanking?: number;
-    maxRanking?: number;
-    treshold?: number;
-    key: string | ((item: T) => string);
-}
+type ExtendedKeyOptions<T> = { key: string | ((item: T) => string) } & (
+    | { minRanking: number; threshold?: number }
+    | { maxRanking: number; threshold?: number }
+    | { threshold: number });
 
 interface Options<T> {
     keys?: Array<string | ((item: T) => string) | ExtendedKeyOptions<T>>;
@@ -39,6 +37,10 @@ interface Options<T> {
  * @param options - Some options to configure the sorter
  * @return the new sorted array
  */
-declare function matchSorter<T>(items: ReadonlyArray<T>, value: string, options?: Options<T>): T[];
+declare function matchSorter<T>(
+    items: ReadonlyArray<T>,
+    value: string,
+    options?: Options<T>
+): T[];
 
 export = matchSorter;

--- a/types/match-sorter/index.d.ts
+++ b/types/match-sorter/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for match-sorter 2.2
+// Type definitions for match-sorter 2.3
 // Project: https://github.com/kentcdodds/match-sorter#readme
 // Definitions by: Claas Ahlrichs <https://github.com/claasahl>
+//                 Christian Ruigrok <https://github.com/chrisru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace matchSorter {
@@ -18,24 +19,15 @@ declare namespace matchSorter {
     }
 }
 
-interface MinRanking {
-    minRanking: number;
-    key: string;
-}
-
-interface MaxRanking {
-    maxRanking: number;
-    key: string;
-}
-
-interface MinMaxRanking {
-    minRanking: number;
-    maxRanking: number;
-    key: string;
+interface ExtendedKeyOptions<T> {
+    minRanking?: number;
+    maxRanking?: number;
+    treshold?: number;
+    key: string | ((item: T) => string);
 }
 
 interface Options<T> {
-    keys?: Array<(string | ((item: T) => string) | MinRanking | MaxRanking | MinMaxRanking)>;
+    keys?: Array<string | ((item: T) => string) | ExtendedKeyOptions<T>>;
     threshold?: number;
     keepDiacritics?: boolean;
 }
@@ -47,6 +39,6 @@ interface Options<T> {
  * @param options - Some options to configure the sorter
  * @return the new sorted array
  */
-declare function matchSorter<T>(items: T[], value: string, options?: Options<T>): T[];
+declare function matchSorter<T>(items: ReadonlyArray<T>, value: string, options?: Options<T>): T[];
 
 export = matchSorter;

--- a/types/match-sorter/match-sorter-tests.ts
+++ b/types/match-sorter/match-sorter-tests.ts
@@ -2,129 +2,165 @@ import matchSorter = require('match-sorter');
 
 // # Basic Sample
 {
-  const list = ['hi', 'hey', 'hello', 'sup', 'yo'];
-  matchSorter(list, 'h'); // ['hi', 'hey', 'hello']
-  matchSorter(list, 'y'); // ['yo', 'hey']
-  matchSorter(list, 'z'); // []
+    const list = ['hi', 'hey', 'hello', 'sup', 'yo'];
+    matchSorter(list, 'h'); // ['hi', 'hey', 'hello']
+    matchSorter(list, 'y'); // ['yo', 'hey']
+    matchSorter(list, 'z'); // []
 }
 
 // # Advanced options
 
 // ## keys: [string]
 {
-  const objList = [
-    {name: 'Janice', color: 'Green'},
-    {name: 'Fred', color: 'Orange'},
-    {name: 'George', color: 'Blue'},
-    {name: 'Jen', color: 'Red'},
-  ];
-  matchSorter(objList, 'g', {keys: ['name', 'color']});
-  // [{name: 'George', color: 'Blue'}, {name: 'Janice', color: 'Green'}, {name: 'Fred', color: 'Orange'}]
+    const objList = [
+        { name: 'Janice', color: 'Green' },
+        { name: 'Fred', color: 'Orange' },
+        { name: 'George', color: 'Blue' },
+        { name: 'Jen', color: 'Red' }
+    ];
+    matchSorter(objList, 'g', { keys: ['name', 'color'] });
+    // [{name: 'George', color: 'Blue'}, {name: 'Janice', color: 'Green'}, {name: 'Fred', color: 'Orange'}]
 
-  matchSorter(objList, 're', {keys: ['color', 'name']});
-  // [{name: 'Jen', color: 'Red'}, {name: 'Janice', color: 'Green'}, {name: 'Fred', color: 'Orange'}, {name: 'George', color: 'Blue'}]
+    matchSorter(objList, 're', { keys: ['color', 'name'] });
+    // [{name: 'Jen', color: 'Red'}, {name: 'Janice', color: 'Green'}, {name: 'Fred', color: 'Orange'}, {name: 'George', color: 'Blue'}]
 }
 
 // ### Array of values
 {
-  const iceCreamYum = [
-    {favoriteIceCream: ['mint', 'chocolate']},
-    {favoriteIceCream: ['candy cane', 'brownie']},
-    {favoriteIceCream: ['birthday cake', 'rocky road', 'strawberry']},
-  ];
-  matchSorter(iceCreamYum, 'cc', {keys: ['favoriteIceCream']});
-  // [{favoriteIceCream: ['candy cane', 'brownie']}, {favoriteIceCream: ['mint', 'chocolate']}]
+    const iceCreamYum = [
+        { favoriteIceCream: ['mint', 'chocolate'] },
+        { favoriteIceCream: ['candy cane', 'brownie'] },
+        { favoriteIceCream: ['birthday cake', 'rocky road', 'strawberry'] }
+    ];
+    matchSorter(iceCreamYum, 'cc', { keys: ['favoriteIceCream'] });
+    // [{favoriteIceCream: ['candy cane', 'brownie']}, {favoriteIceCream: ['mint', 'chocolate']}]
 }
 
 // ### Nested Keys
 {
-  const nestedObjList = [
-    {name: {first: 'Janice'}},
-    {name: {first: 'Fred'}},
-    {name: {first: 'George'}},
-    {name: {first: 'Jen'}},
-  ];
-  matchSorter(nestedObjList, 'j', {keys: ['name.first']});
-  // [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]
+    const nestedObjList = [
+        { name: { first: 'Janice' } },
+        { name: { first: 'Fred' } },
+        { name: { first: 'George' } },
+        { name: { first: 'Jen' } }
+    ];
+    matchSorter(nestedObjList, 'j', { keys: ['name.first'] });
+    // [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]
 }
 {
-  const nestedObjList = [
-    {name: [{first: 'Janice'}]},
-    {name: [{first: 'Fred'}]},
-    {name: [{first: 'George'}]},
-    {name: [{first: 'Jen'}]},
-  ];
-  matchSorter(nestedObjList, 'j', {keys: ['name.0.first']});
-  // [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]
-  // matchSorter(nestedObjList, 'j', {keys: ['name[0].first']}) does not work
+    const nestedObjList = [
+        { name: [{ first: 'Janice' }] },
+        { name: [{ first: 'Fred' }] },
+        { name: [{ first: 'George' }] },
+        { name: [{ first: 'Jen' }] }
+    ];
+    matchSorter(nestedObjList, 'j', { keys: ['name.0.first'] });
+    // [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]
+    // matchSorter(nestedObjList, 'j', {keys: ['name[0].first']}) does not work
 }
 
 // ### Property Callbacks
 {
-  const list = [{name: 'Janice'}, {name: 'Fred'}, {name: 'George'}, {name: 'Jen'}];
-  matchSorter(list, 'j', {keys: [item => item.name]});
-  // [{name: 'Janice'}, {name: 'Jen'}]
+    const list = [
+        { name: 'Janice' },
+        { name: 'Fred' },
+        { name: 'George' },
+        { name: 'Jen' }
+    ];
+    matchSorter(list, 'j', { keys: [item => item.name] });
+    // [{name: 'Janice'}, {name: 'Jen'}]
 }
 
 // ### Min and Max Ranking
 {
-  const tea = [
-    {tea: 'Earl Grey', alias: 'A'},
-    {tea: 'Assam', alias: 'B'},
-    {tea: 'Black', alias: 'C'},
-  ];
-  matchSorter(tea, 'A', {
-    keys: ['tea', {maxRanking: matchSorter.rankings.STARTS_WITH, key: 'alias'}],
-  });
-  // without maxRanking, Earl Grey would come first because the alias "A" would be CASE_SENSITIVE_EQUAL
-  // `tea` key comes before `alias` key, so Assam comes first even though both match as STARTS_WITH
-  // [{tea: 'Assam', alias: 'B'}, {tea: 'Earl Grey', alias: 'A'},{tea: 'Black', alias: 'C'}]
+    const tea = [
+        { tea: 'Earl Grey', alias: 'A' },
+        { tea: 'Assam', alias: 'B' },
+        { tea: 'Black', alias: 'C' }
+    ];
+    matchSorter(tea, 'A', {
+        keys: [
+            'tea',
+            { maxRanking: matchSorter.rankings.STARTS_WITH, key: 'alias' }
+        ]
+    });
+    // without maxRanking, Earl Grey would come first because the alias "A" would be CASE_SENSITIVE_EQUAL
+    // `tea` key comes before `alias` key, so Assam comes first even though both match as STARTS_WITH
+    // [{tea: 'Assam', alias: 'B'}, {tea: 'Earl Grey', alias: 'A'},{tea: 'Black', alias: 'C'}]
 }
 {
-  const tea = [
-    {tea: 'Milk', alias: 'moo'},
-    {tea: 'Oolong', alias: 'B'},
-    {tea: 'Green', alias: 'C'},
-  ];
-  matchSorter(tea, 'oo', {
-    keys: ['tea', {minRanking: matchSorter.rankings.EQUAL, key: 'alias'}],
-  });
-  // minRanking bumps Milk up to EQUAL from CONTAINS (alias)
-  // Oolong matches as STARTS_WITH
-  // Green is missing due to no match
-  // [{tea: 'Milk', alias: 'moo'}, {tea: 'Oolong', alias: 'B'}]
+    const tea = [
+        { tea: 'Milk', alias: 'moo' },
+        { tea: 'Oolong', alias: 'B' },
+        { tea: 'Green', alias: 'C' }
+    ];
+    matchSorter(tea, 'oo', {
+        keys: ['tea', { minRanking: matchSorter.rankings.EQUAL, key: 'alias' }]
+    });
+    // minRanking bumps Milk up to EQUAL from CONTAINS (alias)
+    // Oolong matches as STARTS_WITH
+    // Green is missing due to no match
+    // [{tea: 'Milk', alias: 'moo'}, {tea: 'Oolong', alias: 'B'}]
+}
+
+// # key: methods
+{
+    const tea = [
+        { tea: 'Milk', alias: 'moo' },
+        { tea: 'Oolong', alias: 'B' },
+        { tea: 'Green', alias: 'C' }
+    ];
+    matchSorter(tea, 'oo', {
+        keys: [
+            item => item.tea,
+            { minRanking: matchSorter.rankings.EQUAL, key: item => item.alias }
+        ]
+    });
+    // minRanking bumps Milk up to EQUAL from CONTAINS (alias)
+    // Oolong matches as STARTS_WITH
+    // Green is missing due to no match
+    // [{tea: 'Milk', alias: 'moo'}, {tea: 'Oolong', alias: 'B'}]
 }
 
 // ## threshold: number
 {
-  const fruit = ['orange', 'apple', 'grape', 'banana'];
-  matchSorter(fruit, 'ap', {threshold: matchSorter.rankings.NO_MATCH});
-  // ['apple', 'grape', 'orange', 'banana'] (returns all items, just sorted by best match)
+    const fruit = ['orange', 'apple', 'grape', 'banana'];
+    matchSorter(fruit, 'ap', { threshold: matchSorter.rankings.NO_MATCH });
+    // ['apple', 'grape', 'orange', 'banana'] (returns all items, just sorted by best match)
 
-  const things = ['google', 'airbnb', 'apple', 'apply', 'app'];
-  matchSorter(things, 'app', {threshold: matchSorter.rankings.EQUAL});
-  // ['app'] (only items that are equal)
+    const things = ['google', 'airbnb', 'apple', 'apply', 'app'];
+    matchSorter(things, 'app', { threshold: matchSorter.rankings.EQUAL });
+    // ['app'] (only items that are equal)
 
-  const otherThings = ['fiji apple', 'google', 'app', 'crabapple', 'apple', 'apply'];
-  matchSorter(otherThings, 'app', {threshold: matchSorter.rankings.WORD_STARTS_WITH});
-  // ['app', 'apple', 'apply', 'fiji apple'] (everything that matches with "word starts with" or better)
+    const otherThings = [
+        'fiji apple',
+        'google',
+        'app',
+        'crabapple',
+        'apple',
+        'apply'
+    ];
+    matchSorter(otherThings, 'app', {
+        threshold: matchSorter.rankings.WORD_STARTS_WITH
+    });
+    // ['app', 'apple', 'apply', 'fiji apple'] (everything that matches with "word starts with" or better)
 }
 
 // ## keepDiacritics: boolean
 {
-  const thingsWithDiacritics = [
-    'jalapeño',
-    'à la carte',
-    'café',
-    'papier-mâché',
-    'à la mode',
-  ];
-  matchSorter(thingsWithDiacritics, 'aa');
-  // ['jalapeño', 'à la carte', 'à la mode', 'papier-mâché']
+    const thingsWithDiacritics = [
+        'jalapeño',
+        'à la carte',
+        'café',
+        'papier-mâché',
+        'à la mode'
+    ];
+    matchSorter(thingsWithDiacritics, 'aa');
+    // ['jalapeño', 'à la carte', 'à la mode', 'papier-mâché']
 
-  matchSorter(thingsWithDiacritics, 'aa', {keepDiacritics: true});
-  // ['jalapeño', 'à la carte']
+    matchSorter(thingsWithDiacritics, 'aa', { keepDiacritics: true });
+    // ['jalapeño', 'à la carte']
 
-  matchSorter(thingsWithDiacritics, 'à', {keepDiacritics: true});
-  // ['à la carte', 'à la mode']
+    matchSorter(thingsWithDiacritics, 'à', { keepDiacritics: true });
+    // ['à la carte', 'à la mode']
 }


### PR DESCRIPTION
This is the update for match-sorter 2.3. This also contains the fix for the issues addressed #32038 and fixes some formatting issues in the test file.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kentcdodds/match-sorter/commit/22f1d7300ba3bd8d74c4ae0a717d678150490124 
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
