### PR TITLE
[spotify-web-playback-sdk] add setName method

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Festify Dev Team <https://github.com/Festify>
 //                 Marcus Weiner <https://github.com/mraerino>
 //                 Moritz Gunz <https://github.com/NeoLegends>
+//                 Daniel Almaguer <https://github.com/deini>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -118,6 +119,7 @@ declare namespace Spotify {
         previousTrack(): Promise<void>;
         resume(): Promise<void>;
         seek(pos_ms: number): Promise<void>;
+        setName(name: string): Promise<void>;
         setVolume(volume: number): Promise<void>;
         togglePlay(): Promise<void>;
     }

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -45,6 +45,10 @@ player.getVolume().then((volume: number) => {
     console.log(`The volume of the player is ${volume_percentage}%`);
 });
 
+player.setName("New player name").then(() => {
+    console.log("Player name updated!");
+});
+
 player.setVolume(0.5).then(() => {
     console.log("Volume updated!");
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-playback-sdk/reference/#api-spotify-player-setname
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Adds `setName` as according to the [docs](https://developer.spotify.com/documentation/web-playback-sdk/reference/#api-spotify-player-setname)
