### PR TITLE
Theo: Revert required TS version back to 2.2

### DIFF
--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for theo 8.1
+// Type definitions for theo 8.1.1
 // Project: https://github.com/salesforce-ux/theo
 // Definitions by: Pete Petrash <https://github.com/petekp>
 //                 Niko Laitinen <https://github.com/laitine>

--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Pete Petrash <https://github.com/petekp>
 //                 Niko Laitinen <https://github.com/laitine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 2.2
 
 import { Collection, Map, List, OrderedMap } from "immutable";
 

--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for theo 8.1.1
+// Type definitions for theo 8.1
 // Project: https://github.com/salesforce-ux/theo
 // Definitions by: Pete Petrash <https://github.com/petekp>
 //                 Niko Laitinen <https://github.com/laitine>


### PR DESCRIPTION
• Reverts the required TS version from `3.2` back to `2.2`
• Use the same version as the supported package version