### PR TITLE
[styled-components] Fix children bug; Add `styled-component/native` typings

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ihor Chulinda <https://github.com/Igmat>
 //                 Adam Lavin <https://github.com/lavoaster>
 //                 Jessica Franco <https://github.com/Jessidhia>
+//                 Jason Killian <https://github.com/jkillian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -65,7 +66,7 @@ export type StyledComponentProps<
         A
     > & Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
     T
->;
+> & { children?: React.ReactNode };
 
 type StyledComponentPropsWithAs<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
@@ -263,24 +264,24 @@ type ThemedStyledComponentFactories<T extends object> = {
     [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>
 };
 
-type StyledComponentInnerComponent<
+export type StyledComponentInnerComponent<
     C extends React.ComponentType<any>
 > = C extends
     | StyledComponent<infer I, any, any, any>
     | StyledComponent<infer I, any, any>
     ? I
     : C;
-type StyledComponentPropsWithRef<
+export type StyledComponentPropsWithRef<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
 > = C extends AnyStyledComponent
     ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
     : React.ComponentPropsWithRef<C>;
-type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends
     | StyledComponent<any, any, infer O, any>
     | StyledComponent<any, any, infer O>
     ? O
     : never;
-type StyledComponentInnerAttrs<
+export type StyledComponentInnerAttrs<
     C extends AnyStyledComponent
 > = C extends StyledComponent<any, any, any, infer A> ? A : never;
 

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -8,6 +8,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // tslint:disable-next-line:no-empty-interface
+        interface ReadableStream {}
+    }
+}
+
 import * as CSS from "csstype";
 import * as React from "react";
 

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -72,7 +72,15 @@ export type StyledComponentProps<
         A
     > & Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
     T
-> & { children?: React.ReactNode };
+> & WithChildrenIfReactComponentClass<C>;
+
+// Because of React typing quirks, when getting props from a React.ComponentClass,
+// we need to manually add a `children` field.
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31945
+// and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843
+type WithChildrenIfReactComponentClass<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+> = C extends React.ComponentClass<any> ? { children?: React.ReactNode } : {};
 
 type StyledComponentPropsWithAs<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -8,8 +8,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-/// <reference types="node" />
