### PR TITLE
Fix react-image-crop `containCrop()` definition

### DIFF
--- a/types/react-image-crop/index.d.ts
+++ b/types/react-image-crop/index.d.ts
@@ -51,7 +51,7 @@ declare namespace ReactCrop {
 
     function getPixelCrop(image: HTMLImageElement, percentCrop: Crop): Crop;
     function makeAspectCrop(crop: Crop, imageAspect: number): Crop;
-    function containCrop(crop: Crop, imageAspect: number): Crop;
+    function containCrop(previousCrop: Crop, crop: Crop, imageAspect: number): Crop;
 }
 
 declare class ReactCrop extends Component<ReactCrop.ReactCropProps> {


### PR DESCRIPTION
This PR adds the `previousCrop` argument to `containCrop()` function.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DominicTobias/react-image-crop/blob/0a6c8f115128c7f21f09bad37d7f674d04fe7844/lib/ReactCrop.js#L131
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
