### PR TITLE
nodegit: Fix return type of Repository#createBlobFromBuffer

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -62,3 +62,5 @@ const signature = Git.Signature.now("name", "email");
 signature.name();
 signature.email();
 signature.when();
+
+repo.createBlobFromBuffer(Buffer.from("test")).then((oid: Git.Oid) => oid.cpy());

--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -153,7 +153,7 @@ export class Repository {
     /**
      * Create a blob from a buffer
      */
-    createBlobFromBuffer(buffer: Buffer): Oid;
+    createBlobFromBuffer(buffer: Buffer): Promise<Oid>;
     treeBuilder(tree: Tree): Promise<Treebuilder>;
     /**
      * Gets the default signature for the default user and now timestamp


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/nodegit/nodegit/pull/1614 - the return type was incorrectly annotated, but a PR to fix that has been merged
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.