### PR TITLE
amqplib: Add serverProperties to Connection object

### DIFF
--- a/types/amqplib/amqplib-tests.ts
+++ b/types/amqplib/amqplib-tests.ts
@@ -15,11 +15,12 @@ amqp.connect('amqp://localhost')
 amqp.connect('amqp://localhost')
     .then(connection => {
         connection.serverProperties.copyright; // $ExpectType string | undefined
-        connection.serverProperties.platform; // $ExpectType string | undefined
-        connection.serverProperties.information; // $ExpectType string | undefined
+        connection.serverProperties.platform; // $ExpectType string
+        connection.serverProperties.information; // $ExpectType string
         connection.serverProperties.host; // $ExpectType string
         connection.serverProperties.product; // $ExpectType string
         connection.serverProperties.version; // $ExpectType string
+        connection.serverProperties.customField; // $ExpectType string | undefined
 
         return connection.createChannel()
             .tap(channel => channel.checkQueue('myQueue'))
@@ -45,11 +46,12 @@ import amqpcb = require('amqplib/callback_api');
 amqpcb.connect('amqp://localhost', (err, connection) => {
     if (!err) {
         connection.serverProperties.copyright; // $ExpectType string | undefined
-        connection.serverProperties.platform; // $ExpectType string | undefined
-        connection.serverProperties.information; // $ExpectType string | undefined
+        connection.serverProperties.platform; // $ExpectType string
+        connection.serverProperties.information; // $ExpectType string
         connection.serverProperties.host; // $ExpectType string
         connection.serverProperties.product; // $ExpectType string
         connection.serverProperties.version; // $ExpectType string
+        connection.serverProperties.customField; // $ExpectType string | undefined
 
         connection.createChannel((err, channel) => {
           if (!err) {

--- a/types/amqplib/amqplib-tests.ts
+++ b/types/amqplib/amqplib-tests.ts
@@ -14,6 +14,13 @@ amqp.connect('amqp://localhost')
 
 amqp.connect('amqp://localhost')
     .then(connection => {
+        connection.serverProperties.copyright; // $ExpectType string | undefined
+        connection.serverProperties.platform; // $ExpectType string | undefined
+        connection.serverProperties.information; // $ExpectType string | undefined
+        connection.serverProperties.host; // $ExpectType string
+        connection.serverProperties.product; // $ExpectType string
+        connection.serverProperties.version; // $ExpectType string
+
         return connection.createChannel()
             .tap(channel => channel.checkQueue('myQueue'))
             .then(channel => {
@@ -37,6 +44,13 @@ import amqpcb = require('amqplib/callback_api');
 
 amqpcb.connect('amqp://localhost', (err, connection) => {
     if (!err) {
+        connection.serverProperties.copyright; // $ExpectType string | undefined
+        connection.serverProperties.platform; // $ExpectType string | undefined
+        connection.serverProperties.information; // $ExpectType string | undefined
+        connection.serverProperties.host; // $ExpectType string
+        connection.serverProperties.product; // $ExpectType string
+        connection.serverProperties.version; // $ExpectType string
+
         connection.createChannel((err, channel) => {
           if (!err) {
               channel.assertQueue('myQueue', {}, (err, ok) => {

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -12,73 +12,27 @@ export interface Connection extends events.EventEmitter {
 export interface Channel extends events.EventEmitter {
     close(callback: (err: any) => void): void;
 
-    assertQueue(
-        queue?: string,
-        options?: Options.AssertQueue,
-        callback?: (err: any, ok: Replies.AssertQueue) => void
-    ): void;
+    assertQueue(queue?: string, options?: Options.AssertQueue, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
     checkQueue(queue: string, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
 
-    deleteQueue(
-        queue: string,
-        options?: Options.DeleteQueue,
-        callback?: (err: any, ok: Replies.DeleteQueue) => void
-    ): void;
+    deleteQueue(queue: string, options?: Options.DeleteQueue, callback?: (err: any, ok: Replies.DeleteQueue) => void): void;
     purgeQueue(queue: string, callback?: (err: any, ok: Replies.PurgeQueue) => void): void;
 
-    bindQueue(
-        queue: string,
-        source: string,
-        pattern: string,
-        args?: any,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): void;
-    unbindQueue(
-        queue: string,
-        source: string,
-        pattern: string,
-        args?: any,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): void;
+    bindQueue(queue: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
+    unbindQueue(queue: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
 
-    assertExchange(
-        exchange: string,
-        type: string,
-        options?: Options.AssertExchange,
-        callback?: (err: any, ok: Replies.AssertExchange) => void
-    ): void;
+    assertExchange(exchange: string, type: string, options?: Options.AssertExchange, callback?: (err: any, ok: Replies.AssertExchange) => void): void;
     checkExchange(exchange: string, callback?: (err: any, ok: Replies.Empty) => void): void;
 
-    deleteExchange(
-        exchange: string,
-        options?: Options.DeleteExchange,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): void;
+    deleteExchange(exchange: string, options?: Options.DeleteExchange, callback?: (err: any, ok: Replies.Empty) => void): void;
 
-    bindExchange(
-        destination: string,
-        source: string,
-        pattern: string,
-        args?: any,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): void;
-    unbindExchange(
-        destination: string,
-        source: string,
-        pattern: string,
-        args?: any,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): void;
+    bindExchange(destination: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
+    unbindExchange(destination: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
 
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(
-        queue: string,
-        onMessage: (msg: Message | null) => any,
-        options?: Options.Consume,
-        callback?: (err: any, ok: Replies.Consume) => void
-    ): void;
+    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
 
     cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
     get(queue: string, options?: Options.Get, callback?: (err: any, ok: Message | false) => void): void;
@@ -95,36 +49,22 @@ export interface Channel extends events.EventEmitter {
 }
 
 export interface ConfirmChannel extends Channel {
-    publish(
-        exchange: string,
-        routingKey: string,
-        content: Buffer,
-        options?: Options.Publish,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): boolean;
-    sendToQueue(
-        queue: string,
-        content: Buffer,
-        options?: Options.Publish,
-        callback?: (err: any, ok: Replies.Empty) => void
-    ): boolean;
+    publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): boolean;
+    sendToQueue(queue: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): boolean;
 
     waitForConfirms(callback?: (err: any) => void): void;
 }
 
 export const credentials: {
     external(): {
-        mechanism: string;
-        response(): Buffer;
+      mechanism: string;
+      response(): Buffer;
     };
-    plain(
-        username: string,
-        password: string
-    ): {
-        mechanism: string;
-        response(): Buffer;
-        username: string;
-        password: string;
+    plain(username: string, password: string): {
+      mechanism: string;
+      response(): Buffer;
+      username: string;
+      password: string;
     };
 };
 

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -2,36 +2,92 @@ import events = require('events');
 import { Replies, Options, Message } from './properties';
 export * from './properties';
 
+export interface ServerProperties {
+    host: string;
+    product: string;
+    version: string;
+    platform?: string;
+    copyright?: string;
+    information?: string;
+}
+
 export interface Connection extends events.EventEmitter {
     close(callback?: (err: any) => void): void;
     createChannel(callback: (err: any, channel: Channel) => void): void;
     createConfirmChannel(callback: (err: any, confirmChannel: ConfirmChannel) => void): void;
+    serverProperties: ServerProperties;
 }
 
 export interface Channel extends events.EventEmitter {
     close(callback: (err: any) => void): void;
 
-    assertQueue(queue?: string, options?: Options.AssertQueue, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
+    assertQueue(
+        queue?: string,
+        options?: Options.AssertQueue,
+        callback?: (err: any, ok: Replies.AssertQueue) => void
+    ): void;
     checkQueue(queue: string, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
 
-    deleteQueue(queue: string, options?: Options.DeleteQueue, callback?: (err: any, ok: Replies.DeleteQueue) => void): void;
+    deleteQueue(
+        queue: string,
+        options?: Options.DeleteQueue,
+        callback?: (err: any, ok: Replies.DeleteQueue) => void
+    ): void;
     purgeQueue(queue: string, callback?: (err: any, ok: Replies.PurgeQueue) => void): void;
 
-    bindQueue(queue: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
-    unbindQueue(queue: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
+    bindQueue(
+        queue: string,
+        source: string,
+        pattern: string,
+        args?: any,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): void;
+    unbindQueue(
+        queue: string,
+        source: string,
+        pattern: string,
+        args?: any,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): void;
 
-    assertExchange(exchange: string, type: string, options?: Options.AssertExchange, callback?: (err: any, ok: Replies.AssertExchange) => void): void;
+    assertExchange(
+        exchange: string,
+        type: string,
+        options?: Options.AssertExchange,
+        callback?: (err: any, ok: Replies.AssertExchange) => void
+    ): void;
     checkExchange(exchange: string, callback?: (err: any, ok: Replies.Empty) => void): void;
 
-    deleteExchange(exchange: string, options?: Options.DeleteExchange, callback?: (err: any, ok: Replies.Empty) => void): void;
+    deleteExchange(
+        exchange: string,
+        options?: Options.DeleteExchange,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): void;
 
-    bindExchange(destination: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
-    unbindExchange(destination: string, source: string, pattern: string, args?: any, callback?: (err: any, ok: Replies.Empty) => void): void;
+    bindExchange(
+        destination: string,
+        source: string,
+        pattern: string,
+        args?: any,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): void;
+    unbindExchange(
+        destination: string,
+        source: string,
+        pattern: string,
+        args?: any,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): void;
 
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
+    consume(
+        queue: string,
+        onMessage: (msg: Message | null) => any,
+        options?: Options.Consume,
+        callback?: (err: any, ok: Replies.Consume) => void
+    ): void;
 
     cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
     get(queue: string, options?: Options.Get, callback?: (err: any, ok: Message | false) => void): void;
@@ -48,22 +104,36 @@ export interface Channel extends events.EventEmitter {
 }
 
 export interface ConfirmChannel extends Channel {
-    publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): boolean;
-    sendToQueue(queue: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): boolean;
+    publish(
+        exchange: string,
+        routingKey: string,
+        content: Buffer,
+        options?: Options.Publish,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): boolean;
+    sendToQueue(
+        queue: string,
+        content: Buffer,
+        options?: Options.Publish,
+        callback?: (err: any, ok: Replies.Empty) => void
+    ): boolean;
 
     waitForConfirms(callback?: (err: any) => void): void;
 }
 
 export const credentials: {
     external(): {
-      mechanism: string;
-      response(): Buffer;
+        mechanism: string;
+        response(): Buffer;
     };
-    plain(username: string, password: string): {
-      mechanism: string;
-      response(): Buffer;
-      username: string;
-      password: string;
+    plain(
+        username: string,
+        password: string
+    ): {
+        mechanism: string;
+        response(): Buffer;
+        username: string;
+        password: string;
     };
 };
 

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -1,15 +1,6 @@
 import events = require('events');
-import { Replies, Options, Message } from './properties';
+import { Replies, Options, Message, ServerProperties } from './properties';
 export * from './properties';
-
-export interface ServerProperties {
-    host: string;
-    product: string;
-    version: string;
-    platform?: string;
-    copyright?: string;
-    information?: string;
-}
 
 export interface Connection extends events.EventEmitter {
     close(callback?: (err: any) => void): void;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -8,13 +8,14 @@
 
 import * as Promise from 'bluebird';
 import * as events from 'events';
-import { Replies, Options, Message, GetMessage, ConsumeMessage } from './properties';
+import { Replies, Options, Message, GetMessage, ConsumeMessage, ServerProperties } from './properties';
 export * from './properties';
 
 export interface Connection extends events.EventEmitter {
     close(): Promise<void>;
     createChannel(): Promise<Channel>;
     createConfirmChannel(): Promise<ConfirmChannel>;
+    serverProperties: ServerProperties;
 }
 
 export interface Channel extends events.EventEmitter {

--- a/types/amqplib/properties.d.ts
+++ b/types/amqplib/properties.d.ts
@@ -210,3 +210,12 @@ export interface XDeath {
     "original-expiration"?: any;
     "routing-keys": string[];
 }
+
+export interface ServerProperties {
+    host: string;
+    product: string;
+    version: string;
+    platform?: string;
+    copyright?: string;
+    information?: string;
+}

--- a/types/amqplib/properties.d.ts
+++ b/types/amqplib/properties.d.ts
@@ -215,7 +215,8 @@ export interface ServerProperties {
     host: string;
     product: string;
     version: string;
-    platform?: string;
+    platform: string;
     copyright?: string;
-    information?: string;
+    information: string;
+    [key: string]: string | undefined;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - This PR exposes the serverProperties object: https://github.com/squaremo/amqp.node/pull/452
   - This doc describes what fields are on serverProperties and which are optional: https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.start.server-properties
   - You can download the original spec here which also references the same fields as above: http://www.amqp.org/specification/0-9-1/amqp-org-download
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.