### PR TITLE
[autoprefixer] update grid options type

### DIFF
--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for autoprefixer 9.1
+// Type definitions for autoprefixer 9.4
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by:  Armando Meziat <https://github.com/odnamrataizem>, murt <https://github.com/murt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -15,7 +15,7 @@ declare namespace autoprefixer {
         remove?: boolean;
         supports?: boolean;
         flexbox?: boolean | 'no-2009';
-        grid?: boolean;
+        grid?: boolean | 'autoplace' | 'no-autoplace';
         stats?: any;
         ignoreUnknownVersions?: boolean;
     }


### PR DESCRIPTION
As of autoprefixer 9.4.0 (https://github.com/postcss/autoprefixer/releases/tag/9.4.0), `grid` supports `'autoplace'` and `'no-autoplace'` options, with `true` as deprecated but allowed (https://github.com/postcss/autoprefixer#options).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/autoprefixer#options
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
