### PR TITLE
Allow null as a return type for JwtFromRequestFunction type

### DIFF
--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -52,7 +52,7 @@ export class Verifier {
     verify(req: Request, payload: any, done: (error: any, user?: any, info?: any) => void): void;
 }
 
-export type JwtFromRequestFunction = (req: Request) => string;
+export type JwtFromRequestFunction = (req: Request) => string | null;
 
 export const ExtractJwt: {
     fromHeader(header_name: string): JwtFromRequestFunction;


### PR DESCRIPTION
The JwtFromRequestFunction type should allow a null to be returned to indicate a JWT couldn't be extracted.
As described here: http://www.passportjs.org/packages/passport-jwt/#extracting-the-jwt-from-the-request
