### PR TITLE
[@types/bootstrap-notify] Add parameters to callbacks for bootstrap-notify

### DIFF
--- a/types/bootstrap-notify/bootstrap-notify-tests.ts
+++ b/types/bootstrap-notify/bootstrap-notify-tests.ts
@@ -47,3 +47,20 @@ $.notify({
 		'<a href="{3}" target="{4}" data-notify="url"></a>' +
 	'</div>'
 });
+
+const notifyResult = $.notify({
+	message: 'Callbacks have the popup element as an argument',
+},{
+	onShow: function($ele) {
+		notifyResult.$ele === $ele;
+	},
+	onShown: function($ele) {
+		notifyResult.$ele === $ele;
+	},
+	onClose: function($ele) {
+		notifyResult.$ele === $ele;
+	},
+	onClosed: function($ele) {
+		notifyResult.$ele === $ele;
+	},
+});

--- a/types/bootstrap-notify/index.d.ts
+++ b/types/bootstrap-notify/index.d.ts
@@ -48,16 +48,16 @@ interface NotifySettings {
 		enter?: string;
 		exit?: string;
 	};
-	onShow?: () => void;
-	onShown?: () => void;
-	onClose?: () => void;
-	onClosed?: () => void;
+	onShow?: ($ele: JQuery) => void;
+	onShown?: ($ele: JQuery) => void;
+	onClose?: ($ele: JQuery) => void;
+	onClosed?: ($ele: JQuery) => void;
 	icon_type?: string;
 	template?: string;
 }
 
 interface NotifyReturn {
-	$ele: JQueryStatic;
+	$ele: JQuery;
 	close: () => void;
 	update: (command: string, update: any) => void;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - The callback parameter for `onClose` can be seen in the code here: [bootstrap-notify.js:347](https://github.com/mouse0270/bootstrap-notify/blob/446a6232be3ea9a360c240b615058d6578e9d5f5/bootstrap-notify.js#L347). The other callback calls are on lines near this one.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
