### PR TITLE
[enzyme] Add renderProp() function

### DIFF
--- a/types/chai-enzyme/index.d.ts
+++ b/types/chai-enzyme/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for chai-enzyme 0.6.1
 // Project: https://github.com/producthunt/chai-enzyme
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
-//                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/chai-enzyme/index.d.ts
+++ b/types/chai-enzyme/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for chai-enzyme 0.6.1
 // Project: https://github.com/producthunt/chai-enzyme
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 
 /// <reference types="enzyme" />

--- a/types/commercetools__enzyme-extensions/index.d.ts
+++ b/types/commercetools__enzyme-extensions/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/commercetools/enzyme-extensions
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import * as enzyme from 'enzyme';
 

--- a/types/enzyme-adapter-react-15.4/index.d.ts
+++ b/types/enzyme-adapter-react-15.4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://airbnb.io/enzyme/
 // Definitions by: Nabeelah Ali <https://github.com/nali>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-adapter-react-15/index.d.ts
+++ b/types/enzyme-adapter-react-15/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/enzyme, http://airbnb.io/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/enzyme, http://airbnb.io/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-async-helpers/index.d.ts
+++ b/types/enzyme-async-helpers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zth/enzyme-async-helpers
 // Definitions by: Kim Ehrenpohl <https://github.com/kimehrenpohl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { ReactWrapper, EnzymeSelector } from 'enzyme';
 

--- a/types/enzyme-redux/index.d.ts
+++ b/types/enzyme-redux/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Knegusen/enzyme-redux#readme
 // Definitions by: Dennis Axelsson <https://github.com/knegusen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { ReactWrapper, ShallowWrapper } from 'enzyme';
 import { ReactElement } from 'react';

--- a/types/enzyme-to-json/index.d.ts
+++ b/types/enzyme-to-json/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/adriantoine/enzyme-to-json#readme
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { ReactWrapper, ShallowWrapper } from 'enzyme';
 

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -10,7 +10,7 @@ import {
     ShallowRendererProps,
     ComponentClass as EnzymeComponentClass
 } from "enzyme";
-import { Component, ReactElement, HTMLAttributes, ComponentClass, StatelessComponent } from "react";
+import { Component, ReactElement, ReactNode, HTMLAttributes, ComponentClass, StatelessComponent } from "react";
 
 // Help classes/interfaces
 interface MyComponentProps {
@@ -33,6 +33,10 @@ interface AnotherStatelessProps {
 
 interface MyComponentState {
     stateProperty: string;
+}
+
+interface MyRenderPropProps {
+    children: (params: string) => ReactNode;
 }
 
 function toComponentType<T>(Component: ComponentClass<T> | StatelessComponent<T>): ComponentClass<T> | StatelessComponent<T> {
@@ -58,6 +62,8 @@ class AnotherComponent extends Component<AnotherComponentProps> {
         console.log(args);
     }
 }
+
+class MyRenderPropComponent extends Component<MyRenderPropProps> {}
 
 const MyStatelessComponent = (props: StatelessProps) => <span />;
 
@@ -476,6 +482,11 @@ function ShallowWrapperTest() {
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper);
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, undefined, { lifecycleExperimental: true });
         shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper, { lifecycleExperimental: true });
+    }
+
+    function test_renderProp() {
+        let shallowWrapper = new ShallowWrapper<MyRenderPropProps>(<MyRenderPropComponent children={(params) => <div className={params} />} />);
+        shallowWrapper = shallowWrapper.renderProp('children')('test');
     }
 }
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -364,6 +364,8 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     length: number;
 }
 
+type Parameters<T> = T extends (...args: infer A) => any ? A : never
+
 // tslint:disable-next-line no-empty-interface
 export interface ShallowWrapper<P = {}, S = {}, C = Component> extends CommonWrapper<P, S, C> { }
 export class ShallowWrapper<P = {}, S = {}, C = Component> {
@@ -452,7 +454,7 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
     /**
      * Returns a wrapper of the node rendered by the provided render prop.
      */
-    renderProp<PropName extends keyof P>(prop: PropName): (...params: any[]) => ShallowWrapper<P, S>;
+    renderProp<PropName extends keyof P>(prop: PropName): (...params: Parameters<P[PropName]>) => ShallowWrapper<any, never>;
 }
 
 // tslint:disable-next-line no-empty-interface

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -364,7 +364,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     length: number;
 }
 
-type Parameters<T> = T extends (...args: infer A) => any ? A : never
+export type Parameters<T> = T extends (...args: infer A) => any ? A : never;
 
 // tslint:disable-next-line no-empty-interface
 export interface ShallowWrapper<P = {}, S = {}, C = Component> extends CommonWrapper<P, S, C> { }

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -10,7 +10,7 @@
 //                 Martin Hochel <https://github.com/hotell>
 //                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /// <reference types="cheerio" />
 import { ReactElement, Component, AllHTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Enzyme 3.1
+// Type definitions for Enzyme 3.9
 // Project: https://github.com/airbnb/enzyme
 // Definitions by: Marian Palkus <https://github.com/MarianPalkus>
 //                 Cap3 <http://www.cap3.de>
@@ -8,6 +8,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Torgeir Hovden <https://github.com/thovden>
 //                 Martin Hochel <https://github.com/hotell>
+//                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -447,6 +448,11 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * Returns a wrapper with the direct parent of the node in the current wrapper.
      */
     parent(): ShallowWrapper<any, any>;
+
+    /**
+     * Returns a wrapper of the node rendered by the provided render prop.
+     */
+    renderProp<PropName extends keyof P>(prop: PropName): (...params: any[]) => ShallowWrapper<P, S>;
 }
 
 // tslint:disable-next-line no-empty-interface

--- a/types/jasmine-enzyme/index.d.ts
+++ b/types/jasmine-enzyme/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/formidablelabs/enzyme-matchers/packages/jasmine-enzyme
 // Definitions by: Umar Bolatov <https://github.com/bolatovumar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /// <reference types="jasmine" />
 /// <reference types="react" />

--- a/types/jest-specific-snapshot/index.d.ts
+++ b/types/jest-specific-snapshot/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/igor-dv/jest-specific-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook/tree/master/addons/storyshots, https://github.com/storybooks/storybook/tree/master/addons/storyshorts/storyshots-core
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 import * as React from 'react';
 import { StoryObject } from '@storybook/react';


### PR DESCRIPTION
I know there was already a pull request https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32963/ for that but	unfortunately the `Parameters` suggestion is only available in TypeScript 3.1 and not in 2.8. Any help how to solve this in 2.8 would be welcome ☺️ 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/renderProp.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.