### PR TITLE
@storybook/addon-info: Allow withInfo to be used as top-level story decorator

### DIFF
--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -6,7 +6,7 @@
 // TypeScript Version: 2.8
 
 import * as React from 'react';
-import { RenderFunction } from '@storybook/react';
+import { RenderFunction, StoryDecorator } from '@storybook/react';
 
 export interface WrapStoryProps {
   storyFn?: RenderFunction;
@@ -29,6 +29,10 @@ export interface Options {
   maxPropStringLength?: number;
 }
 
+// TODO: it would be better to use type inference for the parameters
+// type DecoratorParams = StoryDecorator extends (...a: infer A) => any ? A: never;
+export function withInfo(story: RenderFunction, context: { kind: string, story: string }): ReturnType<StoryDecorator>;
+// Legacy, but supported
 export function withInfo(textOrOptions?: string | Options): (storyFn: RenderFunction) => (context?: object) => React.ReactElement<WrapStoryProps>;
 
 export function setDefaults(newDefaults: Options): Options;

--- a/types/storybook__addon-info/storybook__addon-info-tests.tsx
+++ b/types/storybook__addon-info/storybook__addon-info-tests.tsx
@@ -1,10 +1,12 @@
 /// <reference types="storybook__react" />
 
 import * as React from 'react';
-import { storiesOf } from '@storybook/react';
+import { addDecorator, storiesOf } from '@storybook/react';
 import { setDefaults, withInfo } from '@storybook/addon-info';
 
 const { Component } = React;
+
+addDecorator(withInfo);
 
 setDefaults({
     inline: false,


### PR DESCRIPTION
This allows the syntax [suggested by the README](https://github.com/storybooks/storybook/blob/dc38ae87bb1ef80ccd48b1695009e36632cbe5ee/addons/info/README.md#basic-usage)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/blob/9f30442098e5350f5ba4872887cf9d1a03146e74/addons/info/src/index.js#L87
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
