### PR TITLE
overloading problem of genSalt function

### DIFF
--- a/types/bcryptjs/index.d.ts
+++ b/types/bcryptjs/index.d.ts
@@ -29,11 +29,22 @@ export declare function genSaltSync(rounds?: number): string;
  */
 export declare function genSalt(rounds?: number): Promise<string>;
 
-/**
- * Asynchronously generates a salt.
- * @param callback Callback receiving the error, if any, and the resulting salt
- */
-export declare function genSalt(callback: (err: Error, salt: string) => void): void;
+// I have the following code in my typescript project:
+// ```
+// import {genSalt} from 'bcryptjs';
+// import {promisify} from 'util';
+// const genSaltAsync = promisify(genSalt);
+// const salt = genSaltAsync(10);
+// ```
+// The overloading doesn't work as expect,
+// it only recognizes the callback signature but not the one takes in `round` as arg1.
+// To use the expected signature I have to remove the following declaration.
+
+// /**
+//  * Asynchronously generates a salt.
+//  * @param callback Callback receiving the error, if any, and the resulting salt
+//  */
+// export declare function genSalt(callback: (err: Error, salt: string) => void): void;
 
 /**
  * Asynchronously generates a salt.


### PR DESCRIPTION
Hi team, I came across a problem of the overloading for function `genSalt` in `bcryptjs` and appreciate some help to solve it.

Here is my problem:

I have the following code in my typescript project:
```ts
import {genSalt} from 'bcryptjs';
import {promisify} from 'util';
const genSaltAsync = promisify(genSalt);
const salt = genSaltAsync(10);
```
The overloading of function `genSalt` doesn't work as expect, it only recognizes the callback signature but not the one takes in `round` as arg1. To use the expected signature I have to remove the following declaration.

Any suggestion on how to make the signature `genSaltAsync(round)` work? Thanks in advance.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
