### PR TITLE
[react-draft-wysiwyg] Fix `onContentStateChange` prop type

### DIFF
--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jpuri/react-draft-wysiwyg#readme
 // Definitions by: imechZhangLY <https://github.com/imechZhangLY>
 //                 brunoMaurice <https://github.com/brunoMaurice>
+//                 ldanet <https://github.com/ldanet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -20,7 +21,7 @@ export class SelectionState extends Draft.SelectionState {}
 export interface EditorProps {
     onChange?(contentState: ContentState): RawDraftContentState;
     onEditorStateChange?(editorState: EditorState): void;
-    onContentStateChange?(contentState: ContentState): RawDraftContentState;
+    onContentStateChange?(contentState: RawDraftContentState): void;
     initialContentState?: RawDraftContentState;
     defaultContentState?: RawDraftContentState;
     contentState?: RawDraftContentState;

--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -19,7 +19,7 @@ export class ContentBlock extends Draft.ContentBlock {}
 export class SelectionState extends Draft.SelectionState {}
 
 export interface EditorProps {
-    onChange?(contentState: ContentState): RawDraftContentState;
+    onChange?(contentState: RawDraftContentState): void;
     onEditorStateChange?(editorState: EditorState): void;
     onContentStateChange?(contentState: RawDraftContentState): void;
     initialContentState?: RawDraftContentState;

--- a/types/react-draft-wysiwyg/test/uncontrolled-raw-draft-content-state.tsx
+++ b/types/react-draft-wysiwyg/test/uncontrolled-raw-draft-content-state.tsx
@@ -1,0 +1,48 @@
+// From https://github.com/jpuri/react-draft-wysiwyg/blob/master/docs/src/components/Docs/Props/EditorStateProp/index.js#L125
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { Editor, RawDraftContentState } from "react-draft-wysiwyg";
+
+class UncontrolledEditor extends React.Component<
+    {},
+    { contentState: RawDraftContentState }
+> {
+    constructor(props: any) {
+        super(props);
+        this.state = {
+            contentState: JSON.parse(`{
+                "entityMap":{},
+                "blocks":[{
+                    "key":"1ljs",
+                    "text":"Initializing from content state",
+                    "type":"unstyled",
+                    "depth":0,
+                    "inlineStyleRanges":[],
+                    "entityRanges":[],
+                    "data":{}
+                }]
+            }`)
+        };
+    }
+
+    onContentStateChange = (contentState: RawDraftContentState) => {
+        this.setState({
+            contentState
+        });
+    }
+
+    render() {
+        const { contentState } = this.state;
+        return (
+            <Editor
+                initialContentState={contentState}
+                wrapperClassName="demo-wrapper"
+                editorClassName="demo-editor"
+                onContentStateChange={this.onContentStateChange}
+            />
+        );
+    }
+}
+
+ReactDOM.render(<UncontrolledEditor />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/tsconfig.json
+++ b/types/react-draft-wysiwyg/tsconfig.json
@@ -24,6 +24,7 @@
         "test/basic-controlled-tests.tsx",
         "test/basic-tests.tsx",
         "test/custom-toolbar-tests.tsx",
-        "test/focus-blur-callbacks-tests.tsx"
+        "test/focus-blur-callbacks-tests.tsx",
+        "test/uncontrolled-raw-draft-content-state.tsx"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://jpuri.github.io/react-draft-wysiwyg/#/docs (Under Properties > Editor State > bullet point 7.)
- [x] ~Increase the version number in the header if appropriate.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

----

According to the docs ( https://jpuri.github.io/react-draft-wysiwyg/#/docs under Properties > Editor State > bullet point 7. )

>onContentStateChange: Function is called each time there is change in state of editor, function argument passed is object of type RawDraftContentState.

the argument passed to this function prop is of type `RawDraftContentState` and not `ContentState`. I could verify at runtime by logging it that the object indeed matches the [`RawDraftContentState`](https://github.com/facebook/draft-js/blob/master/src/model/encoding/RawDraftContentState.js).
According to its usage example, it shouldn't return anything.

