### PR TITLE
feat: add type for "rollup-plugin-buble"

### DIFF
--- a/types/rollup-plugin-buble/index.d.ts
+++ b/types/rollup-plugin-buble/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for rollup-plugin-buble 0.19
+// Project: https://github.com/rollup/rollup-plugin-buble#readme
+// Definitions by: Hugo Alliaume <https://github.com/Kocal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { Plugin } from 'rollup';
+import { TransformOptions } from 'buble';
+
+export interface Options extends TransformOptions {
+    // Every files will be parsed by default, but you can specify which files to include or exclude
+    include?: Array<string | RegExp> | string | RegExp | null;
+    exclude?: Array<string | RegExp> | string | RegExp | null;
+}
+
+export default function buble(options?: Options): Plugin;

--- a/types/rollup-plugin-buble/package.json
+++ b/types/rollup-plugin-buble/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4"
+    }
+}

--- a/types/rollup-plugin-buble/rollup-plugin-buble-tests.ts
+++ b/types/rollup-plugin-buble/rollup-plugin-buble-tests.ts
@@ -1,0 +1,57 @@
+import buble from 'rollup-plugin-buble';
+
+// No options (default)
+(() => {
+    // $ExpectType Plugin
+    buble();
+})();
+
+// With every options
+(() => {
+    // $ExpectType Plugin
+    buble({
+        target: {
+            chrome: 71,
+            firefox: 64,
+        },
+        objectAssign: true,
+        transforms: {
+            arrow: true,
+            classes: false,
+            collections: true,
+            computedProperty: false,
+            conciseMethodProperty: true,
+            constLoop: false,
+            dangerousForOf: true,
+            dangerousTaggedTemplateString: false,
+            defaultParameter: true,
+            destructuring: false,
+            forOf: true,
+            generator: false,
+            letConst: true,
+            modules: false,
+            numericLiteral: true,
+            parameterDestructuring: false,
+            reservedProperties: true,
+            spreadRest: false,
+            stickyRegExp: true,
+            templateString: false,
+            unicodeRegExp: true,
+        }
+    });
+})();
+
+// Filter files
+(() => {
+    // $ExpectType Plugin
+    buble({
+        include: '*.js',
+        exclude: '*.js',
+    });
+
+    // $ExpectType Plugin
+    buble({
+        include: /.js$/,
+        exclude: ['foo.js', 'bar.js'],
+    });
+})();

--- a/types/rollup-plugin-buble/tsconfig.json
+++ b/types/rollup-plugin-buble/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-buble-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-buble/tslint.json
+++ b/types/rollup-plugin-buble/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR add typings for [rollup-plugin-buble](https://github.com/rollup/rollup-plugin-buble).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
