### PR TITLE
solidity-parser-antlr: make the attribute "type" of ASTNode precise

### DIFF
--- a/types/solidity-parser-antlr/index.d.ts
+++ b/types/solidity-parser-antlr/index.d.ts
@@ -16,7 +16,7 @@ export interface Location {
 }
 
 // Note: This should be consistent with the definition of type ASTNode
-export type TypeString = 'SourceUnit'
+export type ASTNodeTypeString = 'SourceUnit'
 | 'PragmaDirective'
 | 'PragmaName'
 | 'PragmaValue'
@@ -100,7 +100,7 @@ export type TypeString = 'SourceUnit'
 | 'Conditional';
 
 export interface BaseASTNode {
-    type: TypeString;
+    type: ASTNodeTypeString;
     range?: [number, number];
     loc?: Location;
 }

--- a/types/solidity-parser-antlr/index.d.ts
+++ b/types/solidity-parser-antlr/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/federicobond/solidity-parser-antlr
 // Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
 //                 Alex Browne <https://github.com/albrow>
+//                 Xiao Liang <https://github.com/yxliang01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -13,114 +14,208 @@ export interface Location {
     start: LineColumn;
     end: LineColumn;
 }
+
+// Note: This should be consistent with the definition of type ASTNode
+type TypeString = 'SourceUnit'
+| 'PragmaDirective'
+| 'PragmaName'
+| 'PragmaValue'
+| 'Version'
+| 'VersionOperator'
+| 'VersionConstraint'
+| 'ImportDeclaration'
+| 'ImportDirective'
+| 'ContractDefinition'
+| 'InheritanceSpecifier'
+| 'ContractPart'
+| 'StateVariableDeclaration'
+| 'UsingForDeclaration'
+| 'StructDefinition'
+| 'ModifierDefinition'
+| 'ModifierInvocation'
+| 'FunctionDefinition'
+| 'ReturnParameters'
+| 'ModifierList'
+| 'EventDefinition'
+| 'EnumValue'
+| 'EnumDefinition'
+| 'ParameterList'
+| 'Parameter'
+| 'EventParameterList'
+| 'EventParameter'
+| 'FunctionTypeParameterList'
+| 'FunctionTypeParameter'
+| 'VariableDeclaration'
+| 'TypeName'
+| 'UserDefinedTypeName'
+| 'Mapping'
+| 'FunctionTypeName'
+| 'StorageLocation'
+| 'StateMutability'
+| 'Block'
+| 'Statement'
+| 'ExpressionStatement'
+| 'IfStatement'
+| 'WhileStatement'
+| 'SimpleStatement'
+| 'ForStatement'
+| 'InlineAssemblyStatement'
+| 'DoWhileStatement'
+| 'ContinueStatement'
+| 'BreakStatement'
+| 'ReturnStatement'
+| 'ThrowStatement'
+| 'VariableDeclarationStatement'
+| 'IdentifierList'
+| 'ElementaryTypeName'
+| 'Expression'
+| 'PrimaryExpression'
+| 'ExpressionList'
+| 'NameValueList'
+| 'NameValue'
+| 'FunctionCallArguments'
+| 'AssemblyBlock'
+| 'AssemblyItem'
+| 'AssemblyExpression'
+| 'AssemblyCall'
+| 'AssemblyLocalDefinition'
+| 'AssemblyAssignment'
+| 'AssemblyIdentifierOrList'
+| 'AssemblyIdentifierList'
+| 'AssemblyStackAssignment'
+| 'LabelDefinition'
+| 'AssemblySwitch'
+| 'AssemblyCase'
+| 'AssemblyFunctionDefinition'
+| 'AssemblyFunctionReturns'
+| 'AssemblyFor'
+| 'AssemblyIf'
+| 'AssemblyLiteral'
+| 'SubAssembly'
+| 'TupleExpression'
+| 'ElementaryTypeNameExpression'
+| 'NumberLiteral'
+| 'Identifier'
+| 'BinaryOperation'
+| 'Conditional';
+
 export interface BaseASTNode {
-    type: string;
+    type: TypeString;
     range?: [number, number];
     loc?: Location;
 }
 export interface SourceUnit extends BaseASTNode {
+    type: 'SourceUnit';
     children: ASTNode[]; // TODO: Can be more precise
 } // tslint:disable-line:no-empty-interface
-export interface PragmaDirective extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface PragmaName extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface PragmaValue extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Version extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface VersionOperator extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface VersionConstraint extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ImportDeclaration extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ImportDirective extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface PragmaDirective extends BaseASTNode { type: 'PragmaDirective'; }
+export interface PragmaName extends BaseASTNode { type: 'PragmaName'; }
+export interface PragmaValue extends BaseASTNode { type: 'PragmaValue'; }
+export interface Version extends BaseASTNode { type: 'Version'; }
+export interface VersionOperator extends BaseASTNode { type: 'VersionOperator'; }
+export interface VersionConstraint extends BaseASTNode { type: 'VersionConstraint'; }
+export interface ImportDeclaration extends BaseASTNode { type: 'ImportDeclaration'; }
+export interface ImportDirective extends BaseASTNode { type: 'ImportDirective'; }
 export interface ContractDefinition extends BaseASTNode {
+    type: 'ContractDefinition';
     name: string;
     subNodes: ASTNode[]; // TODO: Can be more precise
 }
