### PR TITLE
[filesize] v4.0.0 doesn't support "suffixes" anymore

### DIFF
--- a/types/filesize/index.d.ts
+++ b/types/filesize/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for filesize 3.6
+// Type definitions for filesize 4.0
 // Project: https://github.com/avoidwork/filesize.js
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Renaud Chaput <https://github.com/renchap>
+//                 Roman Nuritdinov <https://github.com/Ky6uk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var fileSize: Filesize.Filesize;
@@ -80,11 +81,6 @@ declare namespace Filesize {
          * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
          */
         symbols?: SiJedec;
-        /**
-         * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
-         * @deprecated: use `symbols`
-         */
-        suffixes?: SiJedec;
         /**
          *  Enables unix style human readable output, e.g ls -lh, default is false
          */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/avoidwork/filesize.js/releases/tag/4.0.0
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.