### PR TITLE
[hoist-non-react-statics] Expose NonReactStatics type alias

### DIFF
--- a/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
+++ b/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
@@ -23,6 +23,10 @@ class B extends React.Component {
         n: PropTypes.number.isRequired,
     };
 
+    static defaultProps = {
+        n: 42,
+    };
+
     getB() {
         return B.b;
     }
@@ -36,11 +40,23 @@ C.propTypes.x;
 C.prototype.getA();
 
 C.propTypes.n; // $ExpectError
+C.defaultProps; // $ExpectError
 C.prototype.getB(); // $ExpectError
 
 <C x={1} />;
+
+const CWithType: hoistNonReactStatics.NonReactStatics<typeof B> = C;
+
+CWithType.propTypes; // $ExpectError
+CWithType.defaultProps; // $ExpectError
+CWithType.prototype.getB(); // $ExpectError
 
 const D = hoistNonReactStatics(A, B, { a: true, b: true });
 
 D.a;
 D.b; // $ExpectError
+
+const DWithType: hoistNonReactStatics.NonReactStatics<typeof B, { a: true; b: true }> = D;
+const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof B> = D; // $ExpectError
+
+DWithType.b; // $ExpectError

--- a/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
+++ b/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
@@ -3,60 +3,220 @@ import * as PropTypes from 'prop-types';
 
 import hoistNonReactStatics = require('hoist-non-react-statics');
 
