### PR TITLE
Add typings for react-resizable

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for react-resizable 1.7
+// Project: https://github.com/STRML/react-resizable
+// Definitions by: Harry Brrundage <https://github.com/airhorns>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+export type Axis = "both" | "x" | "y" | "none";
+
+export interface ResizableState {
+    resizing: boolean;
+    width: number;
+    height: number;
+    slackW: number;
+    slackH: number;
+}
+
+export interface DragCallbackData {
+    node: HTMLElement;
+    x: number;
+    y: number;
+    deltaX: number;
+    deltaY: number;
+    lastX: number;
+    lastY: number;
+}
+
+export interface ResizeCallbackData {
+    node: HTMLElement;
+    size: { width: number; height: number };
+}
+
+export interface ResizableProps {
+    className?: string;
+    width: number;
+    height: number;
+    handleSize?: [number, number];
+    lockAspectRatio?: boolean;
+    axis?: Axis;
+    minConstraints?: [number, number];
+    maxConstraints?: [number, number];
+    onResizeStop?: (e: React.SyntheticEvent, data: ResizeCallbackData) => any;
+    onResizeStart?: (e: React.SyntheticEvent, data: ResizeCallbackData) => any;
+    onResize?: (e: React.SyntheticEvent, data: ResizeCallbackData) => any;
+    draggableOpts?: any;
+}
+
+export class Resizable extends React.Component<
+    ResizableProps,
+    ResizableState
+> {}
+
+export interface ResizableBoxState {
+    height: number;
+    width: number;
+}
+
+export type ResizableBoxProps = ResizableProps;
+
+export class ResizableBox extends React.Component<
+    ResizableBoxProps,
+    ResizableBoxState
+> {}

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Resizable, ResizableBox, ResizeCallbackData } from "react-resizable";
+
+const resizeCallback = (
+    event: React.SyntheticEvent,
+    data: ResizeCallbackData
+) => {
+    console.log(data.size.height);
+    console.log(data.node);
+};
+
+class TestResizableComponent extends React.Component {
+    render() {
+        return (
+            <Resizable
+                width={10}
+                height={20}
+                axis="y"
+                className={"foobar"}
+                minConstraints={[20, 20]}
+                maxConstraints={[42, 42]}
+                handleSize={[5, 5]}
+                lockAspectRatio={false}
+                draggableOpts={{ opaque: true }}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+            >
+                <div>{this.props.children} </div>
+            </Resizable>
+        );
+    }
+}
+
+class TestResizableBoxComponent extends React.Component {
+    render() {
+        return (
+            <ResizableBox
+                width={10}
+                height={20}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+            >
+                <div>{this.props.children}</div>
+            </ResizableBox>
+        );
+    }
+}

--- a/types/react-resizable/tsconfig.json
+++ b/types/react-resizable/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "jsx": "react",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-resizable-tests.tsx"]
+}

--- a/types/react-resizable/tslint.json
+++ b/types/react-resizable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds types for https://github.com/STRML/react-resizable which is a handy dandy library for adding a resize handle to a component.

 - Package structure created via dtsgen
 - Initial typings generated from package version 1.7 using `flow2ts`
 - Types and tests edited by me to be nice and crispy
 - I am using this in a project myself and I figured it's time to upstream!

Checklist:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.