### PR TITLE
[usb] Add getBosDescriptor() and getCapabilities() added in 1.5.0

### DIFF
--- a/types/usb/index.d.ts
+++ b/types/usb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-usb 1.1
+// Type definitions for node-usb 1.5
 // Project: https://github.com/tessel/node-usb
 // Definitions by: Eric Brody <https://github.com/underscorebrody>
 //                 Rob Moran <https://github.com/thegecko>
@@ -31,6 +31,8 @@ export class Device {
   interface(addr: number): Interface;
   controlTransfer(bmRequestType: number, bRequest: number, wValue: number, wIndex: number, data_or_length: any, callback: (error?: LibUSBException, buf?: Buffer) => void): Device;
   getStringDescriptor(desc_index: number, callback: (error?: string, buf?: Buffer) => void): void;
+  getBosDescriptor(callback: (error?: string, descriptor?: BosDescriptor) => void): void;
+  getCapabilities(callback: (error?: string, capabilities?: Capability[]) => void): void;
   setConfiguration(desired: number, cb: (err?: string) => void): void;
   reset(callback: (err?: string) => void): void;
 }
@@ -63,6 +65,27 @@ export class ConfigDescriptor {
   bMaxPower: number;
   extra: Buffer;
   interfaces: InterfaceDescriptor[][];
+}
+
+export class BosDescriptor {
+  bLength: number;
+  bDescriptorType: number;
+  wTotalLength: number;
+  bNumDeviceCaps: number;
+  capabilities: CapabilityDescriptor[];
+}
+
+export class CapabilityDescriptor {
+  bLength: number;
+  bDescriptorType: number;
+  bDevCapabilityType: number;
+  dev_capability_data: Buffer;
+}
+
+export class Capability {
+  descriptor: CapabilityDescriptor;
+  type: number;
+  data: Buffer;
 }
 
 export class Interface {

--- a/types/usb/usb-tests.ts
+++ b/types/usb/usb-tests.ts
@@ -14,6 +14,8 @@ device.open(true);
 device.close();
 const xferDevice: usb.Device = device.controlTransfer(1, 1, 1, 1, 1, (error: usb.LibUSBException, buf: Buffer): usb.Device => new usb.Device());
 device.getStringDescriptor(1, (error: string, buf: Buffer) => null);
+device.getBosDescriptor((error: string, descriptor: usb.BosDescriptor) => null);
+device.getCapabilities((error: string, capabilities: usb.Capability[]) => null);
 device.setConfiguration(1, (error: string) => null);
 device.reset((error: string) => null);
 


### PR DESCRIPTION
This PR Adds getBosDescriptor() and getCapabilities() functionality which were released in node-usb version 1.5.0. Also includes the response types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tessel/node-usb/pull/214
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

