### PR TITLE
Rewrite `defaultProps` support in styled-components

### DIFF
--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -978,9 +978,25 @@ function validateDefaultProps() {
 
     <StyledComponent requiredProp optionalProp="x" />;
 
-    // this test is failing in TS 3.0 but not in 3.1
-    // <StyledComponent requiredProp />;
+    <StyledComponent requiredProp />;
 
     // still respects the type of optionalProp
     <StyledComponent requiredProp optionalProp={1} />; // $ExpectError
+
+    // example of a simple helper that sets defaultProps and update the type
+    type WithDefaultProps<C, D> = C & { defaultProps: D };
+    function withDefaultProps<C, D>(component: C, defaultProps: D): WithDefaultProps<C, D> {
+        (component as WithDefaultProps<C, D>).defaultProps = defaultProps;
+        return component as WithDefaultProps<C, D>;
+    }
+
+    const OtherStyledComponent = withDefaultProps(
+        styled(MyComponent)` color: red `,
+        { requiredProp: true }
+    );
+
+    // this test is failing in TS 3.1 but not in 3.2
+    // <OtherStyledComponent />;
+
+    <OtherStyledComponent requiredProp="1" />; // $ExpectError
 }


### PR DESCRIPTION
This PR fixes #32149 that was introduced #31903

A new approach is the following:
- remove `defaultProps` from the styled component as it really doesn't carry it over
- defaultize props before decorating them with styled component props
  - this is done exactly like `react` typing does it; in fact, I copied helper types from there

Now new styled components don't have `defaultProps` so they can be easily set.
However, TS doesn't set type of newly set `defaultProps` (aka expando), so don't expect it would allow to skip required props.
In order to modify the type, in the tests I added a simple helper function that sets `defaultProps` _and_ returns modified type. This is meant to be an example only.

/cc @gausie @kristian-puccio @dan-kez @aaronmcadam @divideby @Kovensky @alansouzati