### PR TITLE
types/twit: Adds string[] type to Params.follow type

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -6,7 +6,6 @@
 //                 siwalik <https://github.com/siwalikm>
 //                 plhery <https://github.com/plhery>
 //                 justGoscha <https://github.com/justgoscha>
-//
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -263,7 +263,7 @@ declare module 'twit' {
       user_id?: number | string,
       lat?: number,
       long?: number,
-      follow?: boolean | string,
+      follow?: boolean | string | string[],
       include_email?: boolean,
       cursor?: number | string,
       tweet_mode?: string,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -5,6 +5,8 @@
 //                 abraham <https://github.com/abraham>
 //                 siwalik <https://github.com/siwalikm>
 //                 plhery <https://github.com/plhery>
+//                 justGoscha <https://github.com/justgoscha>
+//
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/twit/twit-tests.ts
+++ b/types/twit/twit-tests.ts
@@ -11,3 +11,8 @@ t.post('statuses/update', { status: 'hello!' }).then(res => {
     console.log(status.id_str)
     console.log(res.resp.statusCode)
 })
+
+t.stream('statuses/filter', {
+    track: ['#love','#goscha'],
+    follow: ['40436619', '606663038', '14466815']
+  })


### PR DESCRIPTION
According to the docs and my previous experience working with the API you can provide arrays, here the official documentation:
https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html

This shouldn't be a breaking change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) 
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html
- [x] Increase the version number in the header if appropriate. *(not needed)*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. *not needed*