### PR TITLE
[leaflet-providers] Fix previous breaking change and update tests to catch the mistake in future. Also change indentation to match style-guide.

### DIFF
--- a/types/leaflet-providers/index.d.ts
+++ b/types/leaflet-providers/index.d.ts
@@ -7,27 +7,27 @@
 import * as L from 'leaflet';
 
 declare module 'leaflet' {
-  namespace TileLayer {
-    class Provider extends TileLayer {
-      constructor(provider: string, options?: TileLayerOptions | { [name: string]: string; })
+    namespace TileLayer {
+        class Provider extends TileLayer {
+            constructor(provider: string, options?: TileLayerOptions | { [name: string]: string; })
+        }
+
+        namespace Provider {
+            const providers: ProvidersMap;
+
+            interface ProvidersMap {
+                [providerName: string]: ProviderConfig;
+            }
+
+            interface ProviderConfig {
+                url: string;
+                options?: TileLayerOptions;
+                variants?: {[variantName: string]: string | ProviderConfig};
+            }
+        }
     }
 
-    namespace Provider {
-      const providers: ProvidersMap;
-
-      interface ProvidersMap {
-        [providerName: string]: ProviderConfig;
-      }
-
-      interface ProviderConfig {
-        url: string;
-        options?: TileLayerOptions;
-        variants?: {[variantName: string]: string | ProviderConfig};
-      }
+    namespace tileLayer {
+        function provider(provider: string, options?: TileLayerOptions | { [name: string]: string; }): TileLayer.Provider;
     }
-  }
-
-  namespace tileLayer {
-    function provider(provider: string, options?: TileLayerOptions | { [name: string]: string; }): TileLayer.Provider;
-  }
 }

--- a/types/leaflet-providers/index.d.ts
+++ b/types/leaflet-providers/index.d.ts
@@ -9,7 +9,7 @@ import * as L from 'leaflet';
 declare module 'leaflet' {
   namespace TileLayer {
     class Provider extends TileLayer {
-      constructor(provider: string, options?: TileLayerOptions & { [name: string]: string; })
+      constructor(provider: string, options?: TileLayerOptions | { [name: string]: string; })
     }
 
     namespace Provider {
@@ -28,6 +28,6 @@ declare module 'leaflet' {
   }
 
   namespace tileLayer {
-    function provider(provider: string, options?: TileLayerOptions & { [name: string]: string; }): TileLayer.Provider;
+    function provider(provider: string, options?: TileLayerOptions | { [name: string]: string; }): TileLayer.Provider;
   }
 }

--- a/types/leaflet-providers/leaflet-providers-tests.ts
+++ b/types/leaflet-providers/leaflet-providers-tests.ts
@@ -5,27 +5,43 @@ const map = L.map('map');
 L.tileLayer.provider('Stamen.Watercolor').addTo(map);
 
 L.tileLayer.provider('HERE.terrainDay', {
-  app_id: '<insert ID here>',
-  app_code: '<insert ID here>'
+    app_id: '<insert ID here>',
+    app_code: '<insert ID here>'
 }).addTo(map);
 
 new L.TileLayer.Provider('MapBox').addTo(map);
-new L.TileLayer.Provider('MapBox', {id: 'ID', accessToken: 'ACCESS_TOKEN'}).addTo(map);
-
-L.TileLayer.Provider.providers['nlmaps'] = {
-  url: 'https://geodata.nationaalgeoregister.nl/tiles/service/wmts/{variant}/EPSG:3857/{z}/{x}/{y}.png',
-  options: {
+new L.TileLayer.Provider('MapBox', {
+    id: 'ID',
+    accessToken: 'ACCESS_TOKEN',
     minZoom: 6,
     maxZoom: 19,
     bounds: [[50.5, 3.25], [54, 7.6]],
     attribution: 'Kaartgegevens &copy; <a href="kadaster.nl">Kadaster</a>'
-  },
-  variants: {
-    standaard: 'brtachtergrondkaart',
-    pastel: 'brtachtergrondkaartpastel',
-    grijs: 'brtachtergrondkaartgrijs',
-    luchtfoto: {
-      url: 'https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts/1.0.0/2016_ortho25/EPSG:3857/{z}/{x}/{y}.png',
+}).addTo(map);
+
+L.tileLayer.provider('MapBox', {
+    id: 'ID',
+    accessToken: 'ACCESS_TOKEN',
+    minZoom: 6,
+    maxZoom: 19,
+    bounds: [[50.5, 3.25], [54, 7.6]],
+    attribution: 'Kaartgegevens &copy; <a href="kadaster.nl">Kadaster</a>'
+}).addTo(map);
+
+L.TileLayer.Provider.providers['nlmaps'] = {
+    url: 'https://geodata.nationaalgeoregister.nl/tiles/service/wmts/{variant}/EPSG:3857/{z}/{x}/{y}.png',
+    options: {
+        minZoom: 6,
+        maxZoom: 19,
+        bounds: [[50.5, 3.25], [54, 7.6]],
+        attribution: 'Kaartgegevens &copy; <a href="kadaster.nl">Kadaster</a>'
+    },
+    variants: {
+        standaard: 'brtachtergrondkaart',
+        pastel: 'brtachtergrondkaartpastel',
+        grijs: 'brtachtergrondkaartgrijs',
+        luchtfoto: {
+            url: 'https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts/1.0.0/2016_ortho25/EPSG:3857/{z}/{x}/{y}.png',
+        }
     }
-  }
 };


### PR DESCRIPTION
…at it allows types fulfilling either TileLayerOptions or {[name: string]: string}, instead of both. Requiring both forced every option to be a string, even those declared as numbers in TileLayerOptions.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/20b366a5758aa03da779e1ef1cff85857c7675ca#commitcomment-31957005
- [ ] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
