### PR TITLE
Fix void type for shelljs package, functions return value to ShellArray

### DIFF
--- a/types/shelljs-exec-proxy/shelljs-exec-proxy-tests.ts
+++ b/types/shelljs-exec-proxy/shelljs-exec-proxy-tests.ts
@@ -5,5 +5,5 @@ shell.git.add('.'); // $ExpectType ExecOutputReturnValue
 shell.git.commit('-am', 'Fixed issue #1'); // $ExpectType ExecOutputReturnValue
 shell.git.push('origin', 'master'); // $ExpectType ExecOutputReturnValue
 
-shell.cd('string'); // $ExpectType void
+shell.cd('string'); // $ExpectType ShellString
 shell.cd(123); // $ExpectError

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -4,6 +4,7 @@
 //                 Vojtech Jasny <https://github.com/voy>
 //                 George Kalpakas <https://github.com/gkalpak>
 //                 Paul Huynh <https://github.com/pheromonez>
+//                 Alexander Futász <https://github.com/aldafu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -50,7 +51,7 @@ export function find(...path: Array<string | string[]>): ShellArray;
  * @param source  The source.
  * @param   dest  The destination.
  */
-export function cp(source: string | string[], dest: string): void;
+export function cp(source: string | string[], dest: string): ShellArray;
 
 /**
  * Copies files. The wildcard * is accepted.

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -15,7 +15,7 @@ import glob = require("glob");
 /**
  * Changes to directory dir for the duration of the script. Changes to home directory if no argument is supplied.
  * @param dir Directory to change in.
- * @return    Object with shell exit code.
+ * @return    Object with shell exit code, stderr and stdout.
  */
 export function cd(dir?: string): ShellString;
 
@@ -51,7 +51,7 @@ export function find(...path: Array<string | string[]>): ShellArray;
  * Copies files. The wildcard * is accepted.
  * @param source  The source.
  * @param   dest  The destination.
- * @return        Object with shell exit code.
+ * @return        Object with shell exit code, stderr and stdout.
  */
 export function cp(source: string | string[], dest: string): ShellString;
 
@@ -60,14 +60,14 @@ export function cp(source: string | string[], dest: string): ShellString;
  * @param options Available options: -f: force (default behavior) -n: no-clobber -u: only copy if source is newer than dest -r, -R: recursive -L: follow symlinks -P: don't follow symlinks
  * @param source  The source.
  * @param dest    The destination.
- * @return        Object with shell exit code.
+ * @return        Object with shell exit code, stderr and stdout.
  */
 export function cp(options: string, source: string | string[], dest: string): ShellString;
 
 /**
  * Removes files. The wildcard * is accepted.
  * @param ...files Files to remove.
- * @return        Object with shell exit code.
+ * @return        Object with shell exit code, stderr and stdout.
  */
 export function rm(...files: Array<string | string[]>): ShellString;
 
@@ -75,7 +75,7 @@ export function rm(...files: Array<string | string[]>): ShellString;
  * Removes files. The wildcard * is accepted.
  * @param   options  Available options: -f (force), -r, -R (recursive)
  * @param ...files Files to remove.
- * @return         Object with shell exit code.
+ * @return         Object with shell exit code, stderr and stdout.
  */
 export function rm(options: string, ...files: Array<string | string[]>): ShellString;
 
@@ -83,7 +83,7 @@ export function rm(options: string, ...files: Array<string | string[]>): ShellSt
  * Moves files. The wildcard * is accepted.
  * @param source The source.
  * @param dest   The destination.
- * @return       Object with shell exit code.
+ * @return       Object with shell exit code, stderr and stdout.
  */
 export function mv(source: string | string[], dest: string): ShellString;
 
@@ -92,14 +92,14 @@ export function mv(source: string | string[], dest: string): ShellString;
  * @param options Available options: -f: force (default behavior) -n: no-clobber
  * @param source The source.
  * @param dest   The destination.
- * @return       Object with shell exit code.
+ * @return       Object with shell exit code, stderr and stdout.
  */
 export function mv(options: string, source: string | string[], dest: string): ShellString;
 
 /**
  * Creates directories.
  * @param ...dir Directories to create.
- * @return       Object with shell exit code.
+ * @return       Object with shell exit code, stderr and stdout.
  */
 export function mkdir(...dir: Array<string | string[]>): ShellString;
 
@@ -107,7 +107,7 @@ export function mkdir(...dir: Array<string | string[]>): ShellString;
  * Creates directories.
  * @param   options Available options: p (full paths, will create intermediate dirs if necessary)
  * @param ...dir  The directories to create.
- * @return        Object with shell exit code.
+ * @return        Object with shell exit code, stderr and stdout.
  */
 export function mkdir(options: string, ...dir: Array<string | string[]>): ShellString;
 
