### PR TITLE
[Theo]: Allow arbitrary strings in certain params of string literal union type

### DIFF
--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -5,51 +5,46 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import { Collection, Map, List, OrderedMap } from "immutable";
+import { Collection, Map, List, OrderedMap } from 'immutable'
 
 export type StyleProperty =
-    | "name"
-    | "value"
-    | "type"
-    | "originalValue"
-    | "category"
-    | "comment"
-    | "meta";
+  | 'name'
+  | 'value'
+  | 'type'
+  | 'originalValue'
+  | 'category'
+  | 'comment'
+  | 'meta';
 
 export type Format =
-    | "custom-properties.css"
-    | "cssmodules.css"
-    | "scss"
-    | "sass"
-    | "less"
-    | "styl"
-    | "map.css"
-    | "map.variable.scss"
-    | "list.scss"
-    | "module.js"
-    | "common.js"
-    | "html"
-    | "json"
-    | "raw.json"
-    | "ios.json"
-    | "android.xml"
-    | "aura.tokens";
+  | 'custom-properties.css'
+  | 'cssmodules.css'
+  | 'scss'
+  | 'sass'
+  | 'less'
+  | 'styl'
+  | 'map.css'
+  | 'map.variable.scss'
+  | 'list.scss'
+  | 'module.js'
+  | 'common.js'
+  | 'html'
+  | 'json'
+  | 'raw.json'
+  | 'ios.json'
+  | 'android.xml'
+  | 'aura.tokens';
 
-export function convert(options: ConvertOptions): Promise<string>;
-export function convertSync(options: ConvertOptions): string;
-export function registerFormat(
-    name: string,
-    format: FormatResultFn | string
-): void;
-export function registerTransform(
-    name: string,
-    valueTransforms: string[]
-): void;
-export function registerValueTransform(
-    name: string,
-    predicate: (prop: Prop) => boolean,
-    transform: (prop: Prop) => string | number
-): void;
+export type Transform = 'raw' | 'ios' | 'android' | 'web';
+
+export type ValueTransform =
+  | 'color/rgb'
+  | 'color/hex'
+  | 'color/hex8rgba'
+  | 'color/hex8argb'
+  | 'percentage/float'
+  | 'relative/pixel'
+  | 'relative/pixelValue';
 
 export type Prop = Map<StyleProperty, string | number>;
 export type Props = List<Prop>;
@@ -58,36 +53,52 @@ export type Meta = Map<string, string>;
 export type FormatResultFn = (result: ImmutableStyleMap) => string;
 
 export interface StyleMap {
-    aliases: Aliases;
-    global?: Props;
-    imports?: string[];
-    props: Props;
-    meta: Meta;
-    options: object;
+  aliases: Aliases;
+  global?: Props;
+  imports?: string[];
+  props: Props;
+  meta: Meta;
+  options: object;
 }
 
 export interface ImmutableStyleMap extends Map<string, any> {
-    toJS(): StyleMap;
-    get<K extends keyof StyleMap>(key: K): StyleMap[K];
+  toJS(): StyleMap;
+  get<K extends keyof StyleMap>(key: K): StyleMap[K];
 }
 
 export interface ConvertOptions {
-    transform: TransformOptions;
-    format: FormatOptions;
-    resolveAliases?: boolean;
-    resolveMetaAliases?: boolean;
+  transform: TransformOptions;
+  format: FormatOptions;
+  resolveAliases?: boolean;
+  resolveMetaAliases?: boolean;
 }
 
