### PR TITLE
[ioredis]: Allow non-numbers to be returned from ClusterRetryStrategy

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -972,16 +972,24 @@ declare namespace IORedis {
         count?: number;
     }
 
+    export type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void
+    export type NatMap = {[key: string]: {host: string, port: number}}
+
     interface ClusterOptions {
-        clusterRetryStrategy?(times: number): number | null;
+        clusterRetryStrategy?(times: number, reason?: Error): number | null;
         enableOfflineQueue?: boolean;
         enableReadyCheck?: boolean;
-        scaleReads?: string;
+        scaleReads?: string | Function;
         maxRedirections?: number;
         retryDelayOnFailover?: number;
         retryDelayOnClusterDown?: number;
         retryDelayOnTryAgain?: number;
+        slotsRefreshTimeout?: number;
+        slotsRefreshInterval?: number;
         redisOptions?: RedisOptions;
+        lazyConnect?: boolean;
+        dnsLookup?: DNSLookupFunction;
+        natMap?: NatMap;
     }
 
     interface MultiOptions {

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -972,14 +972,16 @@ declare namespace IORedis {
         count?: number;
     }
 
-    export type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void
-    export type NatMap = {[key: string]: {host: string, port: number}}
+    type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
+    interface NatMap {
+        [key: string]: {host: string, port: number};
+    }
 
     interface ClusterOptions {
         clusterRetryStrategy?(times: number, reason?: Error): number | null;
         enableOfflineQueue?: boolean;
         enableReadyCheck?: boolean;
-        scaleReads?: string | Function;
+        scaleReads?: string;
         maxRedirections?: number;
         retryDelayOnFailover?: number;
         retryDelayOnClusterDown?: number;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -10,6 +10,7 @@
 //                 Dmitry Motovilov <https://github.com/funthing>
 //                 Oleg Repin <https://github.com/iamolegga>
 //                 Ting-Wai To <https://github.com/tingwai-to>
+//                 Alex Petty <https://github.com/pettyalex>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -972,7 +973,7 @@ declare namespace IORedis {
     }
 
     interface ClusterOptions {
-        clusterRetryStrategy?(times: number): number;
+        clusterRetryStrategy?(times: number): number | null;
         enableOfflineQueue?: boolean;
         enableReadyCheck?: boolean;
         scaleReads?: string;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -192,3 +192,12 @@ redis.xread('STREAMS', 'streamName', '0-0');
 redis.xreadgroup('GROUP', 'groupName', 'consumerName', 'STREAMS', 'streamName', '>');
 redis.xrevrange('streamName', '+', '-', 'COUNT', 1);
 redis.xtrim('streamName', 'MAXLEN', '~', 1000);
+
+// ClusterRetryStrategy can return non-numbers to stop retrying
+new Redis.Cluster([], {
+    clusterRetryStrategy: () => null
+});
+
+new Redis.Cluster([], {
+    clusterRetryStrategy: () => 1
+});

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -195,9 +195,9 @@ redis.xtrim('streamName', 'MAXLEN', '~', 1000);
 
 // ClusterRetryStrategy can return non-numbers to stop retrying
 new Redis.Cluster([], {
-    clusterRetryStrategy: () => null
+    clusterRetryStrategy: (times: number, reason?: Error) => null
 });
 
 new Redis.Cluster([], {
-    clusterRetryStrategy: () => 1
+    clusterRetryStrategy: (times: number, reason?: Error) => 1
 });

--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -7,6 +7,7 @@
 //                 Shahar Mor <https://github.com/shaharmor>
 //                 Whemoon Jang <https://github.com/palindrom615>
 //                 Francis Gulotta <https://github.com/reconbot>
+//                 Alex Petty <https://github.com/pettyalex>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -894,7 +895,7 @@ declare namespace IORedis {
     }
 
     interface ClusterOptions {
-        clusterRetryStrategy?(times: number): number;
+        clusterRetryStrategy?(times: number): number | null;
         enableOfflineQueue?: boolean;
         enableReadyCheck?: boolean;
         scaleReads?: string;

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -156,9 +156,9 @@ new Redis.Cluster([{
 
 // ClusterRetryStrategy can return non-numbers to stop retrying
 new Redis.Cluster([], {
-    clusterRetryStrategy: () => null
+    clusterRetryStrategy: (times: number) => null
 });
 
 new Redis.Cluster([], {
-    clusterRetryStrategy: () => 1
+    clusterRetryStrategy: (times: number) => 1
 });

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -153,3 +153,12 @@ new Redis.Cluster([{
     host: 'localhost',
     port: 6379
 }]);
+
+// ClusterRetryStrategy can return non-numbers to stop retrying
+new Redis.Cluster([], {
+    clusterRetryStrategy: () => null
+});
+
+new Redis.Cluster([], {
+    clusterRetryStrategy: () => 1
+});


### PR DESCRIPTION
This updates it to match the internal typescript definitions that ioredis uses and satisfies a common use case.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/master/lib/cluster/ClusterOptions.ts#L19
