### PR TITLE
react-relay: Adds dataFrom prop to QueryRendererProps

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -91,7 +91,7 @@ export const graphql: GraphqlInterface;
 
 export interface QueryRendererProps<T extends RelayRuntimeTypes.OperationBase = RelayRuntimeTypes.OperationDefaults> {
     cacheConfig?: RelayRuntimeTypes.CacheConfig;
-    dataFrom?: "NETWORK_ONLY" | "STORE_THEN_NETWORK";
+    dataFrom?: "NETWORK_ONLY"|"STORE_THEN_NETWORK";
     environment: RelayRuntimeTypes.Environment;
     query?: RelayRuntimeTypes.GraphQLTaggedNode | null;
     render(readyState: ReadyState<T["response"]>): React.ReactElement<any> | undefined | null;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -91,6 +91,7 @@ export const graphql: GraphqlInterface;
 
 export interface QueryRendererProps<T extends RelayRuntimeTypes.OperationBase = RelayRuntimeTypes.OperationDefaults> {
     cacheConfig?: RelayRuntimeTypes.CacheConfig;
+    dataFrom?: "NETWORK_ONLY" | "STORE_THEN_NETWORK";
     environment: RelayRuntimeTypes.Environment;
     query?: RelayRuntimeTypes.GraphQLTaggedNode | null;
     render(readyState: ReadyState<T["response"]>): React.ReactElement<any> | undefined | null;


### PR DESCRIPTION
https://github.com/facebook/relay/blob/master/packages/react-relay/modern/ReactRelayQueryRenderer.js

Line 63.
