### PR TITLE
imap-simple: sync description format of search()

### DIFF
--- a/types/imap-simple/index.d.ts
+++ b/types/imap-simple/index.d.ts
@@ -55,7 +55,7 @@ export class ImapSimple extends NodeJS.EventEmitter {
     getBoxes(callback: (err: Error, boxes: Imap.MailBoxes) => void): void;
     getBoxes(): Promise<Imap.MailBoxes>;
 
-    /** Search for and retrieve mail in the previously opened mailbox. */
+    /** Search for and retrieve mail in the currently open mailbox. */
     search(searchCriteria: any[], fetchOptions: Imap.FetchOptions, callback: (err: Error, messages: Message[]) => void): void;
     search(searchCriteria: any[], fetchOptions: Imap.FetchOptions): Promise<Message[]>;
 


### PR DESCRIPTION
The description of the `search()` method uses the phrase "in the previously opened mailbox", which is inconsistent with what's used in `onmail()`, `append()` and `moveMessage()`, i.e. "in the currently open mailbox". This change rewords the first passage to match the other ones.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).