### PR TITLE
Add plyableDuration to getPhotosReturnType in ReactNative

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6742,6 +6742,7 @@ export interface GetPhotosReturnType {
                 uri: string;
                 height: number;
                 width: number;
+                playableDuration: number;
                 isStored?: boolean;
             };
             timestamp: number;


### PR DESCRIPTION
Add missed attribute plyableDuration, which always exist in GetPhotosReturnType.(even for photos it's number: 0)

React native doc about this: https://facebook.github.io/react-native/docs/cameraroll#getphotos 