### PR TITLE
Fix Definitions for @loadable/server ChunkExtractor

### DIFF
--- a/types/loadable__server/index.d.ts
+++ b/types/loadable__server/index.d.ts
@@ -51,7 +51,7 @@ export class ChunkExtractor {
 	/**
 	 * Get scripts as a string of `<script>` tags
 	 */
-	getScriptTags(): string[];
+	getScriptTags(): string;
 
 	/**
 	 * Get scripts as an array of React `<script>` elements.
@@ -61,7 +61,7 @@ export class ChunkExtractor {
 	/**
 	 * Get "prefetch" and "preload" links as a string of `<link>` tags
 	 */
-	getLinkTags(): string[];
+	getLinkTags(): string;
 
 	/**
 	 * Get "prefetch" and "preload" links as an array of React `<link>` elements
@@ -71,7 +71,7 @@ export class ChunkExtractor {
 	/**
 	 * Get style links as a string of `<link>` tags
 	 */
-	getStyleTags(): string[];
+	getStyleTags(): string;
 
 	/**
 	 * Get style links as an array of React `<link>` elements

--- a/types/loadable__server/loadable__server-tests.tsx
+++ b/types/loadable__server/loadable__server-tests.tsx
@@ -33,8 +33,8 @@ const {
 
 // getLinkTags
 {
-    // Should return an arary of strings
-    const tags: string[] = getLinkTags();
+    // Should return a string
+    const tags: string = getLinkTags();
 }
 
 // getScriptElements
@@ -45,8 +45,8 @@ const {
 
 // getScriptTags
 {
-    // Should return an arary of strings
-    const tags: string[] = getScriptTags();
+    // Should return a string
+    const tags: string = getScriptTags();
 }
 
 // getStyleElements
@@ -57,8 +57,8 @@ const {
 
 // getStyleTags
 {
-    // Should return an arary of strings
-    const tags: string[] = getStyleTags();
+    // Should return a string
+    const tags: string = getStyleTags();
 }
 
 // requireEntrypoint


### PR DESCRIPTION
The `getScriptTags`, `getLinkTags`, and `getStyleTags` ChunkExtractor functions actually return `String` instead of the current `String[]`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [getScriptTags](https://www.smooth-code.com/open-source/loadable-components/docs/api-loadable-server/#chunkextractorgetscripttags), [getLinkTags](https://www.smooth-code.com/open-source/loadable-components/docs/api-loadable-server/#chunkextractorgetlinktags), and [getStyleTags](https://www.smooth-code.com/open-source/loadable-components/docs/api-loadable-server/#chunkextractorgetstyletags)