### PR TITLE
Explicitly specify `Koa.Middleware` params

### DIFF
--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -19,7 +19,7 @@ import { Middleware } from "koa";
 
 import { SendOptions } from "koa-send";
 
-declare function serve(root: string, opts?: serve.Options): Middleware;
+declare function serve(root: string, opts?: serve.Options): Middleware<{}>;
 
 declare namespace serve {
     interface Options extends SendOptions {


### PR DESCRIPTION
This way we explicitly state `koa-static` doesn't add anything to Koa's `ctx`
or `ctx.state`.

It's useful because with those changes it won't erase `ctx.state` type,
converting it into `any`. Like, if we have some middleware:

```ts
import Koa from 'koa';

type FooCtx = { foo: string };
const someMiddleware: Koa.Middleware<FooCtx, {}> = (ctx, next) => {
    ctx.state.foo = "foo";
}
```

Before the changes in this PR it would be:

```ts
const app = new Koa<{}, {}>()
    .use(someMiddleware)
    .use(koaStatic("."))
// app is Koa<any, {}>
```

After the changes in this PR:

```ts
const app = new Koa<{}, {}>()
  .use(someMiddleware)
  .use(koaStatic("."))
// app is Koa<FooCtx, {}>
```
