### PR TITLE
mime: default_type went away in mime v2

### DIFF
--- a/types/mime/index.d.ts
+++ b/types/mime/index.d.ts
@@ -13,5 +13,3 @@ export interface TypeMap { [key: string]: string[]; }
 export function getType(path: string): string | null;
 export function getExtension(mime: string): string | null;
 export function define(mimes: TypeMap, force?: boolean): void;
-
-export const default_type: string;


### PR DESCRIPTION
The `default_type` field only existed in v1 of mime, the field went away in v2. 
(This is the commit where the change happened: https://github.com/broofa/node-mime/commit/a32be4341815d29bd581230fe1616e0ea013584a)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
