### PR TITLE
[react-dom] Allow maybe instance in findDOMNode

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -17,7 +17,7 @@ import {
     DOMAttributes, DOMElement, ReactNode, ReactPortal
 } from 'react';
 
-export function findDOMNode(instance: ReactInstance): Element | null | Text;
+export function findDOMNode(instance: ReactInstance | null | undefined): Element | null | Text;
 export function unmountComponentAtNode(container: Element): boolean;
 
 export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;

--- a/types/react-dom/react-dom-tests.tsx
+++ b/types/react-dom/react-dom-tests.tsx
@@ -30,6 +30,8 @@ describe('ReactDOM', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
         ReactDOM.findDOMNode(rootElement);
+        ReactDOM.findDOMNode(null);
+        ReactDOM.findDOMNode(undefined);
     });
 
     it('createPortal', () => {

--- a/types/react-dom/v15/index.d.ts
+++ b/types/react-dom/v15/index.d.ts
@@ -15,7 +15,7 @@ import {
     DOMAttributes, DOMElement
 } from 'react';
 
-export function findDOMNode<E extends Element>(instance: ReactInstance): E;
+export function findDOMNode<E extends Element>(instance: ReactInstance | null | undefined): E;
 export function findDOMNode(instance: ReactInstance): Element;
 
 export function render<P extends DOMAttributes<T>, T extends Element>(

--- a/types/react-dom/v15/react-dom-tests.ts
+++ b/types/react-dom/v15/react-dom-tests.ts
@@ -25,6 +25,8 @@ describe('ReactDOM', () => {
         const rootElement = document.createElement('div');
         ReactDOM.render(React.createElement('div'), rootElement);
         ReactDOM.findDOMNode(rootElement);
+        ReactDOM.findDOMNode(null);
+        ReactDOM.findDOMNode(undefined);
     });
 });
 


### PR DESCRIPTION
Duplicate of #32667 which was closed because CI timed out. I suspect this will happen again. Pinging some collaborators for manual review. Sorry for the noise and thanks in advance.

/cc @Jessidhia @RyanCavanaugh @sandersn

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:   
  - [v16 findDOMNode](https://github.com/facebook/react/blob/v16.0.0/src/renderers/dom/shared/findDOMNode.js#L30)
  - [v15 findDOMNode](https://github.com/facebook/react/blob/v15.5.0/src/renderers/dom/client/findDOMNode.js#L46)
  - flow maybe types include undefined and null: https://flow.org/en/docs/types/maybe/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

