### PR TITLE
[js-yaml]: Added new noArrayIndent property that is added on v3.12.1

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for js-yaml 3.11
+// Type definitions for js-yaml 3.12
 // Project: https://github.com/nodeca/js-yaml
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Sebastian Clausen <https://github.com/sclausen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -52,6 +52,8 @@ export interface LoadOptions {
 export interface DumpOptions {
 	/** indentation width to use (in spaces). */
 	indent?: number;
+	/** when true, will not add an indentation level to array elements */
+	noArrayIndent?: boolean;
 	/** do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types. */
 	skipInvalid?: boolean;
 	/** specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere */

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -73,6 +73,9 @@ dumpOpts = {
 	indent: num
 };
 dumpOpts = {
+	noArrayIndent: bool
+};
+dumpOpts = {
 	skipInvalid: bool
 };
 dumpOpts = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/js-yaml/pull/461
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.