### PR TITLE
@types/react-svg-inline: allow numeric value for width and height props

### DIFF
--- a/types/react-svg-inline/index.d.ts
+++ b/types/react-svg-inline/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-svg-inline 2.1
+// Type definitions for react-svg-inline 3.1
 // Project: https://github.com/MoOx/react-svg-inline
 // Definitions by: kiyopikko <https://github.com/kiyopikko>
+//                 Hiroshi Ioka <https://github.com/hirochachacha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -15,8 +16,8 @@ declare namespace svgInline {
         fill?: string;
         cleanup?: boolean | Array<"title" | "desc" | "comment" | "defs" | "width" | "height" | "fill" | "sketchMSShapeGroup" | "sketchMSPage" | "sketchMSLayerGroup">;
         cleanupExceptions?: Array<"title" | "desc" | "comment" | "defs" | "width" | "height" | "fill" | "sketchMSShapeGroup" | "sketchMSPage" | "sketchMSLayerGroup">;
-        width?: string;
-        height?: string;
+        width?: string | number;
+        height?: string | number;
         accessibilityLabel?: string;
         accessibilityDesc?: string;
     }

--- a/types/react-svg-inline/react-svg-inline-tests.tsx
+++ b/types/react-svg-inline/react-svg-inline-tests.tsx
@@ -24,7 +24,9 @@ const svgInlines = [
     <SVGInline svg={"<svg><g></g></svg>"} cleanup={["desc", "sketchMSPage", "sketchMSShapeGroup", "sketchMSLayerGroup"]} />,
     <SVGInline svg={"<svg><g></g></svg>"} cleanupExceptions={["title"]} />,
     <SVGInline svg={"<svg><g></g></svg>"} width={"16"} />,
+    <SVGInline svg={"<svg><g></g></svg>"} width={16} />,
     <SVGInline svg={"<svg><g></g></svg>"} height={"32px"} />,
+    <SVGInline svg={"<svg><g></g></svg>"} height={32} />,
     <SVGInline svg={"<svg><g></g></svg>"} accessibilityLabel={"User-friendly Label"} />,
     <SVGInline svg={"<svg><g></g></svg>"} accessibilityDesc={"This description is easy to understand."} />,
 ];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/MoOx/react-svg-inline/blob/8afa7180bf78965998d783616432286b14e1719b/src/index.js#L76-L79
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.