### PR TITLE
Added type for return value of style() function

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -40,7 +40,7 @@ export interface LowLevelStylefunctionArguments {
     scale?: Array<string | number>;
 }
 
-export function style(args: LowLevelStylefunctionArguments): any;
+export function style(args: LowLevelStylefunctionArguments): {[cssProp: string]: string};
 
 export type TLengthStyledSystem = string | 0 | number;
 export type ResponsiveValue<T> = T | Array<T | null>;


### PR DESCRIPTION
The current `any` for `style()` can't pass the `no-unsafe-any` rule of TSLint. The error message is `[tslint] Unsafe use of expression of type 'any'. (no-unsafe-any)`.

This is the source code of `style()`:
https://github.com/jxnblk/styled-system/blob/b7e35cd526952f50f2f36e029217c6b64fd51aa5/src/index.js#L98