### PR TITLE
[redux-form] - Fix for failing Field definition in TypeScript 3.2+

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -13,7 +13,7 @@
 //                 Kamil Wojcik <https://github.com/smifun>
 //                 Mohamed Shaaban <https://github.com/mshaaban088>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.3
+// TypeScript Version: 3.0
 import {
   ComponentClass,
   StatelessComponent,

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -13,7 +13,7 @@
 //                 Kamil Wojcik <https://github.com/smifun>
 //                 Mohamed Shaaban <https://github.com/mshaaban088>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.3
 import {
   ComponentClass,
   StatelessComponent,

--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -61,7 +61,7 @@ export type GenericFieldHTMLAttributes =
     SelectHTMLAttributes<HTMLSelectElement> |
     TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-export class Field<P = GenericFieldHTMLAttributes | BaseFieldProps> extends Component<BaseFieldProps<P> & P> {
+export class Field<P extends GenericFieldHTMLAttributes | BaseFieldProps = GenericFieldHTMLAttributes | BaseFieldProps> extends Component<P> {
     dirty: boolean;
     name: string;
     pristine: boolean;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -287,6 +287,12 @@ const Test = reduxForm<TestFormData>({
                                 component="select"
                             />
 
+                            <Field
+                                name="field4"
+                                component={ MyField }
+                                foo="bar"
+                            />
+
                             <FieldCustom
                                 name="field4"
                                 component={ MyField }


### PR DESCRIPTION
Fixes for the `Field` definition that cause this definition to fail in TypeScript 3.2 and above. Fix suggested by @[weswigham](/weswigham) in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31215.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31215
- [x] Increase the version number in the header if appropriate.
