### PR TITLE
[@types/puppeteer] Add definitions for create browser fetcher and browser fetcher

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2216,11 +2216,11 @@ export interface RevisionInfo {
 
 export interface FetcherOptions {
   /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
-  host: string;
+  host?: string;
   /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
-  path: string;
+  path?: string;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
-  platform: Platform;
+  platform?: Platform;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -31,6 +31,8 @@ export interface JSONObject {
 }
 export type SerializableOrJSHandle = Serializable | JSHandle;
 
+export type Platform = "mac" | "win32" | "win64" | "linux";
+
 /** Defines `$eval` and `$$eval` for Page, Frame and ElementHandle. */
 export interface Evalable {
   /**
@@ -2187,26 +2189,14 @@ export interface CoverageEntry {
   ranges: Array<{start: number, end: number}>;
 }
 
-/** Attaches Puppeteer to an existing Chromium instance */
-export function connect(options?: ConnectOptions): Promise<Browser>;
-/** The default flags that Chromium will be launched with */
-export function defaultArgs(options?: ChromeArgOptions): string[];
-/** Path where Puppeteer expects to find bundled Chromium */
-export function executablePath(): string;
-/** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
-export function launch(options?: LaunchOptions): Promise<Browser>;
-
-/** This methods attaches Puppeteer to an existing Chromium instance. */
-export function createBrowserFetcher(options?: LaunchOptions): BrowserFetcher;
-
 /** BrowserFetcher can download and manage different versions of Chromium. */
 export interface BrowserFetcher {
   /** The method initiates a HEAD request to check if the revision is available. */
   canDownload(revision: string): Promise<boolean>;
   /** The method initiates a GET request to download the revision from the host. */
-  download(revision: string, progressCallback?: (downloadBytes: number, totalBytes: number) => any): Promise<RevisionInfo>;
+  download(revision: string, progressCallback?: (downloadBytes: number, totalBytes: number) => void): Promise<RevisionInfo>;
   localRevisions(): Promise<string[]>;
-  platform(): string;
+  platform(): Platform;
   remove(revision: string): Promise<void>;
   revisionInfo(revision: string): RevisionInfo;
 }
@@ -2223,3 +2213,23 @@ export interface RevisionInfo {
   /** whether the revision is locally available on disk */
   local: boolean;
 }
+
+export interface FetcherOptions {
+  /** A download host to be used. Defaults to `https://storage.googleapis.com`. */
+  host: string;
+  /** A path for the downloads folder. Defaults to `<root>/.local-chromium`, where `<root>` is puppeteer's package root. */
+  path: string;
+  /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
+  platform: Platform;
+}
+
+/** Attaches Puppeteer to an existing Chromium instance */
+export function connect(options?: ConnectOptions): Promise<Browser>;
+/** The default flags that Chromium will be launched with */
+export function defaultArgs(options?: ChromeArgOptions): string[];
+/** Path where Puppeteer expects to find bundled Chromium */
+export function executablePath(): string;
+/** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
+export function launch(options?: LaunchOptions): Promise<Browser>;
+/** This methods attaches Puppeteer to an existing Chromium instance. */
+export function createBrowserFetcher(options?: FetcherOptions): BrowserFetcher;

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2195,3 +2195,31 @@ export function defaultArgs(options?: ChromeArgOptions): string[];
 export function executablePath(): string;
 /** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
 export function launch(options?: LaunchOptions): Promise<Browser>;
+
+/** This methods attaches Puppeteer to an existing Chromium instance. */
+export function createBrowserFetcher(options?: LaunchOptions): BrowserFetcher;
+
+/** BrowserFetcher can download and manage different versions of Chromium. */
+export interface BrowserFetcher {
+  /** The method initiates a HEAD request to check if the revision is available. */
+  canDownload(revision: string): Promise<boolean>;
+  /** The method initiates a GET request to download the revision from the host. */
+  download(revision: string, progressCallback?: (downloadBytes: number, totalBytes: number) => any): Promise<RevisionInfo>;
+  localRevisions(): Promise<string[]>;
+  platform(): string;
+  remove(revision: string): Promise<void>;
+  revisionInfo(revision: string): RevisionInfo;
+}
+
+export interface RevisionInfo {
+  /** The revision the info was created from */
+  revision: string;
+  /** Path to the extracted revision folder */
+  folderPath: string;
+  /** Path to the revision executable */
+  executablePath: string;
+  /** URL this revision can be downloaded from */
+  url: string;
+  /** whether the revision is locally available on disk */
+  local: boolean;
+}

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -621,7 +621,11 @@ puppeteer.launch().then(async browser => {
 
 (async () => {
   const rev = '630727';
-  const browserFetcher = puppeteer.createBrowserFetcher();
+  const browserFetcher = puppeteer.createBrowserFetcher({
+    host: 'https://storage.googleapis.com',
+    path: '/tmp/.local-chromium',
+    platform: 'linux',
+  });
   await browserFetcher.canDownload(rev);
   const revisionInfo = await browserFetcher.download(rev);
   await browserFetcher.remove(rev);

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -618,3 +618,11 @@ puppeteer.launch().then(async browser => {
   );
   console.log('there are', numMatchingEls, 'banana paragaphs');
 });
+
+(async () => {
+  const rev = '630727';
+  const browserFetcher = puppeteer.createBrowserFetcher();
+  await browserFetcher.canDownload(rev);
+  const revisionInfo = await browserFetcher.download(rev);
+  await browserFetcher.remove(rev);
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteercreatebrowserfetcheroptions
   - https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browserfetcher
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

fixes #29980

In the present, tests failed with `error TS2300: Duplicate identifier 'SharedArrayBuffer'` and this will be fixed after #33177 is merged.