### PR TITLE
@types/koa-router: Typesafe middlewares prepending

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -193,6 +193,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    get<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    get<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP post method
@@ -206,6 +217,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    post<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    post<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP put method
@@ -219,6 +241,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    put<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    put<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP link method
@@ -232,6 +265,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    link<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    link<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP unlink method
@@ -245,6 +289,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    unlink<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    unlink<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP delete method
@@ -258,6 +313,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    delete<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    delete<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Alias for `router.delete()` because delete is a reserved word
@@ -271,6 +337,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    del<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    del<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP head method
@@ -284,6 +361,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    head<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    head<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP options method
@@ -297,6 +385,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    options<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    options<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP path method
@@ -310,6 +409,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    patch<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    patch<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Register route with all methods.
@@ -323,6 +433,17 @@ declare class Router<StateT = any, CustomT = {}> {
         path: string | RegExp | (string | RegExp)[],
         ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    all<T, U>(
+        name: string,
+        path: string | RegExp,
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
+    all<T, U>(
+        path: string | RegExp | (string | RegExp)[],
+        middleware: Koa.Middleware<T, U>,
+        routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * Set the path prefix for a Router instance that was already initialized.

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -125,3 +125,66 @@ app2.use((ctx: Context, next: any) => {
 });
 
 app2.listen(8000);
+
+// Prepending middlewares tests
+
+type IBlah = { blah: string; }
+type IWooh = { wooh: string; }
+
+const router4 = new Router<MyState, MyContext>({prefix: "/users"});
+
+router4.get('/',
+    (ctx: Koa.ParameterizedContext<IBlah & IWooh>, next) => {
+        ctx.state.blah = "blah";
+        ctx.state.wooh = "wooh";
+        return next();
+    },
+    (ctx, next) => {
+        console.log(ctx.state.blah);
+        console.log(ctx.state.wooh);
+        console.log(ctx.state.foo);
+        ctx.body = 'Hello World!';
+        return next();
+    })
+
+const middleware1: Koa.Middleware<IBlah> = (ctx, next) => {
+    ctx.state.blah = "blah";
+}
+
+const middleware2: Koa.Middleware<IWooh> = (ctx, next) => {
+    ctx.state.wooh = "blah";
+}
+
+const emptyMiddleware: Koa.Middleware<{}> = (ctx, next) => {
+}
+
+function routeHandler1(ctx: Koa.ParameterizedContext<IWooh>): void {
+    ctx.body = "234";
+}
+
+function routeHandler2(ctx: Koa.ParameterizedContext<IBlah>): void {
+    ctx.body = "234";
+}
+
+function routeHandler3(ctx: Koa.ParameterizedContext<{}>): void {
+    ctx.body = "234";
+}
+
+function routeHandler4(ctx: Router.RouterContext<MyState, MyContext>): void {
+    ctx.body = "234";
+}
+
+const middleware3 = compose([middleware1, middleware2]);
+
+router4.get('/foo', middleware3, routeHandler1);
+router4.post('/foo', middleware1, routeHandler2);
+router4.put('/foo', middleware2, routeHandler3);
+
+router4.patch("foo", '/foo', middleware3, routeHandler1);
+router4.delete('/foo', middleware1, routeHandler2);
+router4.head('/foo', middleware2, routeHandler3);
+
+router4.post('/foo', emptyMiddleware, emptyMiddleware, routeHandler4);
+router4.post('/foo', emptyMiddleware, emptyMiddleware, emptyMiddleware, routeHandler4);
+router4.get('name', '/foo', emptyMiddleware, emptyMiddleware, routeHandler4);
+router4.get('name', '/foo', emptyMiddleware, emptyMiddleware, emptyMiddleware, routeHandler4);


### PR DESCRIPTION
It's sometimes useful to prepend middlewares to the route handler, when
we want to register some middlewares only for particular routes.
Like:

```ts
router.get("/foo",
  (ctx: Koa.Middleware<IFoo>, next) => {
    ctx.state.foo = "foo";
    return next();
  },
  (ctx, next) => {
    // ctx here knows `ctx.state.foo` is `string`
    // ...
  }
);
```

Unfortunately, currently we can't infer that `ctx` there would have
`state.foo`. All middlewares/route-handlers should have the same type
currently.

It seems to be impossible to do that in the general case (for any number
of prepended middlewares), but we could have a special case for 2
middlewares, and if we have to prepend several middlewares - we could
use `koa-compose` to combine them into one, and still do that in a
typesafe way.

Like:

```ts
router.get("/foo",
  compose([
    (ctx: Koa.Middleware<IFoo>, next) => {
      ctx.state.foo = "foo";
      return next();
    },
    (ctx: Koa.Middleware<IBar>, next) => {
      ctx.state.bar = "bar";
      return next();
    }
  ]),
  (ctx, next) => {
    // ctx here knows `ctx.state.foo` is `string`
    // and `ctx.state.bar` is `string`.
  }
);
```

Changes in this PR add that special case for one prepended middleware
for all route methods (`get`, `post`, `head`, etc).

It's not a breaking change - we keep old types here, we only add a
special more type-correct way of prepending one middleware before a
route handler.

What do you think?