### PR TITLE
[node] Correct type of TransformCallback

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -222,7 +222,7 @@ declare module "stream" {
             uncork(): void;
         }
 
-        type TransformCallback = (error?: Error, data?: any) => void;
+        type TransformCallback = (error?: Error | null, data?: any) => void;
 
         interface TransformOptions extends DuplexOptions {
             read?(this: Transform, size: number): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v8.x/api/stream.html#stream_transform_transform_chunk_encoding_callback
- [x] Increase the version number in the header if appropriate: Not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: Not substantial changes

Personal comments:
This change is to allow people to use the `@types/node/stream.d.ts` with the option `strictNullChecks` to true in their `tsconfig.json`
