### PR TITLE
detox: Prevent exporting global "expect" from other modules.

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -8,14 +8,8 @@ declare global {
     const device: Detox.Device;
     const element: Detox.Element;
     const waitFor: Detox.WaitFor;
-    /**
-     * `dexpect` ("Detox-expect") intentionally has the same type as `expect`.
-     * `expect` conflicts with the global `expect` of jest and therefore
-     * exporting it doesn't work which is why `dexpect` was introduced. `expect`
-     * is kept for backwards compatibility.
-     */
-    const dexpect: Detox.Expect<Detox.Expect<any>>;
     const expect: Detox.Expect<Detox.Expect<any>>;
+    const ffffexpect: Detox.Expect<Detox.Expect<any>>;
     const by: Detox.Matchers;
 
     namespace Detox {
@@ -440,5 +434,11 @@ declare global {
         }
     }
 }
+
+// `dexpect` ("Detox-expect") intentionally has the same type as `expect`.
+// `expect` conflicts with the global `expect` of jest and therefore
+// exporting it doesn't work which is why `dexpect` was introduced. `expect`
+// is kept for backwards compatibility.
+declare const dexpect: Detox.Expect<Detox.Expect<any>>;
 
 export { by, detox, device, element, dexpect as expect, waitFor };

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -8,6 +8,7 @@ declare global {
     const device: Detox.Device;
     const element: Detox.Element;
     const waitFor: Detox.WaitFor;
+    const dexpect: Detox.Expect<Detox.Expect<any>>;
     const expect: Detox.Expect<Detox.Expect<any>>;
     const by: Detox.Matchers;
 
@@ -434,4 +435,4 @@ declare global {
     }
 }
 
-export { by, detox, device, element, expect, waitFor };
+export { by, detox, device, element, dexpect as expect, waitFor };

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -8,6 +8,12 @@ declare global {
     const device: Detox.Device;
     const element: Detox.Element;
     const waitFor: Detox.WaitFor;
+    /**
+     * `dexpect` ("Detox-expect") intentionally has the same type as `expect`.
+     * `expect` conflicts with the global `expect` of jest and therefore
+     * exporting it doesn't work which is why `dexpect` was introduced. `expect`
+     * is kept for backwards compatibility.
+     */
     const dexpect: Detox.Expect<Detox.Expect<any>>;
     const expect: Detox.Expect<Detox.Expect<any>>;
     const by: Detox.Matchers;

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -435,10 +435,10 @@ declare global {
     }
 }
 
-// `dexpect` ("Detox-expect") intentionally has the same type as `expect`.
-// `expect` conflicts with the global `expect` of jest and therefore
-// exporting it doesn't work which is why `dexpect` was introduced. `expect`
-// is kept for backwards compatibility.
-declare const dexpect: Detox.Expect<Detox.Expect<any>>;
+export { by, detox, device, element, waitFor };
 
-export { by, detox, device, element, dexpect as expect, waitFor };
+// Not exporting the global `expect` from the top of the file here
+// because `expect` conflicts with the global `expect` of jest and
+// therefore exporting it doesn't work. The global `expect` is kept
+// for backwards compatibility though.
+export const expect: Detox.Expect<Detox.Expect<any>>;

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -9,7 +9,6 @@ declare global {
     const element: Detox.Element;
     const waitFor: Detox.WaitFor;
     const expect: Detox.Expect<Detox.Expect<any>>;
-    const ffffexpect: Detox.Expect<Detox.Expect<any>>;
     const by: Detox.Matchers;
 
     namespace Detox {


### PR DESCRIPTION
I experienced a problem when having both, the types from jest and detox, installed. The problem was that jest already has a global `expect` function. When detox declares its own in its `index.d.ts` that fails and in the last line, instead of the `expect` of detox, jest's `expect` is exported.

As a solution, the new `dexpect` const instead of `expect` is exported. To ensure backwards compatibility, it is aliased as `expect`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
