### PR TITLE
Elliptic: importFromPublic accepts an object containing X and Y as Strings

### DIFF
--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -176,7 +176,7 @@ export class ec {
 
     keyPair(options: ec.KeyPairOptions): ec.KeyPair;
     keyFromPrivate(priv: Buffer | string | ec.KeyPair, enc?: string): ec.KeyPair;
-    keyFromPublic(pub: Buffer | string | ec.KeyPair, enc?: string): ec.KeyPair;
+    keyFromPublic(pub: Buffer | string | {x: string, y: string} | ec.KeyPair, enc?: string): ec.KeyPair;
     genKeyPair(options?: ec.GenKeyPairOptions): ec.KeyPair;
     sign(msg: BNInput, key: Buffer | ec.KeyPair, enc: string, options?: ec.SignOptions): ec.Signature;
     sign(msg: BNInput, key: Buffer | ec.KeyPair, options?: ec.SignOptions): ec.Signature;
@@ -201,7 +201,7 @@ export namespace ec {
     }
 
     class KeyPair {
-        static fromPublic(ec: ec, pub: Buffer | string | KeyPair, enc?: string): KeyPair;
+        static fromPublic(ec: ec, pub: Buffer | string | {x: string, y: string} | KeyPair, enc?: string): KeyPair;
         static fromPrivate(ec: ec, priv: Buffer | string | KeyPair, enc?: string): KeyPair;
 
         ec: ec;


### PR DESCRIPTION
keyFromPublic takes an object containing both x and y strings encoded… as Hex

`_importPubliic` checks for x anf y on input obbject, then passes it to the `ec.point` constructor that checks if they are BNs, if they are not, it parses them as a Hex encoded number.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/indutny/elliptic/blob/776c9b0e99832ab9fa6c5fa6f684c484ca5265b2/lib/elliptic/ec/key.js#L85
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
