### PR TITLE
[rc-slider] Adds tabIndex prop types

### DIFF
--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -5,17 +5,18 @@
 //                 Austin Turner <https://github.com/paustint>
 //                 Jacob Froman <https://github.com/j-fro>
 //                 Deanna Veale <https://github.com/Deanna2>
+//                 Nick Maddren <https://github.com/nicholasmaddren>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
-import { RCTooltip } from 'rc-tooltip';
+import { RCTooltip } from "rc-tooltip";
 
 export interface Marks {
     [number: number]:
-    | JSX.Element
-    | string
-    | { style: any; label: string | JSX.Element };
+        | JSX.Element
+        | string
+        | { style: any; label: string | JSX.Element };
 }
 
 export interface CommonApiProps {
@@ -135,6 +136,11 @@ export interface SliderProps extends CommonApiProps {
      * Set current value of slider.
      */
     value?: number;
+    /**
+     * Set the tabIndex of the slider handle.
+     * @default 0
+     */
+    tabIndex: number;
 }
 
 export interface RangeProps extends CommonApiProps {
@@ -162,6 +168,11 @@ export interface RangeProps extends CommonApiProps {
      * Set current positions of handles.
      */
     value?: number[];
+    /**
+     * Set the tabIndex of each handle.
+     * @default [0,0]
+     */
+    tabIndex: number[];
     /**
      * Determine how many ranges to render, and multiple handles will be rendered (number + 1).
      *  @default 1
@@ -200,9 +211,13 @@ export interface WithTooltipProps {
     tipProps?: Partial<RCTooltip.Props>;
 }
 
-export default class Slider extends React.Component<SliderProps> { }
-export class Range extends React.Component<RangeProps> { }
-export class Handle extends React.Component<HandleProps> { }
+export default class Slider extends React.Component<SliderProps> {}
+export class Range extends React.Component<RangeProps> {}
+export class Handle extends React.Component<HandleProps> {}
 
-export function createSliderWithTooltip(slider: typeof Slider): new() => React.Component<WithTooltipProps & SliderProps>;
-export function createSliderWithTooltip(range: typeof Range): new() => React.Component<WithTooltipProps & RangeProps>;
+export function createSliderWithTooltip(
+    slider: typeof Slider
+): new () => React.Component<WithTooltipProps & SliderProps>;
+export function createSliderWithTooltip(
+    range: typeof Range
+): new () => React.Component<WithTooltipProps & RangeProps>;

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -140,7 +140,7 @@ export interface SliderProps extends CommonApiProps {
      * Set the tabIndex of the slider handle.
      * @default 0
      */
-    tabIndex: number;
+    tabIndex?: number;
 }
 
 export interface RangeProps extends CommonApiProps {
@@ -172,7 +172,7 @@ export interface RangeProps extends CommonApiProps {
      * Set the tabIndex of each handle.
      * @default [0,0]
      */
-    tabIndex: number[];
+    tabIndex?: number[];
     /**
      * Determine how many ranges to render, and multiple handles will be rendered (number + 1).
      *  @default 1


### PR DESCRIPTION
`rc-slider` now has a `tabIndex` prop:

https://www.npmjs.com/package/rc-slider

I have added the relevant types for this.

