### PR TITLE
Add missing insertItems in PaperScope settings

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -21,26 +21,7 @@ declare module paper {
     /**
     * Gives access to paper's configurable settings.
     */
-    export var settings: {
-        
-        /**
-         * controls whether newly created items are automatically inserted into the scene graph, by adding them to project.activeLayer — default: true
-         */
-        insertItems: boolean;
-        /**
-         * controls what value newly created items have their item.applyMatrix property set to (Note that not all items can set this to false) — default: true
-         */
-        applyMatrix: boolean;
-        /**
-         * the size of the curve handles when drawing selections — default: 4
-         */
-        handleSize: number;
-        /*
-         * the default tolerance for hit- tests, when no value is specified — default: 0
-         */
-        hitTolerance: number;
-
-    };
+    export var settings: Settings;
 
     /**
      * The currently active project.
@@ -1163,13 +1144,7 @@ declare module paper {
         /**
         * Gives access to paper's configurable settings.
         */
-        settings: {
-
-            applyMatrix: boolean;
-            handleSize: number;
-            hitTolerance: number;
-
-        };
+        settings: Settings;
 
         /**
          * The currently active project.
@@ -5480,6 +5455,25 @@ declare module paper {
          */
         type: 'mousedown' | 'mouseup' | 'mousedrag' | 'click' | 'doubleclick' | 'mousemove' | 'mouseenter' | 'mouseleave';
 
+    }
+	
+	export interface Settings {
+        /**
+         * controls whether newly created items are automatically inserted into the scene graph, by adding them to project.activeLayer — default: true
+         */
+        insertItems: boolean;
+        /**
+         * controls what value newly created items have their item.applyMatrix property set to (Note that not all items can set this to false) — default: true
+         */
+        applyMatrix: boolean;
+        /**
+         * the size of the curve handles when drawing selections — default: 4
+         */
+        handleSize: number;
+        /*
+         * the default tolerance for hit- tests, when no value is specified — default: 0
+         */
+        hitTolerance: number;
     }
 }
 

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -81,6 +81,10 @@ hitTestResults = paper.project.hitTestAll(hitTestPoint, hitOptionsInterfaceFull)
 
 paper.view.scaling = new paper.Point(1, 1);
 
+paper.settings.insertItems = true
+const paperScope = new paper.PaperScope();
+paperScope.settings.insertItems = false;
+
 function Examples() {
     function BooleanOperations(){
         let text = new paper.PointText({


### PR DESCRIPTION
Definition for `Settings` existed in 2 different places and one was missing `insertItems` property.
This PR adds the complete `Settings` interface and remove duplicated definitions.
It also adds tests for using `Settings` on namespace or on `PaperScope` instance.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://paperjs.org/reference/paperscope/#settings
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.