### PR TITLE
[debug] fix disable() return type

### DIFF
--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -16,7 +16,7 @@ declare namespace debug {
     interface Debug {
         (namespace: string): Debugger;
         coerce: (val: any) => any;
-        disable: () => void;
+        disable: () => string;
         enable: (namespaces: string) => void;
         enabled: (namespaces: string) => boolean;
 


### PR DESCRIPTION
https://github.com/visionmedia/debug/blob/master/src/common.js#L189-L202
debug.disable() method is return string data.

https://github.com/visionmedia/debug#set-dynamically
> Will disable all namespaces. The functions returns the namespaces currently enabled (and skipped).