### PR TITLE
[@types/classnames] Added inferred string-literals to classnames/bind.

### DIFF
--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -1,3 +1,26 @@
-import classNames = require('./index');
+// Type definitions for classnames 2.2
+// Project: https://github.com/JedWatson/classnames
+// Definitions by: Gwilyn Saunders <https://github.com/gwillz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
 
-export function bind(styles: Record<string, string>): typeof classNames;
+type OtherValue = undefined | null | boolean | number | '';
+
+// Allow only valid strings (or string lists/dicts), 'other' values are ignored.
+export type ClassValue<T extends string> = T | ClassDictionary<T> | ClassArray<T> | OtherValue;
+
+export interface ClassArray<T extends string> extends Array<ClassValue<T>> {} // tslint:disable-line no-empty-interface
+
+// Dict can accept anything as it's value, only it's truthy-ness is used.
+// Although using 'any' here breaks the infer-powers below.
+export type ClassDictionary<T extends string> = {
+    [key in T]?: string | number | undefined | null | boolean;
+};
+
+// Bounded classnames can infer what string literals are permitted.
+// Record<T, ...> will infer what literal strings are allows in ClassValue<T>.
+export function bind<T extends string>(styles: Record<T, string>):
+    (...classes: Array<ClassValue<T>>) => string;
+
+declare const cn: {bind: typeof bind};
+export default cn;

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -38,6 +38,20 @@ const className = cx('foo', ['bar'], { baz: true }); // => "abc def xyz"
 
 // falsey values are just ignored
 cx(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
+// @todo we can't infer number types if the given styles map has only
+// string indexes. To be fair though, was this correct anyway? I don't think
+// css rules can be numbers only.
 
 // true is just ignored
 cx(true || "foo");
+// @todo but should it be?
+// Although correct, the definition between 'valid string-literal'
+// and 'everything else but strings' is weird.
+// A clearer definition could be:
+//    The only permitted 'truthy' values should be valid string-literals.
+//    Anything else should be falsey values, and these are ignored.
+
+// @todo is there a way to test bad types?
+// cx("bad");
+// cx({"i am bad": true});
+// cx(["still bad"]);


### PR DESCRIPTION
Currently we do not, but the `classnames.bind()` function can infer what string literals are permitted from the given styles map.

For example:
```ts
// styles.css.d.ts
interface StylesCSS {
  'foo': string; // resolves to 'abc123'
  'bar': string; // resolves to 'xyz789'
}
export default StylesCSS;

// index.ts
import styles from './styles.css';
const cx = classnames.bind(styles);

// This we already know
cx('foo')                   // => 'abc123'
cx(['foo', 'bar'])          // => 'abc123 xyz789'
cx({foo: false, bar: true}) // => 'xyz789'

// Now we can do this
cx('foobar')       // => TypeError: argument of type 'foobar' is not assignable...
cx(['foobar'])     // => TypeError: ...
cx({foobar: true}) // => TypeError: ...
```

This will most probably be a breaking change. Not because the classnames packages itself has changed, but these typings are stricter than previously. I assume the new version number would be 2.3.7.

There are some 'todos' in the `classnames-tests.ts` file that I didn't resolve because those changes would be even more strict. Comments or fixes are welcome.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