@@ -314,7 +314,7 @@ export function dirs(options: string): any;
  * Links source to dest. Use -f to force the link, should dest already exist.
  * @param source The source.
  * @param dest   The destination.
- * @return       Object with shell exit code.
+ * @return       Object with shell exit code, stderr and stdout.
  */
 export function ln(source: string, dest: string): ShellString;
 
@@ -323,7 +323,7 @@ export function ln(source: string, dest: string): ShellString;
  * @param options Available options: s (symlink), f (force)
  * @param source The source.
  * @param dest   The destination.
- * @return       Object with shell exit code.
+ * @return       Object with shell exit code, stderr and stdout.
  */
 export function ln(options: string, source: string, dest: string): ShellString;
 
@@ -412,7 +412,7 @@ export type ShellArray = string[] & ShellReturnValue;
  * - There is no "quiet" option since default behavior is to run silent.
  * @param octalMode The access mode. Octal.
  * @param file      The file to use.
- * @return          Object with shell exit code.
+ * @return          Object with shell exit code, stderr and stdout.
  */
 export function chmod(octalMode: number, file: string): ShellString;
 
@@ -423,7 +423,7 @@ export function chmod(octalMode: number, file: string): ShellString;
  * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
  * @param octalMode The access mode. Octal.
  * @param file      The file to use.
- * @return          Object with shell exit code.
+ * @return          Object with shell exit code, stderr and stdout.
  */
 export function chmod(options: string, octalMode: number, file: string): ShellString;
 
@@ -433,7 +433,7 @@ export function chmod(options: string, octalMode: number, file: string): ShellSt
  * - There is no "quiet" option since default behavior is to run silent.
  * @param mode      The access mode. Can be an octal string or a symbolic mode string.
  * @param file      The file to use.
- * @return          Object with shell exit code.
+ * @return          Object with shell exit code, stderr and stdout.
  */
 export function chmod(mode: string, file: string): ShellString;
 
@@ -444,7 +444,7 @@ export function chmod(mode: string, file: string): ShellString;
  * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
  * @param mode      The access mode. Can be an octal string or a symbolic mode string.
  * @param file      The file to use.
- * @return          Object with shell exit code.
+ * @return          Object with shell exit code, stderr and stdout.
  */
 export function chmod(options: string, mode: string, file: string): ShellString;
 

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -50,16 +50,18 @@ export function find(...path: Array<string | string[]>): ShellArray;
  * Copies files. The wildcard * is accepted.
  * @param source  The source.
  * @param   dest  The destination.
+ * @return        Object with shell exit code.
  */
-export function cp(source: string | string[], dest: string): ShellArray;
+export function cp(source: string | string[], dest: string): ShellString;
 
 /**
  * Copies files. The wildcard * is accepted.
  * @param options Available options: -f: force (default behavior) -n: no-clobber -u: only copy if source is newer than dest -r, -R: recursive -L: follow symlinks -P: don't follow symlinks
  * @param source  The source.
  * @param dest    The destination.
+ * @return        Object with shell exit code.
  */
-export function cp(options: string, source: string | string[], dest: string): void;
+export function cp(options: string, source: string | string[], dest: string): ShellString;
 
 /**
  * Removes files. The wildcard * is accepted.

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -15,8 +15,9 @@ import glob = require("glob");
 /**
  * Changes to directory dir for the duration of the script. Changes to home directory if no argument is supplied.
  * @param dir Directory to change in.
+ * @return    Object with shell exit code.
  */
-export function cd(dir?: string): void;
+export function cd(dir?: string): ShellString;
 
 /**
  * Returns the current directory.
@@ -66,43 +67,49 @@ export function cp(options: string, source: string | string[], dest: string): Sh
 /**
  * Removes files. The wildcard * is accepted.
  * @param ...files Files to remove.
+ * @return        Object with shell exit code.
  */
-export function rm(...files: Array<string | string[]>): void;
+export function rm(...files: Array<string | string[]>): ShellString;
 
 /**
  * Removes files. The wildcard * is accepted.
  * @param   options  Available options: -f (force), -r, -R (recursive)
  * @param ...files Files to remove.
+ * @return         Object with shell exit code.
  */
-export function rm(options: string, ...files: Array<string | string[]>): void;
+export function rm(options: string, ...files: Array<string | string[]>): ShellString;
 
 /**
  * Moves files. The wildcard * is accepted.
  * @param source The source.
  * @param dest   The destination.
+ * @return       Object with shell exit code.
  */
-export function mv(source: string | string[], dest: string): void;
+export function mv(source: string | string[], dest: string): ShellString;
 
 /**
  * Moves files. The wildcard * is accepted.
  * @param options Available options: -f: force (default behavior) -n: no-clobber
  * @param source The source.
  * @param dest   The destination.
+ * @return       Object with shell exit code.
  */
