### PR TITLE
[node-cron] Schedule supports promises

### DIFF
--- a/types/node-cron/index.d.ts
+++ b/types/node-cron/index.d.ts
@@ -4,7 +4,11 @@
 //                 burtek <https://github.com/burtek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function schedule(cronExpression: string, func: () => void, options?: ScheduleOptions): ScheduledTask;
+export function schedule(
+    cronExpression: string,
+    func: () => void | Promise<void>,
+    options?: ScheduleOptions,
+): ScheduledTask;
 
 export function validate(cronExpression: string): boolean;
 

--- a/types/node-cron/node-cron-tests.ts
+++ b/types/node-cron/node-cron-tests.ts
@@ -39,6 +39,13 @@ const task3 = cron.schedule('* * * * *', () => {
 
 task3.destroy();
 
+const taskWithAsync = cron.schedule('* * * * *', () => new Promise((resolve) => {
+    log('will execute every minute until stopped');
+    resolve();
+}));
+
+taskWithAsync.destroy();
+
 const valid = cron.validate('59 * * * *');
 const invalid = cron.validate('60 * * * *');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **See justification below**
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Changes
------------
It is clear from the `node-cron` code that the `func` parameter of `schedule` **already** supports both `() => void` and `() => Promise<void>` (`async` function and/or function that returns promise).

For proof, please see:
https://github.com/node-cron/node-cron/blob/master/src/task.js#L52-L54

Here, `execution` comes from `func`:
https://github.com/node-cron/node-cron/blob/master/src/node-cron.js#L43