### PR TITLE
[jsonwebtoken] set correct type for "expiredAt" in the TokenExpiredError function

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -17,9 +17,9 @@ export class JsonWebTokenError extends Error {
 }
 
 export class TokenExpiredError extends JsonWebTokenError {
-    expiredAt: number;
+    expiredAt: Date;
 
-    constructor(message: string, expiredAt: number);
+    constructor(message: string, expiredAt: Date);
 }
 
 export class NotBeforeError extends JsonWebTokenError {

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -4,7 +4,8 @@
 //                 Daniel Heim <https://github.com/danielheim>,
 //                 Brice BERNARD <https://github.com/brikou>,
 //                 Veli-Pekka Kestilä <https://github.com/vpk>,
-//                 Daniel Parker <https://github.com/rlgod>
+//                 Daniel Parker <https://github.com/rlgod>,
+//                 Kjell Dießel <https://github.com/kettil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-jsonwebtoken/blob/master/README.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

In the version v8.5.0 and v8.3.0 of node-jsonwebtoken, the variable expiredAt (within the function TokenExpiredError) is not a number but a date.

See the linked code locations:
- [verify.js - line 152](https://github.com/auth0/node-jsonwebtoken/blob/1c0de55c4a650cf0e894d089c44b74afc91ff78e/verify.js#L152)
- [verify.js - line 209](https://github.com/auth0/node-jsonwebtoken/blob/1c0de55c4a650cf0e894d089c44b74afc91ff78e/verify.js#L209)

