### PR TITLE
[iobroker] Don't strip null | undefined from async `getState/getObject`

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1081,12 +1081,12 @@ declare global {
             setObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObject(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
             /** Creates or overwrites an object in the object db */
-            setObjectAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            setObjectAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Creates an object in the object db. Existing objects are not overwritten. */
             setObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObjectNotExists(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
             /** Creates an object in the object db. Existing objects are not overwritten. */
-            setObjectNotExistsAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            setObjectNotExistsAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Get all states, channels and devices of this adapter */
             getAdapterObjects(callback: (objects: Record<string, ioBroker.Object>) => void): void;
             /** Get all states, channels and devices of this adapter */
@@ -1095,7 +1095,7 @@ declare global {
             extendObject(id: string, objPart: PartialObject, callback?: SetObjectCallback): void;
             extendObject(id: string, objPart: PartialObject, options: unknown, callback?: SetObjectCallback): void;
             /** Extend an object and create it if it might not exist */
-            extendObjectAsync(id: string, objPart: PartialObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            extendObjectAsync(id: string, objPart: PartialObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /**
              * Deletes an object from the object db
              * @param id - The id of the object without namespace
@@ -1133,17 +1133,17 @@ declare global {
             setForeignObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObject(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
-            setForeignObjectAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            setForeignObjectAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Creates an object (which might not belong to this adapter) in the object db. Existing objects are not overwritten. */
             setForeignObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObjectNotExists(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
             /** Creates an object (which might not belong to this adapter) in the object db. Existing objects are not overwritten. */
-            setForeignObjectNotExistsAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            setForeignObjectNotExistsAsync(id: string, obj: ioBroker.SettableObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Extend an object (which might not belong to this adapter) and create it if it might not exist */
             extendForeignObject(id: string, objPart: PartialObject, callback?: SetObjectCallback): void;
             extendForeignObject(id: string, objPart: PartialObject, options: unknown, callback?: SetObjectCallback): void;
             /** Extend an object (which might not belong to this adapter) and create it if it might not exist */
-            extendForeignObjectAsync(id: string, objPart: PartialObject, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            extendForeignObjectAsync(id: string, objPart: PartialObject, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /**
              * Finds an object by its ID or name
              * @param type - common.type of the state
@@ -1178,36 +1178,36 @@ declare global {
             setState(id: string, state: string | number | boolean | State | Partial<State>, options: unknown, callback?: SetStateCallback): void;
             setState(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown, callback?: SetStateCallback): void;
             /** Writes a value into the states DB. */
-            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<CallbackReturnTypeOf<SetStateCallback>>;
-            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<CallbackReturnTypeOf<SetStateCallback>>;
-            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<CallbackReturnTypeOf<SetStateCallback>>;
+            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            setStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(id: string, state: string | number | boolean | State | Partial<State>, callback?: SetStateChangedCallback): void;
             setStateChanged(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, callback?: SetStateChangedCallback): void;
             setStateChanged(id: string, state: string | number | boolean | State | Partial<State>, options: unknown, callback?: SetStateChangedCallback): void;
             setStateChanged(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown, callback?: SetStateChangedCallback): void;
             /** Writes a value into the states DB only if it has changed. */
-            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
-            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
-            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
+            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(id: string, state: string | number | boolean | State | Partial<State>, callback?: SetStateCallback): void;
             setForeignState(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, callback?: SetStateCallback): void;
             setForeignState(id: string, state: string | number | boolean | State | Partial<State>, options: unknown, callback?: SetStateCallback): void;
             setForeignState(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown, callback?: SetStateCallback): void;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
-            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<CallbackReturnTypeOf<SetStateCallback>>;
-            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<CallbackReturnTypeOf<SetStateCallback>>;
-            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<CallbackReturnTypeOf<SetStateCallback>>;
+            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            setForeignStateAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, callback?: SetStateChangedCallback): void;
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, callback?: SetStateChangedCallback): void;
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, options: unknown, callback?: SetStateChangedCallback): void;
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown, callback?: SetStateChangedCallback): void;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<CallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             // tslint:enable:unified-signatures
 
             /** Read a value from the states DB. */
@@ -1266,7 +1266,7 @@ declare global {
              * @param binary The data to be written
              * @param options (optional) Some internal options.
              */
-            setBinaryStateAsync(id: string, binary: Buffer, options?: unknown): Promise<CallbackReturnTypeOf<SetStateCallback>>;
+            setBinaryStateAsync(id: string, binary: Buffer, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /**
              * Reads a binary state from Redis
              * @param id The id of the state
@@ -1296,7 +1296,7 @@ declare global {
             getEnums(enumList: EnumList, callback: GetEnumsCallback): void;
             getEnums(enumList: EnumList, options: unknown, callback: GetEnumsCallback): void;
             /** Returns the enum tree, filtered by the optional enum name */
-            getEnumsAsync(enumList: EnumList, options?: unknown): Promise<CallbackReturnTypeOf<GetEnumsCallback>>;
+            getEnumsAsync(enumList: EnumList, options?: unknown): Promise<NonNullCallbackReturnTypeOf<GetEnumsCallback>>;
 
             addChannelToEnum(enumName: string, addTo: string, parentDevice: string, channelName: string, callback?: ErrorCallback): void;
             addChannelToEnum(enumName: string, addTo: string, parentDevice: string, channelName: string, options: unknown, callback?: ErrorCallback): void;
@@ -1371,9 +1371,9 @@ declare global {
             createDevice(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native: Record<string, any>, callback?: SetObjectCallback): void;
             createDevice(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native: Record<string, any>, options: unknown, callback?: SetObjectCallback): void;
             /** creates an object with type device */
-            createDeviceAsync(deviceName: string, common?: Partial<ioBroker.ObjectCommon>): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
-            createDeviceAsync(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native?: Record<string, any>): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
-            createDeviceAsync(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native: Record<string, any>, options?: unknown): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            createDeviceAsync(deviceName: string, common?: Partial<ioBroker.ObjectCommon>): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            createDeviceAsync(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native?: Record<string, any>): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            createDeviceAsync(deviceName: string, common: Partial<ioBroker.ObjectCommon>, native: Record<string, any>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** deletes a device, its channels and states */
             deleteDevice(deviceName: string, callback?: ErrorCallback): void;
             deleteDevice(deviceName: string, options: unknown, callback?: ErrorCallback): void;
@@ -1389,14 +1389,14 @@ declare global {
                 native: Record<string, any>, options: unknown, callback?: SetObjectCallback
             ): void;
             /** Creates an object with type channel. It must be located under a device */
-            createChannelAsync(parentDevice: string, channelName: string, roleOrCommon?: string | Partial<ioBroker.ChannelCommon>): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            createChannelAsync(parentDevice: string, channelName: string, roleOrCommon?: string | Partial<ioBroker.ChannelCommon>): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             createChannelAsync(
                 parentDevice: string, channelName: string, roleOrCommon: string | Partial<ioBroker.ChannelCommon>, native?: Record<string, any>
-            ): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             createChannelAsync(
                 parentDevice: string, channelName: string, roleOrCommon: string | Partial<ioBroker.ChannelCommon>, native: Record<string, any>,
                 options?: unknown
-            ): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Deletes a channel and its states. It must have been created with `createChannel` */
             deleteChannel(channelName: string, options?: unknown, callback?: ErrorCallback): void;
             deleteChannel(parentDevice: string, channelName: string, options?: unknown, callback?: ErrorCallback): void;
@@ -1420,15 +1420,15 @@ declare global {
             /**
              * Creates a state and the corresponding object. It must be located in a channel under a device
              */
-            createStateAsync(parentDevice: string, parentChannel: string, stateName: string, roleOrCommon?: string | Partial<ioBroker.StateCommon>): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            createStateAsync(parentDevice: string, parentChannel: string, stateName: string, roleOrCommon?: string | Partial<ioBroker.StateCommon>): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             createStateAsync(
                 parentDevice: string, parentChannel: string, stateName: string, roleOrCommon: string | Partial<ioBroker.StateCommon>,
                 native?: Record<string, any>
-            ): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             createStateAsync(
                 parentDevice: string, parentChannel: string, stateName: string, roleOrCommon: string | Partial<ioBroker.StateCommon>,
                 native: Record<string, any>, options?: unknown
-            ): Promise<CallbackReturnTypeOf<SetObjectCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             /** Deletes a state. It must have been created with `createState` */
             deleteState(stateName: string, options?: unknown, callback?: ErrorCallback): void;
             deleteState(parentChannel: string, stateName: string, options?: unknown, callback?: ErrorCallback): void;
@@ -1518,7 +1518,7 @@ declare global {
              * @param adapterName - adapter name. If adapter name is null, default will be the name of the current adapter.
              * @param path - path to directory without adapter name. E.g. If you want to read "/vis.0/main/views.json", here must be "/main/views.json" and _adapter must be equal to "vis.0".
              */
-            readDirAsync(adapterName: string | null, path: string, options?: unknown): Promise<CallbackReturnTypeOf<ReadDirCallback>>;
+            readDirAsync(adapterName: string | null, path: string, options?: unknown): Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;
 
             mkDir(adapterName: string | null, path: string, callback: ErrorCallback): void;
             mkDir(adapterName: string | null, path: string, options: unknown, callback: ErrorCallback): void;
@@ -1644,7 +1644,10 @@ declare global {
         type GetObjectsCallback3<T extends BaseObject> = (err: string | null, result?: Array<GetObjectsItem<T>>) => void;
 
         type SecondParameterOf<T extends (...args: any[]) => any> = T extends (arg0: any, arg1: infer R, ...args: any[]) => any ? R : never;
-        type CallbackReturnTypeOf<T extends (...args: any[]) => any> = Exclude<SecondParameterOf<T>, null | undefined>;
+        /** Infers the return type from a callback-style API and strips out null and undefined */
+        type NonNullCallbackReturnTypeOf<T extends (...args: any[]) => any> = Exclude<SecondParameterOf<T>, null | undefined>;
+        /** Infers the return type from a callback-style API and and leaves null and undefined in */
+        type CallbackReturnTypeOf<T extends (...args: any[]) => any> = SecondParameterOf<T>;
         type GetStateCallback = (err: string | null, state: State | null | undefined) => void;
         type GetStatesCallback = (err: string | null, states: Record<string, State>) => void;
         /** Version of the callback used by States.getStates */

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1205,9 +1205,15 @@ declare global {
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, options: unknown, callback?: SetStateChangedCallback): void;
             setForeignStateChanged(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown, callback?: SetStateChangedCallback): void;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, options?: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
-            setForeignStateChangedAsync(id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(
+                id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean
+            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(
+                id: string, state: string | number | boolean | State | Partial<State>, options?: unknown
+            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            setForeignStateChangedAsync(
+                id: string, state: string | number | boolean | State | Partial<State>, ack: boolean, options: unknown
+            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             // tslint:enable:unified-signatures
 
             /** Read a value from the states DB. */
@@ -1420,7 +1426,9 @@ declare global {
             /**
              * Creates a state and the corresponding object. It must be located in a channel under a device
              */
-            createStateAsync(parentDevice: string, parentChannel: string, stateName: string, roleOrCommon?: string | Partial<ioBroker.StateCommon>): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            createStateAsync(
+                parentDevice: string, parentChannel: string, stateName: string, roleOrCommon?: string | Partial<ioBroker.StateCommon>
+            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
             createStateAsync(
                 parentDevice: string, parentChannel: string, stateName: string, roleOrCommon: string | Partial<ioBroker.StateCommon>,
                 native?: Record<string, any>

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -149,6 +149,13 @@ adapter.setForeignStateChangedAsync("state.name", "value").then(id => id.toLower
 adapter.setForeignStateChangedAsync("state.name", "value", true).then(id => id.toLowerCase());
 adapter.setForeignStateChangedAsync("state.name", { val: "value", ack: true }).then(id => id.toLowerCase());
 
+adapter.getState("state.id", (err, state) => state && state.from.toLowerCase());
+adapter.getStateAsync("state.id").then(state => state && state.from.toLowerCase());
+adapter.getForeignState("state.id", (err, state) => state && state.from.toLowerCase());
+adapter.getForeignStateAsync("state.id").then(state => state && state.from.toLowerCase());
+adapter.getBinaryState("state.id", (err, state) => state && state.writeUInt16BE(0, 0));
+adapter.getBinaryStateAsync("state.id").then(state => state && state.writeUInt16BE(0, 0));
+
 adapter.setObject("obj.id", { type: "state", common: { name: "foo" }, native: {} });
 adapter.setObject("obj.id", { type: "state", common: { name: "foo" }, native: {} }, (err, id) => { });
 adapter.setForeignObject("obj.id", { type: "state", common: { name: "foo" }, native: {} });
@@ -168,8 +175,8 @@ adapter.setForeignObjectNotExistsAsync("obj.id", { type: "state", common: { name
 adapter.getObject("obj.id", (err, obj) => { });
 adapter.getForeignObject("obj.id", (err, obj) => { });
 
-adapter.getObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
-adapter.getForeignObjectAsync("obj.id").then(obj => obj._id.toLowerCase());
+adapter.getObjectAsync("obj.id").then(obj => obj && obj._id.toLowerCase());
+adapter.getForeignObjectAsync("obj.id").then(obj => obj && obj._id.toLowerCase());
 
 adapter.getForeignObjects("*", (err, objs) => objs["foo"]._id.toLowerCase());
 adapter.getForeignObjectsAsync("*").then(objs => objs["foo"]._id.toLowerCase());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

#31742 stripped out `null | undefined` on some methods where this is a valid return type. This PR fixes that.