### PR TITLE
[@types/luxon] Add Datetime.toRelative/toRelativeCalendar.

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -23,6 +23,35 @@ declare module 'luxon' {
             round?: boolean;
         };
 
+        type ToRelativeOptions = {
+            /** The DateTime to use as the basis to which this time is compared. Defaults to now. */
+            base?: DateTime;
+            locale?: string;
+            style?: 'long' | 'short' | 'narrow';
+            /** If omitted, the method will pick the unit. */
+            unit?: 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
+            /** Defaults to `true`. */
+            round?: boolean;
+            /**
+             * Padding in milliseconds. This allows you to round up the result if it fits inside the threshold.
+             * Don't use in combination with {round: false} because the decimal output will include the padding.
+             * Defaults to 0.
+             */
+            padding?: number;
+            /** The Intl system may choose not to honor this */
+            numberingSystem?: string;
+        };
+
+        type ToRelativeCalendarOptions = {
+            /** The DateTime to use as the basis to which this time is compared. Defaults to now. */
+            base?: DateTime;
+            locale?: string;
+            /** If omitted, the method will pick the unit. */
+            unit?: 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
+            /** The Intl system may choose not to honor this. */
+            numberingSystem?: string;
+        };
+
         type ToSQLOptions = {
             includeOffset?: boolean;
             includeZone?: boolean;
@@ -229,6 +258,8 @@ declare module 'luxon' {
             toMillis(): number;
             toMillis(): number;
             toObject(options?: { includeConfig?: boolean }): DateObject;
+            toRelative(options?: ToRelativeOptions): string | null;
+            toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
             toRFC2822(): string;
             toSQL(options?: ToSQLOptions): string;
             toSQLDate(): string;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -45,6 +45,28 @@ dt.toSQLDate();
 dt.toSQLTime();
 dt.toSQLTime({includeOffset: false, includeZone: true});
 
+dt.toRelative();
+dt.toRelativeCalendar();
+
+// $ExpectType string | null
+dt.toRelative({
+    base: DateTime.local(),
+    locale: 'fr',
+    style: 'long',
+    unit: 'day',
+    round: true,
+    padding: 10,
+    numberingSystem: 'bali',
+});
+
+// $ExpectType string | null
+dt.toRelativeCalendar({
+    base: DateTime.local(),
+    locale: 'fr',
+    unit: 'day',
+    numberingSystem: 'bali',
+});
+
 dt.plus({ hours: 3, minutes: 2 });
 dt.minus({ days: 7 });
 dt.startOf('day');
@@ -67,7 +89,7 @@ DateTime.utc().toLocal();
 
 DateTime.fromMillis(1527780819458).toMillis();
 
-const {input, result, zone} = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
+const {input, result, zone} = DateTime.fromFormatExplain('Aug 6 1982', 'MMMM d yyyy');
 
 /* Duration */
 const dur = Duration.fromObject({ hours: 2, minutes: 7 });


### PR DESCRIPTION
Fixes #32213.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [docs](https://moment.github.io/luxon/docs/manual/moment.html#humanization)
  - [changeset](https://github.com/moment/luxon/pull/390/files#diff-9ecf9d66fc87566271977e944f605443R1754)
- [x] Increase the version number in the header if appropriate.
  - **NOTE:** these methods were added in [v1.19](https://github.com/moment/luxon/blob/master/changelog.md#190), but I'm not updating the version header specifically because #32164 is already opened to add the new methods from v1.10 and I don't want to create an unnecessary conflict. 
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
