### PR TITLE
Fix the generic type of the DraftBlockRenderConfig wrapper for draft-js

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -623,7 +623,7 @@ declare namespace Draft {
 
             interface DraftBlockRenderConfig {
                 element: string;
-                wrapper?: React.ReactElement;
+                wrapper?: React.ReactElement<any>;
             }
 
             class EditorState extends Record {

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Draft.js v0.10.5
-// Project: https://facebook.github.io/draft-js/
+// Project: http://draftjs.org
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 //                 Eelco Lempsink <https://github.com/eelco>
 //                 Yale Cason <https://github.com/ghotiphud>

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -10,6 +10,7 @@
 //                 Ulf Schwekendiek <https://github.com/sulf>
 //                 Pablo Varela <https://github.com/pablopunk>
 //                 Claudio Procida <https://github.com/claudiopro>
+//                 Amen SOUISSI <https://github.com/amensouissi>  
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -620,7 +621,6 @@ declare namespace Draft {
             type BlockMap = Immutable.OrderedMap<string, Draft.Model.ImmutableData.ContentBlock>;
 
             var Record: Immutable.Record.Class;
-
             interface DraftBlockRenderConfig {
                 element: string;
                 wrapper?: React.ReactElement<any>;
@@ -1052,3 +1052,4 @@ export {
     DraftHandleValue,
     DraftInsertionType,
 };
+


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
