### PR TITLE
[@types/express] adds overload for app.use mounting sub-app

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -44,6 +44,7 @@ export type RequestHandlerParams = RequestHandler | ErrorRequestHandler | Array<
 export interface IRouterMatcher<T> {
     (path: PathParams, ...handlers: RequestHandler[]): T;
     (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+    (path: PathParams, Application): T;
 }
 
 export interface IRouterHandler<T> {

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -44,7 +44,7 @@ export type RequestHandlerParams = RequestHandler | ErrorRequestHandler | Array<
 export interface IRouterMatcher<T> {
     (path: PathParams, ...handlers: RequestHandler[]): T;
     (path: PathParams, ...handlers: RequestHandlerParams[]): T;
-    (path: PathParams, Application): T;
+    (path: PathParams, subApplication: Application): T;
 }
 
 export interface IRouterHandler<T> {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -137,6 +137,9 @@ namespace express_tests {
         req.next;
         res.req;
     });
+    
+    // Test mounting sub-apps
+    app.use('/sub-app', express());
 
     // Test on mount event
     app.on('mount', (parent) => true);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -137,7 +137,7 @@ namespace express_tests {
         req.next;
         res.req;
     });
-    
+
     // Test mounting sub-apps
     app.use('/sub-app', express());
 


### PR DESCRIPTION
An overload of `app.use`, see docs for `app.mountpath` here (sub-app): https://expressjs.com/en/api.html#app.mountpath

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://expressjs.com/en/api.html#app.mountpath](https://expressjs.com/en/api.html#app.mountpath)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
