### PR TITLE
[weixin-app] support union types for properties/data/methods in behaviors

### DIFF
--- a/types/weixin-app/index.d.ts
+++ b/types/weixin-app/index.d.ts
@@ -3745,19 +3745,19 @@ declare namespace wx {
 
   type UnboxBehaviorData<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_DATA'] : {};
   type UnboxBehaviorProps<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_PROPS'] : {};
-	type UnboxBehaviorMethod<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_METHODS'] : {};
+	type UnboxBehaviorMethods<T> = T extends Behavior<{}, {}, {}> ? T['__DO_NOT_USE_INTERNAL_FIELD_METHODS'] : {};
 
   type UnboxBehaviorsMethods<
     Behaviors extends Array<Behavior<{}, {}, {}> | string>
-	> = UnionToIntersection<UnboxBehaviorMethod<ArrayType<Behaviors>>>;
+	> = UnboxBehaviorMethods<UnionToIntersection<ArrayType<Behaviors>>>;
 
   type UnboxBehaviorsData<
     Behaviors extends Array<Behavior<{}, {}, {}> | string>
-	> = UnionToIntersection<UnboxBehaviorData<ArrayType<Behaviors>>>;
+	> = UnboxBehaviorData<UnionToIntersection<ArrayType<Behaviors>>>;
 
   type UnboxBehaviorsProps<
     Behaviors extends Array<Behavior<{}, {}, {}> | string>
-	> = UnionToIntersection<UnboxBehaviorProps<ArrayType<Behaviors>>>;
+	> = UnboxBehaviorProps<UnionToIntersection<ArrayType<Behaviors>>>;
 
 	// CombinedInstance models the `this`, i.e. instance type for (user defined) component
 	type CombinedInstance<

--- a/types/weixin-app/weixin-app-tests.ts
+++ b/types/weixin-app/weixin-app-tests.ts
@@ -25,8 +25,46 @@ const parentBehavior = Behavior({
 	}
 });
 
+function createBehaviorWithUnionTypes(n: number) {
+	const properties = n % 2 < 1 ? {
+		unionPropA: {
+			type: String,
+		},
+	} : {
+		unionPropB: {
+			type: Number,
+		},
+	};
+
+	const data = n % 4 < 2 ? {
+		unionDataA: 'a',
+	} : {
+		unionDataB: 1,
+	};
+
+	const methods = n % 8 < 4 ? {
+		unionMethodA(a: number) {
+			return n + 1;
+		},
+	} : {
+		unionMethodB(a: string) {
+			return {value: a};
+		},
+	};
+
+	return Behavior({
+		properties,
+		data,
+		methods
+	});
+}
+
 const behavior = Behavior({
-	behaviors: [parentBehavior, "wx://form-field"],
+	behaviors: [
+		createBehaviorWithUnionTypes(1),
+		parentBehavior,
+		"wx://form-field",
+	],
 	properties: {
 		myBehaviorProperty: {
 			type: String
@@ -126,6 +164,20 @@ Component({
 			console.log(this.data.myParentBehaviorData);
 			console.log(this.data.myParentBehaviorProperty);
 			this.myParentBehaviorMethod(456);
+			if (this.unionMethodA) {
+				console.log(this.unionMethodA(5));
+			}
+			if (this.unionMethodB) {
+				console.log(this.unionMethodB('test').value);
+			}
+			console.log(this.data.unionDataA);
+			console.log(this.data.unionDataB);
+			console.log(this.data.unionPropA);
+			console.log(this.data.unionPropB);
+			console.log(this.properties.unionDataA);
+			console.log(this.properties.unionDataB);
+			console.log(this.properties.unionPropA);
+			console.log(this.properties.unionPropB);
 		},
 		readMyDataAndMyProps() {
 			const stringValue1: string = this.data.myProperty;


### PR DESCRIPTION
Correctly support using union types in the `methods`, `properties`, and `data` of behaviors.

Dynamically generated behaviors can be a use case for union types in `methods`, `properties`, and `data`. For example, using Redux:

```typescript
function connect(store: Store) {
  return <Props>(mapStateToProps: (state: any) => Props) => {
    // ...
    return Behavior({
      // ...
      data: {} as Props,
    })
  }
}

function mapStateToProps(state) {
  if (state.loading) {
    return {loading: true};
  }
  return {
    ...state.someData,
    loading: false,
  };
}

Component({
  behavior: [connect(store)(mapStateToProps)],
});
```
where `connect` uses the return type of mapStateToProps type as the type of the behavior's props. In the example the return type of `mapStateToProps` is a union type.

In the previous implementation below, the type representing the union of the types in the `behaviors` array is first "unboxed" distributively to get the types of the methods/properties/data objects. The resulting union is then converted to an intersection. However, if one of the behavior types had a methods/properties/data type that was a union, that union would also be converted to an intersection, which is not expected.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d77c47c753ef693210fec24067c257c1d8d36d44/types/weixin-app/index.d.ts#L3750-L3752

An example:
```typescript
type A = {foo: number};
type B = {bar: string};
type C = {baz: boolean};
type BehaviorsArrayType = Array<Behavior<{}, A | B, {}>, Behavior<{}, C, {}>>;
```
In the previous implementation:
```typescript
type UnboxedDataType = UnboxBehaviorsMethods<BehaviorsArrayType>; // A & B & C
```
which is incorrect. The expected type is
```typescript
type UnboxedDataType = UnboxBehaviorsMethods<BehaviorsArrayType>; // (A | B) & C, or (A & C) | (B & C)
```
This is fixed by first converting the union of behavior types into an intersection, and then extracting the methods/properties/data.

see also #31989
    

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
