### PR TITLE
@types/victory: Fix signature of VictoryChartProps style property

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1578,7 +1578,7 @@ declare module "victory" {
          * components within chart.
          * @example {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}
          */
-        style?: React.CSSProperties;
+        style?: Pick<VictoryStyleInterface, 'parent'>;
     }
 
     /**


### PR DESCRIPTION
this changes an existing definition

the style property for `VictoryChartProps` is currently set `React.CSSProperties`. However, victory expects a `VictoryStyleInterface`, which only supports a `parent` key as per https://formidable.com/open-source/victory/docs/victory-chart/#style