### PR TITLE
backbone Router routes method

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -379,7 +379,7 @@ declare namespace Backbone {
         * For assigning routes as object hash, do it like this: this.routes = <any>{ "route": callback, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        routes: RoutesHash | any;
+        routes(): RoutesHash;
 
         constructor(options?: RouterOptions);
         initialize(options?: RouterOptions): void;


### PR DESCRIPTION
At least for Backbone 1.1.2, Backbone.Router 's routes property needs to be in the prototype of the emitted class/constructor-function for it to work. So it must be a method or the property needs to be defined with a getter for it to work. I think this is the same as for View 's events property which is defined as method here.

see https://doc.esdoc.org/github.com/typhonjs/backbone-es6/class/src/Router.js~Router.html

