### PR TITLE
[mousetrap] Make constructor parameter optional

### DIFF
--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Mousetrap 1.6.x
 // Project: http://craig.is/killing/mice
-// Definitions by: Dániel Tar <https://github.com/qcz>
+// Definitions by: Dániel Tar <https://github.com/qcz>, Alan Choi <https://github.com/alanhchoi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -10,7 +10,7 @@ interface ExtendedKeyboardEvent extends KeyboardEvent {
 
 interface MousetrapStatic {
     (el: Element): MousetrapInstance;
-    new (el: Element): MousetrapInstance;
+    new (el?: Element): MousetrapInstance;
     addKeycodes(keycodes: { [key: number]: string }): void;
     stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
     bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;

--- a/types/mousetrap/test/index.ts
+++ b/types/mousetrap/test/index.ts
@@ -49,7 +49,11 @@ Mousetrap.reset();
 // event handler to the form element only, instead of the entire document.
 var element = document.querySelector('form');
 var instance = new Mousetrap(element);
-instance.bind('mod+s', function(){ console.log('Instance Saved'); });
+instance.bind('mod+s', function () { console.log('Instance Saved'); });
+
+// Test that we can create an instance of mousetrap without passing element to the constructor.
+var documentInstance = new Mousetrap();
+documentInstance.bind('mod+s', function () { console.log('documentInstance Saved'); });
 
 // Test that the factory method works as well.
 Mousetrap(element).bind('mod+s', function(){ console.log('Factory Saved'); });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ccampbell/mousetrap/blob/215621acf801a04d2cba4c1f990fb3844b9243d8/mousetrap.js#L438

Constructor argument defaults to `document` if no argument is passed.

