### PR TITLE
Set koa-joi-router output object types

### DIFF
--- a/types/koa-joi-router/index.d.ts
+++ b/types/koa-joi-router/index.d.ts
@@ -31,6 +31,8 @@ declare namespace createRouter {
 
     type Method = (path: string|RegExp, handlerOrConfig: Handler | object, ...handlers: Handler[]) => Router;
 
+    type OutputValidation = { body: Joi.SchemaLike } | { headers: Joi.SchemaLike };
+
     interface Spec {
         method: string|string[];
         path: string|RegExp;
@@ -47,7 +49,7 @@ declare namespace createRouter {
             formOptions?: CoBody.Options;
             jsonOptions?: CoBody.Options;
             multipartOptions?: CoBody.Options;
-            output?: {[status: string]: Joi.SchemaLike};
+            output?: {[status: string]: OutputValidation};
             continueOnError?: boolean;
         };
         meta?: any;

--- a/types/koa-joi-router/koa-joi-router-tests.ts
+++ b/types/koa-joi-router/koa-joi-router-tests.ts
@@ -41,8 +41,16 @@ const spec4: router.Spec = {
   validate: {
     type: 'json',
     output: {
-      201: Joi.object(),
-      '400,404': Joi.object(),
+      201: {
+        body: Joi.object(),
+      },
+      '400,404': {
+        headers: Joi.object(),
+        body: Joi.object(),
+      },
+      '500-599': {
+        headers: Joi.object(),
+      },
     },
     jsonOptions: {
         limit: '10kb'


### PR DESCRIPTION
koa-joi-router lets users validate the body and headers of their output. The previous types expected a Joi schema, which works because any key is allowed, but koa-joi-router will throw on runtime as it only checks for `body` or `headers`.

The new type checks that the user uses at least one of `body` or `headers` in the validation object. The union type also works if both keys are specified!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/joi-router#validating-output
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
