### PR TITLE
[@types/enzyme] Add renderProp() to Enzyme ShallowWrapper

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -10,7 +10,7 @@ import {
     ShallowRendererProps,
     ComponentClass as EnzymeComponentClass
 } from "enzyme";
-import { Component, ReactElement, HTMLAttributes, ComponentClass, StatelessComponent } from "react";
+import { Component, ReactElement, ReactNode, HTMLAttributes, ComponentClass, StatelessComponent } from "react";
 
 // Help classes/interfaces
 interface MyComponentProps {
@@ -33,6 +33,10 @@ interface AnotherStatelessProps {
 
 interface MyComponentState {
     stateProperty: string;
+}
+
+interface MyRenderPropProps {
+  children: (params: string) => ReactNode;
 }
 
 function toComponentType<T>(Component: ComponentClass<T> | StatelessComponent<T>): ComponentClass<T> | StatelessComponent<T> {
@@ -58,6 +62,8 @@ class AnotherComponent extends Component<AnotherComponentProps> {
         console.log(args);
     }
 }
+
+class MyRenderPropComponent extends Component<MyRenderPropProps> {}
 
 const MyStatelessComponent = (props: StatelessProps) => <span />;
 
@@ -476,6 +482,12 @@ function ShallowWrapperTest() {
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper);
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, undefined, { lifecycleExperimental: true });
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper, { lifecycleExperimental: true });
+    }
+
+    function test_renderProp() {
+        let shallowWrapper: ShallowWrapper<MyRenderPropComponent>;
+        shallowWrapper = shallow(<MyRenderPropComponent children={(params) => <div className={params} />} />);
+        shallowWrapper = shallowWrapper.renderProp('children')('hello');
     }
 }
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -447,6 +447,11 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * Returns a wrapper with the direct parent of the node in the current wrapper.
      */
     parent(): ShallowWrapper<any, any>;
+
+    /**
+     * Returns a wrapper of the node rendered by the provided render prop.
+     */
+    renderProp(prop: string): (params: any) => ShallowWrapper<any, any>;
 }
 
 // tslint:disable-next-line no-empty-interface


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://airbnb.io/enzyme/docs/api/shallow.html#renderpropkey--shallowwrapper

Fixes #32234

Running `npm run lint enzyme` fails with an error unrelated to my change.