### PR TITLE
@types/dd-trace: Expose TraceProxy interface

### DIFF
--- a/types/dd-trace/dd-trace-tests.ts
+++ b/types/dd-trace/dd-trace-tests.ts
@@ -1,4 +1,4 @@
-import * as tracer from "dd-trace";
+import tracer, { TraceProxy } from "dd-trace";
 import SpanContext = require("dd-trace/src/opentracing/span_context");
 
 tracer.init({
@@ -10,7 +10,7 @@ tracer.init({
     logger: {
         debug: msg => {},
         error: err => {},
-    }
+    },
 });
 
 function useWebFrameworkPlugin(plugin: "express" | "hapi" | "koa" | "restify") {
@@ -54,3 +54,9 @@ const span = tracer.startSpan("memcached", {
         "span.type": "memcached",
     },
 });
+
+interface MyContext {
+    tracer: TraceProxy;
+}
+
+const ctx: MyContext = { tracer };

--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -11,10 +11,7 @@
 import { Tracer, Span, SpanContext } from "opentracing";
 import DatadogSpanContext = require("./src/opentracing/span_context");
 
-declare var trace: TraceProxy;
-export default trace;
-
-declare class TraceProxy extends Tracer {
+export interface TraceProxy extends Tracer {
     /**
      * Initializes the tracer. This should be called before importing other libraries.
      */
@@ -162,7 +159,7 @@ interface TraceOptions {
     tags?: { [key: string]: any } | string;
 }
 
-declare class ScopeManager {
+export interface ScopeManager {
     /**
      * Get the current active scope or null if there is none.
      *
@@ -181,7 +178,7 @@ declare class ScopeManager {
     activate(span: Span, finishSpanOnClose?: boolean): Scope;
 }
 
-declare class Scope {
+export interface Scope {
     /**
      * Get the span wrapped by this scope.
      */
@@ -273,3 +270,6 @@ type PluginConfiguration = { [K in Plugin]: BasePluginOptions } & {
     koa: KoaPluginOptions;
     restify: RestifyPluginOptions;
 };
+
+declare var trace: TraceProxy;
+export default trace;

--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -12,7 +12,7 @@ import { Tracer, Span, SpanContext } from "opentracing";
 import DatadogSpanContext = require("./src/opentracing/span_context");
 
 declare var trace: TraceProxy;
-export = trace;
+export default trace;
 
 declare class TraceProxy extends Tracer {
     /**


### PR DESCRIPTION
- Expose TraceProxy interface
- Switch to default export

Use case:

Consumer wants to reference tracer type in their own type definitions, e.g.

```typescript
interface UserContext {
  tracer: TraceProxy
}
```

While currently there's no way of doing it.

------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

