### PR TITLE
Restore covariant comparison to bluebird's Promise

### DIFF
--- a/types/bluebird-global/index.d.ts
+++ b/types/bluebird-global/index.d.ts
@@ -113,12 +113,15 @@
 import Bluebird = require("bluebird");
 
 declare global {
+    type IterateFunction<T, R> = (item: T, index: number, arrayLength: number) => (R | PromiseLike<R>);
     /*
      * Patch all instance method
      */
     interface Promise<T> {
-        all: Bluebird<T>["all"];
-        any: Bluebird<T>["any"];
+        all(this: Promise<Iterable<{}>>): Bluebird<T>;
+        all(): Bluebird<never>;
+        any<Q>(this: Promise<T & Iterable<Q>>): Bluebird<Q>;
+        any(): Bluebird<never>;
         asCallback: Bluebird<T>["asCallback"];
         bind: Bluebird<T>["bind"];
         call: Bluebird<T>["call"];
@@ -128,9 +131,9 @@ declare global {
         delay: Bluebird<T>["delay"];
         disposer: Bluebird<T>["disposer"];
         done: Bluebird<T>["done"];
-        each: Bluebird<T>["each"];
+        each<Q>(this: Promise<T & Iterable<Q>>, iterator: IterateFunction<Q, any>): Bluebird<T>;
         error: Bluebird<T>["error"];
-        filter: Bluebird<T>["filter"];
+        filter<Q>(this: Promise<T & Iterable<Q>>, filterer: IterateFunction<Q, boolean>, options?: Bluebird.ConcurrencyOption): Bluebird<T>;
         // finally: Bluebird<T>["finally"]; // Provided by lib.es2018.promise.d.ts
         get: Bluebird<T>["get"];
         isCancelled: Bluebird<T>["isCancelled"];
@@ -139,17 +142,17 @@ declare global {
         isRejected: Bluebird<T>["isRejected"];
         isResolved: Bluebird<T>["isResolved"];
         lastly: Bluebird<T>["lastly"];
-        map: Bluebird<T>["map"];
-        mapSeries: Bluebird<T>["mapSeries"];
+        map<U, Q>(this: Promise<T & Iterable<Q>>, mapper: IterateFunction<Q, U>, options?: Bluebird.ConcurrencyOption): Bluebird<U[]>;
+        mapSeries<U, Q>(this: Promise<T & Iterable<Q>>, iterator: IterateFunction<Q, U>): Bluebird<U[]>;
         nodeify: Bluebird<T>["nodeify"];
         props: Bluebird<T>["props"];
         race: Bluebird<T>["race"];
         reason: Bluebird<T>["reason"];
-        reduce: Bluebird<T>["reduce"];
+        reduce<U, Q>(this: Promise<T & Iterable<Q>>, reducer: (memo: U, item: Q, index: number, arrayLength: number) => (U | PromiseLike<U>), initialValue?: U): Bluebird<U>;
         reflect: Bluebird<T>["reflect"];
         return: Bluebird<T>["return"];
-        some: Bluebird<T>["some"];
-        spread: Bluebird<T>["spread"];
+        some(this: Promise<Iterable<{}>>, count: number): Bluebird<T>;
+        spread<U, Q>(this: Bluebird<T & Iterable<Q>>, fulfilledHandler: (...values: Q[]) => (U | PromiseLike<U>)): Bluebird<U>;
         suppressUnhandledRejections: Bluebird<T>["suppressUnhandledRejections"];
         tap: Bluebird<T>["tap"];
         tapCatch: Bluebird<T>["tapCatch"];

--- a/types/bluebird-global/index.d.ts
+++ b/types/bluebird-global/index.d.ts
@@ -146,7 +146,8 @@ declare global {
         mapSeries<U, Q>(this: Promise<T & Iterable<Q>>, iterator: IterateFunction<Q, U>): Bluebird<U[]>;
         nodeify: Bluebird<T>["nodeify"];
         props: Bluebird<T>["props"];
-        race: Bluebird<T>["race"];
+        race<Q>(this: Promise<T & Iterable<Q>>): Bluebird<Q>;
+        race(): Bluebird<never>;
         reason: Bluebird<T>["reason"];
         reduce<U, Q>(this: Promise<T & Iterable<Q>>, reducer: (memo: U, item: Q, index: number, arrayLength: number) => (U | PromiseLike<U>), initialValue?: U): Bluebird<U>;
         reflect: Bluebird<T>["reflect"];

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -553,7 +553,7 @@ bool = fooProm.isResolved();
 strProm = fooProm.call("foo");
 strProm = fooProm.call("foo", 1, 2, 3);
 
-// $ExpectType Bluebird<any>
+// $ExpectType Bluebird<never>
 quxProm.call("qux");
 
 strProm = fooProm.get("foo").then(method => method());

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -553,7 +553,7 @@ bool = fooProm.isResolved();
 strProm = fooProm.call("foo");
 strProm = fooProm.call("foo", 1, 2, 3);
 
-// $ExpectType Bluebird<never>
+// $ExpectType Bluebird<any>
 quxProm.call("qux");
 
 strProm = fooProm.get("foo").then(method => method());

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -350,7 +350,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * });
    * </code>
    */
-  call<U extends keyof R>(propertyName: U, ...args: any[]): Bluebird<any>;
+  call<U extends keyof Q, Q>(this: Bluebird<Q>, propertyName: U, ...args: any[]): Bluebird<Q[U] extends (...args: any[]) => any ? ReturnType<Q[U]> : never>;
 
   /**
    * This is a convenience method for doing:

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -560,12 +560,12 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Like calling `.then`, but the fulfillment value or rejection reason is assumed to be an array, which is flattened to the formal parameters of the handlers.
    */
-  spread<U, Q>(this: Bluebird<R & Iterable<Q>>, fulfilledHandler: (...values: Array<Q>) => Resolvable<U>): Bluebird<U>;
+  spread<U, Q>(this: Bluebird<R & Iterable<Q>>, fulfilledHandler: (...values: Q[]) => Resolvable<U>): Bluebird<U>;
 
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  all(this: Bluebird<Iterable<unknown>>): Bluebird<R>;
+  all(this: Bluebird<Iterable<{}>>): Bluebird<R>;
 
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
@@ -592,7 +592,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  some(this: Bluebird<Iterable<unknown>>, count: number): Bluebird<R>;
+  some(this: Bluebird<Iterable<{}>>, count: number): Bluebird<R>;
 
   /**
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -37,8 +37,6 @@
 
 type Constructor<E> = new (...args: any[]) => E;
 type CatchFilter<E> = ((error: E) => boolean) | (object & E);
-type IterableItem<R> = R extends Iterable<infer U> ? U : never;
-type IterableOrNever<R> = Extract<R, Iterable<any>>;
 type Resolvable<R> = R | PromiseLike<R>;
 type IterateFunction<T, R> = (item: T, index: number, arrayLength: number) => Resolvable<R>;
 
@@ -352,7 +350,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * });
    * </code>
    */
-  call<U extends keyof R>(propertyName: U, ...args: any[]): Bluebird<R[U] extends (...args: any[]) => any ? ReturnType<R[U]> : never>;
+  call<U extends keyof R>(propertyName: U, ...args: any[]): Bluebird<any>;
 
   /**
    * This is a convenience method for doing:
@@ -562,12 +560,17 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Like calling `.then`, but the fulfillment value or rejection reason is assumed to be an array, which is flattened to the formal parameters of the handlers.
    */
-  spread<U>(fulfilledHandler: (...values: Array<IterableItem<R>>) => Resolvable<U>): Bluebird<U>;
+  spread<U, Q>(this: Bluebird<R & Iterable<Q>>, fulfilledHandler: (...values: Array<Q>) => Resolvable<U>): Bluebird<U>;
 
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  all(): Bluebird<IterableOrNever<R>>;
+  all(this: Bluebird<Iterable<unknown>>): Bluebird<R>;
+
+  /**
+   * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   */
+  all(): Bluebird<never>;
 
   /**
    * Same as calling `Promise.props(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
@@ -578,42 +581,59 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Same as calling `Promise.any(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  any(): Bluebird<IterableItem<R>>;
+  any<Q>(this: Bluebird<R & Iterable<Q>>): Bluebird<Q>;
+
+  /**
+   * Same as calling `Promise.any(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   */
+  any(): Bluebird<never>;
 
   /**
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  some(count: number): Bluebird<IterableOrNever<R>>;
+  some(this: Bluebird<Iterable<unknown>>, count: number): Bluebird<R>;
+
+  /**
+   * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   */
+  some(count: number): Bluebird<never>;
 
   /**
    * Same as calling `Promise.race(thisPromise, count)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  race(): Bluebird<IterableItem<R>>;
+  race<Q>(this: Bluebird<R & Iterable<Q>>): Bluebird<Q>;
+
+  /**
+   * Same as calling `Promise.race(thisPromise, count)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
+   */
+  race(): Bluebird<never>;
 
   /**
    * Same as calling `Bluebird.map(thisPromise, mapper)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  map<U>(mapper: IterateFunction<IterableItem<R>, U>, options?: Bluebird.ConcurrencyOption): Bluebird<R extends Iterable<any> ? U[] : never>;
+  map<U, Q>(this: Bluebird<R & Iterable<Q>>, mapper: IterateFunction<Q, U>, options?: Bluebird.ConcurrencyOption): Bluebird<U[]>;
 
   /**
    * Same as calling `Promise.reduce(thisPromise, Function reducer, initialValue)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  reduce<U>(reducer: (memo: U, item: IterableItem<R>, index: number, arrayLength: number) => Resolvable<U>, initialValue?: U): Bluebird<R extends Iterable<any> ? U : never>;
+  reduce<U, Q>(this: Bluebird<R & Iterable<Q>>, reducer: (memo: U, item: Q, index: number, arrayLength: number) => Resolvable<U>, initialValue?: U): Bluebird<U>;
 
   /**
    * Same as calling ``Promise.filter(thisPromise, filterer)``. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  filter(filterer: IterateFunction<IterableItem<R>, boolean>, options?: Bluebird.ConcurrencyOption): Bluebird<IterableOrNever<R>>;
+  filter<Q>(this: Bluebird<R & Iterable<Q>>, filterer: IterateFunction<Q, boolean>, options?: Bluebird.ConcurrencyOption): Bluebird<R>;
 
   /**
    * Same as calling ``Bluebird.each(thisPromise, iterator)``. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  each(iterator: IterateFunction<IterableItem<R>, any>): Bluebird<IterableOrNever<R>>;
+  each<Q>(this: Bluebird<R & Iterable<Q>>, iterator: IterateFunction<Q, any>): Bluebird<R>;
 
   /**
    * Same as calling ``Bluebird.mapSeries(thisPromise, iterator)``. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  mapSeries<U>(iterator: IterateFunction<IterableItem<R>, U>): Bluebird<R extends Iterable<any> ? U[] : never>;
+  mapSeries<U, Q>(this: Bluebird<R & Iterable<Q>>, iterator: IterateFunction<Q, U>): Bluebird<U[]>;
 
   /**
    * Cancel this `promise`. Will not do anything if this promise is already settled or if the cancellation feature has not been enabled

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -1111,6 +1111,7 @@ knex('users')
 //
 // Migrations
 //
+const name = "test";
 const config = {
   directory: "./migrations",
   extension: "js",


### PR DESCRIPTION
Now that typescript@next checks variance more strictly for conditional types, bluebird's Promise is invariant. This PR removes conditional types from bluebird so that Promise compares covariantly again.

This is the correct follow-up to my initial cleanup attempt. Basically, we had to remove any conditional types from Bluebird since conditional types are checked more strictly now. They are replaced with (1) overloads (2) this-parameters (3) inference to intersections.

The combination is harder to read than conditional types. And it required some duplicative changes to bluebird-global, but its source package hasn't been updated in 2 years so I think that is fine.