### PR TITLE
Allow `FederatedCredential` to be passed to `fetch()`

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -42,7 +42,7 @@ interface CMRequestInit {
     referrer?: string;
     referrerPolicy?: string;
     mode?: string;
-    credentials?: PasswordCredential|string;
+    credentials?: PasswordCredential|FederatedCredential|string;
     cache?: string;
     redirect?: string;
     integrity?: string;

--- a/types/webappsec-credential-management/webappsec-credential-management-tests.ts
+++ b/types/webappsec-credential-management/webappsec-credential-management-tests.ts
@@ -135,6 +135,9 @@ function federatedSignIn() {
                     // ... any other providers you care about ...
 
                     default:
+                        fetch(
+                            'https://example.com/loginEndpoint',
+                            { credentials: credential, method: 'POST' });
                         break;
                 }
             } else {
@@ -201,6 +204,12 @@ function additionalDataPost(credential: PasswordCredential, token: string) {
 
 function formEncodedPost(credential: PasswordCredential, token: string) {
     credential.additionalData = new URLSearchParams();
+    fetch(
+        'https://example.com/loginEndpoint',
+        { credentials: credential, method: 'POST' });
+}
+
+function federatedCredentialPost(credential: FederatedCredential) {
     fetch(
         'https://example.com/loginEndpoint',
         { credentials: credential, method: 'POST' });


### PR DESCRIPTION
Per MDN, either `PasswordCredential` *or* `FederatedCredential` can be passed as the `credentials` field in the fetch `init` argument:

https://developer.mozilla.org/en-US/docs/Web/API/FederatedCredential

Note:  I actually can't find anywhere in the `fetch` or credential management
API that says you can pass `PasswordCredential` (or `FederatedCredential`)
instead a string. I've asked at
https://github.com/w3c/webappsec-credential-management/issues/133 for
clarification.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/FederatedCredential
- Increase the version number in the header if appropriate.
- If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
