### PR TITLE
jasmine-data_driven_tests - added missing typing for single array argument data

### DIFF
--- a/types/jasmine-data_driven_tests/index.d.ts
+++ b/types/jasmine-data_driven_tests/index.d.ts
@@ -34,6 +34,6 @@ interface JasmineDataDrivenTest {
         assertion: (arg0: T, arg1: U, done: () => void) => void): void;
     <T>(
         description: string,
-        dataset: T[],
+        dataset: T[] | Array<[T]>,
         assertion: (value: T, done: () => void) => void): void;
 }

--- a/types/jasmine-data_driven_tests/jasmine-data_driven_tests-tests.ts
+++ b/types/jasmine-data_driven_tests/jasmine-data_driven_tests-tests.ts
@@ -37,6 +37,13 @@ xall("A data driven test can be pending",
     }
 );
 
+all("A data set must consist of array-wrapped arrays, if test expects single array input",
+    [[[1, 2]], [[3, 4]], [[5, 6]]],
+    (numberArray: number[]) => {
+        expect(numberArray.length).toBe(2);
+    }
+);
+
 describe("A suite", () => {
     let a: number;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dakolech/jasmine-data_driven_tests/blob/master/src/all.js#L78 <- when there is a single array argument, it is considered to be array of arguments
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.