### PR TITLE
pleasejs: small fixes

### DIFF
--- a/types/pleasejs/index.d.ts
+++ b/types/pleasejs/index.d.ts
@@ -12,32 +12,28 @@ declare namespace PleaseJS{
          * @param {MakeColorOption} options
          * @returns {Array}
          */
-        make_color(options?: MakeColorOption): Array<string>;
-        make_color(options?: MakeColorOption): Array<RGB>;
-        make_color(options?: MakeColorOption): Array<HSV>;
+        make_color(options?: MakeColorOption): Array<string | RGB | HSV>;
 
         /***
          * make a color scheme
          * @param {MakeSchemeOption} options
          * @returns {Array}
          */
-        make_scheme(base_color: HSV, options?: MakeSchemeOption): Array<string>;
-        make_scheme(base_color: HSV, options?: MakeSchemeOption): Array<RGB>;
-        make_scheme(base_color: HSV, options?: MakeSchemeOption): Array<HSV>;
+        make_scheme(base_color: HSV, options?: MakeSchemeOption): Array<string | RGB | HSV>;
 
         /***
          * convert color name into hex string
          * @param {string} name
          * @returns {string}
          */
-        NAME_to_HEX(name: string): string;
+        NAME_to_HEX(name: string): string | undefined;
 
         /***
          * convert color name into RGB
          * @param {string} name
          * @returns {RGB}
          */
-        NAME_to_RGB(name: string): RGB;
+        NAME_to_RGB(name: string): RGB | null;
 
         /***
          * convert color name into RGB
@@ -51,7 +47,7 @@ declare namespace PleaseJS{
          * @param {string} hex
          * @returns {RGB}
          */
-        HEX_to_RGB(hex: string): RGB;
+        HEX_to_RGB(hex: string): RGB | null;
 
         /***
          * convert RGB into HEX


### PR DESCRIPTION
Various fixes to pleasejs: 

- The `make_color` and `make_scheme` methods: Only the first overload could ever be called due TypeScript always choosing the first candidate signature. (https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#user-content-4.15.1) 
Therefore it was only possible to get an `Array<string>` when calling `make_color` or `make_scheme`. 
- `NAME_to_HEX` returns undefined if no name matched (https://github.com/Fooidge/PleaseJS/blob/master/src/Please.js#L292) 
- `HEX_to_RGB` (which is used by `NAME_to_RGB`) returns null if the input string was not a hex color. (https://github.com/Fooidge/PleaseJS/blob/master/src/Please.js#L321)
  
  
  
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
