### PR TITLE
[expo] SQLite rowAffected -> rowsAffected

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2528,7 +2528,7 @@ export namespace SQLite {
 
     interface ResultSet {
         insertId: number;
-        rowAffected: number;
+        rowsAffected: number;
         rows: {
             length: number;
             item: (index: number) => any;

--- a/types/expo/v31/index.d.ts
+++ b/types/expo/v31/index.d.ts
@@ -2480,7 +2480,7 @@ export namespace SQLite {
 
     interface ResultSet {
         insertId: number;
-        rowAffected: number;
+        rowsAffected: number;
         rows: {
             length: number;
             item: (index: number) => any;


### PR DESCRIPTION
From the documentation <https://docs.expo.io/versions/latest/sdk/sqlite/>, ResultSet objects:

```
{
  insertId,
  rowsAffected,
  rows: {
    length,
    item(),
    _array,
  },
}
```

At the moment, the typescript bindings have `rowAffected` instead of `rowsAffected`.

I'm not sure if I should update this in all of `v23`... `v31` (since this typoo is present there, too). At the moment, I changed it only on the last two versions (32 and 31). 