### PR TITLE
[ember] Fix wrongly deprecated Ember.assign

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -495,7 +495,6 @@ export namespace Ember {
     // TODO: replace with an es6 reexport when declare module 'ember' is removed
     /**
      * Copy properties from a source object to a target object.
-     * @deprecated Use Object.assign
      */
     const assign: typeof EmberPolyfillsNs.assign;
     /**

--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -3131,7 +3131,7 @@ declare module 'ember' {
         function isPresent(obj: any): boolean;
         /**
          * Merge the contents of two objects together into the first object.
-         * @deprecated Use Object.assign
+         * @deprecated Use Ember.assign
          */
         function merge<T, U>(original: T, updates: U): T & U;
         /**
@@ -3284,7 +3284,6 @@ declare module 'ember' {
         function typeOf(item: any): string;
         /**
          * Copy properties from a source object to a target object.
-         * @deprecated Use Object.assign
          */
         function assign<T, U>(target: T, source: U): T & U;
         function assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -8,7 +8,6 @@ import { Mix, Mix3, Mix4 } from './types';
 
 /**
  * Copy properties from a source object to a target object.
- * @deprecated Use Object.assign
  */
 export function assign<T extends object, U extends object>(target: T, source: U): Mix<T, U>;
 export function assign<T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): Mix3<T, U, V>;
@@ -17,6 +16,6 @@ export function assign(target: object, ...sources: object[]): any;
 
 /**
  * Merge the contents of two objects together into the first object.
- * @deprecated Use Object.assign
+ * @deprecated Use Ember.assign
  */
 export function merge<T extends object, U extends object>(original: T, updates: U): Mix<T, U>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/master/packages/%40ember/polyfills/lib/assign.ts#L22-L46
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
