### PR TITLE
[@types/luxon] Fix args type for Interval#toDuration

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.10
+// Type definitions for luxon 1.11.1
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -436,7 +436,7 @@ export class Interval {
     splitAt(...dateTimes: DateTime[]): Interval[];
     splitBy(duration: Duration | DurationObject | number): Interval[];
     toDuration(
-        unit: DurationUnit | DurationUnit[],
+        unit?: DurationUnit | DurationUnit[],
         options?: DiffOptions
     ): Duration;
     toFormat(

--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.11.1
+// Type definitions for luxon 1.11
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -144,6 +144,7 @@ i.mapEndpoints((d) => d); // $ExpectType Interval
 i.toISO(); // $ExpectType string
 i.toString(); // $ExpectType string
 i.toDuration('months'); // $ExpectType Duration
+i.toDuration(); // $ExpectType Duration
 
 if (Interval.isInterval(anything)) {
     anything; // $ExpectType Interval


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/docs/class/src/interval.js~Interval.html#instance-method-toDuration
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

According to [luxon reference](https://moment.github.io/luxon/docs/class/src/interval.js~Interval.html#instance-method-toDuration), argument `unit` for function `Interval#toDuration` is optional.