### PR TITLE
[Bull] Add missing getJobCountByTypes definition

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -26,8 +26,8 @@ import * as Redis from "ioredis";
 declare const Bull: {
   (queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
   (queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
-  new (queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
-  new (queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
+  new(queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
+  new(queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
 };
 
 declare namespace Bull {
@@ -553,6 +553,11 @@ declare namespace Bull {
      * Returns a promise that resolves with the job counts for the given queue.
      */
     getJobCounts(): Promise<JobCounts>;
+
+    /**
+     * Returns a promise that resolves with the job counts for the given queue of the given types.
+     */
+    getJobCountByTypes(types: string[]): Promise<JobCounts>;
 
     /**
      * Returns a promise that resolves with the quantity of completed jobs.

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -557,7 +557,7 @@ declare namespace Bull {
     /**
      * Returns a promise that resolves with the job counts for the given queue of the given types.
      */
-    getJobCountByTypes(types: string[]): Promise<JobCounts>;
+    getJobCountByTypes(types: string[] | string): Promise<JobCounts>;
 
     /**
      * Returns a promise that resolves with the quantity of completed jobs.

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -26,8 +26,8 @@ import * as Redis from "ioredis";
 declare const Bull: {
   (queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
   (queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
-  new(queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
-  new(queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
+  new (queueName: string, opts?: Bull.QueueOptions): Bull.Queue;
+  new (queueName: string, url: string, opts?: Bull.QueueOptions): Bull.Queue; // tslint:disable-line unified-signatures
 };
 
 declare namespace Bull {


### PR DESCRIPTION

 ReturnsAdd missing getJobCountByTypes definition
Queue.getJobCountByTypes return a promise that resolves with the job counts for the given queue of the given types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OptimalBits/bull/blob/develop/lib/getters.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


