### PR TITLE
[highland] Fix `Highland.Stream.through` definition

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -305,7 +305,7 @@ barStream = barStreamStream.sequence();
 
 barStream = fooStream.series<Bar>();
 
-barStream = fooStream.through(x => bar);
+bar = fooStream.through(x => bar);
 barStream = fooStream.through(readwritable);
 
 fooStream = fooStream.zip(fooStream);

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1172,7 +1172,7 @@ declare namespace Highland {
 		 *   console.log(err); // => SyntaxError: Unexpected token z
 		 * });
 		 */
-		through<R, U>(f: (x: R) => U): Stream<U>;
+		through<R, U>(f: (x: R) => U): U;
 		through(thru: NodeJS.ReadWriteStream): Stream<any>;
 
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [c] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/caolan/highland/blob/a629aa4f2dbba904e22801d6ebe55b4aa68f338d/lib/index.js#L3383-L3385
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

When a function is provided to `.through`, it is called with the stream and the result is passed without any further wrapping.