### PR TITLE
Add declaration of isEqual() method to pkijs 's RelativeDistinguishedNames class

### DIFF
--- a/types/pkijs/index.d.ts
+++ b/types/pkijs/index.d.ts
@@ -1908,6 +1908,12 @@ declare module "pkijs/src/RelativeDistinguishedNames" {
         fromSchema(schema: any): void;
         toSchema(): any;
         toJSON(): any;
+        /**
+         * Compare two RDN values, or RDN with ArrayBuffer value
+         * @param {(RelativeDistinguishedNames|ArrayBuffer)} compareTo The value compare to current
+         * @returns {boolean}
+         */
+        isEqual(compareTo: RelativeDistinguishedNames|ArrayBuffer): boolean;
     }
 
 }

--- a/types/pkijs/pkijs-tests.ts
+++ b/types/pkijs/pkijs-tests.ts
@@ -12,6 +12,8 @@ import SignerInfo from "pkijs/src/SignerInfo";
 import IssuerAndSerialNumber from "pkijs/src/IssuerAndSerialNumber";
 import SignedAndUnsignedAttributes from "pkijs/src/SignedAndUnsignedAttributes";
 import ContentInfo from "pkijs/src/ContentInfo";
+import RelativeDistinguishedNames from "pkijs/src/RelativeDistinguishedNames";
+
 // *********************************************************************************
 let cmsSignedBuffer = new ArrayBuffer(0); // ArrayBuffer with loaded or created CMS_Signed
 const trustedCertificates: Certificate[] = []; // Array of root certificates from "CA Bundle"
@@ -657,4 +659,14 @@ function handleCABundle(evt: Event) {
         event => parseCAbundle((event.target as any).result);
 
     tempReader.readAsArrayBuffer(currentFiles[0]);
+}
+
+function typetest_RelativeDN_isEqual() {
+
+    const rdn1 = new RelativeDistinguishedNames();
+    const rdn2 = new RelativeDistinguishedNames();
+    const arraybuf = new ArrayBuffer(1);
+
+    rdn1.isEqual(rdn2); // $ExpectType boolean
+    rdn1.isEqual(arraybuf); // $ExpectType boolean
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/PeculiarVentures/PKI.js/blob/master/src/RelativeDistinguishedNames.js>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

It looks like this method was missed when the file was first produced, but it's simple enough to add.. The doc string came straight from the Js source code. (linked)

As far as I can tell this method as been in the class since V2 of the pkijs when it was updated to ES6 (in 2017). 