### PR TITLE
react-mentions: Added support for inputRef prop in v2.4

### DIFF
--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -46,6 +46,24 @@ export interface MentionsInputProps {
 }
 
 /**
+ * Exposes the type for use with the @see MentionsInputComponent.wrappedInstance which is added by react-mentions' use of substyle (https://github.com/jfschwarz/substyle).
+ */
+export interface MentionsInputComponentUnrwapped extends React.Component<MentionsInputProps> {
+    /**
+     * @deprecated since version 2.4.0. Please use @see MentionsInputProps.inputRef
+     */
+    inputRef?: HTMLInputElement | HTMLTextAreaElement;
+}
+
+/**
+ * Used with @see React.RefObject<MentionsInputComponent>.
+ */
+export interface MentionsInputComponent extends React.Component<MentionsInputProps> {
+    // MentionsInput uses substyle (https://github.com/jfschwarz/substyle) which adds this wrappedInstance
+    wrappedInstance?: MentionsInputComponentUnrwapped;
+}
+
+/**
  * Used to reference MentionsInput element in a TSX file.
  */
 export interface MentionsInputClass extends React.ComponentClass<MentionsInputProps> {

--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-mentions 2.3
+// Type definitions for react-mentions 2.4
 // Project: https://github.com/signavio/react-mentions
 // Definitions by: Scott Willeke <https://github.com/activescott>
+//                 Eugene Fedorenko <https://github.com/efedorenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as React from "react";
@@ -41,21 +42,7 @@ export interface MentionsInputProps {
     style?: any;
     regex?: RegExp;
     suggestionsPortalHost?: Element;
-}
-
-/**
- * Exposes the type for use with the @see MentionsInputComponent.wrappedInstance which is added by react-mentions' use of substyle (https://github.com/jfschwarz/substyle).
- */
-export interface MentionsInputComponentUnrwapped extends React.Component<MentionsInputProps> {
-    inputRef?: HTMLInputElement | HTMLTextAreaElement;
-}
-
-/**
- * Used with @see React.RefObject<MentionsInputComponent>.
- */
-export interface MentionsInputComponent extends React.Component<MentionsInputProps> {
-    // MentionsInput uses substyle (https://github.com/jfschwarz/substyle) which adds this wrappedInstance
-    wrappedInstance?: MentionsInputComponentUnrwapped;
+    inputRef?: React.RefObject<HTMLTextAreaElement> | React.RefObject<HTMLInputElement>;
 }
 
 /**

--- a/types/react-mentions/react-mentions-tests.tsx
+++ b/types/react-mentions/react-mentions-tests.tsx
@@ -11,19 +11,32 @@ interface TestProps {
 }
 
 export const TestSimple: React.SFC<TestProps> = (props) => {
+    const inputEl = React.createRef<HTMLTextAreaElement>();
+
+    function handleClick() {
+        if (inputEl.current) {
+            inputEl.current.focus();
+        }
+    }
+
     return (
-        <MentionsInput
-            value={props.value}
-            onChange={props.onChange}
-            placeholder={"Mention people using '@'"}
-            displayTransform={login => `@${login}`}
-        >
-        <Mention
-            trigger="@"
-            data={props.data}
-            onAdd={props.onAdd}
-        />
-        </MentionsInput>
+        <>
+            <MentionsInput
+                value={props.value}
+                onChange={props.onChange}
+                placeholder={"Mention people using '@'"}
+                displayTransform={login => `@${login}`}
+                inputRef={inputEl}
+            >
+                <Mention
+                    trigger="@"
+                    data={props.data}
+                    onAdd={props.onAdd}
+                />
+            </MentionsInput>
+
+            <button onClick={handleClick}>Focus</button>
+        </>
     );
 };
 

--- a/types/react-mentions/tsconfig.json
+++ b/types/react-mentions/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6", "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/signavio/react-mentions/compare/v2.3.1...v2.4.0>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
