### PR TITLE
Fix Box width prop

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -32,7 +32,7 @@ export interface SpaceProps<C> extends BaseProps<C> {
 
 export interface BoxProps extends SpaceProps<BoxClass> {
     className?: string;
-    width?: number | ReadonlyArray<number>;
+    width?: number | string | ReadonlyArray<number>;
     fontSize?: number | ReadonlyArray<number>;
     css?: Object;
     color?: string;


### PR DESCRIPTION
Based on [docs](https://rebassjs.org/props#width), Box prop `width` also accepts string.