### PR TITLE
[mangopay2-nodejs-sdk] Fix property name

### DIFF
--- a/types/mangopay2-nodejs-sdk/index.d.ts
+++ b/types/mangopay2-nodejs-sdk/index.d.ts
@@ -1774,7 +1774,7 @@ declare namespace MangoPay {
       /**
        * This is the URL where to redirect users to proceed to 3D secure validation
        */
-      SecureModeRedirectUrl: string;
+      SecureModeRedirectURL: string;
 
       /**
        * This is the URL where users are automatically redirected after 3D secure validation (if activated)
@@ -2596,7 +2596,7 @@ declare namespace MangoPay {
       /**
        * This is the URL where to redirect users to proceed to 3D secure validation
        */
-      SecureModeRedirectUrl: string;
+      SecureModeRedirectURL: string;
     }
 
     interface CreateCardDirectPayIn {


### PR DESCRIPTION
I found a little typo: `SecureModeRedirectUrl` should be `SecureModeRedirectURL`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Mangopay/mangopay2-nodejs-sdk/search?q=SecureModeRedirectUrl&unscoped_q=SecureModeRedirectUrl
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
