### PR TITLE
[Papaparse] Fix node package reference/import

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -11,7 +11,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import "node";
+/// <reference types="node" />
 
 export as namespace Papa;
 


### PR DESCRIPTION
Papaparse definitions included node via
`import "node"`
rather than
`/// <reference types="node" />`

This was causing node to be included twice, if a user's package.json specified a different version of `@types/node` than the latest (Fairly common since the latest is currently 11.x which is not LTS) this causes the compiler to throw a bunch of cannot redeclare errors.

This is my first PR to DT so please let me know if i have missed anything :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.