### PR TITLE
xml2js: Fix callback type to pass Error

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -12,8 +12,8 @@
 import { EventEmitter } from 'events';
 import * as processors from './lib/processors';
 
-export function parseString(xml: convertableToString, callback: (err: any, result: any) => void): void;
-export function parseString(xml: convertableToString, options: OptionsV2, callback: (err: any, result: any) => void): void;
+export function parseString(xml: convertableToString, callback: (err: Error, result: any) => void): void;
+export function parseString(xml: convertableToString, options: OptionsV2, callback: (err: Error, result: any) => void): void;
 
 export const defaults: {
     '0.1': Options;


### PR DESCRIPTION
This makes it compatible with promisify<xml2js.convertableToString, any>(xml2js.parseString).

There is no better way than `any` to describe the result type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5da3b1277a8ae8afb9c9dadc6ad8363c84f0f202/types/node/v8/index.d.ts#L5726
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
