### PR TITLE
[json2mq] Add types for json2mq

### DIFF
--- a/types/json2mq/index.d.ts
+++ b/types/json2mq/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for json2mq 0.2
+// Project: https://github.com/akiran/json2mq
+// Definitions by: Zhang Yi Jiang <https://github.com/ZhangYiJiang>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = json2mq;
+
+declare function json2mq(query: json2mq.QueryObject | json2mq.QueryObject[]): string;
+
+declare namespace json2mq {
+    interface QueryObject {
+        [property: string]: string | number | boolean;
+    }
+}

--- a/types/json2mq/json2mq-tests.ts
+++ b/types/json2mq/json2mq-tests.ts
@@ -1,0 +1,25 @@
+import * as json2mq from 'json2mq';
+
+json2mq({ screen: true });  // -> 'screen'
+
+json2mq({ handheld: false });  // -> 'not handheld'
+
+json2mq({ minWidth: 100, maxWidth: 200 });
+// -> '(min-width: 100px) and (max-width: 200px)'
+
+json2mq({ minWidth: 100, maxWidth: '20em' });
+// -> '(min-width: 100px) and (max-width: 20em)'
+
+json2mq([{ screen: true, minWidth: 100 }, { handheld: true, orientation: 'landscape' }]);
+// -> 'screen and (min-width: 100px), handheld and (orientation: landscape)'
+
+json2mq({ all: true, monochrome: true });
+// -> 'all and monochrome'
+
+// Test QueryObject
+const mediaQuery: json2mq.QueryObject = {
+    screen: true,
+    monochrome: false,
+    maxWidth: 200,
+    minHeight: '10rem',
+};

--- a/types/json2mq/tsconfig.json
+++ b/types/json2mq/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json2mq-tests.ts"
+    ]
+}

--- a/types/json2mq/tslint.json
+++ b/types/json2mq/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
    - DTS gen generated an outdated tslint.json 
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`. 


npm: https://www.npmjs.com/package/json2mq  
GitHub: https://github.com/akiran/json2mq

Type definition is inferred from the examples. Test cases are also based on examples. 

I'm not sure if I should write this using `exports = json2mq` and  `namespace` or using ES6 style  

```ts
export interface QueryObject;
export default json2mq;
```

The library exports `json2mq` using `module.exports = json2mq`. `QueryObject` is exported to make it easier to pass parameters into the function. 