### PR TITLE
Add types for npm-license-crawler

### DIFF
--- a/types/npm-license-crawler/index.d.ts
+++ b/types/npm-license-crawler/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for npm-license-crawler 0.1
+// Project: https://github.com/mwittig/npm-license-crawler
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export interface Licenses {
+    [repository: string]: {
+        licenses: string;
+        licenseUrl: string;
+        parents: string;
+        repository: string;
+    };
+}
+
+export interface CrawlerOptions {
+    /** export the data as comma-separated values to the given file. The path will be created if it does not exist. */
+    csv?: string;
+    /** show only third-party licenses, i.e., only list the dependencies defined in package.json. */
+    dependencies?: boolean;
+    /** show only development dependencies */
+    development?: boolean;
+    /** path to a directory to be excluded (and its subdirectories) from the search. */
+    exclude?: string | string[];
+    /** export data as JSON to the given file. The path will be created if it does not exist. */
+    json?: string;
+    /** omit version numbers in result (e.g. "npm-license-crawler@0.1.5" becomes "npm-license-crawler") */
+    omitVersion?: boolean;
+    /** show only direct dependencies licenses, i.e., don't list dependencies of dependencies. */
+    onlyDirectDependencies?: boolean;
+    /** show only production dependencies */
+    production?: boolean;
+    /** output the relative file path for license files. */
+    relativeLicensePath?: boolean;
+    /** path to the directory the license search should start from. If omitted the current working directory is assumed. */
+    start: string | string[];
+    /** show only licenses that can't be determined or have been guessed. */
+    unknown?: boolean;
+}
+
+export type Callback = (error: Error | null, licenses: Licenses) => void;
+
+export function dumpLicenses(args: CrawlerOptions, callback: Callback): void;

--- a/types/npm-license-crawler/npm-license-crawler-tests.ts
+++ b/types/npm-license-crawler/npm-license-crawler-tests.ts
@@ -1,0 +1,15 @@
+import { CrawlerOptions, dumpLicenses } from 'npm-license-crawler';
+
+const options: CrawlerOptions = {
+    start: ['../..'],
+    exclude: ['.'],
+    json: 'licenses.json',
+    unknown: true,
+};
+
+dumpLicenses(options, (error, res) => {
+    res.name.licenses; // $ExpectType string
+    res.name.licenseUrl; // $ExpectType string
+    res.name.parents; // $ExpectType string
+    res.name.repository; // $ExpectType string
+});

--- a/types/npm-license-crawler/tsconfig.json
+++ b/types/npm-license-crawler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "npm-license-crawler-tests.ts"
+    ]
+}

--- a/types/npm-license-crawler/tslint.json
+++ b/types/npm-license-crawler/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
