### PR TITLE
@storybook/addon-knobs: remove SelectValue type 

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -50,11 +50,8 @@ export function object<T>(name: string, value: T, groupId?: string): T;
 
 export function radios<T>(name: string, options: { [s: string]: T }, value?: T, groupId?: string): string;
 
-export type SelectValue = string | number;
-export function select<T extends SelectValue>(name: string, options: { [s: string]: T }, value: T | ReadonlyArray<T>, groupId?: string): T;
-export function select<T extends SelectValue>(name: string, options: { [s: string]: ReadonlyArray<T> }, value: ReadonlyArray<T>, groupId?: string): T[];
-export function select<T extends SelectValue>(name: string, options: { [s: string]: T | ReadonlyArray<T> }, value: T | ReadonlyArray<T>, groupId?: string): T | T[];
-export function select<T extends SelectValue>(name: string, options: ReadonlyArray<T>, value: T, groupId?: string): T;
+export function select<T>(name: string, options: { [s: string]: T }, value: T, groupId?: string): T;
+export function select(name: string, options: ReadonlyArray<string>, value: string, groupId?: string): string;
 
 export function date(name: string, value?: Date, groupId?: string): Date;
 

--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -4,6 +4,7 @@
 //                 Martynas Kadisa <https://github.com/martynaskadisa>
 //                 A.MacLeay <https://github.com/amacleay>
 //                 Michael Loughry <https://github.com/MLoughry>
+//                 Alan Choi <https://github.com/alanhchoi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -96,6 +96,12 @@ stories.add('dynamic knobs', () => {
 const readonlyOptionsArray: ReadonlyArray<string> = ['hi'];
 select('With readonly array', readonlyOptionsArray, readonlyOptionsArray[0]);
 
+const optionsObject = {
+  Apple: { taste: 'sweet', color: 'red' },
+  Lemon: { taste: 'sour', color: 'yellow' }
+};
+select('With object', optionsObject, optionsObject.Apple);
+
 const genericArray = array('With regular array', ['hi', 'there']);
 
 const userInputArray = array('With readonly array', readonlyOptionsArray);


### PR DESCRIPTION
Please fill in this template.

- [x] Test the change in your own code. (Compile and run.)
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/storybooks/storybook/blob/next/addons/knobs/src/components/types/Select.js>

When using `select` knob with `options` object, the object can be either `ReadonlyArray<string>` or `{ [key: string]: any }`. It's because when `options` is an array, the array elements are used for `value` attribute of `<option>` tag, which must be a string, while when `options` is an object, its keys are used for the attribute because they are string-typed.

But current type definition forces the values of `options` object to be either `string` or `number`. In fact, they can be in any type, as you can see at the line 19 of the source code above. It retrieves the corresponding value from `options` object and passes it to `onChange` handler, having it emitted by a `channel`.