### PR TITLE
Update react-swipe definition to add childCount prop

### DIFF
--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-swipe 6.0
 // Project: https://github.com/voronianski/react-swipe
-// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>, Ammar Alakkad <https://github.com/AAlakkad> 
+// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>, Ammar Alakkad <https://github.com/AAlakkad>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-swipe 6.0
 // Project: https://github.com/voronianski/react-swipe
-// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
+// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>, Ammar Alakkad <https://github.com/AAlakkad> 
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-swipe 5.0
+// Type definitions for react-swipe 6.0
 // Project: https://github.com/voronianski/react-swipe
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,6 +26,7 @@ declare namespace ReactSwipe {
     interface Props {
         id?: string;
         swipeOptions?: SwipeOptions;
+        childCount?: number;
         style?: Style;
         className?: string;
     }

--- a/types/react-swipe/react-swipe-tests.tsx
+++ b/types/react-swipe/react-swipe-tests.tsx
@@ -53,6 +53,7 @@ class ReactSwipeTest extends React.PureComponent {
                 id="test-carousel"
                 swipeOptions={swipeOptions}
                 style={style}
+                childCount={3}
                 ref={(swipeComponent) => { this.swipeComponent = swipeComponent; }}
             >
                 <div>PANE 1</div>


### PR DESCRIPTION
I've added `childCount` prop to `react-swipe` library, its usage is explained in the library [repository](https://github.com/voronianski/react-swipe#props)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/voronianski/react-swipe#props
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.