### PR TITLE
[cypress-axe] update types for v0.4.0

### DIFF
--- a/types/cypress-axe/index.d.ts
+++ b/types/cypress-axe/index.d.ts
@@ -4,16 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { ElementContext, RunOptions } from 'axe-core';
-
-declare module "axe-core" {
-	interface Node {}
-}
-
 declare namespace Cypress {
     interface Chainable<Subject = any> {
         injectAxe(): void;
-        checkA11y(context?: ElementContext, options?: RunOptions): void;
-        configureAxe(options?: RunOptions): void;
+        checkA11y(
+            context?: import('axe-core').ElementContext,
+            options?: import('axe-core').RunOptions,
+        ): void;
+        configureAxe(options?: import('axe-core').RunOptions): void;
     }
 }

--- a/types/cypress-axe/index.d.ts
+++ b/types/cypress-axe/index.d.ts
@@ -3,7 +3,12 @@
 // Definitions by: Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
+
 import { ElementContext, RunOptions } from 'axe-core';
+
+declare module "axe-core" {
+	interface Node {}
+}
 
 declare namespace Cypress {
     interface Chainable<Subject = any> {

--- a/types/cypress-axe/index.d.ts
+++ b/types/cypress-axe/index.d.ts
@@ -2,17 +2,20 @@
 // Project: https://github.com/avanslaars/cypress-axe#readme
 // Definitions by: Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 2.3
 
-/// <reference lib="dom" />
+import { ElementContext, RunOptions } from 'axe-core';
 
-declare namespace Cypress {
-    interface Chainable<Subject = any> {
-        injectAxe(): void;
-        checkA11y(
-            context?: import('axe-core').ElementContext,
-            options?: import('axe-core').RunOptions,
-        ): void;
-        configureAxe(options?: import('axe-core').RunOptions): void;
+declare module 'axe-core' {
+    interface Node {}
+}
+
+declare global {
+    namespace Cypress {
+        interface Chainable<Subject = any> {
+            injectAxe(): void;
+            checkA11y(context?: ElementContext, options?: RunOptions): void;
+            configureAxe(options?: RunOptions): void;
+        }
     }
 }

--- a/types/cypress-axe/index.d.ts
+++ b/types/cypress-axe/index.d.ts
@@ -1,12 +1,14 @@
-// Type definitions for cypress-axe 0.3
+// Type definitions for cypress-axe 0.4
 // Project: https://github.com/avanslaars/cypress-axe#readme
 // Definitions by: Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
+import { ElementContext, RunOptions } from 'axe-core';
 
 declare namespace Cypress {
     interface Chainable<Subject = any> {
         injectAxe(): void;
-        checkA11y(): void;
+        checkA11y(context?: ElementContext, options?: RunOptions): void;
+        configureAxe(options?: RunOptions): void;
     }
 }

--- a/types/cypress-axe/index.d.ts
+++ b/types/cypress-axe/index.d.ts
@@ -2,7 +2,9 @@
 // Project: https://github.com/avanslaars/cypress-axe#readme
 // Definitions by: Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
+
+/// <reference lib="dom" />
 
 declare namespace Cypress {
     interface Chainable<Subject = any> {

--- a/types/cypress-axe/package.json
+++ b/types/cypress-axe/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "axe-core": "^3.1.2"
+    }
+}

--- a/types/cypress-axe/tslint.json
+++ b/types/cypress-axe/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false
+    }
+}

--- a/types/cypress-axe/tslint.json
+++ b/types/cypress-axe/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-empty-interface": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/avanslaars/cypress-axe/pull/4
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

<details>
  <summary>Previous concerns</summary>
  
  #### Problem 1:
  
  I now need to refer to types from an external module ([`axe-core`](https://github.com/dequelabs/axe-core/blob/773e6dc07bd9361b70226fbaf4ace0a3b421da76/axe.d.ts)).   Importing them with top-level `import` syntax breaks my types (`declare module Cypress` no longer augments the `Cypress` namespace). I can get the types to work   using inline `import()` syntax (e.g. `configureAxe(options?: import('axe-core').RunOptions): void;`) but at one point, I received lint errors with:
  ```
  Namespace '"axe-core"' has no exported member 'ElementContext'.
  Namespace '"axe-core"' has no exported member 'RunOptions'.
  ```
  I cannot reproduce that, however, and it works, so... maybe it's OK? Is there a better solution?
  
  #### Problem 2:
  
  [`axe-core`](https://github.com/dequelabs/axe-core/blob/773e6dc07bd9361b70226fbaf4ace0a3b421da76/axe.d.ts) is causing lint to fail with: 
  ```
  error TS2304: Cannot find name 'Node'.
  ```
  due to their use of `Node` which comes from the `dom` lib and we're not including that here. I tried to follow suit from [`@types/jest-axe`](https://github.com/  DefinitelyTyped/DefinitelyTyped/commit/1251a33064131fd31b832d7584bb9fe0128e1a5d) (originally reported in https://github.com/dequelabs/axe-core/issues/1199) and   augment it, but that triggers `no-single-declare-module` lint errors:
  ```
  File has only 1 module declaration — write it as an external module. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-single-declare-module.md
  ```
  I got it working by using a triple-slash `lib` directive to reference `dom` (requiring a bump of the TypeScript version from 2.3 to 3.1). Is that acceptable or is   there a better option?
  
  Thanks for any assistance.
</details>