### PR TITLE
Two more cleanup items from typescript@next

### DIFF
--- a/types/transducers-js/transducers-js-tests.ts
+++ b/types/transducers-js/transducers-js-tests.ts
@@ -161,12 +161,12 @@ function advancedIntoExample() {
   const string: string = into("", t.map((s: string) => s + s), ["a", "b"]);
   const object1: { [key: string]: number } = into(
     {},
-    t.map((s: string) => [s, s.length]),
+    t.map((s: string) => [s, s.length] as [string, number]),
     ["a", "b"],
   );
   const object2: { [key: string]: boolean } = into(
     {},
-    t.map((kv: [string, number]) => [kv[0], true]),
+    t.map((kv: [string, number]) => [kv[0], true] as [string, boolean]),
     { a: 1, b: 2 }
   );
 }

--- a/types/zipkin-context-cls/tsconfig.json
+++ b/types/zipkin-context-cls/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/zipkin-transport-http/tsconfig.json
+++ b/types/zipkin-transport-http/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
1. Transducers-js' tests incorrectly assumed that tuple types were inferred from array literals. Added an annotation.
2. zipkin-context-cls and zipkin-transport-http both depend on zipkin, which requires either dom or node's Console to be defined. Added `lib: "dom"` in both tsconfigs.