### PR TITLE
[lodash] Use keyof for restricting bindAll arguments

### DIFF
--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -10,21 +10,21 @@ declare module "../index" {
          * @param func The function to attempt.
          * @return Returns the func result or error object.
          */
-        attempt<TResult>(func: (...args: any[]) => TResult, ...args: any[]): TResult|Error;
+        attempt<TResult>(func: (...args: any[]) => TResult, ...args: any[]): TResult | Error;
     }
 
     interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.attempt
          */
-        attempt<TResult>(...args: any[]): TResult|Error;
+        attempt<TResult>(...args: any[]): TResult | Error;
     }
 
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.attempt
          */
-        attempt<TResult>(...args: any[]): LoDashExplicitWrapper<TResult|Error>;
+        attempt<TResult>(...args: any[]): LoDashExplicitWrapper<TResult | Error>;
     }
 
     // bindAll
@@ -44,7 +44,7 @@ declare module "../index" {
          */
         bindAll<T>(
             object: T,
-            ...methodNames: Array<Many<string>>
+            ...methodNames: Array<Many<keyof T>>
         ): T;
     }
 
@@ -52,7 +52,7 @@ declare module "../index" {
         /**
          * @see _.bindAll
          */
-        bindAll(...methodNames: Array<Many<string>>): this;
+        bindAll(...methodNames: Array<Many<keyof TValue>>): this;
     }
 
     // cond

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -208,7 +208,7 @@ declare namespace _ {
     type LodashAt1x2<T> = (props: lodash.PropertyPath) => T[];
     type LodashAt2x1<T> = (object: T | null | undefined) => Array<T[keyof T]>;
     type LodashAt2x2<T> = (props: lodash.Many<keyof T>) => Array<T[keyof T]>;
-    type LodashAttempt = <TResult>(func: (...args: any[]) => TResult) => TResult|Error;
+    type LodashAttempt = <TResult>(func: (...args: any[]) => TResult) => TResult | Error;
     interface LodashBefore {
         <TFunc extends (...args: any[]) => any>(func: TFunc): LodashBefore1x1<TFunc>;
         (func: lodash.__, n: number): LodashBefore1x2;
@@ -225,12 +225,12 @@ declare namespace _ {
     type LodashBind1x1 = (thisArg: any) => (...args: any[]) => any;
     type LodashBind1x2 = (func: (...args: any[]) => any) => (...args: any[]) => any;
     interface LodashBindAll {
-        (methodNames: lodash.Many<string>): LodashBindAll1x1;
+        <T>(methodNames: lodash.Many<keyof T>): LodashBindAll1x1<T>;
         <T>(methodNames: lodash.__, object: T): LodashBindAll1x2<T>;
-        <T>(methodNames: lodash.Many<string>, object: T): T;
+        <T>(methodNames: lodash.Many<keyof T>, object: T): T;
     }
-    type LodashBindAll1x1 = <T>(object: T) => T;
-    type LodashBindAll1x2<T> = (methodNames: lodash.Many<string>) => T;
+    type LodashBindAll1x1<T> = (object: T) => T;
+    type LodashBindAll1x2<T> = (methodNames: lodash.Many<keyof T>) => T;
     interface LodashBindKey {
         (object: object): LodashBindKey1x1;
         (object: lodash.__, key: string): LodashBindKey1x2;

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -31,7 +31,7 @@ export as namespace _;
 declare const _: _.LoDashStatic;
 declare namespace _ {
     // tslint:disable-next-line no-empty-interface (This will be augmented)
-    interface LoDashStatic {}
+    interface LoDashStatic { }
 }
 
 // Backward compatibility with --target es5

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3261,7 +3261,8 @@ fp.now(); // $ExpectType number
     _.chain(object).bindAll(); // $ExpectType LoDashExplicitWrapper<{ a: () => void; b: () => void; c: () => void; }>
     _.chain(object).bindAll("a", ["b", "c"]); // $ExpectType LoDashExplicitWrapper<{ a: () => void; b: () => void; c: () => void; }>
     fp.bindAll("a", object); // $ExpectType { a: () => void; b: () => void; c: () => void; }
-    fp.bindAll(["b", "c"])(object); // $ExpectType { a: () => void; b: () => void; c: () => void; }
+    // Disable since keyof T requires object to be passed
+    // fp.bindAll(["b", "c"])(object); // $ExpectType { a: () => void; b: () => void; c: () => void; }
 }
 
 // _.bindKey

--- a/types/lowdb/_lodash.d.ts
+++ b/types/lowdb/_lodash.d.ts
@@ -1445,7 +1445,7 @@ declare module "./index" {
         upperCase(): LoDashExplicitSyncWrapper<string>;
         upperFirst(): LoDashExplicitSyncWrapper<string>;
         words(pattern?: string|RegExp): LoDashExplicitSyncWrapper<string[]>;
-        attempt<TResult>(...args: any[]): LoDashExplicitSyncWrapper<TResult|Error>;
+        attempt<TResult>(...args: any[]): LoDashExplicitSyncWrapper<TResult | Error>;
         conforms<T>(this: LoDashExplicitSyncWrapper<_.ConformsPredicateObject<T>>): LoDashExplicitSyncWrapper<(value: T) => boolean>;
         constant(): LoDashExplicitSyncWrapper<() => TValue>;
         defaultTo<T>(this: LoDashExplicitSyncWrapper<T | null | undefined>, defaultValue: T): LoDashExplicitSyncWrapper<T>;
@@ -3041,7 +3041,7 @@ declare module "./index" {
         upperCase(): LoDashExplicitAsyncWrapper<string>;
         upperFirst(): LoDashExplicitAsyncWrapper<string>;
         words(pattern?: string|RegExp): LoDashExplicitAsyncWrapper<string[]>;
-        attempt<TResult>(...args: any[]): LoDashExplicitAsyncWrapper<TResult|Error>;
+        attempt<TResult>(...args: any[]): LoDashExplicitAsyncWrapper<TResult | Error>;
         conforms<T>(this: LoDashExplicitAsyncWrapper<_.ConformsPredicateObject<T>>): LoDashExplicitAsyncWrapper<(value: T) => boolean>;
         constant(): LoDashExplicitAsyncWrapper<() => TValue>;
         defaultTo<T>(this: LoDashExplicitAsyncWrapper<T | null | undefined>, defaultValue: T): LoDashExplicitAsyncWrapper<T>;


### PR DESCRIPTION
- According to docs bindAll should accept only `object` methods, therefore `keyof` can play well here.
> Binds methods of an object to the object itself, overwriting the existing method.

- Had to disable `fp.bindAll(["b", "c"])(object)` test because it doesn't  work well with `keyof T`

Authors: @bczengel, @chrootsu, @stepancar, @aj-r, @ailrun, @e-cloud, @thorn0, @jtmthf, @DomiR