### PR TITLE
@type/node: Make cipher optional on private key options

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -401,8 +401,8 @@ declare module "crypto" {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher: string;
-        passphrase: string;
+        cipher?: string;
+        passphrase?: string;
     }
 
     interface RSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {

--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -258,8 +258,8 @@ declare module "crypto" {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher: string;
-        passphrase: string;
+        cipher?: string;
+        passphrase?: string;
     }
 
     interface RSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {


### PR DESCRIPTION
According to https://nodejs.org/api/crypto.html#crypto_keyobject_export_options, the cipher may or may not be specified. If no cipher is specified, a passphrase should not have to be specified either.