### PR TITLE
[luxon] add isDateTime, isDuration and isInterval

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -172,6 +172,7 @@ declare module 'luxon' {
                 options?: DateTimeOptions
             ): ExplainedFormat;
             static invalid(reason: any): DateTime;
+            static isDateTime(o: any): o is DateTime;
             static local(
                 year?: number,
                 month?: number,
@@ -302,6 +303,7 @@ declare module 'luxon' {
                 Object: DurationObject
             ): Duration;
             static invalid(reason?: string): Duration;
+            static isDuration(o: any): o is Duration;
             days: number;
             hours: number;
             invalidReason: string;
@@ -387,6 +389,7 @@ declare module 'luxon' {
             ): Interval;
             static fromISO(string: string, options?: DateTimeOptions): Interval;
             static invalid(reason?: string): Interval;
+            static isInterval(o: any): o is Interval;
             static merge(intervals: Interval[]): Interval[];
             static xor(intervals: Interval[]): Interval[];
             end: DateTime;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -91,6 +91,10 @@ DateTime.fromMillis(1527780819458).toMillis();
 
 const {input, result, zone} = DateTime.fromFormatExplain('Aug 6 1982', 'MMMM d yyyy');
 
+const guardedType: {} = {};
+function useDateTime(arg: DateTime) {}
+if (DateTime.isDateTime(guardedType)) useDateTime(guardedType);
+
 /* Duration */
 const dur = Duration.fromObject({ hours: 2, minutes: 7 });
 dt.plus(dur);
@@ -102,6 +106,9 @@ dur.as('seconds');
 dur.toObject();
 dur.toISO();
 
+function useDuration(arg: Duration) {}
+if (Duration.isDuration(guardedType)) useDuration(guardedType);
+
 /* Interval */
 const later = DateTime.local();
 const i = Interval.fromDateTimes(now, later);
@@ -112,6 +119,9 @@ i.set({end: DateTime.local(2020)});
 
 i.toISO();
 i.toString();
+
+function useInterval(arg: Interval) {}
+if (Interval.isInterval(guardedType)) useInterval(guardedType);
 
 /* Info */
 Info.months();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [isInterval](https://moment.github.io/luxon/docs/class/src/interval.js~Interval.html#static-method-isInterval)
  - [isDateTime](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-isDateTime)
  - [isDuration](https://moment.github.io/luxon/docs/class/src/duration.js~Duration.html#static-method-isDuration)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

