### PR TITLE
Elliptic.js: Key creation also accepts String

### DIFF
--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -175,8 +175,8 @@ export class ec {
     constructor(options: string | curves.PresetCurve)
 
     keyPair(options: ec.KeyPairOptions): ec.KeyPair;
-    keyFromPrivate(priv: Buffer | ec.KeyPair, enc?: string): ec.KeyPair;
-    keyFromPublic(pub: Buffer | ec.KeyPair, enc?: string): ec.KeyPair;
+    keyFromPrivate(priv: Buffer | string | ec.KeyPair, enc?: string): ec.KeyPair;
+    keyFromPublic(pub: Buffer | string | ec.KeyPair, enc?: string): ec.KeyPair;
     genKeyPair(options?: ec.GenKeyPairOptions): ec.KeyPair;
     sign(msg: BNInput, key: Buffer | ec.KeyPair, enc: string, options?: ec.SignOptions): ec.Signature;
     sign(msg: BNInput, key: Buffer | ec.KeyPair, options?: ec.SignOptions): ec.Signature;
@@ -201,8 +201,8 @@ export namespace ec {
     }
 
     class KeyPair {
-        static fromPublic(ec: ec, pub: Buffer | KeyPair, enc?: string): KeyPair;
-        static fromPrivate(ec: ec, priv: Buffer | KeyPair, enc?: string): KeyPair;
+        static fromPublic(ec: ec, pub: Buffer | string | KeyPair, enc?: string): KeyPair;
+        static fromPrivate(ec: ec, priv: Buffer | string | KeyPair, enc?: string): KeyPair;
 
         ec: ec;
 


### PR DESCRIPTION
`_importPrivate` takes the input an creates a BN, this input can be a number encoded as a Hex String in addition to the already supported Buffer.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/key.js#L78
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

