### PR TITLE
[Clean-CSS] Bug fix to allow objects to be passed as constructor

### DIFF
--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -1,6 +1,5 @@
 // Original by Tanguy Krotoff <https://github.com/tkrotoff>
 // Updated by Andrew Potter <https://github.com/GolaWaya>
-// TypeScript Version: 2.4
 
 import * as CleanCSS from 'clean-css';
 
@@ -97,16 +96,3 @@ CleanCssOptions = { returnPromise: false };
 new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
     console.log(minified.styles);
 });
-
-// type conversion
-CleanCssOptions = {};
-// in this case, the compiler will think its an OptionsOutput
-//  so if we want to make it a promise, we will need to cast it specifically its a promise type return
-(CleanCssOptions = CleanCssOptions as CleanCSS.OptionsPromise).returnPromise = true;
-new CleanCSS(CleanCssOptions).minify(source)
-    .then((minified: CleanCSS.Output): void => {
-        console.log(minified.styles);
-    }).catch((error: any): void => {
-        console.log(error);
-    }
-);

--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -1,5 +1,6 @@
 // Original by Tanguy Krotoff <https://github.com/tkrotoff>
 // Updated by Andrew Potter <https://github.com/GolaWaya>
+// TypeScript Version: 2.4
 
 import * as CleanCSS from 'clean-css';
 
@@ -96,7 +97,6 @@ CleanCssOptions = { returnPromise: false };
 new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
     console.log(minified.styles);
 });
-
 
 // type conversion
 CleanCssOptions = {};

--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -81,3 +81,32 @@ new CleanCSS({ returnPromise: true, sourceMap: true }).minify(source, inputSourc
         console.log(error);
     }
 );
