### PR TITLE
webpack-env: Make module.hot.accept callback optional

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -122,13 +122,13 @@ declare namespace __WebpackModuleApi {
          * @param dependencies
          * @param callback
          */
-        accept(dependencies: string[], callback: (updatedDependencies: ModuleId[]) => void): void;
+        accept(dependencies: string[], callback?: (updatedDependencies: ModuleId[]) => void): void;
         /**
          * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
          * @param dependency
          * @param callback
          */
-        accept(dependency: string, callback: () => void): void;
+        accept(dependency: string, callback?: () => void): void;
         /**
          * Accept code updates for this module without notification of parents.
          * This should only be used if the module doesn’t export anything.

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -19,6 +19,9 @@ require(['./someModule', './otherModule'], (someModule: SomeModule, otherModule:
 
 // check if HMR is enabled
 if(module.hot) {
+    // accept update of dependency without a callback
+    module.hot.accept("./handler.js");
+
     // accept update of dependency
     module.hot.accept("./handler.js", function() {
         //...


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/685a0626cb10664133ef2fb2e2f9f4cb3971402a/lib/HotModuleReplacement.runtime.js#L107-L114
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
