### PR TITLE
Cleanup 2019 part 1

### DIFF
--- a/types/baidu-app/index.d.ts
+++ b/types/baidu-app/index.d.ts
@@ -4287,7 +4287,7 @@ declare namespace swan {
 		Methods,
 		Props
 		> = object &
-		ComponentOptions<V, Data | ((this: V) => Data), Methods, Props> &
+		ComponentOptions<V, Data, Methods, Props> &
 		ThisType<CombinedInstance<V, Data, Methods, Readonly<Props>>>;
 
 	interface ComponentRelation<D = any, P = any> {

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -79,7 +79,6 @@ let anyProm: Promise<any>;
 let boolProm: Promise<boolean>;
 let objProm: Promise<object> = Promise.resolve(obj);
 let voidProm: Promise<void>;
-let neverProm: Promise<never>;
 
 let fooProm: Promise<Foo> = Promise.resolve(foo);
 let barProm: Promise<Bar> = Promise.resolve(bar);
@@ -570,8 +569,8 @@ voidProm = fooProm.thenReturn();
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // fooProm
-neverProm = fooProm.throw(err);
-neverProm = fooProm.thenThrow(err);
+fooProm = fooProm.throw(err);
+fooProm = fooProm.thenThrow(err);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -807,7 +806,7 @@ fooProm = Promise.resolve(fooThen);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-neverProm = Promise.reject(reason);
+voidProm = Promise.reject(reason);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -915,8 +914,7 @@ fooArrProm = Promise.all(fooArr);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-let mapProm: Promise<Map<{}, {}>>;
-mapProm = Promise.props(objProm);
+objProm = Promise.props(objProm);
 objProm = Promise.props(obj);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -79,6 +79,7 @@ let anyProm: Promise<any>;
 let boolProm: Promise<boolean>;
 let objProm: Promise<object> = Promise.resolve(obj);
 let voidProm: Promise<void>;
+let neverProm: Promise<never>;
 
 let fooProm: Promise<Foo> = Promise.resolve(foo);
 let barProm: Promise<Bar> = Promise.resolve(bar);
@@ -569,8 +570,8 @@ voidProm = fooProm.thenReturn();
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // fooProm
-fooProm = fooProm.throw(err);
-fooProm = fooProm.thenThrow(err);
+neverProm = fooProm.throw(err);
+neverProm = fooProm.thenThrow(err);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -806,7 +807,7 @@ fooProm = Promise.resolve(fooThen);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-voidProm = Promise.reject(reason);
+neverProm = Promise.reject(reason);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -914,7 +915,8 @@ fooArrProm = Promise.all(fooArr);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-objProm = Promise.props(objProm);
+let mapProm: Promise<Map<{}, {}>>;
+mapProm = Promise.props(objProm);
 objProm = Promise.props(obj);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/cordova-sqlite-storage/index.d.ts
+++ b/types/cordova-sqlite-storage/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for cordova-sqlite-storage 1.5
-// Project: https://github.com/litehelpers/Cordova-sqlite-storage
+// Project: https://github.com/xpbrew/cordova-sqlite-storage
 // Definitions by: rafw87 <https://github.com/rafw87>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -608,7 +608,8 @@ const testObject = {
 };
 
 const p1: Array<number | string | Date | number[]> = d3Array.permute(testObject, ['name', 'val', 'when', 'more']);
-const p2: Array<Date | number[]> = d3Array.permute(testObject, ['when', 'more']);
+// $ExpectType: Array<Date | number[]>
+const p2 = d3Array.permute(testObject, ['when', 'more']);
 // $ExpectError
 const p3 = d3Array.permute(testObject, ['when', 'unknown']);
 


### PR DESCRIPTION
baidu-app: Not sure how this worked before. Taking away the extra thunk doesn't break any tests.

bluebird-tests: 
  1. `throw` now correctly returns `never` instead of passing through the original type.
  2. Bluebird is invariant on `R` now. Not sure why. Could be bad?

cordova-sqlite-storage: Just a project ownership change.

d3-array: return-type inference seems higher priority than before, or maybe index access types.  Probably not a big deal since I think people usually don't specify types for variable declarations.

Part 2 will fix ember.