### PR TITLE
Update debugger.log function

### DIFF
--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -38,7 +38,7 @@ declare namespace debug {
         (formatter: any, ...args: any[]): void;
 
         enabled: boolean;
-        log: (v: any) => string;
+        log: (args: any[]) => any;
         namespace: string;
         extend: (namespace: string, delimiter?: string) => Debugger;
     }

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -38,7 +38,7 @@ declare namespace debug {
         (formatter: any, ...args: any[]): void;
 
         enabled: boolean;
-        log: (args: any[]) => any;
+        log: (...args: any[]) => any;
         namespace: string;
         extend: (namespace: string, delimiter?: string) => Debugger;
     }


### PR DESCRIPTION
Definition of `debugger.log` should be less strict because definition of `console.log` is: `log(message?: any, ...optionalParams: any[]): void;`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/visionmedia/debug#output-streams
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
