### PR TITLE
Importing specific moment modules.

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -14,11 +14,10 @@
 //                 Dmitriy Trifonov <https://github.com/divideby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { MomentInput, MomentFormatSpecification, Moment } from 'moment';
 export type MomentConstructor1 =
-  (inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean) => Moment;
+    (inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, strict?: boolean) => moment.Moment;
 export type MomentConstructor2 =
-  (inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean) => Moment;
+    (inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean) => moment.Moment;
 
 export type MomentConstructor = MomentConstructor1 | MomentConstructor2;
 


### PR DESCRIPTION
Recent moment.d.ts doesn't contain all the moment interfaces required. As a result typescript is throwing error during compilation. Latest moment.d.ts can be found here. https://www.nuget.org/packages/moment.TypeScript.DefinitelyTyped/