### PR TITLE
@types/recharts: adds type definition for fontSize/position on XAxisProps/YAxisProps

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -905,8 +905,9 @@ export interface XPadding {
  * In the current lib, there is not actual implementation for XAxis.
  */
 // NOTE: the lib's implementation doesn't inherits the event props (it's kept in this definition due to the previous typing definition has it).
-export interface XAxisProps extends EventAttributes {
+export interface XAxisProps extends EventAttributes, Partial<PresentationAttributes> {
     allowDecimals?: boolean;
+    position?: PositionType;
     hide?: boolean;
     // The name of data displayed in the axis
     name?: string | number;
@@ -948,7 +949,6 @@ export interface XAxisProps extends EventAttributes {
     // see label section at http://recharts.org/#/en-US/api/XAxis
     label?: string | number | Label | LabelProps;
     allowDuplicatedCategory?: boolean;
-    stroke?: string;
 }
 
 export class XAxis extends React.Component<XAxisProps> { }
@@ -959,8 +959,9 @@ export interface YPadding {
 }
 
 // NOTE: the lib's implementation doesn't inherits the event props (it's kept in this definition due to the previous typing definition has it).
-export interface YAxisProps extends EventAttributes {
+export interface YAxisProps extends EventAttributes, Partial<PresentationAttributes> {
     allowDecimals?: boolean;
+    position?: PositionType;
     hide?: boolean;
     // The name of data displayed in the axis
     name?: string | number;
@@ -1000,7 +1001,6 @@ export interface YAxisProps extends EventAttributes {
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/YAxis
     label?: string | number | Label | LabelProps;
-    stroke?: string;
 }
 
 export class YAxis extends React.Component<YAxisProps> { }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/recharts/recharts/blob/1fa433b89e67ea816c8dda11202d4c8cead25935/src/cartesian/CartesianAxis.js#L319

We spread presentation attributes here into the props

The position prop is based on the fact that the XAxis component takes a Label as a child, see:
http://recharts.org/en-US/api/XAxis

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