+
+// test object return when passing options as object
+let CleanCssOptions: CleanCSS.Options = { returnPromise: true };
+new CleanCSS(CleanCssOptions).minify(source)
+    .then((minified: CleanCSS.Output): void => {
+        console.log(minified.styles);
+    }).catch((error: any): void => {
+        console.log(error);
+    }
+);
+
+CleanCssOptions = { returnPromise: false };
+new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
+    console.log(minified.styles);
+});
+
+
+// type conversion
+CleanCssOptions = {};
+// in this case, the compiler will think its an OptionsOutput
+//  so if we want to make it a promise, we will need to cast it specifically its a promise type return
+(CleanCssOptions = CleanCssOptions as CleanCSS.OptionsPromise).returnPromise = true;
+new CleanCSS(CleanCssOptions).minify(source)
+    .then((minified: CleanCSS.Output): void => {
+        console.log(minified.styles);
+    }).catch((error: any): void => {
+        console.log(error);
+    }
+);

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -9,7 +9,6 @@ import { RequestOptions as HttpsRequestOptions } from "https";
 import { RequestOptions as HttpRequestOptions } from "http";
 
 declare namespace CleanCSS {
-    
     /**
      * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
      */
@@ -18,7 +17,7 @@ declare namespace CleanCSS {
          * Controls compatibility mode used; defaults to ie10+ using `'*'`.
          *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`
          */
-        compatibility?: "*" | "ie9" | "ie8" | "ie7" | CleanCSS.CompatibilityOptions;
+        compatibility?: "*" | "ie9" | "ie8" | "ie7" | CompatibilityOptions;
 
         /**
          * Controls a function for handling remote requests; Defaults to the build in `loadRemoteResource` function
@@ -29,7 +28,7 @@ declare namespace CleanCSS {
          * Controls output CSS formatting; defaults to `false`.
          *  Format hash exposes the following properties: `breaks`, `breakWith`, `indentBy`, `indentWith`, `spaces`, and `wrapAt`.
          */
-        format?: "beautify" | "keep-breaks" | CleanCSS.FormatOptions | false;
+        format?: "beautify" | "keep-breaks" | FormatOptions | false;
 
         /**
          * inline option whitelists which @import rules will be processed.  Defaults to `'local'`
@@ -57,7 +56,7 @@ declare namespace CleanCSS {
          * Controls optimization level used; defaults to `1`.
          * Level hash exposes `1`, and `2`.
          */
-        level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions;
+        level?: 0 | 1 | 2 | OptimizationsOptions;
 
         /**
          * Controls URL rebasing; defaults to `true`;

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -9,15 +9,16 @@ import { RequestOptions as HttpsRequestOptions } from "https";
 import { RequestOptions as HttpRequestOptions } from "http";
 
 declare namespace CleanCSS {
+    
     /**
-     * Options passed when initializing a new instance of CleanCSS
+     * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
      */
-    interface Options {
+    interface OptionsBase {
         /**
          * Controls compatibility mode used; defaults to ie10+ using `'*'`.
          *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`
          */
-        compatibility?: "*" | "ie9" | "ie8" | "ie7" | CompatibilityOptions;
+        compatibility?: "*" | "ie9" | "ie8" | "ie7" | CleanCSS.CompatibilityOptions;
 
         /**
          * Controls a function for handling remote requests; Defaults to the build in `loadRemoteResource` function
@@ -28,7 +29,7 @@ declare namespace CleanCSS {
          * Controls output CSS formatting; defaults to `false`.
          *  Format hash exposes the following properties: `breaks`, `breakWith`, `indentBy`, `indentWith`, `spaces`, and `wrapAt`.
          */
-        format?: "beautify" | "keep-breaks" | FormatOptions | false;
+        format?: "beautify" | "keep-breaks" | CleanCSS.FormatOptions | false;
 
         /**
          * inline option whitelists which @import rules will be processed.  Defaults to `'local'`
@@ -56,7 +57,7 @@ declare namespace CleanCSS {
          * Controls optimization level used; defaults to `1`.
          * Level hash exposes `1`, and `2`.
          */
-        level?: 0 | 1 | 2 | OptimizationsOptions;
+        level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions;
 
         /**
          * Controls URL rebasing; defaults to `true`;
@@ -68,11 +69,6 @@ declare namespace CleanCSS {
          * will live; defaults to the current directory;
          */
         rebaseTo?: string;
-
-        /**
-         * If you prefer clean-css to return a Promise object then you need to explicitely ask for it; defaults to `false`
-         */
-        returnPromise?: boolean;
 
         /**
          *  Controls whether an output source map is built; defaults to `false`
@@ -651,11 +647,29 @@ declare namespace CleanCSS {
     }
 
     /**
+     * Options when returning a promise
+     */
+    type OptionsPromise = OptionsBase & { returnPromise: true };
+
+    /**
+     * Options when returning an output
+     */
+    type OptionsOutput = OptionsBase & { returnPromise?: false };
+
+    /**
+     * Discriminant union of both sets of options types.  If you initialize without setting `returnPromise: true`
+     *  and want to return a promise, you will need to cast to the correct options type so that TypeScript
+     *  knows what the expected return type will be:
+     *  `(options = options as CleanCSS.OptionsPromise).returnPromise = true`
+     */
+    type Options = OptionsPromise | OptionsOutput;
+
+    /**
      * Constructor interface for CleanCSS
      */
     interface Constructor {
-        new(options: Options & { returnPromise: true }): MinifierPromise;
-        new(options?: Options): MinifierOutput;
+        new(options: OptionsPromise): MinifierPromise;
+        new(options?: OptionsOutput): MinifierOutput;
     }
 }
 

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -648,7 +648,7 @@ declare namespace CleanCSS {
     /**
      * Options when returning a promise
      */
-    type OptionsPromise = OptionsBase & { 
+    type OptionsPromise = OptionsBase & {
         /**
          * If you prefer clean-css to return a Promise object then you need to explicitly ask for it; defaults to `false`
          */
@@ -658,7 +658,7 @@ declare namespace CleanCSS {
     /**
      * Options when returning an output
      */
-    type OptionsOutput = OptionsBase & { 
+    type OptionsOutput = OptionsBase & {
         /**
          * If you prefer clean-css to return a Promise object then you need to explicitly ask for it; defaults to `false`
          */

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -8,78 +8,78 @@
 import { RequestOptions as HttpsRequestOptions } from "https";
 import { RequestOptions as HttpRequestOptions } from "http";
 
-declare namespace CleanCSS {
+/**
+ * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
+ */
+interface OptionsBase {
     /**
-     * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
+     * Controls compatibility mode used; defaults to ie10+ using `'*'`.
+     *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`
      */
-    interface OptionsBase {
-        /**
-         * Controls compatibility mode used; defaults to ie10+ using `'*'`.
-         *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`
-         */
-        compatibility?: "*" | "ie9" | "ie8" | "ie7" | CompatibilityOptions;
+    compatibility?: "*" | "ie9" | "ie8" | "ie7" | CleanCSS.CompatibilityOptions;
 
-        /**
-         * Controls a function for handling remote requests; Defaults to the build in `loadRemoteResource` function
-         */
-        fetch?: (uri: string, inlineRequest: HttpRequestOptions | HttpsRequestOptions, inlineTimeout: number, done: (message: string | number, body: string) => void) => void;
+    /**
+     * Controls a function for handling remote requests; Defaults to the build in `loadRemoteResource` function
+     */
+    fetch?: (uri: string, inlineRequest: HttpRequestOptions | HttpsRequestOptions, inlineTimeout: number, done: (message: string | number, body: string) => void) => void;
 
-        /**
-         * Controls output CSS formatting; defaults to `false`.
-         *  Format hash exposes the following properties: `breaks`, `breakWith`, `indentBy`, `indentWith`, `spaces`, and `wrapAt`.
-         */
-        format?: "beautify" | "keep-breaks" | FormatOptions | false;
+    /**
+     * Controls output CSS formatting; defaults to `false`.
+     *  Format hash exposes the following properties: `breaks`, `breakWith`, `indentBy`, `indentWith`, `spaces`, and `wrapAt`.
+     */
+    format?: "beautify" | "keep-breaks" | CleanCSS.FormatOptions | false;
 
-        /**
-         * inline option whitelists which @import rules will be processed.  Defaults to `'local'`
-         * Accepts the following values:
-         *  'local': enables local inlining;
-         *  'remote': enables remote inlining;
-         *  'none': disables all inlining;
-         *  'all': enables all inlining, same as ['local', 'remote'];
-         *  '[uri]': enables remote inlining from the specified uri;
-         *  '![url]': disables remote inlining from the specified uri;
-         */
-        inline?: ReadonlyArray<string> | false;
+    /**
+     * inline option whitelists which @import rules will be processed.  Defaults to `'local'`
+     * Accepts the following values:
+     *  'local': enables local inlining;
+     *  'remote': enables remote inlining;
+     *  'none': disables all inlining;
+     *  'all': enables all inlining, same as ['local', 'remote'];
+     *  '[uri]': enables remote inlining from the specified uri;
+     *  '![url]': disables remote inlining from the specified uri;
+     */
+    inline?: ReadonlyArray<string> | false;
 
-        /**
-         * Controls extra options for inlining remote @import rules
-         */
-        inlineRequest?: HttpRequestOptions | HttpsRequestOptions;
+    /**
+     * Controls extra options for inlining remote @import rules
+     */
+    inlineRequest?: HttpRequestOptions | HttpsRequestOptions;
 
-        /**
-         * Controls number of milliseconds after which inlining a remote @import fails; defaults to `5000`;
-         */
-        inlineTimeout?: number;
+    /**
+     * Controls number of milliseconds after which inlining a remote @import fails; defaults to `5000`;
+     */
+    inlineTimeout?: number;
 
-        /**
-         * Controls optimization level used; defaults to `1`.
-         * Level hash exposes `1`, and `2`.
-         */
-        level?: 0 | 1 | 2 | OptimizationsOptions;
+    /**
+     * Controls optimization level used; defaults to `1`.
+     * Level hash exposes `1`, and `2`.
+     */
+    level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions;
 
-        /**
-         * Controls URL rebasing; defaults to `true`;
-         */
-        rebase?: boolean;
+    /**
+     * Controls URL rebasing; defaults to `true`;
+     */
+    rebase?: boolean;
 
-        /**
-         * controls a directory to which all URLs are rebased, most likely the directory under which the output file
-         * will live; defaults to the current directory;
-         */
-        rebaseTo?: string;
+    /**
+     * controls a directory to which all URLs are rebased, most likely the directory under which the output file
+     * will live; defaults to the current directory;
+     */
+    rebaseTo?: string;
 
-        /**
-         *  Controls whether an output source map is built; defaults to `false`
-         */
-        sourceMap?: boolean;
+    /**
+     *  Controls whether an output source map is built; defaults to `false`
+     */
+    sourceMap?: boolean;
 
-        /**
-         *  Controls embedding sources inside a source map's `sourcesContent` field; defaults to `false`
-         */
-        sourceMapInlineSources?: boolean;
-    }
+    /**
+     *  Controls embedding sources inside a source map's `sourcesContent` field; defaults to `false`
+     */
+    sourceMapInlineSources?: boolean;
+}
 
+declare namespace CleanCSS {
     /**
      * Output returned when calling minify functions
      */
@@ -648,12 +648,22 @@ declare namespace CleanCSS {
     /**
      * Options when returning a promise
      */
-    type OptionsPromise = OptionsBase & { returnPromise: true };
+    type OptionsPromise = OptionsBase & { 
+        /**
+         * If you prefer clean-css to return a Promise object then you need to explicitly ask for it; defaults to `false`
+         */
+        returnPromise: true
+    };
 
     /**
      * Options when returning an output
      */
-    type OptionsOutput = OptionsBase & { returnPromise?: false };
+    type OptionsOutput = OptionsBase & { 
+        /**
+         * If you prefer clean-css to return a Promise object then you need to explicitly ask for it; defaults to `false`
+         */
+        returnPromise?: false
+    };
 
     /**
      * Discriminant union of both sets of options types.  If you initialize without setting `returnPromise: true`


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/jakubpawlowicz/clean-css](https://github.com/jakubpawlowicz/clean-css)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.