### PR TITLE
auth0-js - Added back needed fields for Auth0Error

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -571,12 +571,12 @@ export interface Auth0Error {
     errorDescription: string;
     // Need to include non-intuitive error fields that Auth0 uses
     code?: string;
-    description?: string;	
+    description?: string;
     name?: string;
     policy?: string;
-    original?: any;	
-    statusCode?: number;	
-    statusText?: string;                          
+    original?: any;
+    statusCode?: number;
+    statusText?: string;
 }
 
 export type Auth0ParseHashError = Auth0Error & {

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -569,6 +569,14 @@ export type SpecErrorCodes =
 export interface Auth0Error {
     error: LibErrorCodes | SpecErrorCodes | string;
     errorDescription: string;
+    // Need to include non-intuitive error fields that Auth0 uses
+    code?: string;
+    description?: string;	
+    name?: string;
+    policy?: string;
+    original?: any;	
+    statusCode?: number;	
+    statusText?: string;                          
 }
 
 export type Auth0ParseHashError = Auth0Error & {


### PR DESCRIPTION
Auth0Error can happen where Auth0 service still uses these other fields that someone mistakenly removed a couple months ago (in cases like webAuth.login method).
Responses aren't always in format 'error' & 'errorDescription' and the other fields need to be captured.

Example response = HTTP 401 `{"name":"ValidationError","code":"invalid_user_password","description":"Wrong email or password.","statusCode":400}`

Oct commit that mistakenly removed these
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/c5b6a5e2d5403265f5aa9e0dc3d7f4498622703b#diff-7795f2501af1276ff905e366093a998b

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
