### PR TITLE
Support koa-joi-router 5.2

### DIFF
--- a/types/koa-joi-router/index.d.ts
+++ b/types/koa-joi-router/index.d.ts
@@ -1,14 +1,16 @@
-// Type definitions for koa-joi-router 5.1
+// Type definitions for koa-joi-router 5.2
 // Project: https://github.com/koajs/joi-router
 // Definitions by: Matthew Bull <https://github.com/wingsbob>
 //                 Dave Welsh <https://github.com/move-zig>
 //                 Hiroshi Ioka <https://github.com/hirochachacha>
+//                 Tiger Oakes <https://github.com/NotWoods>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 import * as Koa from 'koa';
 import * as Joi from 'joi';
 import * as KoaRouter from 'koa-router';
+import * as CoBody from 'co-body';
 
 declare module "koa" {
     interface Request {
@@ -23,10 +25,9 @@ interface createRouter {
 }
 
 declare namespace createRouter {
-    type PartialHandler = (ctx: Koa.Context) => any;
     type FullHandler = (ctx: Koa.Context, next: () => Promise<any>) => any;
-    interface NestedHandler extends ReadonlyArray<PartialHandler|FullHandler|NestedHandler> {}
-    type Handler = PartialHandler | FullHandler| NestedHandler;
+    interface NestedHandler extends ReadonlyArray<Handler> {}
+    type Handler = FullHandler | NestedHandler;
 
     type Method = (path: string|RegExp, handlerOrConfig: Handler | object, ...handlers: Handler[]) => Router;
 
@@ -34,17 +35,22 @@ declare namespace createRouter {
         method: string|string[];
         path: string|RegExp;
         handler: Handler;
+        pre?: Handler;
         validate?: {
-            header?: Joi.AnySchema|{[key: string]: Joi.AnySchema};
-            query?: Joi.AnySchema|{[key: string]: Joi.AnySchema};
-            params?: Joi.AnySchema|{[key: string]: Joi.AnySchema};
-            body?: Joi.AnySchema|{[key: string]: Joi.AnySchema};
+            header?: Joi.SchemaLike;
+            query?: Joi.SchemaLike;
+            params?: Joi.SchemaLike;
+            body?: Joi.SchemaLike;
             maxBody?: number;
             failure?: number;
             type?: 'form'|'json'|'multipart';
-            output?: {[status: number]: Joi.AnySchema};
+            formOptions?: CoBody.Options;
+            jsonOptions?: CoBody.Options;
+            multipartOptions?: CoBody.Options;
+            output?: {[status: string]: Joi.SchemaLike};
             continueOnError?: boolean;
         };
+        meta?: any;
     }
 
     interface Router {

--- a/types/koa-joi-router/koa-joi-router-tests.ts
+++ b/types/koa-joi-router/koa-joi-router-tests.ts
@@ -41,6 +41,7 @@ const spec4: router.Spec = {
     type: 'json',
     output: {
       201: Joi.object(),
+      '400,404': Joi.object(),
     }
   },
   handler: (ctx: koa.Context) => {
@@ -54,7 +55,7 @@ router().route(spec4);
 const spec5: router.Spec = {
   method: 'PUT',
   path: '/user',
-  handler: (ctx: koa.Context) => {
+  handler: (ctx) => {
     ctx.status = 201;
     ctx.body = ctx.request.body;
   },

--- a/types/koa-joi-router/koa-joi-router-tests.ts
+++ b/types/koa-joi-router/koa-joi-router-tests.ts
@@ -30,6 +30,7 @@ const spec3: router.Spec = {
     body: Joi.any(),
   },
   handler: (ctx: koa.Context) => ctx.status = 201,
+  pre: (_ctx, next) => next(),
 };
 
 router().route(spec3);
@@ -42,9 +43,12 @@ const spec4: router.Spec = {
     output: {
       201: Joi.object(),
       '400,404': Joi.object(),
+    },
+    jsonOptions: {
+        limit: '10kb'
     }
   },
-  handler: (ctx: koa.Context) => {
+  handler(ctx) {
     ctx.status = 201;
     ctx.body = {};
   },
@@ -59,6 +63,7 @@ const spec5: router.Spec = {
     ctx.status = 201;
     ctx.body = ctx.request.body;
   },
+  meta: 'meta data',
 };
 
 router().route(spec5);


### PR DESCRIPTION
- Removed `PartialHandler`, since `FullHandler` covers functions with only 1 argument too. As a result the `ctx` argument in a spec handler no longer needs to be annotated manually.
- Added support for `pre`, a new property added for 5.2 that runs before the validation and handler.
- Added support for `meta`, a property that isn't used but is stored with the spec by koa-joi-router.
- Added support for more Joi schema types by using the `SchemaLike` type from Joi.
- Added support for output status code ranges such as `'200,201'` and `'400-499'` by changing the index type from number to string.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
