### PR TITLE
add types for aws-param-store

### DIFF
--- a/types/aws-param-store/aws-param-store-tests.ts
+++ b/types/aws-param-store/aws-param-store-tests.ts
@@ -1,0 +1,78 @@
+import { SSM } from 'aws-sdk';
+import {
+    ParameterQuery,
+    parameterQuery,
+    getParameter,
+    getParameters,
+    getParametersByPath,
+    getParameterSync,
+    getParametersSync,
+    getParametersByPathSync,
+} from 'aws-param-store';
+
+declare let bool: boolean;
+declare let query: ParameterQuery;
+declare let psName: SSM.Types.PSParameterName;
+declare let psNames: SSM.Types.ParameterNameList;
+declare let options: SSM.Types.ClientConfiguration;
+declare let paramResult: SSM.Types.Parameter;
+declare let paramsResult: SSM.Types.GetParametersResult;
+declare let paramsByPathResult: SSM.Types.ParameterList;
+declare let allParamResults: SSM.Types.Parameter | SSM.Types.GetParametersByPathResult | SSM.Types.ParameterList;
+declare let promiseParamResult: Promise<SSM.Types.Parameter>;
+declare let promiseParamsResult: Promise<SSM.Types.GetParametersResult>;
+declare let promiseParamsByPathResult: Promise<SSM.Types.ParameterList>;
+declare let promiseAllParamResults: Promise<typeof allParamResults>;
+
+query = parameterQuery();
+
+query.path(psName);
+query.named(psName);
+query.named(psNames);
+query.decryption(bool);
+query.recursive(bool);
+
+promiseAllParamResults = query.execute();
+allParamResults = query.executeSync();
+
+// test chaining
+query = query
+.path(psName)
+.named(psName)
+.named(psNames)
+.decryption(bool)
+.recursive(bool);
+
+promiseAllParamResults = query
+.path(psName)
+.named(psName)
+.named(psNames)
+.decryption(bool)
+.recursive(bool)
+.execute();
+
+allParamResults = query
+.path(psName)
+.named(psName)
+.named(psNames)
+.decryption(bool)
+.recursive(bool)
+.executeSync();
+
+promiseParamResult = getParameter(psName);
+promiseParamResult = getParameter(psName, options);
+
+promiseParamsResult = getParameters(psNames);
+promiseParamsResult = getParameters(psNames, options);
+
+promiseParamsByPathResult = getParametersByPath(psNames);
+promiseParamsByPathResult = getParametersByPath(psNames, options);
+
+paramResult = getParameterSync(psName);
+paramResult = getParameterSync(psName, options);
+
+paramsResult = getParametersSync(psNames);
+paramsResult = getParametersSync(psNames, options);
+
+paramsByPathResult = getParametersByPathSync(psNames);
+paramsByPathResult = getParametersByPathSync(psNames, options);

--- a/types/aws-param-store/index.d.ts
+++ b/types/aws-param-store/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for aws-param-store 2.1
+// Project: https://github.com/vandium-io/aws-param-store#readme
+// Definitions by: Jason Gray <https://github.com/jasonthomasgray>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { SSM } from 'aws-sdk';
+
+export function getParameter(
+    name: SSM.Types.PSParameterName,
+    options?: SSM.Types.ClientConfiguration
+): Promise<SSM.Types.Parameter>;
+
+export function getParameterSync(
+    name: SSM.Types.PSParameterName,
+    options?: SSM.Types.ClientConfiguration
+): SSM.Types.Parameter;
+
+export function getParameters(
+    names: SSM.Types.ParameterNameList,
+    options?: SSM.Types.ClientConfiguration
+): Promise<SSM.Types.GetParametersResult>;
+
+export function getParametersSync(
+    names: SSM.Types.ParameterNameList,
+    options?: SSM.Types.ClientConfiguration
+): SSM.Types.GetParametersResult;
+
+export function getParametersByPath(
+    path: SSM.Types.ParameterNameList,
+    options?: SSM.Types.ClientConfiguration
+): Promise<SSM.Types.ParameterList>;
+
+export function getParametersByPathSync(
+    path: SSM.Types.ParameterNameList,
+    options?: SSM.Types.ClientConfiguration
+): SSM.Types.ParameterList;
+
+export interface ParameterQuery {
+    path(path: SSM.Types.PSParameterName): ParameterQuery;
+    named(nameOrNames: SSM.Types.PSParameterName | SSM.Types.ParameterNameList): ParameterQuery;
+    decryption(enabled: boolean): ParameterQuery;
+    recursive(enabled: boolean): ParameterQuery;
+    execute(): Promise<SSM.Types.ParameterList | SSM.Types.Parameter | SSM.Types.GetParametersResult>;
+    executeSync(): SSM.Types.ParameterList | SSM.Types.Parameter | SSM.Types.GetParametersResult;
+}
+
+export function parameterQuery(options?: SSM.Types.ClientConfiguration): ParameterQuery;

--- a/types/aws-param-store/package.json
+++ b/types/aws-param-store/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.325.0"
+    }
+}

--- a/types/aws-param-store/tsconfig.json
+++ b/types/aws-param-store/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "aws-param-store-tests.ts"
+    ]
+}

--- a/types/aws-param-store/tslint.json
+++ b/types/aws-param-store/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
