### PR TITLE
[@types/next] Remove buildManifest from renderPage for Next.js 8.

### DIFF
--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -36,7 +36,7 @@ export interface NextDocumentContext<Q extends DefaultQuery = DefaultQuery> exte
         E extends PageProps = AnyPageProps,
         P = E,
         EA extends PageProps = AnyPageProps,
-        PA = EA,
+        PA = EA
     >(
         enhancer?:
             | Enhancer<E, P> // tslint:disable-line no-unnecessary-generics
@@ -49,7 +49,7 @@ export interface NextDocumentContext<Q extends DefaultQuery = DefaultQuery> exte
  * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L16
  */
 export interface DefaultDocumentIProps extends RenderPageResponse {
-    styles?: React.ReactNode[];
+    styles?: React.ReactNode;
 }
 
 /**

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -2,10 +2,13 @@ import * as React from "react";
 import { NextContext, NextComponentType } from ".";
 import { DefaultQuery } from "./router";
 
+/**
+ * Result from renderPage().
+ * https://github.com/zeit/next.js/blob/v8.0.0/packages/next/pages/_document.js#L18
+ */
 export interface RenderPageResponse {
-    buildManifest: Record<string, any>;
     html?: string;
-    head?: Array<React.ReactElement<any>>;
+    head?: React.ReactNode;
 }
 
 export interface PageProps {

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -5,6 +5,8 @@ import { DefaultQuery } from "./router";
 /**
  * Result from renderPage().
  * https://github.com/zeit/next.js/blob/v8.0.0/packages/next/pages/_document.js#L18
+ * https://github.com/zeit/next.js/blob/v8.0.0/packages/next-server/server/render.tsx#L159
+ * https://github.com/zeit/next.js/blob/v8.0.0/packages/next-server/server/render.tsx#L44
  */
 export interface RenderPageResponse {
     html?: string;

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for next 7.0
+// Type definitions for next 8.0
 // Project: https://github.com/zeit/next.js/packages/next
 // Definitions by: Drew Hays <https://github.com/dru89>
 //                 Brice BERNARD <https://github.com/brikou>

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -48,7 +48,7 @@ class MyDoc extends Document<WithUrlProps> {
         // with app and component enhancers
         const enhanceApp: Enhancer<PageProps, {}> = App => props => <App />;
         const enhanceComponent: Enhancer<PageProps, {}> = Component => props => <Component />;
-        const { html, head, buildManifest } = renderPage({
+        const { html, head } = renderPage({
             enhanceApp,
             enhanceComponent
         });
@@ -60,7 +60,7 @@ class MyDoc extends Document<WithUrlProps> {
         // Custom prop
         const url = req!.url;
 
-        return { html, head, buildManifest, styles, url };
+        return { html, head, styles, url };
     }
 
     constructor(props: WithUrlProps & DocumentProps) {
@@ -73,12 +73,14 @@ class MyDoc extends Document<WithUrlProps> {
 
     render() {
         const { pathname, query } = this.props.__NEXT_DATA__;
+        const { head, styles } = this.props;
 
         return (
             <html>
                 <Head nonce="nonce" any="property" should="work" here>
+                    {head}
                     <title>My page</title>
-                    {this.props.styles}
+                    {styles}
                 </Head>
                 <body>
                     <Main />

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -55,7 +55,12 @@ class MyDoc extends Document<WithUrlProps> {
 
         const initialProps = await Document.getInitialProps(ctx);
 
-        const styles = [...(initialProps.styles ? initialProps.styles : []), <style />];
+        const styles = (
+            <>
+                {initialProps.styles}
+                <style />
+            </>
+        );
 
         // Custom prop
         const url = req!.url;


### PR DESCRIPTION
This is an initial update for the newly released Next.js 8. I'm updating only what conflicted as I upgraded, vs an extensive check of everything that changed.

Also fixes #32932.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
Before: https://github.com/zeit/next.js/blob/7.0.3/server/render.js#L155
After: https://github.com/zeit/next.js/blob/v8.0.0/packages/next-server/server/render.tsx#L44
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