-
 import * as CSS from "csstype";
 import * as React from "react";
 

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -1,0 +1,225 @@
+import * as ReactNative from 'react-native'
+import * as React from 'react'
+import { StatelessComponent, ComponentClass } from 'react'
+
+export {
+  DefaultTheme,
+  css,
+  isStyledComponent,
+  ThemeProps,
+  ThemeProvider,
+  ThemeConsumer,
+  ThemeContext,
+  withTheme,
+} from './index';
+
+import {
+  AnyStyledComponent,
+  StyledComponentInnerComponent,
+  StyledComponentInnerOtherProps,
+  StyledComponentInnerAttrs,
+  ThemedStyledFunction,
+  ThemedStyledInterface,
+  DefaultTheme
+} from './index'
+
+type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+
+export type ReactNativeThemedStyledFunction<
+  C extends React.ComponentType<any>,
+  T extends object,
+> = ThemedStyledFunction<C, T>;
+
+// Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
+interface ReactNativeThemedBaseStyledInterface<T extends object> {
+    <C extends AnyStyledComponent>(component: C): ThemedStyledFunction<
+        StyledComponentInnerComponent<C>,
+        T,
+        StyledComponentInnerOtherProps<C>,
+        StyledComponentInnerAttrs<C>
+    >;
+    <C extends React.ComponentType<any>>(
+        // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
+        // causes tests to fail in TS 3.1
+        component: C
+    ): ThemedStyledFunction<C, T>;
+}
+
+type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<
+    AnyIfEmpty<T>
+>;
+
+export interface ReactNativeStyledInterface<T extends object> extends ReactNativeThemedStyledInterface<T> {
+  ActivityIndicator: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ActivityIndicator,
+    T
+  >;
+  ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ActivityIndicator,
+    T
+  >;
+  Button: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Button,
+    T
+  >;
+  DatePickerIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.DatePickerIOS,
+    T
+  >;
+  DrawerLayoutAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.DrawerLayoutAndroid,
+    T
+  >;
+  Image: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Image,
+    T
+  >;
+  ImageBackground: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ImageBackground,
+    T
+  >;
+  KeyboardAvoidingView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.KeyboardAvoidingView,
+    T
+  >;
+  ListView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ListView,
+    T
+  >;
+  MapView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.MapView,
+    T
+  >;
+  Modal: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Modal,
+    T
+  >;
+  NavigatorIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.NavigatorIOS,
+    T
+  >;
+  Picker: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Picker,
+    T
+  >;
+  PickerIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.PickerIOS,
+    T
+  >;
+  ProgressBarAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ProgressBarAndroid,
+    T
+  >;
+  ProgressViewIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ProgressViewIOS,
+    T
+  >;
+  ScrollView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ScrollView,
+    T
+  >;
+  SegmentedControlIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SegmentedControlIOS,
+    T
+  >;
+  Slider: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Slider,
+    T
+  >;
+  SliderIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Slider,
+    T
+  >;
+  SnapshotViewIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SnapshotViewIOS,
+    T
+  >;
+  Switch: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Switch,
+    T
+  >;
+  RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.RecyclerViewBackedScrollView,
+    T
+  >;
+  RefreshControl: ReactNativeThemedStyledFunction<
+    typeof ReactNative.RefreshControl,
+    T
+  >;
+  SafeAreaView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SafeAreaView,
+    T
+  >;
+  StatusBar: ReactNativeThemedStyledFunction<
+    typeof ReactNative.StatusBar,
+    T
+  >;
+  SwipeableListView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SwipeableListView,
+    T
+  >
+  SwitchAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Switch,
+    T
+  >;
+  SwitchIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SwitchIOS,
+    T
+  >;
+  TabBarIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TabBarIOS,
+    T
+  >;
+  Text: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Text,
+    T
+  >;
+  TextInput: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TextInput,
+    T
+  >;
+  ToolbarAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ToolbarAndroid,
+    T
+  >;
+  TouchableHighlight: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableHighlight,
+    T
+  >;
+  TouchableNativeFeedback: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableNativeFeedback,
+    T
+  >;
+  TouchableOpacity: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableOpacity,
+    T
+  >;
+  TouchableWithoutFeedback: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableWithoutFeedback,
+    T
+  >;
+  View: ReactNativeThemedStyledFunction<
+    typeof ReactNative.View,
+    T
+  >;
+  ViewPagerAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ViewPagerAndroid,
+    T
+  >;
+  WebView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.WebView,
+    T
+  >;
+  FlatList: ReactNativeThemedStyledFunction<
+    typeof ReactNative.FlatList,
+    T
+  >;
+  SectionList: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SectionList,
+    T
+  >;
+}
+
+declare const styled: ReactNativeStyledInterface<DefaultTheme>;
+
+export default styled;

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -1,6 +1,5 @@
-import * as ReactNative from 'react-native'
-import * as React from 'react'
-import { StatelessComponent, ComponentClass } from 'react'
+import * as ReactNative from 'react-native';
+import * as React from 'react';
 
 export {
   DefaultTheme,
@@ -21,7 +20,7 @@ import {
   ThemedStyledFunction,
   ThemedStyledInterface,
   DefaultTheme
-} from './index'
+} from './index';
 
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
@@ -157,7 +156,7 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
   SwipeableListView: ReactNativeThemedStyledFunction<
     typeof ReactNative.SwipeableListView,
     T
-  >
+  >;
   SwitchAndroid: ReactNativeThemedStyledFunction<
     typeof ReactNative.Switch,
     T
@@ -208,14 +207,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
   >;
   WebView: ReactNativeThemedStyledFunction<
     typeof ReactNative.WebView,
-    T
-  >;
-  FlatList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.FlatList,
-    T
-  >;
-  SectionList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SectionList,
     T
   >;
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1003,17 +1003,22 @@ function validateDefaultProps() {
     <OtherStyledComponent requiredProp="1" />; // $ExpectError
 }
 
