### PR TITLE
recharts - Added radius to Bar props. let set up global radius for all dataSets

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -201,7 +201,7 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     className?: string;
     fill?: string;
-    radius?: number | any[];
+    radius?: number | number[];
     layout?: LayoutType;
     xAxisId?: string | number;
     yAxisId?: string | number;

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -201,6 +201,7 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     className?: string;
     fill?: string;
+    radius?: number | any[];
     layout?: LayoutType;
     xAxisId?: string | number;
     yAxisId?: string | number;

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -204,7 +204,7 @@ class Component extends React.Component<{}, ComponentState> {
                     <Bar dataKey="pv" fill="#8884d8">
                         <LabelList dataKey="name" position="insideTop" angle={45}  />
                     </Bar>
-                    <Bar dataKey="uv" fill="#82ca9d">
+                    <Bar dataKey="uv" fill="#82ca9d" radius={[10, 10, 0, 0]}>
                         <LabelList dataKey="uv" position="top" />
                     </Bar>
                     </BarChart>


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codesandbox.io/s/o5l2nw0y1y



