### PR TITLE
[rtlcss] Add typing for rtlcss

### DIFF
--- a/types/rtlcss/index.d.ts
+++ b/types/rtlcss/index.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for rtlcss 2.4
+// Project: http://rtlcss.com
+// Definitions by:  Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.3
+
+export interface MapOptions {
+    scope: string;
+    ignoreCase: boolean;
+    greedy?: boolean;
+}
+
+export interface StringMap {
+    name: string;
+    priority: number;
+    exclusive?: boolean;
+    search: string|string[];
+    replace: string|string[];
+    options: MapOptions;
+}
+
+export interface ConfigOptions {
+    /**
+     * Applies to CSS rules containing no directional properties,
+     * it will update the selector by applying String Map.
+     */
+    autoRename: boolean;
+    /**
+     * Ensures autoRename is applied only if pair exists.
+     */
+    autoRenameStrict: boolean;
+    /**
+     * An object map of disabled plugins directives,
+     * where keys are plugin names and value are object
+     * hash of disabled directives. e.g. {'rtlcss':{'config':true}}.
+     */
+    blacklist: object;
+    /**
+     * Removes directives comments from output CSS.
+     */
+    clean: boolean;
+    /**
+     * Fallback value for String Map options.
+     */
+    greedy: boolean;
+    /**
+     * Applies String Map to URLs. You can also target specific node types using an object literal.
+     * e.g. {'atrule': true, 'decl': false}.
+     */
+    processUrls: boolean|object;
+    /**
+     * The default array of String Map.
+     */
+    stringMap: StringMap[];
+    /**
+     * When enabled, flips background-position expressed in length units using calc.
+     */
+    useCalc: boolean;
+}
+
+export interface HookOptions {
+    /**
+     * The function to be called before processing the CSS.
+     */
+    pre: () => void;
+    /**
+     * The function to be called after processing the CSS.
+     */
+    post: () => void;
+}
+
+/**
+ * Creates a new RTLCSS instance, process the input and return its result.
+ */
+export function process(css: string, options?: object, plugins?: object|string[], hooks?: HookOptions): string;
+
+/**
+ * Creates a new instance of RTLCSS using the passed configuration object.
+ */
+export function configure(config: ConfigOptions): object;

--- a/types/rtlcss/rtlcss-tests.ts
+++ b/types/rtlcss/rtlcss-tests.ts
@@ -1,0 +1,27 @@
+import * as rtlcss from "rtlcss";
+
+rtlcss.process("body { direction:ltr; }");
+
+const config = {
+    autoRename: false,
+    autoRenameStrict: false,
+    blacklist: {},
+    clean: true,
+    greedy: false,
+    processUrls: false,
+    stringMap: [
+        {
+            name    : 'left-right',
+            priority: 100,
+            search  : ['left', 'Left', 'LEFT'],
+            replace : ['right', 'Right', 'RIGHT'],
+            options : {
+                scope : '*',
+                ignoreCase : false
+            }
+        }
+    ],
+    useCalc: false
+};
+
+rtlcss.configure(config);

--- a/types/rtlcss/tsconfig.json
+++ b/types/rtlcss/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [
+
+      ],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "rtlcss-tests.ts"
+    ]
+}

--- a/types/rtlcss/tslint.json
+++ b/types/rtlcss/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Type defs for `rtlcss` ❤️  It's hard to tell what options are required or not from the documentation. I've followed usage examples to determine this. Also some types are inherited from `postcss` which doesn't have a reference in DT :(

Please fill in this template.

- [x]Use a meaningful title for the pull request. Include the name of the package modified.
- [x]Test the change in your own code. (Compile and run.)
- [x]Add or edit tests to reflect the change. (Run with `npm test`.)
- [x]Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x]Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x]Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x]The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x]If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x]Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
