### PR TITLE
Updated Parameter Path type from ParameterNameList to PSParameterName

### DIFF
--- a/types/aws-param-store/index.d.ts
+++ b/types/aws-param-store/index.d.ts
@@ -27,12 +27,12 @@ export function getParametersSync(
 ): SSM.Types.GetParametersResult;
 
 export function getParametersByPath(
-    path: SSM.Types.ParameterNameList,
+    path: SSM.Types.PSParameterName,
     options?: SSM.Types.ClientConfiguration
 ): Promise<SSM.Types.ParameterList>;
 
 export function getParametersByPathSync(
-    path: SSM.Types.ParameterNameList,
+    path: SSM.Types.PSParameterName,
     options?: SSM.Types.ClientConfiguration
 ): SSM.Types.ParameterList;
 


### PR DESCRIPTION
Updated getParametersByPathSync and getParametersByPath path type to PSParameterName, Since these two methods throwing below error when type was ParameterNameList
```
 throw new Error( queryResult.err.message || queryResult.err.code );
                  ^
Error: Expected params.Path to be a string  
File: param_query.js:99:19
```
