### PR TITLE
libxmljs: Allow booleans in parser options

### DIFF
--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -14,12 +14,15 @@ export const libxml_parser_version: string;
 // tslint:disable-next-line:strict-export-declare-modifiers
 interface StringMap { [key: string]: string; }
 
-export function parseXml(source: string, options?: StringMap): Document;
-export function parseXmlString(source: string, options?: StringMap): Document;
+// tslint:disable-next-line:strict-export-declare-modifiers
+interface ParserOptions { [key: string]: boolean | string; }
 
-export function parseHtml(source: string, options?: StringMap): Document;
-export function parseHtmlString(source: string, options?: StringMap): Document;
-export function parseHtmlFragment(source: string, options?: StringMap): Document;
+export function parseXml(source: string, options?: ParserOptions): Document;
+export function parseXmlString(source: string, options?: ParserOptions): Document;
+
+export function parseHtml(source: string, options?: ParserOptions): Document;
+export function parseHtmlString(source: string, options?: ParserOptions): Document;
+export function parseHtmlFragment(source: string, options?: ParserOptions): Document;
 
 export function memoryUsage(): number;
 export function nodeCount(): number;

--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -116,6 +116,7 @@ export class Element extends Node {
     prevElement(): Element|null;
     nextElement(): Element|null;
     addNextSibling(siblingNode: Node): Node;
+    addPrevSibling(siblingNode: Node): Node;
 
     find(xpath: string, ns_uri?: string): Node[];
     find(xpath: string, namespaces: StringMap): Node[];

--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -15,7 +15,40 @@ export const libxml_parser_version: string;
 interface StringMap { [key: string]: string; }
 
 // tslint:disable-next-line:strict-export-declare-modifiers
-interface ParserOptions { [key: string]: boolean | string; }
+interface ParserOptions {
+    recover?: boolean;
+    noent?: boolean;
+    dtdload?: boolean;
+    doctype?: boolean;
+    dtdattr?: any;
+    dtdvalid?: boolean;
+    noerror?: boolean;
+    errors?: boolean;
+    nowarning?: boolean;
+    warnings?: boolean;
+    pedantic?: boolean;
+    noblanks?: boolean;
+    blanks?: boolean;
+    sax1?: boolean;
+    xinclude?: boolean;
+    nonet?: boolean;
+    net?: boolean;
+    nodict?: boolean;
+    dict?: boolean;
+    nsclean?: boolean;
+    implied?: boolean;
+    nocdata?: boolean;
+    cdata?: boolean;
+    noxincnode?: boolean;
+    compact?: boolean;
+    old?: boolean;
+    nobasefix?: boolean;
+    basefix?: boolean;
+    huge?: boolean;
+    oldsax?: boolean;
+    ignore_enc?: boolean;
+    big_lines?: boolean;
+}
 
 export function parseXml(source: string, options?: ParserOptions): Document;
 export function parseXmlString(source: string, options?: ParserOptions): Document;


### PR DESCRIPTION
I needed to set the option `recover: true`, this allows that. I also added a missing `addPrevSibling()` type based on the existing `addNextSibling()` type.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/libxmljs/libxmljs/wiki/Element#elementaddprevsiblingsiblingnode
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
