### PR TITLE
Change npm so that config get/set uses `any` instead of `string`

### DIFF
--- a/types/npm/index.d.ts
+++ b/types/npm/index.d.ts
@@ -167,8 +167,8 @@ declare namespace NPM {
         Conf: ConfigStatic;
         defs: ConfigDefs;
 
-        get(setting: string): string;
-        set(setting: string, value: string): void;
+        get<T>(setting: string): T;
+        set<T>(setting: string, value: T): void;
 
         loadPrefix(cb: ErrorCallback): void;
         loadCAFile(caFilePath: string, cb: ErrorCallback): void;

--- a/types/npm/index.d.ts
+++ b/types/npm/index.d.ts
@@ -168,7 +168,7 @@ declare namespace NPM {
         defs: ConfigDefs;
 
         get(setting: string): any;
-        set<T>(setting: string, value: T): void;
+        set(setting: string, value: any): void;
 
         loadPrefix(cb: ErrorCallback): void;
         loadCAFile(caFilePath: string, cb: ErrorCallback): void;

--- a/types/npm/index.d.ts
+++ b/types/npm/index.d.ts
@@ -167,7 +167,7 @@ declare namespace NPM {
         Conf: ConfigStatic;
         defs: ConfigDefs;
 
-        get<T>(setting: string): T;
+        get(setting: string): any;
         set<T>(setting: string, value: T): void;
 
         loadPrefix(cb: ErrorCallback): void;

--- a/types/npm/npm-tests.ts
+++ b/types/npm/npm-tests.ts
@@ -22,4 +22,6 @@ npm.load({}, function (er) {
     npm.on("log", function (message: string) {
         console.log(message);
     });
+    
+    npm.config.set('audit', false);
 })


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see usage](https://github.com/npm/cli/blob/59e5056a2129cb2951f4ff3b657ada20657f01a7/lib/install.js#L242) and [see defaults](https://github.com/npm/cli/blob/550bf703ae3e31ba6a300658ae95b6937f67b68f/lib/config/defaults.js#L112)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

