### PR TITLE
Re-deprecate p-throttle

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1138,7 +1138,7 @@
             "libraryName": "p-throttle",
             "typingsPackageName": "p-throttle",
             "sourceRepoURL": "https://github.com/sindresorhus/p-throttle",
-            "asOfVersion": "2.0.0"
+            "asOfVersion": "2.1.0"
         },
         {
             "libraryName": "param-case",


### PR DESCRIPTION
2.0.0 was not published correctly, even though types-publisher thought it deprecated the package correctly. So I am deprecating 2.1.0 instead.