### PR TITLE
[rebass] extend styled-system interfaces, support html attributes, etc.

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -35,7 +35,7 @@ export interface BoxProps
         Omit<React.HTMLProps<HTMLDivElement>, keyof BoxKnownProps> {}
 export const Box: React.FunctionComponent<BoxProps>;
 
-export interface ButtonKnownProps
+interface ButtonKnownProps
     extends BoxKnownProps,
         StyledSystem.FontWeightProps,
         StyledSystem.BorderProps,
@@ -48,7 +48,7 @@ export interface ButtonProps
         Omit<React.HTMLProps<HTMLButtonElement>, keyof ButtonKnownProps> {}
 export const Button: React.FunctionComponent<ButtonProps>;
 
-export interface CardKnownProps
+interface CardKnownProps
     extends BoxKnownProps,
         StyledSystem.BorderProps,
         StyledSystem.BordersProps,
@@ -67,7 +67,7 @@ export interface CardProps
         Omit<React.HTMLProps<HTMLDivElement>, keyof CardKnownProps> {}
 export const Card: React.FunctionComponent<CardProps>;
 
-export interface FlexKnownProps
+interface FlexKnownProps
     extends BoxKnownProps,
         StyledSystem.FlexWrapProps,
         StyledSystem.FlexDirectionProps,
@@ -78,7 +78,7 @@ export interface FlexProps
         Omit<React.HTMLProps<HTMLDivElement>, keyof FlexKnownProps> {}
 export const Flex: React.FunctionComponent<FlexProps>;
 
-export interface ImageKnownProps
+interface ImageKnownProps
     extends BoxKnownProps,
         StyledSystem.HeightProps,
         StyledSystem.BorderRadiusProps {}
@@ -88,13 +88,13 @@ export interface ImageProps
 export const Image: React.FunctionComponent<ImageProps>;
 
 // tslint:disable-next-line no-empty-interface
-export interface LinkKnownProps extends BoxKnownProps {}
+interface LinkKnownProps extends BoxKnownProps {}
 export interface LinkProps
     extends LinkKnownProps,
         Omit<React.HTMLProps<HTMLAnchorElement>, keyof LinkKnownProps> {}
 export const Link: React.FunctionComponent<LinkProps>;
 
-export interface TextKnownProps
+interface TextKnownProps
     extends BoxKnownProps,
         StyledSystem.FontFamilyProps,
         StyledSystem.FontWeightProps,
@@ -107,7 +107,7 @@ export interface TextProps
 export const Text: React.FunctionComponent<TextProps>;
 
 // tslint:disable-next-line no-empty-interface
-export interface HeadingKnownProps extends TextKnownProps {}
+interface HeadingKnownProps extends TextKnownProps {}
 export interface HeadingProps
     extends HeadingKnownProps,
         Omit<React.HTMLProps<HTMLHeadingElement>, keyof HeadingKnownProps> {}

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -4,99 +4,107 @@
 //                 ryee-dev <https://github.com/ryee-dev>
 //                 jamesmckenzie <https://github.com/jamesmckenzie>
 //                 sara f-p <https://github.com/gretzky>
+//                 angusfretwell <https://github.com/angusfretwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
+import * as StyledComponents from "styled-components";
+import * as StyledSystem from "styled-system";
 
