### PR TITLE
@types/yup: Add a ValidationError class to match the source code

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -297,7 +297,7 @@ export interface SchemaDescription {
 
 // ValidationError works a lot more like a class vs. a constructor
 // function that returns an interface. It's also got a couple of
-// static methods and it inherits for the generic Error class in
+// static methods and it inherits from the generic Error class in
 // the [yup codebase][1].
 // [1]: (https://github.com/jquense/yup/blob/master/src/ValidationError.js)
 export class ValidationError extends Error {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -77,12 +77,21 @@ const renderable = yup.lazy(value => {
 });
 const renderables = yup.array().of(renderable);
 
+// ValidationError static methods
+// $ExpectType boolean
+ValidationError.isError(new ValidationError("error", "value", "path"));
+// $ExpectType string | ((params?: any) => string)
+ValidationError.formatError("error", { path: "path" });
+ValidationError.formatError("error");
+ValidationError.formatError(() => "error");
+ValidationError.formatError(() => "error", { path: "path" });
+
 // ValidationError
-let error: ValidationError = yup.ValidationError("error", "value", "path");
-error = yup.ValidationError(["error", "error2"], true, "path");
-error = yup.ValidationError(["error", "error2"], 5, "path");
-error = yup.ValidationError(["error", "error2"], { name: "value" }, "path");
-error = yup.ValidationError(
+let error: ValidationError = new yup.ValidationError("error", "value", "path");
+error = new yup.ValidationError(["error", "error2"], true, "path");
+error = new yup.ValidationError(["error", "error2"], 5, "path");
+error = new yup.ValidationError(["error", "error2"], { name: "value" }, "path");
+error = new yup.ValidationError(
     ["error", "error2"],
     { name: "value" },
     "path",
@@ -93,7 +102,7 @@ error = {
     message: "error",
     path: "path",
     errors: ["error"],
-    inner: [yup.ValidationError("error", true, "path")],
+    inner: [new yup.ValidationError("error", true, "path")],
     type: "date",
     value: { start: "2017-11-10" }
 };
@@ -135,8 +144,8 @@ mixed.default(() => ({ number: 5 }));
 mixed.default();
 mixed.nullable(true);
 mixed.required();
-mixed.required('Foo');
-mixed.required(() => 'Foo');
+mixed.required("Foo");
+mixed.required(() => "Foo");
 mixed.notRequired(); // $ExpectType MixedSchema
 mixed.typeError("type error");
 mixed.typeError(() => "type error");
@@ -155,10 +164,8 @@ mixed
         then: yup.number().min(5),
         otherwise: yup.number().min(0)
     })
-    .when(
-        "$other",
-        (value: any, schema: MixedSchema) =>
-            value === 4 ? schema.required() : schema
+    .when("$other", (value: any, schema: MixedSchema) =>
+        value === 4 ? schema.required() : schema
     );
 // tslint:disable-next-line:no-invalid-template-strings
 mixed.test("is-jimmy", "${path} is not Jimmy", value => value === "jimmy");
@@ -486,8 +493,8 @@ interface ExpectedABC {
 }
 
 const expectedAbc: ExpectedABC = {
-    a: 'qwerty',
-    b: 'asdfg',
+    a: "qwerty",
+    b: "asdfg",
     c: 123
 };
 const actualAbc: yup.Shape<AB, BC> = expectedAbc;


### PR DESCRIPTION
Fixes #31950 

### Context
The existing typings for `ValidationError` were a function that returned an interface which is not sufficiently representing what is [happening in the code](https://github.com/jquense/yup/blob/master/src/ValidationError.js). As can be seen, the source code for the package contains a constructor function called `ValidationError` so I added a class that inherits from `Error` and added the properties and static methods accordingly. 

### DefinitelyTyped Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.