### PR TITLE
react-mentions: Fixed type of event emitted onChange

### DIFF
--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-mentions 2.3
 // Project: https://github.com/signavio/react-mentions
 // Definitions by: Scott Willeke <https://github.com/activescott>
+//                 Eugene Fedorenko <https://github.com/efedorenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as React from "react";
@@ -104,7 +105,12 @@ export type DisplayTransformFunc = (id: string, display: string, type: string) =
 /**
  * Defines the function signature for implementing @see MentionsInputProps.onChange
  */
-export type OnChangeHandlerFunc = (event: { target: { value: string } }, newValue: string, newPlainTextValue: string, mentions: MentionItem[]) => void;
+export type OnChangeHandlerFunc = (
+    event: React.ChangeEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLInputElement>,
+    newValue: string,
+    newPlainTextValue: string,
+    mentions: MentionItem[]
+) => void;
 
 /**
  * The function to implement asynchronous loading of suggestions in @see MentionProps.data .


### PR DESCRIPTION
When `onChange` event is triggered on input or textarea, React emits `React.ChangeEvent` that actually has property `target: { value: string }` that was previously described in type definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ca809fa16fdb3f3c908bac411b0204c501ae71be/types/react/index.d.ts#L1075>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.