### PR TITLE
Added type definitions for node-sql-parser

### DIFF
--- a/types/node-sql-parser/index.d.ts
+++ b/types/node-sql-parser/index.d.ts
@@ -1,0 +1,97 @@
+// Type definitions for node-sql-parser 1.0
+// Project: https://github.com/taozhi8833998/node-sql-parser#readme
+// Definitions by: taozhi8833998 <https://github.com/taozhi8833998>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+export interface With {
+  name: string;
+  stmt: any[];
+  columns?: any[];
+}
+export type WhilteListCheckMode = 'table' | 'column';
+export interface TableColumnAst {
+  tableList: string[];
+  columnsList: string[];
+  ast: AST[] | AST;
+}
+export interface From {
+  db: string | null;
+  table: string;
+  as: string | null;
+}
+export interface Dual {
+  type: 'dual';
+}
+export interface Limit {
+  type: string;
+  value: number;
+}
+export interface OrderBy {
+  type: 'ASC' | 'DESC';
+  expr: any;
+}
+export interface ColumnRef {
+  type: 'column_ref';
+  table: string | null;
+  column: string;
+}
+export interface SetList {
+  column: string;
+  value: any;
+  table: string | null;
+}
+export interface InsertReplaceValue {
+  type: 'expr_list';
+  value: any[];
+}
+export interface Select {
+  with: With | null;
+  type: 'select';
+  options: any[] | null;
+  distinct: 'DISTINCT' | null;
+  columns: any[] | '*';
+  from: Array<From | Dual> | null;
+  where: any;
+  groupby: ColumnRef[] | null;
+  having: any[] | null;
+  orderby: OrderBy[] | null;
+  limit: Limit[] | null;
+}
+export interface Insert_Replace {
+  type: 'replace' | 'insert';
+  db: string | null;
+  table: string;
+  columns: string[] | null;
+  values: InsertReplaceValue[];
+}
+export interface Update {
+  type: 'udpate';
+  db: string | null;
+  table: string;
+  set: SetList[];
+  where: any;
+}
+export interface Delete {
+  type: 'delete';
+  tables: any;
+  from: Array<From | Dual>;
+  where: any;
+}
+export type AST = Select | Insert_Replace | Update | Delete;
+
+export class Parser {
+  constructor();
+
+  parse(sql: string): TableColumnAst;
+
+  astify(sql: string): AST[] | AST;
+
+  sqlify(ast: AST[] | AST): string;
+
+  whiteListCheck(sql: string, whiteList: string[], type?: WhilteListCheckMode): Error | undefined;
+
+  tableList(sql: string): string[];
+
+  columnList(sql: string): string[];
+}

--- a/types/node-sql-parser/node-sql-parser-tests.ts
+++ b/types/node-sql-parser/node-sql-parser-tests.ts
@@ -1,0 +1,19 @@
+import { Parser } from 'node-sql-parser';
+
+const parser = new Parser();
+const sql = 'select id from tableA';
+
+// $ExpectType Select | Insert_Replace | Update | Delete | AST[]
+const selectAst = parser.astify(sql);
+
+// $ExpectType string
+parser.sqlify(selectAst);
+
+// $ExpectType string[]
+parser.tableList(sql);
+
+// $ExpectType string[]
+parser.columnList(sql);
+
+// $ExpectType Error | undefined
+parser.whiteListCheck(sql, ['select::null::tableA'], 'table');

--- a/types/node-sql-parser/tsconfig.json
+++ b/types/node-sql-parser/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-sql-parser-tests.ts"
+    ]
+}

--- a/types/node-sql-parser/tslint.json
+++ b/types/node-sql-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
