### PR TITLE
Cleanup part 3

### DIFF
--- a/types/petit-dom/index.d.ts
+++ b/types/petit-dom/index.d.ts
@@ -98,6 +98,7 @@ export namespace PetitDom {
     };
 
     interface IntrinsicProps {
+        content?: Content | ReadonlyArray<Content>;
         key?: Key;
     }
 

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -403,7 +403,7 @@ export interface StateResultsProvided<TDoc = BasicDoc> {
  * https://community.algolia.com/react-instantsearch/connectors/connectStateResults.html
  */
 export function connectStateResults(stateless: React.StatelessComponent<StateResultsProvided>): React.ComponentClass;
-export function connectStateResults<TProps extends Partial<StateResultsProvided<TDoc>>, TDoc>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, StateResultsProvided<TDoc>>;
+export function connectStateResults<TProps>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, StateResultsProvided<{}>>;
 
 export function connectStats(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 export function connectToggleRefinement(Composed: React.ComponentType<any>): React.ComponentClass<any>;

--- a/types/react-jss/index.d.ts
+++ b/types/react-jss/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
 //                 James Lawrence <https://github.com/jlaw90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 import { createGenerateClassName, JSS, SheetsRegistry } from "jss";
 import * as React from "react";
 import { createTheming, ThemeProvider, withTheme } from "theming";

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -73,11 +73,11 @@ export interface CSSProperties<Props> {
     | DynamicCSSRule<Props>
     | CSSProperties<Props>;
 }
-export type Styles<ClassKey extends string = string, Props = {}> = Record<
+export type Styles<ClassKey extends string | number | symbol = string, Props = {}> = Record<
   ClassKey,
   CSSProperties<Props>
   >;
-export type StyleCreator<C extends string = string, T extends {} = {}, Props = {}> = (
+export type StyleCreator<C extends string | number | symbol = string, T extends {} = {}, Props = {}> = (
   theme: T
 ) => Styles<C, Props>;
 
@@ -93,20 +93,20 @@ export interface InjectOptions extends CreateStyleSheetOptions {
   theming?: Theming;
 }
 
-export type ClassNameMap<C extends string> = Record<C, string>;
+export type ClassNameMap<C extends string | number | symbol> = Record<C, string>;
 export type WithSheet<
-  S extends string | Styles | StyleCreator<string, any>,
+    S extends string | Styles | StyleCreator<keyof S, any>,
   GivenTheme = undefined,
-  Props = {}
+Props = {},
   > = {
   classes: ClassNameMap<
-    S extends string
+    S extends string | number | symbol
       ? S
       : S extends StyleCreator<infer C, any, Props>
       ? C
       : S extends Styles<infer C, Props> ? C : never
     >;
-} & WithTheme<S extends StyleCreator<string, infer T> ? T : GivenTheme>;
+} & WithTheme<S extends StyleCreator<keyof S, infer T> ? T : GivenTheme>;
 
 export interface WithTheme<T> {
   theme: T;

--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -80,7 +80,7 @@ declare namespace SeamlessImmutable {
             propertyPath: [ K, L, M, N ], updaterFunction: (value: T[K][L][M][N], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
             propertyPath: [ K, L, M, N, O ], updaterFunction: (value: T[K][L][M][N][O], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
-        updateIn<TValue>(propertyPath: string[], updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+        updateIn<TValue = any>(propertyPath: string[], updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
 
         without<K extends keyof T>(property: K): Immutable<T>;
         without<K extends keyof T>(...properties: K[]): Immutable<T>;


### PR DESCRIPTION
1. Petit-dom: Add missing property to IntrinsicProps.
2. react-instantsearch-core: Remove unneeded constraint.
3. react-jss: Correctly handle keyof types.
4. seamless-immutable: Make type parameter explicitly default to any.

These changes are the result of typescript@next's:

1. Better JSX checking.
2. Better JSX checking.
3. Better variance checking.
4. Changes to failed type inference.
