### PR TITLE
[@types/yup] Add notType field in MixedSchema locale

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yup 0.26
+// Type definitions for yup 0.27
 // Project: https://github.com/jquense/yup
 // Definitions by: Dominik Hardtke <https://github.com/dhardtke>,
 //                 Vladyslav Tserman <https://github.com/vtserman>,

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -9,6 +9,7 @@
 //                 Robert Bullen <https://github.com/robertbullen>
 //                 Yusuke Sato <https://github.com/sat0yu>
 //                 Dan Rumney <https://github.com/dancrumb>
+//                 Josh Pensky <https://github.com/joshpensky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -99,6 +100,10 @@ export interface MixedSchemaConstructor {
 
 // tslint:disable-next-line:no-empty-interface
 export interface MixedSchema extends Schema<any> {}
+
+export interface MixedSchemaLocale extends MixedSchema {
+    notType(ref?: { path: string, type: string, value: any, originalValue: any }): string;
+}
 
 export interface StringSchemaConstructor {
     (): StringSchema;
@@ -369,7 +374,7 @@ export class Ref {
 export interface Lazy extends Schema<any> {}
 
 export interface LocaleObject {
-    mixed?: { [key in keyof MixedSchema]?: string };
+    mixed?: { [key in keyof MixedSchemaLocale]?: string };
     string?: { [key in keyof StringSchema]?: string };
     number?: { [key in keyof NumberSchema]?: string };
     boolean?: { [key in keyof BooleanSchema]?: string };

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -442,6 +442,9 @@ const validateOptions: ValidateOptions = {
 };
 
 yup.setLocale({
+    mixed: {
+        notType: 'This field must be a valid ${type}'
+    },
     number: { max: "Max message", min: "Min message" },
     string: { email: "String message" }
 });

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -443,7 +443,7 @@ const validateOptions: ValidateOptions = {
 
 yup.setLocale({
     mixed: {
-        notType: 'This field must be a valid ${type}'
+        notType: "This field is not valid",
     },
     number: { max: "Max message", min: "Min message" },
     string: { email: "String message" }


### PR DESCRIPTION
@types/yup was missing [this](https://github.com/jquense/yup/blob/85e93e10c48111d592dcaf681c076c1d45cd5fdc/src/locale.js#L8) definition for the notType function used in mixed schema locale objects 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jquense/yup/blob/85e93e10c48111d592dcaf681c076c1d45cd5fdc/src/locale.js#L8>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