-export interface BaseProps<C> extends React.ClassAttributes<C> {
-    className?: string;
-    as?: any;
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export interface BaseProps extends React.Props<any> {
+    as?: React.ReactType;
+    css?: StyledComponents.CSSObject;
 }
 
-export interface SpaceProps<C> extends BaseProps<C> {
-    m?: number | string | ReadonlyArray<number>;
-    mt?: number | string | ReadonlyArray<number>;
-    mr?: number | string | ReadonlyArray<number>;
-    mb?: number | string | ReadonlyArray<number>;
-    ml?: number | string | ReadonlyArray<number>;
-    mx?: number | string | ReadonlyArray<number>;
-    my?: number | string | ReadonlyArray<number>;
-    p?: number | string | ReadonlyArray<number>;
-    pt?: number | string | ReadonlyArray<number>;
-    pr?: number | string | ReadonlyArray<number>;
-    pb?: number | string | ReadonlyArray<number>;
-    pl?: number | string | ReadonlyArray<number>;
-    px?: number | string | ReadonlyArray<number>;
-    py?: number | string | ReadonlyArray<number>;
-}
+interface BoxKnownProps
+    extends BaseProps,
+        StyledSystem.SpaceProps,
+        StyledSystem.WidthProps,
+        StyledSystem.FontSizeProps,
+        StyledSystem.ColorProps,
+        StyledSystem.FlexProps,
+        StyledSystem.OrderProps,
+        StyledSystem.AlignSelfProps {}
+export interface BoxProps
+    extends BoxKnownProps,
+        Omit<React.HTMLProps<HTMLDivElement>, keyof BoxKnownProps> {}
+export const Box: React.FunctionComponent<BoxProps>;
 
-export interface BoxProps extends SpaceProps<BoxClass> {
-    className?: string;
-    width?: number | string | ReadonlyArray<number>;
-    fontSize?: number | ReadonlyArray<number>;
-    css?: object;
-    color?: string;
-    bg?: string;
-}
-// tslint:disable-next-line:strict-export-declare-modifiers
-type BoxClass = React.FunctionComponent<BoxProps>;
-export const Box: BoxClass;
-
-export interface ButtonProps extends BoxProps {
-    fontWeight?: string;
-    border?: number | string;
-    borderColor?: string;
-    borderRadius?: number | string;
-    variant?: string;
-}
+export interface ButtonKnownProps
+    extends BoxKnownProps,
+        StyledSystem.FontWeightProps,
+        StyledSystem.BorderProps,
+        StyledSystem.BordersProps,
+        StyledSystem.BorderColorProps,
+        StyledSystem.BorderRadiusProps,
+        StyledSystem.ButtonStyleProps {}
+export interface ButtonProps
+    extends ButtonKnownProps,
+        Omit<React.HTMLProps<HTMLButtonElement>, keyof ButtonKnownProps> {}
 export const Button: React.FunctionComponent<ButtonProps>;
 
-export interface CardProps extends BoxProps {
-    border?: number | string;
-    borderColor?: string;
-    borderRadius?: number | string;
-    boxShadow?: string;
-    backgroundImage?: string;
-    backgroundSize?: string;
-    backgroundPosition?: string;
-    backgroundRepeat?: string;
-    opacity?: number;
-    variant?: string;
+export interface CardKnownProps
+    extends BoxKnownProps,
+        StyledSystem.BorderProps,
+        StyledSystem.BordersProps,
+        StyledSystem.BorderColorProps,
+        StyledSystem.BorderRadiusProps,
+        StyledSystem.BoxShadowProps,
+        StyledSystem.BackgroundImageProps,
+        StyledSystem.BackgroundSizeProps,
+        StyledSystem.BackgroundPositionProps,
+        StyledSystem.BackgroundRepeatProps,
+        StyledSystem.OpacityProps {
+    variant?: StyledSystem.ResponsiveValue<string>;
 }
+export interface CardProps
+    extends CardKnownProps,
+        Omit<React.HTMLProps<HTMLDivElement>, keyof CardKnownProps> {}
 export const Card: React.FunctionComponent<CardProps>;
 
-export interface FlexProps extends BoxProps {
-    alignItems?: string;
-    justifyContent?: string;
-    flexDirection?: string;
-    flexWrap?: string;
-}
+export interface FlexKnownProps
+    extends BoxKnownProps,
+        StyledSystem.FlexWrapProps,
+        StyledSystem.FlexDirectionProps,
+        StyledSystem.AlignItemsProps,
+        StyledSystem.JustifyContentProps {}
+export interface FlexProps
+    extends FlexKnownProps,
+        Omit<React.HTMLProps<HTMLDivElement>, keyof FlexKnownProps> {}
 export const Flex: React.FunctionComponent<FlexProps>;
 
-export interface ImageProps extends BoxProps {
-    height?: number | string;
-    borderRadius?: number | string;
-    src?: string;
-    alt?: string;
-}
+export interface ImageKnownProps
+    extends BoxKnownProps,
+        StyledSystem.HeightProps,
+        StyledSystem.BorderRadiusProps {}
+export interface ImageProps
+    extends ImageKnownProps,
+        Omit<React.HTMLProps<HTMLImageElement>, keyof ImageKnownProps> {}
 export const Image: React.FunctionComponent<ImageProps>;
 
-export interface LinkProps extends BoxProps {
-    href?: string;
-}
+export interface LinkKnownProps extends BoxKnownProps {}
+export interface LinkProps
+    extends LinkKnownProps,
+        Omit<React.HTMLProps<HTMLAnchorElement>, keyof LinkKnownProps> {}
 export const Link: React.FunctionComponent<LinkProps>;
 
-export interface TextProps extends BoxProps {
-    fontSize?: number | ReadonlyArray<number>;
-    fontWeight?: string;
-    color?: string;
-    fontFamily?: string;
-    textAlign?: string;
-    lineHeight?: number | string;
-    letterSpacing?: number | string;
-}
+export interface TextKnownProps
+    extends BoxKnownProps,
+        StyledSystem.FontFamilyProps,
+        StyledSystem.FontWeightProps,
+        StyledSystem.TextAlignProps,
+        StyledSystem.LineHeightProps,
+        StyledSystem.LetterSpacingProps {}
+export interface TextProps
+    extends TextKnownProps,
+        Omit<React.HTMLProps<HTMLDivElement>, keyof TextKnownProps> {}
 export const Text: React.FunctionComponent<TextProps>;
 
-export type HeadingProps = TextProps;
+export interface HeadingKnownProps extends TextKnownProps {}
+export interface HeadingProps
+    extends HeadingKnownProps,
+        Omit<React.HTMLProps<HTMLHeadingElement>, keyof HeadingKnownProps> {}
 export const Heading: React.FunctionComponent<HeadingProps>;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -12,6 +12,8 @@ import * as React from "react";
 import * as StyledComponents from "styled-components";
 import * as StyledSystem from "styled-system";
 
+export {};
+
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export interface BaseProps extends React.Props<any> {
@@ -85,6 +87,7 @@ export interface ImageProps
         Omit<React.HTMLProps<HTMLImageElement>, keyof ImageKnownProps> {}
 export const Image: React.FunctionComponent<ImageProps>;
 
+// tslint:disable-next-line no-empty-interface
 export interface LinkKnownProps extends BoxKnownProps {}
 export interface LinkProps
     extends LinkKnownProps,
@@ -103,6 +106,7 @@ export interface TextProps
         Omit<React.HTMLProps<HTMLDivElement>, keyof TextKnownProps> {}
 export const Text: React.FunctionComponent<TextProps>;
 
+// tslint:disable-next-line no-empty-interface
 export interface HeadingKnownProps extends TextKnownProps {}
 export interface HeadingProps
     extends HeadingKnownProps,

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -6,7 +6,7 @@
 //                 sara f-p <https://github.com/gretzky>
 //                 angusfretwell <https://github.com/angusfretwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from "react";
 import * as StyledComponents from "styled-components";

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -1,8 +1,17 @@
 import * as React from "react";
+import styled from "styled-components";
 import { Box, Flex, Text, Heading, Button, Link, Image, Card } from "rebass";
 
 const CustomComponent: React.FunctionComponent = ({ children }) => {
     return <div>{children}</div>;
+};
+
+const ExtendedBox = styled(Box)`
+    color: red;
+`;
+
+ExtendedBox.defaultProps = {
+    p: 3
 };
 
 () => (
@@ -33,10 +42,13 @@ const CustomComponent: React.FunctionComponent = ({ children }) => {
             <Link href="https://rebassjs.org" title="Rebass" target="_blank">
                 Link
             </Link>
-            <Box as={CustomComponent}>CustomComponent</Box>
             <Button bg="magenta" border="1em" borderRadius="1em">
                 Button
             </Button>
+            <Box as={CustomComponent} bg="red">
+                CustomComponent
+            </Box>
+            <ExtendedBox m={2}>ExtendedBox</ExtendedBox>
         </Flex>
     </Box>
 );

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -1,13 +1,17 @@
-import * as React from 'react';
-import { Box, Flex, Text, Heading, Button, Link, Image, Card } from 'rebass';
+import * as React from "react";
+import { Box, Flex, Text, Heading, Button, Link, Image, Card } from "rebass";
+
+const CustomComponent: React.FunctionComponent = ({ children }) => {
+    return <div>{children}</div>;
+};
 
 () => (
-    <Box width={1} css={{ height: '100vh' }} py={[1, 2, 3]} ml="1em">
+    <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em">
         <Flex width={1} alignItems="center" justifyContent="center">
             <Heading fontSize={5} fontWeight="bold">
                 Hi, I'm a heading.
             </Heading>
-            <Text fontSize={3} lineHeight="1em" letterSpacing="1rem">
+            <Text as="p" fontSize={3} lineHeight="1em" letterSpacing="1rem">
                 Hi, I'm text.
             </Text>
             <Card
@@ -26,7 +30,10 @@ import { Box, Flex, Text, Heading, Button, Link, Image, Card } from 'rebass';
                 src="https://source.unsplash.com/random/1280x720"
                 borderRadius="1em"
             />
-            <Link href="https://rebassjs.org">Link</Link>
+            <Link href="https://rebassjs.org" title="Rebass" target="_blank">
+                Link
+            </Link>
+            <Box as={CustomComponent}>CustomComponent</Box>
             <Button bg="magenta" border="1em" borderRadius="1em">
                 Button
             </Button>


### PR DESCRIPTION
Found a few issues while using Rebass in my project - this is my attempt at fixing them. It's my first time contributing to DefinitelyTyped, so feedback would be appreciated! 😄 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Rebass uses [styled-system](https://github.com/jxnblk/styled-system) so I extended the interface provided by `@types/styled-system`, which are more accurate
  - Incorporated @chuckdries's work from #32565 to support HTML attributes
  - Stricter typing for the `as` prop (used `React.ReactType` as suggested [here](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/ADVANCED.md#as-props-passing-a-component-to-be-rendered) rather than `any`) 
  - Stricter typing for the `css` prop (`styled-system` uses `styled-components` or `emotion` internally which both implement this; used interface from `@types/styled-components`)
  - Use `React.Props` over `React.ClassAttributes`. The latter is missed the `children` prop for extended components (see `ExtendedBox` in test)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.