### PR TITLE
@storybook/addon-notes: support global decorator

### DIFF
--- a/types/storybook__addon-notes/index.d.ts
+++ b/types/storybook__addon-notes/index.d.ts
@@ -17,5 +17,9 @@ export type WithNotesOptions = string | {
     markdownOptions?: MarkedOptions;
 };
 
+// It would be preferable to infer the argument types, but that requires TS v 3.1
+// export function withNotes(...args: StoryDecorator extends (...a: infer A) => any ? A : never): ReturnType<StoryDecorator>;
+export function withNotes(story: RenderFunction, context: { kind: string, story: string }): ReturnType<StoryDecorator>;
+// Less-preferred but still supported:
 export function withNotes(options?: WithNotesOptions): StoryDecorator;
 export function withMarkdownNotes(markdown: string, options?: MarkedOptions): StoryDecorator;

--- a/types/storybook__addon-notes/storybook__addon-notes-tests.tsx
+++ b/types/storybook__addon-notes/storybook__addon-notes-tests.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 
-import { storiesOf } from '@storybook/react';
+import { addDecorator, storiesOf } from '@storybook/react';
 import { withNotes, withMarkdownNotes, } from '@storybook/addon-notes';
+
+// New, preferred global registration:
+addDecorator(withNotes);
 
 const SIMPLE_MARKDOWN = `
 ## Markdown for component


### PR DESCRIPTION
Support the global decorator usage supplied in [the README](https://github.com/storybooks/storybook/blob/9f30442098e5350f5ba4872887cf9d1a03146e74/addons/ondevice-notes/README.md#getting-started)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - This fails for me locally

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/blob/9f30442098e5350f5ba4872887cf9d1a03146e74/addons/notes/src/index.js#L8
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
