### PR TITLE
[bull] add name property to Queue interface

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -367,6 +367,11 @@ declare namespace Bull {
 
   interface Queue<T = any> {
     /**
+     * The name of the queue
+     */
+    name: string;
+
+    /**
      * Returns a promise that resolves when Redis is connected and the queue is ready to accept jobs.
      * This replaces the `ready` event emitted on Queue in previous verisons.
      */


### PR DESCRIPTION
Adds the `name` property on the Queue. Useful for inspecting which queue a job came from (`job.queue.name`).

Note: this is defined as a plain string field, but ultimately it might make sense to mark it as a `readonly string` field, even though it's technically reassignable (though I imagine Very Bad Things would happen at that point).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OptimalBits/bull/blob/9b64f7354cafdfff5dd1123b0064686daa41558e/lib/queue.js#L123

This is accessible on the queue instance (even if the existing documentation doesn't suggest it)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.