### PR TITLE
[React] Allow to use ReactElement without Props

### DIFF
--- a/types/alt/index.d.ts
+++ b/types/alt/index.d.ts
@@ -148,7 +148,7 @@ declare module "alt/AltContainer" {
     stores?:Array<AltJS.AltStore<any>>;
     inject?:{[key:string]:any};
     actions?:{[key:string]:Object};
-    render?:(...props:Array<any>) => React.ReactElement<any>;
+    render?:(...props:Array<any>) => React.ReactElement;
     flux?:AltJS.Alt;
     transform?:(store:AltJS.AltStore<any>, actions:any) => any;
     shouldComponentUpdate?:(props:any) => boolean;

--- a/types/atlaskit__button/index.d.ts
+++ b/types/atlaskit__button/index.d.ts
@@ -42,9 +42,9 @@ export interface ButtonProps {
     /** Provides a url for buttons being used as a link. */
     readonly href?: string;
     /** Places an icon within the button, after the button's text. */
-    readonly iconAfter?: ReactElement<any>;
+    readonly iconAfter?: ReactElement;
     /** Places an icon within the button, before the button's text. */
-    readonly iconBefore?: ReactElement<any>;
+    readonly iconBefore?: ReactElement;
     /** Pass a reference on to the styled component */
     readonly innerRef?: (instance: any) => void;
     /** Provide a unique id to the button. */

--- a/types/atlaskit__inline-edit/index.d.ts
+++ b/types/atlaskit__inline-edit/index.d.ts
@@ -12,9 +12,9 @@ export interface BaseProps {
     /** Label above the input. */
     label?: string;
     /** Component to be shown when reading only */
-    readView: ReactElement<any>;
+    readView: ReactElement;
     /** Component to be shown when editing. Should be an @atlaskit/input. */
-    editView?: ReactElement<any>;
+    editView?: ReactElement;
     /** Set whether the read view should fit width, most obvious when hovered. */
     isFitContainerWidthReadView?: boolean;
     /** Greys out text and shows spinner. Does not disable input. */
@@ -38,7 +38,7 @@ export interface BaseProps {
     /** Set whether default stylings should be disabled when editing. */
     disableEditViewFieldBase?: boolean;
     /** Component to be shown in an @atlaskit/inline-dialog when edit view is open. */
-    invalidMessage?: ReactElement<any>;
+    invalidMessage?: ReactElement;
 }
 
 export interface StatelessProps extends BaseProps {

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -623,7 +623,7 @@ declare namespace Draft {
 
             interface DraftBlockRenderConfig {
                 element: string;
-                wrapper?: React.ReactElement<any>;
+                wrapper?: React.ReactElement;
             }
 
             class EditorState extends Record {

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -83,7 +83,7 @@ function ShallowWrapperTest() {
         shallow<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
     let reactElement: ReactElement;
-    let reactElements: Array<ReactElement>;
+    let reactElements: ReactElement[];
     let domElement: Element;
     let boolVal: boolean;
     let stringVal: string;
@@ -485,7 +485,7 @@ function ReactWrapperTest() {
         mount<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
     let reactElement: ReactElement;
-    let reactElements: Array<ReactElement>;
+    let reactElements: ReactElement[];
     let domElement: Element;
     let boolVal: boolean;
     let stringVal: string;

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -82,8 +82,8 @@ function ShallowWrapperTest() {
     let shallowWrapper: ShallowWrapper<MyComponentProps, MyComponentState> =
         shallow<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
-    let reactElement: ReactElement<any>;
-    let reactElements: Array<ReactElement<any>>;
+    let reactElement: ReactElement;
+    let reactElements: Array<ReactElement>;
     let domElement: Element;
     let boolVal: boolean;
     let stringVal: string;
@@ -484,8 +484,8 @@ function ReactWrapperTest() {
     let reactWrapper: ReactWrapper<MyComponentProps, MyComponentState> =
         mount<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
-    let reactElement: ReactElement<any>;
-    let reactElements: Array<ReactElement<any>>;
+    let reactElement: ReactElement;
+    let reactElements: Array<ReactElement>;
     let domElement: Element;
     let boolVal: boolean;
     let stringVal: string;

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -67,12 +67,12 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns whether or not all the given react elements exists in the shallow render tree
      */
-    containsAllMatchingElements(nodes: ReactElement[] | Array<ReactElement[]>): boolean;
+    containsAllMatchingElements(nodes: ReactElement[] | ReactElement[][]): boolean;
 
     /**
      * Returns whether or not one of the given react elements exists in the shallow render tree.
      */
-    containsAnyMatchingElements(nodes: ReactElement[] | Array<ReactElement[]>): boolean;
+    containsAnyMatchingElements(nodes: ReactElement[] | ReactElement[][]): boolean;
 
     /**
      * Returns whether or not the current render tree is equal to the given node, based on the expected value.

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -57,32 +57,32 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns whether or not the current wrapper has a node anywhere in it's render tree that looks like the one passed in.
      */
-    contains(node: ReactElement<any> | Array<ReactElement<any>> | string): boolean;
+    contains(node: ReactElement | Array<ReactElement> | string): boolean;
 
     /**
      * Returns whether or not a given react element exists in the shallow render tree.
      */
-    containsMatchingElement(node: ReactElement<any> | Array<ReactElement<any>>): boolean;
+    containsMatchingElement(node: ReactElement | Array<ReactElement>): boolean;
 
     /**
      * Returns whether or not all the given react elements exists in the shallow render tree
      */
-    containsAllMatchingElements(nodes: Array<ReactElement<any>> | Array<Array<ReactElement<any>>>): boolean;
+    containsAllMatchingElements(nodes: Array<ReactElement> | Array<Array<ReactElement>>): boolean;
 
     /**
      * Returns whether or not one of the given react elements exists in the shallow render tree.
      */
-    containsAnyMatchingElements(nodes: Array<ReactElement<any>> | Array<Array<ReactElement<any>>>): boolean;
+    containsAnyMatchingElements(nodes: Array<ReactElement> | Array<Array<ReactElement>>): boolean;
 
     /**
      * Returns whether or not the current render tree is equal to the given node, based on the expected value.
      */
-    equals(node: ReactElement<any>): boolean;
+    equals(node: ReactElement): boolean;
 
     /**
      * Returns whether or not a given react element matches the shallow render tree.
      */
-    matchesElement(node: ReactElement<any>): boolean;
+    matchesElement(node: ReactElement): boolean;
 
     /**
      * Returns whether or not the current node has a className prop including the passed in class name.
@@ -130,27 +130,27 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns the node at a given index of the current wrapper.
      */
-    get(index: number): ReactElement<any>;
+    get(index: number): ReactElement;
 
     /**
      * Returns the wrapper's underlying node.
      */
-    getNode(): ReactElement<any>;
+    getNode(): ReactElement;
 
     /**
      * Returns the wrapper's underlying nodes.
      */
-    getNodes(): Array<ReactElement<any>>;
+    getNodes(): Array<ReactElement>;
 
     /**
      * Returns the wrapper's underlying node.
      */
-    getElement(): ReactElement<any>;
+    getElement(): ReactElement;
 
     /**
      * Returns the wrapper's underlying node.
      */
-    getElements(): Array<ReactElement<any>>;
+    getElements(): Array<ReactElement>;
 
     /**
      * Returns the outer most DOMComponent of the current wrapper.

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -57,22 +57,22 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns whether or not the current wrapper has a node anywhere in it's render tree that looks like the one passed in.
      */
-    contains(node: ReactElement | Array<ReactElement> | string): boolean;
+    contains(node: ReactElement | ReactElement[] | string): boolean;
 
     /**
      * Returns whether or not a given react element exists in the shallow render tree.
      */
-    containsMatchingElement(node: ReactElement | Array<ReactElement>): boolean;
+    containsMatchingElement(node: ReactElement | ReactElement[]): boolean;
 
     /**
      * Returns whether or not all the given react elements exists in the shallow render tree
      */
-    containsAllMatchingElements(nodes: Array<ReactElement> | Array<Array<ReactElement>>): boolean;
+    containsAllMatchingElements(nodes: ReactElement[] | Array<ReactElement[]>): boolean;
 
     /**
      * Returns whether or not one of the given react elements exists in the shallow render tree.
      */
-    containsAnyMatchingElements(nodes: Array<ReactElement> | Array<Array<ReactElement>>): boolean;
+    containsAnyMatchingElements(nodes: ReactElement[] | Array<ReactElement[]>): boolean;
 
     /**
      * Returns whether or not the current render tree is equal to the given node, based on the expected value.
@@ -140,7 +140,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns the wrapper's underlying nodes.
      */
-    getNodes(): Array<ReactElement>;
+    getNodes(): ReactElement[];
 
     /**
      * Returns the wrapper's underlying node.
@@ -150,7 +150,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Returns the wrapper's underlying node.
      */
-    getElements(): Array<ReactElement>;
+    getElements(): ReactElement[];
 
     /**
      * Returns the outer most DOMComponent of the current wrapper.

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2702,7 +2702,7 @@ export class Svg extends Component<{ width: number, height: number, viewBox?: st
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    node: number | React.ReactElement<any> | React.RefObject<any>,
+    node: number | React.ReactElement | React.RefObject<any>,
     options?: {
         width?: number;
         height?: number;

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -1517,7 +1517,7 @@ export class RadialGradient extends Component<SvgCommonProps> { }
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v24/index.d.ts
+++ b/types/expo/v24/index.d.ts
@@ -2058,7 +2058,7 @@ export class Svg extends Component<{ width: number, height: number }> {
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v25/index.d.ts
+++ b/types/expo/v25/index.d.ts
@@ -2087,7 +2087,7 @@ export class Svg extends Component<{ width: number, height: number }> {
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v26/index.d.ts
+++ b/types/expo/v26/index.d.ts
@@ -2115,7 +2115,7 @@ export class Svg extends Component<{ width: number, height: number, viewBox?: st
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v27/index.d.ts
+++ b/types/expo/v27/index.d.ts
@@ -2194,7 +2194,7 @@ export class Svg extends Component<{ width: number, height: number, viewBox?: st
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v30/index.d.ts
+++ b/types/expo/v30/index.d.ts
@@ -2195,7 +2195,7 @@ export class Svg extends Component<{ width: number, height: number, viewBox?: st
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/expo/v31/index.d.ts
+++ b/types/expo/v31/index.d.ts
@@ -2652,7 +2652,7 @@ export class Svg extends Component<{ width: number, height: number, viewBox?: st
  * Take Snapshot
  */
 export function takeSnapshotAsync(
-    view?: (number | React.ReactElement<any>),
+    view?: (number | React.ReactElement),
     options?: {
         width?: number,
         height?: number,

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -30,7 +30,7 @@ export interface ColumnReorderEndEvent {
     reorderColumn: string;
 }
 
-export type ElementOrFunc<P> = string | React.ReactElement<any> | ((props: P) => (string | React.ReactElement<any>));
+export type ElementOrFunc<P> = string | React.ReactElement | ((props: P) => (string | React.ReactElement));
 
 export type TableRowEventHandler = (event: React.SyntheticEvent<Table>, rowIndex: number) => void;
 
@@ -616,7 +616,7 @@ export interface ColumnGroupProps extends React.ClassAttributes<ColumnGroup> {
      * You can also pass in a function that returns a react elemnt, with the
      * props object above passed in as the first parameter.
      */
-    header?: string | React.ReactElement<any> | ((props: ColumnGroupHeaderProps) => (string | React.ReactElement<any>));
+    header?: string | React.ReactElement | ((props: ColumnGroupHeaderProps) => (string | React.ReactElement));
 }
 
 export class ColumnGroup extends React.Component<ColumnGroupProps> {

--- a/types/fixed-data-table/fixed-data-table-tests.tsx
+++ b/types/fixed-data-table/fixed-data-table-tests.tsx
@@ -3,7 +3,7 @@ import { Table, Cell, Column, CellProps } from "fixed-data-table";
 
 // create your Table
 class MyTable1 extends React.Component {
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <Table
                 rowsCount={100}
@@ -18,7 +18,7 @@ class MyTable1 extends React.Component {
 
 // create your Columns
 class MyTable2 extends React.Component {
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <Table
                 rowsCount={100}
@@ -51,7 +51,7 @@ class MyTable3 extends React.Component<{}, MyTable3State> {
         ]
     };
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <Table
                 rowsCount={this.state.myTableData.length}
@@ -85,7 +85,7 @@ interface MyCellProps extends CellProps {
 }
 
 class MyTextCell extends React.Component<MyCellProps> {
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         const {rowIndex, field, myData} = this.props;
 
         return (
@@ -101,7 +101,7 @@ class MyTextCell extends React.Component<MyCellProps> {
 }
 
 class MyLinkCell extends React.Component<MyCellProps> {
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         const {rowIndex, field, myData} = this.props;
         const link: string = myData[rowIndex][field];
 
@@ -133,7 +133,7 @@ class MyTable4 extends React.Component<{}, MyTable4State> {
         ]
     };
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <Table
                 rowsCount={this.state.tableData.length}
@@ -162,7 +162,7 @@ class MyTable4 extends React.Component<{}, MyTable4State> {
 
 // Listen for events
 class MyTable5 extends React.Component {
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <Table
                 rowsCount={100}

--- a/types/fixed-data-table/index.d.ts
+++ b/types/fixed-data-table/index.d.ts
@@ -291,7 +291,7 @@ declare namespace FixedDataTable {
           *
           * If you pass in a function, you will receive the same props object as the first argument.
           */
-        header?: string | React.ReactElement<any> | ((props: CellProps) => (string | React.ReactElement<any>));
+        header?: string | React.ReactElement | ((props: CellProps) => (string | React.ReactElement));
 
         /**
           * This is the body cell that will be cloned for this
@@ -315,7 +315,7 @@ declare namespace FixedDataTable {
           * If you pass in a function, you will receive the same
           * props object as the first argument.
           */
-        cell?: string | React.ReactElement<any> | ((props: CellProps) => (string | React.ReactElement<any>));
+        cell?: string | React.ReactElement | ((props: CellProps) => (string | React.ReactElement));
 
          /**
           * The footer cell for this column. This can either be a
@@ -338,7 +338,7 @@ declare namespace FixedDataTable {
           * If you pass in a function, you will receive the same
           * props object as the first argument.
           */
-        footer?: string | React.ReactElement<any> | ((props: CellProps) => (string | React.ReactElement<any>));
+        footer?: string | React.ReactElement | ((props: CellProps) => (string | React.ReactElement));
 
         /**
           * This is used to uniquely identify the column, and is not
@@ -440,7 +440,7 @@ declare namespace FixedDataTable {
           * If you pass in a function, you will receive the same props
           * object as the first argument.
           */
-	    header: string | React.ReactElement<any> | ((props: CellProps) => (string | React.ReactElement<any>));
+	    header: string | React.ReactElement | ((props: CellProps) => (string | React.ReactElement));
     }
 
     /**

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -786,7 +786,7 @@ export interface ToastProps {
     color?: "darkGray" | "orange";
     icon?: "arrow-circle-forward";
     text?: string | ReadonlyArray<string>;
-    thumbnail?: React.ReactElement<any>;
+    thumbnail?: React.ReactElement;
 }
 
 /*

--- a/types/jsnox/jsnox-tests.ts
+++ b/types/jsnox/jsnox-tests.ts
@@ -9,7 +9,7 @@ interface PersonProps {
 }
 
 class Person extends React.Component<PersonProps> {
-    render(): React.ReactElement<any> { return null; }
+    render(): React.ReactElement { return null; }
 }
 
 const PersonTag = React.createFactory(Person);

--- a/types/lingui__macro/Trans.d.ts
+++ b/types/lingui__macro/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyArray<ReactElement<any>>;
+    components?: ReadonlyArray<ReactElement>;
     children?: ReactNode;
 }
 

--- a/types/lingui__macro/Trans.d.ts
+++ b/types/lingui__macro/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyArray<ReactElement>;
+    components?: ReadonlyReactElement[];
     children?: ReactNode;
 }
 

--- a/types/lingui__macro/Trans.d.ts
+++ b/types/lingui__macro/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyReactElement[];
+    components?: ReadonlyArray<ReactElement>;
     children?: ReactNode;
 }
 

--- a/types/lingui__react/Trans.d.ts
+++ b/types/lingui__react/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyArray<ReactElement<any>>;
+    components?: ReadonlyArray<ReactElement>;
     children?: ReactNode;
 }
 

--- a/types/lingui__react/Trans.d.ts
+++ b/types/lingui__react/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyArray<ReactElement>;
+    components?: ReadonlyReactElement[];
     children?: ReactNode;
 }
 

--- a/types/lingui__react/Trans.d.ts
+++ b/types/lingui__react/Trans.d.ts
@@ -6,7 +6,7 @@ export interface TransPropsWithoutI18n extends RenderProps {
     defaults?: string;
     values?: object;
     formats?: object;
-    components?: ReadonlyReactElement[];
+    components?: ReadonlyArray<ReactElement>;
     children?: ReactNode;
 }
 

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -559,8 +559,8 @@ declare namespace __MaterialUI {
         className?: string;
         iconClassNameLeft?: string;
         iconClassNameRight?: string;
-        iconElementLeft?: React.ReactElement<any>;
-        iconElementRight?: React.ReactElement<any>;
+        iconElementLeft?: React.ReactElement;
+        iconElementRight?: React.ReactElement;
         iconStyleRight?: React.CSSProperties;
         iconStyleLeft?: React.CSSProperties;
         onLeftIconButtonClick?: React.MouseEventHandler<{}>;
@@ -654,7 +654,7 @@ declare namespace __MaterialUI {
         backgroundColor?: string;
         className?: string;
         color?: string;
-        icon?: React.ReactElement<any>;
+        icon?: React.ReactElement;
         size?: number;
         src?: string;
         style?: React.CSSProperties;
@@ -1037,7 +1037,7 @@ declare namespace __MaterialUI {
         text: string;
     }
     export interface DialogProps extends React.DOMAttributes<{}>, React.Props<Dialog> {
-        actions?: Array<DialogAction | React.ReactElement<any>>;
+        actions?: Array<DialogAction | React.ReactElement>;
         /** @deprecated use a custom `actions` property instead */
         actionFocus?: string;
         actionsContainerClassName?: string;
@@ -1103,10 +1103,10 @@ declare namespace __MaterialUI {
         }
 
         export interface GridTileProps {
-            actionIcon?: React.ReactElement<any>;
+            actionIcon?: React.ReactElement;
             actionPosition?: "left" | "right";
             cols?: number;
-            containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
+            containerElement?: string | React.ReactElement | React.ComponentClass<any>;
             rows?: number;
             style?: React.CSSProperties;
             subtitle?: React.ReactNode;
@@ -1157,9 +1157,9 @@ declare namespace __MaterialUI {
             initiallyOpen?: boolean;
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;
-            leftAvatar?: React.ReactElement<any>;
-            leftCheckbox?: React.ReactElement<any>;
-            leftIcon?: React.ReactElement<any>;
+            leftAvatar?: React.ReactElement;
+            leftCheckbox?: React.ReactElement;
+            leftIcon?: React.ReactElement;
             nestedItems?: Array<React.ReactElement<ListItemProps>>;
             nestedLevel?: number;
             nestedListStyle?: React.CSSProperties;
@@ -1172,10 +1172,10 @@ declare namespace __MaterialUI {
             open?: boolean;
             primaryText?: React.ReactNode;
             primaryTogglesNestedList?: boolean;
-            rightAvatar?: React.ReactElement<any>;
-            rightIcon?: React.ReactElement<any>;
-            rightIconButton?: React.ReactElement<any>;
-            rightToggle?: React.ReactElement<any>;
+            rightAvatar?: React.ReactElement;
+            rightIcon?: React.ReactElement;
+            rightIconButton?: React.ReactElement;
+            rightToggle?: React.ReactElement;
             secondaryText?: React.ReactNode;
             secondaryTextLines?: number; // 1 or 2
             style?: React.CSSProperties;
@@ -1227,11 +1227,11 @@ declare namespace __MaterialUI {
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;
             label?: string | React.ReactNode;
-            leftIcon?: React.ReactElement<any>;
+            leftIcon?: React.ReactElement;
             menuItems?: React.ReactNode;
             onClick?: React.MouseEventHandler<{}>;
             primaryText?: React.ReactNode;
-            rightIcon?: React.ReactElement<any>;
+            rightIcon?: React.ReactElement;
             secondaryText?: React.ReactNode;
             style?: React.CSSProperties;
             containerElement?: React.ReactNode | string;
@@ -1503,7 +1503,7 @@ declare namespace __MaterialUI {
             rippleColor?: string;
             rippleStyle?: React.CSSProperties;
             style?: React.CSSProperties;
-            switchElement: React.ReactElement<any>;
+            switchElement: React.ReactElement;
             switched: boolean;
             thumbStyle?: React.CSSProperties;
             trackStyle?: React.CSSProperties;

--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -147,7 +147,7 @@ export interface Renderer {
   ): React.Component<P, React.ComponentState> | Element | void;
 
   (
-    element: Array<React.ReactElement<any>>,
+    element: Array<React.ReactElement>,
     container: Element | null,
     callback?: () => void
   ): React.Component<any, React.ComponentState> | Element | void;

--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -147,7 +147,7 @@ export interface Renderer {
   ): React.Component<P, React.ComponentState> | Element | void;
 
   (
-    element: Array<React.ReactElement>,
+    element: React.ReactElement[],
     container: Element | null,
     callback?: () => void
   ): React.Component<any, React.ComponentState> | Element | void;

--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -24,7 +24,7 @@ export namespace utils {
     function getTextAlign(value: string, fallback?: TextAlignment): TextAlignment;
 }
 
-export function renderToMjml(email: React.ReactElement<any>): string;
+export function renderToMjml(email: React.ReactElement): string;
 
 export interface Mjml2HtmlOptions {
     fonts?: { [key: string]: string };
@@ -35,7 +35,7 @@ export interface Mjml2HtmlOptions {
     filePath?: string;
 }
 
-export function render(email: React.ReactElement<any>, options?: Mjml2HtmlOptions): { html: string; errors: Error[] };
+export function render(email: React.ReactElement, options?: Mjml2HtmlOptions): { html: string; errors: Error[] };
 
 // Components
 

--- a/types/next-server/head.d.ts
+++ b/types/next-server/head.d.ts
@@ -3,6 +3,6 @@ import * as React from "react";
 export function defaultHead(className?: string): JSX.Element[];
 export default class Head extends React.Component {
     static canUseDOM: boolean;
-    static peek(): Array<React.ReactElement>;
-    static rewind(): Array<React.ReactElement>;
+    static peek(): React.ReactElement[];
+    static rewind(): React.ReactElement[];
 }

--- a/types/next-server/head.d.ts
+++ b/types/next-server/head.d.ts
@@ -3,6 +3,6 @@ import * as React from "react";
 export function defaultHead(className?: string): JSX.Element[];
 export default class Head extends React.Component {
     static canUseDOM: boolean;
-    static peek(): Array<React.ReactElement<any>>;
-    static rewind(): Array<React.ReactElement<any>>;
+    static peek(): Array<React.ReactElement>;
+    static rewind(): Array<React.ReactElement>;
 }

--- a/types/next-server/link.d.ts
+++ b/types/next-server/link.d.ts
@@ -11,7 +11,7 @@ export interface LinkProps {
     href?: string | UrlLike;
     as?: string | UrlLike;
     passHref?: boolean;
-    children: React.ReactElement<any>;
+    children: React.ReactElement;
 }
 
 export default class Link extends React.Component<LinkProps> {}

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -9,7 +9,7 @@ interface Props {
     any?: any;
     array: string[];
     bool: boolean;
-    element: ReactElement<any>;
+    element: ReactElement;
     func(foo: string): void;
     node?: ReactNode;
     requiredNode: NonNullable<ReactNode>;

--- a/types/rc-select/index.d.ts
+++ b/types/rc-select/index.d.ts
@@ -74,7 +74,7 @@ declare namespace RcSelect {
     export class Option extends React.Component<OptionProps> { }
 
     interface OptGroupProps {
-        label?: string | React.ReactElement<any>;
+        label?: string | React.ReactElement;
         key?: string;
         value?: string;
     }

--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -70,9 +70,9 @@ declare namespace TestUtils {
     }
 
     export interface ShallowRenderer {
-        getRenderOutput<E extends ReactElement<any>>(): E;
-        getRenderOutput(): ReactElement<any>;
-        render(element: ReactElement<any>, context?: any): void;
+        getRenderOutput<E extends ReactElement>(): E;
+        getRenderOutput(): ReactElement;
+        render(element: ReactElement, context?: any): void;
         unmount(): void;
     }
 
@@ -129,13 +129,13 @@ declare namespace TestUtils {
         mocked: MockedComponentClass, mockTagName?: string): typeof TestUtils;
 
     export function isElementOfType<T extends HTMLElement>(
-        element: ReactElement<any>, type: string): element is ReactHTMLElement<T>;
+        element: ReactElement, type: string): element is ReactHTMLElement<T>;
     export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
-        element: ReactElement<any>, type: string): element is DOMElement<P, T>;
+        element: ReactElement, type: string): element is DOMElement<P, T>;
     export function isElementOfType<P>(
-        element: ReactElement<any>, type: SFC<P>): element is SFCElement<P>;
+        element: ReactElement, type: SFC<P>): element is SFCElement<P>;
     export function isElementOfType<P, T extends Component<P>, C extends ComponentClass<P>>(
-        element: ReactElement<any>, type: ClassType<P, T, C>): element is CElement<P, T>;
+        element: ReactElement, type: ClassType<P, T, C>): element is CElement<P, T>;
 
     export function isDOMComponent(instance: ReactInstance): instance is Element;
     export function isCompositeComponent(instance: ReactInstance): instance is Component<any>;

--- a/types/react-addons-transition-group/index.d.ts
+++ b/types/react-addons-transition-group/index.d.ts
@@ -9,7 +9,7 @@ import { ComponentClass, TransitionGroupProps } from 'react';
 declare module 'react' {
     export interface HTMLTransitionGroupProps<T> extends HTMLAttributes<T> {
         component?: ReactType;
-        childFactory?: (child: ReactElement<any>) => ReactElement<any>;
+        childFactory?: (child: ReactElement) => ReactElement;
     }
 
     export interface TransitionGroupProps extends HTMLTransitionGroupProps<ReactTransitionGroup> {

--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -104,7 +104,7 @@ export interface DroppableProvidedProps {
 }
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement<any> | null;
+    placeholder?: React.ReactElement | null;
     droppableProps: DroppableProvidedProps;
 }
 
@@ -120,7 +120,7 @@ export interface DroppableProps {
     isDropDisabled?: boolean;
     isCombineEnabled?: boolean;
     direction?: 'vertical' | 'horizontal';
-    children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<any>;
+    children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement;
 }
 
 export class Droppable extends React.Component<DroppableProps> { }
@@ -174,7 +174,7 @@ export interface DraggableProvided {
 
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
-    placeholder?: React.ReactElement<any> | null;
+    placeholder?: React.ReactElement | null;
 }
 
 export interface DraggableStateSnapshot {
@@ -203,7 +203,7 @@ export interface DraggableProps {
     index: number;
     isDragDisabled?: boolean;
     disableInteractiveElementBlocking?: boolean;
-    children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<any>;
+    children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement;
     type?: TypeId;
 }
 

--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -328,7 +328,7 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	 * expandComponent is always used with expandableRow, both of props are enable
 	 * the expand row functionality on table.
 	 */
-	expandComponent?(row: any): string | ReactElement<any>;
+	expandComponent?(row: any): string | ReactElement;
 	/**
 	 * Assign some alternative options for expand row feature, expandColumnOptions
 	 * only have four available property currently.
@@ -430,7 +430,7 @@ export interface FooterData {
 	 * The output value from the formatter function will be used instead of the label if the formatter function is
 	 * defined.
 	 */
-	formatter?(tableData: any[]): string | number | ReactElement<any>;
+	formatter?(tableData: any[]): string | number | ReactElement;
 }
 
 export interface SelectRow<TRow extends object = any> {
@@ -510,7 +510,7 @@ export interface SelectRow<TRow extends object = any> {
 	/**
 	 * Function that returns a component to customize the display of the selection checkbox or radio button with.
 	 */
-	customComponent?(props: CustomSelectProps): string | ReactElement<any>;
+	customComponent?(props: CustomSelectProps): string | ReactElement;
 	/**
 	 * Only unselect visible rows.
 	 */
@@ -620,7 +620,7 @@ export interface Options<TRow extends object = any> {
 	/**
 	 * Change the text displayed on the table if data is empty.
 	 */
-	noDataText?: string | ReactElement<any>;
+	noDataText?: string | ReactElement;
 	/**
 	 * If true, this hides the noDataText on the table when the tableis empty. Default is false.
 	 */
@@ -812,7 +812,7 @@ export interface Options<TRow extends object = any> {
 	 *  `to`: Current end index
 	 *  `total`: The total data volume.
 	 */
-	paginationShowsTotal?: boolean | ((start: number, to: number, total: number) => string | ReactElement<any>);
+	paginationShowsTotal?: boolean | ((start: number, to: number, total: number) => string | ReactElement);
 	/**
 	 * Allows you to modify where to start counting the pages, e.g. to set the first page number to 0.
 	 * Default is 1.
@@ -887,14 +887,14 @@ export interface Options<TRow extends object = any> {
 	 * After v3.0.0, you can custom all the components in the ToolBar also itself too.
 	 * Give a toolBar in options props and toolBar only accept a function and a JSX returned value is necessary.
 	 */
-	toolBar?(props: ToolBarProps): ReactElement<any>;
+	toolBar?(props: ToolBarProps): ReactElement;
 	/**
 	 * Button group which contain the insert, drop, show only select and export CSV buttons, these button all
 	 * grouped as btn-group class in bootstrap. This is a chance that you can custom this button group.
 	 * Give a btnGroup in options props and btnGroup only accept a function and a JSX returned value is necessary.
 	 * This lets you customize just the left-hand-side of the toolbar if desired.
 	 */
-	btnGroup?(props: ButtonGroupProps): ReactElement<any>;
+	btnGroup?(props: ButtonGroupProps): ReactElement;
 	/**
 	 * It's available to customize the insert button by configuring insertBtn in options props, insertBtn only
 	 * accept a function and a JSX returned value is necessary. This function will take one argument: onClick.
@@ -902,7 +902,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `InsertButton` component is also exported as a component, so that you can use it as the base
 	 * for your custom component.
 	 */
-	insertBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement<any>;
+	insertBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement;
 	/**
 	 * It's available to customize delete button by configuring deleteBtn in options props, deleteBtn onl<y
 	 * accept a function and a JSX returned value is necessary. This function will take one argument: onClick.
@@ -910,7 +910,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `DeleteButton` component is also exported as a component, so that you can use it as the base
 	 * for your custom component.
 	 */
-	deleteBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement<any>;
+	deleteBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement;
 	/**
 	 * It's available to customize the export csv button by configuring exportCSVBtn in options props, exportCSVBtn only
 	 * accept a function and a JSX returned value is necessary. This function will take one argument: onClick.
@@ -918,7 +918,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `ExportCSVButton` component is also exported as a component, so that you can use it as the base
 	 * for your custom component.
 	 */
-	exportCSVBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement<any>;
+	exportCSVBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement;
 	/**
 	 * It's available to custom select only toggle button by configuring showSelectedOnlyBtn in options props.
 	 * showSelectedOnlyBtn only accept a function and a JSX returned value is necessary.
@@ -927,7 +927,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `ShowSelectedOnlyButton` component is also exported as a component, so that you can use it as
 	 * the base for your custom component.
 	 */
-	showSelectedOnlyBtn?(onClick: (e: React.MouseEvent<any>) => void, showSelected: boolean): ReactElement<any>;
+	showSelectedOnlyBtn?(onClick: (e: React.MouseEvent<any>) => void, showSelected: boolean): ReactElement;
 	/**
 	 * You can custom the whole search panel(right side) by searchPanel in options props. searchPanel only accept
 	 * a function and a JSX returned value is necessary. This function will take one argument: props, that contains:
@@ -938,7 +938,7 @@ export interface Options<TRow extends object = any> {
 	 *   `clearBtnClick`: the callback function to use when the clear search button is clicked
 	 *   `search`: the callback function for triggering the search, which takes the search text as an input.
 	 */
-	searchPanel?(props: SearchPanelProps): ReactElement<any>;
+	searchPanel?(props: SearchPanelProps): ReactElement;
 	/**
 	 * You can custom the search input field only by searchField in options props. searchField only accept a
 	 * function and a JSX returned value is necessary.
@@ -954,7 +954,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `ClearSearchButton` component is also exported as a component, so that you can use it as the
 	 * base for your own custom component.
 	 */
-	clearSearchBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement<any>;
+	clearSearchBtn?(onClick: (e: React.MouseEvent<any>) => void): ReactElement;
 	/**
 	 * You can customize everything in the insert modal via options.insertModal and we give you the event
 	 * callback, props and some informations: onModalClose, onSave, columns, validateState, ignoreEditable
@@ -966,7 +966,7 @@ export interface Options<TRow extends object = any> {
 		columns: ReadonlyArray<InsertModalColumnDescription<TRow>>,
 		validateState: { [dataField: string]: string },
 		ignoreEditable: boolean
-	): ReactElement<any>;
+	): ReactElement;
 	/**
 	 * You can customize the body of the insert modal via options.insertModalBody and we give you the following
 	 * arguments: columns, validateState {[fieldname]: errorMsg}, ignoreEditable
@@ -989,7 +989,7 @@ export interface Options<TRow extends object = any> {
 	 * The default `InsertModalHeader` component is also exported as a component, so that you can use it as the base
 	 * for your own custom component.
 	 */
-	insertModalHeader?(closeModal: () => void, save: () => void): ReactElement<any>;
+	insertModalHeader?(closeModal: () => void, save: () => void): ReactElement;
 	/**
 	 * It's available to custom the footer of insert modal by configuring options.insertModalFooter. It only accepts
 	 * a function and a JSX returned value is necessary. This function will take two arguments: closeModal and save.
@@ -999,16 +999,16 @@ export interface Options<TRow extends object = any> {
 	 * The default `InsertModalFooter` component is also exported as a component, so that you can use it as the base
 	 * for your own custom component.
 	 */
-	insertModalFooter?(closeModal: () => void, save: () => void): ReactElement<any>;
+	insertModalFooter?(closeModal: () => void, save: () => void): ReactElement;
 	/**
 	 * Function to customize all of components for pagination, including the sizePerPage dropdown and the
 	 * pagination list.
 	 */
-	paginationPanel?(props: PaginationPanelProps): ReactElement<any>;
+	paginationPanel?(props: PaginationPanelProps): ReactElement;
 	/**
 	 * Function to customize the sizePerPage dropdown.
 	 */
-	sizePerPageDropDown?(props: SizePerPageFunctionProps): ReactElement<any>;
+	sizePerPageDropDown?(props: SizePerPageFunctionProps): ReactElement;
 	/**
 	 * Location for the pagination panel to be displayed. Options are 'top' (above the table), 'bottom'
 	 * (below the table) and 'both' (above and below the table).
@@ -1206,13 +1206,13 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 	 *   `direction`: the current sort order.
 	 *   `fieldName`: the dataField name of the field currently being sorted.
 	 */
-	caretRender?(direction: SortOrder | null, fieldName: string): string | ReactElement<any>;
+	caretRender?(direction: SortOrder | null, fieldName: string): string | ReactElement;
 	/**
 	 * To customize the column. This callback function should return a String or a React Component.
 	 * In addition, this function taking four argument: cell, row, formatExtraData, rowIdx.
 	 * The formatExtraData will be the value which you assign it on <TableHeaderColumn>
 	 */
-	dataFormat?(cell: any, row: any, formatExtraData: any, rowIndex: number): string | ReactElement<any>;
+	dataFormat?(cell: any, row: any, formatExtraData: any, rowIndex: number): string | ReactElement;
 	/**
 	 * It's useful with dataFormat, you can give any data you want to be passed to the formatter.
 	 */
@@ -1412,7 +1412,7 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 			editorClass: string,
 			ignoreEditable: boolean,
 			defaultValue: any
-		): ReactElement<any> | boolean;
+		): ReactElement | boolean;
 	};
 	/**
 	 * Support specifying that the column should start sorting with the 'asc' option.
@@ -1912,7 +1912,7 @@ export interface ExpandColumnOptions {
 	/**
 	 * a callback function to customize the appearance of the indicator column.
 	 */
-	expandColumnComponent?(props: ExpandColumnComponentProps): string | ReactElement<any>;
+	expandColumnComponent?(props: ExpandColumnComponentProps): string | ReactElement;
 	/**
 	 * set the width of indicator column.
 	 */
@@ -1925,7 +1925,7 @@ export interface ExpandColumnOptions {
 	/**
 	 * a callback function to customise the header column
 	 */
-	expandedColumnHeaderComponent?(props: ExpandedColumnHeaderProps): string | ReactElement<any>;
+	expandedColumnHeaderComponent?(props: ExpandedColumnHeaderProps): string | ReactElement;
 }
 
 /**
@@ -1990,7 +1990,7 @@ export interface ColumnDescription<TRow extends object = any> {
 	 * Column data format function.
 	 * Comes from TableHeader.dataFormat property.
 	 */
-	format(cell: any, row: TRow, formatExtraData: any, rowIndex: number): string | ReactElement<any>;
+	format(cell: any, row: TRow, formatExtraData: any, rowIndex: number): string | ReactElement;
 	/**
 	 * The formatExtraData setting for the column.
 	 * Comes from TableHeader.formatExtraData property.
@@ -2060,7 +2060,7 @@ export interface ColumnDescription<TRow extends object = any> {
 	 * Custom header value/component/children to use for this column.
 	 * Comes from TableHeader.headerText || TableHeader.children properties.
 	 */
-	text: string | number | boolean | ReactElement<any>;
+	text: string | number | boolean | ReactElement;
 	/**
 	 * Custom sort function to use for this column.
 	 * Comes from TableHeader.sortFunc property.
@@ -2109,19 +2109,19 @@ export interface ToolBarProps {
 		/**
 		 * Search panel component.
 		 */
-		searchPanel: ReactElement<any>;
+		searchPanel: ReactElement;
 		/**
 		 * Button group components.
 		 */
-		btnGroup: ReactElement<any>; // button groups JSX
+		btnGroup: ReactElement; // button groups JSX
 		/**
 		 * The individual search field.
 		 */
-		searchField: ReactElement<any>; // search field JSX
+		searchField: ReactElement; // search field JSX
 		/**
 		 * The button to clear the search field.
 		 */
-		clearBtn: ReactElement<any>; // clear search field JSX
+		clearBtn: ReactElement; // clear search field JSX
 	};
 	/**
 	 * Event callbacks to use with a custom toolbar.
@@ -2161,19 +2161,19 @@ export interface ButtonGroupProps {
 	/**
 	 * Export to CSV button.
 	 */
-	exportCSVBtn: ReactElement<any>;
+	exportCSVBtn: ReactElement;
 	/**
 	 * Insert button (to add a row).
 	 */
-	insertBtn: ReactElement<any>;
+	insertBtn: ReactElement;
 	/**
 	 * Delete button.
 	 */
-	deleteBtn: ReactElement<any>;
+	deleteBtn: ReactElement;
 	/**
 	 * Toggle button to switch between showing all rows and showing selected rows only.
 	 */
-	showSelectedOnlyBtn: ReactElement<any>;
+	showSelectedOnlyBtn: ReactElement;
 }
 
 /**
@@ -2183,11 +2183,11 @@ export interface SearchPanelProps {
 	/**
 	 * Default search field component.
 	 */
-	searchField: ReactElement<any>;
+	searchField: ReactElement;
 	/**
 	 * Default clear search field button component.
 	 */
-	clearBtn: ReactElement<any>;
+	clearBtn: ReactElement;
 	/**
 	 * The default search text.
 	 */
@@ -2247,7 +2247,7 @@ export interface PaginationPanelProps {
 		/**
 		 * Text/element to display when displaying the total number of rows.
 		 */
-		totalText: string | ReactElement<any>;
+		totalText: string | ReactElement;
 		/**
 		 * Default sizePerPageDropdown component.
 		 */
@@ -2318,7 +2318,7 @@ export interface CustomEditor<TRow extends object, K extends keyof TRow> {
 	 *   `onUpdate`: callback function to call to update the value inside the cell.
 	 *   `props`:
 	 */
-	getElement(onUpdate: (updatedCell: TRow[K]) => void, props: CustomEditorProps<TRow, K>): ReactElement<any>;
+	getElement(onUpdate: (updatedCell: TRow[K]) => void, props: CustomEditorProps<TRow, K>): ReactElement;
 	/**
 	 * Additional parameters to pass to the getElement function inside the props argument.
 	 */
@@ -2459,7 +2459,7 @@ export interface InsertModalColumnDescription<TRow extends object = any> {
 	 * Header text/element for the column.
 	 * Comes from TableHeader.headerText or TableHeader.children.
 	 */
-	name: string | ReactElement<any>;
+	name: string | ReactElement;
 	/**
 	 * Field name for the column data.
 	 * Comes from TableHeader.dataField.
@@ -2480,7 +2480,7 @@ export interface InsertModalColumnDescription<TRow extends object = any> {
 		editorClass: string,
 		ignoreEditable: boolean,
 		defaultValue: TRow[keyof TRow]
-	): ReactElement<any> | boolean;
+	): ReactElement | boolean;
 	/**
 	 * Flag to indicate whether this column should be hidden on the Insert Modal page.
 	 * Comes from TableHeader.hiddenOnInsert.

--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -291,7 +291,7 @@ export interface Options {
 	/**
 	 * Change the displaying text on table if data is empty.
 	 */
-	noDataText?: string | ReactElement<any>;
+	noDataText?: string | ReactElement;
 	/**
 	 * A delay for trigger search after a keyup (millisecond)
 	 */
@@ -433,7 +433,7 @@ export interface Options {
 	 * `rowKeys` is the row keys which been deleted, you can call next function to apply this deletion.
 	 */
 	handleConfirmDeleteRow?: (next: Function, rowKeys: any[]) => void;
-	paginationShowsTotal?: boolean | ((start: number, to: number, total: number) => string | ReactElement<any>);
+	paginationShowsTotal?: boolean | ((start: number, to: number, total: number) => string | ReactElement);
 	onSearchChange?: Function;
 	onAddRow?: Function;
 	onExportToCSV?: Function;
@@ -557,12 +557,12 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 	 * 		getElement(REQUIRED): Accept a callback function and take two arguments: onUpdate and props.
 	 * 		customEditorParameters: Another extra data for custom cell edit component.
 	 */
-	customEditor?: { getElement: (onUpdate: any, props: any) => ReactElement<any>, customEditorParameters?: object };
+	customEditor?: { getElement: (onUpdate: any, props: any) => ReactElement, customEditorParameters?: object };
 	/**
 	 * To customize the column. This callback function should return a String or a React Component.
 	 * In addition, this function taking two argument: cell and row.
 	 */
-	dataFormat?: (cell: any, row: any, formatExtraData?: any) => string | ReactElement<any>;
+	dataFormat?: (cell: any, row: any, formatExtraData?: any) => string | ReactElement;
 	/**
 	 * To to enable search or filter data on formatting. Default is false
 	 */

--- a/types/react-bootstrap/lib/Collapse.d.ts
+++ b/types/react-bootstrap/lib/Collapse.d.ts
@@ -4,7 +4,7 @@ import { TransitionCallbacks } from 'react-bootstrap';
 declare namespace Collapse {
     export interface CollapseProps extends TransitionCallbacks, React.ClassAttributes<Collapse> {
         dimension?: 'height' | 'width' | { ( ):string };
-        getDimensionValue?: ( dimension:number, element:React.ReactElement<any> ) => number;
+        getDimensionValue?: ( dimension:number, element:React.ReactElement ) => number;
         in?: boolean;
         timeout?: number;
         transitionAppear?: boolean;

--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -31,7 +31,7 @@ declare namespace Modal {
         onEscapeKeyUp?: (node: HTMLElement) => any;
         onShow?: (node: HTMLElement) => any;
         show?: boolean;
-        transition?: React.ReactElement<any>;
+        transition?: React.ReactElement;
     }
 }
 declare class Modal extends React.Component<Modal.ModalProps> {

--- a/types/react-confirm/index.d.ts
+++ b/types/react-confirm/index.d.ts
@@ -11,7 +11,7 @@ export function confirmable<P>(component: React.ComponentType<ReactConfirmProps 
 export function createConfirmation(component: React.ComponentType<any>, unmountDelay?: number): (props: any) => Promise<string>;
 
 export interface ReactConfirmProps {
-    confirmation: string | React.ReactElement<any>;
+    confirmation: string | React.ReactElement;
     dismiss: () => void;
     proceed: (value?: string) => void;
     cancel: (value?: string) => void;

--- a/types/react-countup/index.d.ts
+++ b/types/react-countup/index.d.ts
@@ -58,7 +58,7 @@ declare namespace ReactCountUp {
             start(): void;
         }): void;
         style?: React.CSSProperties;
-        children?(data: RenderProps): React.ReactElement<any>;
+        children?(data: RenderProps): React.ReactElement;
     }
 }
 

--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -81,17 +81,17 @@ declare namespace AdazzleReactDataGrid {
          * A toolbar to display above the grid.
          * Consider using the toolbar included in "react-data-grid/addons".
          */
-        toolbar?: React.ReactElement<any>
+        toolbar?: React.ReactElement
         /**
          * A context menu to disiplay when the user right-clicks a cell.
          * Consider using "react-contextmenu", included in "react-data-grid/addons".
          */
-        contextMenu?: React.ReactElement<any>
+        contextMenu?: React.ReactElement
         /**
          * A react component to customize how rows are rendered.
          * If you want to define your own, consider extending ReactDataGrid.Row.
          */
-        rowRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        rowRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A component to display when there are no rows to render.
          */
@@ -328,7 +328,7 @@ declare namespace AdazzleReactDataGrid {
         /**
          * A custom formatter for this column's filter.
          */
-        filterRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        filterRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>;
         /**
          * The editor for this column. Several editors are available in "react-data-grid/addons".
          * @default A simple text editor
@@ -340,11 +340,11 @@ declare namespace AdazzleReactDataGrid {
         /**
          * A custom read-only formatter for this column. An image formatter is available in "react-data-grid/addons".
          */
-        formatter?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        formatter?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A custom formatter for this column's header.
          */
-        headerRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        headerRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * Events to be bound to the cells in this specific column.
          * Each event must respect this standard in order to work correctly:

--- a/types/react-data-grid/v1/index.d.ts
+++ b/types/react-data-grid/v1/index.d.ts
@@ -62,17 +62,17 @@ declare namespace AdazzleReactDataGrid {
          * A toolbar to display above the grid.
          * Consider using the toolbar included in "react-data-grid/addons".
          */
-        toolbar?: React.ReactElement<any>
+        toolbar?: React.ReactElement
         /**
          * A context menu to disiplay when the user right-clicks a cell.
          * Consider using "react-contextmenu", included in "react-data-grid/addons".
          */
-        contextMenu?: React.ReactElement<any>
+        contextMenu?: React.ReactElement
         /**
          * A react component to customize how rows are rendered.
          * If you want to define your own, consider extending ReactDataGrid.Row.
          */
-        rowRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        rowRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A component to display when there are no rows to render.
          */
@@ -240,15 +240,15 @@ declare namespace AdazzleReactDataGrid {
          * The editor for this column. Several editors are available in "react-data-grid/addons".
          * @default A simple text editor
          */
-        editor?: React.ReactElement<any>
+        editor?: React.ReactElement
         /**
          * A custom read-only formatter for this column. An image formatter is available in "react-data-grid/addons".
          */
-        formatter?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        formatter?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A custom formatter for this column's header.
          */
-        headerRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        headerRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * Events to be bound to the cells in this specific column.
          * Each event must respect this standard in order to work correctly:

--- a/types/react-data-grid/v2/index.d.ts
+++ b/types/react-data-grid/v2/index.d.ts
@@ -62,17 +62,17 @@ declare namespace AdazzleReactDataGrid {
          * A toolbar to display above the grid.
          * Consider using the toolbar included in "react-data-grid/addons".
          */
-        toolbar?: React.ReactElement<any>
+        toolbar?: React.ReactElement
         /**
          * A context menu to disiplay when the user right-clicks a cell.
          * Consider using "react-contextmenu", included in "react-data-grid/addons".
          */
-        contextMenu?: React.ReactElement<any>
+        contextMenu?: React.ReactElement
         /**
          * A react component to customize how rows are rendered.
          * If you want to define your own, consider extending ReactDataGrid.Row.
          */
-        rowRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        rowRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A component to display when there are no rows to render.
          */
@@ -309,20 +309,20 @@ declare namespace AdazzleReactDataGrid {
         /**
          * A custom formatter for this column's filter.
          */
-        filterRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        filterRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>;
         /**
          * The editor for this column. Several editors are available in "react-data-grid/addons".
          * @default A simple text editor
          */
-        editor?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        editor?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A custom read-only formatter for this column. An image formatter is available in "react-data-grid/addons".
          */
-        formatter?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        formatter?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * A custom formatter for this column's header.
          */
-        headerRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>
+        headerRenderer?: React.ReactElement | React.ComponentClass<any> | React.StatelessComponent<any>
         /**
          * Events to be bound to the cells in this specific column.
          * Each event must respect this standard in order to work correctly:

--- a/types/react-datagrid/index.d.ts
+++ b/types/react-datagrid/index.d.ts
@@ -184,7 +184,7 @@ declare namespace ReactDataGrid {
           * or anything that React can render, so you can customize it as you
           * please.
           */
-        title?: string | React.ReactElement<any>;
+        title?: string | React.ReactElement;
 
         /**
           * Function - if you want custom rendering, specify this property.

--- a/types/react-datagrid/react-datagrid-tests.tsx
+++ b/types/react-datagrid/react-datagrid-tests.tsx
@@ -15,7 +15,7 @@ var sortInfo = [ { name: 'country', dir: 'asc'}]
 
 export module X {
 export class ExampleBasic extends React.Component {
-  render(): React.ReactElement<any> {
+  render(): React.ReactElement {
       return (
           <ReactDataGrid
             key={0}
@@ -30,7 +30,7 @@ export class ExampleBasic extends React.Component {
 
 class ExampleFull extends React.Component {
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
 		    return (
             <ReactDataGrid
               key={1}

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -87,7 +87,7 @@ export interface Renderer {
     ): Component<P, ComponentState> | Element | void;
 
     (
-        element: Array<ReactElement>,
+        element: ReactElement[],
         container: Element | null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -87,7 +87,7 @@ export interface Renderer {
     ): Component<P, ComponentState> | Element | void;
 
     (
-        element: Array<ReactElement<any>>,
+        element: Array<ReactElement>,
         container: Element | null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;

--- a/types/react-dom/node-stream/index.d.ts
+++ b/types/react-dom/node-stream/index.d.ts
@@ -5,14 +5,14 @@ import { ReactElement } from 'react';
  * server.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostream
  */
-export function renderToStream(element: ReactElement<any>): any;
+export function renderToStream(element: ReactElement): any;
 
 /**
  * Similar to renderToStream, except this doesn't create extra DOM attributes
  * such as data-react-id that React uses internally.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostaticstream
  */
-export function renderToStaticStream(element: ReactElement<any>): any;
+export function renderToStaticStream(element: ReactElement): any;
 export const version: string;
 
 export as namespace ReactDOMNodeStream;

--- a/types/react-dom/server/index.d.ts
+++ b/types/react-dom/server/index.d.ts
@@ -18,14 +18,14 @@ import { ReactElement } from 'react';
  * React will preserve it and only attach event handlers, allowing you
  * to have a very performant first-load experience.
  */
-export function renderToString(element: ReactElement<any>): string;
+export function renderToString(element: ReactElement): string;
 
 /**
  * Render a React element to its initial HTML. Returns a Readable stream that outputs
  * an HTML string. The HTML output by this stream is exactly equal to what
  * `ReactDOMServer.renderToString()` would return.
  */
-export function renderToNodeStream(element: ReactElement<any>): NodeJS.ReadableStream;
+export function renderToNodeStream(element: ReactElement): NodeJS.ReadableStream;
 
 /**
  * Similar to `renderToString`, except this doesn't create extra DOM attributes
@@ -33,14 +33,14 @@ export function renderToNodeStream(element: ReactElement<any>): NodeJS.ReadableS
  * to use React as a simple static page generator, as stripping away the extra
  * attributes can save lots of bytes.
  */
-export function renderToStaticMarkup(element: ReactElement<any>): string;
+export function renderToStaticMarkup(element: ReactElement): string;
 
 /**
  * Similar to `renderToNodeStream`, except this doesn't create extra DOM attributes
  * such as `data-reactid`, that React uses internally. The HTML output by this stream
  * is exactly equal to what `ReactDOMServer.renderToStaticMarkup()` would return.
  */
-export function renderToStaticNodeStream(element: ReactElement<any>): NodeJS.ReadableStream;
+export function renderToStaticNodeStream(element: ReactElement): NodeJS.ReadableStream;
 
 export const version: string;
 

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -66,15 +66,15 @@ export interface ShallowRenderer {
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput<E extends ReactElement<any>>(): E;
+    getRenderOutput<E extends ReactElement>(): E;
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput(): ReactElement<any>;
+    getRenderOutput(): ReactElement;
     /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
-    render(element: ReactElement<any>, context?: any): void;
+    render(element: ReactElement, context?: any): void;
     unmount(): void;
 }
 
@@ -186,22 +186,22 @@ export function isElement(element: any): boolean;
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<T extends HTMLElement>(
-    element: ReactElement<any>, type: string): element is ReactHTMLElement<T>;
+    element: ReactElement, type: string): element is ReactHTMLElement<T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
-    element: ReactElement<any>, type: string): element is DOMElement<P, T>;
+    element: ReactElement, type: string): element is DOMElement<P, T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P>(
-    element: ReactElement<any>, type: SFC<P>): element is SFCElement<P>;
+    element: ReactElement, type: SFC<P>): element is SFCElement<P>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P, T extends Component<P>, C extends ComponentClass<P>>(
-    element: ReactElement<any>, type: ClassType<P, T, C>): element is CElement<P, T>;
+    element: ReactElement, type: ClassType<P, T, C>): element is CElement<P, T>;
 
 /**
  * Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).

--- a/types/react-dom/v15/node-stream/index.d.ts
+++ b/types/react-dom/v15/node-stream/index.d.ts
@@ -5,14 +5,14 @@ import { ReactElement } from 'react';
  * server.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostream
  */
-export function renderToStream(element: ReactElement<any>): any;
+export function renderToStream(element: ReactElement): any;
 
 /**
  * Similar to renderToStream, except this doesn't create extra DOM attributes
  * such as data-react-id that React uses internally.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostaticstream
  */
-export function renderToStaticStream(element: ReactElement<any>): any;
+export function renderToStaticStream(element: ReactElement): any;
 export const version: string;
 
 export as namespace ReactDOMNodeStream;

--- a/types/react-dom/v15/server/index.d.ts
+++ b/types/react-dom/v15/server/index.d.ts
@@ -10,7 +10,7 @@ import { ReactElement } from 'react';
  * React will preserve it and only attach event handlers, allowing you
  * to have a very performant first-load experience.
  */
-export function renderToString(element: ReactElement<any>): string;
+export function renderToString(element: ReactElement): string;
 
 /**
  * Similar to `renderToString`, except this doesn't create extra DOM attributes
@@ -18,7 +18,7 @@ export function renderToString(element: ReactElement<any>): string;
  * to use React as a simple static page generator, as stripping away the extra
  * attributes can save lots of bytes.
  */
-export function renderToStaticMarkup(element: ReactElement<any>): string;
+export function renderToStaticMarkup(element: ReactElement): string;
 export const version: string;
 
 export as namespace ReactDOMServer;

--- a/types/react-dom/v15/test-utils/index.d.ts
+++ b/types/react-dom/v15/test-utils/index.d.ts
@@ -66,15 +66,15 @@ export interface ShallowRenderer {
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput<E extends ReactElement<any>>(): E;
+    getRenderOutput<E extends ReactElement>(): E;
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput(): ReactElement<any>;
+    getRenderOutput(): ReactElement;
     /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
-    render(element: ReactElement<any>, context?: any): void;
+    render(element: ReactElement, context?: any): void;
     unmount(): void;
 }
 
@@ -182,22 +182,22 @@ export function isElement(element: any): boolean;
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<T extends HTMLElement>(
-    element: ReactElement<any>, type: string): element is ReactHTMLElement<T>;
+    element: ReactElement, type: string): element is ReactHTMLElement<T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
-    element: ReactElement<any>, type: string): element is DOMElement<P, T>;
+    element: ReactElement, type: string): element is DOMElement<P, T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P>(
-    element: ReactElement<any>, type: SFC<P>): element is SFCElement<P>;
+    element: ReactElement, type: SFC<P>): element is SFCElement<P>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P, T extends Component<P>, C extends ComponentClass<P>>(
-    element: ReactElement<any>, type: ClassType<P, T, C>): element is CElement<P, T>;
+    element: ReactElement, type: ClassType<P, T, C>): element is CElement<P, T>;
 
 /**
  * Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).

--- a/types/react-faux-dom/index.d.ts
+++ b/types/react-faux-dom/index.d.ts
@@ -14,7 +14,7 @@ export class Element extends HTMLElement {
 
     constructor(nodeName: string, parentNode?: Element);
 
-    toReact(): React.ReactElement<any>;
+    toReact(): React.ReactElement;
 }
 
 export const defaultView: {

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -121,7 +121,7 @@ export interface FormFieldApi {
 
 export interface FormFieldPropsWithField {
     field?: string;
-    children(api: FormFieldApi): React.ReactElement<any> | null;
+    children(api: FormFieldApi): React.ReactElement | null;
 }
 export interface FormFieldPropsWithoutField {
     children(api: FormApi): RenderReturn;
@@ -147,7 +147,7 @@ export interface FormInputProps {
 }
 
 export interface FormInputPropsWithChildren extends FormInputProps {
-    children(api: FormFieldApi): React.ReactElement<any> | null;
+    children(api: FormFieldApi): React.ReactElement | null;
 }
 export const FormInput: React.SFC<FormInputPropsWithChildren>;
 

--- a/types/react-hyperscript/index.d.ts
+++ b/types/react-hyperscript/index.d.ts
@@ -8,12 +8,12 @@ import { ComponentClass, StatelessComponent, ReactElement } from 'react';
 
 declare namespace h {}
 
-type Element = ReactElement<any> | string | number | null;
+type Element = ReactElement | string | number | null;
 
 declare function h(
     componentOrTag: ComponentClass | StatelessComponent | string,
     children?: ReadonlyArray<Element> | Element
-): ReactElement<any>;
+): ReactElement;
 
 declare function h<P extends {[attr: string]: any}>(
     componentOrTag: ComponentClass<P> | StatelessComponent<P> | string,

--- a/types/react-image-fallback/index.d.ts
+++ b/types/react-image-fallback/index.d.ts
@@ -17,8 +17,8 @@ export default class ReactImageFallback extends React.Component<
 
 export interface ReactImageFallbackProps {
     src: string;
-    fallbackImage: string | React.ReactElement<any> | string[] | Array<React.ReactElement<any>>;
-    initialImage?: string | React.ReactElement<any>;
+    fallbackImage: string | React.ReactElement | string[] | Array<React.ReactElement>;
+    initialImage?: string | React.ReactElement;
     onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
     onError?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
     initialTimeout?: number;

--- a/types/react-image-fallback/index.d.ts
+++ b/types/react-image-fallback/index.d.ts
@@ -17,7 +17,7 @@ export default class ReactImageFallback extends React.Component<
 
 export interface ReactImageFallbackProps {
     src: string;
-    fallbackImage: string | React.ReactElement | string[] | Array<React.ReactElement>;
+    fallbackImage: string | React.ReactElement | string[] | React.ReactElement[];
     initialImage?: string | React.ReactElement;
     onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
     onError?: (event: React.SyntheticEvent<HTMLImageElement>) => void;

--- a/types/react-imageloader/index.d.ts
+++ b/types/react-imageloader/index.d.ts
@@ -21,7 +21,7 @@ declare module "react-imageloader" {
       onLoad?: (event: any) => void;
 
       /** An optional function that returns a React element to be shown while the image loads. */
-      preloader?: (params: any) => React.ReactElement<any>;
+      preloader?: (params: any) => React.ReactElement;
 
       /** The URL of the image to be loaded. */
       src: string;
@@ -30,7 +30,7 @@ declare module "react-imageloader" {
       style?: React.CSSProperties;
 
       /** A function that takes a props argument and returns a React element to be used as the wrapper component. Defaults to React.DOM.span. */
-      wrapper?: (props: any) => React.ReactElement<any>;
+      wrapper?: (props: any) => React.ReactElement;
   }
 
   class ImageLoader extends React.Component<ImageLoaderProps> {}

--- a/types/react-images/index.d.ts
+++ b/types/react-images/index.d.ts
@@ -64,7 +64,7 @@ export interface LightboxProps {
     /**
      * Spinner component.
      */
-    spinner?: () => React.ReactElement<any>;
+    spinner?: () => React.ReactElement;
 
     /**
      *  Color of spinner. Default value: 'white'

--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -62,7 +62,7 @@ declare namespace InfiniteScroll {
         /**
          * Loader component for indicating "loading more".
          */
-        loader?: React.ReactElement<any>;
+        loader?: React.ReactElement;
         /**
          * Override method to return a different scroll listener if it's not the immediate parent of InfiniteScroll.
          */

--- a/types/react-infinite/index.d.ts
+++ b/types/react-infinite/index.d.ts
@@ -17,11 +17,11 @@ declare namespace Infinite {
 		containerHeight?: number;
 		preloadBatchSize?: number | Object;
 		preloadAdditionalHeight?: number | Object;
-		handleScroll?: (node: React.ReactElement<any>) => void;
+		handleScroll?: (node: React.ReactElement) => void;
 		infiniteLoadBeginBottomOffset?: number;
 		infiniteLoadBeginEdgeOffset?: number;
 		onInfiniteLoad?: () => void;
-		loadingSpinnerDelegate?: React.ReactElement<any>;
+		loadingSpinnerDelegate?: React.ReactElement;
 		isInfiniteLoading?: boolean;
 		timeScrollStateLastsForAfterUserScrolls?: number;
 		className?: string;

--- a/types/react-infinite/react-infinite-tests.tsx
+++ b/types/react-infinite/react-infinite-tests.tsx
@@ -72,14 +72,14 @@ class ListItem extends React.Component<{ key: number; num: number }, {}> {
     }
 }
 
-class InfiniteList extends React.Component<{}, { elements: React.ReactElement<any>[], isInfiniteLoading: boolean }> {
+class InfiniteList extends React.Component<{}, { elements: React.ReactElement[], isInfiniteLoading: boolean }> {
     state = {
         elements: this.buildElements(0, 20),
         isInfiniteLoading: false
     };
 
     buildElements(start: number, end: number) {
-        var elements = [] as React.ReactElement<any>[];
+        var elements = [] as React.ReactElement[];
         for (var i = start; i < end; i++) {
             elements.push(<ListItem key={i} num={i} />)
         }

--- a/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
+++ b/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
@@ -42,7 +42,7 @@ const App = () => (
 const IndexResults = connectStateResults(
   ({ searchState, searchResults, children }) =>
     searchResults && searchResults.nbHits !== 0 ? (
-      children as React.ReactElement<any>
+      children as React.ReactElement
     ) : (
       <div>
         No results has been found for {searchState.query} and index{' '}
@@ -64,6 +64,6 @@ const AllResults = connectStateResults(({ allSearchResults, children }) => {
       <Index indexName="third" />
     </div>
   ) : (
-    children as React.ReactElement<any>
+    children as React.ReactElement
   );
 });

--- a/types/react-instantsearch/react-instantsearch-tests.tsx
+++ b/types/react-instantsearch/react-instantsearch-tests.tsx
@@ -298,7 +298,7 @@ import { createInstantSearch } from "react-instantsearch-core";
   const IndexResults = connectStateResults(
     ({ searchState, searchResults, children }) =>
       searchResults && searchResults.nbHits !== 0 ? (
-        children as React.ReactElement<any>
+        children as React.ReactElement
       ) : (
         <div>
           No results has been found for {searchState.query} and index{' '}
@@ -320,7 +320,7 @@ import { createInstantSearch } from "react-instantsearch-core";
         <Index indexName="third" />
       </div>
     ) : (
-      children as React.ReactElement<any>
+      children as React.ReactElement
     );
   });
 };

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -17,18 +17,18 @@ import {
 
 export function typeOf(value: any): symbol | undefined;
 export function isValidElementType(value: any): value is ReactType;
-export function isAsyncMode(value: any): value is ReactElement<any>;
-export function isContextConsumer(value: any): value is ReactElement<any>;
-export function isContextProvider(value: any): value is ReactElement<any>;
-export function isElement(value: any): value is ReactElement<any>;
-export function isForwardRef(value: any): value is ReactElement<any>;
-export function isFragment(value: any): value is ReactElement<any>;
+export function isAsyncMode(value: any): value is ReactElement;
+export function isContextConsumer(value: any): value is ReactElement;
+export function isContextProvider(value: any): value is ReactElement;
+export function isElement(value: any): value is ReactElement;
+export function isForwardRef(value: any): value is ReactElement;
+export function isFragment(value: any): value is ReactElement;
 export function isLazy(value: any): value is LazyExoticComponent<any>;
 export function isMemo(value: any): value is MemoExoticComponent<any>;
-export function isProfiler(value: any): value is ReactElement<any>;
-export function isPortal(value: any): value is ReactElement<any>;
-export function isStrictMode(value: any): value is ReactElement<any>;
-export function isSuspense(value: any): value is ReactElement<any>;
+export function isProfiler(value: any): value is ReactElement;
+export function isPortal(value: any): value is ReactElement;
+export function isStrictMode(value: any): value is ReactElement;
+export function isSuspense(value: any): value is ReactElement;
 
 export const AsyncMode: symbol;
 export const ContextConsumer: symbol;

--- a/types/react-js-pagination/index.d.ts
+++ b/types/react-js-pagination/index.d.ts
@@ -12,10 +12,10 @@ export interface ReactJsPaginationProps {
     activePage: number;
     itemsCountPerPage?: number;
     pageRangeDisplayed?: number;
-    prevPageText?: string| React.ReactElement<any>;
-    nextPageText?: string | React.ReactElement<any>;
-    lastPageText?: string | React.ReactElement<any>;
-    firstPageText?: string | React.ReactElement<any>;
+    prevPageText?: string| React.ReactElement;
+    nextPageText?: string | React.ReactElement;
+    lastPageText?: string | React.ReactElement;
+    firstPageText?: string | React.ReactElement;
     disabledClass?: string;
     hideDisabled?: boolean;
     hideNavigation?: boolean;

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -123,12 +123,12 @@ declare module "react-jsonschema-form" {
         id: string;
         classNames: string;
         label: string;
-        description: React.ReactElement<any>;
+        description: React.ReactElement;
         rawDescription: string;
-        children: React.ReactElement<any>;
-        errors: React.ReactElement<any>;
+        children: React.ReactElement;
+        errors: React.ReactElement;
         rawErrors: string[];
-        help: React.ReactElement<any>;
+        help: React.ReactElement;
         rawHelp: string;
         hidden: boolean;
         required: boolean;
@@ -142,14 +142,14 @@ declare module "react-jsonschema-form" {
     };
 
     export type ArrayFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<any> }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         canAdd: boolean;
         className: string;
         disabled: boolean;
         idSchema: IdSchema;
         items: {
-            children: React.ReactElement<any>;
+            children: React.ReactElement;
             className: string;
             disabled: boolean;
             hasMoveDown: boolean;
@@ -175,12 +175,12 @@ declare module "react-jsonschema-form" {
     };
 
     export type ObjectFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<any> }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         title: string;
         description: string;
         properties: {
-            content: React.ReactElement<any>;
+            content: React.ReactElement;
             name: string;
             disabled: boolean;
             readonly: boolean;

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -41,7 +41,7 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
  */
 export type PropsOf<C> = C extends new (props: infer P) => React.Component
   ? P
-  : C extends (props: infer P) => React.ReactElement<any> | null ? P : never;
+  : C extends (props: infer P) => React.ReactElement | null ? P : never;
 
 /**
  * a function that takes {component} and returns a component that passes along

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -77,7 +77,7 @@ const App = () => (
 );
 
 function ssrRender(req: any, res: { send: (text: string) => any }) {
-  const mockedRenderToString = (e: React.ReactElement<any>) => `${e}`;
+  const mockedRenderToString = (e: React.ReactElement) => `${e}`;
   const sheets = new SheetsRegistry();
 
   const body = mockedRenderToString(

--- a/types/react-motion-loop/index.d.ts
+++ b/types/react-motion-loop/index.d.ts
@@ -10,7 +10,7 @@ import { MotionProps, PlainStyle, Style } from "react-motion";
 interface ReactMotionLoopProps extends Partial<MotionProps> {
     styleFrom: Style;
     styleTo: Style;
-    children?: (interpolatedStyle: PlainStyle) => ReactElement<any>;
+    children?: (interpolatedStyle: PlainStyle) => ReactElement;
 }
 export class ReactMotionLoop extends Component<ReactMotionLoopProps> {}
 

--- a/types/react-motion-ui-pack/index.d.ts
+++ b/types/react-motion-ui-pack/index.d.ts
@@ -9,7 +9,7 @@ import * as motion from 'react-motion';
 
 declare namespace Transition {
     interface TransitionProps {
-        component?: string | boolean | React.ReactElement<any>;
+        component?: string | boolean | React.ReactElement;
         runOnMount?: boolean;
         appear?: motion.Style;
         enter?: motion.Style;

--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -65,7 +65,7 @@ interface MotionProps {
      * Callback with your interpolated styles. Must return one react element to render
      * @param interpolatedStyle
      */
-    children?: (interpolatedStyle: PlainStyle) => ReactElement<any>;
+    children?: (interpolatedStyle: PlainStyle) => ReactElement;
     /**
      * The callback that fires when the animation comes to a rest.
      */
@@ -113,7 +113,7 @@ interface TransitionProps {
      * <StaggeredMotion/>
      */
     styles: Array<TransitionStyle> | InterpolateFunction;
-    children?: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement<any>;
+    children?: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement;
     /**
      * Triggers when a new element will appear
      * @param styleThatEntered

--- a/types/react-native-draggable-flatlist/index.d.ts
+++ b/types/react-native-draggable-flatlist/index.d.ts
@@ -49,7 +49,7 @@ interface DraggableFlatListProps<Item> extends VirtualizedListWithoutRenderItemP
   /**
    * Function that calls move when the row should become active (in an onPress, onLongPress, etc). Calls moveEnd when the gesture is complete (in onPressOut).
    */
-  renderItem: (info: RenderItemInfo<Item>) => React.ReactElement<any> | null;
+  renderItem: (info: RenderItemInfo<Item>) => React.ReactElement | null;
 }
 
 declare class DraggableFlatList<Item> extends Component<DraggableFlatListProps<Item>> {

--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -762,11 +762,11 @@ export interface ThemeProps {
 
 export interface ThemeProviderProps {
     value: {};
-    children: React.ReactElement<any>;
+    children: React.ReactElement;
 }
 
 export interface ThemeConsumerProps {
-    children(props: ThemeProps): React.ReactElement<any>;
+    children(props: ThemeProps): React.ReactElement;
 }
 
 export namespace ThemeContext {

--- a/types/react-native-navbar/index.d.ts
+++ b/types/react-native-navbar/index.d.ts
@@ -33,9 +33,9 @@ export interface NavigationBarProps {
     style?: ViewStyle;
     tintColor?: string;
     statusBar?: StatusBar;
-    leftButton?: NavigationBarButton | React.ReactElement<any> | null;
-    rightButton?: NavigationBarButton | React.ReactElement<any> | null;
-    title?: NavigationBarTitle | React.ReactElement<any> | null;
+    leftButton?: NavigationBarButton | React.ReactElement | null;
+    rightButton?: NavigationBarButton | React.ReactElement | null;
+    title?: NavigationBarTitle | React.ReactElement | null;
 }
 
 export default class NavigationBar extends React.Component<NavigationBarProps> {}

--- a/types/react-native-photo-view/index.d.ts
+++ b/types/react-native-photo-view/index.d.ts
@@ -22,9 +22,9 @@ export interface ReactNativePhotoViewProps {
     onLoad?: () => void;
     onLoadEnd?: () => void;
     onProgress?: (loaded: number, total: number) => void;
-    onTap?: (point: {x: number, y: number}, target?: React.ReactElement<any>) => void;
-    onViewTap?: (point: {x: number, y: number}, target?: React.ReactElement<any>) => void;
-    onScale?: (scale: number, target?: React.ReactElement<any>) => void;
+    onTap?: (point: {x: number, y: number}, target?: React.ReactElement) => void;
+    onViewTap?: (point: {x: number, y: number}, target?: React.ReactElement) => void;
+    onScale?: (scale: number, target?: React.ReactElement) => void;
 }
 
 export default class ReactNativePhotoView extends React.Component<ReactNativePhotoViewProps & ViewProps> {}

--- a/types/react-native-photo-view/react-native-photo-view-tests.tsx
+++ b/types/react-native-photo-view/react-native-photo-view-tests.tsx
@@ -25,13 +25,13 @@ const test: React.SFC = () => (
         onProgress={(loaded: number, total: number) => {
             console.log(`onProgress ${loaded}/${total}`);
         }}
-        onTap={(point: {x: number; y: number}, target?: React.ReactElement<any>) => {
+        onTap={(point: {x: number; y: number}, target?: React.ReactElement) => {
             console.log('onTap');
         }}
-        onViewTap={(point: {x: number; y: number}, target?: React.ReactElement<any>) => {
+        onViewTap={(point: {x: number; y: number}, target?: React.ReactElement) => {
             console.log(`onViewTap ${point.x},${point.y} ${!!target ? 'targetted' : ''}`);
         }}
-        onScale={(scale: number, target?: React.ReactElement<any>) => {
+        onScale={(scale: number, target?: React.ReactElement) => {
             console.log(`onScale ${scale} ${!!target ? 'targetted' : ''}`);
         }}
     />

--- a/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
+++ b/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
@@ -23,7 +23,7 @@ class SnapCarouselTest extends React.Component {
         );
     }
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <View>
                 <StringCarousel
@@ -81,7 +81,7 @@ class SnapCarouselWithPaginationTest extends React.Component<{}, {activeSlide: n
         );
     }
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <View>
                 <StringCarousel
@@ -126,7 +126,7 @@ class SnapCarouselWithParallaxTest extends React.Component {
         );
     }
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactElement {
         return (
             <View>
                 <StringCarousel

--- a/types/react-native-swiper/react-native-swiper-tests.tsx
+++ b/types/react-native-swiper/react-native-swiper-tests.tsx
@@ -20,7 +20,7 @@ class SwiperTest extends React.Component {
   ) => {
     console.log(this.callback.name, event, state, context);
   }
-  render(): React.ReactElement<any> {
+  render(): React.ReactElement {
     return (
       <Swiper
         horizontal

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3919,7 +3919,7 @@ export interface ListRenderItemInfo<ItemT> {
     };
 }
 
-export type ListRenderItem<ItemT> = (info: ListRenderItemInfo<ItemT>) => React.ReactElement<any> | null;
+export type ListRenderItem<ItemT> = (info: ListRenderItemInfo<ItemT>) => React.ReactElement | null;
 
 export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
@@ -3930,17 +3930,17 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Optional custom style for multi-item rows generated when numColumns > 1
@@ -4146,7 +4146,7 @@ export interface SectionListRenderItemInfo<ItemT> extends ListRenderItemInfo<Ite
     section: SectionListData<ItemT>;
 }
 
-export type SectionListRenderItem<ItemT> = (info: SectionListRenderItemInfo<ItemT>) => React.ReactElement<any> | null;
+export type SectionListRenderItem<ItemT> = (info: SectionListRenderItemInfo<ItemT>) => React.ReactElement | null;
 
 export interface SectionListProps<ItemT> extends VirtualizedListWithoutRenderItemProps<ItemT> {
     /**
@@ -4157,22 +4157,22 @@ export interface SectionListProps<ItemT> extends VirtualizedListWithoutRenderIte
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4258,12 +4258,12 @@ export interface SectionListProps<ItemT> extends VirtualizedListWithoutRenderIte
     /**
      * Rendered at the top of each section. Sticky headers are not yet supported.
      */
-    renderSectionHeader?: (info: { section: SectionListData<ItemT> }) => React.ReactElement<any> | null;
+    renderSectionHeader?: (info: { section: SectionListData<ItemT> }) => React.ReactElement | null;
 
     /**
      * Rendered at the bottom of each section.
      */
-    renderSectionFooter?: (info: { section: SectionListData<ItemT> }) => React.ReactElement<any> | null;
+    renderSectionFooter?: (info: { section: SectionListData<ItemT> }) => React.ReactElement | null;
 
     /**
      * An array of objects with data for each section.
@@ -4323,19 +4323,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<any> | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -4560,7 +4560,7 @@ export interface ListViewProps extends ScrollViewProps {
      * in StaticContainer or other mechanism as appropriate.  Footer is always
      * at the bottom of the list, and header at the top, on every render pass.
      */
-    renderFooter?: () => React.ReactElement<any>;
+    renderFooter?: () => React.ReactElement;
 
     /**
      * () => renderable
@@ -4570,7 +4570,7 @@ export interface ListViewProps extends ScrollViewProps {
      * in StaticContainer or other mechanism as appropriate.  Footer is always
      * at the bottom of the list, and header at the top, on every render pass.
      */
-    renderHeader?: () => React.ReactElement<any>;
+    renderHeader?: () => React.ReactElement;
 
     /**
      * (rowData, sectionID, rowID) => renderable
@@ -4584,7 +4584,7 @@ export interface ListViewProps extends ScrollViewProps {
         sectionID: string | number,
         rowID: string | number,
         highlightRow?: boolean
-    ) => React.ReactElement<any>;
+    ) => React.ReactElement;
 
     /**
      * A function that returns the scrollable component in which the list rows are rendered.
@@ -4601,7 +4601,7 @@ export interface ListViewProps extends ScrollViewProps {
      * stick to the top until it is pushed off the screen by the next section
      * header.
      */
-    renderSectionHeader?: (sectionData: any, sectionId: string | number) => React.ReactElement<any>;
+    renderSectionHeader?: (sectionData: any, sectionId: string | number) => React.ReactElement;
 
     /**
      * (sectionID, rowID, adjacentRowHighlighted) => renderable
@@ -4613,7 +4613,7 @@ export interface ListViewProps extends ScrollViewProps {
         sectionID: string | number,
         rowID: string | number,
         adjacentRowHighlighted?: boolean
-    ) => React.ReactElement<any>;
+    ) => React.ReactElement;
 
     /**
      * How early to start rendering rows before they come on screen, in
@@ -4690,12 +4690,12 @@ export interface MapViewAnnotation {
     onBlur?: () => any;
     title?: string;
     subtitle?: string;
-    leftCalloutView?: React.ReactElement<any>;
-    rightCalloutView?: React.ReactElement<any>;
-    detailCalloutView?: React.ReactElement<any>;
+    leftCalloutView?: React.ReactElement;
+    rightCalloutView?: React.ReactElement;
+    detailCalloutView?: React.ReactElement;
     tintColor?: string;
     image?: ImageURISource;
-    view?: React.ReactElement<any>;
+    view?: React.ReactElement;
     hasLeftCallout?: boolean;
     hasRightCallout?: boolean;
     onLeftCalloutPress?: () => void;
@@ -4854,7 +4854,7 @@ export class MapView extends MapViewBase {
 }
 
 interface MaskedViewIOSProps extends ViewProps {
-    maskElement: React.ReactElement<any>;
+    maskElement: React.ReactElement;
 }
 
 /**
@@ -6639,10 +6639,10 @@ export interface SwipeableListViewProps {
         sectionID: string | number,
         rowID: string | number,
         highlightRow?: boolean
-    ) => React.ReactElement<any>;
+    ) => React.ReactElement;
 
     // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions(rowData: any, sectionID: string | number, rowID: string | number): React.ReactElement<any>;
+    renderQuickActions(rowData: any, sectionID: string | number, rowID: string | number): React.ReactElement;
 }
 
 /**
@@ -8185,7 +8185,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: "window" | React.ReactElement<any> | number,
+        view?: "window" | React.ReactElement | number,
         options?: {
             width?: number;
             height?: number;

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -427,24 +427,24 @@ export interface NavigationSwitchRouterConfig {
 export interface NavigationStackScreenOptions {
   title?: string;
   header?:
-  | React.ReactElement<any>
-  | ((headerProps: HeaderProps) => React.ReactElement<any>)
+  | React.ReactElement
+  | ((headerProps: HeaderProps) => React.ReactElement)
   | null;
   headerTransparent?: boolean;
-  headerTitle?: string | React.ReactElement<any>;
+  headerTitle?: string | React.ReactElement;
   headerTitleStyle?: StyleProp<TextStyle>;
   headerTitleAllowFontScaling?: boolean;
   headerTintColor?: string;
   headerLeft?:
-  | React.ReactElement<any>
-  | ((backButtonProps: HeaderBackButtonProps) => React.ReactElement<any>)
+  | React.ReactElement
+  | ((backButtonProps: HeaderBackButtonProps) => React.ReactElement)
   | null;
   headerBackTitle?: string | null;
-  headerBackImage?: React.ReactElement<any>;
+  headerBackImage?: React.ReactElement;
   headerTruncatedBackTitle?: string;
   headerBackTitleStyle?: StyleProp<TextStyle>;
   headerPressColorAndroid?: string;
-  headerRight?: React.ReactElement<any> | null;
+  headerRight?: React.ReactElement | null;
   headerStyle?: StyleProp<ViewStyle>;
   headerForceInset?: HeaderForceInset;
   headerBackground?: React.ReactNode | React.ReactType;
@@ -539,16 +539,16 @@ export interface TabScene {
 interface NavigationTabScreenOptionsBase {
   title?: string;
   tabBarIcon?:
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean; horizontal: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   tabBarLabel?:
   | string
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | string | null);
+  ) => React.ReactElement | string | null);
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string; accessibilityLabel?: string };
 }
@@ -578,16 +578,16 @@ export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
 export interface NavigationDrawerScreenOptions {
   title?: string;
   drawerIcon?:
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   drawerLabel?:
   | string
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   drawerLockMode?: DrawerLockMode;
 }
 
@@ -804,7 +804,7 @@ export type NavigationAnimationSetter = (
   lastState: NavigationState
 ) => void;
 
-export type NavigationSceneRenderer = () => React.ReactElement<any> | null;
+export type NavigationSceneRenderer = () => React.ReactElement | null;
 
 export type NavigationStyleInterpolator = (
   props: NavigationSceneRendererProps
@@ -1061,7 +1061,7 @@ export interface TabBarTopProps {
         jumpToIndex: (index: number) => void;
       }
     ) => void;
-  renderIcon: (scene: TabScene) => React.ReactElement<any>;
+  renderIcon: (scene: TabScene) => React.ReactElement;
   labelStyle?: TextStyle;
   iconStyle?: ViewStyle;
 }

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -436,7 +436,7 @@ class CustomTransitioner extends React.Component<CustomTransitionerProps, null> 
             />
         );
     }
-    _render = (props: NavigationTransitionProps, prevProps?: NavigationTransitionProps): React.ReactElement<any> => {
+    _render = (props: NavigationTransitionProps, prevProps?: NavigationTransitionProps): React.ReactElement => {
         return (
             <View />
         );

--- a/types/react-navigation/v1/index.d.ts
+++ b/types/react-navigation/v1/index.d.ts
@@ -289,17 +289,17 @@ export interface NavigationStackViewConfig {
 
 export interface NavigationStackScreenOptions {
   title?: string;
-  header?: (React.ReactElement<any> | ((headerProps: HeaderProps) => React.ReactElement<any>)) | null;
+  header?: (React.ReactElement | ((headerProps: HeaderProps) => React.ReactElement)) | null;
   headerTransparent?: boolean;
-  headerTitle?: string | React.ReactElement<any>;
+  headerTitle?: string | React.ReactElement;
   headerTitleStyle?: StyleProp<TextStyle>;
   headerTintColor?: string;
-  headerLeft?: React.ReactElement<any>;
+  headerLeft?: React.ReactElement;
   headerBackTitle?: string | null;
   headerTruncatedBackTitle?: string;
   headerBackTitleStyle?: StyleProp<TextStyle>;
   headerPressColorAndroid?: string;
-  headerRight?: React.ReactElement<any>;
+  headerRight?: React.ReactElement;
   headerStyle?: StyleProp<ViewStyle>;
   headerBackground?: React.ReactNode | React.ReactType;
   gesturesEnabled?: boolean;
@@ -367,13 +367,13 @@ export interface TabScene {
 export interface NavigationTabScreenOptions {
   title?: string;
   tabBarIcon?:
-    React.ReactElement<any>
+    React.ReactElement
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
       any
     > | null));
   tabBarLabel?:
     string
-    | React.ReactElement<any>
+    | React.ReactElement
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
       any
     > | string | null));
@@ -388,13 +388,13 @@ export interface NavigationTabScreenOptions {
 export interface NavigationDrawerScreenOptions {
   title?: string;
   drawerIcon?:
-    React.ReactElement<any>
+    React.ReactElement
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
       any
     > | null));
   drawerLabel?:
     string
-    | React.ReactElement<any>
+    | React.ReactElement
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
       any
     > | null));
@@ -557,7 +557,7 @@ export type NavigationAnimationSetter = (
   lastState: NavigationState
 ) => void;
 
-export type NavigationSceneRenderer = () => (React.ReactElement<any> | null);
+export type NavigationSceneRenderer = () => (React.ReactElement | null);
 
 export type NavigationStyleInterpolator = (
   props: NavigationSceneRendererProps
@@ -737,7 +737,7 @@ export interface TabBarTopProps {
     scene: TabScene,
     jumpToIndex: (index: number) => void,
   }) => void;
-  renderIcon: (scene: TabScene) => React.ReactElement<any>;
+  renderIcon: (scene: TabScene) => React.ReactElement;
   labelStyle?: TextStyle;
   iconStyle?: ViewStyle;
 }

--- a/types/react-navigation/v1/index.d.ts
+++ b/types/react-navigation/v1/index.d.ts
@@ -368,15 +368,11 @@ export interface NavigationTabScreenOptions {
   title?: string;
   tabBarIcon?:
     React.ReactElement
-    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
-    > | null));
+    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement | null));
   tabBarLabel?:
     string
     | React.ReactElement
-    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
-    > | string | null));
+    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement | string | null));
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string };
   tabBarOnPress?: (options: {
@@ -389,15 +385,11 @@ export interface NavigationDrawerScreenOptions {
   title?: string;
   drawerIcon?:
     React.ReactElement
-    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
-    > | null));
+    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement | null));
   drawerLabel?:
     string
     | React.ReactElement
-    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
-    > | null));
+    | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement | null));
 }
 
 export interface NavigationRouteConfigMap {

--- a/types/react-navigation/v1/react-navigation-tests.tsx
+++ b/types/react-navigation/v1/react-navigation-tests.tsx
@@ -366,7 +366,7 @@ class CustomTransitioner extends React.Component<CustomTransitionerProps, null> 
             />
         );
     }
-    _render = (props: NavigationTransitionProps, prevProps: NavigationTransitionProps): React.ReactElement<any> => {
+    _render = (props: NavigationTransitionProps, prevProps: NavigationTransitionProps): React.ReactElement => {
         return (
             <View />
         );

--- a/types/react-navigation/v2/index.d.ts
+++ b/types/react-navigation/v2/index.d.ts
@@ -425,24 +425,24 @@ export interface NavigationSwitchRouterConfig {
 export interface NavigationStackScreenOptions {
   title?: string;
   header?:
-  | React.ReactElement<any>
-  | ((headerProps: HeaderProps) => React.ReactElement<any>)
+  | React.ReactElement
+  | ((headerProps: HeaderProps) => React.ReactElement)
   | null;
   headerTransparent?: boolean;
-  headerTitle?: string | React.ReactElement<any>;
+  headerTitle?: string | React.ReactElement;
   headerTitleStyle?: StyleProp<TextStyle>;
   headerTitleAllowFontScaling?: boolean;
   headerTintColor?: string;
   headerLeft?:
-  | React.ReactElement<any>
-  | ((backButtonProps: HeaderBackButtonProps) => React.ReactElement<any>)
+  | React.ReactElement
+  | ((backButtonProps: HeaderBackButtonProps) => React.ReactElement)
   | null;
   headerBackTitle?: string | null;
-  headerBackImage?: React.ReactElement<any>;
+  headerBackImage?: React.ReactElement;
   headerTruncatedBackTitle?: string;
   headerBackTitleStyle?: StyleProp<TextStyle>;
   headerPressColorAndroid?: string;
-  headerRight?: React.ReactElement<any> | null;
+  headerRight?: React.ReactElement | null;
   headerStyle?: StyleProp<ViewStyle>;
   headerForceInset?: HeaderForceInset;
   headerBackground?: React.ReactNode | React.ReactType;
@@ -534,16 +534,16 @@ export interface TabScene {
 interface NavigationTabScreenOptionsBase {
   title?: string;
   tabBarIcon?:
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean; horizontal: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   tabBarLabel?:
   | string
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | string | null);
+  ) => React.ReactElement | string | null);
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string; accessibilityLabel?: string };
 }
@@ -573,16 +573,16 @@ export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
 export interface NavigationDrawerScreenOptions {
   title?: string;
   drawerIcon?:
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   drawerLabel?:
   | string
-  | React.ReactElement<any>
+  | React.ReactElement
   | ((
     options: { tintColor: string | null; focused: boolean }
-  ) => React.ReactElement<any> | null);
+  ) => React.ReactElement | null);
   drawerLockMode?: DrawerLockMode;
 }
 
@@ -799,7 +799,7 @@ export type NavigationAnimationSetter = (
   lastState: NavigationState
 ) => void;
 
-export type NavigationSceneRenderer = () => React.ReactElement<any> | null;
+export type NavigationSceneRenderer = () => React.ReactElement | null;
 
 export type NavigationStyleInterpolator = (
   props: NavigationSceneRendererProps
@@ -1056,7 +1056,7 @@ export interface TabBarTopProps {
         jumpToIndex: (index: number) => void;
       }
     ) => void;
-  renderIcon: (scene: TabScene) => React.ReactElement<any>;
+  renderIcon: (scene: TabScene) => React.ReactElement;
   labelStyle?: TextStyle;
   iconStyle?: ViewStyle;
 }

--- a/types/react-navigation/v2/react-navigation-tests.tsx
+++ b/types/react-navigation/v2/react-navigation-tests.tsx
@@ -426,7 +426,7 @@ class CustomTransitioner extends React.Component<CustomTransitionerProps, null> 
             />
         );
     }
-    _render = (props: NavigationTransitionProps, prevProps?: NavigationTransitionProps): React.ReactElement<any> => {
+    _render = (props: NavigationTransitionProps, prevProps?: NavigationTransitionProps): React.ReactElement => {
         return (
             <View />
         );

--- a/types/react-overlays/lib/Dropdown.d.ts
+++ b/types/react-overlays/lib/Dropdown.d.ts
@@ -24,7 +24,7 @@ declare namespace Dropdown {
          * argument should spread through to an element containing _both_ the
          * menu and toggle in order to handle keyboard events for focus management.
          */
-        children(renderProps: DropdownRenderProps): React.ReactElement<any>;
+        children(renderProps: DropdownRenderProps): React.ReactElement;
 
         /**
          * Determines the direction and location of the Menu in relation to it's Toggle.

--- a/types/react-overlays/lib/DropdownMenu.d.ts
+++ b/types/react-overlays/lib/DropdownMenu.d.ts
@@ -18,7 +18,7 @@ declare namespace DropdownMenu {
          * A render prop that returns a Menu element. The `props`
          * argument should spread through to **a component that can accept a ref**.
          */
-        children(renderProps: DropdownMenuRenderProps): React.ReactElement<any>;
+        children(renderProps: DropdownMenuRenderProps): React.ReactElement;
 
         /**
          * Controls the visible state of the menu, generally this is

--- a/types/react-overlays/lib/DropdownToggle.d.ts
+++ b/types/react-overlays/lib/DropdownToggle.d.ts
@@ -24,6 +24,6 @@ declare namespace DropdownToggle {
          */
         children(
             renderProps: DropdownToggleRenderProps
-        ): React.ReactElement<any>;
+        ): React.ReactElement;
     }
 }

--- a/types/react-overlays/lib/Overlay.d.ts
+++ b/types/react-overlays/lib/Overlay.d.ts
@@ -47,7 +47,7 @@ declare namespace Overlay {
          * A render prop that returns an element to overlay and position. See
          * the [react-popper documentation](https://github.com/FezVrasta/react-popper#children) for more info.
          */
-        children(renderProps: OverlayRenderProps): React.ReactElement<any>;
+        children(renderProps: OverlayRenderProps): React.ReactElement;
 
         /**
          * A set of popper options and props passed directly to react-popper's Popper component.

--- a/types/react-popover/index.d.ts
+++ b/types/react-popover/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Popover {
         tipSize?: number;
         className?: string;
         style?: React.CSSProperties;
-        target?: React.ReactElement<any>;
+        target?: React.ReactElement;
         appendTarget?: Element;
     }
 }

--- a/types/react-portal/index.d.ts
+++ b/types/react-portal/index.d.ts
@@ -25,7 +25,7 @@ export interface PortalWithStateProps extends React.Props<any> {
     children: (params: PortalFunctionParams) => React.ReactNode;
     node?: Element | null;
     defaultOpen?: boolean;
-    openByClickOn?: React.ReactElement<any>;
+    openByClickOn?: React.ReactElement;
     closeOnEsc?: boolean;
     closeOnOutsideClick?: boolean;
     onOpen?(): void;

--- a/types/react-redux-epic/client.d.ts
+++ b/types/react-redux-epic/client.d.ts
@@ -2,6 +2,6 @@ import * as React from 'react';
 import { Observable } from 'rxjs/Observable';
 
 export function render(
-    element: React.ReactElement<any>,
+    element: React.ReactElement,
     container: Element
 ): Observable<undefined>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -18,6 +18,6 @@ export function wrapRootEpic<T extends Action, S, D, O extends T>(
 ): Epic<T, S, D, O>;
 
 export function renderToString(
-    element: React.ReactElement<any>,
+    element: React.ReactElement,
     wrappedEpic: Epic<any, any>
 ): Observable<{ markup: string }>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -95,7 +95,7 @@ export interface QueryRendererProps<T extends RelayRuntimeTypes.OperationBase = 
     dataFrom?: "NETWORK_ONLY"|"STORE_THEN_NETWORK";
     environment: RelayRuntimeTypes.Environment;
     query?: RelayRuntimeTypes.GraphQLTaggedNode | null;
-    render(readyState: ReadyState<T["response"]>): React.ReactElement<any> | undefined | null;
+    render(readyState: ReadyState<T["response"]>): React.ReactElement | undefined | null;
     variables: T["variables"];
     rerunParamExperimental?: RelayRuntimeTypes.RerunParam;
 }

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -144,7 +144,7 @@ export class NavBar extends Component<CardSubViewProps, void> {
 }
 
 export interface NavigationComponentProps extends NavigationProps {
-    children?: Array<ReactElement>;
+    children?: ReactElement[];
 }
 
 export class Navigation extends Component<NavigationComponentProps> {
@@ -163,7 +163,7 @@ export class Navigation extends Component<NavigationComponentProps> {
 export function Tab(props: TabProps): ReactElement<{}>;
 
 export interface TabBarComponentProps extends TabBarProps {
-    children?: Array<ReactElement>;
+    children?: ReactElement[];
 }
 
 export class Tabs extends Component<

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -144,7 +144,7 @@ export class NavBar extends Component<CardSubViewProps, void> {
 }
 
 export interface NavigationComponentProps extends NavigationProps {
-    children?: Array<ReactElement<any>>;
+    children?: Array<ReactElement>;
 }
 
 export class Navigation extends Component<NavigationComponentProps> {
@@ -163,7 +163,7 @@ export class Navigation extends Component<NavigationComponentProps> {
 export function Tab(props: TabProps): ReactElement<{}>;
 
 export interface TabBarComponentProps extends TabBarProps {
-    children?: Array<ReactElement<any>>;
+    children?: Array<ReactElement>;
 }
 
 export class Tabs extends Component<
@@ -174,14 +174,14 @@ export class Tabs extends Component<
 > {
     props: TabBarComponentProps;
 
-    renderHeader: (sceneProps: TabSubViewProps) => ReactElement<any> | null;
+    renderHeader: (sceneProps: TabSubViewProps) => ReactElement | null;
 
-    renderFooter: (sceneProps: TabSubViewProps) => ReactElement<any> | null;
+    renderFooter: (sceneProps: TabSubViewProps) => ReactElement | null;
 
     renderTabBar: (
         sceneProps: TabSubViewProps,
         props: TabSubViewProps
-    ) => ReactElement<any> | null;
+    ) => ReactElement | null;
 
-    renderScene: (sceneProps: TabSubViewProps) => ReactElement<any> | null;
+    renderScene: (sceneProps: TabSubViewProps) => ReactElement | null;
 }

--- a/types/react-router/v2/lib/RouteUtils.d.ts
+++ b/types/react-router/v2/lib/RouteUtils.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Router from './Router';
 
-type E = React.ReactElement<any>;
+type E = React.ReactElement;
 export function isReactChildren(object: E | E[]): boolean;
 export function createRouteFromReactElement(element: E): Router.PlainRoute;
 export function createRoutesFromReactChildren(children: E | E[], parentRoute: Router.PlainRoute): Router.PlainRoute[];

--- a/types/react-router/v2/lib/Router.d.ts
+++ b/types/react-router/v2/lib/Router.d.ts
@@ -88,7 +88,7 @@ declare namespace Router {
         route?: PlainRoute;
         routeParams?: R;
         routes?: PlainRoute[];
-        children?: React.ReactElement<any>;
+        children?: React.ReactElement;
     }
 
     interface RouterOnContext extends History {

--- a/types/react-select/lib/components/Menu.d.ts
+++ b/types/react-select/lib/components/Menu.d.ts
@@ -47,7 +47,7 @@ export function getMenuPlacement(args: PlacementArgs): MenuState;
 
 export type MenuProps<OptionType> = CommonProps<OptionType> & {
   /** The children to be rendered. */
-  children: ReactElement<any>,
+  children: ReactElement,
   /** Callback to update the portal after possible flip. */
   getPortalPlacement: (state: MenuState) => void,
   /** Props to be passed to the menu wrapper. */

--- a/types/react-select/lib/components/indicators.d.ts
+++ b/types/react-select/lib/components/indicators.d.ts
@@ -16,7 +16,7 @@ export function DownChevron(props: any): any; // TODO svg type
 
 export type IndicatorProps<OptionType> = CommonProps<OptionType> & {
   /** The children to be rendered inside the indicator. */
-  children: ElementType<any>,
+  children: ElementType,
   /** Props that will be passed on to the children. */
   innerProps: any,
   /** The focused state of the select. */

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -36,7 +36,7 @@ export interface SortEnd {
 
 export type SortEndHandler = (sort: SortEnd, event: SortEvent) => void;
 
-export type ContainerGetter = (element: React.ReactElement<any>) => HTMLElement;
+export type ContainerGetter = (element: React.ReactElement) => HTMLElement;
 
 export interface Dimensions {
     width: number;

--- a/types/react-sticky-el/index.d.ts
+++ b/types/react-sticky-el/index.d.ts
@@ -41,7 +41,7 @@ declare namespace Sticky {
          *
          * Defaults to 'div'.
          */
-        wrapperCmp?: keyof React.ReactHTML | React.ReactElement<any>;
+        wrapperCmp?: keyof React.ReactHTML | React.ReactElement;
 
         /**
          * Anything that can be used by React.createElement. Used for holder

--- a/types/react-sticky/index.d.ts
+++ b/types/react-sticky/index.d.ts
@@ -22,7 +22,7 @@ export interface StickyChildArgs {
 }
 
 export interface StickyProps {
-    children: (args: StickyChildArgs) => React.ReactElement<any>;
+    children: (args: StickyChildArgs) => React.ReactElement;
     relative?: boolean;
     isActive?: boolean;
     className?: string;

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -14,7 +14,7 @@ export type AccessorFunction<D = any> = (row: D) => any;
 export type Accessor<D = any> = string | string[] | AccessorFunction<D>;
 export type Aggregator = (values: any, rows: any) => any;
 export type TableCellRenderer = ((cellInfo: CellInfo, column: any) => React.ReactNode) | React.ReactNode;
-export type FilterRender = (params: { column: Column, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement<any>;
+export type FilterRender = (params: { column: Column, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement;
 export type PivotRenderer = ((cellInfo: CellInfo) => React.ReactNode) | (() => any) | string | React.ReactNode;
 
 export type ComponentPropsGetter0 = (finalState: any, rowInfo: undefined, column: undefined, instance?: any) => object | undefined;
@@ -187,7 +187,7 @@ export interface TableProps<D = any, ResolvedData = D> extends
     /** Control callback for functional rendering */
     children: (
         state: FinalState<ResolvedData>,
-        makeTable: () => React.ReactElement<any>,
+        makeTable: () => React.ReactElement,
         instance: Instance<ResolvedData>
     ) => React.ReactNode;
 }

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -42,15 +42,15 @@ export interface ReactTestInstance {
 export interface ReactTestRenderer {
     toJSON(): null | ReactTestRendererJSON;
     toTree(): null | ReactTestRendererTree;
-    unmount(nextElement?: ReactElement<any>): void;
-    update(nextElement: ReactElement<any>): void;
+    unmount(nextElement?: ReactElement): void;
+    update(nextElement: ReactElement): void;
     getInstance(): null | ReactTestInstance;
     root: ReactTestInstance;
 }
 export interface TestRendererOptions {
-    createNodeMock(element: ReactElement<any>): any;
+    createNodeMock(element: ReactElement): any;
 }
-export function create(nextElement: ReactElement<any>, options?: TestRendererOptions): ReactTestRenderer;
+export function create(nextElement: ReactElement, options?: TestRendererOptions): ReactTestRenderer;
 
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.

--- a/types/react-test-renderer/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/react-test-renderer-tests.ts
@@ -5,7 +5,7 @@ import { createRenderer } from 'react-test-renderer/shallow';
 class TestComponent extends React.Component { }
 
 const renderer = create(React.createElement("div"), {
-    createNodeMock: (el: React.ReactElement<any>) => {
+    createNodeMock: (el: React.ReactElement) => {
         return {};
     }
 });

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -8,15 +8,15 @@ export interface ShallowRenderer {
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput<E extends ReactElement<any>>(): E;
+    getRenderOutput<E extends ReactElement>(): E;
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput(): ReactElement<any>;
+    getRenderOutput(): ReactElement;
     /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
-    render(element: ReactElement<any>, context?: any): void;
+    render(element: ReactElement, context?: any): void;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -8,8 +8,8 @@ import { ReactElement } from "react";
 
 export interface ReactTestInstance {
     toJSON(): ReactTestRendererJSON;
-    unmount(nextElement?: ReactElement<any>): void;
-    update(nextElement: ReactElement<any>): void;
+    unmount(nextElement?: ReactElement): void;
+    update(nextElement: ReactElement): void;
     getInstance(): any;
 }
 export interface ReactTestRendererJSON {
@@ -19,7 +19,7 @@ export interface ReactTestRendererJSON {
     $$typeof?: any;
 }
 export interface TestRendererOptions {
-    createNodeMock(element: ReactElement<any>): any;
+    createNodeMock(element: ReactElement): any;
 }
 // https://github.com/facebook/react/blob/master/src/renderers/testing/ReactTestMount.js#L155
-export function create(nextElement: ReactElement<any>, options?: TestRendererOptions): ReactTestInstance;
+export function create(nextElement: ReactElement, options?: TestRendererOptions): ReactTestInstance;

--- a/types/react-test-renderer/v15/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v15/react-test-renderer-tests.ts
@@ -3,7 +3,7 @@ import { create } from "react-test-renderer";
 import { createRenderer } from 'react-test-renderer/shallow';
 
 const tree = create(React.createElement("div"), {
-    createNodeMock: (el: React.ReactElement<any>) => {
+    createNodeMock: (el: React.ReactElement) => {
         return {};
     }
 }).toJSON();

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -4,15 +4,15 @@ export interface ShallowRenderer {
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput<E extends ReactElement<any>>(): E;
+    getRenderOutput<E extends ReactElement>(): E;
     /**
      * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
      */
-    getRenderOutput(): ReactElement<any>;
+    getRenderOutput(): ReactElement;
     /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
-    render(element: ReactElement<any>, context?: any): void;
+    render(element: ReactElement, context?: any): void;
     unmount(): void;
 }
 

--- a/types/react-toastify/index.d.ts
+++ b/types/react-toastify/index.d.ts
@@ -136,7 +136,7 @@ export interface ToastOptions extends ToastAndToastContainerOptions {
     /**
      * String or React Element, only available when calling update.
      */
-    render?: string | React.ReactElement<any>;
+    render?: string | React.ReactElement;
 }
 
 export interface Toast {

--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -13,7 +13,7 @@ declare namespace TransitionGroup {
     type TransitionGroupProps<T extends keyof JSX.IntrinsicElements = "div", V extends ReactType = any> =
         (IntrinsicTransitionGroupProps<T> & JSX.IntrinsicElements[T]) | (ComponentTransitionGroupProps<V>) & {
         children?: ReactElement<TransitionProps> | Array<ReactElement<TransitionProps>>;
-        childFactory?(child: ReactElement<any>): ReactElement<any>;
+        childFactory?(child: ReactElement): ReactElement;
         [prop: string]: any;
     };
 }

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -42,7 +42,7 @@ const Test: React.StatelessComponent = () => {
             component={Container}
             theme="test"
             className="animated-list"
-            childFactory={ (child: React.ReactElement<any>) => child }
+            childFactory={ (child: React.ReactElement) => child }
         >
             <Components.Transition
                 in

--- a/types/react-transition-group/v1/index.d.ts
+++ b/types/react-transition-group/v1/index.d.ts
@@ -8,7 +8,7 @@ import { HTMLAttributes, ReactElement, ReactType } from "react";
 
 export interface HTMLTransitionGroupProps<T> extends HTMLAttributes<T> {
     component?: ReactType;
-    childFactory?(child: ReactElement<any>): ReactElement<any>;
+    childFactory?(child: ReactElement): ReactElement;
 }
 
 import TransitionGroup = require("./TransitionGroup");

--- a/types/react-visibility-sensor/index.d.ts
+++ b/types/react-visibility-sensor/index.d.ts
@@ -39,7 +39,7 @@ interface Props {
   resizeThrottle?: number;
   containment?: HTMLElement;
   delayedCall?: boolean;
-  children?: React.ReactElement<any> | ChildFunction;
+  children?: React.ReactElement | ChildFunction;
 }
 
 declare const ReactVisibilitySensor: React.StatelessComponent<Props>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -59,7 +59,7 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
-        | ((props: P) => ReactElement<any> | null)
+        | ((props: P) => ReactElement | null)
         | (new (props: P) => Component<P, any>);
 
     type Key = string | number;
@@ -83,7 +83,7 @@ declare namespace React {
         ref?: LegacyRef<T>;
     }
 
-    interface ReactElement<P, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
+    interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
         key: Key | null;
@@ -128,7 +128,7 @@ declare namespace React {
         type: keyof ReactSVG;
     }
 
-    interface ReactPortal extends ReactElement<any> {
+    interface ReactPortal extends ReactElement {
         key: Key | null;
         children: ReactNode;
     }
@@ -172,7 +172,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactText = string | number;
-    type ReactChild = ReactElement<any> | ReactText;
+    type ReactChild = ReactElement | ReactText;
 
     interface ReactNodeArray extends Array<ReactNode> {}
     type ReactFragment = {} | ReactNodeArray;
@@ -297,7 +297,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement<any>|null);
+        (props: P): (ReactElement|null);
         readonly $$typeof: symbol;
     }
 
@@ -468,7 +468,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, context?: any): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -476,7 +476,7 @@ declare namespace React {
     }
 
     interface RefForwardingComponent<T, P = {}> {
-        (props: P & { children?: ReactNode }, ref: Ref<T>): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, ref: Ref<T>): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -494,7 +494,7 @@ const mappedChildrenArrayWithKnownChildren: number[] =
     React.Children.map(childrenArray, (child) => child.props.p);
 React.Children.forEach(children, (child) => { });
 const nChildren: number = React.Children.count(children);
-let onlyChild: React.ReactElement<any> = React.Children.only(DOM.div()); // ok
+let onlyChild: React.ReactElement = React.Children.only(DOM.div()); // ok
 onlyChild = React.Children.only([null, [[["Hallo"], true]], false]); // error
 const childrenToArray: React.ReactChild[] = React.Children.toArray(children);
 

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -180,7 +180,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactText = string | number;
-    type ReactChild = ReactElement<any> | ReactText;
+    type ReactChild = ReactElement | ReactText;
 
     interface ReactNodeArray extends Array<ReactNode> {}
     type ReactFragment = {} | ReactNodeArray;
@@ -343,7 +343,7 @@ declare namespace React {
 
     type SFC<P = {}> = StatelessComponent<P>;
     interface StatelessComponent<P = {}> {
-        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, context?: any): ReactElement | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -404,7 +404,7 @@ declare namespace React {
     }
 
     interface ComponentSpec<P, S> extends Mixin<P, S> {
-        render(): ReactElement<any> | null;
+        render(): ReactElement | null;
 
         [propertyName: string]: any;
     }
@@ -3581,11 +3581,11 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     interface ReactChildren {
-        map<T, C extends ReactElement<any>>(children: C[], fn: (child: C, index: number) => T): T[];
+        map<T, C extends ReactElement>(children: C[], fn: (child: C, index: number) => T): T[];
         map<T>(children: ReactNode, fn: (child: ReactChild, index: number) => T): T[];
         forEach(children: ReactNode, fn: (child: ReactChild, index: number) => any): void;
         count(children: ReactNode): number;
-        only(children: ReactNode): ReactElement<any>;
+        only(children: ReactNode): ReactElement;
         toArray(children: ReactNode): ReactChild[];
     }
 
@@ -3621,7 +3621,7 @@ declare namespace React {
 declare global {
     namespace JSX {
         // tslint:disable-next-line:no-empty-interface
-        interface Element extends React.ReactElement<any> { }
+        interface Element extends React.ReactElement { }
         interface ElementClass extends React.Component<any> {
             render(): JSX.Element | null | false;
         }

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -89,7 +89,7 @@ declare namespace React {
         ref?: Ref<T>;
     }
 
-    interface ReactElement<P> {
+    interface ReactElement<P = any> {
         type: string | ComponentClass<P> | SFC<P>;
         props: P;
         key: Key | null;

--- a/types/react/v15/test/index.ts
+++ b/types/react/v15/test/index.ts
@@ -441,7 +441,7 @@ const PropTypesSpecification: React.ComponentSpec<any, any> = {
             return null;
         }
     },
-    render: (): React.ReactElement<any> | null => {
+    render: (): React.ReactElement | null => {
         return null;
     }
 };
@@ -498,7 +498,7 @@ const mappedChildrenArrayWithKnownChildren: number[] =
     React.Children.map(childrenArray, (child) => child.props.p);
 React.Children.forEach(children, (child) => { });
 const nChildren: number = React.Children.count(children);
-let onlyChild: React.ReactElement<any> = React.Children.only(React.DOM.div()); // ok
+let onlyChild: React.ReactElement = React.Children.only(React.DOM.div()); // ok
 onlyChild = React.Children.only([null, [[["Hallo"], true]], false]); // error
 const childrenToArray: React.ReactChild[] = React.Children.toArray(children);
 

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -171,9 +171,9 @@ export interface AreaProps extends EventAttributes, Partial<PresentationAttribut
     stackId?: string | number;
     legendType?: LegendType;
     connectNulls?: boolean;
-    activeDot?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
-    dot?: boolean | object | React.ReactElement<any> | ContentRenderer<DotProps>;
-    label?: boolean | object | ContentRenderer<any> | React.ReactElement<any>;
+    activeDot?: boolean | object | React.ReactElement | ContentRenderer<any>;
+    dot?: boolean | object | React.ReactElement | ContentRenderer<DotProps>;
+    label?: boolean | object | ContentRenderer<any> | React.ReactElement;
     hide?: boolean;
     layout?: LayoutType;
     baseLine?: number | any[];
@@ -214,9 +214,9 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     minPointSize?: number;
     maxBarSize?: number;
     hide?: boolean;
-    shape?: React.ReactElement<any> | ContentRenderer<RectangleProps>;
+    shape?: React.ReactElement | ContentRenderer<RectangleProps>;
     data?: BarData[];
-    background?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
+    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
     // see label section at http://recharts.org/#/en-US/api/Bar
     label?: boolean | Label | React.SFC<LabelProps> | React.ReactElement<LabelProps> | ContentRenderer<any>;
 }
@@ -258,7 +258,7 @@ export interface CartesianAxisProps extends EventAttributes, Partial<Presentatio
     height?: number;
     orientation?: 'top' | 'bottom' | 'left' | 'right';
     viewBox?: ViewBox;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     mirror?: boolean;
@@ -284,8 +284,8 @@ export interface CartesianGridProps extends Partial<PresentationAttributes> {
     y?: number;
     width?: number;
     height?: number;
-    horizontal?: object | React.ReactElement<any> | ContentRenderer<LineProps & CartesianGridProps> | boolean;
-    vertical?: object | React.ReactElement<any> | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    horizontal?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    vertical?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
     horizontalPoints?: number[];
     verticalPoints?: number[];
     horizontalCoordinatesGenerator?: CoordinatesGenerator;
@@ -375,7 +375,7 @@ export interface LegendPayload {
 export type BBoxUpdateCallback = (box: { width: number; height: number; }) => void;
 
 export interface LegendProps {
-    content?: React.ReactElement<any> | ContentRenderer<LegendProps>;
+    content?: React.ReactElement | ContentRenderer<LegendProps>;
     wrapperStyle?: object;
     chartWidth?: number;
     chartHeight?: number;
@@ -410,15 +410,15 @@ export interface LineProps extends EventAttributes, Partial<PresentationAttribut
     layout?: LayoutType;
     connectNulls?: boolean;
     hide?: boolean;
-    activeDot?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement<any> | ContentRenderer<DotProps> | boolean;
+    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
     top?: number;
     left?: number;
     width?: number;
     height?: number;
     data?: object[];
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    label?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
+    label?: boolean | object | React.ReactElement | ContentRenderer<any>;
     points?: Point[];
 }
 
@@ -449,11 +449,11 @@ export interface PieProps extends EventAttributes, Partial<PresentationAttribute
     maxRadius?: number;
     sectors?: object[];
     hide?: boolean;
-    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement<any> | boolean;
+    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement | boolean;
     label?: {
         offsetRadius: number;
-    } | React.ReactElement<any> | ContentRenderer<PieLabelRenderProps> | boolean;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement<any>;
+    } | React.ReactElement | ContentRenderer<PieLabelRenderProps> | boolean;
+    activeShape?: object | ContentRenderer<any> | React.ReactElement;
     activeIndex?: number | number[];
     blendStroke?: boolean;
 }
@@ -500,7 +500,7 @@ export interface PolarAngleAxisProps extends EventAttributes, Partial<Presentati
     axisLine?: boolean | object;
     axisLineType?: 'polygon' | 'circle';
     tickLine?: boolean | object;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
     ticks?: PolarAngleAxisTick[];
     stroke?: string;
     orientation?: 'inner' | 'outer';
@@ -539,7 +539,7 @@ export interface PolarRadiusAxisProps extends EventAttributes, Partial<Presentat
     ticks?: PolarRadiusAxisTick[];
     orientation?: "left" | "right" | "middle";
     axisLine?: boolean | object;
-    tick?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
+    tick?: boolean | object | React.ReactElement | ContentRenderer<any>;
     stroke?: string;
     tickFormatter?: TickFormatterFunction;
     domain?: [PolarRadiusAxisDomain, PolarRadiusAxisDomain];
@@ -576,10 +576,10 @@ export interface RadarProps extends EventAttributes, Partial<PresentationAttribu
     className?: string;
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     points?: RadarPoint[];
-    shape?: React.ReactElement<any> | ContentRenderer<RadarProps>;
-    activeDot?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement<any> | ContentRenderer<DotProps> | boolean;
-    label?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
+    shape?: React.ReactElement | ContentRenderer<RadarProps>;
+    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
+    label?: object | React.ReactElement | ContentRenderer<any> | boolean;
     legendType?: LegendType;
     hide?: boolean;
 }
@@ -611,15 +611,15 @@ export interface RadialBarProps extends EventAttributes, Partial<PresentationAtt
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     angleAxisId?: string | number;
     radiusAxisId?: string | number;
-    shape?: ContentRenderer<any> | React.ReactElement<any>;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement<any>;
+    shape?: ContentRenderer<any> | React.ReactElement;
+    activeShape?: object | ContentRenderer<any> | React.ReactElement;
     cornerRadius?: number | string;
     minPointSize?: number;
     maxBarSize?: number;
     data?: RadialBarData[];
     legendType?: LegendType;
-    label?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
-    background?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
+    label?: boolean | React.ReactElement | ContentRenderer<any> | object;
+    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
     hide?: boolean;
 }
 
@@ -661,7 +661,7 @@ export interface ReferenceAreaProps extends Partial<PresentationAttributes> {
     y2?: number | string;
     xAxisId?: string | number;
     yAxisId?: string | number;
-    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactElement<any>;
+    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactElement;
 }
 
 export class ReferenceArea extends React.Component<ReferenceAreaProps> { }
@@ -687,7 +687,7 @@ export interface ReferenceDotProps extends EventAttributes, Partial<Presentation
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { cx: number; cy: number; }
-    > | React.ReactElement<any>;
+    > | React.ReactElement;
 }
 
 export class ReferenceDot extends React.Component<ReferenceDotProps> { }
@@ -702,14 +702,14 @@ export interface ReferenceLineProps extends Partial<PresentationAttributes<numbe
     ifOverflow?: IfOverflowType;
     x?: number | string;
     y?: number | string;
-    label?: string | number | ContentRenderer<any> | React.ReactElement<any>;
+    label?: string | number | ContentRenderer<any> | React.ReactElement;
     xAxisId?: string | number;
     yAxisId?: string | number;
     shape?: ContentRenderer<
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { x1: number; y1: number; x2: number; y2: number; }
-    > | React.ReactElement<any>;
+    > | React.ReactElement;
 }
 
 export class ReferenceLine extends React.Component<ReferenceLineProps> { }
@@ -745,13 +745,13 @@ export interface ScatterProps extends EventAttributes, Partial<PresentationAttri
     xAxisId?: string | number;
     yAxisId?: string | number;
     zAxisId?: string | number;
-    line?: boolean | object | RechartsFunction | React.ReactElement<any>;
+    line?: boolean | object | RechartsFunction | React.ReactElement;
     lineType?: 'joint' | 'fitting';
     lineJointType?: LineType;
     legendType?: LegendType;
     activeIndex?: number;
-    activeShape?: object | RechartsFunction | React.ReactElement<any>;
-    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement<any> | ContentRenderer<any>;
+    activeShape?: object | RechartsFunction | React.ReactElement;
+    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement | ContentRenderer<any>;
     points?: ScatterPoint[];
     hide?: boolean;
     data?: object[];
@@ -823,7 +823,7 @@ export interface TooltipPayload {
 }
 
 export interface TooltipProps extends Animatable {
-    content?: React.ReactElement<any> | React.StatelessComponent<any> | ContentRenderer<TooltipProps>;
+    content?: React.ReactElement | React.StatelessComponent<any> | ContentRenderer<TooltipProps>;
     viewBox?: ViewBox;
     active?: boolean;
     separator?: string;
@@ -832,7 +832,7 @@ export interface TooltipProps extends Animatable {
     itemStyle?: object;
     labelStyle?: object;
     wrapperStyle?: object;
-    cursor?: boolean | object | React.ReactElement<any> | React.StatelessComponent<any>;
+    cursor?: boolean | object | React.ReactElement | React.StatelessComponent<any>;
     coordinate?: Coordinate;
     position?: Coordinate;
     label?: string | number;
@@ -851,7 +851,7 @@ export interface TreemapProps extends EventAttributes, Animatable {
     data?: any[];
     style?: object;
     aspectRatio?: number;
-    content?: React.ReactElement<any> | ContentRenderer<any>;
+    content?: React.ReactElement | ContentRenderer<any>;
     fill?: string;
     stroke?: string;
     className?: string;
@@ -873,7 +873,7 @@ export interface LabelProps extends Partial<PresentationAttributes> {
     position?: PositionType;
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
-    content?: React.ReactElement<any> | ContentRenderer<any>;
+    content?: React.ReactElement | ContentRenderer<any>;
 }
 
 export class LabelList extends React.Component<LabelListProps> { }
@@ -883,7 +883,7 @@ export interface LabelListProps {
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
     clockWise?: boolean;
-    content?: React.ReactElement<any> | ContentRenderer<LabelProps>;
+    content?: React.ReactElement | ContentRenderer<LabelProps>;
     data?: number;
     dataKey: string | number | RechartsFunction;
     formatter?: LabelFormatter;
@@ -934,7 +934,7 @@ export interface XAxisProps extends EventAttributes {
     padding?: XPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;
@@ -988,7 +988,7 @@ export interface YAxisProps extends EventAttributes {
     padding?: YPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -269,7 +269,7 @@ declare module 'recompose' {
     // toRenderProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#torenderprops
     export function toRenderProps<TInner, TOutter>(
         hoc: InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>
-    ): StatelessComponent<TOutter & { children: (props: TInner) => React.ReactElement<any> }>;
+    ): StatelessComponent<TOutter & { children: (props: TInner) => React.ReactElement }>;
 
     // fromRenderProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#fromrenderprops
     export function fromRenderProps<TInner, TOutter, TRenderProps = {}>(
@@ -335,10 +335,10 @@ declare module 'recompose' {
         type: Component<any> | string,
         props?: Object,
         children?: React.ReactNode
-    ): React.ReactElement<any>;
+    ): React.ReactElement;
 
     // createEagerFactory: https://github.com/acdlite/recompose/blob/master/docs/API.md#createEagerFactory
-    type componentFactory = (props?: Object, children?: React.ReactNode) => React.ReactElement<any>;
+    type componentFactory = (props?: Object, children?: React.ReactNode) => React.ReactElement;
     export function createEagerFactory(
         type: Component<any> | string
     ): componentFactory;

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -533,7 +533,7 @@ function testFromRenderProps() {
     }
 
     interface RenderComponentProps {
-        render: (renderProps: RenderProps) => React.ReactElement<any>;
+        render: (renderProps: RenderProps) => React.ReactElement;
     }
 
     class RenderPropComponent extends React.Component<RenderComponentProps> {

--- a/types/redux-devtools/index.d.ts
+++ b/types/redux-devtools/index.d.ts
@@ -12,7 +12,7 @@ export interface IDevTools {
     instrument(): GenericStoreEnhancer
 }
 
-export declare function createDevTools(el: React.ReactElement<any>): IDevTools;
+export declare function createDevTools(el: React.ReactElement): IDevTools;
 export declare function persistState(debugSessionKey: string): GenericStoreEnhancer;
 
 declare const factory: { instrument(): (opts: any) => any };

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -28,7 +28,7 @@ export interface ErrorOther<T = string> {
 }
 
 export type FormErrors<FormData = {}, T = string> = {
-    [P in keyof FormData]?: ReactElement<any> | T;
+    [P in keyof FormData]?: ReactElement | T;
 } & ErrorOther<T>;
 
 export interface WarningOther<T = void> {
@@ -36,7 +36,7 @@ export interface WarningOther<T = void> {
 }
 
 export type FormWarnings<FormData = {}, T = void> = {
-    [P in keyof FormData]?: ReactElement<any> | string | WarningOther<T>;
+    [P in keyof FormData]?: ReactElement | string | WarningOther<T>;
 };
 
 export interface RegisteredFieldState {

--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -30,11 +30,11 @@ export interface DataShape {
 }
 
 export type FormErrors<FormData extends DataShape> = {
-    [P in keyof FormData]?: ReactElement<any> | string | { _error?: string };
+    [P in keyof FormData]?: ReactElement | string | { _error?: string };
 };
 
 export type FormWarnings<FormData extends DataShape> = {
-    [P in keyof FormData]?: ReactElement<any> | string | { _warning?: string };
+    [P in keyof FormData]?: ReactElement | string | { _warning?: string };
 };
 
 export type FormMeta<FormData extends DataShape> = {

--- a/types/rheostat/rheostat-tests.tsx
+++ b/types/rheostat/rheostat-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Rheostat, { Orientation, Algorithm, PublicState } from 'rheostat';
 
-type Element = React.ReactElement<any>;
+type Element = React.ReactElement;
 
 function Basic(props: {}): Element {
   return <Rheostat />;

--- a/types/storybook-addon-jsx/index.d.ts
+++ b/types/storybook-addon-jsx/index.d.ts
@@ -7,7 +7,7 @@
 import '@storybook/react';
 import { ReactNode, ReactElement } from 'react';
 
-export type displayNameFunc = (element: ReactElement<any>) => string;
+export type displayNameFunc = (element: ReactElement) => string;
 
 declare module '@storybook/react' {
     interface Options {

--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -70,7 +70,7 @@ export interface InitOptions<Rendered = any> {
     storyNameRegex?: RegExp;
     framework?: string;
     test?: Test;
-    renderer?: (node: React.ReactElement<any>) => Rendered;
+    renderer?: (node: React.ReactElement) => Rendered;
     serializer?: (rendered: Rendered) => any;
     integrityOptions?: {};
 }

--- a/types/theming/index.d.ts
+++ b/types/theming/index.d.ts
@@ -19,7 +19,7 @@ export function withTheme<P>(
 
 export interface ThemeProviderProps {
   theme: Theme;
-  children?: React.ReactElement<any>;
+  children?: React.ReactElement;
 }
 /**
  * Provide a theme to an entire react component listening on the default channel

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -54,7 +54,7 @@ declare module "victory" {
      * The child of should be a function that takes an object of tweened values and returns a component to render.
      * @param style
      */
-    children?: (style: AnimationStyle) => React.ReactElement<any>;
+    children?: (style: AnimationStyle) => React.ReactElement;
     /**
      * The number of milliseconds the animation should take to complete.
      * @default 1000
@@ -280,7 +280,7 @@ declare module "victory" {
      * If a cursorComponent is not supplied, a new Line component will be rendered.
      * @default cursorComponent={<Line/>}
      */
-    cursorComponent?: React.ReactElement<any>;
+    cursorComponent?: React.ReactElement;
     /**
      * When the cursorDimension prop is set, the cursor will be a line to inspect the given dimension (either "x" or "y").
      * When this prop is not specified, the cursor will be a 2-dimensional crosshair.
@@ -303,7 +303,7 @@ declare module "victory" {
      * active, text. If cursorLabelComponent is omitted, a new VictoryLabel will be created with the props described above.
      * @default cursorLabelComponent={<VictoryLabel/>}
      */
-    cursorLabelComponent?: React.ReactElement<any>;
+    cursorLabelComponent?: React.ReactElement;
     /**
      * The cursorLabelOffset prop determines the pixel offset of the cursor label
      * from the cursor point. This prop should be an Object with x and y properties, or a
@@ -355,7 +355,7 @@ declare module "victory" {
      * width, height, and style. When this prop is not specified, a <rect/> will be rendered.
      * @default brushComponent={<rect/>}
      */
-    brushComponent?: React.ReactElement<any>;
+    brushComponent?: React.ReactElement;
     /**
      * When the brushDimension prop is set, brushing will only be specific to the to
      * the given dimension (either "x" or "y"), and the entire domain of the other
@@ -398,7 +398,7 @@ declare module "victory" {
      * specified, a <rect/> will be rendered.
      * @default handleComponent={<rect/>}
      */
-    handleComponent?: React.ReactElement<any>;
+    handleComponent?: React.ReactElement;
     /**
      * The handleStyle adds custom styles to the handleComponents. This prop should be given as an object of SVG style attributes.
      *
@@ -440,7 +440,7 @@ declare module "victory" {
      * props on VictoryClipContainer, such as clipPadding.
      * @example clipContainerComponent={<VictoryClipContainer clipPadding={{top: 10, right: 10}}}/>}
      */
-    clipContainerComponent?: React.ReactElement<any>;
+    clipContainerComponent?: React.ReactElement;
     /**
      * When the zoomDimension prop is set, panning and zooming will be restricted to
      * the given dimension (either x or y), and the domain of the other dimension will
@@ -605,12 +605,12 @@ declare module "victory" {
      * Examples: flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
      * @default <Flyout/>
      */
-    flyoutComponent?: React.ReactElement<any>;
+    flyoutComponent?: React.ReactElement;
     /**
      * The groupComponent prop takes a component instance which will be used to create group elements for use within container elements. This prop defaults to a <g> tag.
      * @default groupComponent={<g/>}
      */
-    groupComponent?: React.ReactElement<any>;
+    groupComponent?: React.ReactElement;
     /**
      * The height prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function of datum.
      * If this prop is not set, height will be determined based on an approximate text size calculated from the text and style props provided to VictoryTooltip.
@@ -634,7 +634,7 @@ declare module "victory" {
      * Examples: labelComponent={<VictoryLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
      * @default <VictoryLabel/>
      */
-    labelComponent?: React.ReactElement<any>;
+    labelComponent?: React.ReactElement;
     /**
      * The orientation prop determines which side of the (x, y) coordinate the tooltip should be rendered on.
      * This prop can be given as “top”, “bottom”, “left”, “right”, or as a function of datum that returns one of these values.
@@ -902,7 +902,7 @@ declare module "victory" {
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how popular each dog breed is by percentage in Seattle." />
      * @default <VictoryContainer/>
      */
-    containerComponent?: React.ReactElement<any>;
+    containerComponent?: React.ReactElement;
     /**
      * The theme prop takes a style object with nested data, labels, and parent objects.
      * You can create this object yourself, or you can use a theme provided by Victory.
@@ -919,7 +919,7 @@ declare module "victory" {
      * to a <g> tag on web, and a react-native-svg <G> tag on mobile
      * @default <g/>
      */
-    groupComponent?: React.ReactElement<any>;
+    groupComponent?: React.ReactElement;
   }
 
   /**
@@ -953,7 +953,7 @@ declare module "victory" {
      * not provided, VictoryArea will use its default Area component.
      * @default <Area/>
      */
-    dataComponent?: React.ReactElement<any>;
+    dataComponent?: React.ReactElement;
     /**
      * The domain prop describes the range of values your chart will cover. This prop can be
      * given as a array of the minimum and maximum expected values for your bar chart,
@@ -1003,7 +1003,7 @@ declare module "victory" {
      * data point, they should be created by composing VictoryArea with VictoryScatter
      * @default <VictoryLabel/>
      */
-    labelComponent?: React.ReactElement<any>;
+    labelComponent?: React.ReactElement;
   }
 
   interface VictoryMultiLabeableProps extends VictoryLabableProps {
@@ -1108,7 +1108,7 @@ declare module "victory" {
      * is not supplied, VictoryAxis will render its default AxisLine component.
      * @default <AxisLine/>
      */
-    axisComponent?: React.ReactElement<any>;
+    axisComponent?: React.ReactElement;
     /**
      * The axisLabelComponent prop takes in an entire component which will be used
      * to create the axis label. The new element created from the passed axisLabelComponent
@@ -1119,7 +1119,7 @@ declare module "victory" {
      * VictoryLabel will be created with props described above
      * @default <VictoryLabel/>
      */
-    axisLabelComponent?: React.ReactElement<any>;
+    axisLabelComponent?: React.ReactElement;
     /**
      * This prop specifies whether a given axis is intended to cross another axis.
      */
@@ -1193,7 +1193,7 @@ declare module "victory" {
      * is not supplied, VictoryAxis will render its default GridLine component.
      * @default <GridLine/>
      */
-    gridComponent?: React.ReactElement<any>;
+    gridComponent?: React.ReactElement;
     /**
      * If true, this value will flip the domain of a given axis.
      */
@@ -1270,7 +1270,7 @@ declare module "victory" {
      * is not supplied, VictoryAxis will render its default Tick component.
      * @default <Tick/>
      */
-    tickComponent?: React.ReactElement<any>;
+    tickComponent?: React.ReactElement;
     /**
      * The tickCount prop specifies approximately how many ticks should be drawn on the axis if
      * tickValues are not explicitly provided. This value is calculated by d3 scale and
@@ -1290,7 +1290,7 @@ declare module "victory" {
      * VictoryLabel will be created with props described above
      * @default <VictoryLabel/>
      */
-    tickLabelComponent?: React.ReactElement<any>;
+    tickLabelComponent?: React.ReactElement;
     /**
      * The tickFormat prop specifies how tick values should be expressed visually.
      * tickFormat can be given as a function to be applied to every tickValue, or as
@@ -1876,7 +1876,7 @@ declare module "victory" {
        * VictoryPortal to force components to render above other children.
        * @default <VictoryContainer/>
        */
-      containerComponent?: React.ReactElement<any>;
+      containerComponent?: React.ReactElement;
       /**
        * Specify data via the data prop. VictoryLegend expects data as an
        * array of objects with name (required), symbol, and labels properties.
@@ -1907,14 +1907,14 @@ declare module "victory" {
        * If a dataComponent is not provided, VictoryLegend will use its
        * default Point component.
        */
-      dataComponent?: React.ReactElement<any>;
+      dataComponent?: React.ReactElement;
       /**
        * The groupComponent prop takes an entire component which will be used to
        * create group elements for use within container elements. This prop defaults
        * to a <g> tag on web, and a react-native-svg <G> tag on mobile
        * @default <g/>
        */
-      groupComponent?: React.ReactElement<any>;
+      groupComponent?: React.ReactElement;
       /**
        * The gutter prop defines the number of pixels between legend rows or
        * columns, depending on orientation. When orientation is horizontal,
@@ -1931,7 +1931,7 @@ declare module "victory" {
        * custom component itself. If labelComponent is omitted, a new
        * VictoryLabel will be created with the props described above.
        */
-      labelComponent?: React.ReactElement<any>;
+      labelComponent?: React.ReactElement;
       /**
        * The orientation prop takes a string that defines whether legend data
        * are displayed in a row or column. When orientation is "horizontal",
@@ -2211,7 +2211,7 @@ declare module "victory" {
        * the VictoryPie; and the d3 compatible slice object.
        * If a dataComponent is not provided, VictoryPie's Slice component will be used.
        */
-      dataComponent?: React.ReactElement<any>;
+      dataComponent?: React.ReactElement;
       /**
        * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
        * If this prop is not set, the label radius will default to the radius of the pie + label padding.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Most of the time, we (I) use ReactElement<any>. Passing props to this type is not really useful, so I added a default value.