### PR TITLE
[next] Add support for state types in Next.js' App component

### DIFF
--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -53,6 +53,6 @@ export type AppComponentType<P = {}, IP = P, C = NextAppContext> = NextComponent
 >;
 
 export class Container extends React.Component {}
-export default class App<P = {}> extends React.Component<P & DefaultAppIProps & AppProps> {
+export default class App<P = {}, S = {}> extends React.Component<P & DefaultAppIProps & AppProps, S> {
     static getInitialProps(context: NextAppContext): Promise<DefaultAppIProps>;
 }

--- a/types/next/test/next-app-tests.tsx
+++ b/types/next/test/next-app-tests.tsx
@@ -6,6 +6,10 @@ interface TestAppProps {
     pageProps: any;
 }
 
+interface TestAppState {
+    color: string;
+}
+
 interface TypedQuery extends DefaultQuery {
     id?: string;
 }
@@ -31,6 +35,20 @@ class TestAppWithProps extends App<TestAppProps & WithExampleProps> {
         const { Component, router, pageProps, example } = this.props;
         return <Component {...pageProps} example={example} />;
     }
+}
+
+class ErrorTestAppWithState extends App<TestAppProps & WithExampleProps, TestAppState> {
+    static async getInitialProps({ Component, router, ctx }: NextAppContext) {
+        const pageProps = Component.getInitialProps && (await Component.getInitialProps(ctx));
+        return { pageProps };
+    }
+
+    render() {
+        const { Component, router, pageProps, example } = this.props;
+        return <Component {...pageProps} example={example} />;
+    }
+
+    state: {}; // $ExpectError
 }
 
 class TestAppWithTypedQuery extends App {


### PR DESCRIPTION
Next.js' App component definition doesn't allow us pass the state definition as a type parameter. Currently it's only possible to pass props definition:

```js
interface Props {
  theme: string;
}
export default class MyApp extends App<Props> {
  static async getInitialProps({ Component, router, ctx }) {}
  render () {}
}
```

With this change, we could also type the state:

```js
// ...
interface State {
  loggedUser: {
    email: string;
  };
}
export default class MyApp extends App<Props, State> {
 // ...
}
```

I took a look at the tests and I feel like I should add a new test for this use case. But I'm new to TypeScript and I couldn't understand the tests very well.

Let me know if this change is sane and I'll try to take another look at the tests.

<hr/>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nextjs.org/docs#custom-app
  - one of the use cases: "Keeping state when navigating pages"
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
