### PR TITLE
[jsdom] `runVMScript` should return `any`

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -41,7 +41,7 @@ export class JSDOM {
      * Behind the scenes, a jsdom Window is indeed a VM context.
      * To get access to this ability, use the runVMScript() method.
      */
-    runVMScript(script: Script): void;
+    runVMScript(script: Script): any;
 
     reconfigure(settings: ReconfigureSettings): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Since JSDOM uses `runInContext`, it should have the same return value as `vm.Script`: https://github.com/jsdom/jsdom/blob/16d3913eea0360c7757e75f7e266c3873c85b7dd/lib/api.js#L82 & https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8627ff6e07388b575941c25fd8ab2b57bba77591/types/node/vm.d.ts#L54
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.