### PR TITLE
[cote] add subset attribute to ResponderAdvertisement

### DIFF
--- a/types/cote/cote-tests.ts
+++ b/types/cote/cote-tests.ts
@@ -35,6 +35,7 @@ class Readme {
         });
 
         const req = {
+            __subset: 'subset',
             type: 'randomRequest',
             payload: {
                 val: Math.floor(Math.random() * 10)
@@ -52,7 +53,8 @@ class Readme {
             name: 'Random Responder',
             namespace: 'rnd',
             key: 'a certain key',
-            respondsTo: ['randomRequest']
+            respondsTo: ['randomRequest'],
+            subset: 'subset'
         });
 
         interface RandomRequest {

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -117,7 +117,7 @@ export interface ResponderAdvertisement extends Advertisement {
     respondsTo?: string[];
 
     /**
-     * Subset attribut for directed requests.
+     * Advertisement attribute that lets you target a subgroup of responders using the __subset property of a request.
      */
     subset?: string;
 }

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cote 0.17
+// Type definitions for cote 0.19
 // Project: https://github.com/dashersw/cote#readme
 // Definitions by: makepost <https://github.com/makepost>
 //                 Labat Robin <https://github.com/roblabat>
@@ -115,6 +115,11 @@ export interface ResponderAdvertisement extends Advertisement {
      * Request types that a Responder can listen to.
      */
     respondsTo?: string[];
+
+    /**
+     * Subset attribut for directed requests.
+     */
+    subset?: string;
 }
 
 export class Publisher extends Component {


### PR DESCRIPTION
This pull request add the subset attribut to ResponderAdvertisement according to [#150](https://github.com/dashersw/cote/pull/150)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).