### PR TITLE
Improves typesafety of children and render

### DIFF
--- a/types/create-subscription/index.d.ts
+++ b/types/create-subscription/index.d.ts
@@ -28,10 +28,9 @@ export interface SubscriptionConfig<S, T> {
 }
 
 export interface SubscriptionProps<S, T> {
-    children: (value: T) => React.ReactNode;
     source: S;
 }
 
-export interface Subscription<S, T> extends React.ComponentClass<SubscriptionProps<S, T>> {}
+export interface Subscription<S, T> extends React.ComponentClass<SubscriptionProps<S, T>, any, (value: T) => React.ReactNode> {}
 
 export function createSubscription<S, T>(config: SubscriptionConfig<S, T>): Subscription<S, T>;

--- a/types/dayzed/index.d.ts
+++ b/types/dayzed/index.d.ts
@@ -40,13 +40,12 @@ interface Props {
     firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
     showOutsideDays?: boolean;
     selected?: Date | Date[];
-    children?: RenderFn;
     render?: RenderFn;
     offset?: number;
     onOffsetChanged?(offset: number): void;
     onDateSelected(selectedDate: DateObj): void;
 }
 
-declare class Dayzed extends Component<Props> { }
+declare class Dayzed extends Component<Props, any, any, RenderFn> { }
 
 export default Dayzed;

--- a/types/lingui__react/I18n.d.ts
+++ b/types/lingui__react/I18n.d.ts
@@ -3,9 +3,8 @@ import { I18n } from '@lingui/core';
 
 // tslint:disable-next-line:interface-name
 export interface I18nComponentProps {
-    children: ({ i18n, i18nHash }: { i18n: I18n, i18nHash?: string }) => ReactNode;
     update?: boolean;
     withHash?: boolean;
 }
 
-export default class I18nComponent extends Component<I18nComponentProps> {}
+export default class I18nComponent extends Component<I18nComponentProps, any, any, ({ i18n, i18nHash }: { i18n: I18n, i18nHash?: string }) => ReactNode> {}

