### PR TITLE
Fix "pdfMake" type definitions

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -153,7 +153,7 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface Content {
-        style?: 'string';
+        style?: string;
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
@@ -175,7 +175,7 @@ declare module 'pdfmake/build/pdfmake' {
         compress?: boolean;
         header?: TDocumentHeaderFooterFunction;
         footer?: TDocumentHeaderFooterFunction;
-        content: string | Content;
+        content: (string | Content)[];
         styles?: Style;
         pageSize?: PageSize;
         pageOrientation?: PageOrientation;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -153,7 +153,7 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface Content {
-        style?: string | string[];
+        style?: string;
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -146,7 +146,7 @@ declare module 'pdfmake/build/pdfmake' {
 
     interface Table {
         widths?: Array<(string | number)>;
-        heights?: Array<(string | number)> | TableRowFunction;
+        heights?: string | number | TableRowFunction | Array<(string | number | TableRowFunction)>;
         headerRows?: number;
         body: Content[][] | TableCell[][];
         layout?: string | TableLayoutFunctions;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -165,8 +165,8 @@ declare module 'pdfmake/build/pdfmake' {
         pageBreak?: 'before' | 'after';
         alignment?: Alignment;
         table?: Table;
-        ul?: Content[];
-        ol?: Content[];
+        ul?: Array<string | Content>;
+        ol?: Array<string | Content>;
         [additionalProperty: string]: any;
     }
 

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -156,7 +156,7 @@ declare module 'pdfmake/build/pdfmake' {
         style?: string;
         margin?: Margins;
         text?: string | string[] | Content[];
-        columns?: Content[];
+        columns?: Array<string | Content>;
         stack?: Content[];
         image?: string;
         width?: string | number;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -170,12 +170,17 @@ declare module 'pdfmake/build/pdfmake' {
         [additionalProperty: string]: any;
     }
 
+    interface ContentStack {
+        stack?: Content;
+        [additionalProperty: string]: any;
+    }
+
     interface TDocumentDefinitions {
         info?: TDocumentInformation;
         compress?: boolean;
         header?: TDocumentHeaderFooterFunction;
         footer?: TDocumentHeaderFooterFunction;
-        content: Array<string | Content>;
+        content: Array<string | Content | ContentStack>;
         styles?: Style;
         pageSize?: PageSize;
         pageOrientation?: PageOrientation;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -181,6 +181,11 @@ declare module 'pdfmake/build/pdfmake' {
         pageOrientation?: PageOrientation;
         pageMargins?: Margins;
         defaultStyle?: Style;
+        images?: Image;
+    }
+
+    interface Image {
+        [imageName: string]: string;
     }
 
     type CreatedPdfParams = (

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -153,7 +153,7 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface Content {
-        style?: string;
+        style?: string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
@@ -175,7 +175,7 @@ declare module 'pdfmake/build/pdfmake' {
         compress?: boolean;
         header?: TDocumentHeaderFooterFunction;
         footer?: TDocumentHeaderFooterFunction;
-        content: (string | Content)[];
+        content: Array<string | Content>;
         styles?: Style;
         pageSize?: PageSize;
         pageOrientation?: PageOrientation;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -122,7 +122,7 @@ declare module 'pdfmake/build/pdfmake' {
         [additionalProperty: string]: any;
     }
 
-    type TableRowFunction = (row: number) => number;
+    type TableRowColFunction = (row: number) => number;
 
     interface TableLayoutFunctions {
         hLineWidth?: (i: number, node: any) => number;
@@ -145,8 +145,8 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface Table {
-        widths?: Array<(string | number)>;
-        heights?: string | number | TableRowFunction | Array<(string | number | TableRowFunction)>;
+        widths?: Array<(string | number | TableRowColFunction)>;
+        heights?: string | number | TableRowColFunction | Array<(string | number | TableRowColFunction)>;
         headerRows?: number;
         body: Content[][] | TableCell[][];
         layout?: string | TableLayoutFunctions;

--- a/types/pdfmake/pdfmake-tests.ts
+++ b/types/pdfmake/pdfmake-tests.ts
@@ -1,7 +1,7 @@
 import * as pdfMake from 'pdfmake/build/pdfmake';
 import * as pdfFonts from 'pdfmake/build/vfs_fonts';
 
-const definitions = [
+const definitions: pdfMake.TDocumentDefinitions[] = [
     {
         content: [
             'First paragraph',
@@ -1328,7 +1328,7 @@ const createPdf = () => {
   pdf.vfs = pdfFonts.pdfMake.vfs;
 
   for (const definition of definitions) {
-      const typedDefinition: pdfMake.TDocumentDefinitions = definition;
+      const typedDefinition = definition;
       pdfMake.createPdf(typedDefinition).download();
   }
 };


### PR DESCRIPTION
* in `interface Content`, the `style` key should be the type `string`
* in `interface TDocumentDefinitions`, the `content` key is an array of either `string` or `Content`

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: every example seen here http://pdfmake.org/playground.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
