### PR TITLE
Update replace() definition from @types/node-emoji

### DIFF
--- a/types/node-emoji/index.d.ts
+++ b/types/node-emoji/index.d.ts
@@ -1363,4 +1363,4 @@ export function unemojify(str: string): string;
 export function find(emoji: string): Emoji;
 export function hasEmoji(str: string): boolean;
 export function strip(str: string): string;
-export function replace(str: string, replacement: (emoji: Emoji) => string | string, cleanSpaces?: boolean): string;
+export function replace(str: string, replacement: ((emoji: Emoji) => string) | string, cleanSpaces?: boolean): string;

--- a/types/node-emoji/index.d.ts
+++ b/types/node-emoji/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/omnidan/node-emoji#readme
 // Definitions by: Tristan Jones <https://github.com/jonestristand>
 //                 styu <https://github.com/styu>
+//                 rimiti <https://github.com/rimiti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export const emoji: {
@@ -1362,4 +1363,4 @@ export function unemojify(str: string): string;
 export function find(emoji: string): Emoji;
 export function hasEmoji(str: string): boolean;
 export function strip(str: string): string;
-export function replace(str: string, callback: (emoji: Emoji) => string): string;
+export function replace(str: string, replacement: (emoji: Emoji) => string | string, cleanSpaces?: boolean): string;

--- a/types/node-emoji/node-emoji-tests.ts
+++ b/types/node-emoji/node-emoji-tests.ts
@@ -25,3 +25,7 @@ const hasEmoji: boolean = emoji.hasEmoji('🍕');
 const stripped_emoji: string = emoji.strip('⚠️ 〰️ 〰️ low disk space');
 
 const replaced_emoji: string = emoji.replace('⚠️ 〰️ 〰️ low disk space', (emoji) => `${emoji.key}:`);
+
+const replaced_emoji_with_string: string = emoji.replace('⚠️ 〰️ 〰️ low disk space', 'example');
+
+const replaced_emoji_keep_spaces: string = emoji.replace('⚠️ 〰️ 〰️ low disk space', '', false);


### PR DESCRIPTION
Hello,

This pull request fix the `replace` function definition.

Concerned line of the official repository: 
https://github.com/omnidan/node-emoji/blob/5975ad506a97465d4050f8895a02b79cccea8373/lib/emoji.js#L272

PS: If you are seeking a new maintainer, I'm in! 🚀
