### PR TITLE
[auth0-lock] Update defaultADUsernameFromEmailPrefix type to boolean

### DIFF
--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -130,7 +130,8 @@ const otherOptions : Auth0LockConstructorOptions = {
   hashCleanup: false,
   leeway: 30,
   _enableImpersonation: true,
-  _enableIdPInitiatedLogin: false
+  _enableIdPInitiatedLogin: false,
+  defaultADUsernameFromEmailPrefix: false
 };
 
 new Auth0Lock(CLIENT_ID, DOMAIN, otherOptions);

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -130,7 +130,7 @@ interface Auth0LockConstructorOptions {
     closable?: boolean;
     configurationBaseUrl?: string;
     container?: string;
-    defaultADUsernameFromEmailPrefix?: string;
+    defaultADUsernameFromEmailPrefix?: boolean;
     defaultDatabaseConnection?: string;
     defaultEnterpriseConnection?: string;
     flashMessage?: Auth0LockFlashMessageOptions;


### PR DESCRIPTION
## Description
Update the type of `defaultADUsernameFromEmailPrefix`, it was a `string` but should be a `boolean`

## Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/lock/blob/master/src/core/index.js#L33
- [ ] Increase the version number in the header if appropriate.
