### PR TITLE
ReactStrap: Add support for CustomInput type='switch'

### DIFF
--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for reactstrap 6.4
+// Type definitions for reactstrap 7.1
 // Project: https://github.com/reactstrap/reactstrap#readme
 // Definitions by: Ali Hammad Baig <https://github.com/alihammad>
 //                 Marco Falkenberg <https://github.com/mfal>

--- a/types/reactstrap/lib/CustomInput.d.ts
+++ b/types/reactstrap/lib/CustomInput.d.ts
@@ -5,7 +5,8 @@ export type CustomInputType =
   | 'select'
   | 'file'
   | 'radio'
-  | 'checkbox';
+  | 'checkbox'
+  | 'switch';
 
 export type CustomInputProps<T = {}> = React.InputHTMLAttributes<HTMLInputElement> & {
   type: CustomInputType;


### PR DESCRIPTION
Supports bootstrap release 4.2.0
Supports reactstrap release 7.1.0

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
Never done this before. Didn't see any tests in the repo.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
Not sure how to do this. Didn't see any tslint.json in the repo.

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/twbs/bootstrap/releases/tag/v4.2.0
https://github.com/reactstrap/reactstrap/releases/tag/7.1.0
- [x] Increase the version number in the header if appropriate.
Not sure if this is appropriate or not.

