### PR TITLE
[styled-system]: Add missing justifyItems definition.

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-system 3.2.1
+// Type definitions for styled-system 3.2
 // Project: https://github.com/jxnblk/styled-system#readme
 // Definitions by: Marshall Bowers <https://github.com/maxdeviant>
 //                 Ben McCormick <https://github.com/phobon>

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-system 3.2
+// Type definitions for styled-system 3.2.1
 // Project: https://github.com/jxnblk/styled-system#readme
 // Definitions by: Marshall Bowers <https://github.com/maxdeviant>
 //                 Ben McCormick <https://github.com/phobon>
@@ -420,6 +420,8 @@ export interface JustifyItemsProps {
      */
     justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty>;
 }
+
+export function justifyItems(...args: any[]): any;
 
 export interface JustifyContentProps {
     /**

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -277,7 +277,7 @@ interface GridComponentProps
         GridAutoColumnsProps,
         GridAutoRowsProps,
         GridTemplatesRowsProps,
-        GridTemplatesColumnsProps{}
+        GridTemplatesColumnsProps {}
 const Grid: React.ComponentType<GridComponentProps> = styled`
     ${gridGap};
     ${gridRowGap};

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -43,6 +43,8 @@ import {
     alignContent,
     justifyContent,
     JustifyContentProps,
+    justifyItems,
+    JustifyItemsProps,
     FlexWrapProps,
     flexWrap,
     flexBasis,
@@ -273,7 +275,8 @@ interface GridComponentProps
         GridAutoColumnsProps,
         GridAutoRowsProps,
         GridTemplatesRowsProps,
-        GridTemplatesColumnsProps {}
+        GridTemplatesColumnsProps,
+        JustifyItemsProps {}
 const Grid: React.ComponentType<GridComponentProps> = styled`
     ${gridGap};
     ${gridRowGap};
@@ -285,6 +288,7 @@ const Grid: React.ComponentType<GridComponentProps> = styled`
     ${gridAutoColumns};
     ${gridTemplateRows};
     ${gridTemplateColumns};
+    ${justifyItems};
 `;
 
 interface ButtonProps
@@ -467,6 +471,10 @@ const test = () => (
         <Grid gridTemplateColumns="auto" />
         <Grid gridTemplateColumns={["auto", "1fr"]} />
         <Grid gridTemplateColumns={{ sm: "auto", md: "1fr" }} />
+        // justifyItems
+        <Grid justifyItems="baseline" />
+        <Grid justifyItems={["baseline", "center"]} />
+        <Grid justifyItems={{ sm: "baseline", md: "center" }} />
         // flex (responsive)
         <Box flex="1 1 auto" />
         <Box flex={["1 1 auto"]} />

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -255,7 +255,8 @@ interface FlexComponentProps
         JustifyContentProps,
         FlexWrapProps,
         FlexBasisProps,
-        FlexDirectionProps {}
+        FlexDirectionProps,
+        JustifyItemsProps {}
 const Flex: React.ComponentType<FlexComponentProps> = styled`
     ${alignItems};
     ${alignContent};
@@ -263,6 +264,7 @@ const Flex: React.ComponentType<FlexComponentProps> = styled`
     ${flexWrap};
     ${flexBasis};
     ${flexDirection};
+    ${justifyItems};
 `;
 
 interface GridComponentProps
@@ -275,8 +277,7 @@ interface GridComponentProps
         GridAutoColumnsProps,
         GridAutoRowsProps,
         GridTemplatesRowsProps,
-        GridTemplatesColumnsProps,
-        JustifyItemsProps {}
+        GridTemplatesColumnsProps{}
 const Grid: React.ComponentType<GridComponentProps> = styled`
     ${gridGap};
     ${gridRowGap};
@@ -288,7 +289,6 @@ const Grid: React.ComponentType<GridComponentProps> = styled`
     ${gridAutoColumns};
     ${gridTemplateRows};
     ${gridTemplateColumns};
-    ${justifyItems};
 `;
 
 interface ButtonProps
@@ -431,6 +431,10 @@ const test = () => (
         <Flex flexDirection="column" />
         <Flex flexDirection={["column"]} />
         <Flex flexDirection={{ sm: "column" }} />
+        // justifyItems
+        <Flex justifyItems="baseline" />
+        <Flex justifyItems={["baseline", "center"]} />
+        <Flex justifyItems={{ sm: "baseline", md: "center" }} />
         // gridGap
         <Grid gridGap="1px" />
         <Grid gridGap={["1", "2"]} />
@@ -471,10 +475,6 @@ const test = () => (
         <Grid gridTemplateColumns="auto" />
         <Grid gridTemplateColumns={["auto", "1fr"]} />
         <Grid gridTemplateColumns={{ sm: "auto", md: "1fr" }} />
-        // justifyItems
-        <Grid justifyItems="baseline" />
-        <Grid justifyItems={["baseline", "center"]} />
-        <Grid justifyItems={{ sm: "baseline", md: "center" }} />
         // flex (responsive)
         <Box flex="1 1 auto" />
         <Box flex={["1 1 auto"]} />


### PR DESCRIPTION
JustifyItemsProps existed, but the export for justifyItems was missing.

Note that I added this under Grid instead of Flex because this property is ignore in Flexbox: [MDN: justify-items](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jxnblk/styled-system/blob/9358dff509fec3fbacbf8ff6e9a4be27420ebcbd/docs/table.md#flexbox
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.