### PR TITLE
PapaParse type definition fix for UnparseConfig

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -117,12 +117,12 @@ export interface ParseConfig {
 }
 
 export interface UnparseConfig {
-    quotes?: boolean;      // default: false
-	quoteChar?: string;    // default: '"'
-	escapeChar?: string;   // default: '"'
-	delimiter?: string;    // default: ","
-	header?: boolean;      // default: true
-	newline?: string;      // default: "\r\n"
+    quotes?: boolean | boolean[];   // default: false
+	quoteChar?: string;             // default: '"'
+	escapeChar?: string;            // default: '"'
+	delimiter?: string;             // default: ","
+	header?: boolean;               // default: true
+	newline?: string;               // default: "\r\n"
 }
 
 export interface UnparseObject {

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -66,6 +66,7 @@ Papa.unparse({
 });
 
 Papa.unparse([{ a: 1, b: 1, c: 1 }], { quotes: false });
+Papa.unparse([{ a: 1, b: 1, c: 1 }], { quotes: [false, true, true] });
 Papa.unparse([[1, 2, 3], [4, 5, 6]], { delimiter: "," });
 Papa.unparse({
 	fields: ["3"],


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.papaparse.com/docs#json-to-csv
"Set quotes to true to always enclose each field in quotes, or an array of true/false values correlating to specific to columns to force-quote."

- [ ] Increase the version number in the header if appropriate.
Fix predates currently referenced version in the header
