### PR TITLE
Change SinonStub.resolves() to allow a partial of the type being resolved

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -399,7 +399,7 @@ declare namespace Sinon {
          * The Promise library can be overwritten using the usingPromise method.
          * Since sinon@2.0.0
          */
-        resolves(value?: TReturnValue extends Promise<infer TResolveValue> ? TResolveValue : never): SinonStub<TArgs, TReturnValue>;
+        resolves(value?: TReturnValue extends Promise<infer TResolveValue> ? Partial<TResolveValue> : never): SinonStub<TArgs, TReturnValue>;
         /**
          * Causes the stub to return a Promise which resolves to the argument at the provided index.
          * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31401, a change was made to correctly type the return value of the function being mocked.  This is pretty nice, generally, but a bit too restrictive.  Sometimes you need to mock functions that return a complicated data structure, which makes writing unit tests really cumbersome. 

 I made the change to require a partial type instead of the full type.  That way, when writing unit tests, you can have the stub resolve only the parts of the return value that the test needs, while providing type checking for the parts that are included.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31401
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
