### PR TITLE
react-bootstrap: add missing bsClass, bsSize declarations

### DIFF
--- a/types/react-bootstrap/README.md
+++ b/types/react-bootstrap/README.md
@@ -7,7 +7,7 @@ The reason is that react-bootstrap `v1.0.0` targets Bootstrap v4, and includes i
 typings. react-bootstrap prior to `v1.0.0` targets Bootstrap v3 and does not include any
 typings.
 
-It does not make sense for everyone to upgrade to Bootstrap v3, therefore these typings
+It does not make sense for everyone to upgrade to Bootstrap v4, therefore these typings
 are useful for everyone that wants to stay on Bootstrap v3 and react-bootstrap prior to `v1.0.0`.
 
 The typings for `v1.0.0` were merged in [this pull request](https://github.com/react-bootstrap/react-bootstrap/commit/2079b2292afb835d036fcceef47e8938c4a8d86a).

--- a/types/react-bootstrap/README.md
+++ b/types/react-bootstrap/README.md
@@ -1,0 +1,13 @@
+# react-bootstrap
+
+## Intended compatibilty
+This library is intended for releases of react-bootstrap prior to `v1.0.0`, e.g. `v0.32.4`.
+
+The reason is that react-bootstrap `v1.0.0` targets Bootstrap v4, and includes its own
+typings. react-bootstrap prior to `v1.0.0` targets Bootstrap v3 and does not include any
+typings.
+
+It does not make sense for everyone to upgrade to Bootstrap v3, therefore these typings
+are useful for everyone that wants to stay on Bootstrap v3 and react-bootstrap prior to `v1.0.0`.
+
+The typings for `v1.0.0` were merged in [this pull request](https://github.com/react-bootstrap/react-bootstrap/commit/2079b2292afb835d036fcceef47e8938c4a8d86a).

--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -14,6 +14,7 @@
 //                 Johann Rakotoharisoa <https://github.com/jrakotoharisoa>
 //                 Andrew Makarov <https://github.com/r3nya>
 //                 Duong Tran <https://github.com/t49tran>
+//                 Erik Zivkovic <https://github.com/bes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-bootstrap/lib/Alert.d.ts
+++ b/types/react-bootstrap/lib/Alert.d.ts
@@ -5,6 +5,7 @@ declare namespace Alert {
     export interface AlertProps extends React.HTMLProps<Alert> {
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         closeLabel?: string;
         /** @deprecated since v0.29.0 */dismissAfter?: number;
         // TODO: Add more specific type

--- a/types/react-bootstrap/lib/ButtonGroup.d.ts
+++ b/types/react-bootstrap/lib/ButtonGroup.d.ts
@@ -6,6 +6,7 @@ declare namespace ButtonGroup {
         block?: boolean;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         justified?: boolean;
         vertical?: boolean;
     }

--- a/types/react-bootstrap/lib/ButtonToolbar.d.ts
+++ b/types/react-bootstrap/lib/ButtonToolbar.d.ts
@@ -6,6 +6,7 @@ declare namespace ButtonToolbar {
         block?: boolean;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         justified?: boolean;
         vertical?: boolean;
     }

--- a/types/react-bootstrap/lib/Clearfix.d.ts
+++ b/types/react-bootstrap/lib/Clearfix.d.ts
@@ -7,6 +7,7 @@ declare namespace Clearfix {
         visibleSmBlock?: boolean;
         visibleMdBlock?: boolean;
         visibleLgBlock?: boolean;
+        bsClass?: string;
     }
 }
 declare class Clearfix extends React.Component<Clearfix.ClearfixProps> { }

--- a/types/react-bootstrap/lib/FormControlFeedback.d.ts
+++ b/types/react-bootstrap/lib/FormControlFeedback.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 declare namespace FormControlFeedback {
-    export type FormControlFeedbackProps = React.HTMLProps<FormControlFeedback>;
+    export interface FormControlFeedbackProps extends React.HTMLProps<FormControlFeedback> {
+        bsClass?: string;
+    }
 }
 declare class FormControlFeedback extends React.Component<FormControlFeedback.FormControlFeedbackProps> { }
 export = FormControlFeedback;

--- a/types/react-bootstrap/lib/InputGroupAddon.d.ts
+++ b/types/react-bootstrap/lib/InputGroupAddon.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 declare namespace InputGroupAddon {
-    type InputGroupAddonProps = React.HTMLProps<InputGroupAddon>;
+    interface InputGroupAddonProps extends React.HTMLProps<InputGroupAddon> {
+        bsClass?: string;
+    }
 }
 declare class InputGroupAddon extends React.Component<InputGroupAddon.InputGroupAddonProps> { }
 export = InputGroupAddon;

--- a/types/react-bootstrap/lib/InputGroupButton.d.ts
+++ b/types/react-bootstrap/lib/InputGroupButton.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 declare namespace InputGroupButton {
-    export type InputGroupButtonProps = React.HTMLProps<InputGroupButton>;
+    export interface InputGroupButtonProps extends React.HTMLProps<InputGroupButton> {
+        bsClass?: string;
+    }
 }
 declare class InputGroupButton extends React.Component<InputGroupButton.InputGroupButtonProps> { }
 export = InputGroupButton;

--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -19,6 +19,7 @@ declare namespace Modal {
         backdropStyle?: any;
         backdropTransitionTimeout?: number;
         bsSize?: Sizes;
+        bsClass?: string;
         container?: any; // TODO: Add more specific type
         containerClassName?: string;
         dialogClassName?: string;

--- a/types/react-bootstrap/lib/ModalDialog.d.ts
+++ b/types/react-bootstrap/lib/ModalDialog.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Sizes } from 'react-bootstrap';
 
 declare namespace ModalDialog {
     export interface ModalDialogProps extends React.HTMLProps<ModalDialog> {
@@ -10,6 +11,8 @@ declare namespace ModalDialog {
         onExit?: Function;
         onExited?: Function;
         onExiting?: Function;
+        bsSize?: Sizes;
+        bsClass?: string;
     }
 }
 declare class ModalDialog extends React.Component<ModalDialog.ModalDialogProps> { }

--- a/types/react-bootstrap/lib/ModalFooter.d.ts
+++ b/types/react-bootstrap/lib/ModalFooter.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 declare namespace ModalFooter {
     export interface ModalFooterProps extends React.HTMLProps<ModalFooter> {
         componentClass?: React.ReactType;
+        bsClass?: string;
     }
 }
 declare class ModalFooter extends React.Component<ModalFooter.ModalFooterProps> { }

--- a/types/react-bootstrap/lib/ModalTitle.d.ts
+++ b/types/react-bootstrap/lib/ModalTitle.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 declare namespace ModalTitle {
     export interface ModalTitleProps extends React.HTMLProps<ModalTitle> {
         componentClass?: React.ReactType;
+        bsClass?: string;
     }
 }
 declare class ModalTitle extends React.Component<ModalTitle.ModalTitleProps> { }

--- a/types/react-bootstrap/lib/Nav.d.ts
+++ b/types/react-bootstrap/lib/Nav.d.ts
@@ -8,6 +8,7 @@ declare namespace Nav {
         activeKey?: any;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         collapsible?: boolean;
         eventKey?: any;
         expanded?: boolean;

--- a/types/react-bootstrap/lib/PageHeader.d.ts
+++ b/types/react-bootstrap/lib/PageHeader.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 declare namespace PageHeader {
-    export type PageHeaderProps = React.HTMLProps<PageHeader>;
+    export interface PageHeaderProps extends React.HTMLProps<PageHeader> {
+        bsClass?: string;
+    }
 }
 declare class PageHeader extends React.Component<PageHeader.PageHeaderProps> { }
 export = PageHeader;

--- a/types/react-bootstrap/lib/Pager.d.ts
+++ b/types/react-bootstrap/lib/Pager.d.ts
@@ -5,6 +5,7 @@ import PagerItem = require('./PagerItem');
 declare namespace Pager {
     export interface PagerProps extends React.HTMLProps<Pager> {
         onSelect?: SelectCallback;
+        bsClass?: string;
     }
 }
 declare class Pager extends React.Component<Pager.PagerProps> {

--- a/types/react-bootstrap/lib/Popover.d.ts
+++ b/types/react-bootstrap/lib/Popover.d.ts
@@ -8,6 +8,7 @@ declare namespace Popover {
         arrowOffsetTop?: number | string;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         placement?: string;
         positionLeft?: number | string; // String support added since v0.30.0
         positionTop?: number | string; // String support added since v0.30.0

--- a/types/react-bootstrap/lib/ProgressBar.d.ts
+++ b/types/react-bootstrap/lib/ProgressBar.d.ts
@@ -7,6 +7,7 @@ declare namespace ProgressBar {
         active?: boolean;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         interpolatedClass?: any; // TODO: Add more specific type
         max?: number;
         min?: number;

--- a/types/react-bootstrap/lib/TabContent.d.ts
+++ b/types/react-bootstrap/lib/TabContent.d.ts
@@ -6,6 +6,7 @@ declare namespace TabContent {
         animation?: boolean | React.ReactType;
         mountOnEnter?: boolean;
         unmountOnExit?: boolean;
+        bsClass?: string;
     }
 }
 declare class TabContent extends React.Component<TabContent.TabContentProps> { }

--- a/types/react-bootstrap/lib/Tooltip.d.ts
+++ b/types/react-bootstrap/lib/Tooltip.d.ts
@@ -8,6 +8,7 @@ declare namespace Tooltip {
         arrowOffsetTop?: number | string;
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
         placement?: string;
         positionLeft?: number;
         positionTop?: number;

--- a/types/react-bootstrap/lib/Well.d.ts
+++ b/types/react-bootstrap/lib/Well.d.ts
@@ -5,6 +5,7 @@ declare namespace Well {
     export interface WellProps extends React.HTMLProps<Well> {
         bsSize?: Sizes;
         bsStyle?: string;
+        bsClass?: string;
     }
 }
 declare class Well extends React.Component<Well.WellProps> { }


### PR DESCRIPTION
I tried to find as many as possible of the declarations of bsClass, and bsSize
that were missing.

I used the following sources:
* The documentation for pre-v1.0.0 react-bootstrap at https://react-bootstrap.github.io
* Double checked using the source code for pre-v1.0.0 at https://github.com/react-bootstrap/react-bootstrap

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

f changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap.github.io
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
