### PR TITLE
[massive] Allow named parameters to be passed to Database.query

### DIFF
--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -105,6 +105,9 @@ declare namespace massive {
         term: string;
     }
 
+    type QueryParamTypes = string | number | object;
+    type QueryParams = Array<QueryParamTypes> |  QueryParamTypes;
+
     interface EntitySpecification {
         /** A Database. */
         db: Database;
@@ -442,7 +445,7 @@ declare namespace massive {
         /** Execute a query. */
         query(
             query: Select | Insert | Update | Delete | string,
-            params?: string[] | object,
+            params?: QueryParams,
             options?: ResultProcessingOptions
         ): Promise<any>;
 

--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -442,7 +442,7 @@ declare namespace massive {
         /** Execute a query. */
         query(
             query: Select | Insert | Update | Delete | string,
-            params?: string[],
+            params?: string[] | any,
             options?: ResultProcessingOptions
         ): Promise<any>;
 

--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -442,7 +442,7 @@ declare namespace massive {
         /** Execute a query. */
         query(
             query: Select | Insert | Update | Delete | string,
-            params?: string[] | any,
+            params?: string[] | object,
             options?: ResultProcessingOptions
         ): Promise<any>;
 

--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -106,7 +106,7 @@ declare namespace massive {
     }
 
     type QueryParamTypes = string | number | object;
-    type QueryParams = Array<QueryParamTypes> |  QueryParamTypes;
+    type QueryParams = QueryParamTypes[] |  QueryParamTypes;
 
     interface EntitySpecification {
         /** A Database. */


### PR DESCRIPTION
When using the latest definitions for massive, using the following sample from the massive docs:

```js
db.query(
  'select * from tests where id > ${something}',
  {something: 1}
).then(tests => {
  // all tests matching the criteria
});
```
Produces the following error:

```
Argument of type '{ something: string; }' is not assignable to parameter of type 'string[]'.
  Object literal may only specify known properties, and 'something' does not exist in type 'string[]'.
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://dmfay.github.io/massive-js/queries.html#raw-sql
