### PR TITLE
Correct the retryResult method signature.

### DIFF
--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -116,7 +116,7 @@ export namespace policies {
       onUnavailable(requestInfo: RequestInfo, consistency: types.consistencies, required: number, alive: number): DecisionInfo;
       onWriteTimeout(requestInfo: RequestInfo, consistency: types.consistencies, received: number, blockFor: number, writeType: string): DecisionInfo;
       rethrowResult(): { decision: retryDecision };
-      retryResult(): { decision: retryDecision, consistency: types.consistencies, useCurrentHost: boolean };
+      retryResult(consistency: types.consistencies, useCurrentHost: boolean): { decision: retryDecision, consistency: types.consistencies, useCurrentHost: boolean };
     }
   }
 

--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -116,7 +116,7 @@ export namespace policies {
       onUnavailable(requestInfo: RequestInfo, consistency: types.consistencies, required: number, alive: number): DecisionInfo;
       onWriteTimeout(requestInfo: RequestInfo, consistency: types.consistencies, received: number, blockFor: number, writeType: string): DecisionInfo;
       rethrowResult(): { decision: retryDecision };
-      retryResult(consistency: types.consistencies, useCurrentHost: boolean): { decision: retryDecision, consistency: types.consistencies, useCurrentHost: boolean };
+      retryResult(consistency?: types.consistencies, useCurrentHost?: boolean): { decision: retryDecision, consistency: types.consistencies, useCurrentHost: boolean };
     }
   }
 


### PR DESCRIPTION
The retryResult method as defined at the link below takes two arguments. The type definition only takes one resulting in a compile time error when calling the method.
https://github.com/datastax/nodejs-driver/blob/master/lib/policies/retry.js#L109

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.