### PR TITLE
[recompose] add optional callback type for stateUpdaters

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -130,7 +130,7 @@ declare module 'recompose' {
         TStateUpdaterName extends string
     > = (
         {[stateName in TStateName]: TState} &
-        {[stateUpdateName in TStateUpdaterName]: (state: TState) => TState}
+        {[stateUpdateName in TStateUpdaterName]: (state: TState, callback?: () => void) => TState}
     )
     export function withState<
         TOutter,


### PR DESCRIPTION
This updates the typing of the `stateUpdaters` you get as a prop when using `withState` hoc from `recompose` library. They support sending in an optional callback function, like regular react `setState` does. This adds typing for that.

It is according to this documentation: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstate