### PR TITLE
Add missing children prop in exotic component

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -21,6 +21,7 @@
 //                 Jessica Franco <https://github.com/Jessidhia>
 //                 Paul Sherman <https://github.com/pshrmn>
 //                 Sunil Pai <https://github.com/threepointone>
+//                 Peter Keuter <https://github.com/pkeuter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -297,7 +298,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement<any>|null);
+        (props: P & { children?: ReactNode }): (ReactElement<any>|null);
         readonly $$typeof: symbol;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


This change is needed when using for example: 

```
 private WrappedPlayer = React.forwardRef<HTMLAudioElement>((props, ref) => (
    <audio autoPlay ref={ref} {...props} />
  ));
```

This changes makes it possible to pass children, because now it throws an error because the created forwardref component doesn't accept the children prop.

```
<this.WrappedPlayer ref={this.player}>
          <source src={this.props.url} type="audio/mpeg" />
</this.WrappedPlayer>
```

![image](https://user-images.githubusercontent.com/433441/52274201-3a11a900-294c-11e9-8c25-7eb11dd85de4.png)

By adding `{ children?: ReactNode }`, this problem is mitigated.