-class A extends React.Component<{ x: number; y?: number | null }> {
-    static a = 'a';
+function TestClassComponents() {
+    class A extends React.Component<{ x: number; y?: number | null }> {
+        static a = 'a';
 
-    static propTypes = {
-        x: PropTypes.number.isRequired,
-        y: PropTypes.number,
-    };
+        static propTypes = {
+            x: PropTypes.number.isRequired,
+            y: PropTypes.number,
+        };
 
-    getA() {
-        return A.a;
+        getA() {
+            return A.a;
+        }
     }
+
+    class B extends React.Component {
+        static b = 'b';
+
+        static propTypes = {
+            n: PropTypes.number.isRequired,
+        };
+
+        static defaultProps = {
+            n: 42,
+        };
+
+        getB() {
+            return B.b;
+        }
+    }
+
+    const C = hoistNonReactStatics(A, B);
+
+    C.a !== C.b;
+
+    C.propTypes.x;
+    C.prototype.getA();
+
+    C.propTypes.n; // $ExpectError
+    C.defaultProps; // $ExpectError
+    C.prototype.getB(); // $ExpectError
+
+    <C x={1} />;
+
+    const CWithType: hoistNonReactStatics.NonReactStatics<typeof B> = C;
+
+    CWithType.propTypes; // $ExpectError
+    CWithType.defaultProps; // $ExpectError
+    CWithType.prototype.getB(); // $ExpectError
+
+    const D = hoistNonReactStatics(A, B, { a: true, b: true });
+
+    D.a;
+    D.b; // $ExpectError
+
+    const DWithType: hoistNonReactStatics.NonReactStatics<typeof B, { a: true; b: true }> = D;
+    const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof B> = D; // $ExpectError
+
+    DWithType.b; // $ExpectError
 }
 
-class B extends React.Component {
-    static b = 'b';
+// NOTE: We use Object.assign() to assign statics to functional components as a
+// convenience to avoid having to model the component's type with static fields.
 
-    static propTypes = {
-        n: PropTypes.number.isRequired,
-    };
+function TestFunctionalComponents() {
+    const A = ({x, y}: {x: number; y?: number}) => <div>{x + (y || 0)}</div>;
 
-    static defaultProps = {
-        n: 42,
-    };
+    // tslint:disable-next-line:prefer-object-spread
+    const AWithStatics = Object.assign(A, {
+        a: 'a',
+        propTypes: {
+            x: PropTypes.number.isRequired,
+            y: PropTypes.number,
+        },
+    });
 
-    getB() {
-        return B.b;
-    }
+    const B = ({n}: {n: number}) => <div>{n}</div>;
+
+    // tslint:disable-next-line:prefer-object-spread
+    const BWithStatics = Object.assign(B, {
+        b: 'b',
+        propTypes: {
+            n: PropTypes.number.isRequired,
+        },
+        defaultProps: {
+            n: 42,
+        },
+    });
+
+    const C = hoistNonReactStatics(AWithStatics, BWithStatics);
+
+    C.a !== C.b;
+
+    C.propTypes.x;
+    C.propTypes.n; // $ExpectError
+    C.defaultProps; // $ExpectError
+
+    <C x={1} />;
+
+    const CWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = C;
+
+    CWithType.propTypes; // $ExpectError
+    CWithType.defaultProps; // $ExpectError
+
+    const D = hoistNonReactStatics(AWithStatics, BWithStatics, { a: true, b: true });
+
+    D.a;
+    D.b; // $ExpectError
+
+    const DWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics, { a: true; b: true }> = D;
+    const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = D; // $ExpectError
+
+    DWithType.b; // $ExpectError
 }
 
-const C = hoistNonReactStatics(A, B);
+function TestMemoComponents() {
+    const A = ({x, y}: {x: number; y?: number}) => <div>{x + (y || 0)}</div>;
 
-C.a !== C.b;
+    // tslint:disable-next-line:prefer-object-spread
+    const AWithStatics = Object.assign(A, {
+        a: 'a',
+        propTypes: {
+            x: PropTypes.number.isRequired,
+            y: PropTypes.number,
+        },
+    });
 
-C.propTypes.x;
-C.prototype.getA();
+    const B = React.memo(({n}: {n: number}) => <div>{n}</div>);
 
-C.propTypes.n; // $ExpectError
-C.defaultProps; // $ExpectError
-C.prototype.getB(); // $ExpectError
+    // tslint:disable-next-line:prefer-object-spread
+    const BWithStatics = Object.assign(B, {
+        b: 'b',
+        propTypes: {
+            n: PropTypes.number.isRequired,
+        },
+        defaultProps: {
+            n: 42,
+        },
+    });
 
-<C x={1} />;
+    const C = hoistNonReactStatics(AWithStatics, BWithStatics);
 
-const CWithType: hoistNonReactStatics.NonReactStatics<typeof B> = C;
+    C.a !== C.b;
 
-CWithType.propTypes; // $ExpectError
-CWithType.defaultProps; // $ExpectError
-CWithType.prototype.getB(); // $ExpectError
+    C.propTypes.x;
+    C.propTypes.n; // $ExpectError
+    C.defaultProps; // $ExpectError
 
-const D = hoistNonReactStatics(A, B, { a: true, b: true });
+    <C x={1} />;
 
-D.a;
-D.b; // $ExpectError
+    const CWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = C;
 
-const DWithType: hoistNonReactStatics.NonReactStatics<typeof B, { a: true; b: true }> = D;
-const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof B> = D; // $ExpectError
+    CWithType.propTypes; // $ExpectError
+    CWithType.defaultProps; // $ExpectError
 
-DWithType.b; // $ExpectError
+    const D = hoistNonReactStatics(AWithStatics, BWithStatics, { a: true, b: true });
+
+    D.a;
+    D.b; // $ExpectError
+
+    const DWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics, { a: true; b: true }> = D;
+    const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = D; // $ExpectError
+
+    DWithType.b; // $ExpectError
+}
+
+function TestForwardRefComponents() {
+    const A = ({x, y}: {x: number; y?: number}) => <div>{x + (y || 0)}</div>;
+
+    // tslint:disable-next-line:prefer-object-spread
+    const AWithStatics = Object.assign(A, {
+        a: 'a',
+        propTypes: {
+            x: PropTypes.number.isRequired,
+            y: PropTypes.number,
+        },
+    });
+
+    const B = React.forwardRef(
+        ({n}: {n: number}, ref: React.Ref<HTMLDivElement>) => <div ref={ref}>{n}</div>
+    );
+
+    // tslint:disable-next-line:prefer-object-spread
+    const BWithStatics = Object.assign(B, {
+        b: 'b',
+        propTypes: {
+            n: PropTypes.number.isRequired,
+        },
+        defaultProps: {
+            n: 42,
+        },
+    });
+
+    const C = hoistNonReactStatics(AWithStatics, BWithStatics);
+
+    C.a !== C.b;
+
+    C.propTypes.x;
+    C.propTypes.n; // $ExpectError
+    C.defaultProps; // $ExpectError
+
+    <C x={1} />;
+
+    const CWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = C;
+
+    CWithType.propTypes; // $ExpectError
+    CWithType.defaultProps; // $ExpectError
+
+    const D = hoistNonReactStatics(AWithStatics, BWithStatics, { a: true, b: true });
+
+    D.a;
+    D.b; // $ExpectError
+
+    const DWithType: hoistNonReactStatics.NonReactStatics<typeof BWithStatics, { a: true; b: true }> = D;
+    const DWithTypeError: hoistNonReactStatics.NonReactStatics<typeof BWithStatics> = D; // $ExpectError
+
+    DWithType.b; // $ExpectError
+}

--- a/types/hoist-non-react-statics/index.d.ts
+++ b/types/hoist-non-react-statics/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for hoist-non-react-statics 3.0
+// Type definitions for hoist-non-react-statics 3.3
 // Project: https://github.com/mridgway/hoist-non-react-statics#readme
-// Definitions by: JounQin <https://github.com/JounQin>
+// Definitions by: JounQin <https://github.com/JounQin>, James Reggio <https://github.com/jamesreggio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -8,10 +8,12 @@ import * as React from 'react';
 
 interface REACT_STATICS {
     childContextTypes: true;
+    contextType: true;
     contextTypes: true;
     defaultProps: true;
     displayName: true;
     getDefaultProps: true;
+    getDerivedStateFromError: true;
     getDerivedStateFromProps: true;
     mixins: true;
     propTypes: true;
@@ -28,6 +30,23 @@ interface KNOWN_STATICS {
     arity: true;
 }
 
+interface MEMO_STATICS {
+    '$$typeof': true;
+    compare: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+    type: true;
+}
+
+interface FORWARD_REF_STATICS {
+    '$$typeof': true;
+    render: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+}
+
 declare namespace hoistNonReactStatics {
     type NonReactStatics<
         S extends React.ComponentType<any>,
@@ -37,8 +56,11 @@ declare namespace hoistNonReactStatics {
     > = {
         [key in Exclude<
             keyof S,
-            // only extends static properties, exclude instance properties and known react statics
-            keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+            S extends React.MemoExoticComponent<any>
+                ? keyof MEMO_STATICS | keyof C
+                : S extends React.ForwardRefExoticComponent<any>
+                ? keyof FORWARD_REF_STATICS | keyof C
+                : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
         >]: S[key]
     };
 }

--- a/types/hoist-non-react-statics/index.d.ts
+++ b/types/hoist-non-react-statics/index.d.ts
@@ -28,6 +28,21 @@ interface KNOWN_STATICS {
     arity: true;
 }
 
+declare namespace hoistNonReactStatics {
+    type NonReactStatics<
+        S extends React.ComponentType<any>,
+        C extends {
+            [key: string]: true
+        } = {}
+    > = {
+        [key in Exclude<
+            keyof S,
+            // only extends static properties, exclude instance properties and known react statics
+            keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+        >]: S[key]
+    };
+}
+
 declare function hoistNonReactStatics<
     T extends React.ComponentType<any>,
     S extends React.ComponentType<any>,
@@ -38,13 +53,6 @@ declare function hoistNonReactStatics<
     TargetComponent: T,
     SourceComponent: S,
     customStatic?: C,
-): T &
-    {
-        [key in Exclude<
-            keyof S,
-            // only extends static properties, exclude instance properties and known react statics
-            keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
-        >]: S[key]
-    };
+): T & hoistNonReactStatics.NonReactStatics<S, C>;
 
 export = hoistNonReactStatics;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~ Not appropriate.
- [x] ~Increase the version number in the header if appropriate.~ Not appropriate.
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ Not appropriate.

---

This PR exposes a `NonReactStatics` type alias to reflect the collection of non-static fields that are transferred by the `hoistNonReactStatics` function.

This is a non-breaking change. It includes tests in the style of the existing tests.

The motivation for this change is that it is useful to be able to model the transference of non-React static properties in other type definitions, particularly for packages like `react-redux`, which use `hoistNonReactStatics` during the construction of higher order components. Prior to this change, it was not possible to model these static properties without duplicating much of these type definitions.

This change is the first step in resolving this issue: #20985 

I will be following up with a change that consumes these updates from the types for `react-redux` as soon as they're merged.