### PR TITLE
Update expo's barcode scanner callback to have non-deprecated signature

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -262,13 +262,13 @@ async () => {
     <AppLoading />
 );
 
-const barcodeReadCallback = () => {};
+const barCodeScannedCallback = () => {};
 () => (
     <BarCodeScanner
         type="front"
         torchMode="off"
         barCodeTypes={[BarCodeScanner.Constants.BarCodeType.aztec]}
-        onBarCodeRead={barcodeReadCallback} />
+        onBarCodeScanned={barCodeScannedCallback} />
 );
 
 () => (

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -26,7 +26,7 @@ import { Component, ComponentClass, ComponentType, Ref } from 'react';
 import { ImageRequireSource, ImageURISource, LinkingStatic as ReactNativeLinkingStatic, StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 export type Axis = number;
-export type BarCodeReadCallback = (params: { type: string; data: string; }) => void;
+export type BarCodeScannedCallback = (params: { type: string; data: string; }) => void;
 export type Md5 = string;
 export type Orientation = 'portrait' | 'landscape';
 export type RequireSource = ImageRequireSource;
@@ -711,7 +711,7 @@ export interface BarCodeScannerProps extends ViewProps {
     type?: 'front' | 'back';
     torchMode?: 'on' | 'off';
     barCodeTypes?: string[];
-    onBarCodeRead?: BarCodeReadCallback;
+    onBarCodeScanned?: BarCodeScannedCallback;
 }
 
 export class BarCodeScanner extends Component<BarCodeScannerProps> {
@@ -805,7 +805,7 @@ export interface CameraProps extends ViewProps {
     flashMode?: string | number;
     /** Distance to plane of sharpest focus. A value between `0` and `1`. `0`: infinity focus, `1`: focus as close as possible. Default: `0`. For Android this is available only for some devices and when `useCamera2Api` is set to `true`. */
     focusDepth?: number;
-    onBarCodeRead?: BarCodeReadCallback;
+    onBarCodeScanned?: BarCodeScannedCallback;
     onCameraReady?: () => void;
     onFacesDetected?: (options: { faces: TrackedFaceFeature[] }) => void;
     onMountError?: () => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:< https://github.com/expo/expo/blob/master/packages/expo-barcode-scanner/src/BarCodeScanner.js#L81>
- [?] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hi folks - I updated the signature of the [barcode scanner bundled with Expo](https://docs.expo.io/versions/latest/sdk/bar-code-scanner) to reflect current usage rather than the deprecated signature.

Essentially

```js
onBarCodeRead -> onBarCodeScanned
```

This is my first PR into DefinitelyTyped and am **unsure whether or not to bump a version number**.

In addition, prettier has been run on these files by default. While it's a large swath of small changes, it does iron out the inconsistencies in this file. Doing this as a separate PR is also worth consideration.

Thanks for your reviews, they are appreciated.

![](https://media.giphy.com/media/3owypf6HrM3J7UTvAA/giphy.gif)
