### PR TITLE
@types/dd-trace: Expose TraceProxy interface

### DIFF
--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -12,9 +12,9 @@ import { Tracer, Span, SpanContext } from "opentracing";
 import DatadogSpanContext = require("./src/opentracing/span_context");
 
 declare var trace: TraceProxy;
-export = trace;
+export default trace;
 
-declare class TraceProxy extends Tracer {
+export declare class TraceProxy extends Tracer {
     /**
      * Initializes the tracer. This should be called before importing other libraries.
      */


### PR DESCRIPTION
- Expose TraceProxy interface
- Switch to default export

Use case:

Consumer wants to reference tracer type in their own type definitions, e.g.

```typescript
interface UserContext {
  tracer: TraceProxy
}
```

While currently there's no way of doing it.

------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

