### PR TITLE
[@types/shallowequal] separate shallowequal.comparer

### DIFF
--- a/types/shallowequal/index.d.ts
+++ b/types/shallowequal/index.d.ts
@@ -2,14 +2,24 @@
 // Project: https://github.com/dashed/shallowequal
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Arnd Issler <https://github.com/arndissler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 declare function shallowEqual<TCtx = any>(
     objA: any,
     objB: any,
-    compare?: (this: TCtx, objA: any, objB: any, indexOrKey?: number | string) => boolean | void,
+    customizer?: shallowEqual.Customizer<TCtx>,
     compareContext?: TCtx
 ): boolean;
+
+declare namespace shallowEqual {
+    type Customizer<T = any> = (
+        this: T,
+        objA: any,
+        objB: any,
+        indexOrKey?: number | string
+    ) => boolean | void;
+}
 
 export = shallowEqual;

--- a/types/shallowequal/shallowequal-tests.ts
+++ b/types/shallowequal/shallowequal-tests.ts
@@ -12,13 +12,34 @@ shallowEqual(a, b, (a, b, indexOrKey) => {
 
     return false;
 });
-shallowEqual(a, b, () => {}); // $ExpectType boolean
+shallowEqual(a, b, () => undefined); // $ExpectType boolean
 // $ExpectType boolean
 shallowEqual(
     a,
     b,
     function() {
         this; // $ExpectType { foo: string; }
+        return undefined;
     },
     { foo: 'bar' }
 );
+
+interface Foo {
+    foo: string;
+    bar: number;
+}
+
+const c: Foo = { foo: 'foo', bar: 0 };
+const d: Foo = { foo: 'baz', bar: 1 };
+
+const undefinedCustomizer: shallowEqual.Customizer<Foo> = () => undefined;
+
+const customizer: shallowEqual.Customizer<Foo> = function(a: any, b: any) {
+    this; // $ExpectType Foo
+    a; // $ExpectType any
+    b; // $ExpectType any
+    return undefined;
+};
+
+shallowEqual(c, d, undefinedCustomizer); // $ExpectType boolean
+shallowEqual(c, d, customizer); // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dashed/shallowequal/blob/master/README.md -- _the `customizer`/comparer function should return `undefined` or a bool. Additionally to this I separated the function signature so users can use it as an own type._
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
