### PR TITLE
mui-datatables: Update for lib addition of optional label to column options

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -44,6 +44,7 @@ interface MUIDataTableCustomHeadRenderer extends MUIDataTableColumn {
 
 interface MUIDataTableColumn {
     name: string;
+    label?: string;
     options?: MUIDataTableColumnOptions;
 }
 

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -11,6 +11,7 @@ const dataSimple: string[][] = [
 const columnWithOptions: MUIDataTableColumnDef[] = [
     {
         name: 'Name',
+        label: 'New Name',
         options: {
             display: 'true',
             filter: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/pull/321
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

I'm honestly not too sure how to properly handle the header version numbering. I kept it at 2.0 assuming types-publisher will bump it properly but even so then the types would be 2.0.1 while the lib is 2.0.0-beta-54 while the previous was 2.0.0-beta-53. 