### PR TITLE
[prop-types] add elementType and resetWarningCache

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for prop-types 15.5
+// Type definitions for prop-types 15.7
 // Project: https://github.com/reactjs/prop-types, https://facebook.github.io/react
 // Definitions by: DovydasNavickas <https://github.com/DovydasNavickas>
 //                 Ferdy Budhidharma <https://github.com/ferdaber>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -62,6 +63,7 @@ export const string: Requireable<string>;
 export const node: Requireable<ReactNodeLike>;
 export const element: Requireable<ReactElementLike>;
 export const symbol: Requireable<symbol>;
+export const elementType: Requireable<ReactComponentLike>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
 export function oneOf<T>(types: T[]): Requireable<T>;
 export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
@@ -81,3 +83,8 @@ export function exact<P extends ValidationMap<any>>(type: P): Requireable<Requir
  * @param getStack Returns the component stack.
  */
 export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;
+
+/**
+ * Only available if NODE_ENV=production
+ */
+export function resetWarningCache(): void;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -34,6 +34,7 @@ interface Props {
     };
     optionalNumber?: number | null;
     customProp?: typeof uniqueType;
+    component: PropTypes.ReactComponentLike;
 }
 
 const innerProps = {
@@ -74,7 +75,8 @@ const propTypes: PropTypesMap = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
-    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
+    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>,
+    component: PropTypes.elementType.isRequired
 };
 
 // JS checking
@@ -100,7 +102,8 @@ const propTypesWithoutAnnotation = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
-    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
+    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>,
+    component: PropTypes.elementType.isRequired
 };
 
 const partialPropTypes = {
@@ -150,6 +153,7 @@ type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWit
 type ExtractPropsMismatch = ExtractedPartialProps extends Props ? true : false;
 
 PropTypes.checkPropTypes({ xs: PropTypes.array }, { xs: [] }, 'location', 'componentName');
+PropTypes.resetWarningCache();
 
 // This would be the type that JSX sees
 type Defaultize<T, D> =


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [15.7 changelog](https://github.com/facebook/prop-types/blob/master/CHANGELOG.md#1570)
  - [PropTypes.resetWarningCache()](https://github.com/facebook/prop-types#proptypesresetwarningcache) added with facebook/prop-types#178
  - [PropTypes.elementType (right under `optionalElement`)](https://github.com/facebook/prop-types#usage) added with facebook/prop-types#211
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
