### PR TITLE
Fix parse function return in shell-quote

### DIFF
--- a/types/shell-quote/index.d.ts
+++ b/types/shell-quote/index.d.ts
@@ -1,12 +1,19 @@
 // Type definitions for shell-quote 1.6
 // Project: https://github.com/substack/node-shell-quote
 // Definitions by: Jason Cheatham <https://github.com/jason0x43>
+//                 Cameron Diver <https://github.com/CameronDiver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
+
+export type ParseEntry =
+	| string
+	| { op: string }
+	| { op: 'glob'; pattern: string }
+	| { comment: string };
 
 export function quote(args: string[]): string;
 export function parse(
 	cmd: string,
 	env?: { [key: string]: string } | ((key: string) => string | object),
 	opts?: { [key: string]: string }
-): string[];
+): ParseEntry[];


### PR DESCRIPTION
Changed the return type of the parse function to accurately represent all of the values it can return.

This may need a major version bump, as some existing code depending on this may break.

Signed-off-by: Cameron Diver <cameron@balena.io>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/substack/node-shell-quote#parsing-shell-operators