### PR TITLE
Fix return values of rethrowResult and retryResult

### DIFF
--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -87,7 +87,8 @@ export namespace policies {
 
     interface DecisionInfo {
       decision: number;
-      consistency: number;
+      consistency?: number;
+      useCurrentHost?: boolean;
     }
 
     interface RequestInfo {
@@ -115,8 +116,8 @@ export namespace policies {
       onReadTimeout(requestInfo: RequestInfo, consistency: types.consistencies, received: number, blockFor: number, isDataPresent: boolean): DecisionInfo;
       onUnavailable(requestInfo: RequestInfo, consistency: types.consistencies, required: number, alive: number): DecisionInfo;
       onWriteTimeout(requestInfo: RequestInfo, consistency: types.consistencies, received: number, blockFor: number, writeType: string): DecisionInfo;
-      rethrowResult(): { decision: retryDecision };
-      retryResult(consistency?: types.consistencies, useCurrentHost?: boolean): { decision: retryDecision, consistency: types.consistencies, useCurrentHost: boolean };
+      rethrowResult(): DecisionInfo;
+      retryResult(consistency?: types.consistencies, useCurrentHost?: boolean): DecisionInfo;
     }
   }
 


### PR DESCRIPTION
Bug: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33242

To make the type definition consistent with both the implementation and api docs as indicated in the bug, we are updating the return values of `rethrowResult` and `retryResult` to return a `DecisionInfo` object.

Additionally the `DecisionInfo` object will have it's `consistency` field made optional and a new optional field of `useCurrentHost` is added.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
