### PR TITLE
[cote] add subset attribute to ResponderAdvertisement

### DIFF
--- a/types/cote/cote-tests.ts
+++ b/types/cote/cote-tests.ts
@@ -20,7 +20,8 @@ class Readme {
             }
         };
 
-        randomRequester.send(req)
+        randomRequester
+            .send(req)
             .then(console.log)
             .catch(console.log)
             .then(() => process.exit());
@@ -35,6 +36,7 @@ class Readme {
         });
 
         const req = {
+            __subset: 'subset',
             type: 'randomRequest',
             payload: {
                 val: Math.floor(Math.random() * 10)
@@ -52,6 +54,7 @@ class Readme {
             name: 'Random Responder',
             namespace: 'rnd',
             key: 'a certain key',
+            subset: 'subset',
             respondsTo: ['randomRequest']
         });
 
@@ -80,11 +83,22 @@ class Readme {
             payload: { val: number };
         }
 
-        randomResponder.on('randomRequest', (req: RandomRequest, callback: (error: any, answer?: number) => void) => {
-            const answer = Math.floor(Math.random() * 10);
-            console.log('request', req.payload.val, 'answering with', answer);
-            callback(null, answer);
-        });
+        randomResponder.on(
+            'randomRequest',
+            (
+                req: RandomRequest,
+                callback: (error: any, answer?: number) => void
+            ) => {
+                const answer = Math.floor(Math.random() * 10);
+                console.log(
+                    'request',
+                    req.payload.val,
+                    'answering with',
+                    answer
+                );
+                callback(null, answer);
+            }
+        );
     }
 
     mongooseResponder() {
@@ -139,7 +153,7 @@ class Readme {
             subscribesTo: ['randomUpdate']
         });
 
