### PR TITLE
[yup] Add definition for `isSchema()` method signature

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -26,6 +26,7 @@ export function addMethod<T extends Schema<any>>(
 export function ref(path: string, options?: { contextPrefix: string }): Ref;
 export function lazy<T>(fn: (value: T) => Schema<T>): Lazy;
 export function setLocale(customLocale: LocaleObject): void;
+export function isSchema(obj: any): obj is Schema<any>;
 
 export const mixed: MixedSchemaConstructor;
 export const string: StringSchemaConstructor;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -3,6 +3,7 @@ import * as yup from "yup";
 // tslint:disable-next-line:no-duplicate-imports
 import {
     reach,
+    isSchema,
     date,
     Schema,
     ObjectSchema,
@@ -23,6 +24,10 @@ const schema1 = yup.object().shape({
 });
 reach(schema1, "nested.arr.num");
 reach(schema1, "nested.arr[].num");
+
+// isSchema function
+const isSchemaResult1: boolean = isSchema(schema1);
+const isSchemaResult2: boolean = isSchema({});
 
 // addMethod function
 yup.addMethod<NumberSchema>(yup.number, "minimum", function(


### PR DESCRIPTION
Despite the fact that `isSchema` isn't mentioned in the documentation, it is imported and commonly used.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/blob/master/src/index.js#L44
