### PR TITLE
feat(auth0): Update UserMetadata to have any type for value

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -147,10 +147,20 @@ management
 management
   .updateUser({id: "user_id"}, {"email": "hi@me.co"}, (err: Error, users: auth0.User) => {});
 
-
 // Update user metadata
 management
   .updateUserMetadata({id: "user_id"}, {"key": "value"});
+
+// Update user metadata with JSON object
+management
+    .updateUserMetadata({id: "user_id"}, {
+      key: "value",
+      numKey: 123,
+      objKey: {
+        foo: "bar",
+        another: "value"
+      }
+    });
 
 // Update user metadata using callback
 management

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for auth0 2.9.2
+// Type definitions for auth0 2.9.3
 // Project: https://github.com/auth0/node-auth0
 // Definitions by: Seth Westphal <https://github.com/westy92>
+//                 Ian Howe <https://github.com/ianhowe76>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -32,7 +33,7 @@ export interface RetryOptions {
 }
 
 export interface UserMetadata {
-  [propName: string]: string
+  [propName: string]: any
 }
 
 export interface AppMetadata {


### PR DESCRIPTION
Allow `UserMetadata` type to have key values with `any` type as the api allows any JSON data

see https://auth0.com/docs/users/guides/update-metadata-properties-with-management-api

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

