### PR TITLE
react-hammerjs: Added missing onPinchOut typing

### DIFF
--- a/types/react-hammerjs/index.d.ts
+++ b/types/react-hammerjs/index.d.ts
@@ -38,6 +38,7 @@ declare namespace ReactHammer {
         onPinchCancel?: HammerListener;
         onPinchEnd?: HammerListener;
         onPinchIn?: HammerListener;
+        onPinchOut?: HammerListener;
         onPinchStart?: HammerListener;
         onPress?: HammerListener;
         onPressUp?: HammerListener;


### PR DESCRIPTION
Quick fix:
Modified `/types/react-hammerjs/index.d.ts` to include missing property `onPinchOut`. 

`onPinchOut` is in the package docs, here:
https://github.com/JedWatson/react-hammerjs