### PR TITLE
[Luxon]: Abstract getters on Luzon Zone are not static.

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -5,6 +5,7 @@
 //                 Jonathan Siebern <https://github.com/jsiebern>
 //                 Matt R. Wilson <https://github.com/mastermatt>
 //                 Pietro Vismara <https://github.com/pietrovismara>
+//                 Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -467,11 +468,11 @@ export interface ZoneOffsetOptions {
 }
 
 export class Zone {
-    static offsetName(ts: number, options?: ZoneOffsetOptions): string;
-    static isValid: boolean;
-    static name: string;
-    static type: string;
-    static universal: boolean;
+    offsetName(ts: number, options?: ZoneOffsetOptions): string;
+    isValid: boolean;
+    name: string;
+    type: string;
+    universal: boolean;
     equals(other: Zone): boolean;
     offset(ts: number): number;
 }

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -1,4 +1,4 @@
-import { DateTime, Duration, Interval, Info, Settings, IANAZone } from 'luxon';
+import { DateTime, Duration, Interval, Info, Settings, IANAZone, Zone, ZoneOffsetOptions } from 'luxon';
 
 /* DateTime */
 const dt = DateTime.local(2017, 5, 15, 8, 30);
@@ -285,3 +285,21 @@ dur.reconfigure({ conversionAccuracy: 'longterm' }); // $ExpectType Duration
 
 start.until(end); // $ExpectType Interval
 i.toDuration(['years', 'months', 'days']); // $ExpectType Duration
+
+/* Sample Zone Implementation */
+class SampleZone extends Zone {
+  readonly isValid = false;
+  readonly name = 'Sample';
+  readonly type = 'Example';
+  readonly universal = true;
+
+  offsetName(ts: number, options?: ZoneOffsetOptions) {
+    return 'SampleZone';
+  }
+  equals(other: Zone) {
+    return other.name === this.name;
+  }
+  offset(ts: number) {
+    return 0;
+  }
+}


### PR DESCRIPTION
With the current definition, several items that are supposed to be public members/methods are marked static. Since these are supposed to be returning information for a particular zone, and in the luxon source they are not static members/methods, they should not be marked as static. It is not possible to create an implementation for Zone using the current definition.

References:
  https://moment.github.io/luxon/docs/class/src/zone.js~Zone.html
  https://github.com/moment/luxon/blob/master/src/zone.js

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://moment.github.io/luxon/docs/class/src/zone.js~Zone.html
  https://github.com/moment/luxon/blob/master/src/zone.js
- [ ] Increase the version number in the header if appropriate. - N/A
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - N/A
