### PR TITLE
[node] fix forward declaration of SharedArrayBuffer

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -54,6 +54,9 @@
 // TypeScript 2.1-specific augmentations:
 
 // Forward-declarations for needed types from es2015 and later (in case users are using `--lib es5`)
+// Empty interfaces are used here which merge fine with the real declarations in the lib XXX files
+// just to ensure the names are known and node typings can be sued without importing these libs.
+// if someone really needs these types the libs need to be added via --lib or in tsconfig.json
 interface MapConstructor { }
 interface WeakMapConstructor { }
 interface SetConstructor { }
@@ -72,8 +75,9 @@ interface SymbolConstructor {
     readonly asyncIterator: symbol;
 }
 declare var Symbol: SymbolConstructor;
-declare class SharedArrayBuffer {
-    constructor(byteSize: number);
+// even this is just a forward declaration some properties are added otherwise
+// it would be allowed to pass anything to e.g. Buffer.from()
+interface SharedArrayBuffer {
     readonly byteLength: number;
     slice(begin?: number, end?: number): SharedArrayBuffer;
 }

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -38,7 +38,8 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
     const arrUint8: Uint8Array = new Uint8Array(2);
     const buf5: Buffer = Buffer.from(arrUint8);
     const buf6: Buffer = Buffer.from(buf1);
-    const buf7: Buffer = Buffer.from(new SharedArrayBuffer(123));
+    const sb: SharedArrayBuffer = {} as any;
+    const buf7: Buffer = Buffer.from(sb);
 }
 
 // Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: no functional change
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No functional change, only correct the forward declaration of `SharedArrayBuffer` to an `interface` as a `class` does not merge.

see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342#issuecomment-464442017 and below for more details

refs: #32878