### PR TITLE
add support for getRequest

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -42,9 +42,40 @@ export type RelayContainer = any;
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
-export type ConcreteFragment = any;
-export type ConcreteRequest = any;
-export type ConcreteBatchRequest = any;
+export interface ConcreteFragment {
+    kind: string;
+    name: string;
+    type: string;
+    metadata: {[key: string]: any} | null;
+    argumentDefinitions: any[];
+    selections: any[];
+}
+export interface ConcreteRequest {
+    kind: string;
+    operationKind: string;
+    name: string;
+    id: string | null;
+    text: string | null;
+    metadata: {[key: string]: any};
+    fragment: ConcreteFragment;
+    operation: any;
+}
+export interface ConcreteBatchRequest {
+    kind: string;
+    operationKind: string;
+    name: string;
+    metadata: {[key: string]: any};
+    fragment: ConcreteFragment;
+    requests: Array<{
+        name: string;
+        id: string | null;
+        text: string | null;
+        argumentDependencies: any[] | null;
+        operation: any;
+    }>;
+}
+
+export function getRequest(taggedNode: GraphQLTaggedNode): ConcreteRequest;
 
 export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
 


### PR DESCRIPTION
Added support for the public function `getRequest`: https://github.com/facebook/relay/blob/cadb486cced9eb257bc4083efe2941d0ee169ecc/packages/relay-runtime/index.js#L202

helping defs come from the link that was posted in the comments. used as many `any`s as I could because string literals would cause disagreements with the ts relay compiler.