### PR TITLE
[pikaday] Add null type to setMinDate and setMaxDate parameter, Fix setDate parameter name

### DIFF
--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -44,7 +44,7 @@ declare class Pikaday {
      * can optionally be passed as the second parameter to prevent triggering
      * of the onSelect callback, allowing the date to be set silently.
      */
-    setDate(date: string | Date, triggerOnSelect?: boolean): void;
+    setDate(date: string | Date, preventOnSelect?: boolean): void;
 
     /**
      * Returns a Moment.js object for the selected date (Moment must be

--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -90,12 +90,12 @@ declare class Pikaday {
     /**
      * Update the minimum/earliest date that can be selected.
      */
-    setMinDate(date: Date): void;
+    setMinDate(date: Date | null): void;
 
     /**
      * Update the maximum/latest date that can be selected.
      */
-    setMaxDate(date: Date): void;
+    setMaxDate(date: Date | null): void;
 
     /**
      * Update the range start date. For using two Pikaday instances to

--- a/types/pikaday/pikaday-tests.ts
+++ b/types/pikaday/pikaday-tests.ts
@@ -42,6 +42,8 @@ new Pikaday({field: $('#datepicker')[0]});
     picker.gotoYear(2015);
     picker.setMinDate(new Date());
     picker.setMaxDate(new Date());
+    picker.setMinDate(null);
+    picker.setMaxDate(null);
     picker.setStartRange(new Date());
     picker.setEndRange(new Date());
     picker.isVisible();

--- a/types/pikaday/pikaday-tests.ts
+++ b/types/pikaday/pikaday-tests.ts
@@ -30,6 +30,7 @@ new Pikaday({field: $('#datepicker')[0]});
     picker.toString('YYYY-MM-DD');
     picker.getDate();
     picker.setDate('2015-01-01');
+    picker.setDate('2015-01-01', true);
     picker.getMoment();
     picker.setMoment(moment('14th February 2014', 'DDo MMMM YYYY'));
     picker.setMoment(moment('14th February 2014', 'DDo MMMM YYYY'), true);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[setMinDate](https://github.com/Pikaday/Pikaday/blob/master/pikaday.js#L971)
[setMaxDate](https://github.com/Pikaday/Pikaday/blob/master/pikaday.js#L991)
[setDate](https://github.com/Pikaday/Pikaday/blob/master/pikaday.js#L819)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
