### PR TITLE
[modular-scale] Allow strings in base option

### DIFF
--- a/types/modular-scale/index.d.ts
+++ b/types/modular-scale/index.d.ts
@@ -8,7 +8,7 @@ export interface ModularScaleOptions {
     ratio?: number;
 
     /** The base font size (in pixels) to use for the type scale. Defaults to 16 */
-    base?: number;
+    base?: number | string;
 }
 
 export interface ModularScaleRatio {

--- a/types/modular-scale/modular-scale-tests.ts
+++ b/types/modular-scale/modular-scale-tests.ts
@@ -3,3 +3,7 @@ import ModularScale, { ratios } from 'modular-scale';
 const ms = ModularScale({ ratio: ratios.doubleOctave }); // $ExpectType modularScale
 ms(1); // $ExpectType number
 ms.steps(1); // $ExpectType number[]
+
+const ms2 = ModularScale({ratio: ratios.augFourth, base: 16 }); // $ExpectType modularScale
+
+const ms3 = ModularScale({ratio: ratios.augFourth, base: "16px"}); // $ExpectType modularScale


### PR DESCRIPTION
The base option allows strings containing a CSS size unit like `5em`
or `12px`. See: https://github.com/kristoferjoseph/modular-scale/blob/b01cfdd1b5de4bccbff22c66824b1ca636927b56/README.md#use

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kristoferjoseph/modular-scale/blob/b01cfdd1b5de4bccbff22c66824b1ca636927b56/README.md#use
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.