### PR TITLE
Bump version of p-pipe in notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1150,7 +1150,7 @@
             "libraryName": "p-pipe",
             "typingsPackageName": "p-pipe",
             "sourceRepoURL": "https://github.com/sindresorhus/p-pipe",
-            "asOfVersion": "2.0.0"
+            "asOfVersion": "2.0.1"
         },
         {
             "libraryName": "p-throttle",


### PR DESCRIPTION
types-publisher is once again confused about whether publication of the stub package was successful or not.