### PR TITLE
custom-functions-runtime: Invocation / CancelableInvocation / StreamingInvocation

### DIFF
--- a/types/custom-functions-runtime/custom-functions-runtime-tests.ts
+++ b/types/custom-functions-runtime/custom-functions-runtime-tests.ts
@@ -10,15 +10,18 @@ CustomFunctions.associate({
     RANDOM: (n: number) => n * Math.random()
 });
 
+function callerAddress(invocation: CustomFunctions.Invocation) {
+    return invocation.address;
+}
+
 async function getStockValues(ticker: string): Promise<number> {
     const response = await fetch(`myService.com/prices/${ticker}`);
     return (await response.json())["price"];
 }
 
-async function getStockValuesCancellable(
-    ticker: string,
-    invocation: CustomFunctions.CancelableInvocation
-): Promise<number> {
+async function getStockValuesCancellable(ticker: string,
+    invocation: CustomFunctions.CancelableInvocation): Promise<number> {
+    const address = invocation.address;
     let shouldStop = false;
     invocation.onCanceled = () => (shouldStop = true);
     await pause(1000);
@@ -31,10 +34,9 @@ async function getStockValuesCancellable(
     return (await response.json())["price"];
 }
 
-function stockPriceStream(
-    ticker: string,
-    invocation: CustomFunctions.StreamingInvocation<number>
-) {
+function stockPriceStream(ticker: string,
+    invocation: CustomFunctions.StreamingInvocation<number>) {
+    const address = invocation.address;
     const updateFrequency = 10 /* milliseconds*/;
     let isPending = false;
 

--- a/types/custom-functions-runtime/custom-functions-runtime-tests.ts
+++ b/types/custom-functions-runtime/custom-functions-runtime-tests.ts
@@ -17,10 +17,10 @@ async function getStockValues(ticker: string): Promise<number> {
 
 async function getStockValuesCancellable(
     ticker: string,
-    handler: CustomFunctions.CancelableHandler
+    invocation: CustomFunctions.CancelableInvocation
 ): Promise<number> {
     let shouldStop = false;
-    handler.onCanceled = () => (shouldStop = true);
+    invocation.onCanceled = () => (shouldStop = true);
     await pause(1000);
 
     if (shouldStop) {
@@ -33,7 +33,7 @@ async function getStockValuesCancellable(
 
 function stockPriceStream(
     ticker: string,
-    handler: CustomFunctions.StreamingHandler<number>
+    invocation: CustomFunctions.StreamingInvocation<number>
 ) {
     const updateFrequency = 10 /* milliseconds*/;
     let isPending = false;
@@ -49,14 +49,14 @@ function stockPriceStream(
         try {
             const response = await fetch(url);
             const data = await response.json();
-            handler.setResult(data.price);
+            invocation.setResult(data.price);
         } catch (error) {
-            handler.setResult(error);
+            invocation.setResult(error);
         }
         isPending = false;
     }, updateFrequency);
 
-    handler.onCanceled = () => {
+    invocation.onCanceled = () => {
         clearInterval(timer);
     };
 }

--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -13,89 +13,82 @@ Copyright (c) Microsoft Corporation
 */
 
 /**
- * CustomFunctions namespace, used by Excel Custom Functions
  * @beta
+ * CustomFunctions namespace, used by Excel Custom Functions
  */
 declare namespace CustomFunctions {
     /**
-     * Associates the JavaScript function to the name given by the "id" property in the metadata JSON file.
      * @beta
+     * Associates the JavaScript function to the name given by the "id" property in the metadata JSON file.
      */
     function associate(id: string, functionObject: Function): void;
     /**
-     * Associates the JavaScript functions to the names given by the "id" properties in the metadata JSON file.
      * @beta
+     * Associates the JavaScript functions to the names given by the "id" properties in the metadata JSON file.
      */
     function associate(mappings: { [key: string]: Function }): void;
 
     /**
-     * Provides information about the invocation of a custom function.
      * @beta
+     * Provides information about the invocation of a custom function.
      */
     interface Invocation {
         /**
+         * @beta
          * The cell address where the function is being called, if requested, otherwise undefined.
          * 
          * To request the address for the function, in the metadata JSON file, the function options should specify:
+         * `{ "requiresAddress": true }`
          * 
-         * {
-         *     "requiresAddress": true
-         * }
-         * 
-         * If the metadata JSON file is being generated from JSDoc comments, include the tag "@requiresAddress".
+         * If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`.
          */
         address?: string;
     }
 
     /**
+     * @beta
      * Provides information about the invocation of a cancelable custom function.
      * A cancelable custom function can provide a handler for the onCanceled event.
-     * @beta
      * 
      * To indicate that a function is cancelable, in the metadata JSON file, the function options should specify:
+     * `{ "cancelable": true }`
      * 
-     * {
-     *     "cancelable": true
-     * }
-     * 
-     * If the metadata JSON file is being generated from JSDoc comments, include the tag "@cancelable".
+     * If the metadata JSON file is being generated from JSDoc comments, include the tag `@cancelable`.
      */
     interface CancelableInvocation extends Invocation {
         /**
-         * Event handler called when the custom function is canceled.
          * @beta
+         * Event handler called when the custom function is canceled.
          */
         onCanceled: () => void;
     }
 
     /**
-     * Provides information about the invocation of a cancelable custom function.
      * @beta
-     * @deprecated Use CancelableInvocation instead.
+     * @deprecated Use `CancelableInvocation` instead.
      */
     interface CancelableHandler extends CancelableInvocation {        
     }
 
     /**
+     * @beta
      * Provides information about the invocation of a streaming custom function.
      * A streaming custom function can provide results which can change over time.
      * 
-     * Call setResult() one or more times to provide the result instead of returning
+     * Call `setResult()` one or more times to provide the result instead of returning
      * a result from the function.
-     * @beta
      */
     interface StreamingInvocation<ResultType> extends CancelableInvocation {
         /**
-         * Sets the result for the custom function. May be called more than once.
          * @beta
+         * Set the result for the custom function. May be called more than once.
          */
         setResult: (value: ResultType | Error) => void;
     }
 
     /**
-     * Provides information about the invocation of a streaming custom function.
      * @beta
-     * @deprecated Use StreamingInvocation<ResultType> instead.
+     * @deprecated Use `StreamingInvocation<ResultType>` instead.
      */
     interface StreamingHandler<ResultType> extends StreamingInvocation<ResultType> {
     }

--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -1,8 +1,8 @@
 // Type definitions for Custom Functions 1.4
 // Project: https://github.com/OfficeDev/office-js
-// Definitions by: OfficeDev <https://github.com/OfficeDev>, 
+// Definitions by: OfficeDev <https://github.com/OfficeDev>,
 //                 Adam Krantz <https://github.com/akrantz>,
-//                 Michael Zlatkovsky <https://github.com/Zlatkovsky>, 
+//                 Michael Zlatkovsky <https://github.com/Zlatkovsky>,
 //                 Michelle Scharlock <https://github.com/mscharlock>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
@@ -36,10 +36,10 @@ declare namespace CustomFunctions {
         /**
          * @beta
          * The cell address where the function is being called, if requested, otherwise undefined.
-         * 
+         *
          * To request the address for the function, in the metadata JSON file, the function options should specify:
          * `{ "requiresAddress": true }`
-         * 
+         *
          * If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`.
          */
         address?: string;
@@ -49,10 +49,10 @@ declare namespace CustomFunctions {
      * @beta
      * Provides information about the invocation of a cancelable custom function.
      * A cancelable custom function can provide a handler for the onCanceled event.
-     * 
+     *
      * To indicate that a function is cancelable, in the metadata JSON file, the function options should specify:
      * `{ "cancelable": true }`
-     * 
+     *
      * If the metadata JSON file is being generated from JSDoc comments, include the tag `@cancelable`.
      */
     interface CancelableInvocation extends Invocation {
@@ -67,14 +67,14 @@ declare namespace CustomFunctions {
      * @beta
      * @deprecated Use `CancelableInvocation` instead.
      */
-    interface CancelableHandler extends CancelableInvocation {        
+    interface CancelableHandler extends CancelableInvocation {
     }
 
     /**
      * @beta
      * Provides information about the invocation of a streaming custom function.
      * A streaming custom function can provide results which can change over time.
-     * 
+     *
      * Call `setResult()` one or more times to provide the result instead of returning
      * a result from the function.
      */

--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -15,41 +15,77 @@ Copyright (c) Microsoft Corporation
  */
 declare namespace CustomFunctions {
     /**
-     * @beta
      * Associates the JavaScript function to the name given by the "id" property in the metadata JSON file.
+     * @beta
      */
     function associate(id: string, functionObject: Function): void;
     /**
-     * @beta
      * Associates the JavaScript functions to the names given by the "id" properties in the metadata JSON file.
+     * @beta
      */
     function associate(mappings: { [key: string]: Function }): void;
 
     /**
-     * A handler passed automatically as the last parameter
-     * to a streaming function. With this parameter, a
-     * function can use handler.setResult to set a cell value
-     * or hook into the handler.onCanceled event to
-     * to handle what happens when the function stops streaming.
+     * Provides information about the invocation of a custom function.
      * @beta
      */
-    interface StreamingHandler<T> extends CancelableHandler {
+    interface Invocation {
         /**
-         * Sets the returned result for a streaming custom function.
-         * @beta
+         * The cell address where the function is being called, if requested, otherwise undefined.
+         * 
+         * To request the address for the function, in the metadata JSON file, the function options should specify:
+         * 
+         * {
+         *     "requiresAddress": "true"
+         * }
+         * 
+         * If the metadata JSON file is being generated from JSDoc comments, include the tag "@requiresAddress".
          */
-        setResult: (value: T | Error) => void;
+        address?: string;
     }
 
     /**
+     * Provides information about the invocation of a cancelable custom function,
+     * and allows providing a function to be called when the function is canceled.
      * @beta
-     * CancelableHandler interface
      */
-    interface CancelableHandler {
+    interface CancelableInvocation extends Invocation {
         /**
-         * Handles what should occur when a custom function is canceled.
+         * Event handler called when the custom function is canceled.
          * @beta
          */
         onCanceled: () => void;
+    }
+
+    /**
+     * Provides information and events for the invocation of a cancelable custom function.
+     * @beta
+     * @deprecated Use CancelableInvocation instead.
+     */
+    interface CancelableHandler extends CancelableInvocation {        
+    }
+
+    /**
+     * Provides information and events for the invocation of a streaming custom function whose result
+     * can change over time. Call setResult() one or more times to provide the result 
+     * rather than returning a value from the function.
+     * @beta
+     */
+    interface StreamingInvocation<ResultType> extends CancelableInvocation {
+        /**
+         * Sets the result for the custom function. May be called more than once.
+         * @beta
+         */
+        setResult: (value: ResultType | Error) => void;
+    }
+
+    /**
+     * Provides information and events for the invocation of a streaming custom function whose result
+     * can change over time. Call setResult() one or more times to provide the result 
+     * rather than returning a value from the function.
+     * @beta
+     * @deprecated Use StreamingInvocation<ResultType> instead.
+     */
+    interface StreamingHandler<ResultType> extends StreamingInvocation<ResultType> {
     }
 }

--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for Custom Functions 1.4
 // Project: https://github.com/OfficeDev/office-js
-// Definitions by: OfficeDev <https://github.com/OfficeDev>, Michael Zlatkovsky <https://github.com/Zlatkovsky>, Michelle Scharlock <https://github.com/mscharlock>
+// Definitions by: OfficeDev <https://github.com/OfficeDev>, 
+//                 Adam Krantz <https://github.com/akrantz>,
+//                 Michael Zlatkovsky <https://github.com/Zlatkovsky>, 
+//                 Michelle Scharlock <https://github.com/mscharlock>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -36,7 +39,7 @@ declare namespace CustomFunctions {
          * To request the address for the function, in the metadata JSON file, the function options should specify:
          * 
          * {
-         *     "requiresAddress": "true"
+         *     "requiresAddress": true
          * }
          * 
          * If the metadata JSON file is being generated from JSDoc comments, include the tag "@requiresAddress".
@@ -45,9 +48,17 @@ declare namespace CustomFunctions {
     }
 
     /**
-     * Provides information about the invocation of a cancelable custom function,
-     * and allows providing a function to be called when the function is canceled.
+     * Provides information about the invocation of a cancelable custom function.
+     * A cancelable custom function can provide a handler for the onCanceled event.
      * @beta
+     * 
+     * To indicate that a function is cancelable, in the metadata JSON file, the function options should specify:
+     * 
+     * {
+     *     "cancelable": true
+     * }
+     * 
+     * If the metadata JSON file is being generated from JSDoc comments, include the tag "@cancelable".
      */
     interface CancelableInvocation extends Invocation {
         /**
@@ -58,7 +69,7 @@ declare namespace CustomFunctions {
     }
 
     /**
-     * Provides information and events for the invocation of a cancelable custom function.
+     * Provides information about the invocation of a cancelable custom function.
      * @beta
      * @deprecated Use CancelableInvocation instead.
      */
@@ -66,9 +77,11 @@ declare namespace CustomFunctions {
     }
 
     /**
-     * Provides information and events for the invocation of a streaming custom function whose result
-     * can change over time. Call setResult() one or more times to provide the result 
-     * rather than returning a value from the function.
+     * Provides information about the invocation of a streaming custom function.
+     * A streaming custom function can provide results which can change over time.
+     * 
+     * Call setResult() one or more times to provide the result instead of returning
+     * a result from the function.
      * @beta
      */
     interface StreamingInvocation<ResultType> extends CancelableInvocation {
@@ -80,9 +93,7 @@ declare namespace CustomFunctions {
     }
 
     /**
-     * Provides information and events for the invocation of a streaming custom function whose result
-     * can change over time. Call setResult() one or more times to provide the result 
-     * rather than returning a value from the function.
+     * Provides information about the invocation of a streaming custom function.
      * @beta
      * @deprecated Use StreamingInvocation<ResultType> instead.
      */

--- a/types/custom-functions-runtime/tslint.json
+++ b/types/custom-functions-runtime/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "file-name-casing": false
+        "file-name-casing": false,
+        "no-empty-interface": false
     }
 }


### PR DESCRIPTION
Adds CustomFunctions.Invocation with address property.
Renames CancelableHandler to CancelableInvocation, StreamingHandler to StreamingInvocation.
Updated doc comments.

---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
