### PR TITLE
[ink-text-input] Add definitions for ink-text-input

### DIFF
--- a/types/ink-text-input/index.d.ts
+++ b/types/ink-text-input/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for ink-text-input 2.0
+// Project: https://github.com/vadimdemedes/ink-text-input#readme
+// Definitions by: Łukasz Ostrowski <https://github.com/lukostry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { Component } from 'ink';
+
+export interface TextInputProps {
+    focus?: boolean;
+    onChange?: (value: string) => void;
+    onSubmit?: (value: string) => void;
+    placeholder?: string;
+    value?: string;
+}
+
+export default class TextInput extends Component<TextInputProps> { }

--- a/types/ink-text-input/index.d.ts
+++ b/types/ink-text-input/index.d.ts
@@ -6,7 +6,7 @@
 
 import { Component } from 'ink';
 
-export interface TextInputProps {
+interface TextInputProps {
     focus?: boolean;
     onChange?: (value: string) => void;
     onSubmit?: (value: string) => void;
@@ -14,4 +14,6 @@ export interface TextInputProps {
     value?: string;
 }
 
-export default class TextInput extends Component<TextInputProps> { }
+declare class TextInput extends Component<TextInputProps> { }
+
+export = TextInput;

--- a/types/ink-text-input/ink-text-input-tests.tsx
+++ b/types/ink-text-input/ink-text-input-tests.tsx
@@ -1,6 +1,9 @@
 /** @jsx h */
 import { h, Component } from 'ink';
 import TextInput from 'ink-text-input';
+// NOTE: `import TextInput = require('ink-text-input');` will work as well
+// For importing using ES6 default import as above,
+// `allowSyntheticDefaultImports` flag in compiler options needs to be set to `true`
 
 interface QueryState {
     query: string;

--- a/types/ink-text-input/ink-text-input-tests.tsx
+++ b/types/ink-text-input/ink-text-input-tests.tsx
@@ -1,0 +1,44 @@
+/** @jsx h */
+import { h, Component } from 'ink';
+import TextInput from 'ink-text-input';
+
+interface QueryState {
+    query: string;
+}
+
+class SearchQuery extends Component {
+    constructor() {
+        super();
+
+        this.state = {
+            query: ''
+        };
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    render(props: {}, state: QueryState) {
+        return (
+            <div>
+                Enter your query:
+
+				<TextInput
+                    value={state.query}
+                    onChange={this.handleChange}
+                    onSubmit={this.handleSubmit}
+                />
+            </div>
+        );
+    }
+
+    private handleChange(value: string) {
+        this.setState({
+            query: value,
+        });
+    }
+
+    private handleSubmit(value: string) {
+        console.log(value);
+    }
+}

--- a/types/ink-text-input/tsconfig.json
+++ b/types/ink-text-input/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ink-text-input-tests.tsx"
+    ]
+}

--- a/types/ink-text-input/tsconfig.json
+++ b/types/ink-text-input/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "jsx": "react",
         "module": "commonjs",
         "lib": [

--- a/types/ink-text-input/tslint.json
+++ b/types/ink-text-input/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds definitions for `ink-text-input`. It uses the same TS version as definitions for `ink`. Test file uses the same example as one provided in the project's README: https://github.com/vadimdemedes/ink-text-input

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
