### PR TITLE
[react-click-outside] Add decorator support

### DIFF
--- a/types/react-click-outside/index.d.ts
+++ b/types/react-click-outside/index.d.ts
@@ -1,11 +1,12 @@
 // Type definitions for react-click-outside 3.0
 // Project: https://github.com/kentor/react-click-outside
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
+//                 Roman Nuritdinov <https://github.com/Ky6uk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as React from "react";
 
-declare function enhanceWithClickOutside<P = {}>(wrappedComponent: React.ComponentClass<P>): React.ComponentClass<P>;
+declare function enhanceWithClickOutside<C extends React.ComponentClass<any>>(wrappedComponent: C): C;
 
 declare namespace enhanceWithClickOutside { }
 export = enhanceWithClickOutside;

--- a/types/react-click-outside/react-click-outside-tests.tsx
+++ b/types/react-click-outside/react-click-outside-tests.tsx
@@ -22,6 +22,20 @@ class StatefulComponent extends React.Component<Props, State> {
     }
 }
 
+@enhanceWithClickOutside
+class ComponentWithDecorator extends React.Component<Props, State> {
+    state = { isOpened: true };
+
+    handleClickOutside() {
+        this.setState({ isOpened: false });
+    }
+
+  render() {
+      return <div>{this.props.text}</div>;
+    }
+}
+
 const ClickOutsideStatefulComponent = enhanceWithClickOutside(StatefulComponent);
 
 render(<ClickOutsideStatefulComponent text="" />, document.getElementById('test'));
+render(<ComponentWithDecorator text="" />, document.getElementById('test'));

--- a/types/react-click-outside/tsconfig.json
+++ b/types/react-click-outside/tsconfig.json
@@ -16,7 +16,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "experimentalDecorators": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
These changes provide to use `enhanceWithClickOutside` as decorator in addition to existing usage.