### PR TITLE
[node] definitions for crypto.constants

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -11,6 +11,101 @@ declare module "crypto" {
         (): Certificate;
     };
 
+    namespace constants { // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+        const OPENSSL_VERSION_NUMBER: number;
+
+        /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
+        const SSL_OP_ALL: number;
+        /** Allows legacy insecure renegotiation between OpenSSL and unpatched clients or servers. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html. */
+        const SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
+        /** Attempts to use the server's preferences instead of the client's when selecting a cipher. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html. */
+        const SSL_OP_CIPHER_SERVER_PREFERENCE: number;
+        /** Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER. */
+        const SSL_OP_CISCO_ANYCONNECT: number;
+        /** Instructs OpenSSL to turn on cookie exchange. */
+        const SSL_OP_COOKIE_EXCHANGE: number;
+        /** Instructs OpenSSL to add server-hello extension from an early version of the cryptopro draft. */
+        const SSL_OP_CRYPTOPRO_TLSEXT_BUG: number;
+        /** Instructs OpenSSL to disable a SSL 3.0/TLS 1.0 vulnerability workaround added in OpenSSL 0.9.6d. */
+        const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: number;
+        /** Instructs OpenSSL to always use the tmp_rsa key when performing RSA operations. */
+        const SSL_OP_EPHEMERAL_RSA: number;
+        /** Allows initial connection to servers that do not support RI. */
+        const SSL_OP_LEGACY_SERVER_CONNECT: number;
+        const SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER: number;
+        const SSL_OP_MICROSOFT_SESS_ID_BUG: number;
+        /** Instructs OpenSSL to disable the workaround for a man-in-the-middle protocol-version vulnerability in the SSL 2.0 server implementation. */
+        const SSL_OP_MSIE_SSLV2_RSA_PADDING: number;
+        const SSL_OP_NETSCAPE_CA_DN_BUG: number;
+        const SSL_OP_NETSCAPE_CHALLENGE_BUG: number;
+        const SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG: number;
+        const SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG: number;
+        /** Instructs OpenSSL to disable support for SSL/TLS compression. */
+        const SSL_OP_NO_COMPRESSION: number;
+        const SSL_OP_NO_QUERY_MTU: number;
+        /** Instructs OpenSSL to always start a new session when performing renegotiation. */
+        const SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION: number;
+        const SSL_OP_NO_SSLv2: number;
+        const SSL_OP_NO_SSLv3: number;
+        const SSL_OP_NO_TICKET: number;
+        const SSL_OP_NO_TLSv1: number;
+        const SSL_OP_NO_TLSv1_1: number;
+        const SSL_OP_NO_TLSv1_2: number;
+        const SSL_OP_PKCS1_CHECK_1: number;
+        const SSL_OP_PKCS1_CHECK_2: number;
+        /** Instructs OpenSSL to always create a new key when using temporary/ephemeral DH parameters. */
+        const SSL_OP_SINGLE_DH_USE: number;
+        /** Instructs OpenSSL to always create a new key when using temporary/ephemeral ECDH parameters. */
+        const SSL_OP_SINGLE_ECDH_USE: number;
+        const SSL_OP_SSLEAY_080_CLIENT_DH_BUG: number;
+        const SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG: number;
+        const SSL_OP_TLS_BLOCK_PADDING_BUG: number;
+        const SSL_OP_TLS_D5_BUG: number;
+        /** Instructs OpenSSL to disable version rollback attack detection. */
+        const SSL_OP_TLS_ROLLBACK_BUG: number;
+
+        const ENGINE_METHOD_RSA: number;
+        const ENGINE_METHOD_DSA: number;
+        const ENGINE_METHOD_DH: number;
+        const ENGINE_METHOD_RAND: number;
+        const ENGINE_METHOD_EC: number;
+        const ENGINE_METHOD_CIPHERS: number;
+        const ENGINE_METHOD_DIGESTS: number;
+        const ENGINE_METHOD_PKEY_METHS: number;
+        const ENGINE_METHOD_PKEY_ASN1_METHS: number;
+        const ENGINE_METHOD_ALL: number;
+        const ENGINE_METHOD_NONE: number;
+
+        const DH_CHECK_P_NOT_SAFE_PRIME: number;
+        const DH_CHECK_P_NOT_PRIME: number;
+        const DH_UNABLE_TO_CHECK_GENERATOR: number;
+        const DH_NOT_SUITABLE_GENERATOR: number;
+
+        const ALPN_ENABLED: number;
+
+        const RSA_PKCS1_PADDING: number;
+        const RSA_SSLV23_PADDING: number;
+        const RSA_NO_PADDING: number;
+        const RSA_PKCS1_OAEP_PADDING: number;
+        const RSA_X931_PADDING: number;
+        const RSA_PKCS1_PSS_PADDING: number;
+        /** Sets the salt length for RSA_PKCS1_PSS_PADDING to the digest size when signing or verifying. */
+        const RSA_PSS_SALTLEN_DIGEST: number;
+        /** Sets the salt length for RSA_PKCS1_PSS_PADDING to the maximum permissible value when signing data. */
+        const RSA_PSS_SALTLEN_MAX_SIGN: number;
+        /** Causes the salt length for RSA_PKCS1_PSS_PADDING to be determined automatically when verifying a signature. */
+        const RSA_PSS_SALTLEN_AUTO: number;
+
+        const POINT_CONVERSION_COMPRESSED: number;
+        const POINT_CONVERSION_UNCOMPRESSED: number;
+        const POINT_CONVERSION_HYBRID: number;
+
+        /** Specifies the built-in default cipher list used by Node.js (colon-separated values). */
+        const defaultCoreCipherList: string;
+        /** Specifies the active default cipher list used by the current Node.js process  (colon-separated values). */
+        const defaultCipherList: string;
+    }
+
     /** @deprecated since v10.0.0 */
     const fips: boolean;
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -10,6 +10,7 @@
 //                 Bruno Scheufler <https://github.com/brunoscheufler>
 //                 Chigozirim C. <https://github.com/smac89>
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
+//                 David Junger <https://github.com/touffy>
 //                 Deividas Bakanas <https://github.com/DeividasBakanas>
 //                 Eugene Y. Q. Shen <https://github.com/eyqs>
 //                 Flarna <https://github.com/Flarna>

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -485,3 +485,76 @@ import { promisify } from 'util';
 {
     crypto.createSecretKey(Buffer.from('asdf'));
 }
