### PR TITLE
[react-google-recaptcha] Add onErrored prop type

### DIFF
--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React Google Recaptcha 0.10
+// Type definitions for React Google Recaptcha 1.0
 // Project: https://github.com/dozoisch/react-google-recaptcha
 // Definitions by: Koala Human <https://github.com/KoalaHuman>, Tom Sturge <https://github.com/tomsturge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -66,6 +66,12 @@ export interface ReCAPTCHAProps {
 	 *  Optional callback, called when a challenge expires and has to be redone by the user.
 	 */
 	onExpired?: () => void;
+	/**
+	 *  Optional callback, called when reCAPTCHA encounters an error (usually network connectivity)
+	 *  and cannot continue until connectivity is restored. If you specify a function here, you are
+	 *  responsible for informing the user that they should retry.
+	 */
+	onErrored?: () => void;
 	/**
 	 *  Optional set the stoken parameter, which allows the captcha to be used from different domains,
 	 *  @see reCAPTCHA secure-token

--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for React Google Recaptcha 1.0
 // Project: https://github.com/dozoisch/react-google-recaptcha
-// Definitions by: Koala Human <https://github.com/KoalaHuman>, Tom Sturge <https://github.com/tomsturge>
+// Definitions by: Koala Human <https://github.com/KoalaHuman>
+//                 Tom Sturge <https://github.com/tomsturge>
+//                 Max Bo <https://github.com/MaxwellBo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-google-recaptcha/v0/index.d.ts
+++ b/types/react-google-recaptcha/v0/index.d.ts
@@ -1,0 +1,84 @@
+// Type definitions for React Google Recaptcha 0.10
+// Project: https://github.com/dozoisch/react-google-recaptcha
+// Definitions by: Koala Human <https://github.com/KoalaHuman>, Tom Sturge <https://github.com/tomsturge>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+
+export default ReCAPTCHA;
+
+declare class ReCAPTCHA extends React.Component<ReCAPTCHAProps> {
+	/**
+	 * Resets the reCAPTCHA widget
+	 */
+	reset(): void;
+	/**
+	 * Programatically invoke the reCAPTCHA check. Used if the invisible reCAPTCHA is on a div instead of a button
+	 */
+	execute(): void;
+
+	/**
+	 * Gets the response for the reCAPTCHA widget.
+	 * @return the response of the reCAPTCHA widget.
+	 */
+	getValue(): string | null;
+
+	/**
+	 * Gets the widgetId of reCAPTCHA widget
+	 * @return widgetId | null
+	 */
+	getWidgetId(): number | null;
+}
+
+type Theme = "light" | "dark";
+type Type = "image" | "audio";
+type Size = "compact" | "normal" | "invisible";
+type Badge = "bottomright" | "bottomleft" | "inline";
+
+export interface ReCAPTCHAProps {
+	/**
+	 *  The API client key
+	 */
+	sitekey: string;
+	/**
+	 *  The function to be called when the user successfully completes the normal or compat captcha.
+	 * 	It will also be called with null, when captcha expires
+	 *  @param token string or null
+	 */
+	onChange?: (token: string|null) => void;
+	/**
+	 *  Optional light or dark theme of the widget
+	 *  @default "light"
+	 */
+	theme?: Theme;
+	/**
+	 * Optional image or audio The type of initial captcha
+	 * @default "image"
+	 */
+	type?: Type;
+	/**
+	 *  Optional the tabindex of the element
+	 *  @default 0
+	 */
+	tabindex?: number;
+	/**
+	 *  Optional callback, called when a challenge expires and has to be redone by the user.
+	 */
+	onExpired?: () => void;
+	/**
+	 *  Optional set the stoken parameter, which allows the captcha to be used from different domains,
+	 *  @see reCAPTCHA secure-token
+	 */
+	stoken?: string;
+	/**
+	 *  Optional compact, normal or invisible. This allows you to change the size or do an invisible captcha
+	 */
+	size?: Size;
+	/**
+	 * Optional. The badge location for g-recaptcha with size of "invisible".
+	 *
+	 * @default "bottomright"
+	 */
+	badge?: Badge;
+}

--- a/types/react-google-recaptcha/v0/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/v0/react-google-recaptcha-tests.tsx
@@ -1,0 +1,15 @@
+import ReCAPTCHA from 'react-google-recaptcha';
+import * as React from 'react';
+
+const basicRecapchta = <ReCAPTCHA sitekey="xxx" onChange={a => a}/>;
+const invisibleRecaptcha: React.SFC = () => {
+    const recaptchaRef = React.createRef<ReCAPTCHA>();
+
+    return (
+	    <ReCAPTCHA
+  	        ref={recaptchaRef}
+	        sitekey="xxx"
+	        size="invisible"
+	    />
+    );
+};

--- a/types/react-google-recaptcha/v0/tsconfig.json
+++ b/types/react-google-recaptcha/v0/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "react-google-recaptcha": [ "react-google-recaptcha/v0" ]
+        },
+        "types": [],
+        "jsx": "react",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-google-recaptcha-tests.tsx"
+    ]
+}

--- a/types/react-google-recaptcha/v0/tslint.json
+++ b/types/react-google-recaptcha/v0/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- Added the `onErrored?: () => void;` prop, with description sourced from https://developers.google.com/recaptcha/docs/display

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/recaptcha/docs/display and https://github.com/dozoisch/react-google-recaptcha/blob/9aa2218e7b4d633f329b8ea7b708afb880a06f80/src/recaptcha.js#L143
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
