### PR TITLE
[lodash] Exclude undefined in return of get when default value is specified

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1686,7 +1686,7 @@ declare module "../index" {
             object: TObject | null | undefined,
             path: TKey | [TKey],
             defaultValue: TDefault
-        ): TObject[TKey] | TDefault;
+        ): Exclude<TObject[TKey], undefined> | TDefault;
 
         /**
          * @see _.get

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5140,12 +5140,15 @@ fp.now(); // $ExpectType number
 
 // _.get
 {
+    const dictionary: { a?: string } = { };
+
     _.get([], Symbol.iterator);
     _.get([], [Symbol.iterator]);
 
     _.get("abc", 1); // $ExpectType string
     _.get("abc", ["0"], "_");
     _.get([42], 0, -1); // $ExpectType number
+    _.get(dictionary, "a", 'b'); // $ExpectType string
     _.get({ a: { b: true } }, "a"); // $ExpectType { b: boolean; }
     _.get({ a: { b: true } }, ["a"]); // $ExpectType { b: boolean; }
     _.get({ a: { b: true } }, ["a", "b"]); // $ExpectType any


### PR DESCRIPTION
Hi,
according to source code below:
```javascript
function get(object, path, defaultValue) {
  var result = object == null ? undefined : baseGet(object, path);
  return result === undefined ? defaultValue : result;
}
```
when default value is passed, return type should exclude `undefined`

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/lodash/lodash/blob/4.17.11/lodash.js#L13127>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

