### PR TITLE
[@types/react-native-modal-dropdown]: added scrollEnabled property

### DIFF
--- a/types/react-native-modal-dropdown/index.d.ts
+++ b/types/react-native-modal-dropdown/index.d.ts
@@ -21,6 +21,7 @@ declare namespace RNModalDropdown {
         defaultValue?: string;
         options?: any[];
         animated?: boolean;
+        scrollEnabled?: boolean;
         showsVerticalScrollIndicator?: boolean;
         style?: any;
         textStyle?: any;


### PR DESCRIPTION
ModalDropdown has a scrollEnabled property which was missing from props

changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sohobloo/react-native-modal-dropdown/blob/master/components/ModalDropdown.js
