### PR TITLE
[underscore] Deduce return type from key in _.pluck (round 2)

### DIFF
--- a/types/icepick/icepick-tests.ts
+++ b/types/icepick/icepick-tests.ts
@@ -1,5 +1,4 @@
 import i = require("icepick");
-import * as _ from 'underscore';
 
 "use strict"; // so attempted modifications of frozen objects will throw errors
 
@@ -146,15 +145,13 @@ class Foo {}
 {
     i.map(function(v) { return v * 2 }, [1, 2, 3]); // [2, 4, 6]
 
-    var removeEvens = _.partial(i.filter, function(v: number) { return v % 2; });
-
-    removeEvens([1, 2, 3]); // [1, 3]
+    i.filter(function(v: number) { return v % 2 === 0; }, [1, 2, 3]); // [1, 3]
 }
 {
     var arr = i.freeze([{ a: 1 }, { b: 2 }]);
 
     //ECMAScript 2015
-    //arr.find(function(item) { return item.b != null; }); // {b: 2} 
+    //arr.find(function(item) { return item.b != null; }); // {b: 2}
 }
 
 // chain(coll) - not defined

--- a/types/underscore.string/index.d.ts
+++ b/types/underscore.string/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/epeli/underscore.string
 // Definitions by: Ry Racherbaumer <https://github.com/rygine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as _ from 'underscore';
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://underscorejs.org/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, Josh Baldwin <https://github.com/jbaldwin>, Christopher Currens <https://github.com/ccurrens>, Cassey Lottman <https://github.com/clottman>, Ard Timmerman <https://github.com/confususs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare var _: _.UnderscoreStatic;
 export = _;
@@ -553,9 +554,9 @@ declare module _ {
         * @param propertyName The property to look for on each element within `list`.
         * @return The list of elements within `list` that have the property `propertyName`.
         **/
-        pluck<T extends {}>(
+        pluck<T extends {}, K extends keyof T>(
             list: _.List<T>,
-            propertyName: string): any[];
+            propertyName: K): T[K][];
 
         /**
         * Returns the maximum value in list.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -560,7 +560,7 @@ declare module _ {
 
         pluck(
             list: _.List<any>,
-            propertyName: string): any;
+            propertyName: string): any[];
 
         /**
         * Returns the maximum value in list.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -558,6 +558,10 @@ declare module _ {
             list: _.List<T>,
             propertyName: K): T[K][];
 
+        pluck(
+            list: _.List<any>,
+            propertyName: string): any;
+
         /**
         * Returns the maximum value in list.
         * @param list Finds the maximum value in this list.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -173,7 +173,7 @@ _.contains([1, 2, 3], 3, 1);
 _.invoke([[5, 1, 7], [3, 2, 1]], 'sort');
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33479
-var foo: any = {'a': 1, 'b': 2};
+var foo: any[] = [{'a': 1, 'b': 2}];
 _.pluck(foo, 'a');
 
 var stooges = [{ name: 'moe', age: 40 }, { name: 'larry', age: 50 }, { name: 'curly', age: 60 }];

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -520,7 +520,7 @@ function chain_tests() {
     let numberObjects = [{property: 'odd', value: 1}, {property: 'even', value: 2}, {property: 'even', value: 0}];
     let evenAndOddGroupedNumbers = _.chain(numberObjects)
         .groupBy('property')
-        .mapObject((objects: any) => _.pluck(objects, 'value'))
+        .mapObject((objects) => _.pluck(objects, 'value'))
         .value(); // { odd: [1], even: [0, 2] }
 
   var matrixOfString : string[][] = _.chain({'foo' : '1', 'bar': '1'})

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -172,6 +172,10 @@ _.contains([1, 2, 3], 3, 1);
 
 _.invoke([[5, 1, 7], [3, 2, 1]], 'sort');
 
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33479
+var foo: any = {'a': 1, 'b': 2};
+_.pluck(foo, 'a');
+
 var stooges = [{ name: 'moe', age: 40 }, { name: 'larry', age: 50 }, { name: 'curly', age: 60 }];
 _.pluck(stooges, 'name');
 


### PR DESCRIPTION
This is a second attempt, previous attempt was PR #33095 which was reverted due to issue #33479.

This PR adds a test for that case and provides an overload for pluck that keeps the old, passing, behaviour when there is not enough type information to deduce the return type.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jashkenas/underscore/blob/1.8.0/underscore.js#L273
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.