### PR TITLE
Dockerode: Add VolumeInspectInfo interface and return it from Volume.inspect

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -151,8 +151,8 @@ declare namespace Dockerode {
     modem: any;
     name: string;
 
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
+    inspect(callback: Callback<VolumeInspectInfo>): void;
+    inspect(): Promise<VolumeInspectInfo>;
 
     remove(options: {}, callback: Callback<any>): void;
     remove(callback: Callback<any>): void;
@@ -365,6 +365,22 @@ declare namespace Dockerode {
     Internal: boolean;
     Attachable: boolean;
     Ingress: boolean;
+  }
+
+  interface VolumeInspectInfo {
+    Name: string;
+    Driver: string;
+    Mountpoint: string;
+    Status?: { [key: string]: string };
+    Labels: { [key: string]: string };
+    Scope: 'local' | 'global';
+    // Field is always present, but sometimes is null
+    Options: { [key: string]: string } | null;
+    // Field is sometimes present, and sometimes null
+    UsageData?: {
+      Size: number;
+      RefCount: number;
+    } | null;
   }
 
   interface ContainerInspectInfo {

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1156,9 +1156,18 @@ declare class Dockerode {
   listPlugins(callback: Callback<Dockerode.PluginInfo[]>): void;
   listPlugins(options?: {}): Promise<Dockerode.PluginInfo[]>;
 
-  listVolumes(options: {}, callback: Callback<any[]>): void;
-  listVolumes(callback: Callback<any[]>): void;
-  listVolumes(options?: {}): Promise<any[]>;
+  listVolumes(options: {}, callback: Callback<{
+    Volumes: Dockerode.VolumeInspectInfo[];
+    Warnings: string[];
+  }>): void;
+  listVolumes(callback: Callback<{
+    Volumes: Dockerode.VolumeInspectInfo[];
+    Warnings: string[];
+  }>): void;
+  listVolumes(options?: {}): Promise<{
+    Volumes: Dockerode.VolumeInspectInfo[];
+    Warnings: string[];
+  }>;
 
   listNetworks(options: {}, callback: Callback<any[]>): void;
   listNetworks(callback: Callback<any[]>): void;


### PR DESCRIPTION
Signed-off-by: Cameron Diver <cameron@balena.io>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.docker.com/engine/api/v1.30/#operation/VolumeInspect
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

