### PR TITLE
[react-redux] Expose static members for connected components

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -44,6 +44,8 @@ import {
     Store
 } from 'redux';
 
+import { NonReactStatics } from 'hoist-non-react-statics';
+
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -96,7 +98,10 @@ export type GetProps<C> = C extends ComponentType<infer P> ? P : never;
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps
 // and propTypes), as well as defines WrappedComponent.
-export type ConnectedComponentClass<C, P> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & {
+export type ConnectedComponentClass<
+    C extends ComponentType<any>,
+    P
+> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & NonReactStatics<C> & {
     WrappedComponent: C;
 };
 

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1167,6 +1167,48 @@ function TestLibraryManagedAttributes() {
     <ConnectedComponent2 fn={() => { }} />;
 }
 
+function TestNonReactStatics() {
+    interface OwnProps {
+        bar: number;
+    }
+
+    interface MapStateProps {
+        foo: string;
+    }
+
+    class Component extends React.Component<OwnProps & MapStateProps> {
+        static defaultProps = {
+            bar: 0,
+        };
+
+        static meaningOfLife = 42;
+
+        render() {
+            return <div />;
+        }
+    }
+
+    function mapStateToProps(state: any): MapStateProps {
+        return {
+            foo: 'foo',
+        };
+    }
+
+    Component.meaningOfLife;
+    Component.defaultProps.bar;
+
+    const ConnectedComponent = connect(mapStateToProps)(Component);
+
+    // This is a non-React static and should be hoisted as-is.
+    ConnectedComponent.meaningOfLife;
+
+    // This is a React static, so it's not hoisted.
+    // However, ConnectedComponent is still a ComponentClass, which specifies `defaultProps`
+    // as an optional static member. We can force an error (and assert that `defaultProps`
+    // wasn't hoisted) by reaching into the `defaultProps` object without a null check.
+    ConnectedComponent.defaultProps.bar; // $ExpectError
+}
+
 function TestProviderContext() {
     const store: Store = createStore((state = {}) => state);
     const nullContext = React.createContext(null);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~ Not appropriate.
- [X] ~Increase the version number in the header if appropriate.~ Not appropriate.
- [X] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ Not appropriate.

---

This PR fixes #20985, wherein static members from a connected component were not being exposed in its type (even though they are available at runtime).

The fix required me to expose a type alias in `hoist-non-react-statics` to reflect the non-React statics that are hoisted. Following that change, the fix in `react-redux` was as simple as including that type alias on `ConnectedComponentClass`.

This is a non-breaking change with tests included.