### PR TITLE
[react-event-listener] add onSelectionChange

### DIFF
--- a/types/react-event-listener/index.d.ts
+++ b/types/react-event-listener/index.d.ts
@@ -193,6 +193,8 @@ export interface EventListenerProps {
     onSeekingCapture?(ev: Event): any;
     onSelect?(ev: UIEvent): any;
     onSelectCapture?(ev: UIEvent): any;
+    onSelectionChange?(ev: UIEvent): any;
+    onSelectionChangeCapture?(ev: UIEvent): any;
     onStalled?(ev: Event): any;
     onStalledCapture?(ev: Event): any;
     onStorage?(ev: StorageEvent): any;

--- a/types/react-event-listener/index.d.ts
+++ b/types/react-event-listener/index.d.ts
@@ -193,8 +193,8 @@ export interface EventListenerProps {
     onSeekingCapture?(ev: Event): any;
     onSelect?(ev: UIEvent): any;
     onSelectCapture?(ev: UIEvent): any;
-    onSelectionChange?(ev: UIEvent): any;
-    onSelectionChangeCapture?(ev: UIEvent): any;
+    onSelectionChange?(ev: Event): any;
+    onSelectionChangeCapture?(ev: Event): any;
     onStalled?(ev: Event): any;
     onStalledCapture?(ev: Event): any;
     onStorage?(ev: StorageEvent): any;

--- a/types/react-event-listener/react-event-listener-tests.tsx
+++ b/types/react-event-listener/react-event-listener-tests.tsx
@@ -4,3 +4,4 @@ import EventListener, { withOptions } from "react-event-listener";
 <EventListener target={document} onBeforeUnload={ev => { }} />;
 <EventListener target={window} onResize={withOptions((ev: UIEvent) => { }, { passive: true, capture: true })} />;
 <EventListener target="window" onResize={() => { }}/>;
+<EventListener target={document} onSelectionChange={ev => { }} />;


### PR DESCRIPTION
This library dynamically interprets the React props, so the @types definition is more restrictive than the library supports. This adds `onSelectionChange` and  `onSelectionChangeCapture` to the mix. The event is described here: https://developer.mozilla.org/en-US/docs/Web/Events/selectionchange

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/Events/selectionchange
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~