### PR TITLE
component-emitter: 2 small fixes

### DIFF
--- a/types/component-emitter/component-emitter-tests.ts
+++ b/types/component-emitter/component-emitter-tests.ts
@@ -48,3 +48,5 @@ emitter.emit('some-recurring-event', event_data)
 emitter.listeners('some-recurring-event')
 
 emitter.hasListeners('some-recurring-event')
+
+emitter.emit('some-event').emit("I can use chaining!")

--- a/types/component-emitter/index.d.ts
+++ b/types/component-emitter/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Peter Snider <https://github.com/psnider>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/emitter-component
 
+// TypeScript Version: 2.2
 
 interface Emitter {
     on(event: string, listener: Function): Emitter;

--- a/types/component-emitter/index.d.ts
+++ b/types/component-emitter/index.d.ts
@@ -8,14 +8,14 @@ interface Emitter {
     on(event: string, listener: Function): Emitter;
     once(event: string, listener: Function): Emitter;
     off(event?: string, listener?: Function): Emitter;
-    emit(event: string, ...args: any[]): boolean;
+    emit(event: string, ...args: any[]): Emitter;
     listeners(event: string): Function[];
     hasListeners(event: string): boolean;
 }
 
 declare const Emitter: {
-    (obj?: any): Emitter;
-    new (obj?: any): Emitter;
+    (obj?: object): Emitter;
+    new (obj?: object): Emitter;
 };
 
 export = Emitter;

--- a/types/socketcluster-client/lib/scclientsocket.d.ts
+++ b/types/socketcluster-client/lib/scclientsocket.d.ts
@@ -105,7 +105,7 @@ declare class SCClientSocket extends Emitter {
     on(event: string, listener: Function): this;
     once(event: string, listener: Function): this;
     off(event?: string, listener?: Function): this;
-    emit(event: string, ...args: any[]): boolean;
+    emit(event: string, ...args: any[]): this;
     listeners(event: string): Function[];
     hasListeners(event: string): boolean;
     // tslint:enable:adjacent-overload-signatures

--- a/types/socketcluster-server/scserversocket.d.ts
+++ b/types/socketcluster-server/scserversocket.d.ts
@@ -52,7 +52,7 @@ declare class SCServerSocket extends Emitter {
     sendObjectSingle(object: any): void;
     sendObject(object: any, options?: { batch?: boolean }): void;
 
-    emit(event: string, ...args: any[]): boolean;
+    emit(event: string, ...args: any[]): this;
     emit(event: string, data: any, callback?: SCServerSocket.EmitCallback, options?: SCServerSocket.EmitOptions): void;
 
     triggerAuthenticationEvents(oldState: "authenticated" | "unauthenticated"): void;


### PR DESCRIPTION
2 changes: 

- `.emit()` returns an `Emitter` and not a `boolean`. 
(See: https://github.com/component/emitter/blob/master/index.js#L144) 
- The `Emitter` constructor does not really accept `any`, using the `object` type from TypeScript 2.2 is more correct. 
(e.g. if calling Emitter without the `new` keyword and the argument `true` is given, then the value `true` will be returned instead of an Emitter. The code is here: https://github.com/component/emitter/blob/master/index.js#L17). 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/component/emitter/blob/master/index.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

