### PR TITLE
[yeoman-generator] Add missing args to MemFsEditor.copy

### DIFF
--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for yeoman-generator 3.0
+// Type definitions for yeoman-generator 3.1
 // Project: https://github.com/yeoman/generator, http://yeoman.io
 // Definitions by: Kentaro Okuno <https://github.com/armorik83>
 //                 Jay Anslow <https://github.com/janslow>
 //                 Ika <https://github.com/ikatyang>
 //                 Joshua Cherry <https://github.com/tasadar2>
+//                 Arthur Corenzan <https://github.com/haggen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -71,7 +72,7 @@ declare namespace Generator {
         writeJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
         extendJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
         delete(filepath: string, options?: {}): void;
-        copy(from: string, to: string, options?: {}): void;
+        copy(from: string, to: string, options?: {}, context?: {}, templateOptions?: {}): void;
         copyTpl(from: string, to: string, context: {}, templateOptions?: {}, copyOptions?: {}): void;
         move(from: string, to: string, options?: {}): void;
         exists(filepath: string): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SBoudrias/mem-fs-editor/blob/ce60ee57db563aa52a2d9ffddc690295e062810c/lib/actions/copy.js#L18
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
