### PR TITLE
[detox] Remove named export, define default export

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -442,4 +442,4 @@ export { by, device, element, waitFor };
 // for backwards compatibility though.
 export const expect: Detox.Expect<Detox.Expect<any>>;
 
-export default detox;
+export = detox;

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -434,10 +434,12 @@ declare global {
     }
 }
 
-export { by, detox, device, element, waitFor };
+export { by, device, element, waitFor };
 
 // Not exporting the global `expect` from the top of the file here
 // because `expect` conflicts with the global `expect` of jest and
 // therefore exporting it doesn't work. The global `expect` is kept
 // for backwards compatibility though.
 export const expect: Detox.Expect<Detox.Expect<any>>;
+
+export default detox;

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -42,6 +42,16 @@ declare global {
              */
             cleanup(): Promise<void>;
         }
+
+        // Detox exports all methods from detox global and all of the global constants.
+        interface DetoxExport extends Detox {
+            device: Device;
+            element: Element;
+            waitFor: WaitFor;
+            expect: Expect<Expect<any>>;
+            by: Matchers;
+        }
+
         interface Device {
             /**
              * Launch the app
@@ -434,12 +444,6 @@ declare global {
     }
 }
 
-export { by, device, element, waitFor };
+declare const detoxExport: Detox.DetoxExport;
 
-// Not exporting the global `expect` from the top of the file here
-// because `expect` conflicts with the global `expect` of jest and
-// therefore exporting it doesn't work. The global `expect` is kept
-// for backwards compatibility though.
-export const expect: Detox.Expect<Detox.Expect<any>>;
-
-export = detox;
+export = detoxExport;

--- a/types/detox/runners/jest/adapter/index.d.ts
+++ b/types/detox/runners/jest/adapter/index.d.ts
@@ -9,4 +9,4 @@ interface DetoxJestAdapter {
 
 declare const adapter: DetoxJestAdapter;
 
-export default adapter;
+export = adapter;

--- a/types/detox/runners/mocha/adapter/index.d.ts
+++ b/types/detox/runners/mocha/adapter/index.d.ts
@@ -6,4 +6,4 @@ interface DetoxMochaAdapter {
 
 declare const adapter: DetoxMochaAdapter;
 
-export default adapter;
+export = adapter;

--- a/types/detox/test/detox-jest-setup-tests.ts
+++ b/types/detox/test/detox-jest-setup-tests.ts
@@ -2,6 +2,7 @@ declare var beforeAll: (callback: () => void) => void;
 declare var beforeEach: (callback: () => void) => void;
 declare var afterAll: (callback: () => void) => void;
 
+import defaultDetox from "detox";
 import adapter from "detox/runners/jest/adapter";
 
 // Normally the Detox configuration from the project's package.json like so:
@@ -18,7 +19,7 @@ beforeAll(async () => {
         initGlobals: false,
         launchApp: false,
     };
-    await detox.init(config, initOptions);
+    await defaultDetox.init(config, initOptions);
 });
 
 beforeEach(async () => {

--- a/types/detox/test/detox-jest-setup-tests.ts
+++ b/types/detox/test/detox-jest-setup-tests.ts
@@ -2,8 +2,7 @@ declare var beforeAll: (callback: () => void) => void;
 declare var beforeEach: (callback: () => void) => void;
 declare var afterAll: (callback: () => void) => void;
 
-import defaultDetox from "detox";
-import adapter from "detox/runners/jest/adapter";
+import * as adapter from "detox/runners/jest/adapter";
 
 // Normally the Detox configuration from the project's package.json like so:
 // const config = require("./package.json").detox;

--- a/types/detox/test/detox-jest-setup-tests.ts
+++ b/types/detox/test/detox-jest-setup-tests.ts
@@ -2,6 +2,7 @@ declare var beforeAll: (callback: () => void) => void;
 declare var beforeEach: (callback: () => void) => void;
 declare var afterAll: (callback: () => void) => void;
 
+import * as detox from "detox";
 import * as adapter from "detox/runners/jest/adapter";
 
 // Normally the Detox configuration from the project's package.json like so:
@@ -18,7 +19,7 @@ beforeAll(async () => {
         initGlobals: false,
         launchApp: false,
     };
-    await defaultDetox.init(config, initOptions);
+    await detox.init(config, initOptions);
 });
 
 beforeEach(async () => {

--- a/types/detox/test/detox-jest-setup-tests.ts
+++ b/types/detox/test/detox-jest-setup-tests.ts
@@ -2,8 +2,8 @@ declare var beforeAll: (callback: () => void) => void;
 declare var beforeEach: (callback: () => void) => void;
 declare var afterAll: (callback: () => void) => void;
 
-import * as detox from "detox";
-import * as adapter from "detox/runners/jest/adapter";
+import detox = require("detox");
+import adapter = require("detox/runners/jest/adapter");
 
 // Normally the Detox configuration from the project's package.json like so:
 // const config = require("./package.json").detox;

--- a/types/detox/test/detox-mocha-setup-tests.ts
+++ b/types/detox/test/detox-mocha-setup-tests.ts
@@ -5,6 +5,7 @@ declare var beforeEach: (callback: () => void) => void;
 declare var after: (callback: () => void) => void;
 declare var afterEach: (callback: () => void) => void;
 
+import * as detox from "detox";
 import * as adapter from "detox/runners/mocha/adapter";
 
 // Normally the Detox configuration from the project's package.json like so:

--- a/types/detox/test/detox-mocha-setup-tests.ts
+++ b/types/detox/test/detox-mocha-setup-tests.ts
@@ -5,7 +5,7 @@ declare var beforeEach: (callback: () => void) => void;
 declare var after: (callback: () => void) => void;
 declare var afterEach: (callback: () => void) => void;
 
-import adapter from "detox/runners/mocha/adapter";
+import * as adapter from "detox/runners/mocha/adapter";
 
 // Normally the Detox configuration from the project's package.json like so:
 // const config = require("./package.json").detox;


### PR DESCRIPTION
[`detox` is defined as a named export](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/detox/index.d.ts#L437) when [this is not true](https://github.com/wix/Detox/blob/master/detox/src/index.js). Furthermore, Detox does provide a default export (which should be the `detox` object itself), but currently is not typed as such.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`detox/index.js`](https://github.com/wix/Detox/blob/master/detox/src/index.js) does not include `detox` in the `module.exports` at the bottom (and isn't a member of `ExportWrapper`)