### PR TITLE
Add missing components

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -115,12 +115,11 @@ export interface HeaderProps {
 export interface Components {
     event?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     eventWrapper?: React.ComponentType<EventWrapperProps>;
+    eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dayWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dateCellWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
-    /**
-     * component used as a header for each column in the TimeGridHeader
-     */
-    header?: React.ComponentType<HeaderProps>;
+    timeSlotWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
+    timeGutterWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     toolbar?: React.ComponentType<ToolbarProps>;
     agenda?: {
         date?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
@@ -140,6 +139,10 @@ export interface Components {
         dateHeader?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
         event?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     };
+    /**
+     * component used as a header for each column in the TimeGridHeader
+     */
+    header?: React.ComponentType<HeaderProps>;
 }
 
 export interface ToolbarProps {


### PR DESCRIPTION
I have discovered these by using a proxy:

```javascript
components={new Proxy({}, { get: console.log })}
```

This allowed me to also see the order in which they are called when rendering the calendar so I reordered them so in the types, too. I have never seen a call to `header` but I have not tried all calendar modes. I did this mainly to get ahold of `timeslotWrapper` because I was sure there must be something like it, but it was not in types nor was it in the docs and I didn't want to spend too much time diving into the codebase. This took less than a minute and got me what I needed.