### PR TITLE
Add `diff` to Jest's matcher utils

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -21,8 +21,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import jestDiff = require('jest-diff');
-
 declare var beforeAll: jest.Lifecycle;
 declare var beforeEach: jest.Lifecycle;
 declare var afterAll: jest.Lifecycle;
@@ -348,7 +346,7 @@ declare namespace jest {
         utils: {
             readonly EXPECTED_COLOR: (text: string) => string;
             readonly RECEIVED_COLOR: (text: string) => string;
-            diff: typeof jestDiff;
+            diff: typeof import('jest-diff');
             ensureActualIsNumber(actual: any, matcherName?: string): void;
             ensureExpectedIsNumber(actual: any, matcherName?: string): void;
             ensureNoExpected(actual: any, matcherName?: string): void;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -21,6 +21,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+import jestDiff = require('jest-diff');
+
 declare var beforeAll: jest.Lifecycle;
 declare var beforeEach: jest.Lifecycle;
 declare var afterAll: jest.Lifecycle;
@@ -346,6 +348,7 @@ declare namespace jest {
         utils: {
             readonly EXPECTED_COLOR: (text: string) => string;
             readonly RECEIVED_COLOR: (text: string) => string;
+            diff: typeof jestDiff;
             ensureActualIsNumber(actual: any, matcherName?: string): void;
             ensureExpectedIsNumber(actual: any, matcherName?: string): void;
             ensureNoExpected(actual: any, matcherName?: string): void;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -605,6 +605,8 @@ expect.extend({
 
         const equals: boolean = this.equals({}, {});
 
+        const diff: string = this.diff({}, {});
+
         return {
             message: () => "",
             pass: false,

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -560,6 +560,8 @@ expect.extend({
         const expectedColor = this.utils.EXPECTED_COLOR("blue");
         const receivedColor = this.utils.EXPECTED_COLOR("red");
 
+        const diff: string = this.utils.diff({}, {});
+
         this.utils.ensureActualIsNumber({});
         this.utils.ensureActualIsNumber({}, "matcher");
 
@@ -604,8 +606,6 @@ expect.extend({
         const stringifiedWithMaxDepth: string = this.utils.stringify({}, 3);
 
         const equals: boolean = this.equals({}, {});
-
-        const diff: string = this.diff({}, {});
 
         return {
             message: () => "",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) (a bunch of tests failed, though)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/7605 (all exports from `jest-matcher-utils` are added to `this.utils` in matchers here: https://github.com/facebook/jest/blob/080998edd46f1c75e8864dae1e6b6cad99265a8e/packages/expect/src/index.js#L237-L252)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

![image](https://user-images.githubusercontent.com/1404810/52470082-7a139e80-2b8d-11e9-988a-74767a4ac0c2.png)