### PR TITLE
[xxhashjs] Upgrade to 0.2, fix return type, add more tests

### DIFF
--- a/types/xxhashjs/index.d.ts
+++ b/types/xxhashjs/index.d.ts
@@ -1,19 +1,29 @@
-// Type definitions for xxhashjs 0.1
+// Type definitions for xxhashjs 0.2
 // Project: https://github.com/pierrec/js-xxhash
 // Definitions by: Dibyo Majumdar <https://github.com/mDibyo>
+//                 Nick Zahn <https://github.com/Manc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
 
 export as namespace XXH;
 
+// Ideally we would have a type definition for the "cuint" package.
+// The following interface `UINT` is to resolve the bare minimum.
+interface UINT {
+	toNumber(): number;
+	toString(radix?: number): string;
+}
+
 export interface HashObject {
-  init(seed: number): this;
-  update(data: string | ArrayBuffer): this;
-  digest(): number;
+	init(seed: number): this;
+	update(data: string | ArrayBuffer | Buffer): this;
+	digest(): UINT;
 }
 
 export interface HashInterface {
-  (seed?: number): HashObject;
-  (data: string | ArrayBuffer, seed: number): number;
+	(seed?: number): HashObject;
+	(data: string | ArrayBuffer | Buffer, seed: number): UINT;
 }
 
 export const h32: HashInterface;

--- a/types/xxhashjs/xxhashjs-tests.ts
+++ b/types/xxhashjs/xxhashjs-tests.ts
@@ -1,7 +1,37 @@
 import XXH from 'xxhashjs';
 
-// examples adapted from https://github.com/pierrec/js-xxhash
-const h1 = XXH.h32('abcd', 0xABCD).toString(16);
+// Test data
+const seed = 0xABCD;
+const stringData = 'abcd';
+const arrayBufferData = new ArrayBuffer(4);
+const bufferData = Buffer.from([1, 2, 3, 4]);
 
-const H = XXH.h32(0xABCD);
-const h2 = H.update('abcd').digest().toString(16);
+// Test XXH.h32 methods, initialising with string data
+const value32_1 = XXH.h32(stringData, seed);
+value32_1.toString();
+value32_1.toString(16);
+value32_1.toNumber();
+
+const value32_2 = XXH.h32(seed).update(stringData).digest();
+value32_2.toString();
+value32_2.toString(16);
+value32_2.toNumber();
+
+// Test XXH.h64 methods, initialising with string data
+const value64_1 = XXH.h64(stringData, seed);
+value64_1.toString();
+value64_1.toString(16);
+value64_1.toNumber();
+
+const value64_2 = XXH.h64(seed).update(stringData).digest();
+value64_2.toString();
+value64_2.toString(16);
+value64_2.toNumber();
+
+// Initialise with ArrayBuffer
+XXH.h32(arrayBufferData, seed);
+XXH.h64(arrayBufferData, seed);
+
+// Initialise with Buffer
+XXH.h32(bufferData, seed);
+XXH.h64(bufferData, seed);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pierrec/js-xxhash
- [x] Increase the version number in the header if appropriate.

Most important change is changing the return type of `digest()` and the `(data, seed)` functions to `UINT`, an object. In the current version this is typed as `number`. You would not notice this if you only use the `toString()` method on it, which works for both, but if you actually want to use and access the number, you will be surprised to find an object instead of the promised number.

Because `UINT` – or more specifically `UINT32` and `UINT64` – come from an external package "cuint", which doesn't have a type definition, I added the two most significant methods for users of *this* "xxhashjs" package in `interface UINT`. Once there is a type definition for "cuint", it can be used instead, but all the other methods of it are (in my opinion) not relevant for users of "xxhashjs", because they're only used internally.

I've extended the accepted types for the `data` argument as described in the official documentation.

I've also added more tests to reflect all this.