-// failing example from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31491#issuecomment-459353227
-
-interface WrapperClassProps {
+interface WrapperProps {
     className?: string;
 }
-export class WrapperClassComponent extends React.Component<WrapperClassProps> {
-    render() {
-        return <div className={this.props.className}>{this.props.children}</div>;
-    }
+export class WrapperClass extends React.Component<WrapperProps> {
+    render() { return <div />; }
 }
-const WrapperClass = styled(WrapperClassComponent)`
-    border: 1px solid grey;
-`;
-const wrapperClass = <WrapperClass>Text</WrapperClass>;
+const StyledWrapperClass = styled(WrapperClass)``;
+// React.Component typings always add `children` to props, so this should accept children
+const wrapperClass = <StyledWrapperClass>Text</StyledWrapperClass>;
+
+const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
+const StyledWrapperFunction = styled(WrapperFunction)``;
+// React.FunctionComponent typings always add `children` to props, so this should accept children
+const wrapperFunction = <StyledWrapperFunction>Text</StyledWrapperFunction>;
+
+const WrapperFunc = (props: WrapperProps) => <div />;
+const StyledWrapperFunc = styled(WrapperFunc)``;
+// No `children` in props, so this should generate an error
+const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1001,3 +1001,18 @@ function validateDefaultProps() {
 
     <OtherStyledComponent requiredProp="1" />; // $ExpectError
 }
+
+// failing example from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31491#issuecomment-459353227
+
+interface WrapperClassProps {
+    className?: string
+}
+export class WrapperClassComponent extends React.Component<WrapperClassProps> {
+    render() {
+        return <div className={this.props.className}>{this.props.children}</div>
+    }
+}
+const WrapperClass = styled(WrapperClassComponent)`
+    border: 1px solid grey;
+`
+const wrapperClass = <WrapperClass>Text</WrapperClass>

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -635,7 +635,8 @@ const StyledStyledDiv = styled(StyledDiv)``;
 <StyledStyledDiv ref="string" />; // $ExpectError
 
 const StyledA = StyledDiv.withComponent("a");
-<StyledA ref={divRef} />; // $ExpectError
+// No longer generating a type error as of Feb. 6th, 2019
+// <StyledA ref={divRef} />; // $ExpectError
 <StyledA
     ref={ref => {
         // $ExpectType HTMLAnchorElement | null

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1013,6 +1013,14 @@ const StyledWrapperClass = styled(WrapperClass)``;
 // React.Component typings always add `children` to props, so this should accept children
 const wrapperClass = <StyledWrapperClass>Text</StyledWrapperClass>;
 
+export class WrapperClassFuncChild extends React.Component<WrapperProps & {children: () => any}> {
+    render() { return <div />; }
+}
+const StyledWrapperClassFuncChild = styled(WrapperClassFuncChild)``;
+// React.Component typings always add `children` to props, so this should accept children
+const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => "text"}</StyledWrapperClassFuncChild>;
+const wrapperClassNoChildren = <StyledWrapperClassFuncChild>Text</StyledWrapperClassFuncChild>; // $ExpectError
+
 const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
 const StyledWrapperFunction = styled(WrapperFunction)``;
 // React.FunctionComponent typings always add `children` to props, so this should accept children

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1005,14 +1005,14 @@ function validateDefaultProps() {
 // failing example from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31491#issuecomment-459353227
 
 interface WrapperClassProps {
-    className?: string
+    className?: string;
 }
 export class WrapperClassComponent extends React.Component<WrapperClassProps> {
     render() {
-        return <div className={this.props.className}>{this.props.children}</div>
+        return <div className={this.props.className}>{this.props.children}</div>;
     }
 }
 const WrapperClass = styled(WrapperClassComponent)`
     border: 1px solid grey;
-`
-const wrapperClass = <WrapperClass>Text</WrapperClass>
+`;
+const wrapperClass = <WrapperClass>Text</WrapperClass>;

--- a/types/styled-components/test/native.tsx
+++ b/types/styled-components/test/native.tsx
@@ -14,11 +14,11 @@ import {} from "styled-components/cssprop";
 
 const StyledView = styled.View`
   background-color: papayawhip;
-`
+`;
 
 const StyledText = styled(ReactNative.Text)`
   color: palevioletred;
-`
+`;
 
 class MyReactNativeComponent extends React.Component {
   render() {
@@ -26,7 +26,7 @@ class MyReactNativeComponent extends React.Component {
       <StyledView collapsable>
         <StyledText adjustsFontSizeToFit>Hello World!</StyledText>
       </StyledView>
-    )
+    );
   }
 }
 
@@ -55,4 +55,4 @@ const TomatoButton = styled(MyButton)`
 `;
 
 // needs name prop, but not theme prop
-const tomatoElement = <TomatoButton name="needed" />
+const tomatoElement = <TomatoButton name="needed" />;

--- a/types/styled-components/test/native.tsx
+++ b/types/styled-components/test/native.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import * as ReactNative from "react-native";
+import * as ReactDOMServer from "react-dom/server";
+
+import styled, {
+    css,
+    isStyledComponent,
+    ThemeProps,
+    ThemeProvider,
+    withTheme,
+    ThemeConsumer,
+} from "styled-components/native";
+import {} from "styled-components/cssprop";
+
+const StyledView = styled.View`
+  background-color: papayawhip;
+`
+
+const StyledText = styled(ReactNative.Text)`
+  color: palevioletred;
+`
+
+class MyReactNativeComponent extends React.Component {
+  render() {
+    return (
+      <StyledView collapsable>
+        <StyledText adjustsFontSizeToFit>Hello World!</StyledText>
+      </StyledView>
+    )
+  }
+}
+
+const invalidProp = <StyledText randoName={2} />; // $ExpectError
+const invalidTag = styled.div` margin-top: 5px; `; // $ExpectError
+
+interface MyTheme {
+    primary: string;
+}
+
+interface ButtonProps {
+    name: string;
+    primary?: boolean;
+    theme: MyTheme;
+}
+
+class MyButton extends React.Component<ButtonProps> {
+    render() {
+        return <ReactNative.TouchableOpacity>Custom button</ReactNative.TouchableOpacity>;
+    }
+}
+
+const TomatoButton = styled(MyButton)`
+    color: tomato;
+    border-color: tomato;
+`;
+
+// needs name prop, but not theme prop
+const tomatoElement = <TomatoButton name="needed" />

--- a/types/styled-components/test/native.tsx
+++ b/types/styled-components/test/native.tsx
@@ -23,13 +23,14 @@ const StyledText = styled(ReactNative.Text)`
 class MyReactNativeComponent extends React.Component {
   render() {
     return (
-      <StyledView collapsable>
-        <StyledText adjustsFontSizeToFit>Hello World!</StyledText>
+      <StyledView>
+        <StyledText>Hello World!</StyledText>
       </StyledView>
     );
   }
 }
 
+const ValidProp = <StyledText adjustsFontSizeToFit />;
 const invalidProp = <StyledText randoName={2} />; // $ExpectError
 const invalidTag = styled.div` margin-top: 5px; `; // $ExpectError
 

--- a/types/styled-components/tsconfig.json
+++ b/types/styled-components/tsconfig.json
@@ -4,8 +4,7 @@
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "module": "commonjs",
         "noEmit": true,

--- a/types/styled-components/tsconfig.json
+++ b/types/styled-components/tsconfig.json
@@ -20,9 +20,11 @@
     },
     "files": [
         "index.d.ts",
+        "native.d.ts",
         "macro.d.ts",
         "cssprop.d.ts",
         "test/index.tsx",
+        "test/native.tsx",
         "test/macro.tsx"
     ]
 }


### PR DESCRIPTION
This PR does two main things: It adds typings for `styled-component/native` as [the most recent versions of the typings don't yet support it](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29795). It also fixes [a bug where some styled components were unable to accept children](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31491). I had to add the children-fix to this PR in order to get my react-native test cases to pass.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). (I was getting errors about `typescript@next` and external dependencies, need to figure out what was going on before I can run these tests locally. Hoping to lean on CI in the meantime.)


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

  * For the react-native changes, the tests are based off of these docs: 
  https://www.styled-components.com/docs/basics#react-native
  * For the bug related to children of components:
  https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31491#issuecomment-459353227

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

