### PR TITLE
[redux-immutable] Add missing 'any' type for consistency

### DIFF
--- a/types/redux-immutable/index.d.ts
+++ b/types/redux-immutable/index.d.ts
@@ -12,4 +12,4 @@ import { Collection } from 'immutable';
 
 export declare function combineReducers<S, A extends Action, T>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Keyed<T, S>): Reducer<S, A>;
 export declare function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S, A>;
-export declare function combineReducers<S>(reducers: ReducersMapObject<S>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S>;
+export declare function combineReducers<S>(reducers: ReducersMapObject<S, any>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/reduxjs/redux/blob/master/index.d.ts#L92>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Follow official type definition from redux:
<img width="819" alt="screen shot 2019-01-23 at 17 41 07" src="https://user-images.githubusercontent.com/5276065/51649153-199f2300-1f38-11e9-8402-59760084a244.png">

Fixes error(which works well with the official redux type definition):
<img width="813" alt="screen shot 2019-01-23 at 17 41 21" src="https://user-images.githubusercontent.com/5276065/51649179-2d4a8980-1f38-11e9-96e9-3c6d1b5c15b0.png">
<img width="599" alt="screen shot 2019-01-23 at 17 41 39" src="https://user-images.githubusercontent.com/5276065/51649184-3176a700-1f38-11e9-9799-05760eb91c44.png">


