### PR TITLE
Add type definitions for mui-datatables

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -168,6 +168,6 @@ export interface MUIDataTableProps {
     options?: MUIDataTableOptions;
 }
 
-export const MUIDataTable: React.ComponentType<MUIDataTableProps>;
+declare const MUIDataTable: React.ComponentType<MUIDataTableProps>;
 
 export default MUIDataTable;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,0 +1,173 @@
+// Type definitions for mui-datatables 2.0
+// Project: https://github.com/gregnb/mui-datatable
+// Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+
+interface MUIDataTableData {
+    index: number;
+    data: any[];
+}
+
+interface MUIDataTableStateRows {
+    data: string[];
+    lookup: any;
+}
+
+interface MUIDataTableState {
+    announceText: string | null;
+    activeColumn: string | null;
+    page: number;
+    rowsPerPage: number;
+    filterList: string[][];
+    selectedRows: MUIDataTableStateRows;
+    expandedRows: MUIDataTableStateRows;
+    showResponsive: boolean;
+    searchText: string | null;
+    rowsPerPageOptions: number[];
+}
+
+interface MUIDataTableMeta {
+    rowIndex: number;
+    columnIndex: number;
+    columnData: MUIDataTableColumnOptions[];
+    rowData: any[];
+    tableData: MUIDataTableData[];
+    tableState: MUIDataTableState;
+}
+
+interface MUIDataTableCustomHeadRenderer extends MUIDataTableColumn {
+    index: number;
+}
+
+interface MUIDataTableColumn {
+    name: string;
+    options?: MUIDataTableColumnOptions;
+}
+
+interface MUIDataTableTextLabelsBody {
+    noMatch: string;
+    toolTip: string;
+}
+
+interface MUIDataTableTextLabelsPagination {
+    next: string;
+    previous: string;
+    rowsPerPage: string;
+    displayRows: string;
+}
+
+interface MUIDataTableTextLabelsToolbar {
+    search: string;
+    downloadCsv: string;
+    print: string;
+    viewColumns: string;
+    filterTable: string;
+}
+
+interface MUIDataTableTextLabelsFilter {
+    all: string;
+    title: string;
+    reset: string;
+}
+
+interface MUIDataTableTextLabelsViewColumns {
+    title: string;
+    titleAria: string;
+}
+
+interface MUIDataTableTextLabelsSelectedRows {
+    text: string;
+    delete: string;
+    deleteAria: string;
+}
+
+interface MUIDataTableTextLabels {
+    body: MUIDataTableTextLabelsBody;
+    pagination: MUIDataTableTextLabelsPagination;
+    toolbar: MUIDataTableTextLabelsToolbar;
+    filter: MUIDataTableTextLabelsFilter;
+    viewColumns: MUIDataTableTextLabelsViewColumns;
+    selectedRows: MUIDataTableTextLabelsSelectedRows;
+}
+
+export interface MUIDataTableColumnOptions {
+    display?: 'true' | 'false' | 'excluded';
+    filter?: boolean;
+    filterList?: string[];
+    filterOptions?: string[];
+    sort?: boolean;
+    sortDirection?: 'asc' | 'desc';
+    download?: boolean;
+    hint?: string;
+    customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string;
+    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
+    setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => string;
+}
+
+export interface MUIDataTableOptions {
+    page?: number;
+    count?: number;
+    serverSide?: boolean;
+    rowsSelected?: any[];
+    filterType?: 'dropdown' | 'checkbox' | 'multiselect' | 'textField';
+    textLabels?: MUIDataTableTextLabels;
+    pagination?: boolean;
+    selectableRows?: boolean;
+    IsRowSelectable?: (dataIndex: any) => boolean;
+    resizableColumns?: boolean;
+    expandableRows?: boolean;
+    renderExpandableRow?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
+    customToolbar?: () => React.ReactNode;
+    customToolbarSelect?: () => React.ReactNode;
+    customFooter?: () => React.ReactNode;
+    customSort?: (data: any[], colIndex: number, order: string) => any[];
+    elevation?: number;
+    caseSensitive?: boolean;
+    responsive?: 'stacked' | 'scroll';
+    rowsPerPage?: number;
+    rowsPerPageOptions?: number[];
+    rowHover?: boolean;
+    fixedHeader?: boolean;
+    sortFilterList?: boolean;
+    sort?: boolean;
+    filter?: boolean;
+    search?: boolean;
+    print?: boolean;
+    download?: boolean;
+    downloadOptions?: { filename: string; separator: string };
+    viewColumns?: boolean;
+    onRowsSelect?: (currentRowsSelected: any[], rowsSelected: any[]) => void;
+    onRowsDelete?: (rowsDeleted: any[]) => void;
+    onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
+    onCellClick?: (colIndex: number, rowIndex: number) => void;
+    onChangePage?: (currentPage: number) => void;
+    onChangeRowsPerPage?: (numberOfRows: number) => void;
+    onSearchChange?: (searchText: string) => void;
+    onFilterChange?: (changedColumn: string, filterList: any[]) => void;
+    onColumnSortChange?: (changedColumn: string, direction: string) => void;
+    onColumnViewChange?: (changedColumn: string, action: string) => void;
+    onTableChange?: (action: string, tableState: object) => void;
+    setRowProps?: (row: any[], rowIndex: number) => any;
+}
+
+export type MUIDataTableColumnDef = string | MUIDataTableColumn;
+
+export interface MuiDatatablesTableState {
+    page: number;
+    rowsPerPage: number;
+    filterList: any[];
+}
+
+export interface MUIDataTableProps {
+    title: string;
+    columns: MUIDataTableColumnDef[];
+    data: any[];
+    options?: MUIDataTableOptions;
+}
+
+export const MUIDataTable: React.ComponentType<MUIDataTableProps>;
+
+export default MUIDataTable;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,0 +1,83 @@
+import MUIDataTable, { MUIDataTableColumnDef, MUIDataTableOptions } from 'mui-datatables';
+import * as React from 'react';
+
+const dataSimple: string[][] = [
+    ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
+    ['John Walsh', 'Test Corp', 'Hartford', 'CT'],
+    ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
+    ['James Houston', 'Test Corp', 'Dallas', 'TX']
+];
+
+const columnWithOptions: MUIDataTableColumnDef[] = [
+    {
+        name: 'Name',
+        options: {
+            display: 'true',
+            filter: true,
+            sort: true,
+            sortDirection: 'asc',
+            download: true,
+        }
+    }
+];
+
+const options: MUIDataTableOptions = {
+    filterType: 'checkbox',
+    responsive: 'scroll',
+    selectableRows: false,
+    elevation: 0,
+    rowsPerPageOptions: [5, 10, 20, 25, 50, 100],
+    downloadOptions: {
+        filename: 'filename.csv',
+        separator: ','
+    },
+    sortFilterList: false,
+    textLabels: {
+        body: {
+            noMatch: 'Sorry, no matching records found',
+            toolTip: 'Sort',
+        },
+        pagination: {
+            next: 'Next Page',
+            previous: 'Previous Page',
+            rowsPerPage: 'Rows per page:',
+            displayRows: 'of',
+        },
+        toolbar: {
+            search: 'Search',
+            downloadCsv: 'Download CSV',
+            print: 'Print',
+            viewColumns: 'View Columns',
+            filterTable: 'Filter Table',
+        },
+        filter: {
+            all: 'All',
+            title: 'FILTERS',
+            reset: 'RESET',
+        },
+        viewColumns: {
+            title: 'Show Columns',
+            titleAria: 'Show/Hide Table Columns',
+        },
+        selectedRows: {
+            text: 'rows(s) selected',
+            delete: 'Delete',
+            deleteAria: 'Delete Selected Rows',
+        }
+    }
+};
+
+class MuiDataTable extends React.Component {
+    render() {
+        return (
+            <MUIDataTable
+                title='MUI Data Table'
+                data={dataSimple}
+                columns={columnWithOptions}
+                options={options}
+            />
+        );
+    }
+}
+
+<MuiDataTable/>;

--- a/types/mui-datatables/tsconfig.json
+++ b/types/mui-datatables/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mui-datatables-tests.tsx"
+    ]
+}

--- a/types/mui-datatables/tslint.json
+++ b/types/mui-datatables/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project. ==> Based on [this gist](https://gist.github.com/nidheeshdas/ebdb07d147d7ff89e09bb44fe822ba31) as well as dissecting the package myself / reading what is documented all the while following the DefinitelyTyped common type declaration methodologies
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
