### PR TITLE
[express-unless] Loosen too restrictive typings for path property, add missing ext property

### DIFF
--- a/types/express-unless/express-unless-tests.ts
+++ b/types/express-unless/express-unless-tests.ts
@@ -9,3 +9,9 @@ var middleware: unless.RequestHandler = function(req, res, next) {
 middleware.unless = unless;
 app.use(middleware.unless({ method: "OPTIONS" }));
 app.use(middleware.unless(req => req.path === "test"));
+
+app.use(middleware.unless({ path: "/index", useOriginalUrl: true }));
+app.use(middleware.unless({ path: /home/g, ext: ".jpg" }));
+app.use(middleware.unless({ path: { url: "/index" }, ext: [ ".html", ".htm" ] }));
+app.use(middleware.unless({ path: { url: "/index", methods: [ "GET", "POST" ] } }));
+app.use(middleware.unless({ path: [ "/index", "/home", /home/i, { url: "/main", methods: [ "GET" ] }, { url: /home/i } ] }));

--- a/types/express-unless/express-unless-tests.ts
+++ b/types/express-unless/express-unless-tests.ts
@@ -15,3 +15,5 @@ app.use(middleware.unless({ path: /home/g, ext: ".jpg" }));
 app.use(middleware.unless({ path: { url: "/index" }, ext: [ ".html", ".htm" ] }));
 app.use(middleware.unless({ path: { url: "/index", methods: [ "GET", "POST" ] } }));
 app.use(middleware.unless({ path: [ "/index", "/home", /home/i, { url: "/main", methods: [ "GET" ] }, { url: /home/i } ] }));
+app.use(middleware.unless({ path: [ "/index", "/home", /home/i, { url: "/main", method: "GET" }, { url: /home/i } ] }));
+app.use(middleware.unless({ path: [ "/index", "/home", /home/i, { url: "/main", method: [ "GET" ] }, { url: /home/i } ] }));

--- a/types/express-unless/index.d.ts
+++ b/types/express-unless/index.d.ts
@@ -12,7 +12,7 @@ declare function unless(options: unless.Options): express.RequestHandler;
 declare function unless(options: unless.Options["custom"]): express.RequestHandler;
 
 declare namespace unless {
-    type pathFilter = string | RegExp | { url: string | RegExp, methods?: string[] };
+    type pathFilter = string | RegExp | { url: string | RegExp, methods?: string[], method?: string | string[] };
 
     export interface Options {
         custom?: (req: express.Request) => boolean;

--- a/types/express-unless/index.d.ts
+++ b/types/express-unless/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://www.npmjs.org/package/express-unless
 // Definitions by: Wonshik Kim <https://github.com/wokim>
 //                 Joao Vieira <https://github.com/joaovieira>
+//                 Michal Kaminski <https://github.com/michal-b-kaminski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -11,11 +12,14 @@ declare function unless(options: unless.Options): express.RequestHandler;
 declare function unless(options: unless.Options["custom"]): express.RequestHandler;
 
 declare namespace unless {
+    type pathFilter = string | RegExp | { url: string | RegExp, methods?: string[] };
+
     export interface Options {
         custom?: (req: express.Request) => boolean;
-        path?: string | string[];
+        path?: pathFilter | pathFilter[];
         ext?: string | string[];
         method?: string | string[];
+        useOriginalUrl?: boolean;
     }
     export interface RequestHandler extends express.RequestHandler {
         unless?: typeof unless;


### PR DESCRIPTION
Previous pull request (#32549) restricted types for `Options.path` property too much. This PR adds other possible types. 
Additionaly, adds missing `Options.useOriginalUrl` property.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jfromaniello/express-unless#current-options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
