### PR TITLE
[@feathersjs/authentication-oauth2] Fix TypeScript version

### DIFF
--- a/types/feathersjs__authentication-oauth2/index.d.ts
+++ b/types/feathersjs__authentication-oauth2/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by:  Jan Lohage <https://github.com/j2L4e>
 //                  Nick Bolles <https://github.com/NickBolles>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as self from '@feathersjs/authentication-oauth2';
 import { Application, Paginated, Service } from '@feathersjs/feathers';


### PR DESCRIPTION
Fixes - Error: feathersjs__authentication-oauth2 depends on passport-github but
has a lower required TypeScript version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A - see commit description
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.