### PR TITLE
googlemaps - all fields except "name" optional in PlaceResult

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -124,7 +124,7 @@ data.setStyle({
     cursor: "pointer",
     fillColor: "#79B55B",
     fillOpacity: 1,
-    icon: <google.maps.Icon>{ url: "//maps.google.com/mapfiles/ms/icons/blue.png" },
+    icon: { url: "//maps.google.com/mapfiles/ms/icons/blue.png" } as google.maps.Icon,
     shape: { coords: [1, 2, 3], type: "circle" },
     strokeColor: "#79B55B",
     strokeOpacity: 1,
@@ -449,3 +449,8 @@ service.findPlaceFromPhoneNumber({
 
     results[0].name; // $ExpectType string
 });
+
+/***** google.maps.places.Autocomplete *****/
+const autocomplete = new google.maps.places.Autocomplete(document.createElement('input'));
+const placeResult = autocomplete.getPlace();
+placeResult.name; // $ExpectType string

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -11,6 +11,7 @@
 //                  Sven Kreiss <https://github.com/svenkreiss>
 //                  Umar Bolatov <https://github.com/bolatovumar>
 //                  Michael Gauthier <https://github.com/gauthierm>
+//                  Colin Doig <https://github.com/captain-igloo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*
@@ -2726,29 +2727,29 @@ declare namespace google.maps {
     }
 
     export interface PlaceResult {
-      address_components: GeocoderAddressComponent[];
-      adr_address: string;
-      aspects: PlaceAspectRating[];
-      formatted_address: string;
-      formatted_phone_number: string;
-      geometry: PlaceGeometry;
-      html_attributions: string[];
-      icon: string;
-      id: string;
-      international_phone_number: string;
+      address_components?: GeocoderAddressComponent[];
+      adr_address?: string;
+      aspects?: PlaceAspectRating[];
+      formatted_address?: string;
+      formatted_phone_number?: string;
+      geometry?: PlaceGeometry;
+      html_attributions?: string[];
+      icon?: string;
+      id?: string;
+      international_phone_number?: string;
       name: string;
-      opening_hours: OpeningHours;
-      permanently_closed: boolean;
-      photos: PlacePhoto[];
-      place_id: string;
-      price_level: number;
-      rating: number;
-      reviews: PlaceReview[];
-      types: string[];
-      url: string;
-      utc_offset: number;
-      vicinity: string;
-      website: string;
+      opening_hours?: OpeningHours;
+      permanently_closed?: boolean;
+      photos?: PlacePhoto[];
+      place_id?: string;
+      price_level?: number;
+      rating?: number;
+      reviews?: PlaceReview[];
+      types?: string[];
+      url?: string;
+      utc_offset?: number;
+      vicinity?: string;
+      website?: string;
     }
 
     export interface PlaceReview {


### PR DESCRIPTION
Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If you type an address that doesn't exist into a google maps autocomplete and press enter, the PlaceResult has only "name" populated.