### PR TITLE
[libsodium-wrappers] Make variant optional for from_base64 / to_base64

### DIFF
--- a/types/libsodium-wrappers/index.d.ts
+++ b/types/libsodium-wrappers/index.d.ts
@@ -1031,7 +1031,7 @@ export function crypto_stream_keygen(outputFormat?: Uint8ArrayOutputFormat | nul
 
 export function crypto_stream_keygen(outputFormat?: StringOutputFormat | null): string;
 
-export function from_base64(input: string, variant: base64_variants): Uint8Array;
+export function from_base64(input: string, variant?: base64_variants): Uint8Array;
 
 export function from_hex(input: string): Uint8Array;
 
@@ -1077,7 +1077,7 @@ export function sodium_version_string(): string;
 
 export function symbols(): string[];
 
-export function to_base64(input: string | Uint8Array, variant: base64_variants): string;
+export function to_base64(input: string | Uint8Array, variant?: base64_variants): string;
 
 export function to_hex(input: string | Uint8Array): string;
 


### PR DESCRIPTION
The library will safely fall back to `URLSAFE_NO_PADDING` if not specified.

---

#### Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

#### If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Marks a parameter for `to_base64` and `from_base64` optional from [this line](https://github.com/jedisct1/libsodium.js/blob/9ca8b8e96bcd7745b275dd43c6cd8f3c551b2217/wrapper/wrap-template.js#L343) in the source:

```js
    function check_base64_variant(variant) {
      if (variant == undefined) {
        return base64_variants.URLSAFE_NO_PADDING;
      }

…

    function from_base64(input, variant) {
      variant = check_base64_variant(variant);

…

    function to_base64(input, variant) {
      variant = check_base64_variant(variant);
```