### PR TITLE
Update sequelize index.d.ts to include uniqueKey option in belongsToMany association

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1379,7 +1379,11 @@ declare namespace sequelize {
          * Should the join model have timestamps
          */
         timestamps?: boolean;
-
+         
+        /**
+         * Belongs-To-Many creates a unique key when primary key is not present on through model. This unique key name can be overridden using uniqueKey option.
+         */
+        uniqueKey?: string;
     }
 
     /**


### PR DESCRIPTION
After this PR (https://github.com/sequelize/sequelize/pull/9914/files/e86ea72b2dc3c89525a42678bb268af338b40a9a) a uniqueKey option can be added to the `belongsToMany` association.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sequelize/sequelize/pull/9914/files/e86ea72b2dc3c89525a42678bb268af338b40a9a
