### PR TITLE
Add comma option to arrayFormat to match qs update

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -19,7 +19,7 @@ declare namespace QueryString {
         encode?: boolean;
         encoder?: (str: string) => any;
         filter?: Array<string | number> | ((prefix: string, value: any) => any);
-        arrayFormat?: 'indices' | 'brackets' | 'repeat';
+        arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma';
         indices?: boolean;
         sort?: (a: any, b: any) => number;
         serializeDate?: (d: Date) => string;


### PR DESCRIPTION
Update index.d.ts: Add comma as an arrayFormat option to match the updated qs code.

Comma support added to qs in this merged PR:
https://github.com/ljharb/qs/pull/276