### PR TITLE
Update type ImageRequireSource from number to any.

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3594,7 +3594,7 @@ export interface ImageURISource {
     scale?: number;
 }
 
-export type ImageRequireSource = number;
+export type ImageRequireSource = any;
 
 /**
  * @see ImagePropsIOS.onProgress


### PR DESCRIPTION
Hi @alloy 
Not sure if you are the maintainer of this package, but I did see you worked on it as well :)

I've encountered this while implementing a navigation component with a bottom tab that use icons. Icons are coming from `react-native-vector-icons` and are typed as `export ImageSource = any;` in icons.d.ts of that package. Tracing the function seems to eventually return a promise `resolve({ uri: image, scale });` I'm not sure if this is the universal accepted type for an ImageSource though, as how I pass it currently is as a string, which works perfectly fine as well. I'm sure though that a type of number does not make sense, so in this case I'd like to suggest to convert its type to `any` for now. What do you say ?

Gerard
