### PR TITLE
[w3c-web-usb] Include addEventListener overload to fix strict TypeScript

### DIFF
--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for W3C Web USB API 1.0
 // Project: https://wicg.github.io/webusb/
 // Definitions by: Lars Knudsen <https://github.com/larsgk>
+//                 Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 type USBDirection = "in" | "out";
 type USBEndpointType = "bulk" | "interrupt" | "isochronous";
@@ -111,8 +112,8 @@ declare class USB extends EventTarget {
     ondisconnect(): (this: this, ev: Event) => any;
     getDevices(): Promise<USBDevice[]>;
     requestDevice(options?: USBDeviceRequestOptions): Promise<USBDevice>;
-
     addEventListener(type: "connect" | "disconnect", listener: (this: this, ev: USBConnectionEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
 }
 
 declare class USBDevice {

--- a/types/w3c-web-usb/tsconfig.json
+++ b/types/w3c-web-usb/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Compiling TypeScript in strict mode with this type throws the following error:

> error TS2416: Property 'addEventListener' in type 'USB' is not assignable to the same property in base type 'EventTarget'.

This is due to a missing overload as outlined here:
https://github.com/Microsoft/TypeScript/issues/9604#issuecomment-231659171

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