-export interface TransformOptions {
-    type?: string;
-    file: string;
-    data?: string;
+export interface TransformOptions<T extends string> {
+  type?: Transform | T;
+  file: string;
+  data?: string;
 }
 
 export interface FormatOptions {
-    type: Format;
-    options?: (
-        options: object,
-        transformPropName?: (name: string) => string
-    ) => void;
+  type: Format;
+  options?: (
+    options: object,
+    transformPropName?: (name: string) => string
+  ) => void;
 }
+
+export function convert(options: ConvertOptions): Promise<string>;
+export function convertSync(options: ConvertOptions): string;
+export function registerFormat<T extends string>(
+  name: Format | T,
+  format: FormatResultFn | string
+): void;
+export function registerTransform<T extends string>(
+  name: Transform | T,
+  valueTransforms: ValueTransform[] | T[]
+): void;
+export function registerValueTransform<T extends string>(
+  name: ValueTransform | T,
+  predicate: (prop: Prop) => boolean,
+  transform: (prop: Prop) => string | number
+): void;

--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -5,46 +5,46 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import { Collection, Map, List, OrderedMap } from 'immutable'
+import { Collection, Map, List, OrderedMap } from "immutable";
 
 export type StyleProperty =
-  | 'name'
-  | 'value'
-  | 'type'
-  | 'originalValue'
-  | 'category'
-  | 'comment'
-  | 'meta';
+    | "name"
+    | "value"
+    | "type"
+    | "originalValue"
+    | "category"
+    | "comment"
+    | "meta";
 
 export type Format =
-  | 'custom-properties.css'
-  | 'cssmodules.css'
-  | 'scss'
-  | 'sass'
-  | 'less'
-  | 'styl'
-  | 'map.css'
-  | 'map.variable.scss'
-  | 'list.scss'
-  | 'module.js'
-  | 'common.js'
-  | 'html'
-  | 'json'
-  | 'raw.json'
-  | 'ios.json'
-  | 'android.xml'
-  | 'aura.tokens';
+    | "custom-properties.css"
+    | "cssmodules.css"
+    | "scss"
+    | "sass"
+    | "less"
+    | "styl"
+    | "map.css"
+    | "map.variable.scss"
+    | "list.scss"
+    | "module.js"
+    | "common.js"
+    | "html"
+    | "json"
+    | "raw.json"
+    | "ios.json"
+    | "android.xml"
+    | "aura.tokens";
 
-export type Transform = 'raw' | 'ios' | 'android' | 'web';
+export type Transform = "raw" | "ios" | "android" | "web";
 
 export type ValueTransform =
-  | 'color/rgb'
-  | 'color/hex'
-  | 'color/hex8rgba'
-  | 'color/hex8argb'
-  | 'percentage/float'
-  | 'relative/pixel'
-  | 'relative/pixelValue';
+    | "color/rgb"
+    | "color/hex"
+    | "color/hex8rgba"
+    | "color/hex8argb"
+    | "percentage/float"
+    | "relative/pixel"
+    | "relative/pixelValue";
 
 export type Prop = Map<StyleProperty, string | number>;
 export type Props = List<Prop>;
@@ -53,52 +53,52 @@ export type Meta = Map<string, string>;
 export type FormatResultFn = (result: ImmutableStyleMap) => string;
 
 export interface StyleMap {
-  aliases: Aliases;
-  global?: Props;
-  imports?: string[];
-  props: Props;
-  meta: Meta;
-  options: object;
+    aliases: Aliases;
+    global?: Props;
+    imports?: string[];
+    props: Props;
+    meta: Meta;
+    options: object;
 }
 
 export interface ImmutableStyleMap extends Map<string, any> {
-  toJS(): StyleMap;
-  get<K extends keyof StyleMap>(key: K): StyleMap[K];
+    toJS(): StyleMap;
+    get<K extends keyof StyleMap>(key: K): StyleMap[K];
 }
 
 export interface ConvertOptions {
-  transform: TransformOptions;
-  format: FormatOptions;
-  resolveAliases?: boolean;
-  resolveMetaAliases?: boolean;
+    transform: TransformOptions;
+    format: FormatOptions;
+    resolveAliases?: boolean;
+    resolveMetaAliases?: boolean;
 }
 
-export interface TransformOptions<T extends string> {
-  type?: Transform | T;
-  file: string;
-  data?: string;
+export interface TransformOptions<T extends string = never> {
+    type?: Transform | T;
+    file: string;
+    data?: string;
 }
 
 export interface FormatOptions {
-  type: Format;
-  options?: (
-    options: object,
-    transformPropName?: (name: string) => string
-  ) => void;
+    type: Format;
+    options?: (
+        options: object,
+        transformPropName?: (name: string) => string
+    ) => void;
 }
 
 export function convert(options: ConvertOptions): Promise<string>;
 export function convertSync(options: ConvertOptions): string;
-export function registerFormat<T extends string>(
-  name: Format | T,
-  format: FormatResultFn | string
+export function registerFormat<T extends string = never>(
+    name: Format | T,
+    format: FormatResultFn | string
 ): void;
-export function registerTransform<T extends string>(
-  name: Transform | T,
-  valueTransforms: ValueTransform[] | T[]
+export function registerTransform<T extends string = never>(
+    name: Transform | T,
+    valueTransforms: ValueTransform[] | T[]
 ): void;
-export function registerValueTransform<T extends string>(
-  name: ValueTransform | T,
-  predicate: (prop: Prop) => boolean,
-  transform: (prop: Prop) => string | number
+export function registerValueTransform<T extends string = never>(
+    name: ValueTransform | T,
+    predicate: (prop: Prop) => boolean,
+    transform: (prop: Prop) => string | number
 ): void;

--- a/types/theo/index.d.ts
+++ b/types/theo/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for theo 8.1
+// Type definitions for Theo 8.1
 // Project: https://github.com/salesforce-ux/theo
 // Definitions by: Pete Petrash <https://github.com/petekp>
 //                 Niko Laitinen <https://github.com/laitine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Collection, Map, List, OrderedMap } from "immutable";
 

--- a/types/theo/tslint.json
+++ b/types/theo/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}


### PR DESCRIPTION
• Restore `Transform` and `ValueTransform` string union literal types
• Use generics to allow arbitrary strings for parameters of the above types
• Move exported functions to the bottom of the file