### PR TITLE
loglevel: Move noConflict and getLogger to a DefaultLogger interface

### DIFF
--- a/types/loglevel/index.d.ts
+++ b/types/loglevel/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-declare var log: log.Logger;
+declare var log: log.DefaultLogger;
 export as namespace log;
 export = log;
 
@@ -43,6 +43,30 @@ declare namespace log {
     type LoggingMethod = (...message: any[]) => void;
 
     type MethodFactory = (methodName: string, level: LogLevelNumbers, loggerName: string) => LoggingMethod;
+
+    interface DefaultLogger extends Logger {
+        /**
+         * If you're using another JavaScript library that exposes a 'log' global, you can run into conflicts with loglevel.
+         * Similarly to jQuery, you can solve this by putting loglevel into no-conflict mode immediately after it is loaded
+         * onto the page. This resets to 'log' global to its value before loglevel was loaded (typically undefined), and
+         * returns the loglevel object, which you can then bind to another name yourself.
+         */
+        noConflict(): any;
+
+        /**
+         * This gets you a new logger object that works exactly like the root log object, but can have its level and
+         * logging methods set independently. All loggers must have a name (which is a non-empty string). Calling
+         * getLogger() multiple times with the same name will return an identical logger object.
+         * In large applications, it can be incredibly useful to turn logging on and off for particular modules as you are
+         * working with them. Using the getLogger() method lets you create a separate logger for each part of your
+         * application with its own logging level. Likewise, for small, independent modules, using a named logger instead
+         * of the default root logger allows developers using your module to selectively turn on deep, trace-level logging
+         * when trying to debug problems, while logging only errors or silencing logging altogether under normal
+         * circumstances.
+         * @param name The name of the produced logger
+         */
+        getLogger(name: string): Logger;
+    }
 
     interface Logger {
         /**
@@ -106,14 +130,6 @@ declare namespace log {
         setLevel(level: LogLevelDesc, persist?: boolean): void;
 
         /**
-         * If you're using another JavaScript library that exposes a 'log' global, you can run into conflicts with loglevel.
-         * Similarly to jQuery, you can solve this by putting loglevel into no-conflict mode immediately after it is loaded
-         * onto the page. This resets to 'log' global to its value before loglevel was loaded (typically undefined), and
-         * returns the loglevel object, which you can then bind to another name yourself.
-         */
-        noConflict(): any;
-
-        /**
          * Returns the current logging level, as a value from LogLevel.
          * It's very unlikely you'll need to use this for normal application logging; it's provided partly to help plugin
          * development, and partly to let you optimize logging code as below, where debug data is only generated if the
@@ -136,20 +152,6 @@ declare namespace log {
          * @param level as a string, like 'error' (case-insensitive) or as a number from 0 to 5 (or as log.levels. values)
          */
         setDefaultLevel(level: LogLevelDesc): void;
-
-        /**
-         * This gets you a new logger object that works exactly like the root log object, but can have its level and
-         * logging methods set independently. All loggers must have a name (which is a non-empty string). Calling
-         * getLogger() multiple times with the same name will return an identical logger object.
-         * In large applications, it can be incredibly useful to turn logging on and off for particular modules as you are
-         * working with them. Using the getLogger() method lets you create a separate logger for each part of your
-         * application with its own logging level. Likewise, for small, independent modules, using a named logger instead
-         * of the default root logger allows developers using your module to selectively turn on deep, trace-level logging
-         * when trying to debug problems, while logging only errors or silencing logging altogether under normal
-         * circumstances.
-         * @param name The name of the produced logger
-         */
-        getLogger(name: string): Logger;
 
         /**
          * This enables all log messages, and is equivalent to log.setLevel("trace").


### PR DESCRIPTION
The `noConflict` and `getLogger` methods only exist on the default logger. (See: https://github.com/pimterry/loglevel/blob/master/lib/loglevel.js#L236). 

I have therefore moved these two methods to a separate interface. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pimterry/loglevel/blob/master/lib/loglevel.js#L236
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
