### PR TITLE
Handle ComponentType

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -868,10 +868,10 @@ function ReactWrapperTest() {
 
     function test_component_type() {
       const wrapper1 = shallow(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
-      wrapper1.find(ComponentType);
+      wrapper1.find(ComponentType).props().stringProp; // $ExpectType string
 
       const wrapper2 = mount(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
-      wrapper2.find(ComponentType);
+      wrapper2.find(ComponentType).props().stringProp; // $ExpectType string
     }
 }
 

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -35,6 +35,10 @@ interface MyComponentState {
     stateProperty: string;
 }
 
+function toComponentType<T>(Component: ComponentClass<T> | StatelessComponent<T>): ComponentClass<T> | StatelessComponent<T> {
+  return Component;
+}
+
 class MyComponent extends Component<MyComponentProps, MyComponentState> {
     handleEcho(value: string) {
         return value;
@@ -58,6 +62,8 @@ class AnotherComponent extends Component<AnotherComponentProps> {
 const MyStatelessComponent = (props: StatelessProps) => <span />;
 
 const AnotherStatelessComponent = (props: AnotherStatelessProps) => <span />;
+
+const ComponentType = toComponentType(MyComponent);
 
 // Enzyme.configure
 function configureTest() {
@@ -858,6 +864,14 @@ function ReactWrapperTest() {
         reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, reactWrapper);
         reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, undefined, { attachTo: document.createElement('div') });
         reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, reactWrapper, { attachTo: document.createElement('div') });
+    }
+
+    function test_component_type() {
+      const wrapper1 = shallow(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
+      wrapper1.find(ComponentType);
+
+      const wrapper2 = mount(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
+      wrapper2.find(ComponentType);
     }
 }
 

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -868,10 +868,10 @@ function ReactWrapperTest() {
 
     function test_component_type() {
       const wrapper1 = shallow(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
-      wrapper1.find(ComponentType).props().stringProp; // $ExpectType string
+      wrapper1.find<MyComponentProps>(ComponentType).props().stringProp; // $ExpectType string
 
       const wrapper2 = mount(<div><ComponentType stringProp={"S"} numberProp={1} /></div>);
-      wrapper2.find(ComponentType).props().stringProp; // $ExpectType string
+      wrapper2.find<MyComponentProps>(ComponentType).props().stringProp; // $ExpectType string
     }
 }
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -27,7 +27,9 @@ export interface ComponentClass<Props> {
     new(props: Props, context?: any): Component<Props>;
 }
 
-export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;
+export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element | null;
+
+export type ComponentType<Props> = ComponentClass<Props> | StatelessComponent<Props>;
 
 /**
  * Many methods in Enzyme's API accept a selector as an argument. Selectors in Enzyme can fall into one of the
@@ -372,8 +374,8 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * Find every node in the render tree that matches the provided selector.
      * @param selector The selector to match.
      */
-    find<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     find<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
+    find<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -381,8 +383,8 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
+    filter<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     filter(props: EnzymePropSelector | string): ShallowWrapper<P, S>;
 
     /**
@@ -394,8 +396,8 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector
      * can be provided and it will filter the children by this selector.
      */
-    children<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     children<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
+    children<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     children(selector: string): ShallowWrapper<HTMLAttributes, any>;
     children(props?: EnzymePropSelector): ShallowWrapper<any, any>;
 
@@ -425,8 +427,8 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      *
      * Note: can only be called on a wrapper of a single node.
      */
-    parents<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     parents<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
+    parents<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     parents(selector: string): ShallowWrapper<HTMLAttributes, any>;
     parents(props?: EnzymePropSelector): ShallowWrapper<any, any>;
 
@@ -436,8 +438,8 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      *
      * Note: can only be called on a wrapper of a single node.
      */
-    closest<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     closest<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
+    closest<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     closest(props: EnzymePropSelector): ShallowWrapper<any, any>;
     closest(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -487,8 +489,8 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      * Find every node in the render tree that matches the provided selector.
      * @param selector The selector to match.
      */
-    find<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     find<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
+    find<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
 
@@ -501,16 +503,16 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
+    filter<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     filter(props: EnzymePropSelector | string): ReactWrapper<P, S>;
 
     /**
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector
      * can be provided and it will filter the children by this selector.
      */
-    children<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     children<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
+    children<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     children(selector: string): ReactWrapper<HTMLAttributes, any>;
     children(props?: EnzymePropSelector): ReactWrapper<any, any>;
 
@@ -526,8 +528,8 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      *
      * Note: can only be called on a wrapper of a single node.
      */
-    parents<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     parents<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
+    parents<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     parents(selector: string): ReactWrapper<HTMLAttributes, any>;
     parents(props?: EnzymePropSelector): ReactWrapper<any, any>;
 
@@ -537,8 +539,8 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      *
      * Note: can only be called on a wrapper of a single node.
      */
-    closest<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     closest<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
+    closest<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     closest(props: EnzymePropSelector): ReactWrapper<any, any>;
     closest(selector: string): ReactWrapper<HTMLAttributes, any>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

1) Stateless component can return null (cf React types)

2) Before theses changes, ComponentType has issues with enzyme functions. Now
- Stateless component match the first line and return ShallowWrapper<P2, never>
- ComponentClass match the second line and return ShallowWrapper<P2, any>
- ComponentType match the second line and return ShallowWrapper<P2, any>
