### PR TITLE
[helmet] Fix spelling of a option in hsts and hpkp

### DIFF
--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -125,6 +125,13 @@ function hpkpTest() {
         includeSubDomains: false
     }));
 
+    // Deprecated: Use includeSubDomains instead. (Uppercase "D")
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        includeSubdomains: false
+    }));
+
     app.use(helmet.hpkp({
         maxAge: 7776000000,
         sha256s: ['AbCdEf123=', 'ZyXwVu456='],
@@ -165,6 +172,12 @@ function hstsTest() {
     app.use(helmet.hsts({
       maxAge: 7776000000,
       includeSubDomains: true
+    }));
+
+    // Deprecated: Use includeSubDomains instead. (Uppercase "D")
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+      includeSubdomains: true
     }));
 
     app.use(helmet.hsts({

--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -122,13 +122,13 @@ function hpkpTest() {
     app.use(helmet.hpkp({
         maxAge: 7776000000,
         sha256s: ['AbCdEf123=', 'ZyXwVu456='],
-        includeSubdomains: false
+        includeSubDomains: false
     }));
 
     app.use(helmet.hpkp({
         maxAge: 7776000000,
         sha256s: ['AbCdEf123=', 'ZyXwVu456='],
-        includeSubdomains: true
+        includeSubDomains: true
     }));
 
     app.use(helmet.hpkp({
@@ -164,7 +164,7 @@ function hstsTest() {
 
     app.use(helmet.hsts({
       maxAge: 7776000000,
-      includeSubdomains: true
+      includeSubDomains: true
     }));
 
     app.use(helmet.hsts({

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -142,7 +142,7 @@ declare namespace helmet {
 
     export interface IHelmetHstsConfiguration {
         maxAge?: number;
-        includeSubdomains?: boolean;
+        includeSubDomains?: boolean;
         preload?: boolean;
         setIf?: IHelmetSetIfFunction;
         force?: boolean;

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for helmet
 // Project: https://github.com/helmetjs/helmet
-// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, Evan Hahn <https://github.com/EvanHahn>, Elliot Blackburn <https://github.com/bluehatbrit>
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, Evan Hahn <https://github.com/EvanHahn>, Elliot Blackburn <https://github.com/bluehatbrit>, Daniel Müller <https://github.com/chdanielmueller>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -134,7 +134,7 @@ declare namespace helmet {
     export interface IHelmetHpkpConfiguration {
         maxAge: number;
         sha256s: string[];
-        includeSubdomains?: boolean;
+        includeSubDomains?: boolean;
         reportUri?: string;
         reportOnly?: boolean;
         setIf?: IHelmetSetIfFunction;

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -134,6 +134,10 @@ declare namespace helmet {
     export interface IHelmetHpkpConfiguration {
         maxAge: number;
         sha256s: string[];
+        /**
+         * @deprecated Use includeSubDomains instead. (Uppercase "D")
+         */
+        includeSubdomains?: boolean;
         includeSubDomains?: boolean;
         reportUri?: string;
         reportOnly?: boolean;
@@ -142,6 +146,10 @@ declare namespace helmet {
 
     export interface IHelmetHstsConfiguration {
         maxAge?: number;
+        /**
+         * @deprecated Use includeSubDomains instead. (Uppercase "D")
+         */
+        includeSubdomains?: boolean;
         includeSubDomains?: boolean;
         preload?: boolean;
         setIf?: IHelmetSetIfFunction;

--- a/types/koa-helmet/koa-helmet-tests.ts
+++ b/types/koa-helmet/koa-helmet-tests.ts
@@ -95,13 +95,13 @@ function hpkpTest() {
     app.use(helmet.hpkp({
         maxAge: 7776000000,
         sha256s: ['AbCdEf123=', 'ZyXwVu456='],
-        includeSubdomains: false
+        includeSubDomains: false
     }));
 
     app.use(helmet.hpkp({
         maxAge: 7776000000,
         sha256s: ['AbCdEf123=', 'ZyXwVu456='],
-        includeSubdomains: true
+        includeSubDomains: true
     }));
 
     app.use(helmet.hpkp({
@@ -137,7 +137,7 @@ function hstsTest() {
 
     app.use(helmet.hsts({
       maxAge: 7776000000,
-      includeSubdomains: true
+      includeSubDomains: true
     }));
 
     app.use(helmet.hsts({


### PR DESCRIPTION
Change for the option "includeSubdomains":
The "D" of "Domains" should be written in uppercase according to the docs:
https://helmetjs.github.io/docs/hsts/
https://www.npmjs.com/package/hpkp

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://helmetjs.github.io/docs/hsts/
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.