### PR TITLE
@types/recharts: fix error `Generic type 'ReactElement<P, T>' requires between ...`

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -13,6 +13,7 @@
 //                 Andrew Palugniok <https://github.com/apalugniok>
 //                 Robert Stigsson <https://github.com/RobertStigsson>
 //                 Kosaku Kurino <https://github.com/kousaku-maron>
+//                 Shin Adachi <https://github.com/shnjp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -171,9 +172,9 @@ export interface AreaProps extends EventAttributes, Partial<PresentationAttribut
     stackId?: string | number;
     legendType?: LegendType;
     connectNulls?: boolean;
-    activeDot?: boolean | object | React.ReactElement | ContentRenderer<any>;
-    dot?: boolean | object | React.ReactElement | ContentRenderer<DotProps>;
-    label?: boolean | object | ContentRenderer<any> | React.ReactElement;
+    activeDot?: boolean | object | React.ReactType | ContentRenderer<any>;
+    dot?: boolean | object | React.ReactType | ContentRenderer<DotProps>;
+    label?: boolean | object | ContentRenderer<any> | React.ReactType;
     hide?: boolean;
     layout?: LayoutType;
     baseLine?: number | any[];
@@ -215,11 +216,11 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     minPointSize?: number;
     maxBarSize?: number;
     hide?: boolean;
-    shape?: React.ReactElement | ContentRenderer<RectangleProps>;
+    shape?: React.ReactType | ContentRenderer<RectangleProps>;
     data?: BarData[];
-    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
+    background?: boolean | React.ReactType | ContentRenderer<any> | object;
     // see label section at http://recharts.org/#/en-US/api/Bar
-    label?: boolean | Label | React.SFC<LabelProps> | React.ReactElement<LabelProps> | ContentRenderer<any>;
+    label?: boolean | Label | React.SFC<LabelProps> | React.ReactType<LabelProps> | ContentRenderer<any>;
 }
 
 export class Bar extends React.Component<BarProps> { }
@@ -259,7 +260,7 @@ export interface CartesianAxisProps extends EventAttributes, Partial<Presentatio
     height?: number;
     orientation?: 'top' | 'bottom' | 'left' | 'right';
     viewBox?: ViewBox;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactType;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     mirror?: boolean;
@@ -285,8 +286,8 @@ export interface CartesianGridProps extends Partial<PresentationAttributes> {
     y?: number;
     width?: number;
     height?: number;
-    horizontal?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
-    vertical?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    horizontal?: object | React.ReactType | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    vertical?: object | React.ReactType | ContentRenderer<LineProps & CartesianGridProps> | boolean;
     horizontalPoints?: number[];
     verticalPoints?: number[];
     horizontalCoordinatesGenerator?: CoordinatesGenerator;
@@ -376,7 +377,7 @@ export interface LegendPayload {
 export type BBoxUpdateCallback = (box: { width: number; height: number; }) => void;
 
 export interface LegendProps {
-    content?: React.ReactElement | ContentRenderer<LegendProps>;
+    content?: React.ReactType | ContentRenderer<LegendProps>;
     wrapperStyle?: object;
     chartWidth?: number;
     chartHeight?: number;
@@ -411,15 +412,15 @@ export interface LineProps extends EventAttributes, Partial<PresentationAttribut
     layout?: LayoutType;
     connectNulls?: boolean;
     hide?: boolean;
-    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
+    activeDot?: object | React.ReactType | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactType | ContentRenderer<DotProps> | boolean;
     top?: number;
     left?: number;
     width?: number;
     height?: number;
     data?: object[];
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    label?: boolean | object | React.ReactElement | ContentRenderer<any>;
+    label?: boolean | object | React.ReactType | ContentRenderer<any>;
     points?: Point[];
 }
 
@@ -450,11 +451,11 @@ export interface PieProps extends EventAttributes, Partial<PresentationAttribute
     maxRadius?: number;
     sectors?: object[];
     hide?: boolean;
-    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement | boolean;
+    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactType | boolean;
     label?: {
         offsetRadius: number;
-    } | React.ReactElement | ContentRenderer<PieLabelRenderProps> | boolean;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement;
+    } | React.ReactType | ContentRenderer<PieLabelRenderProps> | boolean;
+    activeShape?: object | ContentRenderer<any> | React.ReactType;
     activeIndex?: number | number[];
     blendStroke?: boolean;
 }
@@ -501,7 +502,7 @@ export interface PolarAngleAxisProps extends EventAttributes, Partial<Presentati
     axisLine?: boolean | object;
     axisLineType?: 'polygon' | 'circle';
     tickLine?: boolean | object;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactType;
     ticks?: PolarAngleAxisTick[];
     stroke?: string;
     orientation?: 'inner' | 'outer';
@@ -540,7 +541,7 @@ export interface PolarRadiusAxisProps extends EventAttributes, Partial<Presentat
     ticks?: PolarRadiusAxisTick[];
     orientation?: "left" | "right" | "middle";
     axisLine?: boolean | object;
-    tick?: boolean | object | React.ReactElement | ContentRenderer<any>;
+    tick?: boolean | object | React.ReactType | ContentRenderer<any>;
     stroke?: string;
     tickFormatter?: TickFormatterFunction;
     domain?: [PolarRadiusAxisDomain, PolarRadiusAxisDomain];
@@ -577,10 +578,10 @@ export interface RadarProps extends EventAttributes, Partial<PresentationAttribu
     className?: string;
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     points?: RadarPoint[];
-    shape?: React.ReactElement | ContentRenderer<RadarProps>;
-    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
-    label?: object | React.ReactElement | ContentRenderer<any> | boolean;
+    shape?: React.ReactType | ContentRenderer<RadarProps>;
+    activeDot?: object | React.ReactType | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactType | ContentRenderer<DotProps> | boolean;
+    label?: object | React.ReactType | ContentRenderer<any> | boolean;
     legendType?: LegendType;
     hide?: boolean;
 }
