### PR TITLE
@types/postman-collection - Fix ItemGroup items to allow items to be ItemGroup<T>

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -154,7 +154,7 @@ export interface ItemGroupDefinition extends PropertyDefinition {
 
 export class ItemGroup<TItem> extends Property<ItemGroupDefinition> {
     auth?: RequestAuth;
-    items: PropertyList<TItem>;
+    items: PropertyList<TItem | ItemGroup<TItem>>;
     events: EventList;
 
     constructor(definition?: ItemGroupDefinition);

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -137,7 +137,7 @@ igDef.event; // $ExpectType EventDefinition[] | undefined
 // ItemGroup Tests
 const ig = new pmCollection.ItemGroup<pmCollection.Certificate>();
 ig.auth; // $ExpectType RequestAuth | undefined
-ig.items; // $ExpectType PropertyList<Certificate>
+ig.items; // $ExpectType PropertyList<Certificate | ItemGroup<Certificate>>
 ig.events; // $ExpectType EventList
 
 ig.authorizeRequestsUsing("string"); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.postmanlabs.com/postman-collection/ItemGroup.html 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
