### PR TITLE
Updated Dockerode Service definition

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -8,6 +8,7 @@
 //                 Rob Moran <https://github.com/thegecko>
 //                 Cameron Diver <https://github.com/CameronDiver>
 //                 Pascal Sthamer <https://github.com/p4sca1>
+//                 Kasra Bigdeli <https://github.com/githubsaturn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -174,6 +175,10 @@ declare namespace Dockerode {
 
     update(options: {}, callback: Callback<any>): void;
     update(options: {}): Promise<any>;
+      
+    logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
+    logs(callback: Callback<NodeJS.ReadableStream>): void;
+    logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
   }
 
   class Task {

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -8,7 +8,6 @@
 //                 Rob Moran <https://github.com/thegecko>
 //                 Cameron Diver <https://github.com/CameronDiver>
 //                 Pascal Sthamer <https://github.com/p4sca1>
-//                 Kasra Bigdeli <https://github.com/githubsaturn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -174,7 +174,7 @@ declare namespace Dockerode {
 
     update(options: {}, callback: Callback<any>): void;
     update(options: {}): Promise<any>;
-      
+
     logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
     logs(callback: Callback<NodeJS.ReadableStream>): void;
     logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;


### PR DESCRIPTION
Added logs to Service definition of Dockerode. Service, similar to Container, has log related methods:
https://github.com/apocas/dockerode/blob/master/lib/service.js#L140
https://github.com/apocas/dockerode/blob/master/lib/container.js#L990

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/apocas/dockerode/blob/master/lib/service.js#L140>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
