### PR TITLE
DocumentArray disciminator() should be able to receive both document and model interface

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2409,6 +2409,13 @@ declare module "mongoose" {
          */
         discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
 
+        /**
+         * Adds a discriminator type.
+         * @param name discriminator model name
+         * @param schema discriminator model schema
+         */
+        discriminator<U extends Document, M extends Model<U>>(name: string, schema: Schema): M;
+
       }
 
       /*


### PR DESCRIPTION

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.) - No new tests required
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongoosejs.com/docs/discriminators.html#embedded-discriminators-in-arrays
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Since documentArray.discriminator returns a model, there is a possibility to pass an interface for the model (as well as an interface for the document) allowing the developer to specify instance methods and static functions for the document and model.
