### PR TITLE
Add definition for `default()` method signature

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -8,6 +8,7 @@
 //                 Vincent Pizzo <https://github.com/vincentjames501>
 //                 Robert Bullen <https://github.com/robertbullen>
 //                 Yusuke Sato <https://github.com/sat0yu>
+//                 Dan Rumney <https://github.com/dancrumb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -67,6 +68,7 @@ export interface Schema<T> {
     strip(strip: boolean): this;
     withMutation(fn: (current: this) => void): void;
     default(value?: any): this;
+    default(): T;
     nullable(isNullable: boolean): this;
     required(message?: TestOptionsMessage): this;
     notRequired(): this;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -67,7 +67,7 @@ export interface Schema<T> {
     strict(isStrict: boolean): this;
     strip(strip: boolean): this;
     withMutation(fn: (current: this) => void): void;
-    default(value?: any): this;
+    default(value: any): this;
     default(): T;
     nullable(isNullable: boolean): this;
     required(message?: TestOptionsMessage): this;


### PR DESCRIPTION
Per the documentation (https://github.com/jquense/yup#mixeddefault-any) a call to `default` with no value should return an instance of the type that the schema describes, rather than the schema itself.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
