### PR TITLE
[pikaday] Enable strictNullChecks, noImplicitThis

### DIFF
--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -36,7 +36,7 @@ declare class Pikaday {
      * Returns a JavaScript Date object for the selected day, or null if
      * no date is selected.
      */
-    getDate(): Date;
+    getDate(): Date | null;
 
     /**
      * Set the current selection. This will be restricted within the bounds
@@ -50,7 +50,7 @@ declare class Pikaday {
      * Returns a Moment.js object for the selected date (Moment must be
      * loaded before Pikaday).
      */
-    getMoment(): moment.Moment;
+    getMoment(): moment.Moment | null;
 
     /**
      * Set the current selection with a Moment.js object (see setDate).
@@ -159,7 +159,7 @@ declare namespace Pikaday {
         /**
          * Bind the datepicker to a form field.
          */
-        field?: HTMLElement;
+        field?: HTMLElement | null;
 
         /**
          * The default output format for toString() and field value.
@@ -171,7 +171,7 @@ declare namespace Pikaday {
          * Use a different element to trigger opening the datepicker.
          * Default: field element.
          */
-        trigger?: HTMLElement;
+        trigger?: HTMLElement | null;
 
         /**
          * Automatically show/hide the datepicker on field focus.
@@ -201,7 +201,7 @@ declare namespace Pikaday {
          * DOM node to render calendar into, see container example.
          * Default: undefined.
          */
-        container?: HTMLElement;
+        container?: HTMLElement | null;
 
         /**
          * The initial date to view when first opened.
@@ -330,12 +330,12 @@ declare namespace Pikaday {
          * Function which will be used for parsing input string and getting a date object from it.
          * This function will take precedence over moment.
          */
-        parse?(date: string, format: string): Date;
+        parse?(date: string, format: string): Date | null;
 
         /**
          * Callback function for when a date is selected.
          */
-        onSelect?(date: Date): void;
+        onSelect?(this: Pikaday, date: Date): void;
 
         /**
          * Callback function for when the picker becomes visible.

--- a/types/pikaday/pikaday-tests.ts
+++ b/types/pikaday/pikaday-tests.ts
@@ -14,15 +14,15 @@ new Pikaday({field: $('#datepicker')[0]});
             console.log(date.toISOString());
         }
     });
-    field.parentNode.insertBefore(picker.el, field.nextSibling);
+    field.parentNode!.insertBefore(picker.el, field.nextSibling);
 })();
 
 (() => {
     const picker = new Pikaday({
         field: document.getElementById('datepicker'),
         format: 'D MMM YYYY',
-        onSelect: () => {
-            console.log(this.getMoment().format('Do MMMM YYYY'));
+        onSelect() {
+            console.log(this.getMoment()!.format('Do MMMM YYYY'));
         }
     });
 
@@ -116,3 +116,7 @@ new Pikaday({field: $('#datepicker')[0]});
         toString: (date, format) => '2017-08-23'
     });
 })();
+
+new Pikaday({
+    parse: (date) => null
+});

--- a/types/pikaday/tsconfig.json
+++ b/types/pikaday/tsconfig.json
@@ -6,8 +6,8 @@
             "dom"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
This PR switches on `strictNullChecks` and `noImplicitThis` for the pikaday types and adds appropriate nulls and explicit `this` annotations.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Pikaday/Pikaday/blob/master/pikaday.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
