### PR TITLE
fix ObjectColumnRender of DataTables.net

### DIFF
--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1150,10 +1150,6 @@ declare namespace DataTables {
         ext: ExtSettings;
     }
 
-    interface ObjectColumnRender {
-        display(d?: number | string | object): string | object;
-    }
-
     interface ObjectOrderFixed {
         /**
          * Two-element array:
@@ -1686,14 +1682,22 @@ declare namespace DataTables {
     }
 
     interface ObjectColumnData {
-        _: string;
-        filter?: string;
-        display?: string;
-        type?: string;
-        sort?: string;
+        _: string | FunctionColumnData;
+        filter?: string | FunctionColumnData;
+        display?: string | FunctionColumnData;
+        type?: string | FunctionColumnData;
+        sort?: string | FunctionColumnData;
     }
 
     type FunctionColumnRender = (data: any, type: any, row: any, meta: CellMetaSettings) => any;
+
+    interface ObjectColumnRender {
+        _?: string | FunctionColumnRender;
+        filter?: string | FunctionColumnRender;
+        display?: string | FunctionColumnRender;
+        type?: string | FunctionColumnRender;
+        sort?: string | FunctionColumnRender;
+    }
 
     interface CellMetaSettings {
         row: number;

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1682,21 +1682,21 @@ declare namespace DataTables {
     }
 
     interface ObjectColumnData {
-        _: string | FunctionColumnData;
-        filter?: string | FunctionColumnData;
-        display?: string | FunctionColumnData;
-        type?: string | FunctionColumnData;
-        sort?: string | FunctionColumnData;
+        _: string | number | FunctionColumnData;
+        filter?: string | number | FunctionColumnData;
+        display?: string | number | FunctionColumnData;
+        type?: string | number | FunctionColumnData;
+        sort?: string | number | FunctionColumnData;
     }
 
     type FunctionColumnRender = (data: any, type: any, row: any, meta: CellMetaSettings) => any;
 
     interface ObjectColumnRender {
-        _?: string | FunctionColumnRender;
-        filter?: string | FunctionColumnRender;
-        display?: string | FunctionColumnRender;
-        type?: string | FunctionColumnRender;
-        sort?: string | FunctionColumnRender;
+        _?: string | number | FunctionColumnRender;
+        filter?: string | number | FunctionColumnRender;
+        display?: string | number | FunctionColumnRender;
+        type?: string | number | FunctionColumnRender;
+        sort?: string | number | FunctionColumnRender;
     }
 
     interface CellMetaSettings {


### PR DESCRIPTION
You can either pass a property name or a FunctionColumnRender

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