--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -19,9 +19,8 @@ export interface Options {
 export type LoadableComponent<T> = React.ComponentType<T & { fallback?: JSX.Element }>;
 export type LoadableLibrary<TModule> = React.ComponentType<{
 	fallback?: JSX.Element;
-	children?: (module: TModule) => React.ReactNode;
 	ref?: React.Ref<TModule>;
-}> &
+}, (module: TModule) => React.ReactNode> &
 	TModule;
 
 declare function lib<T>(

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3024,7 +3024,7 @@ const ChipExampleSimple = () => (
     <Chip><Avatar size={32} color={blue300} backgroundColor={indigo900}>UI</Avatar> Avatar</Chip>
     <Chip style={styles.chip}>Styled</Chip>
     <Chip containerElement="span">String Container</Chip>
-    <Chip containerElement={() => {}}>ReactNode Container</Chip>
+    <Chip containerElement={<Component/>}>ReactNode Container</Chip>
   </div>
 );
 

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -19,7 +19,6 @@ export interface ReactElementLike {
 export interface ReactNodeArray extends Array<ReactNodeLike> {}
 
 export type ReactNodeLike =
-    | {}
     | ReactElementLike
     | ReactNodeArray
     | string

--- a/types/rc-tooltip/rc-tooltip-tests.tsx
+++ b/types/rc-tooltip/rc-tooltip-tests.tsx
@@ -46,7 +46,7 @@ ReactDOM.render(
     <Tooltip
         placement="bottomRight"
         trigger={['click', 'focus']}
-        overlay={() => <span>tooltip</span>}
+        overlay={<span>tooltip</span>}
     >
         <a href='#'>hover</a>
     </Tooltip>,
@@ -56,5 +56,5 @@ ReactDOM.render(
 const props: RCTooltip.Props = {
     placement: "bottomRight",
     trigger: ['click', 'focus'],
-    overlay: () => <span>tooltip</span>,
+    overlay: <span>tooltip</span>,
 };

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -104,14 +104,13 @@ export interface NavigateOptions<TState> {
 }
 
 export interface LocationProps {
-    children: LocationProviderRenderFn;
+    
 }
 
-export class Location extends React.Component<LocationProps> { }
+export class Location extends React.Component<LocationProps, any, any, LocationProviderRenderFn> { }
 
 export interface LocationProviderProps {
     history?: History;
-    children?: React.ReactNode | LocationProviderRenderFn;
 }
 
 export type LocationProviderRenderFn = (
@@ -123,7 +122,7 @@ export interface LocationContext {
     navigate: NavigateFn;
 }
 
-export class LocationProvider extends React.Component<LocationProviderProps> { }
+export class LocationProvider extends React.Component<LocationProviderProps, any, any, React.ReactNode | LocationProviderRenderFn> { }
 
 export interface ServerLocationProps {
     url: string;

--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -62,4 +62,4 @@ export type StepProps = StepObject & (
  *   }
  * }
  */
-export const Step: React.ComponentType<StepProps>;
+export const Step: React.ComponentType<StepProps, React.ReactNode | ((wizard: WizardContext) => React.ReactNode)>;

--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -119,10 +119,9 @@ export interface DroppableProps {
     isDropDisabled?: boolean;
     isCombineEnabled?: boolean;
     direction?: 'vertical' | 'horizontal';
-    children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<any>;
 }
 
-export class Droppable extends React.Component<DroppableProps> { }
+export class Droppable extends React.Component<DroppableProps, any, any, (provided: DroppableProvided, snapshot: DroppableStateSnapshot)=> React.ReactElement<any>> { }
 
 /**
  *  Draggable
@@ -202,8 +201,7 @@ export interface DraggableProps {
     index: number;
     isDragDisabled?: boolean;
     disableInteractiveElementBlocking?: boolean;
-    children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<any>;
     type?: TypeId;
 }
 
-export class Draggable extends React.Component<DraggableProps> { }
+export class Draggable extends React.Component<DraggableProps, any, any, (provided: DraggableProvided, snapshot: DraggableStateSnapshot) => React.ReactElement<any>> { }

--- a/types/react-broadcast/index.d.ts
+++ b/types/react-broadcast/index.d.ts
@@ -12,7 +12,6 @@ export namespace Subscriber {
     }
     interface Props<T> extends Partial<DefaultProps> {
         channel: string;
-        children?: ((state: T) => React.ReactNode);
     }
 }
 
@@ -28,4 +27,4 @@ export namespace Broadcast {
 }
 
 export class Broadcast<T> extends React.Component<Broadcast.Props<T>, any> { }
-export class Subscriber<T> extends React.Component<Subscriber.Props<T>, any> { }
+export class Subscriber<T> extends React.Component<Subscriber.Props<T>, any, any, ((state: T) => React.ReactNode)> { }

--- a/types/react-broadcast/react-broadcast-tests.tsx
+++ b/types/react-broadcast/react-broadcast-tests.tsx
@@ -8,7 +8,7 @@ class ExampleOfUsingReactBroadcast extends React.Component {
       <Broadcast channel="my-channel" value={42}>
         <div>
           <Subscriber channel="my-channel">
-            {state => <div>{state}</div>}
+            {state => <div>{JSON.stringify(state)}</div>}
           </Subscriber>
         </div>
       </Broadcast>

--- a/types/react-copy-write/index.d.ts
+++ b/types/react-copy-write/index.d.ts
@@ -28,12 +28,11 @@ interface ConsumerPropsExplicitRender<T> extends ConsumerPropsBase<T> {
 }
 
 interface ConsumerPropsImplicitRender<T> extends ConsumerPropsBase<T> {
-    children?: RenderFn<T>;
 }
 
 type ConsumerProps<T> = ConsumerPropsExplicitRender<T> | ConsumerPropsImplicitRender<T>;
 
-declare class Consumer<T> extends Component<ConsumerProps<T>> {}
+declare class Consumer<T> extends Component<ConsumerProps<T>, any, any, RenderFn<T>> {}
 
 interface ProviderProps<T> {
     children: JSX.Element | JSX.Element[];

--- a/types/react-countup/index.d.ts
+++ b/types/react-countup/index.d.ts
@@ -58,8 +58,7 @@ declare namespace ReactCountUp {
             start(): void;
         }): void;
         style?: React.CSSProperties;
-        children?(data: RenderProps): React.ReactElement<any>;
     }
 }
 
-declare class ReactCountUp extends React.PureComponent<ReactCountUp.Props> {}
+declare class ReactCountUp extends React.PureComponent<ReactCountUp.Props, any, any, (data: ReactCountUp.RenderProps) => React.ReactElement<any>> {}

--- a/types/react-dragtastic/index.d.ts
+++ b/types/react-dragtastic/index.d.ts
@@ -57,21 +57,19 @@ export interface DraggableProps {
     subscribeTo?: ReadonlyArray<string> | null;
     /** An optional int representing the distance in pixels the user's pointer must travel to activate the draggable. Defaults to 8 */
     delay?: number;
-
-    children: (arg: State & {
-        /** A boolean representing if the draggable is currently active. */
-        isActive: boolean;
-        events: {
-            onMouseDown: MouseEventHandler,
-            onTouchStart: TouchEventHandler
-        }
-    }) => ReactNode;
 }
 
 /**
  * This defines a draggable zone. At a minimum, spread the events over the element that should be draggable (usually the root element).
  */
-export class Draggable extends Component<DraggableProps, any> { }
+export class Draggable extends Component<DraggableProps, any, any, (arg: State & {
+    /** A boolean representing if the draggable is currently active. */
+    isActive: boolean;
+    events: {
+        onMouseDown: MouseEventHandler,
+        onTouchStart: TouchEventHandler
+    }
+}) => ReactNode> { }
 
 // ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 // DROPPABLE
@@ -99,24 +97,22 @@ export interface DroppableProps {
      * For example, you may pass ['type', 'data'] to only rerender if these keys change.
      */
     subscribeTo?: ReadonlyArray<string> | null;
-
-    children: (arg: State & {
-        /** A boolean representing if the user is currently hovering the <Droppable/>. */
-        isOver: boolean,
-        /** A boolean representing if this droppable will accept the currently dragging <DragComponent/>. */
-        willAccept: boolean,
-        events: {
-            onMouseEnter: () => void,
-            onMouseLeave: () => void,
-            onMouseUp: () => void,
-        }
-    }) => ReactNode;
 }
 
 /**
  * This defines a droppable zone. At a minimum, spread the events over the element that should be droppable (usually the root element).
  */
-export class Droppable extends Component<DroppableProps, any> { }
+export class Droppable extends Component<DroppableProps, any, any, (arg: State & {
+    /** A boolean representing if the user is currently hovering the <Droppable/>. */
+    isOver: boolean,
+    /** A boolean representing if this droppable will accept the currently dragging <DragComponent/>. */
+    willAccept: boolean,
+    events: {
+        onMouseEnter: () => void,
+        onMouseLeave: () => void,
+        onMouseUp: () => void,
+    }
+}) => ReactNode> { }
 
 // ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 // DRAG
@@ -134,17 +130,15 @@ export interface DragComponentProps {
      * For example, you may pass ['type', 'data'] to only rerender if these keys change.
      */
     subscribeTo?: ReadonlyArray<string> | null;
-
-    children: (arg: State & {
-        /** A boolean representing whether the user is currently hovering a <Droppable/> that accepts the type of the currently active <Draggable/> */
-        isOverAccepted: boolean
-    }) => ReactNode;
 }
 
 /**
  * By default, children passed to this component will only render if the user is currently dragging, but this can be overridden.
  */
-export class DragComponent extends Component<DragComponentProps, any> { }
+export class DragComponent extends Component<DragComponentProps, any, any, (arg: State & {
+    /** A boolean representing whether the user is currently hovering a <Droppable/> that accepts the type of the currently active <Draggable/> */
+    isOverAccepted: boolean
+}) => ReactNode> { }
 
 // ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 // DRAG STATE
@@ -156,12 +150,10 @@ export interface DragStateProps {
      * For example, you may pass ['type', 'data'] to only rerender if these keys change.
      */
     subscribeTo?: ReadonlyArray<string> | null;
-
-    children: (arg: State) => ReactNode;
 }
 
 /**
  * This component is used just like a draggable or droppable, but does not accept or trigger any drag events.
  * Use it if you need to notify a component about changes in the dragState without making that component a draggable or droppable zone.
  */
-export class DragState extends Component<DragStateProps, any> { }
+export class DragState extends Component<DragStateProps, any, any, (arg: State) => ReactNode> { }

--- a/types/react-form/index.d.ts
+++ b/types/react-form/index.d.ts
@@ -91,7 +91,10 @@ export interface FormContext {
 
 export class Form
     extends React.Component<
-        FormProps & { children?: ((props: FormFunctionProps) => RenderReturn) | RenderReturn }
+        FormProps,
+        any,
+        any, 
+        ((props: FormFunctionProps) => RenderReturn) | RenderReturn
     >
     implements React.ChildContextProvider<FormContext> {
         static defaultProps: FormProps;
@@ -156,7 +159,10 @@ export interface RadioGroupContext {
 
 export class RadioGroup
     extends React.Component<
-        FieldProps & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn }
+        FieldProps,
+        any,
+        any,
+        ((props: FieldApi) => RenderReturn) | RenderReturn
     >
     implements React.ChildContextProvider<RadioGroupContext> {
     getChildContext(): {
@@ -183,7 +189,10 @@ export const StyledRadio: React.StatelessComponent<StyledProps & React.InputHTML
 
 export class StyledRadioGroup
     extends React.Component<
-        StyledProps & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn }
+        StyledProps,
+        any,
+        any,
+        ((props: FieldApi) => RenderReturn) | RenderReturn
     >
     implements React.ChildContextProvider<RadioGroupContext> {
     getChildContext(): {

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -65,8 +65,10 @@ export interface FormContext {
 
 export class Form
     extends React.Component<
-        FormProps & { children?: ((props: FormFunctionProps) => RenderReturn) | RenderReturn },
-        FormState
+        FormProps,
+        FormState,
+        any,
+        ((props: FormFunctionProps) => RenderReturn) | RenderReturn
     >
     implements FormApi, React.ChildContextProvider<FormContext> {
         static defaultProps: FormProps;
@@ -146,10 +148,7 @@ export interface FormInputProps {
     errorProps?: FormErrorProps;
 }
 
-export interface FormInputPropsWithChildren extends FormInputProps {
-    children(api: FormFieldApi): React.ReactElement<any> | null;
-}
-export const FormInput: React.SFC<FormInputPropsWithChildren>;
+export const FormInput: React.SFC<FormInputProps, (api: FormFieldApi) => React.ReactElement<any> | null>;
 
 // ==============================
 //             Inputs

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -58,7 +58,7 @@ declare namespace React {
     type ComponentType<P = {}, T_Children = ReactNode> = ComponentClass<P, any, T_Children> | FunctionComponent<P, T_Children>;
 
     type JSXElementConstructor<P, T_Children> =
-        | ((props: P & {children?: T_Children}) => ReactElement<any> | null)
+        | ((props: P & {children?: T_Children}) => ReactElement<any, any, T_Children> | null)
         | (new (props: P & {children?: T_Children}) => Component<P, any, any, T_Children>);
 
     type Key = string | number;
@@ -136,7 +136,7 @@ declare namespace React {
     // Factories
     // ----------------------------------------------------------------------
 
-    type Factory<P, T_Children> = (props?: Attributes & P, ...children: T_Children[]) => ReactElement<P>;
+    type Factory<P, T_Children> = (props?: Attributes & P, ...children: T_Children[]) => ReactElement<P, any, T_Children>;
 
     /**
      * @deprecated Please use `FunctionComponentFactory`
@@ -196,7 +196,7 @@ declare namespace React {
     function createFactory<P, T_Children>(type: FunctionComponent<P>): FunctionComponentFactory<P, T_Children>;
     function createFactory<P, T_Children>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>, T_Children>): CFactory<P, ClassicComponent<P, ComponentState>, T_Children>;
-    function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P, any, T_Children>, T_Children>(
+    function createFactory<P, T extends Component<P, ComponentState, any, T_Children>, C extends ComponentClass<P, any, T_Children>, T_Children>(
         type: ClassType<P, T, C, T_Children>): CFactory<P, T, T_Children>;
     function createFactory<P, T_Children>(type: ComponentClass<P, any, T_Children>): Factory<P, T_Children>;
 
@@ -224,19 +224,19 @@ declare namespace React {
     function createElement<P extends {}, T_Children = ReactNode>(
         type: FunctionComponent<P, T_Children>,
         props?: Attributes & P | null,
-        ...children: Array<T_Children | undefined>): FunctionComponentElement<P, T_Children>;
+        ...children: T_Children[]): FunctionComponentElement<P, T_Children>;
     function createElement<P extends {}, T_Children = ReactNode>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>, T_Children>,
         props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
-        ...children: Array<T_Children | undefined>): CElement<P, ClassicComponent<P, ComponentState>, T_Children>;
-    function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P, any, T_Children>, T_Children = ReactNode>(
+        ...children: T_Children[]): CElement<P, ClassicComponent<P, ComponentState>, T_Children>;
+    function createElement<P extends {}, T extends Component<P, ComponentState, any, T_Children>, C extends ComponentClass<P, any, T_Children>, T_Children = ReactNode>(
         type: ClassType<P, T, C, T_Children>,
         props?: ClassAttributes<T> & P | null,
-        ...children: Array<T_Children | undefined>): CElement<P, T, T_Children>;
+        ...children: T_Children[]): CElement<P, T, T_Children>;
     function createElement<P extends {}, T_Children = ReactNode>(
         type: FunctionComponent<P, T_Children> | ComponentClass<P, any, T_Children> | string,
         props?: Attributes & P | null,
-        ...children: Array<T_Children | undefined>): ReactElement<P>;
+        ...children: T_Children[]): ReactElement<P>;
 
     // DOM Elements
     // ReactHTMLElement
@@ -2675,7 +2675,7 @@ declare global {
     namespace JSX {
         // tslint:disable-next-line:no-empty-interface
         interface Element extends React.ReactElement<any, any> { }
-        interface ElementClass extends React.Component<any> {
+        interface ElementClass extends React.Component<any, any, any, any> {
             render(): React.ReactNode;
         }
         interface ElementAttributesProperty { props: {}; }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -177,6 +177,9 @@ declare namespace React {
     type ReactFragment = {} | ReactNodeArray;
     type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
 
+    interface ReactRenderableArray extends Array<ReactRenderable> {}
+    type ReactRenderable = JSX.Element | string | number | null | ReactRenderableArray;
+
     //
     // Top Level API
     // ----------------------------------------------------------------------
@@ -414,7 +417,7 @@ declare namespace React {
         ): void;
 
         forceUpdate(callBack?: () => void): void;
-        render(): ReactNode;
+        render(): ReactRenderable;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -2673,7 +2676,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface Element extends React.ReactElement<any, any> { }
         interface ElementClass extends React.Component<any> {
-            render(): React.ReactNode;
+            render(): React.ReactRenderable;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -22,13 +22,13 @@ FunctionComponent2.defaultProps = {
 };
 <FunctionComponent2>24</FunctionComponent2>;
 
-const FunctionComponentChildrenIsFunction: React.FunctionComponent<{}, () => string> = ({children}) => {
+const FunctionComponentChildrenIsFunction: React.FunctionComponent<{foo: string}, () => string> = ({children}) => {
     if (children) {
         return <div>{children()}</div>;
     }
     return null;
 };
-<FunctionComponentChildrenIsFunction>{() => "Hello World!"}</FunctionComponentChildrenIsFunction>;
+<FunctionComponentChildrenIsFunction foo="bar">{() => "Hello World!"}</FunctionComponentChildrenIsFunction>;
 <FunctionComponentChildrenIsFunction><div/></FunctionComponentChildrenIsFunction>; // $ExpectError
 
 const FunctionalComponentShouldNotReturnObject: React.FunctionComponent = () => { // $ExpectError
@@ -394,3 +394,21 @@ class ComponentShouldNotReturnObject extends React.Component {
         };
     }
 }
+
+class ComponentOnlyWantsFunction extends React.Component<{}, {}, {}, () => string> {
+    render() {
+        return <div>{this.props.children!()}</div>;
+    }
+}
+<ComponentOnlyWantsFunction>{() => "hi"}</ComponentOnlyWantsFunction>;
+
+export interface SubscriptionProps<S, T> {
+    children: (value: T) => React.ReactNode;
+    source: S;
+}
+export interface Subscription<S, T> extends React.ComponentClass<SubscriptionProps<S, T>, any, (value: T) => React.ReactNode> {}
+
+declare const Foo: Subscription<string, number>;
+const q = <Foo source="world">{(value: number) => "What"}</Foo>;
+<Foo source="world"/>; // $ExpectError
+<Foo source="world">Hi</Foo> // $ExpectError

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -22,6 +22,22 @@ FunctionComponent2.defaultProps = {
 };
 <FunctionComponent2>24</FunctionComponent2>;
 
+const FunctionComponentChildrenIsFunction: React.FunctionComponent<{}, () => string> = ({children}) => {
+    if (children) {
+        return <div>{children()}</div>;
+    }
+    return null;
+};
+<FunctionComponentChildrenIsFunction>{() => "Hello World!"}</FunctionComponentChildrenIsFunction>;
+<FunctionComponentChildrenIsFunction><div/></FunctionComponentChildrenIsFunction>; // $ExpectError
+
+const FunctionalComponentShouldNotReturnObject: React.FunctionComponent = () => { // $ExpectError
+    return {
+        hello: "world"
+    };
+};
+<FunctionalComponentShouldNotReturnObject/>;
+
 // svg sanity check
 <svg viewBox="0 0 1000 1000">
     <g>
@@ -370,3 +386,11 @@ type propTypesTest1 = typeof testPropTypes extends DeclaredPropTypes<TestPropTyp
 type propTypesTest2 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps2> ? true : false;
 // $ExpectType true
 type propTypesTest3 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps3> ? true : false;
+
+class ComponentShouldNotReturnObject extends React.Component {
+    render() { // $ExpectError
+        return {
+            hello: "world"
+        };
+    }
+}


### PR DESCRIPTION
1. `React.Component#render()` no longer allows you to return effectively `any`.
2. All components learned an additional generic that is what children they accept. 
    * This defaults to `ReactNode` and I believe it to be back compat for the normal case.
    * In the case that a Component previously accepted something like an object or a function as part of its `children`, **this change is breaking** and that code will require a change to the generics of its respective type.
    * This also means that a component that ONLY accepts functions for children can now do so.
    * We might be able to preserve things like singleton children as well as ordered children but I am saving that for another PR.
3. This still allows `undefined` to be returned from `render()` but I believe we can fix that when "not types" arrive.

Examples from tests:
```ts
const FunctionalComponentShouldNotReturnObject: React.FunctionComponent = () => { // $ExpectError
    return {
        hello: "world"
    };
};
```

```ts
const FunctionComponentChildrenIsFunction: React.FunctionComponent<{}, () => string> = ({children}) => {
    if (children) {
        return <div>{children()}</div>;
    }
    return null;
};
<FunctionComponentChildrenIsFunction>{() => "Hello World!"}</FunctionComponentChildrenIsFunction>;
<FunctionComponentChildrenIsFunction><div/></FunctionComponentChildrenIsFunction>; // $ExpectError
```