### PR TITLE
fix typo in types/google__maps definition of QueryAutocompleteResult

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -3107,7 +3107,7 @@ export interface QueryAutocompleteResult {
      * contains an `offset` value and a `length`.
      * These describe the location of the entered term in the prediction result text, so that the term can be highlighted if desired.
      */
-    matched_substring: PredictionSubstring[];
+    matched_substrings: PredictionSubstring[];
 }
 
 /** A Radar Search request must include at least one of `keyword`, `name`, or `type`. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - Merged upstream at: https://github.com/indrimuska/google-maps-api-typings/commit/ce2103548eb53113213725b531b4b0c346bc62a1
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
