### PR TITLE
nock.back.record returns rawHeaders array

### DIFF
--- a/types/nock/index.d.ts
+++ b/types/nock/index.d.ts
@@ -150,6 +150,7 @@ declare namespace nock {
         response?: string | any;
         headers?: HttpHeaders;
         reqheaders?: { [key: string]: string | RegExp | { (headerValue: string): boolean; }; };
+        rawHeaders?: string[];
         options?: Options;
     }
 


### PR DESCRIPTION
Using nock to record http requests the afterRecord method will have a rawHeaders attribute.

Presently this results in an error:
fetch.spec.ts:32:25 - error TS2551: Property 'rawHeaders' does not exist on type 'NockDefinition'.

rawHeaders is an optional string array