### PR TITLE
Mongoose: fix sslValidate type

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -337,7 +337,7 @@ declare module "mongoose" {
     /** Use ssl connection (needs to have a mongod server with ssl support) (default: true) */
     ssl?: boolean;
     /** Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher) */
-    sslValidate?: object;
+    sslValidate?: boolean;
     /** Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons. */
     poolSize?: number;
     /** Reconnect on error (default: true) */


### PR DESCRIPTION
In the MongoDB node client documentation, option sslValidate is defined as a boolean (http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html) whereas in the type package it is typed as an object.

Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html
