### PR TITLE
[pg]: Add QueryResult array possibility if query has multiple statements

### DIFF
--- a/types/pg-pool/pg-pool-tests.ts
+++ b/types/pg-pool/pg-pool-tests.ts
@@ -1,4 +1,5 @@
 import { Pool } from "pg-pool";
+import { QueryResult } from "pg";
 
 let pool = new Pool()
 
@@ -20,7 +21,7 @@ let pool2 = new Pool({
 pool.connect().then(client => {
   client.query('select $1::text as name', ['pg-pool']).then(res => {
     client.release()
-    console.log('hello from', res.rows[0].name)
+    console.log('hello from', (res as QueryResult).rows[0].name)
   })
   .catch(e => {
     client.release()
@@ -31,11 +32,11 @@ pool.connect().then(client => {
 async function helperTest() {
     const time = await pool.query('SELECT NOW()');
     const name = await pool.query('select $1::text as name', ['brianc']);
-    console.log(name.rows[0].name, 'says hello at', time.rows[0].name);
+    console.log((name as QueryResult).rows[0].name, 'says hello at', (time as QueryResult).rows[0].name);
 }
 
 pool.query('SELECT $1::text as name', ['brianc'], function (err, res) {
-  console.log(res.rows[0].name) // brianc
+  console.log((res as QueryResult).rows[0].name) // brianc
 })
 
 pool.end();

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -154,12 +154,12 @@ export class Pool extends events.EventEmitter {
     end(callback: () => void): void;
 
     query<T extends Submittable>(queryStream: T): T;
-    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
+    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult | QueryArrayResult[]>;
+    query(queryConfig: QueryConfig): Promise<QueryResult | QueryResult[]>;
+    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult | QueryResult[]>;
+    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult | QueryArrayResult[]) => void): Query;
+    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult | QueryResult[]) => void): Query;
+    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult | QueryResult[]) => void): Query;
 
     on(event: "error", listener: (err: Error, client: PoolClient) => void): this;
     on(event: "connect" | "acquire" | "remove", listener: (client: PoolClient) => void): this;
@@ -172,12 +172,12 @@ export class ClientBase extends events.EventEmitter {
     connect(callback: (err: Error) => void): void;
 
     query<T extends Submittable>(queryStream: T): T;
-    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
+    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult | QueryArrayResult[]>;
+    query(queryConfig: QueryConfig): Promise<QueryResult | QueryResult[]>;
+    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult | QueryResult[]>;
+    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult | QueryArrayResult[]) => void): Query;
+    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult | QueryResult[]) => void): Query;
+    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult | QueryResult[]) => void): Query;
 
     copyFrom(queryText: string): stream.Writable;
     copyTo(queryText: string): stream.Readable;


### PR DESCRIPTION
This is sure to be unpopular, because it ruins the library's usability, but multi-statement results were added to pg back in v7.0.0:

https://github.com/brianc/node-postgres/commit/28b330c88ebac2ea3ad565f8f2ce4ebe5c9a5579

This means that any query could possibly return an array of results instead of just one, and there's no way for TypeScript to distinguish the two cases. It's completely dynamic. So the user has to cast to one of the two types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/commit/28b330c88ebac2ea3ad565f8f2ce4ebe5c9a5579
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
