### PR TITLE
jscookie: small changes to make it more correct. Might break existing code?

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -79,7 +79,7 @@ declare namespace Cookies {
          * or SDK. Note: The noConflict method is not necessary when using
          * AMD or CommonJS, thus it is not exposed in those environments.
          */
-        noConflict?(): CookiesStatic;
+        noConflict?(): CookiesStatic<T>;
 
         /**
          * Create a new instance of the api that overrides the default
@@ -88,7 +88,7 @@ declare namespace Cookies {
          * will run the converter first for each cookie. The returned
          * string will be used as the cookie value.
          */
-        withConverter(converter: CookieReadConverter | { write: CookieWriteConverter<T>; read: CookieReadConverter; }): CookiesStatic;
+        withConverter<TConv extends object>(converter: CookieReadConverter | { write: CookieWriteConverter<TConv>; read: CookieReadConverter; }): CookiesStatic<TConv>;
     }
 
     type CookieWriteConverter<T extends object> = (value: string | T, name: string) => string;

--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -79,7 +79,7 @@ declare namespace Cookies {
          * or SDK. Note: The noConflict method is not necessary when using
          * AMD or CommonJS, thus it is not exposed in those environments.
          */
-        noConflict(): CookiesStatic;
+        noConflict?(): CookiesStatic;
 
         /**
          * Create a new instance of the api that overrides the default
@@ -88,10 +88,11 @@ declare namespace Cookies {
          * will run the converter first for each cookie. The returned
          * string will be used as the cookie value.
          */
-        withConverter(converter: CookieConverter | { write: CookieConverter; read: CookieConverter; }): CookiesStatic;
+        withConverter(converter: CookieReadConverter | { write: CookieWriteConverter; read: CookieReadConverter; }): CookiesStatic;
     }
 
-    type CookieConverter = (value: string, name: string) => string;
+    type CookieWriteConverter = (value: string | object, name: string) => string;
+    type CookieReadConverter = (value: string, name: string) => string;
 }
 
 declare const Cookies: Cookies.CookiesStatic;

--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -33,7 +33,7 @@ declare namespace Cookies {
         secure?: boolean;
     }
 
-    interface CookiesStatic {
+    interface CookiesStatic<T extends object = object> {
         /**
          * Allows default cookie attributes to be accessed, changed, or reset
          */
@@ -42,7 +42,7 @@ declare namespace Cookies {
         /**
          * Create a cookie
          */
-        set(name: string, value: string | object, options?: CookieAttributes): void;
+        set(name: string, value: string | T, options?: CookieAttributes): void;
 
         /**
          * Read cookie
@@ -88,10 +88,10 @@ declare namespace Cookies {
          * will run the converter first for each cookie. The returned
          * string will be used as the cookie value.
          */
-        withConverter(converter: CookieReadConverter | { write: CookieWriteConverter; read: CookieReadConverter; }): CookiesStatic;
+        withConverter(converter: CookieReadConverter | { write: CookieWriteConverter<T>; read: CookieReadConverter; }): CookiesStatic;
     }
 
-    type CookieWriteConverter = (value: string | object, name: string) => string;
+    type CookieWriteConverter<T extends object> = (value: string | T, name: string) => string;
     type CookieReadConverter = (value: string, name: string) => string;
 }
 

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -19,7 +19,7 @@ Cookies.get();
 Cookies.remove('name');
 Cookies.remove('name', { path: '' });
 
-const Cookies2 = (Cookies.noConflict as () => Cookies.CookiesStatic)();
+const Cookies2 = Cookies.noConflict!();
 Cookies2; // $ExpectType CookiesStatic
 
 Cookies.set('name', { foo: 'bar' });

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -19,7 +19,8 @@ Cookies.get();
 Cookies.remove('name');
 Cookies.remove('name', { path: '' });
 
-const Cookies2: Cookies.CookiesStatic = (Cookies.noConflict as () => Cookies.CookiesStatic)();
+const Cookies2 = (Cookies.noConflict as () => Cookies.CookiesStatic)();
+Cookies2; // $ExpectType CookiesStatic
 
 Cookies.set('name', { foo: 'bar' });
 
@@ -40,11 +41,13 @@ Cookies.defaults.path = '';
 delete Cookies.defaults.path;
 
 const PHPCookies = Cookies.withConverter({
-    write(value: string | object) {
+    write(value) {
+        value; // $ExpectType string | object
         return encodeURIComponent(value as string)
             .replace(/%(23|24|26|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
     },
-    read(value: string) {
+    read(value) {
+        value; // $ExpectType string
         return value
             .replace(/\+/g, ' ')
             .replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -19,8 +19,7 @@ Cookies.get();
 Cookies.remove('name');
 Cookies.remove('name', { path: '' });
 
-const Cookies2 = Cookies.noConflict();
-Cookies2; // $ExpectType CookiesStatic
+const Cookies2: Cookies.CookiesStatic = (Cookies.noConflict as () => Cookies.CookiesStatic)();
 
 Cookies.set('name', { foo: 'bar' });
 
@@ -41,11 +40,11 @@ Cookies.defaults.path = '';
 delete Cookies.defaults.path;
 
 const PHPCookies = Cookies.withConverter({
-    write(value) {
-        return encodeURIComponent(value)
+    write(value: string | object) {
+        return encodeURIComponent(value as string)
             .replace(/%(23|24|26|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
     },
-    read(value) {
+    read(value: string) {
         return value
             .replace(/\+/g, ' ')
             .replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -20,7 +20,7 @@ Cookies.remove('name');
 Cookies.remove('name', { path: '' });
 
 const Cookies2 = Cookies.noConflict!();
-Cookies2; // $ExpectType CookiesStatic
+Cookies2; // $ExpectType CookiesStatic<object>
 
 Cookies.set('name', { foo: 'bar' });
 

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -40,7 +40,7 @@ cookies.get('escaped');
 Cookies.defaults.path = '';
 delete Cookies.defaults.path;
 
-const PHPCookies = Cookies.withConverter({
+const PHPCookies = Cookies.withConverter<object>({
     write(value) {
         value; // $ExpectType string | object
         return encodeURIComponent(value as string)


### PR DESCRIPTION
These changes will make the js-cookie declaration "more correct". 
However, the changes might break existing code, and I'm therefore not sure if they should be included.

The changes:

- `noConflict` marked as being maybe present: To reflect that the method is not exposed on AMD or CommonJS environments. 
- Changed the type of `value` in the `write` method from `string` to `string | object`. 
The `value` argument will be an object if `JSON.stringify` throws an exception while trying to serialize the value given in the `set` method. Here is an example: 
```JavaScript
var foo = {};
foo.foo = foo;
Cookies.withConverter({
	read: function (value) {return value;}, 
	write: function(value, name){console.log(typeof value); return "foo";}
}).set("foo", foo)
```
The above code will print `object` into the console.   

I could also have changed the type of `const Cookies` to `Cookies.CookiesStatic | undefined` (since the `noConflict`, method sets `Cookies` to undefined). 
However, this would surely break every existing usage of js-cookie, so I've not included that change. 



Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
