### PR TITLE
[facebook-js-sdk] Updated types to SDK version 3.2 & fixed FB.login()

### DIFF
--- a/types/facebook-js-sdk/facebook-js-sdk-tests.ts
+++ b/types/facebook-js-sdk/facebook-js-sdk-tests.ts
@@ -22,6 +22,14 @@ FB.getLoginStatus(function(response: fb.StatusResponse) {
 const authResponse: fb.AuthResponse = FB.getAuthResponse();
 console.log(authResponse.accessToken);
 
+FB.login();
+
+FB.login(function(response: fb.StatusResponse) {
+    console.log(response);
+    console.log(response.status);
+    console.log(response.authResponse.accessToken);
+});
+
 FB.login(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for the Facebook Javascript SDK 3.1
+// Type definitions for the Facebook Javascript SDK 3.2
 // Project: https://developers.facebook.com/docs/javascript
 // Definitions by:  Amrit Kahlon    <https://github.com/amritk>
 //                  Mahmoud Zohdi   <https://github.com/mahmoudzohdi>
@@ -50,7 +50,7 @@ declare namespace facebook {
          * @param callback function to handle the response.
          * @param options optional ILoginOption to add params such as scope.
          */
-        login(callback: (response: StatusResponse) => void, options: LoginOptions): void;
+        login(callback: (response: StatusResponse) => void, options?: LoginOptions): void;
 
         /**
          * Use this function to log the user in
@@ -61,12 +61,12 @@ declare namespace facebook {
          *
          * @param options optional ILoginOption to add params such as scope.
          */
-        login(options: LoginOptions): void;
+        login(options?: LoginOptions): void;
 
         /**
          * The method FB.logout() logs the user out of your site and, in some cases, Facebook.
          *
-         * @param callback function to handle the response
+         * @param callback optional function to handle the response
          */
         logout(callback?: (response: StatusResponse) => void): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.facebook.com/docs/javascript/reference/v3.2
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Changes

- changed version from 3.1 to 3.2 (current) - there are no actual type changes
- made the `options` parameter of `FB.login()` optional again because the [documentation](https://developers.facebook.com/docs/reference/javascript/FB.login/v3.2) is bogus and states that the parameter `opts` is required while showing an example where it isn't passed (it indeed is not required)
