### PR TITLE
Chart.js - missing tooltip axis option

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -329,6 +329,7 @@ declare namespace Chart {
     }
 
     interface ChartTooltipOptions {
+        axis?: 'y'; 
         enabled?: boolean;
         custom?(a: any): void;
         mode?: InteractionMode;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -329,7 +329,7 @@ declare namespace Chart {
     }
 
     interface ChartTooltipOptions {
-        axis?: 'y'; 
+        axis?: 'y';
         enabled?: boolean;
         custom?(a: any): void;
         mode?: InteractionMode;


### PR DESCRIPTION
According to https://www.chartjs.org/docs/latest/general/interactions/modes.html#index there is an option to specify intersections for tooltips on the y axis, but the option is missing in type definition.
