### PR TITLE
[elliptic] pers option in genKeyPair method is optional

### DIFF
--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -187,7 +187,7 @@ export class ec {
 
 export namespace ec {
     interface GenKeyPairOptions {
-        pers: any;
+        pers?: any;
         entropy: any;
         persEnc?: string;
         entropyEnc?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

------------------

`pers` option is [passed to `HmacDRBG` constructor](https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/index.js#L60) from `hmac-drbg` package where it's optional [according to docs](https://github.com/indutny/hmac-drbg#usage)