-export interface InheritanceSpecifier extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ContractPart extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface InheritanceSpecifier extends BaseASTNode { type: 'InheritanceSpecifier'; }
+export interface ContractPart extends BaseASTNode { type: 'ContractPart'; }
 export interface StateVariableDeclaration extends BaseASTNode {
+    type: 'StateVariableDeclaration';
     variables: VariableDeclaration[];
 }
-export interface UsingForDeclaration extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface StructDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface UsingForDeclaration extends BaseASTNode { type: 'UsingForDeclaration'; }
+export interface StructDefinition extends BaseASTNode { type: 'StructDefinition'; }
 export interface ModifierDefinition extends BaseASTNode {
+    type: 'ModifierDefinition';
     name: string;
 }
 export interface ModifierInvocation extends BaseASTNode {
+    type: 'ModifierInvocation';
     name: string;
 }
 export interface FunctionDefinition extends BaseASTNode {
+    type: 'FunctionDefinition';
     name: string;
     parameters: ParameterList;
     body: Block | null;
 }
-export interface ReturnParameters extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ModifierList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface EventDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface EnumValue extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface EnumDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ParameterList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Parameter extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface EventParameterList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface EventParameter extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface FunctionTypeParameterList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface FunctionTypeParameter extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface ReturnParameters extends BaseASTNode { type: 'ReturnParameters'; }
+export interface ModifierList extends BaseASTNode { type: 'ModifierList'; }
+export interface EventDefinition extends BaseASTNode { type: 'EventDefinition'; }
+export interface EnumValue extends BaseASTNode { type: 'EnumValue'; }
+export interface EnumDefinition extends BaseASTNode { type: 'EnumDefinition'; }
+export interface ParameterList extends BaseASTNode { type: 'ParameterList'; }
+export interface Parameter extends BaseASTNode { type: 'Parameter'; }
+export interface EventParameterList extends BaseASTNode { type: 'EventParameterList'; }
+export interface EventParameter extends BaseASTNode { type: 'EventParameter'; }
+export interface FunctionTypeParameterList extends BaseASTNode { type: 'FunctionTypeParameterList'; }
+export interface FunctionTypeParameter extends BaseASTNode { type: 'FunctionTypeParameter'; }
 export interface VariableDeclaration extends BaseASTNode {
+    type: 'VariableDeclaration';
     visibility: "public" | "private";
     isStateVar: boolean;
 }
-export interface TypeName extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface UserDefinedTypeName extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Mapping extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface FunctionTypeName extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface StorageLocation extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface StateMutability extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Block extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Statement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface TypeName extends BaseASTNode { type: 'TypeName'; }
+export interface UserDefinedTypeName extends BaseASTNode { type: 'UserDefinedTypeName'; }
+export interface Mapping extends BaseASTNode { type: 'Mapping'; }
+export interface FunctionTypeName extends BaseASTNode { type: 'FunctionTypeName'; }
+export interface StorageLocation extends BaseASTNode { type: 'StorageLocation'; }
+export interface StateMutability extends BaseASTNode { type: 'StateMutability'; }
+export interface Block extends BaseASTNode { type: 'Block'; }
+export interface Statement extends BaseASTNode { type: 'Statement'; }
 export interface ExpressionStatement extends BaseASTNode {
+    type: 'ExpressionStatement';
     expression: ASTNode;
 }
 export interface IfStatement extends BaseASTNode {
+    type: 'IfStatement';
     trueBody: ASTNode;
     falseBody: ASTNode;
 }
