### PR TITLE
platform: The parse and toString methods are not maybe undef

### DIFF
--- a/types/platform/index.d.ts
+++ b/types/platform/index.d.ts
@@ -18,8 +18,8 @@ declare interface Platform {
         version?: string;
         toString(): string;
     };
-    parse?(ua: string): Platform;
-    toString?(): string;
+    parse(ua: string): Platform;
+    toString(): string;
 }
 
 declare var platform: Platform;

--- a/types/platform/platform-tests.ts
+++ b/types/platform/platform-tests.ts
@@ -16,7 +16,8 @@ var tests: TestContainer = {
         prerelease: null,
         product: null,
         ua: "Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC Sensation XE with Beats Audio Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.77 Mobile Safari/535.7",
-        version: "16.0.912.77"
+        version: "16.0.912.77",
+        parse: function () {throw new Error()}
     },
     'WebKit Nightly 528.4 (like Safari 4.x) on Mac OS X 10.4.11': {
         description: "WebKit Nightly 528.4 (like Safari 4.x) on Mac OS X 10.4.11",
@@ -31,7 +32,8 @@ var tests: TestContainer = {
         prerelease: "alpha",
         product: null,
         ua: "Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_4_11; tr) AppleWebKit/528.4+ (KHTML, like Gecko) Version/4.0dp1 Safari/526.11.2",
-        version: "528.4"
+        version: "528.4",
+        parse: function () {throw new Error()}
     }
 };
 


### PR DESCRIPTION
The methods are always present, and not "maybe undefined" as currently declared in the declaration file. 

Documentation: https://github.com/bestiejs/platform.js/blob/master/doc/README.md#platformparseuanavigatoruseragent

The methods were declared as optional in order to fix the tests, where the mocks did not include the parse method. 


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bestiejs/platform.js/blob/master/doc/README.md#platformparseuanavigatoruseragent
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.