### PR TITLE
[toobusy-js] Adding overload for getter with no args

### DIFF
--- a/types/toobusy-js/index.d.ts
+++ b/types/toobusy-js/index.d.ts
@@ -20,6 +20,7 @@ declare namespace toobusy_js {
      * @param  [newInterval] New interval to set. If not provided, will return the existing interval.
      * @return               New or existing interval.
      */
+    function interval(): number;
     function interval(newInterval?: number): number;
     /**
      * Returns last lag reading from last check interval.
@@ -37,6 +38,7 @@ declare namespace toobusy_js {
      * @param  [newLag] New maxLag (highwater) threshold.
      * @return          New or existing maxLag (highwater) threshold.
      */
+    function maxLag(): number;
     function maxLag(newLag?: number): number;
     /**
      * Set or get the smoothing factor. Default is 0.3333....
@@ -47,6 +49,7 @@ declare namespace toobusy_js {
      * @param  [newFactor] New smoothing factor.
      * @return             New or existing smoothing factor.
      */
+    function smoothingFactor(): number;
     function smoothingFactor(newFactor?: number): number;
     /**
      * Shuts down toobusy.


### PR DESCRIPTION
Before this update, TS threw this error:
error TS2554: Expected 1 arguments, but got 0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/functions.html#overloads
- [x] Increase the version number in the header if appropriate.


Continuous Integration / travis-ci / pr  failed... hmmm 
