### PR TITLE
[react] better prop typing for JS users

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -491,6 +491,10 @@ declare namespace React {
         getDefaultProps?(): P;
     }
 
+    type JSXElementConstructor<P> =
+        | ((props: P) => ReactElement<any> | null)
+        | (new (props: P) => Component<P, any, any>)
+
     /**
      * We use an intersection type to infer multiple type parameters from
      * a single argument, which is useful for many top-level API defs.
@@ -719,8 +723,8 @@ declare namespace React {
      * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
      * or ComponentPropsWithoutRef when refs are not supported.
      */
-    type ComponentProps<T extends ReactType> =
-        T extends ComponentType<infer P>
+    type ComponentProps<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =
+        T extends JSXElementConstructor<infer P>
             ? P
             : T extends keyof JSX.IntrinsicElements
                 ? JSX.IntrinsicElements[T]
@@ -2629,9 +2633,18 @@ declare namespace React {
     }
 }
 
-// Declared props take priority over inferred props
+type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false
+
+// Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+// If props is type any, use propTypes definitions, otherwise for each `any` property of props, use the propTypes type
 // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
-type MergePropTypes<P, T> = P & Pick<T, Exclude<keyof T, keyof P>>;
+type MergePropTypes<P, T> = IsExactlyAny<P> extends true ? T : ({
+    [K in keyof P]: IsExactlyAny<P[K]> extends true
+        ? K extends keyof T
+        ? T[K]
+        : P[K]
+        : P[K]
+} & Pick<T, Exclude<keyof T, keyof P>>);
 
 // Any prop that has a default prop becomes optional, but its type is unchanged
 // Undeclared default props are augmented into the resulting allowable attributes

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -493,7 +493,7 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement<any> | null)
-        | (new (props: P) => Component<P, any, any>)
+        | (new (props: P) => Component<P, any>);
 
     /**
      * We use an intersection type to infer multiple type parameters from
@@ -2633,7 +2633,9 @@ declare namespace React {
     }
 }
 
-type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false
+// naked 'any' type in a conditional type will short circuit and union both the then/else branches
+// so boolean is only resolved for T = any
+type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false;
 
 // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
 // If props is type any, use propTypes definitions, otherwise for each `any` property of props, use the propTypes type

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -222,3 +222,30 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     // $ExpectError the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
 //     <ForwardRef str='abc' />
 // ];
+
+// const weakComponentPropTypes = {
+//     foo: PropTypes.string,
+//     bar: PropTypes.bool.isRequired
+// };
+// interface WeakComponentProps1 {
+//     foo: any;
+//     bar: number;
+// }
+// interface WeakComponentProps2 {
+//     foo: string;
+//     bar: any;
+// }
+
+// // $ExpectType true
+// type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+//     foo?: string | null
+//     bar: boolean
+// } ? true : false;
+// type weakComponentTest2 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+//     foo?: string | null
+//     bar: number
+// } ? true : false;
+// type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+//     foo: string
+//     bar: boolean
+// } ? true : false;


### PR DESCRIPTION
## Context
The `LibraryManagedAttributes` feature in JSX was supposed to help with two things:
- For TypeScript users to be able to use `defaultProps` without non-null asserting their own props in component implementations
- For JavaScript users to get richer type intelligence coming from `propTypes` and `defaultProps`

Unfortunately the merging type for `propTypes` did not work very well because most JS users have their props definitions inferred as either `any` or an object of `any`s:
```js
// props is `any` type
function Component(props) {
  return /* ... */
}

// props is { foo: any, bar?: boolean, baz: any } type
function BetterComponent({ foo, bar = false, baz }) {
  return /* ... */
}
```

NB - this problem doesn't affect class components because their props are automatically assumed to be of type `{}` due to the default generic type parameter of `React.Component`, but with hooks becoming more prevalent, we need to give more TLC to function components

So we try to do better for JS users and more intelligently merge the types of prop types.

Also, `ComponentProps` will fail if a component's props type doesn't exactly match its `propTypes` type, which sometimes can happen, so we should be more relaxed with that check since those static properties are not relevant in those conditional types where `ComponentProps` is used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.