### PR TITLE
[@types/kafka-node] Add connect event for HighLevelConsumer

### DIFF
--- a/types/kafka-node/index.d.ts
+++ b/types/kafka-node/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for kafka-node 2.0
 // Project: https://github.com/SOHU-Co/kafka-node/
-// Definitions by: Daniel Imrie-Situnayake <https://github.com/dansitu>, Bill <https://github.com/bkim54>, Michael Haan <https://github.com/sfrooster>, Amiram Korach <https://github.com/amiram>
+// Definitions by: Daniel Imrie-Situnayake <https://github.com/dansitu>
+//                 Bill <https://github.com/bkim54>
+//                 Michael Haan <https://github.com/sfrooster>
+//                 Amiram Korach <https://github.com/amiram>
+//                 Insanehong <https://github.com/insanehong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -61,7 +65,7 @@ export class HighLevelConsumer {
     client: Client;
     on(eventName: "message", cb: (message: Message) => any): void;
     on(eventName: "error" | "offsetOutOfRange", cb: (error: any) => any): void;
-    on(eventName: "rebalancing" | "rebalanced", cb: () => any): void;
+    on(eventName: "rebalancing" | "rebalanced" | "connect", cb: () => any): void;
     addTopics(topics: string[] | Topic[], cb?: (error: any, added: string[] | Topic[]) => any): void;
     removeTopics(topics: string | string[], cb: (error: any, removed: number) => any): void;
     commit(cb: (error: any, data: any) => any): void;

--- a/types/kafka-node/kafka-node-tests.ts
+++ b/types/kafka-node/kafka-node-tests.ts
@@ -244,6 +244,8 @@ consumerGroup.on('error', (err) => {
 });
 consumerGroup.on('message', (msg) => {
 });
+consumerGroup.on('connect', () => {
+});
 consumerGroup.close(true, () => {
 });
 


### PR DESCRIPTION
ConsumerGroup and ConsumerGroupStream of kafka-node had already "connect" event .
But types/kafka-node missed event in HighLevelConsumer.

- https://github.com/SOHU-Co/kafka-node/pull/935
- https://github.com/SOHU-Co/kafka-node/blob/master/lib/consumerGroupStream.js#L69
- https://github.com/SOHU-Co/kafka-node/blob/master/lib/consumerGroup.js#L591
- https://github.com/SOHU-Co/kafka-node/blob/master/example/consumerGroupMember.js#L21

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
