### PR TITLE
Fixing failing no-inferred-empty-object-type

### DIFF
--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -13,7 +13,7 @@ declare namespace TransitionGroup {
     type TransitionGroupProps<T extends keyof JSX.IntrinsicElements = "div", V extends ReactType = any> =
         (IntrinsicTransitionGroupProps<T> & JSX.IntrinsicElements[T]) | (ComponentTransitionGroupProps<V>) & {
         children?: ReactElement<TransitionProps> | Array<ReactElement<TransitionProps>>;
-        childFactory?(child: ReactElement): ReactElement;
+        childFactory?(child: ReactElement<any>): ReactElement<any>;
         [prop: string]: any;
     };
 }


### PR DESCRIPTION
Fixing failing `no-inferred-empty-object-type` for all the CRA users

Please fill in this template.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://palantir.github.io/tslint/rules/no-inferred-empty-object-type/

`no-inferred-empty-object-type` started working recently, there were plethora of bugs regarding this rule not working, so it's probably why it used to pass tslint check
