### PR TITLE
@types/react-image-crop: Updated props definitions to match the latest release

### DIFF
--- a/types/react-image-crop/index.d.ts
+++ b/types/react-image-crop/index.d.ts
@@ -40,7 +40,7 @@ declare namespace ReactCrop {
         onDragStart?: () => void;
         onDragEnd?: () => void;
         disabled?: boolean;
-        crossorigin?: "anonymous" | 'use-credentials';
+        crossorigin?: 'anonymous' | 'use-credentials';
         children?: ReactNode;
         style?: CSSProperties;
         imageStyle?: CSSProperties;

--- a/types/react-image-crop/index.d.ts
+++ b/types/react-image-crop/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-image-crop 3.0
+// Type definitions for react-image-crop 6.0
 // Project: https://github.com/DominicTobias/react-image-crop
 // Definitions by: Daniela Yassuda <https://github.com/danielasy>
+//                 Elias Chaaya <https://github.com/chaaya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -39,10 +40,13 @@ declare namespace ReactCrop {
         onDragStart?: () => void;
         onDragEnd?: () => void;
         disabled?: boolean;
-        crossorigin?: string;
+        crossorigin?: "anonymous" | 'use-credentials';
         children?: ReactNode;
         style?: CSSProperties;
         imageStyle?: CSSProperties;
+        onImageError?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
+        className?: string;
+        locked?: boolean;
     }
 
     function getPixelCrop(image: HTMLImageElement, percentCrop: Crop): Crop;

--- a/types/react-image-crop/index.d.ts
+++ b/types/react-image-crop/index.d.ts
@@ -36,7 +36,7 @@ declare namespace ReactCrop {
         keepSelection?: boolean;
         onChange: (crop: Crop, pixelCrop: PixelCrop) => void;
         onComplete?: (crop: Crop, pixelCrop: PixelCrop) => void;
-        onImageLoaded?: (target: HTMLImageElement) => void;
+        onImageLoaded?: (target: HTMLImageElement, pixelCrop: PixelCrop) => void;
         onDragStart?: () => void;
         onDragEnd?: () => void;
         disabled?: boolean;

--- a/types/react-image-crop/test/react-image-crop-global-tests.ts
+++ b/types/react-image-crop/test/react-image-crop-global-tests.ts
@@ -85,6 +85,10 @@ class CompleteTest extends React.Component<{}, TestState> {
         });
     }
 
+    onImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+        console.warn('Error loading image');
+    }
+
     render() {
         return React.createElement(
             ReactCrop,
@@ -104,6 +108,9 @@ class CompleteTest extends React.Component<{}, TestState> {
                 onDragStart: () => console.log('Drag start'),
                 onDragEnd: () => console.log('Drag end'),
                 crossorigin: 'anonymous',
+                onImageError: this.onImageError,
+                className: 'my-cropper',
+                locked: false
             },
         );
     }

--- a/types/react-image-crop/test/react-image-crop-module-tests.tsx
+++ b/types/react-image-crop/test/react-image-crop-module-tests.tsx
@@ -81,6 +81,10 @@ class CompleteTest extends React.Component<{}, TestState> {
         });
     }
 
+    onImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+        console.warn('Error loading image');
+    }
+
     render() {
         return (
             <ReactCrop
@@ -99,6 +103,9 @@ class CompleteTest extends React.Component<{}, TestState> {
                 onDragStart={() => console.log('Drag start')}
                 onDragEnd={() => console.log('Drag end')}
                 crossorigin="anonymous"
+                onImageError={this.onImageError}
+                className="my-cropper"
+                locked={false}
             />
         );
     }


### PR DESCRIPTION
Updated the definitions to match the latest release v6.0.11 of [react-image-crop](https://github.com/DominicTobias/react-image-crop/releases/tag/6.0.11)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DominicTobias/react-image-crop#props>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

@danielasy 