### PR TITLE
chore(node): enforce encoding parameters

### DIFF
--- a/types/fs-extra-promise/fs-extra-promise-tests.ts
+++ b/types/fs-extra-promise/fs-extra-promise-tests.ts
@@ -19,7 +19,7 @@ let strOrBuf: string | Buffer;
 let buffer: Buffer;
 declare const modeNum: number;
 declare const modeStr: string;
-declare const encoding: string;
+declare const encoding: BufferEncoding;
 declare const symlinkType: "file" | "dir" | "junction";
 declare const flags: string;
 declare const srcpath: string;
@@ -164,7 +164,10 @@ fs.readFile(filename, (err: Error, data: Buffer) => {
 });
 buffer = fs.readFileSync(filename);
 str = fs.readFileSync(filename, encoding);
-strOrBuf = fs.readFileSync(filename, openOpts);
+strOrBuf = fs.readFileSync(filename, {
+    ...openOpts,
+    encoding: 'utf8'
+});
 
 fs.writeFile(filename, data, errorCallback);
 fs.writeFile(filename, data, { encoding }, errorCallback);
@@ -195,14 +198,14 @@ bool = fs.existsSync(path);
 readStream = fs.createReadStream(path);
 readStream = fs.createReadStream(path, {
 	flags: str,
-	encoding: str,
+	encoding,
 	fd: num,
 	mode: num
 });
 writeStream = fs.createWriteStream(path);
 writeStream = fs.createWriteStream(path, {
 	flags: str,
-	encoding: str
+	encoding
 });
 
 function isDirectoryCallback(err: Error, isDirectory: boolean) {}

--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -210,7 +210,7 @@ fs.write(0, new Buffer(""), 0, 0, null).then(x => {
 });
 
 // $ExpectType Promise<void>
-fs.writeFile("foo.txt", "i am foo", { encoding: "utf-8" });
+fs.writeFile("foo.txt", "i am foo", { encoding: "utf8" });
 
 // $ExpectType Promise<string>
 fs.mkdtemp("foo");

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -110,10 +110,10 @@ export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoExcept
 export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function access(path: string | Buffer, mode?: number): Promise<void>;
 
-export function appendFile(file: string | Buffer | number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; },
+export function appendFile(file: string | Buffer | number, data: any, options: { encoding?: BufferEncoding; mode?: number | string; flag?: string; },
     callback: (err: NodeJS.ErrnoException) => void): void;
 export function appendFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
