### PR TITLE
Add type definitions for @mapbox/s3urls

### DIFF
--- a/types/mapbox__s3urls/index.d.ts
+++ b/types/mapbox__s3urls/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for mapbox__s3urls 1.5
+// Project: https://github.com/mapbox/s3urls
+// Definitions by: Sebastian Vera <https://github.com/sebastianvera>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// tslint:disable-next-line no-single-declare-module
+declare module "@mapbox/s3urls" {
+    function fromUrl(
+        url: string
+    ): { Bucket: string | undefined; Key: string | undefined };
+
+    function toUrl(
+        bucket: string,
+        key: string
+    ): {
+        s3: string;
+        "bucket-in-path": string;
+        "bucket-in-host": string;
+    };
+
+    function convert(
+        url: string,
+        to: "s3" | "bucket-in-path" | "bucket-in-host"
+    ): string;
+
+    function signed(
+        url: string,
+        expires: number,
+        cb: (err: Error | undefined, url: string) => void
+    ): void;
+
+    function valid(url: string): boolean;
+}

--- a/types/mapbox__s3urls/mapbox__s3urls-tests.ts
+++ b/types/mapbox__s3urls/mapbox__s3urls-tests.ts
@@ -1,0 +1,15 @@
+import * as s3urls from "@mapbox/s3urls";
+
+s3urls.toUrl("bucket", "key"); // $ExpectType { s3: string; "bucket-in-path": string; "bucket-in-host": string; }
+s3urls.toUrl("bucket", "key")["s3"]; // $ExpectType string
+s3urls.toUrl("bucket", "key")["bucket-in-host"]; // $ExpectType string
+s3urls.toUrl("bucket", "key")["bucket-in-path"]; // $ExpectType string
+
+s3urls.valid("s3://bucket/key"); // $ExpectType boolean
+s3urls.valid("invalid"); // $ExpectType boolean
+
+s3urls.convert("s3://bucket/key", "s3"); // $ExpectType string
+s3urls.convert("s3://bucket/key", "bucket-in-path"); // $ExpectType string
+s3urls.convert("s3://bucket/key", "bucket-in-host"); // $ExpectType string
+
+s3urls.fromUrl("s3://bucket/key"); // $ExpectType object

--- a/types/mapbox__s3urls/tsconfig.json
+++ b/types/mapbox__s3urls/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "paths": {
+            "@mapbox/s3urls": ["mapbox__s3urls"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "mapbox__s3urls-tests.ts"]
+}

--- a/types/mapbox__s3urls/tslint.json
+++ b/types/mapbox__s3urls/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.