### PR TITLE
Don't define global for `chai`

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1697,8 +1697,6 @@ declare namespace Chai {
     }
 }
 
-declare const chai: Chai.ChaiStatic;
-
 declare module "chai" {
     export = chai;
 }

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1698,7 +1698,7 @@ declare namespace Chai {
 }
 
 declare module "chai" {
-    export = chai;
+    export = Chai;
 }
 
 interface Object {


### PR DESCRIPTION
I would like to propose that chai is not defined as a global.

Seems wrong since chai is not in global unless you put it there

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
