### PR TITLE
slate & slate-react: Changes for 0.44.0 and 0.37.0

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -289,7 +289,7 @@ export class Editor extends React.Component<EditorProps, EditorState> implements
     moveToStartOfPreviousText: CoreEditor['moveToStartOfPreviousText'];
     moveToStartOfText: CoreEditor['moveToStartOfText'];
     moveToRangeOfDocument: CoreEditor['moveToRangeOfDocument'];
-    moveToRangeOf: CoreEditor['moveToRangeOf'];
+    moveToRangeOfNode: CoreEditor['moveToRangeOfNode'];
     select: CoreEditor['select'];
     addMarkAtRange: CoreEditor['addMarkAtRange'];
     deleteAtRange: CoreEditor['deleteAtRange'];

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -220,7 +220,7 @@ editor
 .moveToEndOfPreviousText()
 .moveToEndOfText()
 .moveToFocus()
-.moveToRangeOf(inline)
+.moveToRangeOfNode(inline)
 .moveToRangeOfDocument()
 .moveToStart()
 .moveToStartOfBlock()

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for slate 0.43
+// Type definitions for slate 0.44
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Andy Kent <https://github.com/andykent>
 //                 Jamie Talbot <https://github.com/majelbstoat>
@@ -8,6 +8,7 @@
 //                 Francesco Agnoletto <https://github.com/Kornil>
 //                 Irwan Fario Subastian <https://github.com/isubasti>
 //                 Hanna Greaves <https://github.com/sgreav>
+//                 Jack Allen <https://github.com/jackall3n>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as Immutable from "immutable";
@@ -1144,7 +1145,7 @@ export class Editor implements Controller {
     moveToStartOfPreviousText(): Editor;
     moveToStartOfText(): Editor;
     moveToRangeOfDocument(): Editor;
-    moveToRangeOf(node: Node): Editor;
+    moveToRangeOfNode(node: Node): Editor;
     select(properties: Range | RangeProperties): Editor;
     addMarkAtRange(range: Range, mark: Mark | MarkProperties | string): Editor;
     deleteAtRange(range: Range): Editor;
@@ -1933,7 +1934,7 @@ export interface Controller {
     /**
      * Move the current selection's anchor to the start of the provided node and its focus to the end of it.
      */
-    moveToRangeOf(node: Node): Controller;
+    moveToRangeOfNode(node: Node): Controller;
     /**
      * Merge the current selection with the provided properties
      */

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -461,6 +461,8 @@ declare class BaseNode<
     getPreviousNode(path: Path): Node | null;
     getPreviousSibling(path: Path): Node | null;
     getPreviousText(path: Path): Text | null;
+    getRootBlocksAtRange(range: Range): Immutable.List<Block>;
+    getRootInlinesAtRange(range: Range): Immutable.List<Block>;
     getSelectionIndexes(
         range: Range,
         isSelected?: boolean

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -402,8 +402,6 @@ declare class BaseNode<
     findDescendants(iterator: (node: Node) => boolean): Node | null;
     getActiveMarksAtRange(range: Range): Immutable.Set<Mark>;
     getAncestors(path: Path): Immutable.List<Node> | null;
-    getBlocksAtRange(range: Range): Immutable.List<Block>;
-    getBlocksAtRangeAsArray(range: Range): Block[];
     getBlocks(): Immutable.List<Block>;
     getBlocksAsArray(): Block[];
     getBlocksByType(type: string): Immutable.List<Block>;
@@ -433,6 +431,8 @@ declare class BaseNode<
     getInsertMarksAtRange(range: Range): Immutable.Set<Mark>;
     getKeysToPathsTable(): object;
     getLastText(): Text | null;
+    getLeafBlocksAtRange(range: Range): Immutable.List<Block>;
+    getLeafBlocksAtRangeAsArray(range: Range): Block[];
     getMarks(): Immutable.Set<Mark>;
     getMarksAsArray(): Mark[];
     getMarksAtPosition(key: string, offset: number): Immutable.Set<Mark>;
@@ -884,6 +884,8 @@ export type ErrorCode =
     | "child_required"
     | "child_type_invalid"
     | "child_unknown"
+    | "child_min_invalid"
+    | "child_max_invalid"
     | "first_child_object_invalid"
     | "first_child_type_invalid"
     | "last_child_object_invalid"

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -210,7 +210,7 @@ editor
 .moveToEndOfPreviousText()
 .moveToEndOfText()
 .moveToFocus()
-.moveToRangeOf(inline)
+.moveToRangeOfNode(inline)
 .moveToRangeOfDocument()
 .moveToStart()
 .moveToStartOfBlock()


### PR DESCRIPTION

**Changes:** 
[updated] Updated Editor API with moveToRangeOfNode()
[updated] Update Document method for getLeafBlocksAtRange() and 
[added] getRootBlocksAtRange & getRootInlinesAtRange

**Tasks**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [0.44.0](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/Changelog.md#0440--november-8-2018) & [0.37.0](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/Changelog.md#0370--august-3-2018)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

