### PR TITLE
Fix browser.storage.onChange parameters

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -3188,7 +3188,7 @@ declare namespace browser.storage {
      * @param changes Object mapping each key that changed to its corresponding `storage.StorageChange` for that item.
      * @param areaName The name of the storage area (`"sync"`, `"local"` or `"managed"`) the changes are for.
      */
-    const onChanged: WebExtEvent<(changes: StorageChange, areaName: string) => void>;
+    const onChanged: WebExtEvent<(changes: {[key: string]: StorageChange}, areaName: string) => void>;
 }
 
 /**


### PR DESCRIPTION
The changes parameter is an object that maps the name of a changed parameter to its StorageChange.
Refer to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged#Parameters

I have tested this in my own code, and it works nicely.
I have not updated the existing testcases. They are basically just a placeholder and don't test anything.
Covering my small contribution would mean setting up a proper suite in the first place, which is non-trivial.

Please fill in this template.

- [ X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [O ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ X (deemed not appropriate)] Increase the version number in the header if appropriate.
- [ X (no substantial changes)] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.