### PR TITLE
change bn.js to use default export to fix declaration gen

### DIFF
--- a/types/bn.js/bn.js-tests.ts
+++ b/types/bn.js/bn.js-tests.ts
@@ -1,5 +1,5 @@
 // test that it works as a require
-import BN = require('bn.js');
+import BN from 'bn.js';
 
 let bn = new BN(42);
 bn = bn.add(bn);

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -524,4 +524,4 @@ declare class BN {
     invm(b: BN): BN;
 }
 
-export = BN;
+export default BN;

--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import BN = require('bn.js');
+import BN from 'bn.js';
 
 // incomplete typings
 export const utils: any;

--- a/types/ethereumjs-tx/index.d.ts
+++ b/types/ethereumjs-tx/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="node"/>
 
-import BN = require("bn.js");
+import BN from 'bn.js';
 
 declare class EthereumTx {
     raw: Buffer[];

--- a/types/ethereumjs-util/index.d.ts
+++ b/types/ethereumjs-util/index.d.ts
@@ -8,7 +8,7 @@
 // TODO: import types for [`rlp`](https://github.com/ethereumjs/rlp)
 // TODO: import types for [`secp256k1`](https://github.com/cryptocoinjs/secp256k1-node/)
 
-import BN = require("bn.js");
+import BN from 'bn.js';
 
 export const SHA3_NULL_S: string;
 

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -1,4 +1,4 @@
-import BigNumber = require("bn.js");
+import BigNumber from 'bn.js';
 import { Provider } from "../providers";
 import Contract, { CustomOptions as CustomContractOptions } from "./contract";
 import PromiEvent from "../promiEvent";

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -1,4 +1,4 @@
-import BigNumber = require("bn.js");
+import BigNumber from 'bn.js';
 import * as us from "underscore";
 
 type Unit =

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -1,5 +1,5 @@
 import Web3 = require("web3");
-import BigNumber = require("bn.js");
+import BigNumber from "bn.js";
 import { TransactionReceipt } from "web3/types";
 import PromiEvent from "web3/promiEvent";
 import { NEW_ABI_STANDARD, OLD_ABI_STANDARD } from "web3/test/abi-tests";


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I firmly believe `bn.js` should be using `export default`. I have setup a minimal repo that illustrates the issue here: https://github.com/danwbyrne/bn-repo; In short, setting `declaration: true` in compilerOptions causes cascading errors of the form:

```
Exported variable 'X' has or is using name 'BN' from external module "path/to/node_modules/@types/bn.js/index" but cannot be named.
```

 that can only be resolved by:

1. importing `bn.js` to any file that has the issue and ignore the useless import.
2. changing `bn.js` to use `export default`.

for precedence on this issue (and how I discovered the solution) we can look at the `BigNumber` library: ([.d.ts](https://github.com/MikeMcl/bignumber.js/blob/bde4ac1f6380eae9ba54e5015cdf02f866cd5be4/bignumber.d.ts#L35))([index](https://github.com/MikeMcl/bignumber.js/blob/bde4ac1f6380eae9ba54e5015cdf02f866cd5be4/bignumber.js#L1))

it does **not** use `default` exports in its index, however it still uses `default` in its `.d.ts`. Whether this is because of the `(function (...args) {...` setup of the index file, *OR* if it was to solve issues like what I've laid out above.

`bn.js` uses an almost identical index file layout with no `default` exports, but it does have the `(function (...args) {...` layout like `BigNumber` does [here](https://github.com/indutny/bn.js/blob/24cc2dd51b58694088a637a314689f61c9ba65a4/lib/bn.js#L1).

Additionally some packages needed an import adjustment so those were made.
