### PR TITLE
@types/swagger-schema-official Add specific values for "in" on Parameters acording to swagger spec

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -47,24 +47,29 @@ export interface BaseParameter {
 }
 
 export interface BodyParameter extends BaseParameter {
+  in: 'body';
   schema?: Schema;
 }
 
 export interface QueryParameter extends BaseParameter, BaseSchema {
+  in: 'query';
   type: string;
   allowEmptyValue?: boolean;
 }
 
 export interface PathParameter extends BaseParameter, BaseSchema {
+  in: 'path';
   type: string;
   required: boolean;
 }
 
 export interface HeaderParameter extends BaseParameter, BaseSchema {
+  in: 'header';
   type: string;
 }
 
 export interface FormDataParameter extends BaseParameter, BaseSchema {
+  in: 'formData';
   type: string;
   collectionFormat?: string;
   allowEmptyValue?: boolean;

--- a/types/swagger-schema-official/swagger-schema-official-tests.ts
+++ b/types/swagger-schema-official/swagger-schema-official-tests.ts
@@ -1373,7 +1373,6 @@ const reference_support: swagger.Spec = {
                     {
                         "in": "body",
                         "name": "bodyParameter",
-                        "type": "string",
                         "description": "The body parameter"
                     }
                 ],


### PR DESCRIPTION
In Parameter union `type Parameter =
  BodyParameter |
  FormDataParameter |
  QueryParameter |
  PathParameter |
  HeaderParameter;` every type has unique `in` value per type, see [Swagger Spec v2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v2.0/schema.json).
Add `in` fields with values to specific interfaces according to the schema.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Swagger Spec v2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v2.0/schema.json)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.