### PR TITLE
[express-winston] Update RequestFilter and ResponseFilter types

### DIFF
--- a/types/express-winston/express-winston-tests.ts
+++ b/types/express-winston/express-winston-tests.ts
@@ -18,7 +18,7 @@ app.use(expressWinston.logger({
   meta: true,
   metaField: 'metaField',
   msg: 'msg',
-  requestFilter: (req, prop) => true,
+  requestFilter: (req, prop) => req[prop],
   requestWhitelist: ['foo', 'bar'],
   skip: (req, res) => false,
   statusLevels: ({ error: 'error', success: 'success', warn: 'warn' }),
@@ -69,8 +69,8 @@ app.use(expressWinston.errorLogger({
 
 expressWinston.bodyBlacklist.push('potato');
 expressWinston.bodyWhitelist.push('apple');
-expressWinston.defaultRequestFilter = (req: express.Request, prop: string) => true;
-expressWinston.defaultResponseFilter = (res: express.Response, prop: string) => true;
+expressWinston.defaultRequestFilter = (req: expressWinston.FilterRequest, prop: string) => req[prop];
+expressWinston.defaultResponseFilter = (res: expressWinston.FilterResponse, prop: string) => res[prop];
 expressWinston.defaultSkip = () => true;
 expressWinston.ignoredRoutes.push('/ignored');
 expressWinston.responseWhitelist.push('body');

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -8,10 +8,18 @@ import { ErrorRequestHandler, Handler, Request, Response } from 'express';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';
 
+export interface FilterRequest extends Request {
+  [other: string]: any;
+}
+
+export interface FilterResponse extends Response {
+  [other: string]: any;
+}
+
 export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => object;
 export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
-export type RequestFilter = (req: Request, propName: string) => boolean;
-export type ResponseFilter = (res: Response, propName: string) => boolean;
+export type RequestFilter = (req: FilterRequest, propName: string) => any;
+export type ResponseFilter = (res: FilterResponse, propName: string) => any;
 export type RouteFilter = (req: Request, res: Response) => boolean;
 
 export interface BaseLoggerOptions {


### PR DESCRIPTION
Based on the express-winston source code, RequestFilter and ResponseFilter should return the object in the request or response, not boolean. @bithavoc
https://github.com/bithavoc/express-winston/blob/master/index.js#L78

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bithavoc/express-winston/blob/master/index.js#L78>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

