### PR TITLE
jsonwebtoken: Allow audience to be verified with regular expressions

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -59,7 +59,7 @@ export interface SignOptions {
 
 export interface VerifyOptions {
     algorithms?: string[];
-    audience?: string | string[];
+    audience?: string | RegExp | Array<string | RegExp>;
     clockTimestamp?: number;
     clockTolerance?: number;
     issuer?: string | string[];

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -101,6 +101,12 @@ cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, { audience: "urn:foo" }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
+jwt.verify(token, cert, { audience: /urn:f[o]{2}/ }, (err, decoded) => {
+    // if audience mismatch, err == invalid audience
+});
+jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded) => {
+    // if audience mismatch, err == invalid audience
+});
 
 // verify issuer
 cert = fs.readFileSync("public.pem"); // get public key


### PR DESCRIPTION
Audience checks were enhanced to allow verification with regular expressions here: https://github.com/auth0/node-jsonwebtoken/pull/398

Per [the docs](https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback):
>`audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
Eg: `"urn:foo"`, `/urn:f[o]{2}/`, `[/urn:f[o]{2}/, "urn:bar"]`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
