### PR TITLE
pathjs: various small fixes

### DIFF
--- a/types/pathjs/index.d.ts
+++ b/types/pathjs/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Lokesh Peta <https://github.com/lokeshpeta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export interface IDictionary<T> {
+    [id: string]: T;
+}
+
 interface IPathHistory{
 	initial: any;
 	pushState(state: any, title: string, path: string):void;
@@ -19,11 +23,11 @@ interface IPathRoute{
 }
 
 interface IPathRoutes{
-	current: IPathRoute,
-    root: IPathRoute,
-	rescue: Function,
-	previous: IPathRoute,
-	defined: {}
+	current?: string,
+    root?: string,
+	rescue?: Function,
+	previous?: string,
+	defined: IDictionary<IPathRoute>
 }
 
 interface IPathCore{
@@ -43,7 +47,7 @@ interface IPath {
 	
 	history: IPathHistory;
 	
-	match(path: string, parameterize: boolean): IPathRoute;
+	match(path: string, parameterize: boolean): IPathRoute | null;
 	
 	dispatch(passed_route: string): void;
 	

--- a/types/pathjs/pathjs-tests.ts
+++ b/types/pathjs/pathjs-tests.ts
@@ -1,4 +1,4 @@
-
+import {Path} from "./index";
 
 Path.map("/test/:id")
 .to(()=>{ });


### PR DESCRIPTION
A few small fixes to `pathjs`: 

- Changed `current`, `root`, and `previous` in the interface `IPathRoutes` from being of type `IPathRoute` and made them optional. 
If you look at the code: https://github.com/mtrpcic/pathjs/blob/master/path.js it is obvious that e.g. `Path.routes.root` has type `string` and is optinal. 
- `IPathRoutes.defined` changed from type `{}` to `IDictionary<IPathRoute>`. 
This is purely to make the type more descriptive of what actually happens. 
- The `match` method can potentially return null. 
Specifically this `null`: https://github.com/mtrpcic/pathjs/blob/master/path.js#L81


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
