### PR TITLE
[history-v3] Add missing hash property in Location and descriptor

### DIFF
--- a/types/history/v3/index.d.ts
+++ b/types/history/v3/index.d.ts
@@ -38,6 +38,7 @@ export interface Location {
     pathname: Pathname;
     search: Search;
     query: Query;
+    hash: Hash;
     state: LocationState;
     action: Action;
     key: LocationKey;
@@ -47,6 +48,7 @@ export interface LocationDescriptorObject {
     pathname?: Pathname;
     search?: Search;
     query?: Query;
+    hash?: Hash;
     state?: LocationState;
 }
 


### PR DESCRIPTION
A `hash` property is missing in `Location` and `LocationDescriptorObject`. 

Although it is not mentioned in the documentation, Locations are created using the `createLocation` function, which takes a `LocationDescriptor` as input, which is either a string or a `LocationDescriptorObject`.
The function is defined here:
https://github.com/ReactTraining/history/blob/v3.2.0/modules/LocationUtils.js#L9
As we can see,  the `LocationDescriptorObject` is expected to maybe have a `hash` property, and the returned location always include a `hash`. 

The only other function that expects a `LocationDescriptor` is `createPath` which is defined here: 
https://github.com/ReactTraining/history/blob/v3.2.0/modules/PathUtils.js#L72
It also expects a `hash` attribute to maybe be present in the `LocationDescriptorObject`.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] ~Add or edit tests to reflect the change.~ (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/history/blob/v3.3.0/modules/LocationUtils.js#L9
- [X] ~Increase the version number in the header if appropriate.~
- [X] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

Edit: Formatting and using links that point to history version the type is said to support