-export function mv(options: string, source: string | string[], dest: string): void;
+export function mv(options: string, source: string | string[], dest: string): ShellString;
 
 /**
  * Creates directories.
  * @param ...dir Directories to create.
+ * @return       Object with shell exit code.
  */
-export function mkdir(...dir: Array<string | string[]>): void;
+export function mkdir(...dir: Array<string | string[]>): ShellString;
 
 /**
  * Creates directories.
  * @param   options Available options: p (full paths, will create intermediate dirs if necessary)
  * @param ...dir  The directories to create.
+ * @return        Object with shell exit code.
  */
-export function mkdir(options: string, ...dir: Array<string | string[]>): void;
+export function mkdir(options: string, ...dir: Array<string | string[]>): ShellString;
 
 /**
  * Evaluates expression using the available primaries and returns corresponding value.
@@ -307,16 +314,18 @@ export function dirs(options: string): any;
  * Links source to dest. Use -f to force the link, should dest already exist.
  * @param source The source.
  * @param dest   The destination.
+ * @return       Object with shell exit code.
  */
-export function ln(source: string, dest: string): void;
+export function ln(source: string, dest: string): ShellString;
 
 /**
  * Links source to dest. Use -f to force the link, should dest already exist.
  * @param options Available options: s (symlink), f (force)
  * @param source The source.
  * @param dest   The destination.
+ * @return       Object with shell exit code.
  */
-export function ln(options: string, source: string, dest: string): void;
+export function ln(options: string, source: string, dest: string): ShellString;
 
 /**
  * Exits the current process with the given exit code.
@@ -403,8 +412,9 @@ export type ShellArray = string[] & ShellReturnValue;
  * - There is no "quiet" option since default behavior is to run silent.
  * @param octalMode The access mode. Octal.
  * @param file      The file to use.
+ * @return          Object with shell exit code.
  */
-export function chmod(octalMode: number, file: string): void;
+export function chmod(octalMode: number, file: string): ShellString;
 
 /**
  * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
@@ -413,8 +423,9 @@ export function chmod(octalMode: number, file: string): void;
  * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
  * @param octalMode The access mode. Octal.
  * @param file      The file to use.
+ * @return          Object with shell exit code.
  */
-export function chmod(options: string, octalMode: number, file: string): void;
+export function chmod(options: string, octalMode: number, file: string): ShellString;
 
 /**
  * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
@@ -422,8 +433,9 @@ export function chmod(options: string, octalMode: number, file: string): void;
  * - There is no "quiet" option since default behavior is to run silent.
  * @param mode      The access mode. Can be an octal string or a symbolic mode string.
  * @param file      The file to use.
+ * @return          Object with shell exit code.
  */
-export function chmod(mode: string, file: string): void;
+export function chmod(mode: string, file: string): ShellString;
 
 /**
  * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
@@ -432,8 +444,9 @@ export function chmod(mode: string, file: string): void;
  * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
  * @param mode      The access mode. Can be an octal string or a symbolic mode string.
  * @param file      The file to use.
+ * @return          Object with shell exit code.
  */
-export function chmod(options: string, mode: string, file: string): void;
+export function chmod(options: string, mode: string, file: string): ShellString;
 
 // Non-Unix commands
 
@@ -459,10 +472,10 @@ export interface TouchOptionsArray {
     '-r'?: string;
 }
 
-export function touch(...files: string[]): void;
-export function touch(files: string[]): void;
-export function touch(options: TouchOptionsLiteral, ...files: Array<string | string[]>): void;
-export function touch(options: TouchOptionsArray, ...files: Array<string | string[]>): void;
+export function touch(...files: string[]): ShellString;
+export function touch(files: string[]): ShellString;
+export function touch(options: TouchOptionsLiteral, ...files: Array<string | string[]>): ShellString;
+export function touch(options: TouchOptionsArray, ...files: Array<string | string[]>): ShellString;
 
 export interface HeadOptions {
     /** Show the first <num> lines of the files. */


### PR DESCRIPTION
`cp` function returns an object that is e.g. important for error code
checking. Previously the type was defined as `void` which made it impossible to find out whether a call to `cp` was successful or not.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: It's not really documented anywhere, but you can see it here:
```shell
 node
> const s = require('shelljs')
undefined
> s.cp('foo', 'bar')
cp: no such file or directory: foo
{ [String: '']
  stdout: '',
  stderr: 'cp: no such file or directory: foo',
  code: 1,
  cat: [Function: bound ],
  exec: [Function: bound ],
  grep: [Function: bound ],
  head: [Function: bound ],
  sed: [Function: bound ],
  sort: [Function: bound ],
  tail: [Function: bound ],
  to: [Function: bound ],
  toEnd: [Function: bound ],
  uniq: [Function: bound ] }
```
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
