### PR TITLE
fix(@types/select2): Add missing $.fn.select2 typing

### DIFF
--- a/types/select2/v3/index.d.ts
+++ b/types/select2/v3/index.d.ts
@@ -168,6 +168,14 @@ interface Select2Plugin {
     (method: 'search'): JQuery;
 
     (options: Select2Options): JQuery;
+
+    /**
+     * Select2 exposes its default options via the $.fn.select2.defaults
+     * object. Properties changed in this object (same properties configurable
+     * through the constructor) will take effect for every instance created
+     * after the change.
+     */
+    defaults: Partial<Select2Options>;
 }
 
 interface JQuery {

--- a/types/select2/v3/select2-tests.ts
+++ b/types/select2/v3/select2-tests.ts
@@ -1,3 +1,8 @@
+$.extend($.fn.select2.defaults, {
+  width: 'copy',
+  minimumInputLength: 12
+});
+
 $("#e9").select2();
 $("#e2").select2({
     placeholder: "Select a State",


### PR DESCRIPTION
As per bottom of docs at http://select2.github.io/select2/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://select2.github.io/select2/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
