### PR TITLE
[jest-image-snapshot]: Update to fix #32760 & for library updates

### DIFF
--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-image-snapshot 2.4
+// Type definitions for jest-image-snapshot 2.8
 // Project: https://github.com/americanexpress/jest-image-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -27,9 +27,17 @@ export interface MatchImageSnapshotOptions {
      */
     customSnapshotsDir?: string;
     /**
+     * A custom absolute path of a directory to keep this diff in
+     */
+    customDiffDir?: string;
+    /**
      * A custom name to give this snapshot. If not provided, one is computed automatically.
      */
     customSnapshotIdentifier?: string;
+    /**
+     * Changes diff image layout direction, default is horizontal.
+     */
+    diffDirection?: 'horizontal' | 'vertical';
     /**
      * Removes coloring from the console output, useful if storing the results to a file.
      * Defaults to false.
@@ -47,6 +55,10 @@ export interface MatchImageSnapshotOptions {
      * Defaults to 'pixel'.
      */
     failureThresholdType?: 'pixel' | 'percent';
+    /**
+     * Updates a snapshot even if it passed the threshold against the existing one, defaults to false.
+     */
+    updatePassedSnapshot?: boolean;
 }
 
 /**
@@ -55,7 +67,7 @@ export interface MatchImageSnapshotOptions {
  *   import { toMatchImageSnapshot } from 'jest-image-snapshot';
  *   expect.extend({ toMatchImageSnapshot });
  */
-export function toMatchImageSnapshot(): { message(): string; pass: boolean; };
+export function toMatchImageSnapshot(options?: MatchImageSnapshotOptions): { message(): string; pass: boolean; };
 
 /**
  * Configurable function that can be passed to jest's expect.extend.
@@ -69,7 +81,7 @@ export function configureToMatchImageSnapshot(options: MatchImageSnapshotOptions
 declare global {
     namespace jest {
         interface Matchers<R> {
-            toMatchImageSnapshot(): R;
+            toMatchImageSnapshot(options?: MatchImageSnapshotOptions): R;
         }
     }
 }

--- a/types/jest-image-snapshot/jest-image-snapshot-tests.ts
+++ b/types/jest-image-snapshot/jest-image-snapshot-tests.ts
@@ -1,5 +1,5 @@
 // Typescript Version: 2.3
-import { toMatchImageSnapshot, configureToMatchImageSnapshot } from 'jest-image-snapshot';
+import { toMatchImageSnapshot, configureToMatchImageSnapshot, MatchImageSnapshotOptions } from 'jest-image-snapshot';
 
 it('should be able to use toMatchImageSnapshot in a test', () => {
     expect.extend({ toMatchImageSnapshot });
@@ -20,4 +20,23 @@ it('should be able to use configureToMatchImageSnapshot in a test', () => {
     expect.extend({ toMatchImageSnapshot: matchFn });
 
     expect('Me').toMatchImageSnapshot();
+});
+
+it('Should be able to use configuration directly in toMatchImageSnapshot', () => {
+    expect.extend({ toMatchImageSnapshot });
+
+    const options: MatchImageSnapshotOptions = {
+        noColors: true,
+        customDiffConfig: {
+            threshold: 5,
+            includeAA: false
+        },
+        customDiffDir: './diffs',
+        diffDirection: 'vertical',
+        updatePassedSnapshot: true,
+        failureThreshold: 10,
+        failureThresholdType: 'percent'
+    };
+
+    expect('Me').toMatchImageSnapshot(options);
 });


### PR DESCRIPTION
* Add new options to MatchImageSnapshotOptions
* toMatchImageSnapshot can be given options directly instead of needing  to use configureToMatchImageSnapshot first for specifying the options.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://github.com/americanexpress/jest-image-snapshot
  Issue #32760 
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - N/A