+
+{
+    // crypto_constants_test
+    let num: number;
+    let str: string;
+
+    num = crypto.constants.OPENSSL_VERSION_NUMBER;
+    num = crypto.constants.SSL_OP_ALL;
+    num = crypto.constants.SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
+    num = crypto.constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+    num = crypto.constants.SSL_OP_CISCO_ANYCONNECT;
+    num = crypto.constants.SSL_OP_COOKIE_EXCHANGE;
+    num = crypto.constants.SSL_OP_CRYPTOPRO_TLSEXT_BUG;
+    num = crypto.constants.SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+    num = crypto.constants.SSL_OP_EPHEMERAL_RSA;
+    num = crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT;
+    num = crypto.constants.SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER;
+    num = crypto.constants.SSL_OP_MICROSOFT_SESS_ID_BUG;
+    num = crypto.constants.SSL_OP_MSIE_SSLV2_RSA_PADDING;
+    num = crypto.constants.SSL_OP_NETSCAPE_CA_DN_BUG;
+    num = crypto.constants.SSL_OP_NETSCAPE_CHALLENGE_BUG;
+    num = crypto.constants.SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG;
+    num = crypto.constants.SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG;
+    num = crypto.constants.SSL_OP_NO_COMPRESSION;
+    num = crypto.constants.SSL_OP_NO_QUERY_MTU;
+    num = crypto.constants.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+    num = crypto.constants.SSL_OP_NO_SSLv2;
+    num = crypto.constants.SSL_OP_NO_SSLv3;
+    num = crypto.constants.SSL_OP_NO_TICKET;
+    num = crypto.constants.SSL_OP_NO_TLSv1;
+    num = crypto.constants.SSL_OP_NO_TLSv1_1;
+    num = crypto.constants.SSL_OP_NO_TLSv1_2;
+    num = crypto.constants.SSL_OP_PKCS1_CHECK_1;
+    num = crypto.constants.SSL_OP_PKCS1_CHECK_2;
+    num = crypto.constants.SSL_OP_SINGLE_DH_USE;
+    num = crypto.constants.SSL_OP_SINGLE_ECDH_USE;
+    num = crypto.constants.SSL_OP_SSLEAY_080_CLIENT_DH_BUG;
+    num = crypto.constants.SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG;
+    num = crypto.constants.SSL_OP_TLS_BLOCK_PADDING_BUG;
+    num = crypto.constants.SSL_OP_TLS_D5_BUG;
+    num = crypto.constants.SSL_OP_TLS_ROLLBACK_BUG;
+    num = crypto.constants.ENGINE_METHOD_RSA;
+    num = crypto.constants.ENGINE_METHOD_DSA;
+    num = crypto.constants.ENGINE_METHOD_DH;
+    num = crypto.constants.ENGINE_METHOD_RAND;
+    num = crypto.constants.ENGINE_METHOD_EC;
+    num = crypto.constants.ENGINE_METHOD_CIPHERS;
+    num = crypto.constants.ENGINE_METHOD_DIGESTS;
+    num = crypto.constants.ENGINE_METHOD_PKEY_METHS;
+    num = crypto.constants.ENGINE_METHOD_PKEY_ASN1_METHS;
+    num = crypto.constants.ENGINE_METHOD_ALL;
+    num = crypto.constants.ENGINE_METHOD_NONE;
+    num = crypto.constants.DH_CHECK_P_NOT_SAFE_PRIME;
+    num = crypto.constants.DH_CHECK_P_NOT_PRIME;
+    num = crypto.constants.DH_UNABLE_TO_CHECK_GENERATOR;
+    num = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
+    num = crypto.constants.ALPN_ENABLED;
+    num = crypto.constants.RSA_PKCS1_PADDING;
+    num = crypto.constants.RSA_SSLV23_PADDING;
+    num = crypto.constants.RSA_NO_PADDING;
+    num = crypto.constants.RSA_PKCS1_OAEP_PADDING;
+    num = crypto.constants.RSA_X931_PADDING;
+    num = crypto.constants.RSA_PKCS1_PSS_PADDING;
+    num = crypto.constants.RSA_PSS_SALTLEN_DIGEST;
+    num = crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN;
+    num = crypto.constants.RSA_PSS_SALTLEN_AUTO;
+    num = crypto.constants.POINT_CONVERSION_COMPRESSED;
+    num = crypto.constants.POINT_CONVERSION_UNCOMPRESSED;
+    num = crypto.constants.POINT_CONVERSION_HYBRID;
+
+    str = crypto.constants.defaultCoreCipherList;
+    str = crypto.constants.defaultCipherList;
+}


### PR DESCRIPTION
The `constants` property was missing entirely from the definitions for the node `crypto` module, so TypeScript kept complaining when any constant was used.

This PR adds the actual constants and comments copied from the Node.js docs.

https://nodejs.org/dist/latest/docs/api/crypto.html#crypto_crypto_constants
