### PR TITLE
improve(buble): use `SourceMap` type from `magic-string` package

### DIFF
--- a/types/buble/buble-tests.ts
+++ b/types/buble/buble-tests.ts
@@ -8,7 +8,7 @@ const input = 'const answer = () => 42;';
 
     console.log(output.code);
     console.log(output.map.toString());
-    console.log(output.map.toUrl);
+    console.log(output.map.toUrl());
 })();
 
 // Transform for Chrome & Firefox

--- a/types/buble/index.d.ts
+++ b/types/buble/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for buble 0.19
 // Project: https://github.com/Rich-Harris/buble#README
-// Definitions by: Kocal <https://github.com/Kocal>
+// Definitions by: Hugo Alliaume <https://github.com/Kocal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/buble/index.d.ts
+++ b/types/buble/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/Rich-Harris/buble#README
 // Definitions by: Kocal <https://github.com/Kocal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import { SourceMap } from "magic-string";
 
 export interface TransformOptions {
     // source: https://github.com/Rich-Harris/buble/blob/master/src/support.js
@@ -56,10 +59,7 @@ export interface TransformOptions {
 
 export interface TransformOutput {
     code: string;
-    map: {
-        toString(): string;
-        toUrl(): string;
-    };
+    map: SourceMap;
 }
 
 export function transform(content: string, options?: TransformOptions): TransformOutput;

--- a/types/buble/package.json
+++ b/types/buble/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "magic-string": "^0.25.0"
+  }
+}


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32515#discussion_r251208856.

Had to limit TypeScript version to 2.1+, because `magic-strinc` use `Partial`:

![capture d ecran de 2019-01-26 21-16-36](https://user-images.githubusercontent.com/2103975/51792397-93414600-21b0-11e9-8cd1-eec708f3646f.png)


---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
