### PR TITLE
Fix and align shadowOffset type

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1563,7 +1563,7 @@ declare module paper {
          * The shadow’s offset.
          * Default - 0
          */
-        shadowOffset: number;
+        shadowOffset: number | number[] | {x: number, y: number} | Point;
 
         /**
          * The color the item is highlighted with when selected. If the item does not specify its own color, the color defined by its layer is used instead.
@@ -4371,7 +4371,7 @@ declare module paper {
          * The shadow's offset.
          * Default: 0
          */
-        shadowOffset?: Point;
+        shadowOffset?: number | number[] | {x: number, y: number} | Point;
 
         /**
          * The color the item is highlighted with when selected. If the item does not specify its own color, the color defined by its layer is used instead.


### PR DESCRIPTION
shadowOffset property accept different types and only one was defined. Also shadowOffset exists in Item class and in Style class and types were different.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://paperjs.org/reference/item/#shadowoffset
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.