### PR TITLE
@types/catbox: Fix PolicyOptionVariants<T> to always extends DecoratedPolicyOptions<T>

### DIFF
--- a/types/catbox/index.d.ts
+++ b/types/catbox/index.d.ts
@@ -231,7 +231,7 @@ export interface DecoratedPolicyOptions<T> extends PolicyOptions<T> {
     /**
      * @default false
      */
-    getDecoratedValue?: boolean;
+    getDecoratedValue: boolean | undefined;
 }
 
 export interface GenerateFuncFlags {


### PR DESCRIPTION
Hello,

**TL;DR**
This small fix avoid Typescript compilation and type-checking to **always** let `PolicyOptionVariants<T>` be extends as `DecoratedPolicyOptions<T>` ([line 143](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/catbox/index.d.ts#L143)) because the `getDecoratedValue` property of the `DecoratedPolicyOptions<T>` interface is optionnal ([line 234](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/catbox/index.d.ts#L234)).

**DETAILS**
`get(id: Id): Promise<O extends DecoratedPolicyOptions<T> ? DecoratedResult<T> : T | null>;` ([line 143](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/catbox/index.d.ts#L143)) is always returning `DecoratedResult<T>` :

In this context `O` is a generic that must extends `PolicyOptions<T> | DecoratedPolicyOptions<T>` and `DecoratedPolicyOptions<T>` is an interface that extends `PolicyOptions<T>`.

The problem is that the `DecoratedPolicyOptions<T>` interface only have a single property which is optionnal allowing `PolicyOptions<T>` to also extends `DecoratedPolicyOptions<T>`.

This is why the following condition `O extends DecoratedPolicyOptions<T>` is always true because `O` always extends `DecoratedPolicyOptions<T>`.

Authors : @jasonswearingen @AJamesPhillips @saboya
