### PR TITLE
Add types for progress-stream 2.0

### DIFF
--- a/types/progress-stream/index.d.ts
+++ b/types/progress-stream/index.d.ts
@@ -31,12 +31,63 @@ declare namespace progress_stream {
 
     type ProgressListener = (progress: Progress) => void;
 
-    type ProgressStream = stream.Transform & {
-        on(event: "progress", listener: ProgressListener): ProgressStream;
-        on(event: "length", listener: (length: number) => void): ProgressStream;
+    interface ProgressStream extends stream.Transform {
+        on(event: "progress", listener: ProgressListener): this;
+        on(event: "length", listener: (length: number) => void): this;
+        once(event: "progress", listener: ProgressListener): this;
+        once(event: "length", listener: (length: number) => void): this;
         setLength(length: number): void;
         progress(): Progress;
-    };
+
+        // We have to redeclare all on/once overloads from stream.Transform in
+        // order for this ProgressStream interface to extend stream.Transform
+        // correctly. Using an intersection type instead may be an option once
+        // https://github.com/Microsoft/TypeScript/issues/30031 is resolved.
+
+        // stream.Readable events
+
+        /* tslint:disable-next-line adjacent-overload-signatures */
+        on(event: "close", listener: () => void): this;
+        on(event: "data", listener: (chunk: any) => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        on(event: "end", listener: () => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        on(event: "readable", listener: () => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        /* tslint:disable-next-line adjacent-overload-signatures */
+        once(event: "close", listener: () => void): this;
+        once(event: "data", listener: (chunk: any) => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        once(event: "end", listener: () => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        once(event: "readable", listener: () => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+
+        // stream.Writable events
+
+        /* tslint:disable-next-line adjacent-overload-signatures unified-signatures */
+        on(event: "drain", listener: () => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        on(event: "finish", listener: () => void): this;
+        on(event: "pipe", listener: (src: stream.Readable) => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        on(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        /* tslint:disable-next-line adjacent-overload-signatures unified-signatures */
+        once(event: "drain", listener: () => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        once(event: "finish", listener: () => void): this;
+        once(event: "pipe", listener: (src: stream.Readable) => void): this;
+        /* tslint:disable-next-line unified-signatures */
+        once(event: "unpipe", listener: (src: stream.Readable) => void): this;
+
+        // events shared by stream.Readable and stream.Writable
+
+        /* tslint:disable-next-line adjacent-overload-signatures */
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
+        /* tslint:disable-next-line adjacent-overload-signatures */
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
+        /* tslint:enable adjacent-overload-signatures unified-signatures */
+    }
 
     interface Progress {
         percentage: number;

--- a/types/progress-stream/index.d.ts
+++ b/types/progress-stream/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for progress-stream 2.0
+// Project: https://github.com/freeall/progress-stream
+// Definitions by: Mick Dekkers <https://github.com/mickdekkers>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+
+import stream = require("stream");
+export = progress_stream;
+
+declare function progress_stream(
+    options: progress_stream.Options,
+    progressListener: progress_stream.ProgressListener,
+): progress_stream.ProgressStream;
+
+declare function progress_stream(
+    optionsOrProgressListener?:
+        | progress_stream.Options
+        | progress_stream.ProgressListener,
+): progress_stream.ProgressStream;
+
+declare namespace progress_stream {
+    interface Options {
+        time?: number;
+        speed?: number;
+        length?: number;
+        drain?: boolean;
+        transferred?: number;
+    }
+
+    type ProgressListener = (progress: Progress) => void;
+
+    type ProgressStream = stream.Transform & {
+        on(event: "progress", listener: ProgressListener): ProgressStream;
+        on(event: "length", listener: (length: number) => void): ProgressStream;
+        setLength(length: number): void;
+        progress(): Progress;
+    };
+
+    interface Progress {
+        percentage: number;
+        transferred: number;
+        length: number;
+        remaining: number;
+        eta: number;
+        runtime: number;
+        delta: number;
+        speed: number;
+    }
+}

--- a/types/progress-stream/progress-stream-tests.ts
+++ b/types/progress-stream/progress-stream-tests.ts
@@ -1,0 +1,71 @@
+import progress = require("progress-stream");
+import stream = require("stream");
+
+const options: progress.Options = {
+    time: 100,
+    speed: 100,
+    length: 100,
+    drain: true,
+    transferred: 0,
+};
+
+const progressListener = (progress: progress.Progress) => {
+    // $ExpectType number
+    progress.percentage;
+    // $ExpectType number
+    progress.transferred;
+    // $ExpectType number
+    progress.length;
+    // $ExpectType number
+    progress.remaining;
+    // $ExpectType number
+    progress.eta;
+    // $ExpectType number
+    progress.runtime;
+    // $ExpectType number
+    progress.delta;
+    // $ExpectType number
+    progress.speed;
+};
+
+// $ExpectType ProgressStream
+const p = progress();
+
+// $ExpectType ProgressStream
+progress(options);
+
+// $ExpectType ProgressStream
+progress(options, progressListener);
+
+// $ExpectType ProgressStream
+progress(progressListener);
+
+// $ExpectType ProgressStream
+p.on("progress", progressListener);
+
+// $ExpectType ProgressStream
+p.on("length", (length: number) => {});
+
+p.setLength(200); // $ExpectType void
+
+p.progress(); // $ExpectType Progress
+
+// Check if ProgressStream extends stream.Transform correctly
+
+// $ExpectType ProgressStream
+p.on("close", () => {});
+// $ExpectType ProgressStream
+p.on("data", (chunk: any) => {});
+// $ExpectType ProgressStream
+p.on("end", () => {});
+// $ExpectType ProgressStream
+p.on("error", (err: Error) => {});
+// $ExpectType ProgressStream
+p.on("readable", () => {});
+// $ExpectType ProgressStream
+p.pause();
+
+const writable = new stream.Writable();
+
+// $ExpectType Writable
+p.pipe(writable);

--- a/types/progress-stream/tsconfig.json
+++ b/types/progress-stream/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "progress-stream-tests.ts"]
+}

--- a/types/progress-stream/tslint.json
+++ b/types/progress-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
The tests are currently failing, but I'm not sure why. The code compiles fine with TypeScript 3.3.3, and tslint in vscode doesn't report any problems with the definitions or the tests (even after running the "Reload Window" command).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
