### PR TITLE
[cassandra-driver] Added missing and fixed existing declarations

### DIFF
--- a/types/cassandra-driver/cassandra-driver-tests.ts
+++ b/types/cassandra-driver/cassandra-driver-tests.ts
@@ -102,3 +102,35 @@ const mapper = new cassandra.mapping.Mapper(
 const videoMapper = mapper.forModel('Video');
 videoMapper.insert({ videoId: 'uuid', addedDate: new Date(), userId: 'uuid', name: 'My video', description: 'My desc' });
 videoMapper.find({ videoId: 'uuid' }).then(results => results.first());
+
+console.log(cassandra.version);
+
+const metadata = new cassandra.metadata.Metadata(cassandra.defaultOptions(), undefined);
+let refreshFinished: Promise<void> = metadata.refreshKeyspaces();
+refreshFinished = metadata.refreshKeyspaces(true);
+metadata.refreshKeyspaces(() => {});
+metadata.refreshKeyspaces(true, () => {});
+
+const start: cassandra.token.Token = new cassandra.token.Token("x");
+const end: cassandra.token.Token = new cassandra.token.Token("z");
+
+const tokenizer: cassandra.token.Tokenizer = {
+  hash: (value: Buffer | number[]) => new cassandra.token.Token("x"),
+  parse: (value: string) => new cassandra.token.Token("x"),
+  minToken: () => new cassandra.token.Token("x"),
+  split: (start: cassandra.token.Token, end: cassandra.token.Token, numberOfSplits: number) => [],
+  splitBase: (start: number, end: number, ringEnd: number, ringLength: number, numberOfSplits: number): number[] => [1],
+  stringify: (token: cassandra.token.Token): string => "asd"
+};
+
+const range: cassandra.token.TokenRange = new cassandra.token.TokenRange(start, end, tokenizer);
+
+class MyLoadBalancingPolicy extends cassandra.policies.loadBalancing.LoadBalancingPolicy {
+  getDistance() {
+    return cassandra.types.distance.ignored;
+  }
+}
+
+const myPolicy: cassandra.policies.loadBalancing.LoadBalancingPolicy = new MyLoadBalancingPolicy();
+let existingPolicy: cassandra.policies.loadBalancing.LoadBalancingPolicy = new cassandra.policies.loadBalancing.DCAwareRoundRobinPolicy();
+existingPolicy = new cassandra.policies.loadBalancing.DCAwareRoundRobinPolicy("dc");

--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -34,43 +34,29 @@ export namespace policies {
   }
 
   namespace loadBalancing {
-    let DCAwareRoundRobinPolicy: DCAwareRoundRobinPolicyStatic;
-    let RoundRobinPolicy: RoundRobinPolicyStatic;
-    let TokenAwarePolicy: TokenAwarePolicyStatic;
-    let WhiteListPolicy: WhiteListPolicyStatic;
-
-    interface LoadBalancingPolicy {
+    class LoadBalancingPolicy {
       init(client: Client, hosts: HostMap, callback: Callback): void;
       getDistance(host: Host): types.distance;
       newQueryPlan(keyspace: string, queryOptions: ExecutionOptions | null, callback: Callback): void;
+      getOptions(): Map<string, any>;
     }
 
-    interface DCAwareRoundRobinPolicyStatic {
-      new (localDc?: string): DCAwareRoundRobinPolicy;
-    }
-
-    interface DCAwareRoundRobinPolicy extends LoadBalancingPolicy {
+    class DCAwareRoundRobinPolicy extends LoadBalancingPolicy {
+      localDc: string;
       localHostsArray: Host[];
-      remoteHostsArray: Host[];
+
+      constructor(localDc?: string);
     }
 
-    interface RoundRobinPolicyStatic {
-      new (): RoundRobinPolicy;
+    class RoundRobinPolicy extends LoadBalancingPolicy {}
+
+    class TokenAwarePolicy extends LoadBalancingPolicy {
+      constructor(childPolicy: LoadBalancingPolicy);
     }
 
-    interface RoundRobinPolicy extends LoadBalancingPolicy { }
-
-    interface TokenAwarePolicyStatic {
-      new (childPolicy: LoadBalancingPolicy): TokenAwarePolicy;
+    class WhiteListPolicy extends LoadBalancingPolicy {
+      constructor(childPolicy: LoadBalancingPolicy, whiteList: string[]);
     }
-
-    interface TokenAwarePolicy extends LoadBalancingPolicy { }
-
-    interface WhiteListPolicyStatic {
-      new (childPolicy: LoadBalancingPolicy, whiteList: string[]): WhiteListPolicy;
-    }
-
-    interface WhiteListPolicy extends LoadBalancingPolicy { }
   }
 
   namespace reconnection {

--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -812,29 +812,6 @@ export namespace metadata {
 
   interface MaterializedView extends DataCollection { }
 
-  class Token {
-    getType(): types.dataTypes;
-    getValue(): any;
-    compare(other: Token): number;
-    equals(other: Token): boolean;
-  }
-
-  interface TokenRange {
-    start: Token;
-    end: Token;
-
-    splitEvenly(numberOfSplits: number): TokenRange[];
-    isEmpty(): boolean;
-    isWrappedAround(): boolean;
-    unwrap(): TokenRange[];
-    contains(token: Token): boolean;
-    equals(other: TokenRange): boolean;
-    compare(other: TokenRange): number;
-  }
-
-  class ByteOrderedToken extends Token {}
-  class Murmur3Token extends Token {}
-  class BytRandomToken extends Token {}
 
   interface QueryTrace {
     requestType: any;
@@ -865,19 +842,19 @@ export namespace metadata {
     getFunctions(keyspaceName: string, name: string): Promise<SchemaFunction[]>;
     getMaterializedView(keyspaceName: string, name: string, callback: MetadataCallback<MaterializedView>): void;
     getMaterializedView(keyspaceName: string, name: string, callback: Callback): Promise<MaterializedView>;
-    getReplicas(keyspaceName: string, token: Buffer | Token | TokenRange): any[]; // TODO
+    getReplicas(keyspaceName: string, token: Buffer | token.Token | token.TokenRange): any[]; // TODO
     getTable(keyspaceName: string, name: string, callback: MetadataCallback<TableMetadata>): void;
     getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
-    getTokenRanges(): Set<TokenRange>;
-    getTokenRangesForHost(keyspaceName: string, host: Host): Set<TokenRange> | null;
+    getTokenRanges(): Set<token.TokenRange>;
+    getTokenRangesForHost(keyspaceName: string, host: Host): Set<token.TokenRange> | null;
     getTrace(traceId: types.Uuid, consistency: types.consistencies, callback: MetadataCallback<QueryTrace>): void;
     getTrace(traceId: types.Uuid, consistency: types.consistencies, callback: Callback): Promise<QueryTrace>;
     getTrace(traceId: types.Uuid, callback: MetadataCallback<QueryTrace>): void;
     getTrace(traceId: types.Uuid): Promise<QueryTrace>;
     getUdt(keyspaceName: string, name: string, callback: MetadataCallback<any>): void; // TODO
     getUdt(keyspaceName: string, name: string): Promise<any>; // TODO
-    newToken(components: Buffer[] | Buffer | string): Token;
-    newTokenRange(start: Token, end: Token): TokenRange;
+    newToken(components: Buffer[] | Buffer | string): token.Token;
+    newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
     refreshKeyspace(name: string, callback: Callback): void;
     refreshKeyspace(name: string): Promise<void>;
     refreshKeyspaces(waitReconnect: () => boolean, callback: Callback): void;
@@ -941,6 +918,7 @@ export interface ExecutionOptions {
 }
 
 export let ExecutionOptions: ExecutionOptionsStatic;
+export let ExecutionProfile: ExecutionProfileStatic;
 
 export namespace mapping {
   let Mapper: MapperStatic;
@@ -1150,3 +1128,41 @@ export namespace metrics {
   }
   interface DefaultMetrics extends ClientMetrics {}
 }
+
+export namespace token {
+  interface Tokenizer {
+    hash(value: Buffer | number[]): Token;
+    parse(value: string): Token;
+    minToken(): Token;
+    split(start: Token, end: Token, numberOfSplits: number): TokenRange[];
+    splitBase(start: number, end: number, ringEnd: number, ringLength: number, numberOfSplits: number): number[];
+    stringify(token: Token): string;
+  }
+
+  class Token {
+    constructor(value: any);
+
+    getType(): { code: number, info: any };
+    getValue(): any;
+    compare(other: Token): number;
+    equals(other: Token): boolean;
+  }
+
+  class TokenRange {
+    start: Token;
+    end: Token;
+
+    constructor(start: Token, end: Token, tokenizer: Tokenizer);
+
+    splitEvenly(numberOfSplits: number): TokenRange[];
+    isEmpty(): boolean;
+    isWrappedAround(): boolean;
+    unwrap(): TokenRange[];
+    contains(token: Token): boolean;
+    equals(other: TokenRange): boolean;
+    compare(other: TokenRange): number;
+  }
+}
+
+export const defaultOptions: () => ClientOptions;
+export const version: string;

--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -798,7 +798,6 @@ export namespace metadata {
 
   interface MaterializedView extends DataCollection { }
 
-
   interface QueryTrace {
     requestType: any;
     coordinator: any;
@@ -843,12 +842,9 @@ export namespace metadata {
     newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
     refreshKeyspace(name: string, callback: Callback): void;
     refreshKeyspace(name: string): Promise<void>;
-    refreshKeyspaces(waitReconnect: () => boolean, callback: Callback): void;
-    refreshKeyspaces(waitReconnect: () => boolean): Promise<void>;
     refreshKeyspaces(waitReconnect: boolean, callback: Callback): void;
-    refreshKeyspaces(waitReconnect: boolean): Promise<void>;
+    refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
     refreshKeyspaces(callback: Callback): void;
-    refreshKeyspaces(): Promise<void>;
   }
 
   interface SchemaFunction {
@@ -1150,5 +1146,5 @@ export namespace token {
   }
 }
 
-export const defaultOptions: () => ClientOptions;
+export function defaultOptions(): ClientOptions;
 export const version: string;

--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -499,8 +499,6 @@ export namespace types {
 }
 
 export let Client: ClientStatic;
-export let Host: HostStatic;
-export let HostMap: HostMapStatic;
 export let Encoder: EncoderStatic;
 
 export interface ClientOptions {
@@ -611,24 +609,16 @@ export interface Client extends events.EventEmitter {
   stream(query: string, params?: any, options?: QueryOptions, callback?: Callback): NodeJS.ReadableStream;
 }
 
-export interface HostStatic {
-  new (address: string, protocolVersion: number, options: ClientOptions): Host;
-}
-
 export interface Host extends events.EventEmitter {
   address: string;
   cassandraVersion: string;
-  dataCenter: string;
+  datacenter: string;
   rack: string;
   tokens: string[];
 
   canBeConsideredAsUp(): boolean;
   getCassandraVersion(): number[];
   isUp(): boolean;
-}
-
-export interface HostMapStatic {
-  new (): HostMap;
 }
 
 export interface HostMap extends events.EventEmitter {


### PR DESCRIPTION
Removed some interfaces and variables simulating newable classes that were not exported from library and could not be instantiated in user code (`Host` + `HostStatic`, `HostMap` + `HostMapStatic`, `Aggregate` + `metadata.AggregateStatic`, `Index` + `metadata.IndexStatic`, `MaterializedView` + `metadata.MaterializedViewStatic`, `SchemaFunction` + `metadata.SchemaFunctionStatic`, `TableMetadata` + `metadata.TableMetadataStatic`, `ClientState` + `metadata.ClientStateStatic`).

Updated `metadata` namespace - removed some "constructors" as mentioned above, added missing functions in `Metadata` class, added Promise returning overloads for functions in `Metadata` class.

Updated `loadBalancing` namespace - replaced interface + variable pairs simulating newable classes and replaced them with classes, to allow implementing user load balancing policies.

Added top-level missing exports - `defaultOptions` function, `version` constant, `ExecutionProfile` constructor.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - top-level exports: https://github.com/datastax/nodejs-driver/blob/master/index.js
  - metadata namespace: https://github.com/datastax/nodejs-driver/blob/master/lib/metadata/index.js
  - loadBalancing namespace: https://github.com/datastax/nodejs-driver/blob/master/lib/policies/load-balancing.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.