### PR TITLE
[react-albus] convert exports as classes instead of consts

### DIFF
--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -6,8 +6,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import { History } from "history";
+import * as React from 'react';
+import { History } from 'history';
 
 export interface StepObject {
     id: string;
@@ -39,17 +39,18 @@ export interface WizardProps {
     basename?: string;
 }
 
-export const Wizard: React.ComponentType<WizardProps>;
+export class Wizard extends React.Component<WizardProps, any> {}
 
 export interface StepsProps {
     step?: StepObject;
 }
 
-export const Steps: React.ComponentType<StepsProps>;
+export class Steps extends React.Component<StepsProps, any> {}
 
-export type StepProps = StepObject & (
-    | { render?: (wizard: WizardContext) => React.ReactNode }
-    | { children: (wizard: WizardContext) => React.ReactNode });
+export type StepProps = StepObject &
+    (
+        | { render?: (wizard: WizardContext) => React.ReactNode }
+        | { children: (wizard: WizardContext) => React.ReactNode });
 
 /**
  * In addition to id, any additional props added to <Step> will be available on each step object.
@@ -62,4 +63,4 @@ export type StepProps = StepObject & (
  *   }
  * }
  */
-export const Step: React.ComponentType<StepProps>;
+export class Step extends React.Component<StepProps, any> {}


### PR DESCRIPTION
Context for change:
In our app, we're altering the original render method from Steps. The changes allow extension of a class to be valid.

```
import { Steps as AlbusSteps } from 'react-albus';

class Steps extends AlbusSteps {
  public render() {
    return this.props.children;
  }
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
