### PR TITLE
[webpack]: Fixed type of beforeRun hook.

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -988,7 +988,7 @@ declare namespace webpack {
             shouldEmit: SyncBailHook<Compilation>;
             done: AsyncSeriesHook<Stats>;
             additionalPass: AsyncSeriesHook;
-            beforeRun: AsyncSeriesHook<Compilation>;
+            beforeRun: AsyncSeriesHook<Compiler>;
             run: AsyncSeriesHook<Compilation>;
             emit: AsyncSeriesHook<Compilation>;
             afterEmit: AsyncSeriesHook<Compilation>;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -989,7 +989,7 @@ declare namespace webpack {
             done: AsyncSeriesHook<Stats>;
             additionalPass: AsyncSeriesHook;
             beforeRun: AsyncSeriesHook<Compiler>;
-            run: AsyncSeriesHook<Compilation>;
+            run: AsyncSeriesHook<Compiler>;
             emit: AsyncSeriesHook<Compilation>;
             afterEmit: AsyncSeriesHook<Compilation>;
             thisCompilation: SyncHook<Compilation, { normalModuleFactory: NormalModuleFactory }>;

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -285,7 +285,8 @@ configuration = {
                 );
             });
 
-            this.hooks.beforeRun.tap("SomePlugin", (compiler: webpack.Compiler) => {})
+            this.hooks.beforeRun.tap("SomePlugin", (compiler: webpack.Compiler) => {});
+            this.hooks.run.tap("SomePlugin", (compiler: webpack.Compiler) => {});
         }
     ]
 };

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -284,6 +284,8 @@ configuration = {
                     callback
                 );
             });
+
+            this.hooks.beforeRun.tap("SomePlugin", (compiler: webpack.Compiler) => {})
         }
     ]
 };


### PR DESCRIPTION
Previously this took a `Compilation` parameter, but actually takes a `Compiler`. See https://github.com/webpack/webpack/blob/ccc7db79bab25ed3ef49435abc8866b63721b8b6/lib/Compiler.js#L50-L51

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/ccc7db79bab25ed3ef49435abc8866b63721b8b6/lib/Compiler.js#L50-L51
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
