### PR TITLE
Lodash: fix `values` when used with enums

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5904,6 +5904,8 @@ fp.now(); // $ExpectType number
         c: 'c';
     } = anything;
     _.values(abcObjectLiteral); // $ExpectType ('a' | 'b' | 'c')[]
+    enum AbcEnum { a = 'a', b = 'b', c = 'c' };
+    _.values(AbcEnum); // $ExpectType AbcEnum[]
 
     _(true).values(); // $ExpectType LoDashImplicitWrapper<any[]>
     _("hi").values(); // $ExpectType LoDashImplicitWrapper<string[]>

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5898,6 +5898,12 @@ fp.now(); // $ExpectType number
     _.values(numDict); // $ExpectType AbcObject[]
     _.values(list); // $ExpectType AbcObject[]
     _.values(abcObject); // $ExpectType (string | number | boolean)[]
+    const abcObjectLiteral: {
+        a: 'a';
+        b: 'b';
+        c: 'c';
+    } = anything;
+    _.values(abcObjectLiteral); // $ExpectType ('a' | 'b' | 'c')[]
 
     _(true).values(); // $ExpectType LoDashImplicitWrapper<any[]>
     _("hi").values(); // $ExpectType LoDashImplicitWrapper<string[]>


### PR DESCRIPTION
See the failing test. I'm not sure how to fix this. If I remove the first `values` overload, it fixes this issue but seems to create other issues.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
