### PR TITLE
[@types/rebass] Allow strings for SpaceProps and some BoxProps properties

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -33,8 +33,8 @@ export interface SpaceProps<C> extends BaseProps<C> {
 
 export interface BoxProps extends SpaceProps<BoxClass> {
     className?: string;
-    width?: number | string | ReadonlyArray<number>;
-    fontSize?: number | ReadonlyArray<number>;
+    width?: number | string | ReadonlyArray<number | string>;
+    fontSize?: number | string | ReadonlyArray<number | string>;
     css?: object;
     color?: string;
     bg?: string;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -15,20 +15,20 @@ export interface BaseProps<C> extends React.ClassAttributes<C> {
 }
 
 export interface SpaceProps<C> extends BaseProps<C> {
-    m?: number | string | ReadonlyArray<number>;
-    mt?: number | string | ReadonlyArray<number>;
-    mr?: number | string | ReadonlyArray<number>;
-    mb?: number | string | ReadonlyArray<number>;
-    ml?: number | string | ReadonlyArray<number>;
-    mx?: number | string | ReadonlyArray<number>;
-    my?: number | string | ReadonlyArray<number>;
-    p?: number | string | ReadonlyArray<number>;
-    pt?: number | string | ReadonlyArray<number>;
-    pr?: number | string | ReadonlyArray<number>;
-    pb?: number | string | ReadonlyArray<number>;
-    pl?: number | string | ReadonlyArray<number>;
-    px?: number | string | ReadonlyArray<number>;
-    py?: number | string | ReadonlyArray<number>;
+    m?: number | string | ReadonlyArray<number | string>;
+    mt?: number | string | ReadonlyArray<number | string>;
+    mr?: number | string | ReadonlyArray<number | string>;
+    mb?: number | string | ReadonlyArray<number | string>;
+    ml?: number | string | ReadonlyArray<number | string>;
+    mx?: number | string | ReadonlyArray<number | string>;
+    my?: number | string | ReadonlyArray<number | string>;
+    p?: number | string | ReadonlyArray<number | string>;
+    pt?: number | string | ReadonlyArray<number | string>;
+    pr?: number | string | ReadonlyArray<number | string>;
+    pb?: number | string | ReadonlyArray<number | string>;
+    pl?: number | string | ReadonlyArray<number | string>;
+    px?: number | string | ReadonlyArray<number | string>;
+    py?: number | string | ReadonlyArray<number | string>;
 }
 
 export interface BoxProps extends SpaceProps<BoxClass> {

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for Rebass 3.0
-// Project: https://github.com/jxnblk/rebass
+// Type definitions for Rebass 3.1
+// Project: https://github.com/rebassjs/rebass
 // Definitions by: rhysd <https://github.com/rhysd>
 //                 ryee-dev <https://github.com/ryee-dev>
 //                 jamesmckenzie <https://github.com/jamesmckenzie>


### PR DESCRIPTION
This PR is to add types to rebass for the SpaceProps and updating the allowable types for some BoxProps properties. This is a key thing that I'm working on that is not supported by @types/rebass but it allowed in rebass itself.

(Also, tried running both `npm run line rebass` and `tsc` in the types/rebass directory, but am chasing a never ending trail of errors [`Cannot find module 'csstype', 'Unexpected token  } in JSON...', all unrelated to rebass or the changes made here. 🤷🏻‍♂️])

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [n/a] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

[spacing](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space)
[width](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#width)
[fontSize](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#fontsize)

- [x] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
