### PR TITLE
react-lazyload: Improve typing of children

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Component } from "react";
+import { Component, ReactNode } from "react";
 
 export interface LazyLoadProps {
     once?: boolean;
@@ -13,7 +13,7 @@ export interface LazyLoadProps {
     overflow?: boolean;
     resize?: boolean;
     scroll?: boolean;
-    children?: JSX.Element;
+    children?: ReactNode;
     throttle?: number | boolean;
     debounce?: number | boolean;
     placeholder?: any;

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -16,7 +16,7 @@ export interface LazyLoadProps {
     children?: ReactNode;
     throttle?: number | boolean;
     debounce?: number | boolean;
-    placeholder?: any;
+    placeholder?: ReactNode;
     unmountIfInvisible?: boolean;
 }
 


### PR DESCRIPTION
`JSX.Element` is too restrictive as a type for children. Lazyload checks the scroll position and decides to [`render()` either `children` as is, or `placeholder` as is (or render its internally defined placeholder)](https://github.com/twobin/react-lazyload/blob/master/src/index.jsx#L271). [The `render()` function can return many more things than just a `JSX.Element`](https://reactjs.org/docs/react-component.html#render), and according to the React type definitions, [the return type of the `render()` function is `ReactNode`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L418) (which conveniently matches the default type for `children`).

---
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-component.html#render
- [X] ~Increase the version number in the header if appropriate.~
- [X] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

