### PR TITLE
Define KnockoutObservableType to match returned type of fromJS

### DIFF
--- a/types/knockout.mapping/index.d.ts
+++ b/types/knockout.mapping/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/SteveSanderson/knockout.mapping
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, 
 //                 Mathias Lorenzen <https://github.com/ffMathy>
+//                 Per Lindén <https://github.com/turdwaster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="knockout" />
 
@@ -13,8 +14,14 @@ declare var self: KnockoutMapping;
 export = self;
 
 declare global {
-    type KnockoutObservableType<T> = {	
-        [P in keyof T]: KnockoutObservable<KnockoutObservableType<T[P]>>|T[P];	
+	type KnockoutObservableType<T> = {
+		[P in keyof T]:
+        T[P] extends Date ? KnockoutObservable<Date> :
+        T[P] extends string ? KnockoutObservable<string> :
+        T[P] extends boolean ? KnockoutObservable<boolean> :
+        T[P] extends number ? KnockoutObservable<number> :
+        T[P] extends (infer ElType)[] ? KnockoutObservableArray<KnockoutObservableType<ElType>> :
+        T[P];
     };
     
     interface KnockoutMappingCreateOptions {

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -9,7 +9,6 @@
 //                 Leonardo Lombardi <https://github.com/ltlombardi>
 //                 Retsam <https://github.com/Retsam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 interface KnockoutSubscribableFunctions<T> {
     notifySubscribers(valueToWrite?: T, event?: string): void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Uhm, https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html ?
- [X] Increase the version number in the header if appropriate. - there was none - changed TS version
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.