### PR TITLE
[@babel/traverse]: Allowed node aliases as keys in visitors.

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -150,3 +150,8 @@ const VisitorStateTest: Visitor<SomeVisitorState> = {
         }
     }
 };
+
+const VisitorAliasTest: Visitor = {
+    Function() {},
+    Expression() {},
+};

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -145,6 +145,8 @@ export class Binding {
 
 export type Visitor<S = {}> = VisitNodeObject<S, Node> & {
     [Type in Node["type"]]?: VisitNode<S, Extract<Node, { type: Type; }>>;
+} & {
+    [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>
 };
 
 export type VisitNode<S, P> = VisitNodeFunction<S, P> | VisitNodeObject<S, P>;

--- a/types/babel__traverse/package.json
+++ b/types/babel__traverse/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.3.0"
     }
 }


### PR DESCRIPTION
This is made possible by https://github.com/babel/babel/pull/9110.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#toc-visitors
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