+export function appendFile(file: string | Buffer | number, data: any, options?: { encoding?: BufferEncoding; mode?: number | string; flag?: string; }): Promise<void>;
 
 export function chmod(path: string | Buffer, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
@@ -180,9 +180,13 @@ export function read(fd: number, buffer: Buffer, offset: number, length: number,
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<ReadResult>;
 
 export function readFile(file: string | Buffer | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(file: string | Buffer | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
+export function readFile(file: string | Buffer | number, encoding: BufferEncoding, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+export function readFile(
+    file: string | Buffer | number,
+    options: { flag?: string; } | { encoding: BufferEncoding; flag?: string; },
+    callback: (err: NodeJS.ErrnoException, data: Buffer) => void
+): void;
+export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: BufferEncoding; flag?: string; }): Promise<string>;
 // tslint:disable-next-line:unified-signatures
 export function readFile(file: string | Buffer | number, encoding: string): Promise<string>;
 export function readFile(file: string | Buffer | number): Promise<Buffer>;
@@ -236,9 +240,9 @@ export function write(fd: number, buffer: Buffer, offset: number, length: number
 export function write(fd: number, buffer: Buffer, offset: number, length: number, callback: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
 export function write(fd: number, data: any, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
 export function write(fd: number, data: any, offset: number, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write(fd: number, data: any, offset: number, encoding: string, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
+export function write(fd: number, data: any, offset: number, encoding: BufferEncoding, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
 export function write(fd: number, buffer: Buffer, offset: number, length: number, position?: number | null): Promise<WriteResult>;
-export function write(fd: number, data: any, offset: number, encoding?: string): Promise<WriteResult>;
+export function write(fd: number, data: any, offset: number, encoding?: BufferEncoding): Promise<WriteResult>;
 
 export function writeFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 export function writeFile(file: string | Buffer | number, data: any, options?: WriteFileOptions | string): Promise<void>;
@@ -289,12 +293,12 @@ export interface ReadOptions {
     throws?: boolean;
     fs?: object;
     reviver?: any;
-    encoding?: string;
+    encoding?: BufferEncoding;
     flag?: string;
 }
 
 export interface WriteFileOptions {
-    encoding?: string;
+    encoding?: BufferEncoding;
     flag?: string;
     mode?: number;
 }

--- a/types/fs-extra/v4/index.d.ts
+++ b/types/fs-extra/v4/index.d.ts
@@ -276,12 +276,12 @@ export interface ReadOptions {
     throws?: boolean;
     fs?: object;
     reviver?: any;
-    encoding?: string;
+    encoding?: BufferEncoding | null;
     flag?: string;
 }
 
 export interface WriteFileOptions {
-    encoding?: string;
+    encoding?: BufferEncoding;
     flag?: string;
     mode?: number;
 }

--- a/types/jpegtran-bin/jpegtran-bin-tests.ts
+++ b/types/jpegtran-bin/jpegtran-bin-tests.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import * as jpegtran from "jpegtran-bin";
 
-execFile(jpegtran, ["-outfile", "output.jpg", "input.jpg"], { encoding: "utf-8" }, (err: Error | null) => {
+execFile(jpegtran, ["-outfile", "output.jpg", "input.jpg"], { encoding: "utf8" }, (err: Error | null) => {
     console.log("Image minified!");
 });

--- a/types/mozjpeg/mozjpeg-tests.ts
+++ b/types/mozjpeg/mozjpeg-tests.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import * as mozjpeg from "mozjpeg";
 
-execFile(mozjpeg, ["-outfile", "output.jpg", "input.jpg"], {encoding: "utf-8"}, (err: Error | null) => {
+execFile(mozjpeg, ["-outfile", "output.jpg", "input.jpg"], {encoding: "utf8"}, (err: Error | null) => {
     console.log("Image minified!");
 });

--- a/types/mz/mz-tests.ts
+++ b/types/mz/mz-tests.ts
@@ -214,7 +214,7 @@ import zlib = require('mz/zlib')
 describe('zlib', function () {
 
   it('.gzip().then().gunzip()', function (done) {
-    var buf = new Buffer("lol", 'utf-8');
+    var buf = new Buffer("lol", 'utf8');
     zlib.gzip(buf).then(function (res) {
       return zlib.gunzip(res)
     }).then(function (string) {
@@ -225,7 +225,7 @@ describe('zlib', function () {
 
   describe('callback support', function () {
     it('.gzip() and .gunzip()', function (done) {
-    var buf = new Buffer("lol", 'utf-8');
+    var buf = new Buffer("lol", 'utf8');
       zlib.gzip(buf, function (err, res) {
         assert(!err)
         assert(Buffer.isBuffer(res))

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -114,7 +114,7 @@ declare module "child_process" {
     }
 
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: string | null; // specify `null`.
+        encoding: BufferEncoding | null; // specify `null`.
     }
 
     interface ExecException extends Error {
@@ -135,7 +135,11 @@ declare module "child_process" {
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
     // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function exec(command: string, options: { encoding: string } & ExecOptions, callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
+    function exec(
+        command: string,
+        options: { encoding: BufferEncoding } & ExecOptions,
+        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void
+    ): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
     function exec(command: string, options: ExecOptions, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
@@ -143,7 +147,7 @@ declare module "child_process" {
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: ({ encoding?: string | null } & ExecOptions) | undefined | null,
+        options: ({ encoding?: BufferEncoding | null } & ExecOptions) | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
 
@@ -153,7 +157,7 @@ declare module "child_process" {
         function __promisify__(command: string, options: { encoding: "buffer" | null } & ExecOptions): Promise<{ stdout: Buffer, stderr: Buffer }>;
         function __promisify__(command: string, options: { encoding: BufferEncoding } & ExecOptions): Promise<{ stdout: string, stderr: string }>;
         function __promisify__(command: string, options: ExecOptions): Promise<{ stdout: string, stderr: string }>;
-        function __promisify__(command: string, options?: ({ encoding?: string | null } & ExecOptions) | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(command: string, options?: ({ encoding?: BufferEncoding | null } & ExecOptions) | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
     interface ExecFileOptions extends CommonOptions {
@@ -168,13 +172,16 @@ declare module "child_process" {
         encoding: 'buffer' | null;
     }
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-        encoding: string;
+        encoding: BufferEncoding;
+    }
+    interface ExecFileOptionsOptionalEncoding extends ExecFileOptions {
+        encoding?: BufferEncoding | null;
     }
 
     function execFile(file: string): ChildProcess;
-    function execFile(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsOptionalEncoding | undefined | null): ChildProcess;
     function execFile(file: string, args?: ReadonlyArray<string> | null): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptionsOptionalEncoding | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(file: string, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
@@ -219,13 +226,13 @@ declare module "child_process" {
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        options: ExecFileOptionsOptionalEncoding | undefined | null,
         callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
-        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        options: ExecFileOptionsOptionalEncoding | undefined | null,
         callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
 
@@ -241,11 +248,11 @@ declare module "child_process" {
         function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithOtherEncoding): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
         function __promisify__(file: string, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
         function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
-        function __promisify__(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(file: string, options: ExecFileOptionsOptionalEncoding | undefined | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
         function __promisify__(
             file: string,
             args: string[] | undefined | null,
-            options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+            options: ExecFileOptionsOptionalEncoding | undefined | null,
         ): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
@@ -268,7 +275,7 @@ declare module "child_process" {
         stdio?: StdioOptions;
         killSignal?: string | number;
         maxBuffer?: number;
-        encoding?: string;
+        encoding?: BufferEncoding;
         shell?: boolean | string;
         windowsVerbatimArguments?: boolean;
     }
@@ -276,7 +283,7 @@ declare module "child_process" {
         encoding: BufferEncoding;
     }
     interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
-        encoding: string; // specify `null`.
+        encoding: BufferEncoding; // specify `null`.
     }
     interface SpawnSyncReturns<T> {
         pid: number;
@@ -301,13 +308,13 @@ declare module "child_process" {
         shell?: string;
         killSignal?: string | number;
         maxBuffer?: number;
-        encoding?: string;
+        encoding?: BufferEncoding;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
     }
     interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
-        encoding: string; // specify `null`.
+        encoding: BufferEncoding; // specify `null`.
     }
     function execSync(command: string): Buffer;
     function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;
@@ -319,14 +326,14 @@ declare module "child_process" {
         stdio?: StdioOptions;
         killSignal?: string | number;
         maxBuffer?: number;
-        encoding?: string;
+        encoding?: BufferEncoding;
         shell?: boolean | string;
     }
     interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;
     }
     interface ExecFileSyncOptionsWithBufferEncoding extends ExecFileSyncOptions {
-        encoding: string; // specify `null`.
+        encoding: BufferEncoding; // specify `null`.
     }
     function execFileSync(command: string): Buffer;
     function execFileSync(command: string, options?: ExecFileSyncOptionsWithStringEncoding): string;

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -183,12 +183,10 @@ declare module "crypto" {
     ): Cipher;
 
     interface Cipher extends NodeJS.ReadWriteStream {
-        update(data: BinaryLike): Buffer;
-        update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Binary, output_encoding: HexBase64BinaryEncoding): string;
-        update(data: Binary, input_encoding: any, output_encoding: HexBase64BinaryEncoding): string;
-        // second arg ignored
+        update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding, output_encoding: HexBase64BinaryEncoding): string;
+        update(data: BinaryLike): Buffer;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -229,9 +227,9 @@ declare module "crypto" {
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Binary, input_encoding: any, output_encoding: Utf8AsciiBinaryEncoding): string;
         // second arg is ignored
-        update(data: string, input_encoding: HexBase64BinaryEncoding, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(data: string, input_encoding: HexBase64BinaryEncoding, output_encoding: BufferEncoding): string;
         final(): Buffer;
-        final(output_encoding: string): string;
+        final(output_encoding: BufferEncoding): string;
         setAutoPadding(auto_padding?: boolean): this;
         // setAuthTag(tag: Binary): this;
         // setAAD(buffer: Binary): this;

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -308,9 +308,9 @@ declare module "crypto" {
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: HexBase64Latin1Encoding): string;
         setPublicKey(public_key: Binary): void;
-        setPublicKey(public_key: string, encoding: string): void;
+        setPublicKey(public_key: string, encoding: BufferEncoding): void;
         setPrivateKey(private_key: Binary): void;
-        setPrivateKey(private_key: string, encoding: string): void;
+        setPrivateKey(private_key: string, encoding: BufferEncoding): void;
         verifyError: number;
     }
     function getDiffieHellman(group_name: string): DiffieHellman;

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -48,6 +48,9 @@ declare module "fs" {
         name: string;
     }
 
+    type EncodingOptions = { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null;
+    type EncodingOptionsBuffer = { encoding: "buffer" } | "buffer";
+
     interface FSWatcher extends events.EventEmitter {
         close(): void;
 
@@ -496,21 +499,14 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlink(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
+    function readlink(path: PathLike, options: EncodingOptions, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlink(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, linkString: Buffer) => void): void;
-
-    /**
-     * Asynchronous readlink(2) - read value of a symbolic link.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function readlink(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string | Buffer) => void): void;
+    function readlink(path: PathLike, options: EncodingOptionsBuffer, callback: (err: NodeJS.ErrnoException, linkString: Buffer) => void): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
@@ -525,21 +521,14 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-
-        /**
-         * Asynchronous readlink(2) - read value of a symbolic link.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike, options: EncodingOptionsBuffer): Promise<Buffer>;
     }
 
     /**
@@ -547,42 +536,28 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlinkSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function readlinkSync(path: PathLike, options?: EncodingOptions): string;
 
     /**
      * Synchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readlinkSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
-
-    /**
-     * Synchronous readlink(2) - read value of a symbolic link.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function readlinkSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function readlinkSync(path: PathLike, options: EncodingOptionsBuffer): Buffer;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpath(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+    function realpath(path: PathLike, options: EncodingOptions, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpath(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
-
-    /**
-     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function realpath(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
+    function realpath(path: PathLike, options: EncodingOptionsBuffer, callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
@@ -597,25 +572,22 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
+        function __promisify__(path: PathLike, options: EncodingOptionsBuffer): Promise<Buffer>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
-
-        function native(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
-        function native(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
-        function native(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
+        function native(path: PathLike, options: EncodingOptions, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+        function native(path: PathLike, options: EncodingOptionsBuffer, callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
         function native(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
     }
 
@@ -624,26 +596,18 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpathSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function realpathSync(path: PathLike, options?: EncodingOptions): string;
 
     /**
      * Synchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function realpathSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
-
-    /**
-     * Synchronous realpath(3) - return the canonicalized absolute pathname.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function realpathSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function realpathSync(path: PathLike, options: EncodingOptionsBuffer): Buffer;
 
     namespace realpathSync {
-        function native(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
-        function native(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
-        function native(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+        function native(path: PathLike, options?: EncodingOptions): string;
+        function native(path: PathLike, options: EncodingOptionsBuffer): Buffer;
     }
 
     /**
@@ -739,21 +703,14 @@ declare module "fs" {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtemp(prefix: string, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
+    function mkdtemp(prefix: string, options: EncodingOptions, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtemp(prefix: string, options: "buffer" | { encoding: "buffer" }, callback: (err: NodeJS.ErrnoException, folder: Buffer) => void): void;
-
-    /**
-     * Asynchronously creates a unique temporary directory.
-     * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function mkdtemp(prefix: string, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string | Buffer) => void): void;
+    function mkdtemp(prefix: string, options: BufferEncoding, callback: (err: NodeJS.ErrnoException, folder: Buffer) => void): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
@@ -768,21 +725,14 @@ declare module "fs" {
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(prefix: string, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function __promisify__(prefix: string, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-
-        /**
-         * Asynchronously creates a unique temporary directory.
-         * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function __promisify__(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(prefix: string, options: BufferEncoding): Promise<Buffer>;
     }
 
     /**
@@ -790,21 +740,14 @@ declare module "fs" {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtempSync(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function mkdtempSync(prefix: string, options?: EncodingOptions): string;
 
     /**
      * Synchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function mkdtempSync(prefix: string, options: { encoding: "buffer" } | "buffer"): Buffer;
-
-    /**
-     * Synchronously creates a unique temporary directory.
-     * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function mkdtempSync(prefix: string, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function mkdtempSync(prefix: string, options: BufferEncoding): Buffer;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -822,18 +765,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
-
-    /**
-     * Asynchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function readdir(
-        path: PathLike,
-        options: { encoding?: string | null; withFileTypes?: false } | string | undefined | null,
-        callback: (err: NodeJS.ErrnoException, files: string[] | Buffer[]) => void,
-    ): void;
+    function readdir(path: PathLike, options: EncodingOptionsBuffer & { withFileTypes?: false }, callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -867,13 +799,6 @@ declare module "fs" {
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function __promisify__(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): Promise<string[] | Buffer[]>;
-
-        /**
-         * Asynchronous readdir(3) - read a directory.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
          */
         function __promisify__(path: PathLike, options: { withFileTypes: true }): Promise<Dirent[]>;
@@ -884,7 +809,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
+    function readdirSync(path: PathLike, options?: EncodingOptions & { withFileTypes?: false } | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
@@ -892,13 +817,6 @@ declare module "fs" {
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
-
-    /**
-     * Synchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-     */
-    function readdirSync(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): string[] | Buffer[];
 
     /**
      * Asynchronous readdir(3) - read a directory.
@@ -1087,7 +1005,7 @@ declare module "fs" {
         fd: number,
         string: any,
         position: number | undefined | null,
-        encoding: string | undefined | null,
+        encoding: BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException, written: number, str: string) => void,
     ): void;
 
@@ -1130,7 +1048,7 @@ declare module "fs" {
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
          * @param encoding The expected string encoding.
          */
-        function __promisify__(fd: number, string: any, position?: number | null, encoding?: string | null): Promise<{ bytesWritten: number, buffer: string }>;
+        function __promisify__(fd: number, string: any, position?: number | null, encoding?: BufferEncoding | null): Promise<{ bytesWritten: number, buffer: string }>;
     }
 
     /**
@@ -1149,7 +1067,7 @@ declare module "fs" {
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      * @param encoding The expected string encoding.
      */
-    function writeSync(fd: number, string: any, position?: number | null, encoding?: string | null): number;
+    function writeSync(fd: number, string: any, position?: number | null, encoding?: BufferEncoding | null): number;
 
     /**
      * Asynchronously reads data from the file referenced by the supplied file descriptor.
@@ -1207,21 +1125,7 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFile(path: PathLike | number, options: { encoding: string; flag?: string; } | string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * URL support is _experimental_.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
-    function readFile(
-        path: PathLike | number,
-        options: { encoding?: string | null; flag?: string; } | string | undefined | null,
-        callback: (err: NodeJS.ErrnoException, data: string | Buffer) => void,
-    ): void;
+    function readFile(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1249,17 +1153,7 @@ declare module "fs" {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        function __promisify__(path: PathLike | number, options: { encoding: string; flag?: string; } | string): Promise<string>;
-
-        /**
-         * Asynchronously reads the entire contents of a file.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * URL support is _experimental_.
-         * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-         * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
-         */
-        function __promisify__(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | string): Promise<string>;
     }
 
     /**
@@ -1279,19 +1173,9 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string; } | string): string;
+    function readFileSync(path: PathLike | number, options: { encoding: BufferEncoding; flag?: string; } | BufferEncoding): string;
 
-    /**
-     * Synchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * URL support is _experimental_.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
-    function readFileSync(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): string | Buffer;
-
-    type WriteFileOptions = { encoding?: string | null; mode?: number | string; flag?: string; } | string | null;
+    type WriteFileOptions = EncodingOptions & { mode?: number | string; flag?: string; } | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -1431,7 +1315,7 @@ declare module "fs" {
      */
     function watch(
         filename: PathLike,
-        options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null,
+        options?: EncodingOptions & { persistent?: boolean, recursive?: boolean } | null,
         listener?: (event: string, filename: string) => void,
     ): FSWatcher;
 
@@ -1445,21 +1329,6 @@ declare module "fs" {
      * If `recursive` is not supplied, the default of `false` is used.
      */
     function watch(filename: PathLike, options: { encoding: "buffer", persistent?: boolean, recursive?: boolean } | "buffer", listener?: (event: string, filename: Buffer) => void): FSWatcher;
-
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * URL support is _experimental_.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
-    function watch(
-        filename: PathLike,
-        options: { encoding?: string | null, persistent?: boolean, recursive?: boolean } | string | null,
-        listener?: (event: string, filename: string | Buffer) => void,
-    ): FSWatcher;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
@@ -1686,7 +1555,7 @@ declare module "fs" {
      */
     function createReadStream(path: PathLike, options?: string | {
         flags?: string;
-        encoding?: string;
+        encoding?: BufferEncoding;
         fd?: number;
         mode?: number;
         autoClose?: boolean;
@@ -1702,7 +1571,7 @@ declare module "fs" {
      */
     function createWriteStream(path: PathLike, options?: string | {
         flags?: string;
-        encoding?: string;
+        encoding?: BufferEncoding;
         fd?: number;
         mode?: number;
         autoClose?: boolean;
@@ -1798,7 +1667,7 @@ declare module "fs" {
              * If `mode` is a string, it is parsed as an octal integer.
              * If `flag` is not supplied, the default of `'a'` is used.
              */
-            appendFile(data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+            appendFile(data: any, options?: EncodingOptions & { mode?: string | number, flag?: string | number } | null): Promise<void>;
 
             /**
              * Asynchronous fchown(2) - Change ownership of a file.
@@ -1848,14 +1717,6 @@ declare module "fs" {
             readFile(options: { encoding: BufferEncoding, flag?: string | number } | BufferEncoding): Promise<string>;
 
             /**
-             * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
-             * The `FileHandle` must have been opened for reading.
-             * @param options An object that may contain an optional flag.
-             * If a flag is not provided, it defaults to `'r'`.
-             */
-            readFile(options?: { encoding?: string | null, flag?: string | number } | string | null): Promise<string | Buffer>;
-
-            /**
              * Asynchronous fstat(2) - Get file status.
              */
             stat(): Promise<Stats>;
@@ -1892,7 +1753,7 @@ declare module "fs" {
              * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
              * @param encoding The expected string encoding.
              */
-            write(data: any, position?: number | null, encoding?: string | null): Promise<{ bytesWritten: number, buffer: string }>;
+            write(data: any, position?: number | null, encoding?: BufferEncoding | null): Promise<{ bytesWritten: number, buffer: string }>;
 
             /**
              * Asynchronously writes data to a file, replacing the file if it already exists. The underlying file will _not_ be closed automatically.
@@ -1905,7 +1766,7 @@ declare module "fs" {
              * If `mode` is a string, it is parsed as an octal integer.
              * If `flag` is not supplied, the default of `'w'` is used.
              */
-            writeFile(data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+            writeFile(data: any, options?: EncodingOptions & { mode?: string | number, flag?: string | number } | null): Promise<void>;
 
             /**
              * Asynchronous close(2) - close a `FileHandle`.
@@ -1983,7 +1844,7 @@ declare module "fs" {
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
          * @param encoding The expected string encoding.
          */
-        function write(handle: FileHandle, string: any, position?: number | null, encoding?: string | null): Promise<{ bytesWritten: number, buffer: string }>;
+        function write(handle: FileHandle, string: any, position?: number | null, encoding?: BufferEncoding | null): Promise<{ bytesWritten: number, buffer: string }>;
 
         /**
          * Asynchronous rename(2) - Change the name or location of a file or directory.
@@ -2039,42 +1900,28 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readdir(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string[]>;
+        function readdir(path: PathLike, options?: EncodingOptions): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readdir(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer[]>;
-
-        /**
-         * Asynchronous readdir(3) - read a directory.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function readdir(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string[] | Buffer[]>;
+        function readdir(path: PathLike, options: EncodingOptionsBuffer): Promise<Buffer[]>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readlink(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function readlink(path: PathLike, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function readlink(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-
-        /**
-         * Asynchronous readlink(2) - read value of a symbolic link.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function readlink(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function readlink(path: PathLike, options: EncodingOptionsBuffer): Promise<Buffer>;
 
         /**
          * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
@@ -2176,42 +2023,28 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function realpath(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function realpath(path: PathLike, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function realpath(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-
-        /**
-         * Asynchronous realpath(3) - return the canonicalized absolute pathname.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function realpath(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function realpath(path: PathLike, options: EncodingOptionsBuffer): Promise<Buffer>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function mkdtemp(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function mkdtemp(prefix: string, options?: EncodingOptions): Promise<string>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        function mkdtemp(prefix: string, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-
-        /**
-         * Asynchronously creates a unique temporary directory.
-         * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
-         * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
-         */
-        function mkdtemp(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function mkdtemp(prefix: string, options: EncodingOptionsBuffer): Promise<Buffer>;
 
         /**
          * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -2226,7 +2059,7 @@ declare module "fs" {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'w'` is used.
          */
-        function writeFile(path: PathLike | FileHandle, data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+        function writeFile(path: PathLike | FileHandle, data: any, options?: BufferEncoding & { mode?: string | number, flag?: string | number } | null): Promise<void>;
 
         /**
          * Asynchronously append data to a file, creating the file if it does not exist.
@@ -2240,7 +2073,7 @@ declare module "fs" {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'a'` is used.
          */
-        function appendFile(path: PathLike | FileHandle, data: any, options?: { encoding?: string | null, mode?: string | number, flag?: string | number } | string | null): Promise<void>;
+        function appendFile(path: PathLike | FileHandle, data: any, options?: BufferEncoding & { mode?: string | number, flag?: string | number } | null): Promise<void>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -2259,14 +2092,5 @@ declare module "fs" {
          * If a flag is not provided, it defaults to `'r'`.
          */
         function readFile(path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: string | number } | BufferEncoding): Promise<string>;
-
-        /**
-         * Asynchronously reads the entire contents of a file.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
-         */
-        function readFile(path: PathLike | FileHandle, options?: { encoding?: string | null, flag?: string | number } | string | null): Promise<string | Buffer>;
     }
 }

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -236,10 +236,10 @@ declare var exports: any;
 type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
 interface Buffer extends Uint8Array {
     constructor: typeof Buffer;
-    write(string: string, encoding?: string): number;
-    write(string: string, offset: number, encoding?: string): number;
-    write(string: string, offset: number, length: number, encoding?: string): number;
-    toString(encoding?: string, start?: number, end?: number): string;
+    write(string: string, encoding?: BufferEncoding): number;
+    write(string: string, offset: number, encoding?: BufferEncoding): number;
+    write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
+    toString(encoding?: BufferEncoding, start?: number, end?: number): string;
     toJSON(): { type: 'Buffer', data: number[] };
     equals(otherBuffer: Uint8Array): boolean;
     compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
@@ -285,10 +285,15 @@ interface Buffer extends Uint8Array {
     writeDoubleLE(value: number, offset: number): number;
     writeDoubleBE(value: number, offset: number): number;
     fill(value: any, offset?: number, end?: number): this;
-    indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
-    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
+
+    indexOf(value: string | number | Uint8Array, byteOffset?: number): number;
+    indexOf(value: string, byteOffset?: number, encoding?: BufferEncoding): number;
+    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number): number;
+    lastIndexOf(value: string, byteOffset?: number, encoding?: BufferEncoding): number;
+    includes(value: string | number | Buffer, byteOffset?: number): boolean;
+    includes(value: string, byteOffset?: number, encoding?: BufferEncoding): boolean;
+
     entries(): IterableIterator<[number, number]>;
-    includes(value: string | number | Buffer, byteOffset?: number, encoding?: string): boolean;
     keys(): IterableIterator<number>;
     values(): IterableIterator<number>;
 }
@@ -306,7 +311,7 @@ declare const Buffer: {
      * @param encoding encoding to use, optional.  Default is 'utf8'
      * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
      */
-    new(str: string, encoding?: string): Buffer;
+    new(str: string, encoding?: BufferEncoding): Buffer;
     /**
      * Allocates a new buffer of {size} octets.
      *
@@ -365,7 +370,7 @@ declare const Buffer: {
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.
      */
-    from(str: string, encoding?: string): Buffer;
+    from(str: string, encoding?: BufferEncoding): Buffer;
     /**
      * Creates a new Buffer using the passed {data}
      * @param values to create a new Buffer
@@ -383,7 +388,7 @@ declare const Buffer: {
      *
      * @param encoding string to test.
      */
-    isEncoding(encoding: string): boolean | undefined;
+    isEncoding(encoding: string): encoding is BufferEncoding;
     /**
      * Gives the actual byte length of a string. encoding defaults to 'utf8'.
      * This is not the same as String.prototype.length since that returns the number of characters in a string.
@@ -391,7 +396,7 @@ declare const Buffer: {
      * @param string string to test.
      * @param encoding encoding used to evaluate (defaults to 'utf8')
      */
-    byteLength(string: string | NodeJS.TypedArray | DataView | ArrayBuffer | SharedArrayBuffer, encoding?: string): number;
+    byteLength(string: string | NodeJS.TypedArray | DataView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
     /**
      * Returns a buffer which is the result of concatenating all the buffers in the list together.
      *
@@ -416,7 +421,7 @@ declare const Buffer: {
      *    If parameter is omitted, buffer will be filled with zeros.
      * @param encoding encoding used for call to buf.fill while initalizing
      */
-    alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;
+    alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
     /**
      * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
      * of the newly created Buffer are unknown and may contain sensitive data.
@@ -585,7 +590,7 @@ declare namespace NodeJS {
     interface ReadableStream extends EventEmitter {
         readable: boolean;
         read(size?: number): string | Buffer;
-        setEncoding(encoding: string): this;
+        setEncoding(encoding: BufferEncoding): this;
         pause(): this;
         resume(): this;
         isPaused(): boolean;
@@ -600,11 +605,11 @@ declare namespace NodeJS {
     interface WritableStream extends EventEmitter {
         writable: boolean;
         write(buffer: Buffer | string, cb?: Function): boolean;
-        write(str: string, encoding?: string, cb?: Function): boolean;
+        write(str: string, encoding?: BufferEncoding, cb?: Function): boolean;
         end(cb?: Function): void;
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
-        end(str: string, encoding?: string, cb?: Function): void;
+        end(str: string, encoding?: BufferEncoding, cb?: Function): void;
     }
 
     interface ReadWriteStream extends ReadableStream, WritableStream { }
@@ -700,10 +705,10 @@ declare namespace NodeJS {
         readonly writableLength: number;
         columns?: number;
         rows?: number;
-        _write(chunk: any, encoding: string, callback: Function): void;
+        _write(chunk: any, encoding: BufferEncoding, callback: Function): void;
         _destroy(err: Error | null, callback: Function): void;
         _final(callback: Function): void;
-        setDefaultEncoding(encoding: string): this;
+        setDefaultEncoding(encoding: BufferEncoding): this;
         cork(): void;
         uncork(): void;
         destroy(error?: Error): void;
@@ -715,7 +720,7 @@ declare namespace NodeJS {
         setRawMode?(mode: boolean): void;
         _read(size: number): void;
         _destroy(err: Error | null, callback: Function): void;
-        push(chunk: any, encoding?: string): boolean;
+        push(chunk: any, encoding?: BufferEncoding): boolean;
         destroy(error?: Error): void;
     }
 

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -564,7 +564,7 @@ declare module "http2" {
         connection: net.Socket | tls.TLSSocket;
         end(callback?: () => void): void;
         end(data?: string | Buffer, callback?: () => void): void;
-        end(data?: string | Buffer, encoding?: string, callback?: () => void): void;
+        end(data?: string, encoding?: BufferEncoding, callback?: () => void): void;
         readonly finished: boolean;
         getHeader(name: string): string;
         getHeaderNames(): string[];
@@ -580,7 +580,7 @@ declare module "http2" {
         statusMessage: '';
         stream: ServerHttp2Stream;
         write(chunk: string | Buffer, callback?: (err: Error) => void): boolean;
-        write(chunk: string | Buffer, encoding?: string, callback?: (err: Error) => void): boolean;
+        write(chunk: string, encoding?: BufferEncoding, callback?: (err: Error) => void): boolean;
         writeContinue(): void;
         writeHead(statusCode: number, headers?: OutgoingHttpHeaders): void;
         writeHead(statusCode: number, statusMessage?: string, headers?: OutgoingHttpHeaders): void;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -41,16 +41,16 @@ declare module "net" {
         write(buffer: Buffer): boolean;
         write(buffer: Buffer, cb?: Function): boolean;
         write(str: string, cb?: Function): boolean;
-        write(str: string, encoding?: string, cb?: Function): boolean;
-        write(str: string, encoding?: string, fd?: string): boolean;
-        write(data: any, encoding?: string, callback?: Function): void;
+        write(str: string, encoding?: BufferEncoding, cb?: Function): boolean;
+        write(str: string, encoding?: BufferEncoding, fd?: string): boolean;
+        write(data: any, encoding?: BufferEncoding, callback?: Function): void;
 
         connect(options: SocketConnectOpts, connectionListener?: Function): this;
         connect(port: number, host: string, connectionListener?: Function): this;
         connect(port: number, connectionListener?: Function): this;
         connect(path: string, connectionListener?: Function): this;
 
-        setEncoding(encoding?: string): this;
+        setEncoding(encoding?: BufferEncoding): this;
         pause(): this;
         resume(): this;
         setTimeout(timeout: number, callback?: Function): this;
@@ -75,8 +75,8 @@ declare module "net" {
         end(): void;
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
-        end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
+        end(str: string, encoding?: BufferEncoding, cb?: Function): void;
+        end(data?: any, encoding?: BufferEncoding): void;
 
         /**
          * events.EventEmitter

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -182,7 +182,7 @@ import Module = require("module");
         let buffer: Buffer;
         let stringOrBuffer: string | Buffer;
         const nullEncoding: string | null = null;
-        const stringEncoding: string | null = 'utf8';
+        const stringEncoding: BufferEncoding | null = 'utf8';
 
         content = fs.readFileSync('testfile', 'utf8');
         content = fs.readFileSync('testfile', { encoding: 'utf8' });
@@ -233,7 +233,7 @@ import Module = require("module");
         listS = fs.readdirSync('path');
         listS = fs.readdirSync('path', { encoding: 'utf8' });
         listS = fs.readdirSync('path', { encoding: null });
-        listS = fs.readdirSync('path', { encoding: undefined }) as string[];
+        listS = fs.readdirSync('path', { encoding: undefined });
         listS = fs.readdirSync('path', 'utf8');
         listS = fs.readdirSync('path', null);
         listS = fs.readdirSync('path', undefined);
@@ -299,87 +299,88 @@ import Module = require("module");
     }
 
     {
-        let s = '123';
+        const s: BufferEncoding = 'utf8';
+        let res: string;
         let b: Buffer;
-        fs.readlink('/path/to/folder', (err, linkString) => s = linkString);
-        fs.readlink('/path/to/folder', undefined, (err, linkString) => s = linkString);
-        fs.readlink('/path/to/folder', 'utf8', (err, linkString) => s = linkString);
+        fs.readlink('/path/to/folder', (err, linkString) => res = linkString);
+        fs.readlink('/path/to/folder', undefined, (err, linkString) => res = linkString);
+        fs.readlink('/path/to/folder', 'utf8', (err, linkString) => res = linkString);
         fs.readlink('/path/to/folder', 'buffer', (err, linkString) => b = linkString);
-        fs.readlink('/path/to/folder', s, (err, linkString) => typeof linkString === 'string' ? s = linkString : b = linkString);
-        fs.readlink('/path/to/folder', {}, (err, linkString) => s = linkString);
-        fs.readlink('/path/to/folder', { encoding: undefined }, (err, linkString) => s = linkString);
-        fs.readlink('/path/to/folder', { encoding: 'utf8' }, (err, linkString) => s = linkString);
+        fs.readlink('/path/to/folder', {}, (err, linkString) => res = linkString);
+        fs.readlink('/path/to/folder', { encoding: undefined }, (err, linkString) => res = linkString);
+        fs.readlink('/path/to/folder', { encoding: 'utf8' }, (err, linkString) => res = linkString);
         fs.readlink('/path/to/folder', { encoding: 'buffer' }, (err, linkString) => b = linkString);
-        fs.readlink('/path/to/folder', { encoding: s }, (err, linkString) => typeof linkString === "string" ? s = linkString : b = linkString);
+        fs.readlink('/path/to/folder', { encoding: s }, (err, linkString) => typeof linkString === "string" ? res = linkString : b = linkString);
 
-        s = fs.readlinkSync('/path/to/folder');
-        s = fs.readlinkSync('/path/to/folder', undefined);
-        s = fs.readlinkSync('/path/to/folder', 'utf8');
+        res = fs.readlinkSync('/path/to/folder');
+        res = fs.readlinkSync('/path/to/folder', undefined);
+        res = fs.readlinkSync('/path/to/folder', 'utf8');
         b = fs.readlinkSync('/path/to/folder', 'buffer');
         const v1 = fs.readlinkSync('/path/to/folder', s);
-        typeof v1 === "string" ? s = v1 : b = v1;
+        typeof v1 === "string" ? res = v1 : b = v1;
 
-        s = fs.readlinkSync('/path/to/folder', {});
-        s = fs.readlinkSync('/path/to/folder', { encoding: undefined });
-        s = fs.readlinkSync('/path/to/folder', { encoding: 'utf8' });
+        res = fs.readlinkSync('/path/to/folder', {});
+        res = fs.readlinkSync('/path/to/folder', { encoding: undefined });
+        res = fs.readlinkSync('/path/to/folder', { encoding: 'utf8' });
         b = fs.readlinkSync('/path/to/folder', { encoding: 'buffer' });
         const v2 = fs.readlinkSync('/path/to/folder', { encoding: s });
-        typeof v2 === "string" ? s = v2 : b = v2;
+        typeof v2 === "string" ? res = v2 : b = v2;
     }
 
     {
-        let s = '123';
+        const s: BufferEncoding = 'utf8';
+        let res: string;
         let b: Buffer;
-        fs.realpath('/path/to/folder', (err, resolvedPath) => s = resolvedPath);
-        fs.realpath('/path/to/folder', undefined, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath('/path/to/folder', 'utf8', (err, resolvedPath) => s = resolvedPath);
+        fs.realpath('/path/to/folder', (err, resolvedPath) => res = resolvedPath);
+        fs.realpath('/path/to/folder', undefined, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath('/path/to/folder', 'utf8', (err, resolvedPath) => res = resolvedPath);
         fs.realpath('/path/to/folder', 'buffer', (err, resolvedPath) => b = resolvedPath);
-        fs.realpath('/path/to/folder', s, (err, resolvedPath) => typeof resolvedPath === 'string' ? s = resolvedPath : b = resolvedPath);
-        fs.realpath('/path/to/folder', {}, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath('/path/to/folder', { encoding: undefined }, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath('/path/to/folder', { encoding: 'utf8' }, (err, resolvedPath) => s = resolvedPath);
+        fs.realpath('/path/to/folder', s, (err, resolvedPath) => typeof resolvedPath === 'string' ? res = resolvedPath : b = resolvedPath);
+        fs.realpath('/path/to/folder', {}, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath('/path/to/folder', { encoding: undefined }, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath('/path/to/folder', { encoding: 'utf8' }, (err, resolvedPath) => res = resolvedPath);
         fs.realpath('/path/to/folder', { encoding: 'buffer' }, (err, resolvedPath) => b = resolvedPath);
-        fs.realpath('/path/to/folder', { encoding: s }, (err, resolvedPath) => typeof resolvedPath === "string" ? s = resolvedPath : b = resolvedPath);
+        fs.realpath('/path/to/folder', { encoding: s }, (err, resolvedPath) => typeof resolvedPath === "string" ? res = resolvedPath : b = resolvedPath);
 
-        s = fs.realpathSync('/path/to/folder');
-        s = fs.realpathSync('/path/to/folder', undefined);
-        s = fs.realpathSync('/path/to/folder', 'utf8');
+        res = fs.realpathSync('/path/to/folder');
+        res = fs.realpathSync('/path/to/folder', undefined);
+        res = fs.realpathSync('/path/to/folder', 'utf8');
         b = fs.realpathSync('/path/to/folder', 'buffer');
         const v1 = fs.realpathSync('/path/to/folder', s);
-        typeof v1 === "string" ? s = v1 : b = v1;
+        typeof v1 === "string" ? res = v1 : b = v1;
 
-        s = fs.realpathSync('/path/to/folder', {});
-        s = fs.realpathSync('/path/to/folder', { encoding: undefined });
-        s = fs.realpathSync('/path/to/folder', { encoding: 'utf8' });
+        res = fs.realpathSync('/path/to/folder', {});
+        res = fs.realpathSync('/path/to/folder', { encoding: undefined });
+        res = fs.realpathSync('/path/to/folder', { encoding: 'utf8' });
         b = fs.realpathSync('/path/to/folder', { encoding: 'buffer' });
         const v2 = fs.realpathSync('/path/to/folder', { encoding: s });
-        typeof v2 === "string" ? s = v2 : b = v2;
+        typeof v2 === "string" ? res = v2 : b = v2;
 
         // native
-        fs.realpath.native('/path/to/folder', (err, resolvedPath) => s = resolvedPath);
-        fs.realpath.native('/path/to/folder', undefined, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath.native('/path/to/folder', 'utf8', (err, resolvedPath) => s = resolvedPath);
+        fs.realpath.native('/path/to/folder', (err, resolvedPath) => res = resolvedPath);
+        fs.realpath.native('/path/to/folder', undefined, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath.native('/path/to/folder', 'utf8', (err, resolvedPath) => res = resolvedPath);
         fs.realpath.native('/path/to/folder', 'buffer', (err, resolvedPath) => b = resolvedPath);
-        fs.realpath.native('/path/to/folder', s, (err, resolvedPath) => typeof resolvedPath === 'string' ? s = resolvedPath : b = resolvedPath);
-        fs.realpath.native('/path/to/folder', {}, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath.native('/path/to/folder', { encoding: undefined }, (err, resolvedPath) => s = resolvedPath);
-        fs.realpath.native('/path/to/folder', { encoding: 'utf8' }, (err, resolvedPath) => s = resolvedPath);
+        fs.realpath.native('/path/to/folder', s, (err, resolvedPath) => typeof resolvedPath === 'string' ? res = resolvedPath : b = resolvedPath);
+        fs.realpath.native('/path/to/folder', {}, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath.native('/path/to/folder', { encoding: undefined }, (err, resolvedPath) => res = resolvedPath);
+        fs.realpath.native('/path/to/folder', { encoding: 'utf8' }, (err, resolvedPath) => res = resolvedPath);
         fs.realpath.native('/path/to/folder', { encoding: 'buffer' }, (err, resolvedPath) => b = resolvedPath);
-        fs.realpath.native('/path/to/folder', { encoding: s }, (err, resolvedPath) => typeof resolvedPath === "string" ? s = resolvedPath : b = resolvedPath);
+        fs.realpath.native('/path/to/folder', { encoding: s }, (err, resolvedPath) => typeof resolvedPath === "string" ? res = resolvedPath : b = resolvedPath);
 
-        s = fs.realpathSync.native('/path/to/folder');
-        s = fs.realpathSync.native('/path/to/folder', undefined);
-        s = fs.realpathSync.native('/path/to/folder', 'utf8');
+        res = fs.realpathSync.native('/path/to/folder');
+        res = fs.realpathSync.native('/path/to/folder', undefined);
+        res = fs.realpathSync.native('/path/to/folder', 'utf8');
         b = fs.realpathSync.native('/path/to/folder', 'buffer');
         const v3 = fs.realpathSync.native('/path/to/folder', s);
-        typeof v3 === "string" ? s = v3 : b = v3;
+        typeof v3 === "string" ? res = v3 : b = v3;
 
-        s = fs.realpathSync.native('/path/to/folder', {});
-        s = fs.realpathSync.native('/path/to/folder', { encoding: undefined });
-        s = fs.realpathSync.native('/path/to/folder', { encoding: 'utf8' });
+        res = fs.realpathSync.native('/path/to/folder', {});
+        res = fs.realpathSync.native('/path/to/folder', { encoding: undefined });
+        res = fs.realpathSync.native('/path/to/folder', { encoding: 'utf8' });
         b = fs.realpathSync.native('/path/to/folder', { encoding: 'buffer' });
         const v4 = fs.realpathSync.native('/path/to/folder', { encoding: s });
-        typeof v4 === "string" ? s = v4 : b = v4;
+        typeof v4 === "string" ? res = v4 : b = v4;
     }
 
     {
@@ -670,7 +671,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType any
             chunk;
-            // $ExpectType string
+            // $ExpectType BufferEncoding
             enc;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -678,7 +679,7 @@ function simplified_stream_ctor_test() {
         writev(chunks, cb) {
             // $ExpectType Writable
             this;
-            // $ExpectType { chunk: any; encoding: string; }[]
+            // $ExpectType { chunk: any; encoding: BufferEncoding; }[]
             chunks;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -711,7 +712,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType any
             chunk;
-            // $ExpectType string
+            // $ExpectType BufferEncoding
             enc;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -719,7 +720,7 @@ function simplified_stream_ctor_test() {
         writev(chunks, cb) {
             // $ExpectType Duplex
             this;
-            // $ExpectType { chunk: any; encoding: string; }[]
+            // $ExpectType { chunk: any; encoding: BufferEncoding; }[]
             chunks;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -754,7 +755,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType any
             chunk;
-            // $ExpectType string
+            // $ExpectType BufferEncoding
             enc;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -762,7 +763,7 @@ function simplified_stream_ctor_test() {
         writev(chunks, cb) {
             // $ExpectType Transform
             this;
-            // $ExpectType { chunk: any; encoding: string; }[]
+            // $ExpectType { chunk: any; encoding: BufferEncoding; }[]
             chunks;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
@@ -786,7 +787,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType any
             chunk;
-            // $ExpectType string
+            // $ExpectType BufferEncoding
             enc;
             // $ExpectType TransformCallback
             cb;
@@ -1355,9 +1356,9 @@ async function asyncStreamPipelineFinished() {
         childProcess.execFile("npm", () => {});
         childProcess.execFile("npm", { windowsHide: true }, () => {});
         childProcess.execFile("npm", ["-v"], () => {});
-        childProcess.execFile("npm", ["-v"], { windowsHide: true, encoding: 'utf-8' }, (stdout, stderr) => { assert(stdout instanceof String); });
+        childProcess.execFile("npm", ["-v"], { windowsHide: true, encoding: 'utf8' }, (stdout, stderr) => { assert(stdout instanceof String); });
         childProcess.execFile("npm", ["-v"], { windowsHide: true, encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
-        childProcess.execFile("npm", { encoding: 'utf-8' }, (stdout, stderr) => { assert(stdout instanceof String); });
+        childProcess.execFile("npm", { encoding: 'utf8' }, (stdout, stderr) => { assert(stdout instanceof String); });
         childProcess.execFile("npm", { encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
     }
 
@@ -1370,9 +1371,9 @@ async function asyncStreamPipelineFinished() {
         const execFile = util.promisify(childProcess.execFile);
         let r: { stdout: string | Buffer, stderr: string | Buffer } = await execFile("npm");
         r = await execFile("npm", ["-v"]);
-        r = await execFile("npm", ["-v"], { encoding: 'utf-8' });
+        r = await execFile("npm", ["-v"], { encoding: 'utf8' });
         r = await execFile("npm", ["-v"], { encoding: 'buffer' });
-        r = await execFile("npm", { encoding: 'utf-8' });
+        r = await execFile("npm", { encoding: 'utf8' });
         r = await execFile("npm", { encoding: 'buffer' });
     }
 
@@ -1632,184 +1633,6 @@ async function asyncStreamPipelineFinished() {
                 console.log('worker %d is dead', worker.process.pid);
             }
         });
-    }
-}
-
-////////////////////////////////////////////////////
-/// os tests : https://nodejs.org/api/os.html
-////////////////////////////////////////////////////
-
-{
-    {
-        let result: string;
-
-        result = os.tmpdir();
-        result = os.homedir();
-        result = os.endianness();
-        result = os.hostname();
-        result = os.type();
-        result = os.arch();
-        result = os.release();
-        result = os.EOL;
-    }
-
-    {
-        let result: number;
-
-        result = os.uptime();
-        result = os.totalmem();
-        result = os.freemem();
-    }
-
-    {
-        let result: number[];
-
-        result = os.loadavg();
-    }
-
-    {
-        let result: os.CpuInfo[];
-
-        result = os.cpus();
-    }
-
-    {
-        let result: { [index: string]: os.NetworkInterfaceInfo[] };
-
-        result = os.networkInterfaces();
-    }
-
-    {
-        let result: number;
-
-        result = os.constants.signals.SIGHUP;
-        result = os.constants.signals.SIGINT;
-        result = os.constants.signals.SIGQUIT;
-        result = os.constants.signals.SIGILL;
-        result = os.constants.signals.SIGTRAP;
-        result = os.constants.signals.SIGABRT;
-        result = os.constants.signals.SIGIOT;
-        result = os.constants.signals.SIGBUS;
-        result = os.constants.signals.SIGFPE;
-        result = os.constants.signals.SIGKILL;
-        result = os.constants.signals.SIGUSR1;
-        result = os.constants.signals.SIGSEGV;
-        result = os.constants.signals.SIGUSR2;
-        result = os.constants.signals.SIGPIPE;
-        result = os.constants.signals.SIGALRM;
-        result = os.constants.signals.SIGTERM;
-        result = os.constants.signals.SIGCHLD;
-        result = os.constants.signals.SIGSTKFLT;
-        result = os.constants.signals.SIGCONT;
-        result = os.constants.signals.SIGSTOP;
-        result = os.constants.signals.SIGTSTP;
-        result = os.constants.signals.SIGTTIN;
-        result = os.constants.signals.SIGTTOU;
-        result = os.constants.signals.SIGURG;
-        result = os.constants.signals.SIGXCPU;
-        result = os.constants.signals.SIGXFSZ;
-        result = os.constants.signals.SIGVTALRM;
-        result = os.constants.signals.SIGPROF;
-        result = os.constants.signals.SIGWINCH;
-        result = os.constants.signals.SIGIO;
-        result = os.constants.signals.SIGPOLL;
-        result = os.constants.signals.SIGPWR;
-        result = os.constants.signals.SIGSYS;
-        result = os.constants.signals.SIGUNUSED;
-    }
-
-    {
-        let result: number;
-
-        result = os.constants.errno.E2BIG;
-        result = os.constants.errno.EACCES;
-        result = os.constants.errno.EADDRINUSE;
-        result = os.constants.errno.EADDRNOTAVAIL;
-        result = os.constants.errno.EAFNOSUPPORT;
-        result = os.constants.errno.EAGAIN;
-        result = os.constants.errno.EALREADY;
-        result = os.constants.errno.EBADF;
-        result = os.constants.errno.EBADMSG;
-        result = os.constants.errno.EBUSY;
-        result = os.constants.errno.ECANCELED;
-        result = os.constants.errno.ECHILD;
-        result = os.constants.errno.ECONNABORTED;
-        result = os.constants.errno.ECONNREFUSED;
-        result = os.constants.errno.ECONNRESET;
-        result = os.constants.errno.EDEADLK;
-        result = os.constants.errno.EDESTADDRREQ;
-        result = os.constants.errno.EDOM;
-        result = os.constants.errno.EDQUOT;
-        result = os.constants.errno.EEXIST;
-        result = os.constants.errno.EFAULT;
-        result = os.constants.errno.EFBIG;
-        result = os.constants.errno.EHOSTUNREACH;
-        result = os.constants.errno.EIDRM;
-        result = os.constants.errno.EILSEQ;
-        result = os.constants.errno.EINPROGRESS;
-        result = os.constants.errno.EINTR;
-        result = os.constants.errno.EINVAL;
-        result = os.constants.errno.EIO;
-        result = os.constants.errno.EISCONN;
-        result = os.constants.errno.EISDIR;
-        result = os.constants.errno.ELOOP;
-        result = os.constants.errno.EMFILE;
-        result = os.constants.errno.EMLINK;
-        result = os.constants.errno.EMSGSIZE;
-        result = os.constants.errno.EMULTIHOP;
-        result = os.constants.errno.ENAMETOOLONG;
-        result = os.constants.errno.ENETDOWN;
-        result = os.constants.errno.ENETRESET;
-        result = os.constants.errno.ENETUNREACH;
-        result = os.constants.errno.ENFILE;
-        result = os.constants.errno.ENOBUFS;
-        result = os.constants.errno.ENODATA;
-        result = os.constants.errno.ENODEV;
-        result = os.constants.errno.ENOENT;
-        result = os.constants.errno.ENOEXEC;
-        result = os.constants.errno.ENOLCK;
-        result = os.constants.errno.ENOLINK;
-        result = os.constants.errno.ENOMEM;
-        result = os.constants.errno.ENOMSG;
-        result = os.constants.errno.ENOPROTOOPT;
-        result = os.constants.errno.ENOSPC;
-        result = os.constants.errno.ENOSR;
-        result = os.constants.errno.ENOSTR;
-        result = os.constants.errno.ENOSYS;
-        result = os.constants.errno.ENOTCONN;
-        result = os.constants.errno.ENOTDIR;
-        result = os.constants.errno.ENOTEMPTY;
-        result = os.constants.errno.ENOTSOCK;
-        result = os.constants.errno.ENOTSUP;
-        result = os.constants.errno.ENOTTY;
-        result = os.constants.errno.ENXIO;
-        result = os.constants.errno.EOPNOTSUPP;
-        result = os.constants.errno.EOVERFLOW;
-        result = os.constants.errno.EPERM;
-        result = os.constants.errno.EPIPE;
-        result = os.constants.errno.EPROTO;
-        result = os.constants.errno.EPROTONOSUPPORT;
-        result = os.constants.errno.EPROTOTYPE;
-        result = os.constants.errno.ERANGE;
-        result = os.constants.errno.EROFS;
-        result = os.constants.errno.ESPIPE;
-        result = os.constants.errno.ESRCH;
-        result = os.constants.errno.ESTALE;
-        result = os.constants.errno.ETIME;
-        result = os.constants.errno.ETIMEDOUT;
-        result = os.constants.errno.ETXTBSY;
-        result = os.constants.errno.EWOULDBLOCK;
-        result = os.constants.errno.EXDEV;
-    }
-
-    {
-        const prio = os.getPriority();
-        os.setPriority(prio + 1);
-
-        const prio2 = os.getPriority(1);
-        os.setPriority(2, prio + 1);
-
-        os.setPriority(os.constants.priority.PRIORITY_LOW);
     }
 }
 
@@ -2818,8 +2641,6 @@ import * as constants from 'constants';
             response.write('', 'utf8', (err: Error) => {});
             response.write(Buffer.from([]));
             response.write(Buffer.from([]), (err: Error) => {});
-            response.write(Buffer.from([]), 'utf8');
-            response.write(Buffer.from([]), 'utf8', (err: Error) => {});
             response.end();
             response.end(() => {});
             response.end('');
@@ -2828,8 +2649,6 @@ import * as constants from 'constants';
             response.end('', 'utf8', () => {});
             response.end(Buffer.from([]));
             response.end(Buffer.from([]), () => {});
-            response.end(Buffer.from([]), 'utf8');
-            response.end(Buffer.from([]), 'utf8', () => {});
 
             request.on('aborted', (hadError: boolean, code: number) => {});
             request.on('close', () => {});

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -30,6 +30,14 @@ declare module "os" {
 
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;
 
+    interface UserInfo<T extends string | Buffer> {
+        username: T;
+        uid: number;
+        gid: number;
+        shell: null | string;
+        homedir: T;
+    }
+
     function hostname(): string;
     function loadavg(): number[];
     function uptime(): number;
@@ -40,7 +48,8 @@ declare module "os" {
     function release(): string;
     function networkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
     function homedir(): string;
-    function userInfo(options?: { encoding: string }): { username: string, uid: number, gid: number, shell: any, homedir: string };
+    function userInfo(options?: { encoding: BufferEncoding }): UserInfo<string>;
+    function userInfo(options?: { encoding: 'buffer' }): UserInfo<Buffer>;
     const constants: {
         UV_UDP_REUSEADDR: number;
         signals: {

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -10,7 +10,7 @@ declare module "stream" {
 
         interface ReadableOptions {
             highWaterMark?: number;
-            encoding?: string;
+            encoding?: BufferEncoding;
             objectMode?: boolean;
             read?(this: Readable, size: number): void;
             destroy?(this: Readable, error: Error | null, callback: (error: Error | null) => void): void;
@@ -23,14 +23,14 @@ declare module "stream" {
             constructor(opts?: ReadableOptions);
             _read(size: number): void;
             read(size?: number): any;
-            setEncoding(encoding: string): this;
+            setEncoding(encoding: BufferEncoding): this;
             pause(): this;
             resume(): this;
             isPaused(): boolean;
             unpipe(destination?: NodeJS.WritableStream): this;
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): this;
-            push(chunk: any, encoding?: string): boolean;
+            push(chunk: any, encoding?: BufferEncoding): boolean;
             _destroy(error: Error | null, callback: (error: Error | null) => void): void;
             destroy(error?: Error): void;
 
@@ -99,8 +99,8 @@ declare module "stream" {
             highWaterMark?: number;
             decodeStrings?: boolean;
             objectMode?: boolean;
-            write?(this: Writable, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-            writev?(this: Writable, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
+            write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+            writev?(this: Writable, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
             final?(this: Writable, callback: (error?: Error | null) => void): void;
         }
@@ -110,16 +110,16 @@ declare module "stream" {
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
             constructor(opts?: WritableOptions);
-            _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-            _writev?(chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
+            _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+            _writev?(chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             _destroy(error: Error | null, callback: (error: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
-            write(chunk: any, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
-            setDefaultEncoding(encoding: string): this;
+            write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
+            setDefaultEncoding(encoding: BufferEncoding): this;
             end(cb?: () => void): void;
             end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding?: string, cb?: () => void): void;
+            end(chunk: any, encoding?: BufferEncoding, cb?: () => void): void;
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
@@ -196,8 +196,8 @@ declare module "stream" {
             readableObjectMode?: boolean;
             writableObjectMode?: boolean;
             read?(this: Duplex, size: number): void;
-            write?(this: Duplex, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-            writev?(this: Duplex, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
+            write?(this: Duplex, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+            writev?(this: Duplex, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
             destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
         }
@@ -208,16 +208,16 @@ declare module "stream" {
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
             constructor(opts?: DuplexOptions);
-            _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-            _writev?(chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
+            _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+            _writev?(chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             _destroy(error: Error | null, callback: (error: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
-            write(chunk: any, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
-            setDefaultEncoding(encoding: string): this;
+            write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
+            setDefaultEncoding(encoding: BufferEncoding): this;
             end(cb?: () => void): void;
             end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding?: string, cb?: () => void): void;
+            end(chunk: any, encoding?: BufferEncoding, cb?: () => void): void;
             cork(): void;
             uncork(): void;
         }
@@ -226,17 +226,17 @@ declare module "stream" {
 
         interface TransformOptions extends DuplexOptions {
             read?(this: Transform, size: number): void;
-            write?(this: Transform, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-            writev?(this: Transform, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
+            write?(this: Transform, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+            writev?(this: Transform, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
             destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
-            transform?(this: Transform, chunk: any, encoding: string, callback: TransformCallback): void;
+            transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }
 
         class Transform extends Duplex {
             constructor(opts?: TransformOptions);
-            _transform(chunk: any, encoding: string, callback: TransformCallback): void;
+            _transform(chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             _flush(callback: TransformCallback): void;
         }
 

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -160,10 +160,8 @@ b.fill('a').fill('b');
     includes = buffer.includes("23", 1, "utf8");
     includes = buffer.includes(23);
     includes = buffer.includes(23, 1);
-    includes = buffer.includes(23, 1, "utf8");
     includes = buffer.includes(buffer);
     includes = buffer.includes(buffer, 1);
-    includes = buffer.includes(buffer, 1, "utf8");
 }
 
 {

--- a/types/node/test/os.ts
+++ b/types/node/test/os.ts
@@ -1,0 +1,180 @@
+import * as os from 'os';
+
+{
+    let result: string;
+
+    result = os.tmpdir();
+    result = os.homedir();
+    result = os.endianness();
+    result = os.hostname();
+    result = os.type();
+    result = os.arch();
+    result = os.release();
+    result = os.EOL;
+}
+
+{
+    let result: number;
+
+    result = os.uptime();
+    result = os.totalmem();
+    result = os.freemem();
+}
+
+{
+    let result: number[];
+
+    result = os.loadavg();
+}
+
+{
+    let result: os.CpuInfo[];
+
+    result = os.cpus();
+}
+
+{
+    let result: { [index: string]: os.NetworkInterfaceInfo[] };
+
+    result = os.networkInterfaces();
+}
+
+{
+    let result: number;
+
+    result = os.constants.signals.SIGHUP;
+    result = os.constants.signals.SIGINT;
+    result = os.constants.signals.SIGQUIT;
+    result = os.constants.signals.SIGILL;
+    result = os.constants.signals.SIGTRAP;
+    result = os.constants.signals.SIGABRT;
+    result = os.constants.signals.SIGIOT;
+    result = os.constants.signals.SIGBUS;
+    result = os.constants.signals.SIGFPE;
+    result = os.constants.signals.SIGKILL;
+    result = os.constants.signals.SIGUSR1;
+    result = os.constants.signals.SIGSEGV;
+    result = os.constants.signals.SIGUSR2;
+    result = os.constants.signals.SIGPIPE;
+    result = os.constants.signals.SIGALRM;
+    result = os.constants.signals.SIGTERM;
+    result = os.constants.signals.SIGCHLD;
+    result = os.constants.signals.SIGSTKFLT;
+    result = os.constants.signals.SIGCONT;
+    result = os.constants.signals.SIGSTOP;
+    result = os.constants.signals.SIGTSTP;
+    result = os.constants.signals.SIGTTIN;
+    result = os.constants.signals.SIGTTOU;
+    result = os.constants.signals.SIGURG;
+    result = os.constants.signals.SIGXCPU;
+    result = os.constants.signals.SIGXFSZ;
+    result = os.constants.signals.SIGVTALRM;
+    result = os.constants.signals.SIGPROF;
+    result = os.constants.signals.SIGWINCH;
+    result = os.constants.signals.SIGIO;
+    result = os.constants.signals.SIGPOLL;
+    result = os.constants.signals.SIGPWR;
+    result = os.constants.signals.SIGSYS;
+    result = os.constants.signals.SIGUNUSED;
+}
+
+{
+    let result: number;
+
+    result = os.constants.errno.E2BIG;
+    result = os.constants.errno.EACCES;
+    result = os.constants.errno.EADDRINUSE;
+    result = os.constants.errno.EADDRNOTAVAIL;
+    result = os.constants.errno.EAFNOSUPPORT;
+    result = os.constants.errno.EAGAIN;
+    result = os.constants.errno.EALREADY;
+    result = os.constants.errno.EBADF;
+    result = os.constants.errno.EBADMSG;
+    result = os.constants.errno.EBUSY;
+    result = os.constants.errno.ECANCELED;
+    result = os.constants.errno.ECHILD;
+    result = os.constants.errno.ECONNABORTED;
+    result = os.constants.errno.ECONNREFUSED;
+    result = os.constants.errno.ECONNRESET;
+    result = os.constants.errno.EDEADLK;
+    result = os.constants.errno.EDESTADDRREQ;
+    result = os.constants.errno.EDOM;
+    result = os.constants.errno.EDQUOT;
+    result = os.constants.errno.EEXIST;
+    result = os.constants.errno.EFAULT;
+    result = os.constants.errno.EFBIG;
+    result = os.constants.errno.EHOSTUNREACH;
+    result = os.constants.errno.EIDRM;
+    result = os.constants.errno.EILSEQ;
+    result = os.constants.errno.EINPROGRESS;
+    result = os.constants.errno.EINTR;
+    result = os.constants.errno.EINVAL;
+    result = os.constants.errno.EIO;
+    result = os.constants.errno.EISCONN;
+    result = os.constants.errno.EISDIR;
+    result = os.constants.errno.ELOOP;
+    result = os.constants.errno.EMFILE;
+    result = os.constants.errno.EMLINK;
+    result = os.constants.errno.EMSGSIZE;
+    result = os.constants.errno.EMULTIHOP;
+    result = os.constants.errno.ENAMETOOLONG;
+    result = os.constants.errno.ENETDOWN;
+    result = os.constants.errno.ENETRESET;
+    result = os.constants.errno.ENETUNREACH;
+    result = os.constants.errno.ENFILE;
+    result = os.constants.errno.ENOBUFS;
+    result = os.constants.errno.ENODATA;
+    result = os.constants.errno.ENODEV;
+    result = os.constants.errno.ENOENT;
+    result = os.constants.errno.ENOEXEC;
+    result = os.constants.errno.ENOLCK;
+    result = os.constants.errno.ENOLINK;
+    result = os.constants.errno.ENOMEM;
+    result = os.constants.errno.ENOMSG;
+    result = os.constants.errno.ENOPROTOOPT;
+    result = os.constants.errno.ENOSPC;
+    result = os.constants.errno.ENOSR;
+    result = os.constants.errno.ENOSTR;
+    result = os.constants.errno.ENOSYS;
+    result = os.constants.errno.ENOTCONN;
+    result = os.constants.errno.ENOTDIR;
+    result = os.constants.errno.ENOTEMPTY;
+    result = os.constants.errno.ENOTSOCK;
+    result = os.constants.errno.ENOTSUP;
+    result = os.constants.errno.ENOTTY;
+    result = os.constants.errno.ENXIO;
+    result = os.constants.errno.EOPNOTSUPP;
+    result = os.constants.errno.EOVERFLOW;
+    result = os.constants.errno.EPERM;
+    result = os.constants.errno.EPIPE;
+    result = os.constants.errno.EPROTO;
+    result = os.constants.errno.EPROTONOSUPPORT;
+    result = os.constants.errno.EPROTOTYPE;
+    result = os.constants.errno.ERANGE;
+    result = os.constants.errno.EROFS;
+    result = os.constants.errno.ESPIPE;
+    result = os.constants.errno.ESRCH;
+    result = os.constants.errno.ESTALE;
+    result = os.constants.errno.ETIME;
+    result = os.constants.errno.ETIMEDOUT;
+    result = os.constants.errno.ETXTBSY;
+    result = os.constants.errno.EWOULDBLOCK;
+    result = os.constants.errno.EXDEV;
+}
+
+{
+    const prio = os.getPriority();
+    os.setPriority(prio + 1);
+
+    const prio2 = os.getPriority(1);
+    os.setPriority(2, prio + 1);
+
+    os.setPriority(os.constants.priority.PRIORITY_LOW);
+}
+
+{
+    const strHome: string = os.userInfo().homedir;
+    const buffHome: Buffer = os.userInfo({
+        encoding: 'buffer',
+    }).homedir;
+}

--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -52,7 +52,8 @@
         "test/dgram.ts",
         "test/buffer.ts",
         "test/tty.ts",
-        "test/crypto.ts"
+        "test/crypto.ts",
+        "test/os.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -127,7 +127,7 @@ function message_attachments_test() {
             },
             {   // binary buffer as an attachment
                 filename: 'text2.txt',
-                content: new Buffer('hello world!', 'utf-8')
+                content: new Buffer('hello world!', 'utf8')
             },
             {   // file on disk as an attachment
                 filename: 'text3.txt',

--- a/types/passport-saml/passport-saml-tests.ts
+++ b/types/passport-saml/passport-saml-tests.ts
@@ -22,7 +22,7 @@ const samlStrategy = new SamlStrategy.Strategy(
 				// key removed, null if no key is removed
 			}
 		},
-		cert: fs.readFileSync('/path/to/cert.crt', 'UTF8')
+		cert: fs.readFileSync('/path/to/cert.crt', 'utf8')
 	},
 	(profile: {}, done: (err: Error | null, user: {}, info?: {}) => void) => {
 		const user = {};

--- a/types/pngquant-bin/pngquant-bin-tests.ts
+++ b/types/pngquant-bin/pngquant-bin-tests.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import * as pngquant from "pngquant-bin";
 
-execFile(pngquant, ["-o", "output.png", "input.png"], { encoding: "utf-8" }, (err: Error | null) => {
+execFile(pngquant, ["-o", "output.png", "input.png"], { encoding: "utf8" }, (err: Error | null) => {
     console.log("Image minified!");
 });

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -101,7 +101,7 @@ declare namespace resolve {
 
   export interface SyncOpts extends Opts {
     /** how to read files synchronously (defaults to fs.readFileSync) */
-    readFileSync?: (file: string, charset: string) => string | Buffer;
+    readFileSync?: (file: string, charset: BufferEncoding) => string | Buffer;
     /** function to synchronously test whether a file exists */
     isFile?: (file: string) => boolean;
   }

--- a/types/snappy/snappy-tests.ts
+++ b/types/snappy/snappy-tests.ts
@@ -13,7 +13,7 @@ snappy.uncompress(data, (err, data) => {
   if (err) {
     throw err;
   }
-  console.log(data.toString('UTF8'));
+  console.log(data.toString('utf8'));
 });
 snappy.uncompress(otherData, { asBuffer: false }, (err, original) => {
   if (err) {

--- a/types/svg-sprite/svg-sprite-tests.ts
+++ b/types/svg-sprite/svg-sprite-tests.ts
@@ -13,8 +13,8 @@ var config: SVGSpriter.Config;
 var spriter       = new SVGSpriter(config);
 
 // Add SVG source files — the manual way ...
-spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', {encoding: 'utf-8'}));
-spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', {encoding: 'utf-8'}));
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', {encoding: 'utf8'}));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', {encoding: 'utf8'}));
 /* ... */
 
 // Compile the sprite

--- a/types/through2/index.d.ts
+++ b/types/through2/index.d.ts
@@ -22,7 +22,7 @@ declare namespace through2 {
     }
 
     type TransformCallback = (err?: any, data?: any) => void;
-    type TransformFunction = (this: stream.Transform, chunk: any, enc: string, callback: TransformCallback) => void;
+    type TransformFunction = (this: stream.Transform, chunk: any, enc: BufferEncoding, callback: TransformCallback) => void;
     type FlushCallback = (this: stream.Transform, flushCallback: () => void) => void;
 
 	/**

--- a/types/through2/through2-tests.ts
+++ b/types/through2/through2-tests.ts
@@ -24,7 +24,7 @@ rws = through2(function (entry: any, enc: string, callback: () => void) {
 });
 
 rws = through2(function (entry, enc, callback) {
-    var str: string = enc;
+    var str: BufferEncoding = enc;
     this.push(entry, str);
     callback(null, 'continue');
 }, () => {

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -268,7 +268,7 @@ configuration = {
                     const prevTimestamp = prevTimestamps.get(filepath) || startTime;
                     const newTimestamp = compilation.fileTimestamps.get(filepath) || Infinity;
                     if (prevTimestamp < newTimestamp) {
-                        this.inputFileSystem.readFileSync(filepath).toString('utf-8');
+                        this.inputFileSystem.readFileSync(filepath).toString('utf8');
                     }
                 }
             });

--- a/types/yargs/v10/yargs-tests.ts
+++ b/types/yargs/v10/yargs-tests.ts
@@ -523,10 +523,10 @@ function Argv$configObject() {
 function Argv$configParseFunction() {
     const ya = yargs
         .config('settings', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .config('settings', 'description', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .argv;
 }

--- a/types/yargs/v11/yargs-tests.ts
+++ b/types/yargs/v11/yargs-tests.ts
@@ -523,10 +523,10 @@ function Argv$configObject() {
 function Argv$configParseFunction() {
     const ya = yargs
         .config('settings', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .config('settings', 'description', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .argv;
 }

--- a/types/yargs/v8/yargs-tests.ts
+++ b/types/yargs/v8/yargs-tests.ts
@@ -505,10 +505,10 @@ function Argv$configObject() {
 function Argv$configParseFunction() {
     const ya = yargs
         .config('settings', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .config('settings', 'description', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .argv;
 }

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -623,10 +623,10 @@ function Argv$configObject() {
 function Argv$configParseFunction() {
     const ya = yargs
         .config('settings', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .config('settings', 'description', (configPath) => {
-            return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
         })
         .argv;
 }

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -23,8 +23,8 @@ async function test() {
     const fd1 = await yauzl.fromFd(0);
     const fd2 = await yauzl.fromFd(0, options);
 
-    const buffer1 = await yauzl.fromBuffer(Buffer.from("test", "utf-8"));
-    const buffer2 = await yauzl.fromBuffer(Buffer.from("test", "utf-8"), options);
+    const buffer1 = await yauzl.fromBuffer(Buffer.from("test", "utf8"));
+    const buffer2 = await yauzl.fromBuffer(Buffer.from("test", "utf8"), options);
 
     const rar1 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1);
     const rar2 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1, options);

--- a/types/zopflipng-bin/zopflipng-bin-tests.ts
+++ b/types/zopflipng-bin/zopflipng-bin-tests.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import * as zopflipng from "zopflipng-bin";
 
-execFile(zopflipng, ["-m", "--lossy_8bit", "input.png", "outout.png"], { encoding: "utf-8" }, (err: Error | null) => {
+execFile(zopflipng, ["-m", "--lossy_8bit", "input.png", "outout.png"], { encoding: "utf8" }, (err: Error | null) => {
     console.log("Image minified!");
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This will likely have breaking changes but will vastly improve type safety, we may not merge this until node v12 lands.

tl;dr: Replace occurences of `string` with `BufferEncoding` where context is encoding related, exception is TextEncoder/Decoder.