### PR TITLE
[webpack-dev-server] Add httpProxyMiddleware.Filter support to context property of ProxyConfigArrayItem

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -28,7 +28,7 @@ declare namespace WebpackDevServer {
 
     type ProxyConfigArrayItem = {
         path?: string | string[];
-        context?: string | string[]
+        context?: string | string[] | httpProxyMiddleware.Filter
     } & httpProxyMiddleware.Config;
 
     type ProxyConfigArray = ProxyConfigArrayItem[];

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -87,6 +87,9 @@ const c3: WebpackDevServer.Configuration = {
 const c4: WebpackDevServer.Configuration = {
     writeToDisk: (filePath: string) => true,
 };
+const c5: WebpackDevServer.Configuration = {
+    proxy: [{context: (pathname: string) => true}]
+};
 
 // API example
 server = new WebpackDevServer(compiler, config);


### PR DESCRIPTION
webpack-dev-server [proxy documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy) gives an example of using Filter function for context property and in reality dev-server supports it. However, it was missing on `@types/webpack-dev-server`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/dev-server/#devserverproxy
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
