### PR TITLE
[rc-slider] Add tabIndex to Handle props

### DIFF
--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -6,6 +6,7 @@
 //                 Jacob Froman <https://github.com/j-fro>
 //                 Deanna Veale <https://github.com/Deanna2>
 //                 Nick Maddren <https://github.com/nicholasmaddren>
+//                 Roman Nevolin <https://github.com/nulladdict>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -204,6 +205,11 @@ export interface HandleProps extends CommonApiProps {
      * Styling option offset
      */
     offset: number;
+   /**
+    * Set the tabIndex of the slider handle.
+    * @default 0
+    */
+    tabIndex?: number;
 }
 
 export interface WithTooltipProps {

--- a/types/rc-slider/rc-slider-tests.tsx
+++ b/types/rc-slider/rc-slider-tests.tsx
@@ -15,6 +15,7 @@ ReactDOM.render(
         className="bottom"
         vertical={true}
         offset={10}
+        tabIndex={-1}
     />,
     document.querySelector('.another-app')
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Handle.jsx source code](https://github.com/react-component/slider/blob/master/src/Handle.jsx#L60)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

According to the source code Handle accepts `tabIndex` props, but typings for it are missing, this pr fixes that