### PR TITLE
[@babel/types] Add importKind to ImportDeclaration

### DIFF
--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -443,6 +443,8 @@ export interface ImportDeclaration extends Node {
     type: "ImportDeclaration";
     specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
     source: StringLiteral;
+    // importKind is only set when flow syntax was parsed
+    importKind: void | "type" | "typeof" | "value";
 }
 
 export interface ImportDefaultSpecifier extends Node {

--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -445,7 +445,7 @@ export interface ImportDeclaration extends Node {
     specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
     source: StringLiteral;
     // importKind is only set when flow syntax was parsed
-    importKind: void | "type" | "typeof" | "value";
+    importKind: undefined | "type" | "typeof" | "value";
 }
 
 export interface ImportDefaultSpecifier extends Node {

--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -4,6 +4,7 @@
 //                 Sam Baxter <https://github.com/baxtersa>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Boris Cherny <https://github.com/bcherny>
+//                 Daniel Tschinder <https://github.com/danez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Should this definition be copied/renamed? currently it is `babel-types`, but as the babel package is called `@babel/types` should it be `babel__types`? Not sure what the naming conventions are here, or how typescript figures out which type definition package belongs to which package?

Fixes babel/babel#9485


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/pull/9490
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
