### PR TITLE
CKEDITOR 4: fix minor issues with dom.node typings

### DIFF
--- a/types/ckeditor/ckeditor-tests.ts
+++ b/types/ckeditor/ckeditor-tests.ts
@@ -289,6 +289,17 @@ function test_dom_node() {
     strong.insertBefore(em);
     strong.insertBeforeMe(em);
     element.isReadOnly();
+    var prev = node.getPreviousSourceNode();
+    prev = node.getPreviousSourceNode(true);
+    prev = node.getPreviousSourceNode(true, CKEDITOR.NODE_TEXT);
+    prev = node.getPreviousSourceNode(true, CKEDITOR.NODE_COMMENT, node);
+    prev = node.getPreviousSourceNode(true, CKEDITOR.NODE_COMMENT, (current: CKEDITOR.dom.node) => false);
+    var next = node.getNextSourceNode();
+    next = node.getNextSourceNode(true);
+    next = node.getNextSourceNode(true, CKEDITOR.NODE_ELEMENT);
+    next = node.getNextSourceNode(true, CKEDITOR.NODE_DOCUMENT, node);
+    next = node.getNextSourceNode(true, CKEDITOR.NODE_DOCUMENT_FRAGMENT, (current: CKEDITOR.dom.node) => true);
+    console.log(node.type);
 }
 
 function test_dom_nodeList() {

--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -333,6 +333,7 @@ declare namespace CKEDITOR {
         }
 
         class node extends domObject {
+            type: number;
             constructor(domNode: Node);
             appendTo(element: element): element;
             clone(includeChildren: boolean, cloneId: boolean): node;
@@ -347,12 +348,12 @@ declare namespace CKEDITOR {
             getDocument(): document;
             getIndex(normalized?: boolean): number;
             getNext(evaluator?: (node: node) => boolean): node;
-            getNextSourceNode(startFromSibling: boolean, nodeType: number, guard: node | ((node: node) => boolean)): void;
+            getNextSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): void;
             getParent(allowFragmentParent?: boolean): element;
             getParents(closerFirst?: boolean): node[];
             getPosition(otherNode: node): void;
             getPrevious(evaluator?: (node: node) => boolean): node;
-            getPreviousSourceNode(startFromSibling: boolean, nodeType: number, guard: node | ((node: node) => boolean)): void;
+            getPreviousSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): void;
             hasAscendant(name: string, includeSelf: boolean): boolean;
             remove(preserveChildren?: boolean): node;
             replace(nodeToReplace: node): void;

--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -348,12 +348,12 @@ declare namespace CKEDITOR {
             getDocument(): document;
             getIndex(normalized?: boolean): number;
             getNext(evaluator?: (node: node) => boolean): node;
-            getNextSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): void;
+            getNextSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): node;
             getParent(allowFragmentParent?: boolean): element;
             getParents(closerFirst?: boolean): node[];
             getPosition(otherNode: node): void;
             getPrevious(evaluator?: (node: node) => boolean): node;
-            getPreviousSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): void;
+            getPreviousSourceNode(startFromSibling?: boolean, nodeType?: number, guard?: node | ((node: node) => boolean)): node;
             hasAscendant(name: string, includeSelf: boolean): boolean;
             remove(preserveChildren?: boolean): node;
             replace(nodeToReplace: node): void;


### PR DESCRIPTION
This PR includes some minor fixes to the dom.node typings:
- adds a `type` attribute. Technically, the docs don't say that node has a "type" attribute, however CKEDITOR uses node.type internally and the docs for the node's constructor say it returns one of the subclasses of node, all of which have a `type` attribute.
- makes the parameters of `getNextSourceNode` and `getPreviousSourceNode` optional. The code itself treats them as optional and it makes sense that they're optional, the docs simply didn't mark them as optional.
- adds a return type to  `getNextSourceNode` and `getPreviousSourceNode`. The methods do actually return values and they're even getters, but the docs didn't supply a return type.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_node.html
https://github.com/ckeditor/ckeditor-dev/edit/major/core/dom/node.js
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.