@@ -612,15 +613,15 @@ export interface RadialBarProps extends EventAttributes, Partial<PresentationAtt
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     angleAxisId?: string | number;
     radiusAxisId?: string | number;
-    shape?: ContentRenderer<any> | React.ReactElement;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement;
+    shape?: ContentRenderer<any> | React.ReactType;
+    activeShape?: object | ContentRenderer<any> | React.ReactType;
     cornerRadius?: number | string;
     minPointSize?: number;
     maxBarSize?: number;
     data?: RadialBarData[];
     legendType?: LegendType;
-    label?: boolean | React.ReactElement | ContentRenderer<any> | object;
-    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
+    label?: boolean | React.ReactType | ContentRenderer<any> | object;
+    background?: boolean | React.ReactType | ContentRenderer<any> | object;
     hide?: boolean;
 }
 
@@ -662,7 +663,7 @@ export interface ReferenceAreaProps extends Partial<PresentationAttributes> {
     y2?: number | string;
     xAxisId?: string | number;
     yAxisId?: string | number;
-    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactElement;
+    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactType;
 }
 
 export class ReferenceArea extends React.Component<ReferenceAreaProps> { }
@@ -688,7 +689,7 @@ export interface ReferenceDotProps extends EventAttributes, Partial<Presentation
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { cx: number; cy: number; }
-    > | React.ReactElement;
+    > | React.ReactType;
 }
 
 export class ReferenceDot extends React.Component<ReferenceDotProps> { }
@@ -703,14 +704,14 @@ export interface ReferenceLineProps extends Partial<PresentationAttributes<numbe
     ifOverflow?: IfOverflowType;
     x?: number | string;
     y?: number | string;
-    label?: string | number | ContentRenderer<any> | React.ReactElement;
+    label?: string | number | ContentRenderer<any> | React.ReactType;
     xAxisId?: string | number;
     yAxisId?: string | number;
     shape?: ContentRenderer<
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { x1: number; y1: number; x2: number; y2: number; }
-    > | React.ReactElement;
+    > | React.ReactType;
 }
 
 export class ReferenceLine extends React.Component<ReferenceLineProps> { }
@@ -746,13 +747,13 @@ export interface ScatterProps extends EventAttributes, Partial<PresentationAttri
     xAxisId?: string | number;
     yAxisId?: string | number;
     zAxisId?: string | number;
-    line?: boolean | object | RechartsFunction | React.ReactElement;
+    line?: boolean | object | RechartsFunction | React.ReactType;
     lineType?: 'joint' | 'fitting';
     lineJointType?: LineType;
     legendType?: LegendType;
     activeIndex?: number;
-    activeShape?: object | RechartsFunction | React.ReactElement;
-    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement | ContentRenderer<any>;
+    activeShape?: object | RechartsFunction | React.ReactType;
+    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactType | ContentRenderer<any>;
     points?: ScatterPoint[];
     hide?: boolean;
     data?: object[];
@@ -824,7 +825,7 @@ export interface TooltipPayload {
 }
 
 export interface TooltipProps extends Animatable {
-    content?: React.ReactElement | React.StatelessComponent<any> | ContentRenderer<TooltipProps>;
+    content?: React.ReactType | ContentRenderer<TooltipProps>;
     viewBox?: ViewBox;
     active?: boolean;
     separator?: string;
@@ -833,11 +834,11 @@ export interface TooltipProps extends Animatable {
     itemStyle?: object;
     labelStyle?: object;
     wrapperStyle?: object;
-    cursor?: boolean | object | React.ReactElement | React.StatelessComponent<any>;
+    cursor?: boolean | object | React.ReactType;
     coordinate?: Coordinate;
     position?: Coordinate;
     label?: string | number;
-	  labelFormatter?: LabelFormatter;
+      labelFormatter?: LabelFormatter;
     payload?: TooltipPayload[];
     itemSorter?: ItemSorter<TooltipPayload>;
     filterNull?: boolean;
@@ -852,7 +853,7 @@ export interface TreemapProps extends EventAttributes, Animatable {
     data?: any[];
     style?: object;
     aspectRatio?: number;
-    content?: React.ReactElement | ContentRenderer<any>;
+    content?: React.ReactType | ContentRenderer<any>;
     fill?: string;
     stroke?: string;
     className?: string;
@@ -874,7 +875,7 @@ export interface LabelProps extends Partial<PresentationAttributes> {
     position?: PositionType;
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
-    content?: React.ReactElement | ContentRenderer<any>;
+    content?: React.ReactType | ContentRenderer<any>;
 }
 
 export class LabelList extends React.Component<LabelListProps> { }
@@ -884,7 +885,7 @@ export interface LabelListProps {
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
     clockWise?: boolean;
-    content?: React.ReactElement | ContentRenderer<LabelProps>;
+    content?: React.ReactType | ContentRenderer<LabelProps>;
     data?: number;
     dataKey: string | number | RechartsFunction;
     formatter?: LabelFormatter;
@@ -935,7 +936,7 @@ export interface XAxisProps extends EventAttributes {
     padding?: XPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactType;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;
@@ -989,7 +990,7 @@ export interface YAxisProps extends EventAttributes {
     padding?: YPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactType;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;


### PR DESCRIPTION
@types/recharts@1.1.13 with typescript@3.1.6 and @types/react@16.8.2 produces error `Generic type 'ReactElement<P, T>' requires between 1 and 2 type arguments.`



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33501