### PR TITLE
Fix mangopay2-nodejs-sdk types

### DIFF
--- a/types/mangopay2-nodejs-sdk/index.d.ts
+++ b/types/mangopay2-nodejs-sdk/index.d.ts
@@ -266,7 +266,7 @@ declare namespace MangoPay {
 
   // Determines the shape of the response
   interface ReadResponseHeaders {
-    readResponseHeaders: true;
+    resolveWithFullResponse: true;
   }
 
   interface PaginationOptions {
@@ -306,11 +306,11 @@ declare namespace MangoPay {
   }
 
   interface MethodOptionWithResponse extends MethodOptions {
-    readResponseHeaders: true;
+    resolveWithFullResponse: true;
   }
 
   interface MethodOptionWithoutResponse extends MethodOptions {
-    readResponseHeaders?: false;
+    resolveWithFullResponse?: false;
   }
 
   interface DependsObject {

--- a/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
+++ b/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
@@ -54,7 +54,7 @@ api.Users.create(legalUser).then(data => {
   console.log(`${legalUser.Name} user created at ${legalUser.CreationDate}`);
 });
 
-api.Users.create(legalUser, { readResponseHeaders: true }).then(data => {
+api.Users.create(legalUser, { resolveWithFullResponse: true }).then(data => {
   const d = data; // $ExpectType WithResponse<UserLegalData>
   const value = data.body; // $ExpectType UserLegalData
 });


### PR DESCRIPTION
I used the `resolveWithFullResponse` property before the type package was available and it has been misnamed as `readResponseHeaders`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Mangopay/mangopay2-nodejs-sdk/blob/master/examples/readResponseHeaders.js#L25
https://github.com/Mangopay/mangopay2-nodejs-sdk/blob/master/lib/api.js#L171
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
