### PR TITLE
ref lib name changed

### DIFF
--- a/types/node/ts3.1/index.d.ts
+++ b/types/node/ts3.1/index.d.ts
@@ -7,7 +7,7 @@
 
 // Reference required types from the default lib:
 /// <reference lib="es2018" />
-/// <reference lib="esnext.asyncIterable" />
+/// <reference lib="esnext.asynciterable" />
 /// <reference lib="esnext.intl" />
 
 // Base definitions for all NodeJS modules that are not specific to any version of TypeScript:

--- a/types/node/v10/ts3.1/index.d.ts
+++ b/types/node/v10/ts3.1/index.d.ts
@@ -7,7 +7,7 @@
 
 // Reference required types from the default lib:
 /// <reference lib="es2018" />
-/// <reference lib="esnext.asyncIterable" />
+/// <reference lib="esnext.asynciterable" />
 /// <reference lib="esnext.intl" />
 
 // Base definitions for all NodeJS modules that are not specific to any version of TypeScript:


### PR DESCRIPTION
Updated ref types
lib.esnext.asynciterable lib name was wrong.
The reason for error is that the I character is not i in all languages.

Example when you use /// <reference lib="esnext.asyncIterable" /> and build your project you will get the following error

node_modules/@types/node/ts3.1/index.d.ts:10:21 - error TS2727: Cannot find lib
definition for 'esnext.asyncıterable'. Did you mean 'esnext.asynciterable'?