### PR TITLE
[@types/luxon] Add possible null interval intersection result

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -426,7 +426,7 @@ export class Interval {
     engulfs(other: Interval): boolean;
     equals(other: Interval): boolean;
     hasSame(unit: DurationUnit): boolean;
-    intersection(other: Interval): Interval;
+    intersection(other: Interval): Interval | null;
     isAfter(dateTime: DateTime): boolean;
     isBefore(dateTime: DateTime): boolean;
     isEmpty(): boolean;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -140,6 +140,7 @@ i.length('years'); // $ExpectType number
 i.contains(DateTime.local(2019)); // $ExpectType boolean
 i.set({end: DateTime.local(2020)}); // $ExpectType Interval
 i.mapEndpoints((d) => d); // $ExpectType Interval
+i.intersection(i); // $ExpectType Interval | null
 
 i.toISO(); // $ExpectType string
 i.toString(); // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/4c4f9021362432e1406a3a147a916122b676affb/src/interval.js#L405
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`a.intersection(b)` for `Interval`s `a` and `b` will return `null` if `a` and `b` do not overlap. This adds `null` to the method's possible return types.