### PR TITLE
[dotenv]: Add config.d.ts that was missing but can be imported in JS

### DIFF
--- a/types/dotenv/config.d.ts
+++ b/types/dotenv/config.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for dotenv 6.1
+// Project: https://github.com/motdotla/dotenv
+// Definitions by: Jussi Kinnula <https://github.com/jussikinnula>
+//                 Borek Bernard <https://github.com/borekb>
+//                 Eric Naeseth <https://github.com/enaeseth>
+//                 Max Beatty <https://github.com/maxbeatty>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Dotenv {}


### PR DESCRIPTION
Dotenv can be imported like this:

```typescript
import 'dotenv/config';
```

But the *d.ts* file is missing and therefore it tells that the module doesn't exist. This PR can solve this case I think.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/motdotla/dotenv/blob/master/config.js