### PR TITLE
[image-size] Add 'orientation' attribute to image-size typings

### DIFF
--- a/types/image-size/index.d.ts
+++ b/types/image-size/index.d.ts
@@ -11,6 +11,7 @@ interface ImageInfo {
     width: number;
     height: number;
     type: string;
+    orientation?: number;
 }
 
 declare function sizeOf(path: string): ImageInfo;


### PR DESCRIPTION
Version 0.7.1 added an orientation attribute for JPEG images (only) based on its EXIF data in https://github.com/image-size/image-size/commit/93cb70f09c143542085297af52e7ebf9d9177fd8

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/image-size/image-size/commit/93cb70f09c143542085297af52e7ebf9d9177fd8
- [ ] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

