### PR TITLE
Add new property 'controlSize' for googlemaps

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -4,6 +4,7 @@ let mapOptions: google.maps.MapOptions = {
     backgroundColor: "#fff",
     center: { lat: -25.363, lng: 131.044 },
     clickableIcons: true,
+    controlSize: 30,
     draggable: true,
     fullscreenControl: true,
     fullscreenControlOptions: {

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -93,6 +93,14 @@ declare namespace google.maps {
      * interest, also known as a POI. By default map icons are clickable.
      */
     clickableIcons?: boolean
+    /**
+     * Size in pixels of the controls appearing on the map. This value must be
+     * supplied directly when creating the Map, updating this value later may
+     * bring the controls into an undefined state. Only governs the controls
+     * made by the Maps API itself. Does not scale developer created custom
+     * controls.
+     */
+    controlSize?: number;
     /** Enables/disables all default UI. May be overridden individually. */
     disableDefaultUI?: boolean;
     /** Enables/disables zoom and center on double click. Enabled by default. */


### PR DESCRIPTION
They've added a new property to specify the size of the controls in a map: https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.controlSize
