### PR TITLE
react-native: Add showPopupMenu property in UIManagerStatic

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8217,7 +8217,7 @@ export interface UIManagerStatic {
      *
      * To obtain a native node handle for a component, you can use
      * `React.findNodeHandle(component)`.
-     * 
+     *
      * Note that this works only on Android
      */
     showPopupMenu(

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8224,7 +8224,7 @@ export interface UIManagerStatic {
         node: number,
         items: string[],
         error: () => void, /* currently unused */
-        success: (item: string, buttonIndex: number | undefined) => void
+        success: (item: string, index: number | undefined) => void
     ): void;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -15,6 +15,7 @@
 //                 Martin van Dam <https://github.com/mvdam>
 //                 Kacper Wiszczuk <https://github.com/esemesek>
 //                 Ryan Nickel <https://github.com/mrnickel>
+//                 Souvik Ghosh <https://github.com/souvik-ghosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -8206,6 +8207,25 @@ export interface UIManagerStatic {
      *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
      */
     setLayoutAnimationEnabledExperimental(value: boolean): void;
+    
+    /**
+     * Used to display an Android PopupMenu. If a menu item is pressed, the success callback will
+     * be called with the following arguments:
+     *
+     *  - item - the menu item.
+     *  - index - index of the pressed item in array. Returns `undefined` if cancelled.
+     *
+     * To obtain a native node handle for a component, you can use
+     * `React.findNodeHandle(component)`.
+     * 
+     * Note that this works only on Android
+     */
+    showPopupMenu(
+        node: number,
+        items: string[],
+        error: () => void, /* currently unused */
+        success: (item: string, buttonIndex: number | undefined) => void
+    ): void;
 }
 
 export interface SwitchPropsIOS extends ViewProps {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8207,7 +8207,7 @@ export interface UIManagerStatic {
      *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
      */
     setLayoutAnimationEnabledExperimental(value: boolean): void;
-    
+
     /**
      * Used to display an Android PopupMenu. If a menu item is pressed, the success callback will
      * be called with the following arguments:


### PR DESCRIPTION
property 'showPopupMenu' was missing

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/issues/3004#issuecomment-202598006