### PR TITLE
[Ramda] - Added type definition for R.move

### DIFF
--- a/types/ramda/es/move.d.ts
+++ b/types/ramda/es/move.d.ts
@@ -1,0 +1,2 @@
+import { move } from '../index';
+export default move;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -26,6 +26,7 @@
 //                 Drew Wyatt <https://github.com/drewwyatt>
 //                 John Ottenlips <https://github.com/jottenlips>
 //                 Nitesh Phadatare <https://github.com/minitesh>
+//                 Krantisinh Deshmukh <https://github.com/krantisinh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -163,6 +164,7 @@
 /// <reference path="./es/minBy.d.ts" />
 /// <reference path="./es/min.d.ts" />
 /// <reference path="./es/modulo.d.ts" />
+/// <reference path="./es/move.d.ts" />
 /// <reference path="./es/multiply.d.ts" />
 /// <reference path="./es/nAry.d.ts" />
 /// <reference path="./es/negate.d.ts" />
@@ -1574,6 +1576,12 @@ declare namespace R {
          */
         multiply(a: number, b: number): number;
         multiply(a: number): (b: number) => number;
+
+        /**
+         * Moves an item, at index `from`, to index `to`, in a list of elements.
+         * A new list will be created containing the new elements order.
+         */
+        move: CurriedFunction3<number, number, any[], any[]>;
 
         /**
          * Wraps a function of any arity (including nullary) in a function that accepts exactly n parameters.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1578,10 +1578,12 @@ declare namespace R {
         multiply(a: number): (b: number) => number;
 
         /**
-         * Moves an item, at index `from`, to index `to`, in a list of elements.
+         * Moves an item, at index `from`, to index `to`, in a `list` of elements.
          * A new list will be created containing the new elements order.
          */
-        move: CurriedFunction3<number, number, any[], any[]>;
+        move<T>(from: number, to: number, list: ReadonlyArray<T>): T[];
+        move(from: number, to: number): <T>(list: ReadonlyArray<T>) => T[];
+        move(from: number): (<T>(to: number, list: ReadonlyArray<T>) => T[]);
 
         /**
          * Wraps a function of any arity (including nullary) in a function that accepts exactly n parameters.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1583,7 +1583,10 @@ declare namespace R {
          */
         move<T>(from: number, to: number, list: ReadonlyArray<T>): T[];
         move(from: number, to: number): <T>(list: ReadonlyArray<T>) => T[];
-        move(from: number): (<T>(to: number, list: ReadonlyArray<T>) => T[]);
+        move(from: number): {
+            <T>(to: number, list: ReadonlyArray<T>): T[];
+            (to: number): <T>(list: ReadonlyArray<T>) => T[];
+        };
 
         /**
          * Wraps a function of any arity (including nullary) in a function that accepts exactly n parameters.

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1116,6 +1116,23 @@ interface Obj {
 };
 
 () => {
+    const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+    R.move(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+    R.move(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
+
+    const moveCurried1 = R.move(0, 2);
+    moveCurried1(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried2 = R.move(0);
+    moveCurried2(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried3 = R.move(0);
+    const moveCurried4 = moveCurried3(2);
+    moveCurried4(sampleList);  // => ['b', 'c', 'a', 'd', 'e', 'f']
+};
+
+() => {
     R.none(R.isNaN, [1, 2, 3]); // => true
     R.none(R.isNaN, [1, 2, 3, NaN]); // => false
     R.none(R.isNaN)([1, 2, 3, NaN]); // => false
@@ -2761,21 +2778,4 @@ class Why {
 
 () => {
     R.bind(console.log, console);
-};
-
-() => {
-    const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
-
-    R.move(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-    R.move(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
-
-    const moveCurried1 = R.move(0, 2);
-    moveCurried1(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-
-    const moveCurried2 = R.move(0);
-    moveCurried2(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-
-    const moveCurried3 = R.move(0);
-    const moveCurried4 = moveCurried3(2);
-    moveCurried4(sampleList);  // => ['b', 'c', 'a', 'd', 'e', 'f']
 };

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1126,6 +1126,10 @@ interface Obj {
 
     const moveCurried2 = R.move(0);
     moveCurried2<string>(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried3 = R.move(0);
+    const moveCurried4 = moveCurried3(2);
+    moveCurried4<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1118,18 +1118,14 @@ interface Obj {
 () => {
     const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-    R.move(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-    R.move(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
+    R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+    R.move<string>(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
 
     const moveCurried1 = R.move(0, 2);
-    moveCurried1(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+    moveCurried1<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
 
     const moveCurried2 = R.move(0);
-    moveCurried2(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-
-    const moveCurried3 = R.move(0);
-    const moveCurried4 = moveCurried3(2);
-    moveCurried4(sampleList);  // => ['b', 'c', 'a', 'd', 'e', 'f']
+    moveCurried2<string>(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2762,3 +2762,20 @@ class Why {
 () => {
     R.bind(console.log, console);
 };
+
+() => {
+    const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+    R.move(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+    R.move(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
+
+    const moveCurried1 = R.move(0, 2);
+    moveCurried1(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried2 = R.move(0);
+    moveCurried2(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried3 = R.move(0);
+    const moveCurried4 = moveCurried3(2);
+    moveCurried4(sampleList);  // => ['b', 'c', 'a', 'd', 'e', 'f']
+};


### PR DESCRIPTION
Added a missing type definition for R.move

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#move