### PR TITLE
Add fromSeconds and toSeconds definitions to luxon

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -144,6 +144,7 @@ declare module 'luxon' {
                 text: string,
                 options?: DateTimeOptions
             ): DateTime;
+            static fromSeconds(seconds: number, options?: DateTimeOptions): DateTime;
             static fromSQL(text: string, options?: DateTimeOptions): DateTime;
             static fromFormat(
                 text: string,
@@ -261,6 +262,7 @@ declare module 'luxon' {
             toRelative(options?: ToRelativeOptions): string | null;
             toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
             toRFC2822(): string;
+            toSeconds(): number;
             toSQL(options?: ToSQLOptions): string;
             toSQLDate(): string;
             toSQLTime(options?: ToSQLOptions): string;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -39,6 +39,7 @@ dt.toLocaleString();
 dt.toLocaleString(DateTime.DATE_MED);
 dt.toISO();
 dt.toISO({includeOffset: true});
+dt.toSeconds();
 dt.toSQL();
 dt.toSQL({includeOffset: false, includeZone: true});
 dt.toSQLDate();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toSeconds>>
<<https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-fromSeconds>>
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.