### PR TITLE
react-paginate: export ReactPaginateProps interface in v5 and v6

### DIFF
--- a/types/react-paginate/index.d.ts
+++ b/types/react-paginate/index.d.ts
@@ -7,12 +7,13 @@
 //                 Yasunori Ohoka <https://github.com/yasupeke>
 //                 Shingo Sato <https://github.com/sugarshin>
 //                 SPWizard01 <https://github.com/SPWizard01>
+//                 Kevin Rambaud <https://github.com/kevinrambaud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from 'react';
 
-interface ReactPaginateProps {
+export interface ReactPaginateProps {
     /**
      * The total number of pages.
      */

--- a/types/react-paginate/v5/index.d.ts
+++ b/types/react-paginate/v5/index.d.ts
@@ -5,12 +5,13 @@
 //                 pegel03 <https://github.com/pegel03>
 //                 Simon Archer <https://github.com/archy-bold>
 //                 Yasunori Ohoka <https://github.com/yasupeke>
+//                 Kevin Rambaud <https://github.com/kevinrambaud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from 'react';
 
-interface ReactPaginateProps {
+export interface ReactPaginateProps {
     /**
      * The total number of pages.
      */


### PR DESCRIPTION
For some reasons, I would need to export the `ReactPaginateProps` interface to use in another declaration file. Not sure why this isn't already the case, it's always useful to have it exported.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
