### PR TITLE
 Fix RequestCallback in @types/request

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -183,7 +183,7 @@ declare namespace request {
     type OptionsWithUrl = UrlOptions & CoreOptions;
     type Options = OptionsWithUri | OptionsWithUrl;
 
-    type RequestCallback = (error: any, response: Response, body: any) => void;
+    type RequestCallback = (error: any, response?: Response, body: any) => void;
 
     interface HttpArchiveRequest {
         url?: string;


### PR DESCRIPTION
`require('request')('foo', function () { console.log(arguments.length); });` result: 1, so the second argument (Response) must be declared optional.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
