### PR TITLE
react-widgets: add defaultCurrentDate property to DateTimePicker

### DIFF
--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -42,6 +42,10 @@ interface DateTimePickerProps extends ReactWidgetsCommonDropdownProps<DateTimePi
      */
     currentDate?: Date;
     /**
+     * Default current date
+     */
+    defaultCurrentDate?: Date;
+    /**
      * Default value for current date. Useful for suggesting a date when the caldenar opens without keep forcing it once 'value' is set.
      */
     date?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://jquense.github.io/react-widgets/api/DateTimePicker/#currentDate