### PR TITLE
[@types/axios-case-converter] Added types for axios-case-converter

### DIFF
--- a/types/axios-case-converter/axios-case-converter-tests.ts
+++ b/types/axios-case-converter/axios-case-converter-tests.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+import applyConverters from "axios-case-converter";
+
+applyConverters(); // $ExpectError
+
+applyConverters(axios.create()); // $ExpectType AxiosInstance

--- a/types/axios-case-converter/index.d.ts
+++ b/types/axios-case-converter/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for axios-case-converter 0.3
+// Project: https://github.com/mpyw/axios-case-converter
+// Definitions by: Derek Kniffin <https://github.com/dkniffin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { AxiosInstance } from "axios";
+
+export default function applyConverters(axios: AxiosInstance): AxiosInstance;

--- a/types/axios-case-converter/package.json
+++ b/types/axios-case-converter/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "axios": "^0.16.1"
+    }
+}

--- a/types/axios-case-converter/tsconfig.json
+++ b/types/axios-case-converter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "axios-case-converter-tests.ts"
+    ]
+}

--- a/types/axios-case-converter/tslint.json
+++ b/types/axios-case-converter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
