### PR TITLE
fix issue: serialport: type error for "stopbits" #32692

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -56,7 +56,7 @@ declare namespace SerialPort {
 		dataBits?: 8|7|6|5;
 		highWaterMark?: number;
 		lock?: boolean;
-		stopBits?: 1|2;
+		stopbits?: 1|2;
 		parity?: 'none'|'even'|'mark'|'odd'|'space';
 		rtscts?: boolean;
 		xon?: boolean;

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -15,7 +15,7 @@ function test_connect_config() {
             lock: false,
             baudRate: 115200,
             dataBits: 5,
-            stopBits: 2,
+            stopbits: 2,
             parity: 'odd',
             rtscts: true,
             xon: true,


### PR DESCRIPTION
Please fill in this template.

- [ ]  when i use "stopBits" from interface OpenOptions, there's an error occured with output: TypeError: "stopbits" is invalid: undefined. I think the member "stopBits" should be "stopbits".

- [ ] the source code path is types/serialport/index.d.ts.
- [ ] Test the change compile and run in my own code. 
- [ ] npm test passed