### PR TITLE
Angular IPromise interop with platform Promise.

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -294,6 +294,14 @@ foo.then((x) => {
     x.toFixed();
 });
 
+namespace TestPromiseInterop {
+    declare const promiseInterop: ng.IPromise<number>;
+    const ngStringPromise: ng.IPromise<string> =
+        promiseInterop.then((num) => Promise.resolve(String(num)));
+    const caughtStringPromise: ng.IPromise<string|number> =
+        promiseInterop.catch((reason) => Promise.resolve('oh noes'));
+}
+
 // $q signature tests
 namespace TestQ {
     interface AbcObject {

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1199,6 +1199,15 @@ declare namespace angular {
          */
         then<TResult1 = T, TResult2 = never>(
             successCallback?:
+                | ((value: T) => PromiseLike<never> | PromiseLike<TResult1> | TResult1)
+                | null,
+            errorCallback?:
+                | ((reason: any) => PromiseLike<never> | PromiseLike<TResult2> | TResult2)
+                | null,
+            notifyCallback?: (state: any) => any
+        ): IPromise<TResult1 | TResult2>;
+        then<TResult1 = T, TResult2 = never>(
+            successCallback?:
                 | ((value: T) => IPromise<never> | IPromise<TResult1> | TResult1)
                 | null,
             errorCallback?:
@@ -1210,6 +1219,11 @@ declare namespace angular {
         /**
          * Shorthand for promise.then(null, errorCallback)
          */
+        catch<TResult = never>(
+            onRejected?:
+                | ((reason: any) => PromiseLike<never> | PromiseLike<TResult> | TResult)
+                | null
+        ): IPromise<T | TResult>;
         catch<TResult = never>(
             onRejected?:
                 | ((reason: any) => IPromise<never> | IPromise<TResult> | TResult)

--- a/types/angular/tsconfig.json
+++ b/types/angular/tsconfig.json
@@ -11,7 +11,8 @@
         "lib": [
             "es5",
             "dom",
-            "es2015.iterable"
+            "es2015.iterable",
+            "es2015.promise"
         ],
         "noImplicitAny": false,
         "noImplicitThis": false,


### PR DESCRIPTION
Angular promises support `.then()` chaining of functions that return
arbitrary `then()`able values.
    https://docs.angularjs.org/api/ng/service/$q#the-promise-api

This change updates the definition of `ng.IPromise.then()` to match that
by overloading the function to handle `PromiseLike` values.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/service/$q#the-promise-api
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
