### PR TITLE
MUI-Datatables: Improved tests and interface definitions

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -85,7 +85,7 @@ interface MUIDataTableTextLabelsSelectedRows {
     deleteAria: string;
 }
 
-interface MUIDataTableTextLabels {
+export interface MUIDataTableTextLabels {
     body: MUIDataTableTextLabelsBody;
     pagination: MUIDataTableTextLabelsPagination;
     toolbar: MUIDataTableTextLabelsToolbar;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,84 +1,72 @@
-import MUIDataTable, { MUIDataTableColumnDef, MUIDataTableOptions } from 'mui-datatables';
+import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels } from 'mui-datatables';
 import * as React from 'react';
 
-const dataSimple: string[][] = [
-    ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
-    ['John Walsh', 'Test Corp', 'Hartford', 'CT'],
-    ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
-    ['James Houston', 'Test Corp', 'Dallas', 'TX']
-];
+interface Props extends MUIDataTableOptions {
+    data: any;
+    title: string;
+    textLabels?: MUIDataTableTextLabels;
+}
 
-const columnWithOptions: MUIDataTableColumnDef[] = [
-    {
-        name: 'Name',
-        label: 'New Name',
-        options: {
-            display: 'true',
-            filter: true,
-            sort: true,
-            sortDirection: 'asc',
-            download: true,
+class MuiCustomTable extends React.Component<Props> {
+    private readonly data: string[][] = this.props.data.map((asset: any) => Object.values(asset));
+    private readonly columns = [...new Set(this.props.data.map((entry: any) => Object.keys(entry)).flat().map((title: string) => title.toUpperCase()))] as string[];
+    private readonly TableOptions: MUIDataTableOptions = {
+        filterType: 'checkbox',
+        responsive: 'scroll',
+        selectableRows: false,
+        elevation: 0,
+        rowsPerPageOptions: [5, 10, 20, 25, 50, 100],
+        downloadOptions: {
+            filename: 'filename.csv',
+            separator: ','
+        },
+        sortFilterList: false,
+        textLabels: {
+            body: {
+                noMatch: 'Sorry, no matching records found',
+                toolTip: 'Sort',
+            },
+            pagination: {
+                next: 'Next Page',
+                previous: 'Previous Page',
+                rowsPerPage: 'Rows per page:',
+                displayRows: 'of',
+            },
+            toolbar: {
+                search: 'Search',
+                downloadCsv: 'Download CSV',
+                print: 'Print',
+                viewColumns: 'View Columns',
+                filterTable: 'Filter Table',
+            },
+            filter: {
+                all: 'All',
+                title: 'FILTERS',
+                reset: 'RESET',
+            },
+            viewColumns: {
+                title: 'Show Columns',
+                titleAria: 'Show/Hide Table Columns',
+            },
+            selectedRows: {
+                text: 'rows(s) selected',
+                delete: 'Delete',
+                deleteAria: 'Delete Selected Rows',
+            }
         }
-    }
-];
+    };
 
-const options: MUIDataTableOptions = {
-    filterType: 'checkbox',
-    responsive: 'scroll',
-    selectableRows: false,
-    elevation: 0,
-    rowsPerPageOptions: [5, 10, 20, 25, 50, 100],
-    downloadOptions: {
-        filename: 'filename.csv',
-        separator: ','
-    },
-    sortFilterList: false,
-    textLabels: {
-        body: {
-            noMatch: 'Sorry, no matching records found',
-            toolTip: 'Sort',
-        },
-        pagination: {
-            next: 'Next Page',
-            previous: 'Previous Page',
-            rowsPerPage: 'Rows per page:',
-            displayRows: 'of',
-        },
-        toolbar: {
-            search: 'Search',
-            downloadCsv: 'Download CSV',
-            print: 'Print',
-            viewColumns: 'View Columns',
-            filterTable: 'Filter Table',
-        },
-        filter: {
-            all: 'All',
-            title: 'FILTERS',
-            reset: 'RESET',
-        },
-        viewColumns: {
-            title: 'Show Columns',
-            titleAria: 'Show/Hide Table Columns',
-        },
-        selectedRows: {
-            text: 'rows(s) selected',
-            delete: 'Delete',
-            deleteAria: 'Delete Selected Rows',
-        }
-    }
-};
-
-class MuiDataTable extends React.Component {
     render() {
-        return (
-            <MUIDataTable
-                title='MUI Data Table'
-                data={dataSimple}
-                columns={columnWithOptions}
-                options={options}
-            />
-        );
+        return (<MUIDataTable title={this.props.title} data={this.data} columns={this.columns} options={this.TableOptions}/>);
     }
 }
 
-<MuiDataTable/>;
+const TableFruits = [
+    {id: 1, name: "Apple", amount: 1},
+    {id: 2, name: "Pear", amount: 2},
+    {id: 3, name: "Strawberry", amount: 5},
+    {id: 4, name: "Banana", amount: 7},
+    {id: 5, name: "Orange", amount: 9},
+];
+
+<MuiCustomTable title="Awesome Table" data={TableFruits}/>;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -9,7 +9,11 @@ interface Props extends MUIDataTableOptions {
 
 class MuiCustomTable extends React.Component<Props> {
     private readonly data: string[][] = this.props.data.map((asset: any) => Object.values(asset));
-    private readonly columns = [...new Set(this.props.data.map((entry: any) => Object.keys(entry)).flat().map((title: string) => title.toUpperCase()))] as string[];
+    private readonly columns = this.props.data
+                                .map((entry: any) => Object.keys(entry))
+                                .flat()
+                                .map((title: string) => title.toUpperCase())
+                                .filter((element: string, index: number, array: string[]) => array.indexOf(element) === index);
     private readonly TableOptions: MUIDataTableOptions = {
         filterType: 'checkbox',
         responsive: 'scroll',

--- a/types/mui-datatables/tsconfig.json
+++ b/types/mui-datatables/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
+            "es2017.object",
             "es6",
             "dom"
         ],
@@ -16,7 +17,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "downlevelIteration": true,
     },
     "files": [
         "index.d.ts",

--- a/types/mui-datatables/tsconfig.json
+++ b/types/mui-datatables/tsconfig.json
@@ -17,8 +17,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "downlevelIteration": true,
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
- Exported an extra interface to make typing all the translation text labels much easier
- Improved tests to make use of React class props, now the test also represents usage for creating a variable Mui-datatable using React classes

Signed-off-by: Jeroen Claassens <support@favna.xyz>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Marked none of the above because it is purely an internal change that I stumbled upon while implementing the library in a bigger project