### PR TITLE
Added `set` method to available types for `dot-object` package

### DIFF
--- a/types/dot-object/dot-object-tests.ts
+++ b/types/dot-object/dot-object-tests.ts
@@ -47,11 +47,20 @@ var newObj = {
     nested: {
       value: 'Hi there!'
     }
+  },
+  breath: {
+    value: 'Hello'
   }
 };
 
 var val = dot.pick('some.nested.value', newObj);
 console.log(val);
+
+// Set a new value
+val = dot.str('breath.value', 'World', newObj);
+
+// Replacing with a new object
+val = dot.set('breath', { value: 'Goodbye' }, newObj);
 
 // Pick & Remove the value
 val = dot.pick('some.nested.value', newObj, true);

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Dot-Object v1.5
+// Type definitions for Dot-Object v1.7.1
 // Project: https://github.com/rhalff/dot-object
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -1,8 +1,8 @@
 // Type definitions for Dot-Object 1.7
-// TypeScript Version: 2.2
 // Project: https://github.com/rhalff/dot-object
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 
 declare namespace DotObject {

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Dot-Object v1.7.1
+// Type definitions for Dot-Object v1.7
 // Project: https://github.com/rhalff/dot-object
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Dot-Object v1.7
+// Type definitions for Dot-Object 1.7
 // Project: https://github.com/rhalff/dot-object
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -128,7 +128,7 @@ declare namespace DotObject {
          * @param {Object} obj object to be modified
          * @param {Function|Array} mods optional modifier
         */
-        str(path: string, v: any, obj: Object, mods?: ModifierFunctionWrapper | Array<ModifierFunctionWrapper>): void;
+        str(path: string, v: any, obj: object, mods?: ModifierFunctionWrapper | Array<ModifierFunctionWrapper>): void;
         /**
          *
          * Replace/merge an object to an existing object property
@@ -138,7 +138,7 @@ declare namespace DotObject {
          * @param {Object} obj object to be modified
          * @param {Boolean} merge optional merge
         */
-		set(path: string, v: any, obj: Object, merge?: Boolean): void;
+		set(path: string, v: any, obj: object, merge?: boolean): void;
         /**
          *
          * Transfer a property from one object to another object.

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -120,12 +120,25 @@ declare namespace DotObject {
          */
         remove(path: string, obj: any): any;
         /**
+         *
+         * Replace/create with a string
+         *
          * @param {String} path dotted path
          * @param {String} v value to be set
          * @param {Object} obj object to be modified
          * @param {Function|Array} mods optional modifier
         */
         str(path: string, v: any, obj: Object, mods?: ModifierFunctionWrapper | Array<ModifierFunctionWrapper>): void;
+        /**
+         *
+         * Replace/merge an object to an existing object property
+         *
+         * @param {String} path dotted path
+         * @param {Object} v object to be set
+         * @param {Object} obj object to be modified
+         * @param {Boolean} merge optional merge
+        */
+		set(path: string, v: any, obj: Object, merge?: Boolean): void;
         /**
          *
          * Transfer a property from one object to another object.

--- a/types/dot-object/index.d.ts
+++ b/types/dot-object/index.d.ts
@@ -1,4 +1,5 @@
 // Type definitions for Dot-Object 1.7
+// TypeScript Version: 2.2
 // Project: https://github.com/rhalff/dot-object
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/dot-object/tslint.json
+++ b/types/dot-object/tslint.json
@@ -7,7 +7,6 @@
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,
-        "dt-header": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,


### PR DESCRIPTION
Added `set` which does exist (https://github.com/rhalff/dot-object/blob/master/index.js#L358) but is undocumented. Used for replacing an object -> https://github.com/rhalff/dot-object/issues/8.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rhalff/dot-object/blob/master/index.js#L358
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.