### PR TITLE
Fix `initialize` function name typo in mermaidAPI

### DIFF
--- a/types/mermaid/mermaid-tests.ts
+++ b/types/mermaid/mermaid-tests.ts
@@ -13,7 +13,7 @@ mermaid.initialize(config);
 // mermaidAPI usage
 
 const { mermaidAPI } = mermaid;
-mermaidAPI.initalize({});
+mermaidAPI.initialize({});
 
 const element = document.querySelector("#graphDiv")!;
 

--- a/types/mermaid/mermaidAPI.d.ts
+++ b/types/mermaid/mermaidAPI.d.ts
@@ -240,7 +240,7 @@ declare namespace mermaidAPI {
 
     function parse(text: string): any;
 
-    function initalize(options: Config): void;
+    function initialize(options: Config): void;
 
     function getConfig(): Config;
 }


### PR DESCRIPTION
The function in `mermaidAPI` is currently misspelled as `initalize`
when it should be `initialize`.