### PR TITLE
puppeteer: safer args for page.eval and friends

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -18,6 +18,19 @@ export type WrapElementHandle<X> = X extends Element ? ElementHandle<X> : X;
 /** Unwraps a DOM element out of an ElementHandle instance */
 export type UnwrapElementHandle<X> = X extends ElementHandle<infer E> ? E : X;
 
+export type Serializable =
+  | number
+  | string
+  | boolean
+  | null
+  | JSONArray
+  | JSONObject;
+export interface JSONArray extends Array<Serializable> { }
+export interface JSONObject {
+  [key: string]: Serializable;
+}
+export type SerializableOrJSHandle = Serializable | JSHandle;
+
 /** Defines `$eval` and `$$eval` for Page, Frame and ElementHandle. */
 export interface Evalable {
   /**
@@ -106,7 +119,7 @@ export interface Evalable {
   $eval<R>(
     selector: string,
     pageFunction: (element: Element, ...args: any[]) => R | Promise<R>,
-    ...args: any[],
+    ...args: SerializableOrJSHandle[],
   ): Promise<WrapElementHandle<R>>;
 
   /**
@@ -195,7 +208,7 @@ export interface Evalable {
   $$eval<R>(
     selector: string,
     pageFunction: (elements: Element[], ...args: any[]) => R | Promise<R>,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<WrapElementHandle<R>>;
 }
 
@@ -718,7 +731,7 @@ export interface Worker {
    */
   evaluate<T>(
     pageFunction: (...args: any[]) => T | Promise<T>,
-    ...args: any[],
+    ...args: SerializableOrJSHandle[],
   ): Promise<T>;
 
   /**
@@ -727,7 +740,7 @@ export interface Worker {
    */
   evaluateHandle<T>(
     pageFunction: (...args: any[]) => T | Promise<T>,
-    ...args: any[],
+    ...args: SerializableOrJSHandle[],
   ): Promise<T>;
 
   executionContext(): Promise<ExecutionContext>;
@@ -830,11 +843,11 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle, Ev
 export interface ExecutionContext {
   evaluate(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<any>;
   evaluateHandle(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<JSHandle>;
   queryObjects(prototypeHandle: JSHandle): JSHandle;
 }
@@ -1141,7 +1154,7 @@ export interface FrameBase extends Evalable {
    */
   evaluate(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<any>;
 
   /**
@@ -1154,7 +1167,7 @@ export interface FrameBase extends Evalable {
    */
   evaluateHandle(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<JSHandle>;
 
   /** This method fetches an element with selector and focuses it. */
@@ -1219,7 +1232,11 @@ export interface FrameBase extends Evalable {
   /**
    * Shortcut for waitForFunction.
    */
-  waitFor(selector: ((...args: any[]) => any) | string, options?: WaitForSelectorOptions, ...args: any[]): Promise<any>;
+  waitFor(
+    selector: ((...args: any[]) => any) | string,
+    options?: WaitForSelectorOptions,
+    ...args: SerializableOrJSHandle[]
+  ): Promise<any>;
 
   /**
    * Allows waiting for various conditions.
@@ -1227,7 +1244,7 @@ export interface FrameBase extends Evalable {
   waitForFunction(
     fn: string | ((...args: any[]) => any),
     options?: PageFnOptions,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<any>;
 
   /**
@@ -1539,7 +1556,7 @@ export interface Page extends EventEmitter, FrameBase {
    */
   evaluateHandle(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<JSHandle>;
 
   /**
@@ -1550,7 +1567,7 @@ export interface Page extends EventEmitter, FrameBase {
    */
   evaluateOnNewDocument(
     fn: EvaluateFn,
-    ...args: any[]
+    ...args: SerializableOrJSHandle[]
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
page.evaluate and similar functions are currently typed as if
they accept 'any' args, but they will throw exceptions unless
the args are either Serializable (with JSON.stringify) or JSHandles.

In GoogleChrome/puppeteer#3591, @SimonSchick recommended that tighter
type definitions was a preferable way to address this rather than
runtime error checking.

I've been using these updated types in my project for the last couple of
months without problem.

I suspect that some of the X1, X2 type parameters should also
be changed to reflect that they can only be SerializableOrJSHandle,
but I wasn't sure how to change the existing UnwrapElementHandle<X1>
types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pptr.dev/#?product=Puppeteer&version=v1.11.0&show=api-pageevaluatepagefunction-args
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
