### PR TITLE
redux-form - Removed wrong type reference to FormData

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -13,6 +13,7 @@
 //                 Kamil Wojcik <https://github.com/smifun>
 //                 Mohamed Shaaban <https://github.com/mshaaban088>
 //                 Ethan Setnik <https://github.com/esetnik>
+//                 Walter Barbagallo <https://github.com/bwlt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 import {

--- a/types/redux-form/lib/actions.d.ts
+++ b/types/redux-form/lib/actions.d.ts
@@ -36,11 +36,11 @@ export declare function registerField(form: string, name: string, type: FieldTyp
 export declare function reset(form: string): FormAction;
 export declare function resetSection(form: string, ...sections: string[]): FormAction;
 export declare function startAsyncValidation(form: string): FormAction;
-export declare function stopAsyncValidation(form: string, errors?: FormErrors<FormData, any>): FormAction;
+export declare function stopAsyncValidation(form: string, errors?: FormErrors<any, any>): FormAction;
 export declare function setSubmitFailed(form: string, ...fields: string[]): FormAction;
 export declare function setSubmitSucceeded(form: string, ...fields: string[]): FormAction;
 export declare function startSubmit(form: string): FormAction;
-export declare function stopSubmit(form: string, errors?: FormErrors<FormData, any>): FormAction;
+export declare function stopSubmit(form: string, errors?: FormErrors<any, any>): FormAction;
 export declare function submit(form: string): FormAction;
 export declare function clearSubmit(form: string): FormAction;
 export declare function clearSubmitErrors(form: string): FormAction;
@@ -49,8 +49,8 @@ export declare function clearFields(form: string, keepTouched: boolean, persiste
 export declare function touch(form: string, ...fields: string[]): FormAction;
 export declare function unregisterField(form: string, name: string): FormAction;
 export declare function untouch(form: string, ...fields: string[]): FormAction;
-export declare function updateSyncErrors<T = any>(from: string, syncErrors: FormErrors<FormData, T>, error: T): FormAction;
-export declare function updateSyncWarnings<T = any>(form: string, syncWarnings: FormWarnings<FormData, T>, warning: T): FormAction;
+export declare function updateSyncErrors<T = any>(from: string, syncErrors: FormErrors<any, T>, error: T): FormAction;
+export declare function updateSyncWarnings<T = any>(form: string, syncWarnings: FormWarnings<any, T>, warning: T): FormAction;
 
 declare const actions: {
     arrayInsert: typeof arrayInsert,


### PR DESCRIPTION
FormData is ambiguous.
It can be resolved with [lib.dom FormData interface](https://github.com/Microsoft/TypeScript/blob/v3.3.1/lib/lib.dom.d.ts#L5196),
or it can break the compiler if the dom lib is not included in the compilerOptions lib.