### PR TITLE
[segment-analytics] Add optional context property to SegmentOpts

### DIFF
--- a/types/segment-analytics/index.d.ts
+++ b/types/segment-analytics/index.d.ts
@@ -12,7 +12,7 @@ declare namespace SegmentAnalytics {
   interface SegmentOpts {
     integrations?: any;
     anonymousId?: string;
-    context?: Object;
+    context?: object;
   }
 
   // The actual analytics.js object

--- a/types/segment-analytics/index.d.ts
+++ b/types/segment-analytics/index.d.ts
@@ -12,6 +12,7 @@ declare namespace SegmentAnalytics {
   interface SegmentOpts {
     integrations?: any;
     anonymousId?: string;
+    context?: Object;
   }
 
   // The actual analytics.js object

--- a/types/segment-analytics/segment-analytics-tests.ts
+++ b/types/segment-analytics/segment-analytics-tests.ts
@@ -13,6 +13,11 @@ var testProps = {
 var testOpts = {
   integrations: {
     Mixpanel: true
+  },
+  context: {
+    campaign: {
+      name: 'Cheese Promo'
+    }
   }
 };
 


### PR DESCRIPTION
Segment now supports _context_ in the "options" object, which allows us to augment the default context sent by all events. I have tested adding a context to the options of Identify, Page and Track calls.

See Segment's [_analytics.js_](https://github.com/segmentio/analytics.js/blob/master/analytics.js#L607) for an example of their use of _context_ within the _options_ object.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/segmentio/analytics.js/blob/master/analytics.js#L607
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
