### PR TITLE
[react-router]: Stricter Route type

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -19,6 +19,7 @@
 //                 Maksim Sharipov <https://github.com/pret-a-porter>
 //                 Duong Tran <https://github.com/t49tran>
 //                 Ben Smith <https://github.com/8enSmith>
+//                 Thomas den Hollander <https://github.com/ThomasdenH>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -81,16 +82,27 @@ export interface RouteChildrenProps<
   match: match<Params> | null;
 }
 
-export interface RouteProps {
+// Denote the three ways to render something with a router
+export interface RoutePropsRenderMethodComponent {
+  component: React.ComponentType<RouteComponentProps> | React.ComponentType;
+}
+export interface RoutePropsRenderMethodRender {
+  render: ((props: RouteComponentProps) => React.ReactNode);
+}
+export interface RoutePropsRenderMethodChildren {
+  children: ((props: RouteChildrenProps) => React.ReactNode) | React.ReactNode;
+}
+export type RoutePropsRenderMethod = RoutePropsRenderMethodComponent | RoutePropsRenderMethodRender | RoutePropsRenderMethodChildren;
+
+export interface BaseRouteProps {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-  render?: ((props: RouteComponentProps<any>) => React.ReactNode);
-  children?: ((props: RouteChildrenProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string | string[];
   exact?: boolean;
   sensitive?: boolean;
   strict?: boolean;
 }
+export type RouteProps = BaseRouteProps & RoutePropsRenderMethod;
+
 export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }
 
 export interface RouterProps {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/web/api/Route/route-props
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR solves two problems related to `Route`:
- It was possible to specify a `Route` with no or multiple render methods. This PR uses multiple type definitions to make sure the user provides exactly one method.
- The Router now makes sure that every property of the supplied component is actually set. It previously used `<any>`, but since the properties are not supplied, the component would incorrectly assume them to be defined.

Two things I'm uncertain about:
- I don't think it's possible to write tests for this since the types have only gotten stricter. I have tested this on my own code.
- This is a breaking change, how should I denote this?