-        randomSubscriber.on('randomUpdate', (req) => {
+        randomSubscriber.on('randomUpdate', req => {
             console.log('notified of ', req);
         });
     }
@@ -152,15 +166,18 @@ class Readme {
         app.listen(process.argv[2] || 5555);
 
         function handler(req: any, res: any) {
-            fs.readFile(__dirname + '/index.html', (err: Error, data: Buffer) => {
-                if (err) {
-                    res.writeHead(500);
-                    return res.end('Error loading index.html');
-                }
+            fs.readFile(
+                __dirname + '/index.html',
+                (err: Error, data: Buffer) => {
+                    if (err) {
+                        res.writeHead(500);
+                        return res.end('Error loading index.html');
+                    }
 
-                res.writeHead(200);
-                res.end(data);
-            });
+                    res.writeHead(200);
+                    res.end(data);
+                }
+            );
         }
 
         const sockend = new cote.Sockend(io, {
@@ -205,21 +222,23 @@ class Readme {
 
         const rates: { [key: string]: number } = {
             usd_eur: 0.91,
-            eur_usd: 1.10
+            eur_usd: 1.1
         };
 
         interface Convert {
             type: 'convert';
             payload: {
-                amount: number,
-                from: string,
-                to: string
+                amount: number;
+                from: string;
+                to: string;
             };
         }
 
         responder.on('convert', (req: Convert) => {
             const { payload } = req;
-            return Promise.resolve(payload.amount * rates[`${payload.from}_${payload.to}`]);
+            return Promise.resolve(
+                payload.amount * rates[`${payload.from}_${payload.to}`]
+            );
         });
     }
 
@@ -228,7 +247,10 @@ class Readme {
     }
 
     multicastComponent() {
-        const req = new cote.Requester({ name: 'req' }, { multicast: '239.1.11.111' });
+        const req = new cote.Requester(
+            { name: 'req' },
+            { multicast: '239.1.11.111' }
+        );
     }
 
     broadcast() {
@@ -236,7 +258,10 @@ class Readme {
     }
 
     broadcastComponent() {
-        const req = new cote.Requester({ name: 'req' }, { broadcast: '255.255.255.255' });
+        const req = new cote.Requester(
+            { name: 'req' },
+            { broadcast: '255.255.255.255' }
+        );
     }
 }
 
@@ -262,7 +287,7 @@ class InitialObservations {
         techno.removeAllListeners();
 
         const village = new cote.Subscriber({ name: 'Village' });
-        const doHelp = () => { };
+        const doHelp = () => {};
         village.many('wolf', 2, doHelp);
         village.emit('wolf');
         village.emit('wolf');
@@ -297,19 +322,16 @@ class InitialObservations {
         //     name: 'Requester',
         //     respondsTo: ['foo']
         // })
-
         // Incorrect:
         // const responder = new cote.Responder({
         //     name: 'Responder',
         //     subscribesTo: ['bar']
         // })
-
         // Incorrect:
         // const publisher = new cote.Publisher({
         //     name: 'Publisher',
         //     requests: ['baz']
         // })
-
         // Incorrect:
         // const subscriber = new cote.Subscriber({
         //     name: 'Subscriber',
@@ -318,31 +340,52 @@ class InitialObservations {
     }
 
     discovery() {
-        new cote.Responder({ name: 'LocalUnlessForwarded' }, { address: '127.0.0.1' });
+        new cote.Responder(
+            { name: 'LocalUnlessForwarded' },
+            { address: '127.0.0.1' }
+        );
 
-        new cote.Publisher({ name: 'PassionateGreeter' }, { helloInterval: 100 });
+        new cote.Publisher(
+            { name: 'PassionateGreeter' },
+            { helloInterval: 100 }
+        );
 
-        new cote.Requester({ name: 'Optimist' }, {
-            checkInterval: 1e5,
-            nodeTimeout: 1e6
-        });
+        new cote.Requester(
+            { name: 'Optimist' },
+            {
+                checkInterval: 1e5,
+                nodeTimeout: 1e6
+            }
+        );
 
-        new cote.Subscriber({ name: 'Hachiko' }, { masterTimeout: 9 * 365 * 24 * 60 * 60 * 1000 });
+        new cote.Subscriber(
+            { name: 'Hachiko' },
+            { masterTimeout: 9 * 365 * 24 * 60 * 60 * 1000 }
+        );
 
-        new cote.Monitor({ name: 'HelloService', port: 2345 }, {
-            monitor: false,
-            statusLogsEnabled: false
-        });
+        new cote.Monitor(
+            { name: 'HelloService', port: 2345 },
+            {
+                monitor: false,
+                statusLogsEnabled: false
+            }
+        );
 
-        new cote.Monitor({ name: 'OfflineLogger', port: 2346 }, {
-            disableScreen: true,
-            helloLogsEnabled: false,
-            log: true
-        });
+        new cote.Monitor(
+            { name: 'OfflineLogger', port: 2346 },
+            {
+                disableScreen: true,
+                helloLogsEnabled: false,
+                log: true
+            }
+        );
 
         new cote.Responder({ name: 'HearsNoneAbove' }, { ignoreProcess: true });
 
-        new cote.Requester({ name: 'OwnStatusReporter' }, { statusInterval: 100 });
+        new cote.Requester(
+            { name: 'OwnStatusReporter' },
+            { statusInterval: 100 }
+        );
     }
 
     callbackApi() {
@@ -364,7 +407,8 @@ class InitialObservations {
             }
         };
 
-        randomRequester.send(req)
+        randomRequester
+            .send(req)
             .then(console.log)
             .catch(console.log)
             .then(() => process.exit());
@@ -385,7 +429,8 @@ class InitialObservations {
             }
         };
 
-        randomRequester.send(req)
+        randomRequester
+            .send(req)
             .then(console.log)
             .catch(console.log)
             .then(() => process.exit());

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for cote 0.19.1
+// Type definitions for cote 0.19
 // Project: https://github.com/dashersw/cote#readme
 // Definitions by: makepost <https://github.com/makepost>
 //                 Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import { EventEmitter2 } from 'eventemitter2';
 import * as SocketIO from 'socket.io';

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for cote 0.17
+// Type definitions for cote 0.19.1
 // Project: https://github.com/dashersw/cote#readme
 // Definitions by: makepost <https://github.com/makepost>
 //                 Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter2 } from "eventemitter2";
-import * as SocketIO from "socket.io";
-import { Stream } from "stream";
-import { Server } from "http";
+import { EventEmitter2 } from 'eventemitter2';
+import * as SocketIO from 'socket.io';
+import { Stream } from 'stream';
+import { Server } from 'http';
 
 export abstract class Component extends EventEmitter2 {
     constructor(
@@ -15,7 +15,6 @@ export abstract class Component extends EventEmitter2 {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: Advertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -34,7 +33,6 @@ export class Requester extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: RequesterAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -56,7 +54,10 @@ export class Requester extends Component {
      * @param event Request.
      * @param callback Function to execute after getting a result.
      */
-    send<T extends Event>(event: T, callback: (error: any, result: any) => void): void;
+    send<T extends Event>(
+        event: T,
+        callback: (error: any, result: any) => void
+    ): void;
 }
 
 /**
@@ -75,7 +76,6 @@ export class Responder extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: ResponderAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -100,10 +100,9 @@ export class Responder extends Component {
      */
     on<T extends Event>(
         type: string | string[],
-        listener: (
-            ((event: T, callback: (error: any, result: any) => void) => void) |
-            ((event: T) => Promise<any>)
-        )
+        listener:
+            | ((event: T, callback: (error: any, result: any) => void) => void)
+            | ((event: T) => Promise<any>)
     ): this;
 }
 
@@ -115,6 +114,11 @@ export interface ResponderAdvertisement extends Advertisement {
      * Request types that a Responder can listen to.
      */
     respondsTo?: string[];
+
+    /**
+     * Subset attribut for directed requests.
+     */
+    subset?: string;
 }
 
 export class Publisher extends Component {
@@ -123,7 +127,6 @@ export class Publisher extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: PublisherAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -137,10 +140,7 @@ export class Publisher extends Component {
      * @param type EventEmitter-compatible type.
      * @param event Request.
      */
-    publish<T extends Event>(
-        type: string,
-        event: T
-    ): void;
+    publish<T extends Event>(type: string, event: T): void;
 }
 
 /**
@@ -159,7 +159,6 @@ export class Subscriber extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SubscriberAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -194,12 +193,10 @@ export class Sockend extends Component {
      */
     constructor(
         io: SocketIO.Server,
-
         /**
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SockendAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -210,7 +207,9 @@ export class Sockend extends Component {
 /**
  * Configuration which controls the data being advertised for auto-discovery.
  */
-export interface SockendAdvertisement extends ResponderAdvertisement, PublisherAdvertisement { }
+export interface SockendAdvertisement
+    extends ResponderAdvertisement,
+        PublisherAdvertisement {}
 
 export class Monitor extends Component {
     constructor(
@@ -218,14 +217,12 @@ export class Monitor extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: MonitorAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
         discoveryOptions?: DiscoveryOptions,
-
         stream?: Stream
-    )
+    );
 }
 
 /**
@@ -243,9 +240,11 @@ export interface MonitorAdvertisement extends Advertisement {
  *
  * @param port Open in browser to see network graph in action.
  */
-export function MonitoringTool(port: number): {
-    monitor: Monitor,
-    server: Server
+export function MonitoringTool(
+    port: number
+): {
+    monitor: Monitor;
+    server: Server;
 };
 
 /**
@@ -276,7 +275,7 @@ export class TimeBalancedRequester extends Requester {
  * Keeps track of open, pending requests for each known Responder. Each new
  * request goes to the Responder with the minimum open requests.
  */
-export class PendingBalancedRequester extends Requester { }
+export class PendingBalancedRequester extends Requester {}
 
 /**
  * Event is nothing but object with `type`.
@@ -295,11 +294,11 @@ export interface Status extends Event {
 /**
  * Advertisement in internal `cote:added` and `cote:removed` events.
  */
-export interface StatusAdvertisement extends
-    RequesterAdvertisement,
-    ResponderAdvertisement,
-    PublisherAdvertisement,
-    SubscriberAdvertisement { }
+export interface StatusAdvertisement
+    extends RequesterAdvertisement,
+        ResponderAdvertisement,
+        PublisherAdvertisement,
+        SubscriberAdvertisement {}
 
 /**
  * Configuration which controls the data being advertised for auto-discovery.


### PR DESCRIPTION
This pull request add the subset attribut to ResponderAdvertisement according to [#150](https://github.com/dashersw/cote/pull/150)

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).