### PR TITLE
[react] ReactType -> ElementType

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -51,11 +51,15 @@ declare namespace React {
     // React Elements
     // ----------------------------------------------------------------------
 
-    type ReactType<P = any> =
+    type ElementType<P = any> =
         {
             [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
         }[keyof JSX.IntrinsicElements] |
         ComponentType<P>;
+    /**
+     * @deprecated Please use `ElementType`
+     */
+    type ReactType<P = any> = ElementType<P>;
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
@@ -734,11 +738,11 @@ declare namespace React {
             : T extends keyof JSX.IntrinsicElements
                 ? JSX.IntrinsicElements[T]
                 : {};
-    type ComponentPropsWithRef<T extends ReactType> =
+    type ComponentPropsWithRef<T extends ElementType> =
         T extends ComponentClass<infer P>
             ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
             : PropsWithRef<ComponentProps<T>>;
-    type ComponentPropsWithoutRef<T extends ReactType> =
+    type ComponentPropsWithoutRef<T extends ElementType> =
         PropsWithoutRef<ComponentProps<T>>;
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,


### PR DESCRIPTION
Deprecates `ReactType` in favor of `ElementType`. `ElementType` is consistent with [flow types](https://github.com/facebook/flow/blob/master/website/en/docs/react/types.md#toc-react-elementtype), [`prop-types` `elementType` (between `element` and `instanceOf`)](https://github.com/facebook/prop-types#usage), [react docs](https://reactjs.org/docs/jsx-in-depth.html#specifying-the-react-element-type) and [`react-is` `isValidElementType`](https://github.com/facebook/react/tree/master/packages/react-is#determining-if-a-component-is-valid).