### PR TITLE
[react-datepicker] Allow `null` value for some props

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -9,6 +9,7 @@
 //                 Sean Kelley <https://github.com/seansfkelley>
 //                 Justin Grant <https://github.com/justingrant>
 //                 Jake Boone <https://github.com/jakeboone02>
+//                 Roman Nuritdinov <https://github.com/Ky6uk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -41,7 +42,7 @@ export interface ReactDatePickerProps {
 	disabled?: boolean;
 	disabledKeyboardNavigation?: boolean;
 	dropdownMode?: 'scroll' | 'select';
-	endDate?: Date;
+	endDate?: Date | null;
 	excludeDates?: Date[];
 	excludeTimes?: Date[];
 	filterDate?(date: Date): boolean;
@@ -57,9 +58,9 @@ export interface ReactDatePickerProps {
 	inline?: boolean;
 	isClearable?: boolean;
 	locale?: string;
-	maxDate?: Date;
+	maxDate?: Date | null;
 	maxTime?: Date;
-	minDate?: Date;
+	minDate?: Date | null;
 	minTime?: Date;
 	monthsShown?: number;
 	name?: string;
@@ -112,7 +113,7 @@ export interface ReactDatePickerProps {
 	showTimeSelectOnly?: boolean;
 	showWeekNumbers?: boolean;
 	showYearDropdown?: boolean;
-	startDate?: Date;
+	startDate?: Date | null;
 	startOpen?: boolean;
 	tabIndex?: number;
 	timeCaption?: string;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -121,6 +121,14 @@ const defaultLocale = getDefaultLocale();
 	<span />
 </DatePicker>;
 
+<DatePicker
+    minDate={null}
+    maxDate={null}
+    startDate={null}
+    endDate={null}
+    onChange={() => null}
+/>;
+
 function handleRef(ref: DatePicker | null) {
     if (ref) {
         ref.setBlur();

--- a/types/react-datepicker/tsconfig.json
+++ b/types/react-datepicker/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
* Props `endData`, `startDate`, `minDate` and `maxDate` can receive `null` value
* Enabled `strictNullChecks` flag