### PR TITLE
ThreeJS: Adding customDepthMaterial and customDistanceMaterial to Mesh

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5301,6 +5301,8 @@ export class Mesh extends Object3D {
 
     geometry: Geometry | BufferGeometry;
     material: Material | Material[];
+    customDepthMaterial: Material | undefined
+    customDistanceMaterial: Material | undefined
     drawMode: TrianglesDrawModes;
     morphTargetInfluences?: number[];
     morphTargetDictionary?: { [key: string]: number; };


### PR DESCRIPTION
https://threejs.org/docs/index.html#api/en/core/Object3D.customDepthMaterial
https://threejs.org/docs/index.html#api/en/core/Object3D.customDistanceMaterial

These properties exist in the Object3D documentation but can only be applied to Mesh types.

"Custom depth material to be used when rendering to the depth map. Can only be used in context of meshes."