### PR TITLE
added typings for @storybook/addons and @storybook/channels

### DIFF
--- a/types/storybook__addons/index.d.ts
+++ b/types/storybook__addons/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for @storybook/addons 4.1
+// Project: https://github.com/storybooks/storybook/tree/master/lib/addons
+// Definitions by: Bob Matcuk <https://github.com/bmatcuk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+
+import Channel = require("@storybook/channels");
+import { RenderFunction, StoryDecorator } from "@storybook/react";
+
+export const mockChannel: Channel;
+
+export interface Context {
+    kind: string;
+    story: string;
+}
+
+export type GetStoryFunc = (context: Context) => ReturnType<StoryDecorator>;
+
+export interface Wrapper<Options, Parameters> {
+    (getStory: GetStoryFunc, context: Context, optsAndParams: { options: Options, parameters: Parameters }):
+        ReturnType<StoryDecorator>;
+}
+
+export interface MakeDecoratorOptions<ParameterName extends string, Options, Parameters> {
+    name: string;
+    parameterName: ParameterName;
+    wrapper: Wrapper<Options, Parameters>;
+    skipIfNoParametersOrOptions?: boolean;
+    allowDeprecatedUsage?: boolean;
+}
+
+export interface DecoratorContext<ParameterName extends string, T> extends Context {
+    parameters?: Record<ParameterName, T>;
+}
+
+export interface DecoratorWithOptions<ParameterName extends string, T> {
+    // Support for older, but not deprecated style:
+    //   .addDecorator(decorator(options))
+    (story: RenderFunction, context: DecoratorContext<ParameterName, T>): ReturnType<StoryDecorator>;
+
+    // Support for the deprecated style:
+    //   .add(decorator(options)(() => <Story />)
+    (story: RenderFunction): (context: DecoratorContext<ParameterName, T>) => ReturnType<StoryDecorator>;
+}
+
+export interface Decorator<ParameterName extends string, Options, Parameters> {
+    // Supports newer style:
+    //   .addDecorator(decorator)
+    //   .add('story', () => <Story />)
+    (story: RenderFunction, context: DecoratorContext<ParameterName, Parameters>): ReturnType<StoryDecorator>;
+
+    // Support for older styles which pass options.
+    // See DecoratorWithOptions above.
+    (options: Options): DecoratorWithOptions<ParameterName, Parameters>;
+    (...options: Options[]): DecoratorWithOptions<ParameterName, Parameters>;
+}
+
+// If you manually specify the type parameters, the first type (ParameterName)
+// must match the "parameterName" option, ie:
+//
+//   makeDecorator<"myParam", ..., ...>({ parameterName: "myParam", ... })
+//
+// TypeScript is pretty good about inferring all of the type generics if you
+// include the type declarations on the options/parameters in your wrapper
+// function.
+export function makeDecorator<ParameterName extends string, Options = any, Parameters = any>(
+    options: MakeDecoratorOptions<ParameterName, Options, Parameters>):
+        Decorator<ParameterName, Options, Parameters>;
+
+export class AddonStore {
+    constructor();
+    getChannel(): Channel;
+    hasChannel(): boolean;
+    setChannel(channel: any): void;
+    getPreview(): any;
+    getDatabase(): any;
+    setDatabase(database: any): void;
+    getPanels(): any;
+    addPanel(name: any, panel: any): void;
+    register(name: any, loader: any): any;
+    loadAddons(api: any): any;
+}
+
+declare const DefaultAddonStore: AddonStore;
+export default DefaultAddonStore;

--- a/types/storybook__addons/storybook__addons-tests.ts
+++ b/types/storybook__addons/storybook__addons-tests.ts
@@ -1,0 +1,25 @@
+import addons, { makeDecorator } from "@storybook/addons";
+import { addDecorator, storiesOf } from "@storybook/react";
+
+// Example from Storybook documentation
+const withNotes = makeDecorator({
+    name: "withNotes",
+    parameterName: "notes",
+    wrapper: (getStory, context, {options, parameters}: {options: number, parameters: string}) => {
+        const channel = addons.getChannel();
+        channel.emit("MYADDON/add_notes", parameters);
+        return getStory(context);
+    }
+});
+
+// new style
+addDecorator(withNotes);
+
+// old style, but still supported
+addDecorator(withNotes(42));
+
+// the deprecated style actually isn't supported by
+// @storybook/react's typings, so, no test for that...
+storiesOf("Hello", module)
+    .addDecorator(withNotes)        // new style
+    .addDecorator(withNotes(42));   // old style, but still supported

--- a/types/storybook__addons/tsconfig.json
+++ b/types/storybook__addons/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@storybook/addons": [
+                "storybook__addons"
+            ],
+            "@storybook/channels": [
+                "storybook__channels"
+            ],
+            "@storybook/react": [
+                "storybook__react"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "storybook__addons-tests.ts"
+    ]
+}

--- a/types/storybook__addons/tslint.json
+++ b/types/storybook__addons/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/storybook__channels/index.d.ts
+++ b/types/storybook__channels/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for @storybook/channels 4.1
+// Project: https://github.com/storybooks/storybook/tree/master/lib/channels
+// Definitions by: Bob Matcuk <https://github.com/bmatcuk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+
+type EventName = PropertyKey;
+type EventHandler = (event: Channel.Event) => void;
+type Listener = (...args: any) => void;
+
+declare namespace Channel {
+    interface Event {
+        type: EventName;
+        args: any;
+        from: string;
+    }
+
+    interface Transport {
+        setHandler(handler: EventHandler): void;
+        send(event: any): void;
+    }
+}
+
+declare class Channel {
+    constructor(options?: { transport?: Channel.Transport, async?: boolean });
+    addListener(type: EventName, listener: Listener): void;
+    addPeerListener(type: EventName, listener: Listener): void;
+    emit(type: EventName, ...args: any): void;
+    eventNames(): EventName[];
+    listenerCount(type: EventName): number;
+    listeners(type: EventName): Listener[];
+    on(type: EventName, listener: Listener): void;
+    once(type: EventName, listener: Listener): void;
+    prependListener(type: EventName, listener: Listener): void;
+    removeAllListeners(type: EventName): void;
+    removeListener(type: EventName, listener: Listener): void;
+}
+
+export = Channel;

--- a/types/storybook__channels/storybook__channels-tests.ts
+++ b/types/storybook__channels/storybook__channels-tests.ts
@@ -1,0 +1,21 @@
+import Channel = require("@storybook/channels");
+
+const transport: Channel.Transport = {
+    setHandler(handler) { },
+    send(event) { },
+};
+const channel = new Channel({ transport, async: true });
+const listener = (...args: any) => { };
+channel.addListener("event", listener);
+channel.addPeerListener("event", listener);
+channel.emit("event", 42);
+channel.on("event", listener);
+channel.once("event", listener);
+channel.prependListener("event", listener);
+
+const events: PropertyKey[] = channel.eventNames();
+const count: number = channel.listenerCount("event");
+const listeners: Array<(...args: any) => void> = channel.listeners("event");
+
+channel.removeListener("event", listener);
+channel.removeAllListeners("event");

--- a/types/storybook__channels/tsconfig.json
+++ b/types/storybook__channels/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@storybook/channels": [
+                "storybook__channels"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "storybook__channels-tests.ts"
+    ]
+}

--- a/types/storybook__channels/tslint.json
+++ b/types/storybook__channels/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
My goal was to create definitions for @storybook/addons, but it has a small dependency on @storybook/channels, which is also missing types. So, I did both. I hope that's ok. I can split into two separate PRs/commits, but addons will have a dependency on channels so that's why I did it together.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.