### PR TITLE
Add EventEmitter to TrackPublication type

### DIFF
--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -404,7 +404,7 @@ export class TrackNameTooLongError extends TwilioError {
     code: 53302;
     message: 'Track name is too long';
 }
-export class TrackPublication {
+export class TrackPublication extends EventEmitter {
     trackName: string;
     trackSid: Track.SID;
 }


### PR DESCRIPTION
Per https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta5/docs/TrackPublication.html, `TrackPublication` is an `EventEmitter`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