-export interface WhileStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface SimpleStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ForStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface InlineAssemblyStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface DoWhileStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ContinueStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface BreakStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ReturnStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ThrowStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface VariableDeclarationStatement extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface IdentifierList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ElementaryTypeName extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Expression extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface PrimaryExpression extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ExpressionList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface NameValueList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface NameValue extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface FunctionCallArguments extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyBlock extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyItem extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyExpression extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyCall extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyLocalDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyAssignment extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyIdentifierOrList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyIdentifierList extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyStackAssignment extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface LabelDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblySwitch extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyCase extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyFunctionDefinition extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyFunctionReturns extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyFor extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyIf extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface AssemblyLiteral extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface SubAssembly extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface TupleExpression extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface ElementaryTypeNameExpression extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface NumberLiteral extends BaseASTNode {} // tslint:disable-line:no-empty-interface
-export interface Identifier extends BaseASTNode {} // tslint:disable-line:no-empty-interface
+export interface WhileStatement extends BaseASTNode { type: 'WhileStatement'; }
+export interface SimpleStatement extends BaseASTNode { type: 'SimpleStatement'; }
+export interface ForStatement extends BaseASTNode { type: 'ForStatement'; }
+export interface InlineAssemblyStatement extends BaseASTNode { type: 'InlineAssemblyStatement'; }
+export interface DoWhileStatement extends BaseASTNode { type: 'DoWhileStatement'; }
+export interface ContinueStatement extends BaseASTNode { type: 'ContinueStatement'; }
+export interface BreakStatement extends BaseASTNode { type: 'BreakStatement'; }
+export interface ReturnStatement extends BaseASTNode { type: 'ReturnStatement'; }
+export interface ThrowStatement extends BaseASTNode { type: 'ThrowStatement'; }
+export interface VariableDeclarationStatement extends BaseASTNode { type: 'VariableDeclarationStatement'; }
+export interface IdentifierList extends BaseASTNode { type: 'IdentifierList'; }
+export interface ElementaryTypeName extends BaseASTNode { type: 'ElementaryTypeName'; }
+export interface Expression extends BaseASTNode { type: 'Expression'; }
+export interface PrimaryExpression extends BaseASTNode { type: 'PrimaryExpression'; }
+export interface ExpressionList extends BaseASTNode { type: 'ExpressionList'; }
+export interface NameValueList extends BaseASTNode { type: 'NameValueList'; }
+export interface NameValue extends BaseASTNode { type: 'NameValue'; }
+export interface FunctionCallArguments extends BaseASTNode { type: 'FunctionCallArguments'; }
+export interface AssemblyBlock extends BaseASTNode { type: 'AssemblyBlock'; }
+export interface AssemblyItem extends BaseASTNode { type: 'AssemblyItem'; }
+export interface AssemblyExpression extends BaseASTNode { type: 'AssemblyExpression'; }
+export interface AssemblyCall extends BaseASTNode { type: 'AssemblyCall'; }
+export interface AssemblyLocalDefinition extends BaseASTNode { type: 'AssemblyLocalDefinition'; }
+export interface AssemblyAssignment extends BaseASTNode { type: 'AssemblyAssignment'; }
+export interface AssemblyIdentifierOrList extends BaseASTNode { type: 'AssemblyIdentifierOrList'; }
+export interface AssemblyIdentifierList extends BaseASTNode { type: 'AssemblyIdentifierList'; }
+export interface AssemblyStackAssignment extends BaseASTNode { type: 'AssemblyStackAssignment'; }
+export interface LabelDefinition extends BaseASTNode { type: 'LabelDefinition'; }
+export interface AssemblySwitch extends BaseASTNode { type: 'AssemblySwitch'; }
+export interface AssemblyCase extends BaseASTNode { type: 'AssemblyCase'; }
+export interface AssemblyFunctionDefinition extends BaseASTNode { type: 'AssemblyFunctionDefinition'; }
+export interface AssemblyFunctionReturns extends BaseASTNode { type: 'AssemblyFunctionReturns'; }
+export interface AssemblyFor extends BaseASTNode { type: 'AssemblyFor'; }
+export interface AssemblyIf extends BaseASTNode { type: 'AssemblyIf'; }
+export interface AssemblyLiteral extends BaseASTNode { type: 'AssemblyLiteral'; }
+export interface SubAssembly extends BaseASTNode { type: 'SubAssembly'; }
+export interface TupleExpression extends BaseASTNode { type: 'TupleExpression'; }
+export interface ElementaryTypeNameExpression extends BaseASTNode { type: 'ElementaryTypeNameExpression'; }
+export interface NumberLiteral extends BaseASTNode { type: 'NumberLiteral'; }
+export interface Identifier extends BaseASTNode { type: 'Identifier'; }
 export type BinOp =
     | "+"
     | "-"
@@ -153,11 +248,13 @@ export type BinOp =
     | "/="
     | "%=";
 export interface BinaryOperation extends BaseASTNode {
+    type: 'BinaryOperation';
     left: ASTNode;
     right: ASTNode;
     operator: BinOp;
 }
 export interface Conditional extends BaseASTNode {
+    type: 'Conditional';
     trueExpression: ASTNode;
     falseExpression: ASTNode;
 }

--- a/types/solidity-parser-antlr/index.d.ts
+++ b/types/solidity-parser-antlr/index.d.ts
@@ -16,7 +16,7 @@ export interface Location {
 }
 
 // Note: This should be consistent with the definition of type ASTNode
-type TypeString = 'SourceUnit'
+export type TypeString = 'SourceUnit'
 | 'PragmaDirective'
 | 'PragmaName'
 | 'PragmaValue'


### PR DESCRIPTION
Back then, the `type` is just defined as `string` type. Now, it is very precisely defined for the interfaces extending `BaseASTNode`.

