### PR TITLE
[vis] DataSet.get may return null + type parameter for DataSet.map

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -459,7 +459,7 @@ export class DataSet<T extends DataItem | DataGroup | Node | Edge> {
    * @returns When no item is found, null is returned when a single item was requested,
    * and and empty Array is returned in case of multiple id's.
    */
-  get(id: IdType, options?: DataSelectionOptions<T>): T;
+  get(id: IdType, options?: DataSelectionOptions<T>): T|null;
 
   /**
    * Get multiple items from the DataSet.
@@ -494,7 +494,7 @@ export class DataSet<T extends DataItem | DataGroup | Node | Edge> {
    * @param [options] Optional options.
    * @returns The mapped items.
    */
-  map(callback: (item: T, id: IdType) => any, options?: DataSelectionOptions<T>): any[];
+  map<M>(callback: (item: T, id: IdType) => M, options?: DataSelectionOptions<T>): M[];
 
   /**
    * Find the item with maximum value of specified field.
@@ -589,7 +589,7 @@ export interface DataSelectionOptions<T> {
   /**
    * Order the items by a field name or custom sort function.
    */
-  order?: string | any;
+  order?: string | ((a: T, b: T) => number);
 
   /**
    * Determine the type of output of the get function.
@@ -597,7 +597,7 @@ export interface DataSelectionOptions<T> {
    * The default returnType is an Array.
    * The Object type will return a JSON object with the ID's as keys.
    */
-  returnType?: string;
+  returnType?: "Array" | "Object";
 }
 
 export class DataView<T extends DataItem | DataGroup> {


### PR DESCRIPTION
This PR adds a few changes to the `DataSet<T>` and `DataSelectionOptions<T>` type:

- `DataSet.get` may also return null (change return type from `T` to `T|null`)
- Add type parameter for `DataSet.map` to correctly reflect mapping function's return type (previously just used `any`)
- Define types for sort function in `DataSelectionOptions.order`
- Define possible values for `DataSelectionOptions.returnType`