### PR TITLE
feat(graphql): add TArgs generic to more graphql types

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -17,6 +17,7 @@
 //                 Curtis Layne <https://github.com/clayne11>
 //                 Jonathan Cardoso <https://github.com/JCMais>
 //                 Pavel Lang <https://github.com/langpavel>
+//                 Mark Caudill <https://github.com/mc0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -140,8 +140,8 @@ export function assertAbstractType(type: any): GraphQLAbstractType;
  * List Modifier
  *
  * A list is a kind of type marker, a wrapping type which points to another
- * type. Lists are often created within the context of defining the fields of
- * an object type.
+ * type. Lists are often created within the context of defining the fields
+ * of an object type.
  *
  * Example:
  *

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -342,36 +342,48 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
  *     });
  *
  */
-export class GraphQLObjectType<TSource = any, TContext = any> {
+export class GraphQLObjectType<
+    TSource = any,
+    TContext = any,
+    TArgs = { [key: string]: any }
+> {
     name: string;
     description: Maybe<string>;
     astNode: Maybe<ObjectTypeDefinitionNode>;
     extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
     isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
 
-    constructor(config: GraphQLObjectTypeConfig<TSource, TContext>);
-    getFields(): GraphQLFieldMap<any, TContext>;
+    constructor(config: GraphQLObjectTypeConfig<TSource, TContext, TArgs>);
+    getFields(): GraphQLFieldMap<any, TContext, TArgs>;
     getInterfaces(): GraphQLInterfaceType[];
     toString(): string;
     toJSON(): string;
     inspect(): string;
 }
 
-export interface GraphQLObjectTypeConfig<TSource, TContext> {
+export interface GraphQLObjectTypeConfig<
+    TSource,
+    TContext,
+    TArgs = { [key: string]: any }
+> {
     name: string;
     interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
+    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
     isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
     description?: Maybe<string>;
     astNode?: Maybe<ObjectTypeDefinitionNode>;
     extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
 
-export type GraphQLTypeResolver<TSource, TContext> = (
+export type GraphQLTypeResolver<
+    TSource,
+    TContext,
+    TArgs = { [key: string]: any }
+> = (
     value: TSource,
     context: TContext,
     info: GraphQLResolveInfo
-) => MaybePromise<Maybe<GraphQLObjectType<TSource, TContext> | string>>;
+) => MaybePromise<Maybe<GraphQLObjectType<TSource, TContext, TArgs> | string>>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
     source: TSource,
@@ -423,8 +435,8 @@ export interface GraphQLArgumentConfig {
     astNode?: Maybe<InputValueDefinitionNode>;
 }
 
-export type GraphQLFieldConfigMap<TSource, TContext> = {
-    [key: string]: GraphQLFieldConfig<TSource, TContext>;
+export type GraphQLFieldConfigMap<TSource, TContext, TArgs = { [key: string]: any }> = {
+    [key: string]: GraphQLFieldConfig<TSource, TContext, TArgs>;
 };
 
 export interface GraphQLField<TSource, TContext, TArgs = { [key: string]: any }> {
@@ -449,8 +461,12 @@ export interface GraphQLArgument {
 
 export function isRequiredArgument(arg: GraphQLArgument): boolean;
 
-export type GraphQLFieldMap<TSource, TContext> = {
-    [key: string]: GraphQLField<TSource, TContext>;
+export type GraphQLFieldMap<
+    TSource,
+    TContext,
+    TArgs = { [key: string]: any }
+> = {
+    [key: string]: GraphQLField<TSource, TContext, TArgs>;
 };
 
 /**
@@ -487,15 +503,19 @@ export class GraphQLInterfaceType {
     inspect(): string;
 }
 
-export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
+export interface GraphQLInterfaceTypeConfig<
+    TSource,
+    TContext,
+    TArgs = { [key: string]: any }
+> {
     name: string;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
+    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
     /**
      * Optionally provide a custom type resolver function. If one is not provided,
      * the default implementation will call `isTypeOf` on each implementing
      * Object type.
      */
-    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
+    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext, TArgs>>;
     description?: Maybe<string>;
     astNode?: Maybe<InterfaceTypeDefinitionNode>;
     extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://graphql.org/graphql-js/type/#graphqlobjecttype
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This builds off of some changes from #22789 and continues having TArgs be optional. This is not a breaking change. It's possible that `unknown` is a better option for TArgs; however, that would be TS3 specific and be a breaking change.

This change is to allow overriding TArgs in more places. For example, allowing `any` args or to restrict args further. This primarily impacts the `GraphQLFieldConfigMap` and `GraphQLObjectType` types.

Using `GraphQLFieldConfigMap` with generics:
```js
const Query = new GraphQLObjectType({
  fields: (): GraphQLFieldConfigMap<void, Context, any> => ({
    someField: getFieldConfig(),
  })
});
```

Using `GraphQLObjectType` with generics:
```js
const Query = new GraphQLObjectType<void, Context, any>({
  fields: () => ({
    someField: getFieldConfig(),
  })
});
```