### PR TITLE
feat: add typings for rollup-plugin-node-globals

### DIFF
--- a/types/rollup-plugin-node-globals/index.d.ts
+++ b/types/rollup-plugin-node-globals/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for rollup-plugin-node-globals 1.4
 // Project: https://github.com/calvinmetcalf/rollup-plugin-node-globals#readme
-// Definitions by: Kocal <https://github.com/kocal>
+// Definitions by: Hugo Alliaume <https://github.com/kocal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/rollup-plugin-node-globals/index.d.ts
+++ b/types/rollup-plugin-node-globals/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for rollup-plugin-node-globals 1.4
+// Project: https://github.com/calvinmetcalf/rollup-plugin-node-globals#readme
+// Definitions by: Kocal <https://github.com/kocal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/rollup-plugin-node-globals/index.d.ts
+++ b/types/rollup-plugin-node-globals/index.d.ts
@@ -2,3 +2,27 @@
 // Project: https://github.com/calvinmetcalf/rollup-plugin-node-globals#readme
 // Definitions by: Kocal <https://github.com/kocal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { Plugin } from 'rollup';
+
+export interface Options {
+    // Every files will be parsed by default, but you can specify which files to include or exclude
+    include?: Array<string | RegExp> | string | RegExp | null;
+    exclude?: Array<string | RegExp> | string | RegExp | null;
+
+    // Enable sourcemaps support
+    sourceMap ?: boolean;
+
+    // Plugin's options
+    process?: boolean;
+    global?: boolean;
+    buffer?: boolean;
+    dirname?: boolean;
+    filename?: boolean;
+    baseDir?: string;
+}
+
+export default function globals(options?: Options): Plugin;

--- a/types/rollup-plugin-node-globals/package.json
+++ b/types/rollup-plugin-node-globals/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4"
+    }
+}

--- a/types/rollup-plugin-node-globals/rollup-plugin-node-globals-tests.ts
+++ b/types/rollup-plugin-node-globals/rollup-plugin-node-globals-tests.ts
@@ -1,0 +1,43 @@
+import globals from 'rollup-plugin-node-globals';
+
+// No options (default)
+(() => {
+    // $ExpectType Plugin
+    globals();
+})();
+
+// With every options
+(() => {
+    // $ExpectType Plugin
+    globals({
+        process: false,
+        global: false,
+        buffer: false,
+        dirname: false,
+        filename: false,
+        baseDir: '/',
+    });
+})();
+
+// Filter files
+(() => {
+    // $ExpectType Plugin
+    globals({
+        include: '*.js',
+        exclude: '*.js',
+    });
+
+    // $ExpectType Plugin
+    globals({
+        include: /.js$/,
+        exclude: ['foo.js', 'bar.js'],
+    });
+})();
+
+// Sourcemaps
+(() => {
+    // $ExpectType Plugin
+    globals({
+        sourceMap: false,
+    });
+})();

--- a/types/rollup-plugin-node-globals/tsconfig.json
+++ b/types/rollup-plugin-node-globals/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-node-globals-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-node-globals/tslint.json
+++ b/types/rollup-plugin-node-globals/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION

This PR add typings for [rollup-plugin-node-globals](https://github.com/calvinmetcalf/rollup-plugin-node-globals) 1.4.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
