### PR TITLE
Fix AuthenticateOptions interface

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Passport 0.4
+﻿// Type definitions for Passport 0.4
 // Project: http://passportjs.org
 // Definitions by: Horiuchi_H <https://github.com/horiuchi>
 //                 Eric Naeseth <https://github.com/enaeseth>
@@ -50,7 +50,8 @@ declare namespace passport {
         successReturnToOrRedirect?: string;
         pauseStream?: boolean;
         userProperty?: string;
-        passReqToCallback?: boolean;
+        passReqToCallback?: boolean;	
+	[key: string]: any;
     }
 
     interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Hello. I use https://github.com/AzureAD/passport-azure-ad OIDCStrategy with typescript. That package suppose to have own options in configure. But options from passport-azure-add don`t math with ones, that already exists in passport. I talk about AuthenticateOptions.

So it would be nice to able to configure own options and not to have typescript errors.
