### PR TITLE
accounting.js: TFormat is not defined. Use string instead.

### DIFF
--- a/types/accounting/index.d.ts
+++ b/types/accounting/index.d.ts
@@ -13,7 +13,7 @@ declare namespace accounting {
 
     interface CurrencySettings<TFormat> {
         symbol?: string;     // default currency symbol is '$'
-        format?: TFormat;    // controls output: %s = symbol, %v = value/number
+        format?: string;    // controls output: %s = symbol, %v = value/number
         decimal?: string;    // decimal point separator
         thousand?: string;   // thousands separator
         precision?: number;   // decimal places


### PR DESCRIPTION
TFormat is not defined anywhere. Use string instead.