### PR TITLE
[UTIF] updated from 2.0.1 to 3.0.0

### DIFF
--- a/types/utif/index.d.ts
+++ b/types/utif/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for utif 2.0
+// Type definitions for utif 3.0
 // Project: https://github.com/photopea/UTIF.js
 // Definitions by: Jan Pesa <https://github.com/smajl>
 //                 Naveen Kumar Sangi <https://github.com/nkprince007>
@@ -17,10 +17,10 @@ export type TiffTag = string[] | number[];
  */
 // tslint:disable-next-line:interface-name
 export interface IFD {
-    [property: string]: TiffTag | number | Uint8Array;
-    data: Uint8Array;
-    width: number;
-    height: number;
+	[property: string]: TiffTag | number | Uint8Array;
+	data: Uint8Array;
+	width: number;
+	height: number;
 }
 
 /**
@@ -31,13 +31,13 @@ export interface IFD {
 export function decode(buffer: Buffer | ArrayBuffer): IFD[];
 
 /**
- * Loops through each IFD. If there is an image inside it, it is decoded and three new properties are added to the IFD: width, height and data.
+ * If there is an image inside the IFD, is decoded and three new properties are added to the IFD: width, height and data.
  * Note: TIFF files may have various number of channels and various color depth. The interpretation of data depends on many tags (see the TIFF 6 specification).
  *
  * @param buffer A Buffer or ArrayBuffer containing TIFF or EXIF data
- * @param ifds An array of image file directories parsed via UTIF.decode()
+ * @param ifd the element of the output of UTIF.decode()
  */
-export function decodeImages(buffer: Buffer | ArrayBuffer, ifds: IFD[]): void;
+export function decodeImage(buffer: Buffer | ArrayBuffer, ifd: IFD): void;
 
 /**
  * Returns Uint8Array of the image in RGBA format, 8 bits per channel (ready to use in context2d.putImageData() etc.)

--- a/types/utif/index.d.ts
+++ b/types/utif/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/photopea/UTIF.js
 // Definitions by: Jan Pesa <https://github.com/smajl>
 //                 Naveen Kumar Sangi <https://github.com/nkprince007>
+//                 Massimiliano Caniparoli <https://github.com/massic80>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import 'node';
@@ -31,11 +32,11 @@ export interface IFD {
 export function decode(buffer: Buffer | ArrayBuffer): IFD[];
 
 /**
- * If there is an image inside the IFD, is decoded and three new properties are added to the IFD: width, height and data.
+ * If there is an image inside the IFD, it is decoded and three new properties are added to the IFD: width, height and data.
  * Note: TIFF files may have various number of channels and various color depth. The interpretation of data depends on many tags (see the TIFF 6 specification).
  *
  * @param buffer A Buffer or ArrayBuffer containing TIFF or EXIF data
- * @param ifd the element of the output of UTIF.decode()
+ * @param ifd The element of the output of UTIF.decode()
  */
 export function decodeImage(buffer: Buffer | ArrayBuffer, ifd: IFD): void;
 

--- a/types/utif/utif-tests.ts
+++ b/types/utif/utif-tests.ts
@@ -10,6 +10,6 @@ UTIF.encodeImage(rgba, 8, 8);
 // $ExpectType ArrayBuffer
 UTIF.encode(IFDs);
 // $ExpectType void
-UTIF.decodeImages(new ArrayBuffer(64), IFDs);
+UTIF.decodeImage(new ArrayBuffer(64), IFDs[0]);
 // $ExpectType void
 UTIF.replaceIMG();


### PR DESCRIPTION
The new version has decodeImage instead of decodeImages.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/photopea/UTIF.js/blob/master/UTIF.js#L101
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
