### PR TITLE
Add type definition for Node.js API function process.hrtime.bigint()

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -35,6 +35,7 @@
 //                 Jeremie Rodriguez <https://github.com/jeremiergz>
 //                 Samuel Ainsworth <https://github.com/samuela>
 //                 Kyle Uehlein <https://github.com/kuehlein>
+//                 Anders Eriksson <https://github.com/Anders-E>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.1.

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -766,7 +766,10 @@ declare namespace NodeJS {
         release: ProcessRelease;
         umask(mask?: number): number;
         uptime(): number;
-        hrtime(time?: [number, number]): [number, number];
+        hrtime: {
+            (): (time?: [number, number]) => [number, number];
+            bigint: () => number;
+        };
         domain: Domain;
 
         // Worker

--- a/types/node/v10/index.d.ts
+++ b/types/node/v10/index.d.ts
@@ -33,6 +33,7 @@
 //                 Jeremie Rodriguez <https://github.com/jeremiergz>
 //                 Samuel Ainsworth <https://github.com/samuela>
 //                 Kyle Uehlein <https://github.com/kuehlein>
+//                 Anders Eriksson <https://github.com/Anders-E>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.1.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/process.html#process_process_hrtime_bigint>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Notes:**
Since `npm run lint node/v10` seemed to run with TS 3.0, I did not use the `bigint` type available since TS 3.2. Also, I wasn't sure if this merits a test or not, if so, I'll gladly add one.