### PR TITLE
[Slate]: Correct `getMarksAtIndex` return type

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -299,7 +299,7 @@ export class Text extends Immutable.Record({}) {
     ): Immutable.Set<Mark>;
     getMarks(): Immutable.OrderedSet<Mark>;
     getMarksAsArray(): Mark[];
-    getMarksAtIndex(index: number): Mark;
+    getMarksAtIndex(index: number): Immutable.OrderedSet<Mark>;
     getNode(key: string): Node | null;
     getPath(key: string | Path): Path;
     hasNode(key: string): boolean;


### PR DESCRIPTION
`Mark` rather than a set of `Marks` was being returned

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/slate/blob/1ce7c7cc8937dba80c6b75f154a6e3dab2855aa5/packages/slate/src/interfaces/element.js#L833
