### PR TITLE
[webappsec-credential-management] Make userHandle optional

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -494,7 +494,7 @@ interface AuthenticatorAttestationResponse extends AuthenticatorResponse {
 interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
     readonly authenticatorData: ArrayBuffer;
     readonly signature: ArrayBuffer;
-    readonly userHandle?: ArrayBuffer;
+    readonly userHandle: ArrayBuffer | null;
 }
 
 /**

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.3
 // Project: https://github.com/w3c/webappsec-credential-management
 // Definitions by: Iain McGinniss <https://github.com/iainmcgin>
+//                 Joao Peixoto <https://github.com/Hartimer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -493,7 +494,7 @@ interface AuthenticatorAttestationResponse extends AuthenticatorResponse {
 interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
     readonly authenticatorData: ArrayBuffer;
     readonly signature: ArrayBuffer;
-    readonly userHandle: ArrayBuffer;
+    readonly userHandle?: ArrayBuffer;
 }
 
 /**

--- a/types/webappsec-credential-management/webappsec-credential-management-tests.ts
+++ b/types/webappsec-credential-management/webappsec-credential-management-tests.ts
@@ -5,7 +5,7 @@ function passwordBasedSignInDeprecated() {
         return;
     }
 
-    navigator.credentials.get({password: true}).then((credential) => {
+    navigator.credentials.get({ password: true }).then((credential) => {
         if (!credential) {
             return;
         }
@@ -117,7 +117,7 @@ function federatedSignIn() {
     navigator.credentials
         .get({
             password: true,
-            federated: {providers: ['https://federation.com']}
+            federated: { providers: ['https://federation.com'] }
         })
         .then((credential) => {
             if (!credential) return;
@@ -141,7 +141,7 @@ function federatedSignIn() {
                 const pwCred = credential as PasswordCredential;
                 fetch(
                     'https://example.com/loginEndpoint',
-                    {credentials: pwCred, method: 'POST'});
+                    { credentials: pwCred, method: 'POST' });
             }
         });
 }
@@ -159,7 +159,7 @@ function passwordPostSignInConfirmation() {
 
             const formElem = (e.target as HTMLFormElement);
             const c = new PasswordCredential(formElem);
-            fetch(formElem.action, {method: 'POST', credentials: c}).then(r => {
+            fetch(formElem.action, { method: 'POST', credentials: c }).then(r => {
                 if (r.status === 200) {
                     navigator.credentials!.store(c);
                 }
@@ -172,7 +172,7 @@ function passwordPostSignInConfirmation() {
 function federationPostSignInConfirmation() {
     if (navigator.credentials) {
         navigator.credentials.store(new FederatedCredential(
-            {id: 'username', provider: 'https://federation.com'}));
+            { id: 'username', provider: 'https://federation.com' }));
     }
 }
 
@@ -188,7 +188,7 @@ function existingFormPost(credential: PasswordCredential) {
     credential.passwordName = 'p';
     fetch(
         'https://example.com/loginEndpoint',
-        {credentials: credential, method: 'POST'});
+        { credentials: credential, method: 'POST' });
 }
 
 function additionalDataPost(credential: PasswordCredential, token: string) {
@@ -196,14 +196,14 @@ function additionalDataPost(credential: PasswordCredential, token: string) {
     credential.additionalData.append('csrf', token);
     fetch(
         'https://example.com/loginEndpoint',
-        {credentials: credential, method: 'POST'});
+        { credentials: credential, method: 'POST' });
 }
 
 function formEncodedPost(credential: PasswordCredential, token: string) {
     credential.additionalData = new URLSearchParams();
     fetch(
         'https://example.com/loginEndpoint',
-        {credentials: credential, method: 'POST'});
+        { credentials: credential, method: 'POST' });
 }
 
 // requireUserMediation example: not included in the spec, but included here
@@ -236,7 +236,7 @@ function createPasswordCredential() {
     }
 
     navigator.credentials.create({
-        password: {id: 'username', password: 'password'}
+        password: { id: 'username', password: 'password' }
     }).then((credential) => {
         // Credential created!
     });
@@ -266,7 +266,7 @@ function createFederatedCredential() {
     }
 
     navigator.credentials.create({
-        federated: {id: 'username', provider: 'provider'}
+        federated: { id: 'username', provider: 'provider' }
     }).then((credential) => {
         // Credential created!
     });
@@ -293,7 +293,7 @@ function webauthnRegister() {
             },
             challenge,
             pubKeyCredParams: [
-                {type: 'public-key', alg: -7},
+                { type: 'public-key', alg: -7 },
             ],
             excludeCredentials: [
                 {
@@ -329,16 +329,18 @@ function webauthnAuthenticate() {
     const challenge = new Uint8Array(32);
     window.crypto.getRandomValues(challenge);
 
-    const authPromise = navigator.credentials.get({publicKey: {
-        challenge,
-        timeout: 5000,
-        rpId: document.domain,
-        allowCredentials: [{
-            type: "public-key",
-            id: credentialID,
-            transports: ['internal', 'ble', 'nfc', 'usb']
-        }],
-    }});
+    const authPromise = navigator.credentials.get({
+        publicKey: {
+            challenge,
+            timeout: 5000,
+            rpId: document.domain,
+            allowCredentials: [{
+                type: "public-key",
+                id: credentialID,
+                transports: ['internal', 'ble', 'nfc', 'usb']
+            }],
+        }
+    });
 
     authPromise.then((cred) => {
         if (cred === null) {
@@ -362,6 +364,7 @@ function mockAuthenticatorAssertionResponse() {
         clientDataJSON: new ArrayBuffer(0),
         authenticatorData: new ArrayBuffer(0),
         signature: new ArrayBuffer(0),
+        userHandle: null,
     };
     sampleResponse.userHandle === undefined;
 }

--- a/types/webappsec-credential-management/webappsec-credential-management-tests.ts
+++ b/types/webappsec-credential-management/webappsec-credential-management-tests.ts
@@ -352,3 +352,16 @@ function webauthnAuthenticate() {
         console.log(e.message);
     });
 }
+
+function mockAuthenticatorAssertionResponse() {
+    if (!navigator.credentials) {
+        return;
+    }
+
+    const sampleResponse: AuthenticatorAssertionResponse = {
+        clientDataJSON: new ArrayBuffer(0),
+        authenticatorData: new ArrayBuffer(0),
+        signature: new ArrayBuffer(0),
+    };
+    sampleResponse.userHandle === undefined;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/webauthn/#iface-authenticatorassertionresponse
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

