### PR TITLE
Add package.json to get-urls

### DIFF
--- a/types/get-urls/package.json
+++ b/types/get-urls/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "normalize-url": "*"
+  }
+}


### PR DESCRIPTION
It depends on normalize-url, which now has its own types
