### PR TITLE
react-jsonschema-form: now we can use 'disabled' on the Form

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-jsonschema-form 1.0.1
+// Type definitions for react-jsonschema-form 1.2
 // Project: https://github.com/mozilla-services/react-jsonschema-form
-// Definitions by: Dan Fox <https://github.com/iamdanfox>
+// Definitions by: Carlo Cancellieri <https://github.com/ccancellieri>
+//                 Dan Fox <https://github.com/iamdanfox>
 //                 Ivan Jiang <https://github.com/iplus26>
 //                 Philippe Bourdages <https://github.com/phbou72>
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -48,6 +48,7 @@ declare module "react-jsonschema-form" {
         autocomplete?: string;
         enctype?: string;
         acceptcharset?: string;
+        disabled?: boolean;
     }
 
     export default class Form<T> extends React.Component<FormProps<T>> {}

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -74,6 +74,11 @@ export default function ErrorListExample(props: ErrorListProps) {
     );
 }
 
+export const DisabledForm = (p:any) => 
+    <div className="react-jsonschema-form-example">
+        {<Form schema={{}} formData={{}} disabled />}
+    </div>;
+
 export class Example extends React.Component<any, IExampleState> {
     public state: IExampleState = {
         formData: {


### PR DESCRIPTION
Hi,
 I've to disable the entire form (ref. to the changes here -> https://github.com/mozilla-services/react-jsonschema-form/pull/1056)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla-services/react-jsonschema-form/pull/1056
- [x] Increase the version number in the header if appropriate.
