### PR TITLE
[@ledgerhq/hw-transport] Fix tests for typescript 3.4

### DIFF
--- a/types/ledgerhq__hw-transport-node-hid/ledgerhq__hw-transport-node-hid-tests.ts
+++ b/types/ledgerhq__hw-transport-node-hid/ledgerhq__hw-transport-node-hid-tests.ts
@@ -2,8 +2,7 @@ import Transport from "@ledgerhq/hw-transport-node-hid";
 
 // $ExpectType Promise<boolean>
 Transport.isSupported();
-// $ExpectType Promise<ReadonlyArray<string>>
-Transport.list();
+const list: Promise<ReadonlyArray<string>> = Transport.list();
 // $ExpectType Promise<TransportNodeHid>
 Transport.open("test");
 

--- a/types/ledgerhq__hw-transport-u2f/ledgerhq__hw-transport-u2f-tests.ts
+++ b/types/ledgerhq__hw-transport-u2f/ledgerhq__hw-transport-u2f-tests.ts
@@ -2,8 +2,7 @@ import Transport from "@ledgerhq/hw-transport-u2f";
 
 // $ExpectType Promise<boolean>
 Transport.isSupported();
-// $ExpectType Promise<ReadonlyArray<string>>
-Transport.list();
+const list: Promise<ReadonlyArray<string>> = Transport.list();
 // $ExpectType Promise<TransportU2F>
 Transport.open("test");
 

--- a/types/ledgerhq__hw-transport/ledgerhq__hw-transport-tests.ts
+++ b/types/ledgerhq__hw-transport/ledgerhq__hw-transport-tests.ts
@@ -2,8 +2,7 @@ import Transport from "@ledgerhq/hw-transport";
 
 // $ExpectType Promise<boolean>
 Transport.isSupported();
-// $ExpectType Promise<ReadonlyArray<string>>
-Transport.list();
+const list: Promise<ReadonlyArray<string>> = Transport.list();
 // $ExpectType Promise<Transport<string>>
 Transport.open("test");
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No functional change, just update tests to work with typescript 3.4 which seems to have a different handling of `ReadonlyArray` now (see e.g. #32661 for details).

I tried to assert on `readonly string[]` instead `ReadonlyArray<string>` but this fails for older typescript versions. I think the current test should do effectively the same as before.