### PR TITLE
Add promise unwrapping on mock return Promise methods

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -912,7 +912,7 @@ declare namespace jest {
         /**
          * Simple sugar function for: `jest.fn().mockImplementation(() => Promise.resolve(value));`
          */
-        mockResolvedValue(value: T | PromiseLike<T>): Mock<Promise<T>, Y>;
+        mockResolvedValue<v = T>(value: v | PromiseLike<v>): Mock<Promise<v>, Y>;
         /**
          * Simple sugar function for: `jest.fn().mockImplementationOnce(() => Promise.resolve(value));`
          *
@@ -932,7 +932,7 @@ declare namespace jest {
          * });
          *
          */
-        mockResolvedValueOnce(value: T | PromiseLike<T>): Mock<Promise<T>, Y>;
+        mockResolvedValueOnce<v = T>(value: v | PromiseLike<v>): Mock<Promise<v>, Y>;
         /**
          * Simple sugar function for: `jest.fn().mockImplementation(() => Promise.reject(value));`
          *
@@ -944,7 +944,7 @@ declare namespace jest {
          *   await asyncMock(); // throws "Async error"
          * });
          */
-        mockRejectedValue(value: any): Mock<Promise<T>, Y>;
+        mockRejectedValue<v = T>(value: any): Mock<Promise<v>, Y>;
 
         /**
          * Simple sugar function for: `jest.fn().mockImplementationOnce(() => Promise.reject(value));`
@@ -962,7 +962,7 @@ declare namespace jest {
          * });
          *
          */
-        mockRejectedValueOnce(value: any): Mock<Promise<T>, Y>;
+        mockRejectedValueOnce<v = T>(value: any): Mock<Promise<v>, Y>;
     }
 
     /**

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -315,6 +315,17 @@ const mock11 = jest.fn((arg: unknown) => arg);
 // $ExpectType number
 mock1('test');
 
+// mockResolved/mockRejected shouldn't wrap Mock return in Promise
+mock1.mockResolvedValue(1)
+    .mockResolvedValueOnce(1)
+    .mockResolvedValueOnce(1)
+    .mockResolvedValueOnce(1);
+
+mock1.mockRejectedValue(1)
+    .mockRejectedValueOnce(1)
+    .mockRejectedValueOnce(1)
+    .mockRejectedValueOnce(1);
+
 // $ExpectError
 mock7('abc');
 // $ExpectError


### PR DESCRIPTION
This change is a bugfix on mockResolvedValue and mockRejectedValue methods. The current typings dictate that the mock returned by these methods expects its output to be wrapped in a Promise, which breaks the Jest provided example of how to utilize these methods.

Example of bug (using Jest docs):
```
const myMockFn = jest
  .fn()
  .mockReturnValue('default')
  .mockReturnValueOnce('first call') // TSError: Expecting Promise<string>
  .mockReturnValueOnce('second call');
```

___

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/en/mock-function-api.html#mockfnmockreturnvalueoncevalue
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


