### PR TITLE
Change listFields() return type to FieldObjects[]

### DIFF
--- a/types/jira-client/index.d.ts
+++ b/types/jira-client/index.d.ts
@@ -89,7 +89,7 @@ declare class JiraApi {
 
     createCustomField(field: JiraApi.FieldObject): Promise<JiraApi.JsonResponse>;
 
-    listFields(): Promise<JiraApi.JsonResponse>;
+    listFields(): Promise<JiraApi.FieldObject[]>;
 
     createFieldOption(fieldKey: string, option: JiraApi.FieldOptionObject): Promise<JiraApi.JsonResponse>;
 


### PR DESCRIPTION
The return type of listFields() should be FieldObjects[] to match to: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-api-2-field-get

This change is located at: types/jira-client/index.d.ts

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-api-2-field-get
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.