### PR TITLE
puppeteer: preserve type information in Page.evaluate and friends

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -490,6 +490,7 @@ export interface EmulateOptions {
 }
 
 export type EvaluateFn = string | ((...args: any[]) => any);
+export type EvaluateFnReturnType<T extends EvaluateFn> = T extends ((...args: any[]) => infer R) ? R : any;
 
 export type LoadEvent =
   | "load"
@@ -729,10 +730,10 @@ export interface Worker {
    * If the function passed to the `worker.evaluate` returns a non-Serializable value,
    * then `worker.evaluate` resolves to `undefined`.
    */
-  evaluate<T>(
-    pageFunction: (...args: any[]) => T | Promise<T>,
+  evaluate<T extends EvaluateFn>(
+    pageFunction: T,
     ...args: SerializableOrJSHandle[],
-  ): Promise<T>;
+  ): Promise<EvaluateFnReturnType<T>>;
 
   /**
    * The only difference between `worker.evaluate` and `worker.evaluateHandle` is
@@ -841,10 +842,10 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle, Ev
 
 /** The class represents a context for JavaScript execution. */
 export interface ExecutionContext {
-  evaluate(
-    fn: EvaluateFn,
+  evaluate<F extends EvaluateFn>(
+    fn: F,
     ...args: SerializableOrJSHandle[]
-  ): Promise<any>;
+  ): Promise<EvaluateFnReturnType<F>>;
   evaluateHandle(
     fn: EvaluateFn,
     ...args: SerializableOrJSHandle[]
@@ -1152,10 +1153,10 @@ export interface FrameBase extends Evalable {
    * @param fn Function to be evaluated in browser context
    * @param args Arguments to pass to `fn`
    */
-  evaluate(
-    fn: EvaluateFn,
+  evaluate<F extends EvaluateFn>(
+    fn: F,
     ...args: SerializableOrJSHandle[]
-  ): Promise<any>;
+  ): Promise<EvaluateFnReturnType<F>>;
 
   /**
    * Evaluates a function in the page context.
@@ -1233,19 +1234,19 @@ export interface FrameBase extends Evalable {
    * Shortcut for waitForFunction.
    */
   waitFor(
-    selector: ((...args: any[]) => any) | string,
+    selector: EvaluateFn,
     options?: WaitForSelectorOptions,
     ...args: SerializableOrJSHandle[]
-  ): Promise<any>;
+  ): Promise<JSHandle>;
 
   /**
    * Allows waiting for various conditions.
    */
   waitForFunction(
-    fn: string | ((...args: any[]) => any),
+    fn: EvaluateFn,
     options?: PageFnOptions,
     ...args: SerializableOrJSHandle[]
-  ): Promise<any>;
+  ): Promise<JSHandle>;
 
   /**
    * Wait for the page navigation occur.

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -531,7 +531,7 @@ puppeteer.launch().then(async browser => {
   });
 });
 
-// evaluate returns type of inner function
+// evaluates return type of inner function
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
@@ -547,6 +547,7 @@ puppeteer.launch().then(async browser => {
   console.log('body html has length', s.length);
 });
 
+// JSHandle.jsonValue produces compatible type
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
@@ -574,4 +575,46 @@ puppeteer.launch().then(async browser => {
   await page.setExtraHTTPHeaders({
     a: '1'
   });
+});
+
+// ElementHandles are well-typed
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const link: puppeteer.JSHandle = await page.evaluateHandle(
+    () => document.body.querySelector('a')
+  );
+  const linkEl: puppeteer.ElementHandle | null = link.asElement();
+  if (linkEl !== null) {
+    const href = await page.evaluate(
+      (el: HTMLElement): string | null => el.getAttribute('href'),
+      linkEl);
+    console.log('href is', href);
+  }
+});
+
+// test $$eval return type
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  const paragraphContents: string[] = await page.$$eval(
+    'p', (ps: Element[]): string[] => ps.map(p => p.textContent || ''));
+  console.log('pgraph contents', paragraphContents);
+});
+
+// JSHandle of non-serializable works
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  const reHandle: puppeteer.JSHandle = await page.evaluateHandle(
+    () => /\s*bananas?\s*/i,
+  );
+  const numMatchingEls: number = await page.$$eval(
+    'p', (els: Element[], re: RegExp) =>
+      els.filter(el => el.textContent && re.test(el.textContent)).length,
+      reHandle
+  );
+  console.log('there are', numMatchingEls, 'banana paragaphs');
 });

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -513,3 +513,31 @@ puppeteer.launch().then(async browser => {
     });
   });
 });
+
+// evaluate returns type of inner function
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const s = await page.evaluate(() => document.body.innerHTML);
+  console.log('body html has length', s.length);
+});
+
+// even through a double promise.
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const s = await page.evaluate(() => Promise.resolve(document.body.innerHTML));
+  console.log('body html has length', s.length);
+});
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const s = await page
+    .waitForFunction(
+      (searchStrs: string[]) => searchStrs.find(v => document.body.innerText.includes(v)),
+      { timeout: 2000 },
+      ['once', 'upon', 'a', 'midnight', 'dreary'])
+    .then(j => j.jsonValue());
+  console.log('found in page', s.toLowerCase());
+});


### PR DESCRIPTION
When the EvaluteFn is not a string, it may have type information.
We should try and use its type to inform the return type of
Page.evaluate, or whichever similar function was used.

Some functions (.evaluateHandle, .waitForFunction) return a JSHandle.
JSHandles are not parameterized, so we do not know the underlying type.
It may be worth changing that in a future PR.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [JSHandle.jsonValue() returns any](https://pptr.dev/#?product=Puppeteer&version=v1.12.1&show=api-jshandlejsonvalue)
  - [Page.evaluate resolves to the return value of pageFunction](https://pptr.dev/#?product=Puppeteer&version=v1.12.1&show=api-pageevaluatepagefunction-args)
- [ ] Increase the version number in the header if appropriate.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
