### PR TITLE
Superagent 4.x Request.end() doesn't return anything

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SuperAgent 3.8
+// Type definitions for SuperAgent 4.1
 // Project: https://github.com/visionmedia/superagent
 // Definitions by: Nico Zelaya <https://github.com/NicoZelaya>
 //                 Michael Ledin <https://github.com/mxl>

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -128,7 +128,7 @@ declare namespace request {
         ca(cert: Buffer): this;
         cert(cert: Buffer | string): this;
         clearTimeout(): this;
-        end(callback?: CallbackHandler): this;
+        end(callback?: CallbackHandler): void;
         field(name: string, val: MultipartValue): this;
         field(fields: { [fieldName: string]: MultipartValue }): this;
         get(field: string): string;

--- a/types/supertest-as-promised/index.d.ts
+++ b/types/supertest-as-promised/index.d.ts
@@ -18,9 +18,11 @@ declare namespace supertestAsPromised {
     interface Response extends supertest.Response {
     }
 
+    type CallbackHandler = (err: any, res: Response) => void;
     interface Test extends supertest.Test, superagent.Request {
         toPromise(): PromiseBluebird<Response>;
         timeout(): Promise<Response> & this;
+        end(callback?: CallbackHandler): this;
     }
 
     function agent(app?: any): SuperTest<Test>;


### PR DESCRIPTION
The Superagent 4.x `end` function on `Request` [doesn't return anything](https://github.com/visionmedia/superagent/blob/f3ac20cc7c6497c002a94f5930cf2603ec7c9c6c/lib/client.js#L664), as documented on their upgrade instructions. This bit us in prod when we upgraded, as we expected the type definitions to match.

supertest-as-promised [does not match](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L120) Superagent's `end` method, so an override is necessary in its `Test` interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/visionmedia/superagent#upgrading-from-previous-versions
- [x] Increase the version number in the header if appropriate.