### PR TITLE
cls-hooked: update namespace methods to include enter and exist for a context

### DIFF
--- a/types/cls-hooked/cls-hooked-tests.ts
+++ b/types/cls-hooked/cls-hooked-tests.ts
@@ -35,7 +35,7 @@ bindWithMiddleware(() => {
 
 // In some place in application, we want to set value to be used elsewhere
 appNamespace.enter(context);
-appNamespace.set('requestId','someId');
+appNamespace.set('requestId', 'someId');
 appNamespace.exit(context);
 
 // Retrieve that value set before without losing the context when chaining several middleware

--- a/types/cls-hooked/cls-hooked-tests.ts
+++ b/types/cls-hooked/cls-hooked-tests.ts
@@ -33,7 +33,7 @@ bindWithMiddleware(() => {
     // Some middleware that doing something in the application
 });
 
-// In some place in application, we want to set value to be used elsewhere
+// In some place in the application, we want to set a value to a given key to be used elsewhere
 appNamespace.enter(context);
 appNamespace.set('requestId', 'someId');
 appNamespace.exit(context);

--- a/types/cls-hooked/cls-hooked-tests.ts
+++ b/types/cls-hooked/cls-hooked-tests.ts
@@ -29,7 +29,7 @@ function bindWithMiddleware(middlewareFn: () => void) {
     return session.bind(middlewareFn, context);
 }
 
-bindWithMiddleware(()=>{
+bindWithMiddleware(() => {
     // Some middleware that doing something in the application
 });
 

--- a/types/cls-hooked/cls-hooked-tests.ts
+++ b/types/cls-hooked/cls-hooked-tests.ts
@@ -21,3 +21,24 @@ bindLater((x: number) => {
 
 const session2 = cls.getNamespace('my session');
 session2.get('user');
+
+const appNamespace = cls.createNamespace('applicationNameSpace');
+const context = appNamespace.createContext();
+
+function bindWithMiddleware(middlewareFn: () => void) {
+    return session.bind(middlewareFn, context);
+}
+
+bindWithMiddleware(()=>{
+    // Some middleware that doing something in the application
+});
+
+// In some place in application, we want to set value to be used elsewhere
+appNamespace.enter(context);
+appNamespace.set('requestId','someId');
+appNamespace.exit(context);
+
+// Retrieve that value set before without losing the context when chaining several middleware
+appNamespace.enter(context);
+appNamespace.get('requestId');
+appNamespace.exit(context);

--- a/types/cls-hooked/index.d.ts
+++ b/types/cls-hooked/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cls-hooked 4.2
+// Type definitions for cls-hooked 4.3
 // Project: https://github.com/jeff-lewis/cls-hooked
 // Definitions by: Leo Liang <https://github.com/aleung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -12,14 +12,14 @@ export interface Namespace {
 
     set<T>(key: string, value: T): T;
     get(key: string): any;
-    enter(context: any): void;
-    exit(context: any): void;
     run(fn: (...args: any[]) => void): void;
     runAndReturn<T>(fn: (...args: any[]) => T): T;
     runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T>;
     bind<F extends Function>(fn: F, context?: any): F; // tslint:disable-line: ban-types
     bindEmitter(emitter: EventEmitter): void;
     createContext(): any;
+    enter(context: any): void;
+    exit(context: any): void;
 }
 
 export function createNamespace(name: string): Namespace;

--- a/types/cls-hooked/index.d.ts
+++ b/types/cls-hooked/index.d.ts
@@ -12,6 +12,8 @@ export interface Namespace {
 
     set<T>(key: string, value: T): T;
     get(key: string): any;
+    enter(context: any): void;
+    exit(context: any): void;
     run(fn: (...args: any[]) => void): void;
     runAndReturn<T>(fn: (...args: any[]) => T): T;
     runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T>;


### PR DESCRIPTION
Update namespace methods to include enter and exist for a context.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
- Both functions added in the namespace definition are already part of the cls-hooked library so no change in the original library code. [cls-hooked project](https://github.com/Jeff-Lewis/cls-hooked)
- But since there is [bug issue](https://github.com/Jeff-Lewis/cls-hooked/issues/36) for that matter caused by behavior inconsistencies across node versions. The solution to have the access to the context is doable with the library but not reflected in the types name-space. This merge request is proposed to give users the ability to work around that bug when using "@types/cookie-parser"
- The usage is explained in the use case added to the test file. Long story short, when using only the functions exposed in the current version and using many middle-wares in a express application, cls-hooked will lose the context. So when we want to access a certain key in the name-space, this one is undefined.  The solution proposed in here is to control the context of a given name-space manually. That's add flexibility and control in the application.
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
