### PR TITLE
Fix deprecated version i18next-browser-languagedetector

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -730,7 +730,7 @@
             "libraryName": "i18next-browser-languagedetector",
             "typingsPackageName": "i18next-browser-languagedetector",
             "sourceRepoURL": "https://github.com/i18next/i18next-browser-languagedetector",
-            "asOfVersion": "2.0.2"
+            "asOfVersion": "3.0.0"
         },
         {
             "libraryName": "i18next-xhr-backend",


### PR DESCRIPTION
It added types at version 3.0.0, not 2.0.2. 2.0.2 is an existing version
on @types/i18next-browser-languagedetector.

This, embarrassingly, crashes the @types publisher. I will add a check
that prevents this mistake from happening again.
