### PR TITLE
@types/chromecast-caf-receiver - Update MediaInformation definition

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1441,6 +1441,12 @@ export interface MediaInformation {
      * The media tracks.
      */
     tracks?: Track[];
+
+    /**
+     * VMAP ad request configuration. Used if breaks and breakClips are not
+     * provided.
+     */
+    vmapAdsRequest?: VastAdsRequest;
 }
 
 /**


### PR DESCRIPTION
Add missing optional vmapAdsRequest field to MediaInformation definition.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.MediaInformation>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

