### PR TITLE
wrongly typed callbacks for clusterize.js

### DIFF
--- a/types/clusterize.js/index.d.ts
+++ b/types/clusterize.js/index.d.ts
@@ -32,9 +32,9 @@ declare namespace Clusterize {
     }
 
     interface Callbacks {
-        clusterWillChange?(cb: () => void): void;
-        clusterChanged?(cb: () => void): void;
-        scrollingProgress?(cb: (progress: number) => void): void;
+        clusterWillChange?: () => void;
+        clusterChanged?: () => void;
+        scrollingProgress?: (progress: number) => void;
     }
 }
 


### PR DESCRIPTION
As official demo code shows that the callbacks are wrongly typed.

```
// Callbacks usage example
var clusterize = new Clusterize({
  …
  callbacks: {
    clusterWillChange: function() {},
    clusterChanged: function() {},
    scrollingProgress: function(progress) {}
  }
});
```

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
