### PR TITLE
[Luxon] Added DateTime.zone and Interval.mapEndpoints definitions

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -395,7 +395,7 @@ declare module 'luxon' {
             toISO(options?: ISOTimeOptions): string;
             toString(): string;
             union(other: Interval): Interval;
-            mapEndpoints(cb: (d: DateTime) => DateTime): Interval
+            mapEndpoints(cb: (d: DateTime) => DateTime): Interval;
         }
 
         namespace Settings {

--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -4,6 +4,7 @@
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
 //                 Jonathan Siebern <https://github.com/jsiebern>
 //                 Matt R. Wilson <https://github.com/mastermatt>
+//                 Pietro Vismara <https://github.com/pietrovismara>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -196,6 +197,7 @@ declare module 'luxon' {
             weeksInWeekYear: number;
             year: number;
             zoneName: string;
+            zone: Zone;
             diff(
                 other: DateTime,
                 unit?: DurationUnit | DurationUnit[],
@@ -393,6 +395,7 @@ declare module 'luxon' {
             toISO(options?: ISOTimeOptions): string;
             toString(): string;
             union(other: Interval): Interval;
+            mapEndpoints(cb: (d: DateTime) => DateTime): Interval
         }
 
         namespace Settings {

--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.4
+// Type definitions for luxon 1.10
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -49,6 +49,8 @@ dt.plus({ hours: 3, minutes: 2 });
 dt.minus({ days: 7 });
 dt.startOf('day');
 dt.endOf('hour');
+dt.zone;
+dt.zoneName;
 
 dt.set({ hour: 3 }).hour;
 
@@ -87,6 +89,7 @@ i.length();
 i.length('years');
 i.contains(DateTime.local(2019));
 i.set({end: DateTime.local(2020)});
+i.mapEndpoints((d) => d);
 
 i.toISO();
 i.toString();

--- a/types/node-geocoder/index.d.ts
+++ b/types/node-geocoder/index.d.ts
@@ -73,6 +73,9 @@ declare namespace node_geocoder {
         zipcode?: string;
         minConfidence?: number;
         limit?: number;
+        bounded?: number;
+        viewbox?: string;
+        countrycodes?: string;
     }
 
     interface BatchResult {

--- a/types/node-geocoder/index.d.ts
+++ b/types/node-geocoder/index.d.ts
@@ -73,9 +73,6 @@ declare namespace node_geocoder {
         zipcode?: string;
         minConfidence?: number;
         limit?: number;
-        bounded?: number;
-        viewbox?: string;
-        countrycodes?: string;
     }
 
     interface BatchResult {


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [DateTime.zone](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-get-zone)
- [Interval.mapEndpoints](https://moment.github.io/luxon/docs/class/src/interval.js~Interval.html#instance-method-mapEndpoints)


I also added a few query parameters for `node-geocoder`, that can be used with the `locationiq` provider:
[Documentation -> Query Parameters](https://locationiq.com/docs)