### PR TITLE
[set-cookie-parser] add options definition

### DIFF
--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for set-cookie-parser
 // Project: https://github.com/nfriedly/set-cookie-parser
 // Definitions by: Nick Paddock <https://github.com/nickp10>
+//                 Ilya Zaytsev <https://github.com/ilyaztsv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -8,10 +9,10 @@
 declare module "set-cookie-parser" {
     import http = require("http");
 
-    function SetCookieParser(input: string | ReadonlyArray<string> | http.IncomingMessage): SetCookieParser.Cookie[];
+    function SetCookieParser(input: string | ReadonlyArray<string> | http.IncomingMessage, options?: SetCookieParser.Options): SetCookieParser.Cookie[];
 
     namespace SetCookieParser {
-        function parse(input: string | ReadonlyArray<string> | http.IncomingMessage): Cookie[];
+        function parse(input: string | ReadonlyArray<string> | http.IncomingMessage, options?: Options): Cookie[];
 
         function splitCookiesString(input: string | ReadonlyArray<string> | void): string[];
 
@@ -24,6 +25,11 @@ declare module "set-cookie-parser" {
             domain?: string;
             secure?: boolean;
             httpOnly?: boolean;
+        }
+
+        type Options = {
+            decodeValues?: boolean;
+            map?: boolean;
         }
     }
 

--- a/types/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/types/set-cookie-parser/set-cookie-parser-tests.ts
@@ -88,3 +88,22 @@ assert.deepStrictEqual(cookiesString, [
     'foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
     'baz=buz; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
 ])
+
+// Use decodeValues=false option
+var notDecodedValueCookies = setCookie.parse('user=%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 3000 10:01:11 GMT; HttpOnly; Secure', { decodeValues: false });
+assert.equal(notDecodedValueCookies[0].value, '%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2');
+
+var decodedValueCookies = setCookie.parse('user=%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 3000 10:01:11 GMT; HttpOnly; Secure', { decodeValues: true });
+assert.equal(decodedValueCookies[0].value, 'Илья Зайцев');
+
+// Use map=true option
+var expectedCookiesMap = {
+    foo: {
+        name: 'foo',
+        value: 'bar',
+        maxAge: 1000,
+        domain: '.example.com',
+    }
+};
+var cookiesMap = setCookie.parse('foo=bar; Max-Age=1000; Domain=.example.com;', { map: true });
+assert.deepStrictEqual(cookiesMap, expectedCookiesMap);


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nfriedly/set-cookie-parser#set-cookie-parser--->>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
