### PR TITLE
[@types/mathjs] fix types of filter function arguments

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1299,8 +1299,8 @@ declare namespace math {
          * traversed. The function must return a boolean.
          */
         filter(
-            x: Matrix | MathArray,
-            test: ((value: any, index: any, matrix: Matrix | MathArray) => Matrix | MathArray) | RegExp
+            x: Matrix | MathArray | string[],
+            test: ((value: any, index: any, matrix: Matrix | MathArray | string[]) => boolean) | RegExp
         ): Matrix | MathArray;
 
         /**

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -281,6 +281,12 @@ Matrices examples
       return value * value;
 	  });  // returns [1, 4, 9]
 	}
+
+	// filter matrix
+	{
+	  math.filter([6, -2, -1, 4, 3], function(x) { return x > 0; }); // returns [6, 4, 3]
+	  math.filter(["23", "foo", "100", "55", "bar"], /[0-9]+/); // returns ["23", "100", "55"]
+	}
 }
 
 /*


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mathjs.org/docs/reference/functions/filter.html

I found that original filter method type and DefinitelyTyped's types are mismatched and fixed these problem. This type of problem already happened to [`map` function](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30211) before.

1. return type of `test` function is not a boolean
2. DefinitelyTyped version doesn't accept `string[]`

Authors: @siavol  @andnp  @bradbesserman 
