### PR TITLE
@types/catbox: Allow object for id argument for generateFunc method

### DIFF
--- a/types/catbox/index.d.ts
+++ b/types/catbox/index.d.ts
@@ -249,7 +249,7 @@ export interface GenerateFuncFlags {
  *      * ttl - the cache ttl value in milliseconds. Set to 0 to skip storing in the cache. Defaults to the cache global policy.
  * @see {@link https://github.com/hapijs/catbox#policy}
  */
-export type GenerateFunc<T> = (id: string, flags: GenerateFuncFlags) => Promise<T>;
+export type GenerateFunc<T> = (id: Id, flags: GenerateFuncFlags) => Promise<T>;
 
 /**
  * An object with logging information about the generation operation containing the following keys (as relevant):


### PR DESCRIPTION
Hello,

Small fix to fit the catbox documentation saying that the `id` argument of the `generateFunc` method allows type `object` if it contains the `id: string` property.

In the type file, each `id` argument were typed as `Id` except for the one of the `generateFunc` method.

Authors : @jasonswearingen @AJamesPhillips @saboya