### PR TITLE
serialport - Add includeDelimiter option to readline parser

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -100,7 +100,7 @@ declare namespace SerialPort {
 			constructor(options: {delimiter: string | Buffer | number[], includeDelimiter?: boolean});
 		}
 		class Readline extends Delimiter {
-			constructor(options: {delimiter: string | Buffer | number[], encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex'});
+			constructor(options: {delimiter: string | Buffer | number[], encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex', includeDelimiter?: boolean});
 		}
 		class Ready extends Stream.Transform {
 			constructor(options: {delimiter: string | Buffer | number[]});

--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/EmergingTechnologyAdvisors/node-serialport
 // Definitions by: Jeremy Foster <https://github.com/codefoster>
 //                 Andrew Pearson <https://github.com/apearson>
+//                 Cameron Tacklind <https://github.com/cinderblock>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -105,8 +105,8 @@ function test_parsers() {
 
     const ByteLengthParser = new SerialPort.parsers.ByteLength({length: 8});
     const CCTalkParser = new SerialPort.parsers.CCTalk();
-    const DelimiterParser = new SerialPort.parsers.Delimiter({ delimiter: Buffer.from('EOL') });
-    const ReadlineParser = new SerialPort.parsers.Readline({ delimiter: '\r\n' });
+    const DelimiterParser = new SerialPort.parsers.Delimiter({ delimiter: Buffer.from('EOL'), includeDelimiter: true });
+    const ReadlineParser = new SerialPort.parsers.Readline({ delimiter: '\r\n', includeDelimiter: false });
     const ReadyParser = new SerialPort.parsers.Ready({ delimiter: 'READY' });
     const RegexParser = new SerialPort.parsers.Regex({regex: /.*/});
 

--- a/types/serialport/v6/index.d.ts
+++ b/types/serialport/v6/index.d.ts
@@ -90,7 +90,7 @@ declare namespace SerialPort {
 			constructor(options: {delimiter: string | Buffer | number[], includeDelimiter?: boolean});
 		}
 		class Readline extends Delimiter {
-			constructor(options: {delimiter: string | Buffer | number[], encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex'});
+			constructor(options: {delimiter: string | Buffer | number[], encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex', includeDelimiter?: boolean});
 		}
 		class Ready extends Stream.Transform {
 			constructor(options: {data: string | Buffer | number[]});


### PR DESCRIPTION
`Readline`'s arguments are passed to `Delimiter`, therefore `includeDelimiter` should be added as an option to `Readline`'s constructor.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-serialport/node-serialport/blob/a80d0b73a1d8424901ab73b314de344dad798d12/packages/parser-readline/readline.js#L16-L22
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
