### PR TITLE
Bump version of fastify-static's notNeeded version

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -580,7 +580,7 @@
             "libraryName": "fastify-static",
             "typingsPackageName": "fastify-static",
             "sourceRepoURL": "https://github.com/fastify/fastify-static",
-            "asOfVersion": "2.2.0"
+            "asOfVersion": "2.2.1"
         },
         {
             "libraryName": "fecha",


### PR DESCRIPTION
Deprecation of 2.2.0 failed, so trying again

types-publisher *thought* that deprecation succeeded, but it didn't succeed in the two-step deprecation process: 2.2.0 never actually got published.