### PR TITLE
[cron] Fix types definitions

### DIFF
--- a/types/cron/cron-tests.ts
+++ b/types/cron/cron-tests.ts
@@ -1,5 +1,7 @@
 
 import cron = require('cron');
+import moment = require('moment');
+
 var CronJob = cron.CronJob;
 var CronTime = cron.CronTime;
 
@@ -34,6 +36,16 @@ var job = new CronJob(new Date(), () => {
   timeZone /* Time zone of this job. */
 );
 
+// Another example with Moment
+var job = new CronJob(moment(), () => {
+  /* runs once at the specified moment. */
+  }, () => {
+    /* This function is executed when the job stops */
+  },
+  true, /* Start the job right now */
+  timeZone /* Time zone of this job. */
+);
+
 // For good measure
 var job = new CronJob({
   cronTime: '00 30 11 * * 1-5',
@@ -48,7 +60,8 @@ var job = new CronJob({
   timeZone: 'America/Los_Angeles'
 });
 console.log(job.lastDate());
-console.log(job.nextDates(1));
+console.log(job.nextDates());// Should be a Moment object
+console.log(job.nextDates(1));// Should be an array of Moment object
 console.log(job.running);
 job.setTime(new CronTime('00 30 11 * * 1-2'));
 job.start();
@@ -67,4 +80,5 @@ try {
 // Check cronTime fomat
 new CronTime('* * * * * *');
 new CronTime(new Date());
+new CronTime(moment());
 

--- a/types/cron/index.d.ts
+++ b/types/cron/index.d.ts
@@ -4,6 +4,8 @@
 //                 Lundarl Gholoi <https://github.com/winup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import { Moment } from 'moment';
+
 export declare class CronTime {
     /**
      * Create a new ```CronTime```.
@@ -11,13 +13,14 @@ export declare class CronTime {
      * @param zone Timezone name. You can check all timezones available at [Moment Timezone Website](http://momentjs.com/timezone/).
      * @param utcOffset UTC offset. Don't use both ```zone``` and ```utcOffset``` together or weird things may happen.
      */
-    constructor(source: string | Date, zone?: string, utcOffset?: string | number);
+    constructor(source: string | Date | Moment, zone?: string, utcOffset?: string | number);
 
     /**
      * Tells you when ```CronTime``` will be run.
      * @param i Indicate which turn of run after now. If not given return next run time.
      */
-    public sendAt(i?: number): Date;
+    public sendAt(): Moment;
+    public sendAt(i?: number): Moment[];
     /**
      * Get the number of milliseconds in the future at which to fire our callbacks.
      */
@@ -28,7 +31,7 @@ export declare interface CronJobParameters {
     /**
      * The time to fire off your job. This can be in the form of cron syntax or a JS ```Date``` object.
      */
-    cronTime: string | Date;
+    cronTime: string | Date | Moment;
     /**
      * The function to fire at the specified time. If an ```onComplete``` callback was provided, ```onTick``` will receive it as an argument. ```onTick``` may call ```onComplete``` when it has finished its work.
      */
@@ -85,7 +88,7 @@ export declare class CronJob {
      * @param utcOffset This allows you to specify the offset of your timezone rather than using the ```timeZone``` param. Probably don't use both ```timeZone``` and ```utcOffset``` together or weird things may happen.
      * @param unrefTimeout If you have code that keeps the event loop running and want to stop the node process when that finishes regardless of the state of your cronjob, you can do so making use of this parameter. This is off by default and cron will run as if it needs to control the event loop. For more information take a look at [timers#timers_timeout_unref](https://nodejs.org/api/timers.html#timers_timeout_unref) from the NodeJS docs.
      */
-    constructor(cronTime: string | Date, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean);
+    constructor(cronTime: string | Date | Moment, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean);
     /**
      * Create a new ```CronJob```.
      * @param options Job parameters.
@@ -113,7 +116,8 @@ export declare class CronJob {
      * Tells you when a ```CronTime``` will be run.
      * @param i Indicate which turn of run after now. If not given return next run time.
      */
-    public nextDates(i?: number): Date;
+    public nextDates(): Moment;
+    public nextDates(i?: number): Moment[];
     /**
      * Add another ```onTick``` function.
      * @param callback Target function.
@@ -122,8 +126,8 @@ export declare class CronJob {
 }
 
 export declare var job:
-    ((cronTime: string | Date, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean) => CronJob)
+    ((cronTime: string | Date | Moment, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean) => CronJob)
     | ((options: CronJobParameters) => CronJob);
-export declare var time: (source: string | Date, zone?: string) => CronTime;
-export declare var sendAt: (cronTime: CronTime) => Date;
-export declare var timeout: (cronTime: CronTime) => number;
+export declare var time: (source: string | Date | Moment, zone?: string) => CronTime;
+export declare var sendAt: (cronTime: string | Date | Moment) => Moment;
+export declare var timeout: (cronTime: string | Date | Moment) => number;

--- a/types/cron/package.json
+++ b/types/cron/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "moment": ">=2.14.0"
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/kelektiv/node-cron/blob/master/lib/cron.js#L42
This check for a `Moment` object so the `source` can be one.
https://github.com/kelektiv/node-cron/blob/master/lib/cron.js#L135
`sendAt` returns a `Moment` object and not a `Date`.
https://github.com/kelektiv/node-cron/blob/master/lib/cron.js#L672
The `CronTime` constructor do not take a `CronTime` as a first parameter but a string, `Date` or `Moment`.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.