### PR TITLE
types/faker: Add randomize and https to imageUrl

### DIFF
--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -117,7 +117,7 @@ declare namespace Faker {
 		image: {
 			image(): string;
 			avatar(): string;
-			imageUrl(width?: number, height?: number, category?: string): string;
+			imageUrl(width?: number, height?: number, category?: string, randomize?: boolean, https?: boolean): string;
 			abstract(width?: number, height?: number): string;
 			animals(width?: number, height?: number): string;
 			business(width?: number, height?: number): string;


### PR DESCRIPTION
If changing an existing definition:
[x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Marak/faker.js/blob/master/lib/image.js#L43

Add additional types for `randomize` and `https` in `imageUrl` function

Related to issue DefinitelyTyped#14260