### PR TITLE
[web3]: toWei does not accept number

### DIFF
--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -19,6 +19,7 @@
 //                 Donam Kim <https://github.com/donamk>
 //                 Doug Kent <https://github.com/dkent600>
 //                 Daniel Zhou <https://github.com/nerddan>
+//                 Alex Kvak <https://github.com/alexkvak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -89,7 +89,7 @@ export default interface Utils {
     toDecimal(val: any): number;
     toHex(val: any): string;
     toUtf8(val: any): string;
-    toWei(val: string | number, unit?: Unit): string;
+    toWei(val: string, unit?: Unit): string;
     toWei(val: BigNumber, unit?: Unit): BigNumber;
     unitMap: any;
 }

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -163,6 +163,9 @@ const shhPromise: Promise<string> = web3.shh.generateSymKeyFromPassword("xyz");
 // --------------------------------------------------------------------------
 const weiStr: string = web3.utils.toWei("100", "gwei");
 const weiBn: BigNumber = web3.utils.toWei(web3.utils.toBN("1"));
+// $ExpectError
+const weiNumber = web3.utils.toWei(100);
+
 const rndHex: string = Web3.utils.randomHex(10);
 const sha3: string = web3.utils.soliditySha3(0, 1, "abc");
 const fromWei1: BigNumber = web3.utils.fromWei(new BigNumber(1));


### PR DESCRIPTION
According to docs https://web3js.readthedocs.io/en/1.0/web3-utils.html#id76 and code https://github.com/ethereum/web3.js/blob/1.0/packages/web3-utils/src/index.js#L266 toWei function does not accept number at all.