### PR TITLE
[ink-select-input] Type definitions for ink-select-input

### DIFF
--- a/types/ink-select-input/index.d.ts
+++ b/types/ink-select-input/index.d.ts
@@ -6,12 +6,12 @@
 
 import { Component, InkComponent } from 'ink';
 
-export interface ItemOfSelectInput {
+interface ItemOfSelectInput {
     label: string;
     value: any;
 }
 
-export interface SelectInputProps<T extends ItemOfSelectInput = ItemOfSelectInput> {
+interface SelectInputProps<T extends ItemOfSelectInput = ItemOfSelectInput> {
     focus?: boolean;
     indicatorComponent?: InkComponent;
     itemComponent?: InkComponent;
@@ -20,4 +20,6 @@ export interface SelectInputProps<T extends ItemOfSelectInput = ItemOfSelectInpu
     onSelect?: (item: T) => void;
 }
 
-export default class SelectInput extends Component<SelectInputProps> { }
+declare class SelectInput extends Component<SelectInputProps> { }
+
+export = SelectInput;

--- a/types/ink-select-input/index.d.ts
+++ b/types/ink-select-input/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for ink-select-input 2.0
+// Project: https://github.com/vadimdemedes/ink-select-input#readme
+// Definitions by: Łukasz Ostrowski <https://github.com/lukostry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { Component, InkComponent } from 'ink';
+
+export interface ItemOfSelectInput {
+    label: string;
+    value: any;
+}
+
+export interface SelectInputProps<T extends ItemOfSelectInput = ItemOfSelectInput> {
+    focus?: boolean;
+    indicatorComponent?: InkComponent;
+    itemComponent?: InkComponent;
+    items?: ReadonlyArray<T>;
+    limit?: number;
+    onSelect?: (item: T) => void;
+}
+
+export default class SelectInput extends Component<SelectInputProps> { }

--- a/types/ink-select-input/ink-select-input-tests.tsx
+++ b/types/ink-select-input/ink-select-input-tests.tsx
@@ -1,0 +1,27 @@
+/** @jsx h */
+import { h, InkComponent } from 'ink';
+import SelectInput from 'ink-select-input';
+
+interface DemoItem {
+  label: string;
+  value: string;
+}
+
+const items: ReadonlyArray<DemoItem> = [{
+  label: 'First',
+  value: 'first'
+}, {
+  label: 'Second',
+  value: 'second'
+}, {
+  label: 'Third',
+  value: 'third'
+}];
+
+const Demo: InkComponent = () => {
+  const handleSelect = (item: DemoItem) => {
+    console.log(item);
+  };
+
+  return <SelectInput items={items} onSelect={handleSelect} />;
+};

--- a/types/ink-select-input/ink-select-input-tests.tsx
+++ b/types/ink-select-input/ink-select-input-tests.tsx
@@ -1,27 +1,32 @@
 /** @jsx h */
 import { h, InkComponent } from 'ink';
 import SelectInput from 'ink-select-input';
+// NOTE: `import SelectInput = require('ink-select-input');` will work as well.
+// If importing using ES6 default import as above,
+// `allowSyntheticDefaultImports` flag in compiler options needs to be set to `true`
 
 interface DemoItem {
-  label: string;
-  value: string;
+    label: string;
+     value: string;
 }
 
 const items: ReadonlyArray<DemoItem> = [{
-  label: 'First',
-  value: 'first'
-}, {
-  label: 'Second',
-  value: 'second'
-}, {
-  label: 'Third',
-  value: 'third'
+    label: 'First',
+    value: 'first'
+},
+{
+    label: 'Second',
+    value: 'second'
+},
+{
+    label: 'Third',
+    value: 'third'
 }];
 
 const Demo: InkComponent = () => {
-  const handleSelect = (item: DemoItem) => {
-    console.log(item);
-  };
+    const handleSelect = (item: DemoItem) => {
+        console.log(item);
+    };
 
-  return <SelectInput items={items} onSelect={handleSelect} />;
+    return <SelectInput items={items} onSelect={handleSelect} />;
 };

--- a/types/ink-select-input/tsconfig.json
+++ b/types/ink-select-input/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ink-select-input-tests.tsx"
+    ]
+}

--- a/types/ink-select-input/tsconfig.json
+++ b/types/ink-select-input/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "jsx": "react",
         "module": "commonjs",
         "lib": [

--- a/types/ink-select-input/tslint.json
+++ b/types/ink-select-input/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds definitions for `ink-select-input`. It uses the same TS version as definitions for `ink`. Test file uses the same example as one provided in the project's README: https://github.com/vadimdemedes/ink-select-input

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
