### PR TITLE
Fix capitalisation of ExtractJwt in @feathersjs/authentication-jwt

### DIFF
--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -54,7 +54,7 @@ export class Verifier {
 
 export type JwtFromRequestFunction = (req: Request) => string;
 
-export const ExtractJWT: {
+export const ExtractJwt: {
     fromHeader(header_name: string): JwtFromRequestFunction;
     fromBodyField(field_name: string): JwtFromRequestFunction;
     fromUrlQueryParameter(param_name: string): JwtFromRequestFunction;


### PR DESCRIPTION
I have just updated the capitalisation of the ExtractJwt property in line with the original here: https://github.com/feathersjs/feathers/blob/master/packages/authentication-jwt/lib/index.js

This doesn't work correctly as it is.