### PR TITLE
Openlayers: Add stopClick to DrawOptions

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -11855,6 +11855,7 @@ export namespace olx {
             freehandCondition?: ol.EventsConditionType;
             freehand?: boolean;
             wrapX?: boolean;
+            stopClick?: boolean;
         }
 
         interface ExtentOptions {

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -1007,16 +1007,19 @@ let draw: ol.interaction.Draw = new ol.interaction.Draw({
 });
 draw = new ol.interaction.Draw({
     type: "Point",
-    style: styleArray
+    style: styleArray,
+    stopClick: booleanValue
 });
 draw = new ol.interaction.Draw({
     type: "Point",
-    style: styleFunction
+    style: styleFunction,
+    stopClick: booleanValue
 });
 const styleFunctionAsStyle = (feature: ol.Feature, resolution: number): ol.style.Style => style;
 draw = new ol.interaction.Draw({
     type: "Point",
-    style: styleFunctionAsStyle
+    style: styleFunctionAsStyle,
+    stopClick: booleanValue
 });
 ol.interaction.Draw.createBox();
 ol.interaction.Draw.createRegularPolygon();
@@ -1030,7 +1033,8 @@ ol.interaction.defaults({
 const styleFunctionAsArray = (feature: ol.Feature, resolution: number): ol.style.Style[] => styleArray;
 draw = new ol.interaction.Draw({
     type: "Point",
-    style: styleFunctionAsArray
+    style: styleFunctionAsArray,
+    stopClick: booleanValue
 });
 
 const itExtent = new ol.interaction.Extent({

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -1002,7 +1002,8 @@ let draw: ol.interaction.Draw = new ol.interaction.Draw({
     geometryName: stringValue,
     condition: ol.events.condition.never,
     freehandCondition: ol.events.condition.never,
-    wrapX: booleanValue
+    wrapX: booleanValue,
+    stopClick: booleanValue
 });
 draw = new ol.interaction.Draw({
     type: "Point",


### PR DESCRIPTION
Add stopClick to DrawOptions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://openlayers.org/en/v4.6.5/apidoc/ol.interaction.Draw.html


