### PR TITLE
reactstrap: Add 'rows' property to input

### DIFF
--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -40,6 +40,7 @@ export type InputProps<T = {}> = React.InputHTMLAttributes<HTMLInputElement> & {
   addon?: boolean;
   className?: string;
   cssModule?: CSSModule;
+  rows?: number;
 } & T;
 
 declare class Input<T> extends React.Component<InputProps<T>> {}


### PR DESCRIPTION
Reactstrap does not have a `<Textarea>` and instead uses  `<Input type="textarea" rows={3}>` for getting a textarea with three rows. Rows is not defined in the types which causes typescript to fail with 

```
(64,14): Type '{ type: "textarea"; name: string; rows: number; autoFocus: true; placeholder: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; value: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Input<{}>> & Readonly<{ children?: ReactNode; }> & Readonly<InputHTMLAttributes<HTMLInputElement> & { type?: "number" | "search" | ... 23 more ... | undefined; ... 9 more ...; cssModule?: CSSModule | undefined; }>'.
  Property 'rows' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Input<{}>> & Readonly<{ children?: ReactNode; }> & Readonly<InputHTMLAttributes<HTMLInputElement> & { type?: "number" | "search" | ... 23 more ... | undefined; ... 9 more ...; cssModule?: CSSModule | undefined; }>'.
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactstrap/reactstrap/search?q=rows&unscoped_q=rows
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

