### PR TITLE
Add types for npm-registry-package-info

### DIFF
--- a/types/npm-registry-package-info/index.d.ts
+++ b/types/npm-registry-package-info/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for npm-registry-package-info 1.0
+// Project: https://github.com/kgryte/npm-registry-package-info#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace pkginfo {
+    interface Options {
+        /** Boolean indicating whether to return only the latest package information from a registry. */
+        latest?: boolean;
+        /** Array of package names (required). */
+        packages: string[];
+        /** Registry port. Default: 443 (HTTPS) or 80 (HTTP). */
+        port?: number;
+        /** Registry protocol. Default: 'https'. */
+        protocol?: 'http' | 'https';
+        /** Registry. Default: 'registry.npmjs.org'. */
+        registry?: string;
+    }
+
+    interface Data {
+        data: any;
+        meta: {
+            failure: number;
+            success: number;
+            total: number;
+        };
+    }
+
+    type Callback = (error: Error | null, data: Data) => void;
+
+    function factory(opts: Options, callback: Callback): () => void;
+}
+
+declare function pkginfo(opts: pkginfo.Options, callback: pkginfo.Callback): void;
+
+export = pkginfo;

--- a/types/npm-registry-package-info/npm-registry-package-info-tests.ts
+++ b/types/npm-registry-package-info/npm-registry-package-info-tests.ts
@@ -1,0 +1,21 @@
+import pkginfo = require('npm-registry-package-info');
+
+const opts: pkginfo.Options = {
+    latest: true,
+    packages: ['dstructs-array', 'flow-map', 'utils-merge2'],
+    port: 80,
+    protocol: 'http',
+    registry: 'my.favorite.npm/registry',
+};
+
+pkginfo(opts, (error, data) => {
+  data;  // $ExpectType Data
+});
+
+const pkgs = ['dstructs-matrix', 'compute-stdev', 'compute-variance'];
+
+const get = pkginfo.factory({ packages: pkgs }, (error, data) => {
+  data;  // $ExpectType Data
+});
+
+get();

--- a/types/npm-registry-package-info/tsconfig.json
+++ b/types/npm-registry-package-info/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "npm-registry-package-info-tests.ts"
+    ]
+}

--- a/types/npm-registry-package-info/tslint.json
+++ b/types/npm-registry-package-info/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
