### PR TITLE
[rebass] Support standard HTML attributes as Rebass component props

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -41,10 +41,8 @@ export interface BoxProps extends SpaceProps<BoxClass> {
     order?: string;
     alignSelf?: string;
 }
-type BoxClass = React.StatelessComponent<BoxProps | React.HTMLProps<HTMLDivElement>> ;
-export declare const Box: BoxClass;
 // tslint:disable-next-line:strict-export-declare-modifiers
-type BoxClass = React.FunctionComponent<BoxProps>;
+type BoxClass = React.FunctionComponent<BoxProps | React.HTMLProps<HTMLDivElement>>;
 export const Box: BoxClass;
 
 export interface ButtonProps extends BoxProps {
@@ -54,9 +52,7 @@ export interface ButtonProps extends BoxProps {
     borderRadius?: number | string;
     variant?: string;
 }
-type ButtonClass = React.StatelessComponent<ButtonProps | React.HTMLProps<HTMLButtonElement>> ;
-export declare const Button: ButtonClass;
-export const Button: React.FunctionComponent<ButtonProps>;
+export const Button: React.FunctionComponent<ButtonProps | React.HTMLProps<HTMLButtonElement>>;
 
 export interface CardProps extends BoxProps {
     border?: number | string;
@@ -70,9 +66,7 @@ export interface CardProps extends BoxProps {
     opacity?: number;
     variant?: string;
 }
-type CardClass = React.StatelessComponent<CardProps | React.HTMLProps<HTMLDivElement>>;
-export declare const Card: CardClass;
-export const Card: React.FunctionComponent<CardProps>;
+export const Card: React.FunctionComponent<CardProps | React.HTMLProps<HTMLDivElement>>;
 
 export interface FlexProps extends BoxProps {
     alignItems?: string;
@@ -80,22 +74,16 @@ export interface FlexProps extends BoxProps {
     flexDirection?: string;
     flexWrap?: string;
 }
-type FlexClass = React.StatelessComponent<FlexProps | React.HTMLProps<HTMLDivElement>>;
-export declare const Flex: FlexClass;
-export const Flex: React.FunctionComponent<FlexProps>;
+export const Flex: React.FunctionComponent<FlexProps | React.HTMLProps<HTMLDivElement>>;
 
 export interface ImageProps extends BoxProps {
     height?: number | string;
     borderRadius?: number | string;
 }
-type ImageClass = React.StatelessComponent<ImageProps | React.HTMLProps<HTMLImageElement>>;
-export declare const Image: ImageClass;
-export const Image: React.FunctionComponent<ImageProps>;
+export const Image: React.FunctionComponent<ImageProps | React.HTMLProps<HTMLImageElement>>;
 
 export interface LinkProps extends BoxProps {}
-type LinkClass = React.StatelessComponent<LinkProps | React.HTMLProps<HTMLAnchorElement>>;
-export declare const Link: LinkClass;
-export const Link: React.FunctionComponent<LinkProps>;
+export const Link: React.FunctionComponent<LinkProps | React.HTMLProps<HTMLAnchorElement>>;
 
 export interface TextProps extends BoxProps {
     fontSize?: number | ReadonlyArray<number>;
@@ -106,12 +94,7 @@ export interface TextProps extends BoxProps {
     lineHeight?: number | string;
     letterSpacing?: number | string;
 }
-type TextClass = React.StatelessComponent<TextProps | React.HTMLProps<HTMLDivElement>>;
-export declare const Text: TextClass;
-export const Text: React.FunctionComponent<TextProps>;
+export const Text: React.FunctionComponent<TextProps | React.HTMLProps<HTMLDivElement>>;
 
-export interface HeadingProps extends TextProps {}
-type HeadingClass = React.StatelessComponent<HeadingProps | React.HTMLProps<HTMLHeadingElement>>;
-export declare const Heading: HeadingClass;
 export type HeadingProps = TextProps;
-export const Heading: React.FunctionComponent<HeadingProps>;
+export const Heading: React.FunctionComponent<HeadingProps | React.HTMLProps<HTMLHeadingElement>>;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Rebass 3.0
+// Type definitions for Rebass 3.0.1
 // Project: https://github.com/jxnblk/rebass
 // Definitions by: rhysd <https://github.com/rhysd>
 //                 ryee-dev <https://github.com/ryee-dev>

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: rhysd <https://github.com/rhysd>
 //                 ryee-dev <https://github.com/ryee-dev>
 //                 jamesmckenzie <https://github.com/jamesmckenzie>
+//                 chuckdries <https://github.com/chuckdries>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -38,6 +39,8 @@ export interface BoxProps extends SpaceProps<BoxClass> {
     color?: string;
     bg?: string;
 }
+type BoxClass = React.StatelessComponent<BoxProps & React.HTMLProps<HTMLDivElement>> ;
+export declare const Box: BoxClass;
 // tslint:disable-next-line:strict-export-declare-modifiers
 type BoxClass = React.FunctionComponent<BoxProps>;
 export const Box: BoxClass;
@@ -49,6 +52,8 @@ export interface ButtonProps extends BoxProps {
     borderRadius?: number | string;
     variant?: string;
 }
+type ButtonClass = React.StatelessComponent<ButtonProps & React.HTMLProps<HTMLButtonElement>> ;
+export declare const Button: ButtonClass;
 export const Button: React.FunctionComponent<ButtonProps>;
 
 export interface CardProps extends BoxProps {
@@ -63,6 +68,8 @@ export interface CardProps extends BoxProps {
     opacity?: number;
     variant?: string;
 }
+type CardClass = React.StatelessComponent<CardProps & React.HTMLProps<HTMLDivElement>>;
+export declare const Card: CardClass;
 export const Card: React.FunctionComponent<CardProps>;
 
 export interface FlexProps extends BoxProps {
@@ -71,6 +78,8 @@ export interface FlexProps extends BoxProps {
     flexDirection?: string;
     flexWrap?: string;
 }
+type FlexClass = React.StatelessComponent<FlexProps & React.HTMLProps<HTMLDivElement>>;
+export declare const Flex: FlexClass;
 export const Flex: React.FunctionComponent<FlexProps>;
 
 export interface ImageProps extends BoxProps {
@@ -79,11 +88,15 @@ export interface ImageProps extends BoxProps {
     src?: string;
     alt?: string;
 }
+type ImageClass = React.StatelessComponent<ImageProps & React.HTMLProps<HTMLImageElement>>;
+export declare const Image: ImageClass;
 export const Image: React.FunctionComponent<ImageProps>;
 
 export interface LinkProps extends BoxProps {
     href?: string;
 }
+type LinkClass = React.StatelessComponent<LinkProps & React.HTMLProps<HTMLAnchorElement>>;
+export declare const Link: LinkClass;
 export const Link: React.FunctionComponent<LinkProps>;
 
 export interface TextProps extends BoxProps {
@@ -95,7 +108,12 @@ export interface TextProps extends BoxProps {
     lineHeight?: number | string;
     letterSpacing?: number | string;
 }
+type TextClass = React.StatelessComponent<TextProps & React.HTMLProps<HTMLDivElement>>;
+export declare const Text: TextClass;
 export const Text: React.FunctionComponent<TextProps>;
 
+export interface HeadingProps extends TextProps {}
+type HeadingClass = React.StatelessComponent<HeadingProps & React.HTMLProps<HTMLHeadingElement>>;
+export declare const Heading: HeadingClass;
 export type HeadingProps = TextProps;
 export const Heading: React.FunctionComponent<HeadingProps>;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -41,7 +41,7 @@ export interface BoxProps extends SpaceProps<BoxClass> {
     order?: string;
     alignSelf?: string;
 }
-type BoxClass = React.StatelessComponent<BoxProps & React.HTMLProps<HTMLDivElement>> ;
+type BoxClass = React.StatelessComponent<BoxProps | React.HTMLProps<HTMLDivElement>> ;
 export declare const Box: BoxClass;
 // tslint:disable-next-line:strict-export-declare-modifiers
 type BoxClass = React.FunctionComponent<BoxProps>;
@@ -54,7 +54,7 @@ export interface ButtonProps extends BoxProps {
     borderRadius?: number | string;
     variant?: string;
 }
-type ButtonClass = React.StatelessComponent<ButtonProps & React.HTMLProps<HTMLButtonElement>> ;
+type ButtonClass = React.StatelessComponent<ButtonProps | React.HTMLProps<HTMLButtonElement>> ;
 export declare const Button: ButtonClass;
 export const Button: React.FunctionComponent<ButtonProps>;
 
@@ -70,7 +70,7 @@ export interface CardProps extends BoxProps {
     opacity?: number;
     variant?: string;
 }
-type CardClass = React.StatelessComponent<CardProps & React.HTMLProps<HTMLDivElement>>;
+type CardClass = React.StatelessComponent<CardProps | React.HTMLProps<HTMLDivElement>>;
 export declare const Card: CardClass;
 export const Card: React.FunctionComponent<CardProps>;
 
@@ -80,7 +80,7 @@ export interface FlexProps extends BoxProps {
     flexDirection?: string;
     flexWrap?: string;
 }
-type FlexClass = React.StatelessComponent<FlexProps & React.HTMLProps<HTMLDivElement>>;
+type FlexClass = React.StatelessComponent<FlexProps | React.HTMLProps<HTMLDivElement>>;
 export declare const Flex: FlexClass;
 export const Flex: React.FunctionComponent<FlexProps>;
 
@@ -88,12 +88,12 @@ export interface ImageProps extends BoxProps {
     height?: number | string;
     borderRadius?: number | string;
 }
-type ImageClass = React.StatelessComponent<ImageProps & React.HTMLProps<HTMLImageElement>>;
+type ImageClass = React.StatelessComponent<ImageProps | React.HTMLProps<HTMLImageElement>>;
 export declare const Image: ImageClass;
 export const Image: React.FunctionComponent<ImageProps>;
 
 export interface LinkProps extends BoxProps {}
-type LinkClass = React.StatelessComponent<LinkProps & React.HTMLProps<HTMLAnchorElement>>;
+type LinkClass = React.StatelessComponent<LinkProps | React.HTMLProps<HTMLAnchorElement>>;
 export declare const Link: LinkClass;
 export const Link: React.FunctionComponent<LinkProps>;
 
@@ -106,12 +106,12 @@ export interface TextProps extends BoxProps {
     lineHeight?: number | string;
     letterSpacing?: number | string;
 }
-type TextClass = React.StatelessComponent<TextProps & React.HTMLProps<HTMLDivElement>>;
+type TextClass = React.StatelessComponent<TextProps | React.HTMLProps<HTMLDivElement>>;
 export declare const Text: TextClass;
 export const Text: React.FunctionComponent<TextProps>;
 
 export interface HeadingProps extends TextProps {}
-type HeadingClass = React.StatelessComponent<HeadingProps & React.HTMLProps<HTMLHeadingElement>>;
+type HeadingClass = React.StatelessComponent<HeadingProps | React.HTMLProps<HTMLHeadingElement>>;
 export declare const Heading: HeadingClass;
 export type HeadingProps = TextProps;
 export const Heading: React.FunctionComponent<HeadingProps>;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Rebass 3.0.1
+// Type definitions for Rebass 3.0
 // Project: https://github.com/jxnblk/rebass
 // Definitions by: rhysd <https://github.com/rhysd>
 //                 ryee-dev <https://github.com/ryee-dev>
@@ -82,8 +82,8 @@ export interface ImageProps extends BoxProps {
 }
 export const Image: React.FunctionComponent<ImageProps | React.HTMLProps<HTMLImageElement>>;
 
-export interface LinkProps extends BoxProps {}
-export const Link: React.FunctionComponent<LinkProps | React.HTMLProps<HTMLAnchorElement>>;
+// export interface LinkProps extends BoxProps {}
+export const Link: React.FunctionComponent<BoxProps | React.HTMLProps<HTMLAnchorElement>>;
 
 export interface TextProps extends BoxProps {
     fontSize?: number | ReadonlyArray<number>;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -32,12 +32,14 @@ export interface SpaceProps<C> extends BaseProps<C> {
 }
 
 export interface BoxProps extends SpaceProps<BoxClass> {
-    className?: string;
     width?: number | string | ReadonlyArray<number>;
     fontSize?: number | ReadonlyArray<number>;
     css?: object;
     color?: string;
     bg?: string;
+    flex?: string;
+    order?: string;
+    alignSelf?: string;
 }
 type BoxClass = React.StatelessComponent<BoxProps & React.HTMLProps<HTMLDivElement>> ;
 export declare const Box: BoxClass;
@@ -85,16 +87,12 @@ export const Flex: React.FunctionComponent<FlexProps>;
 export interface ImageProps extends BoxProps {
     height?: number | string;
     borderRadius?: number | string;
-    src?: string;
-    alt?: string;
 }
 type ImageClass = React.StatelessComponent<ImageProps & React.HTMLProps<HTMLImageElement>>;
 export declare const Image: ImageClass;
 export const Image: React.FunctionComponent<ImageProps>;
 
-export interface LinkProps extends BoxProps {
-    href?: string;
-}
+export interface LinkProps extends BoxProps {}
 type LinkClass = React.StatelessComponent<LinkProps & React.HTMLProps<HTMLAnchorElement>>;
 export declare const Link: LinkClass;
 export const Link: React.FunctionComponent<LinkProps>;

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -27,7 +27,7 @@ import { Box, Flex, Text, Heading, Button, Link, Image, Card } from 'rebass';
                 borderRadius="1em"
             />
             <Link href="https://rebassjs.org">Link</Link>
-            <Button bg="magenta" border="1em" borderRadius="1em">
+            <Button bg="magenta" border="1em" borderRadius="1em" onClick={() => {}}>
                 Button
             </Button>
         </Flex>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rebassjs.org/Button  
> note: Rebass is a package that simply wraps native HTML elements. This documentation link is to demonstrate that the Button component is indeed a native button and should behave as such. The previous type definitions simply hard-coded a select set of common HTML attributes instead of adding them properly. 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.