### PR TITLE
[multiparty] Add types for multiparty.Form#on() methods and originalFilename renaming

### DIFF
--- a/types/multiparty/index.d.ts
+++ b/types/multiparty/index.d.ts
@@ -19,6 +19,13 @@ export declare class Form extends events.EventEmitter {
      * @param callback
      */
     parse(request: http.IncomingMessage, callback?: (error: Error, fields: any, files: any) => any): void;
+
+    on(event: "part", listener: (part: Part) => void): this;
+    on(event: "close", listener: () => void): this;
+    on(event: "error", listener: (err: Error) => void): this;
+    on(event: "progress", listener: (bytesReceived: number, bytesExpected: number) => void): this;
+    on(event: "field", listener: (name: string, value: string) => void): this;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 
 export interface File {
@@ -44,7 +51,7 @@ export interface File {
     size: number;
 }
 
-interface Part extends stream.Readable {
+export interface Part extends stream.Readable {
     /**
      * the headers for this part. For example, you may be interested in content-type
      */

--- a/types/multiparty/index.d.ts
+++ b/types/multiparty/index.d.ts
@@ -36,7 +36,7 @@ export interface File {
     /**
      * the filename that the user reports for the file
      */
-    originalFileName: string;
+    originalFilename: string;
     /**
      * the absolute path of the uploaded file on disk
      */


### PR DESCRIPTION
Hi, developers! Thank you very much for your wonderful project! I'm not get accustom to contribute DefinitelyTyped.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - [multiparty-tests.ts L13..L55](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d5fe4dcadbc7477bb869aca75cd71181fb828487/types/multiparty/multiparty-tests.ts#L13..L55)
   - [multiparty#readme](https://github.com/pillarjs/multiparty#readme)
   - <https://github.com/pillarjs/multiparty/blob/master/index.js#L650> provided by @elunic
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

## Question
Could you tell whether I should define types for other methods like `addListener()`, `once()`, `prependListener()`, `removeListener()` ...? Because `multiparty.Form` extends `EventEmitter`.
