### PR TITLE
Add type definitions for ResizeObserver API (in Chrome)

### DIFF
--- a/types/resize-observer-browser/index.d.ts
+++ b/types/resize-observer-browser/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for non-npm package resize-observer-browser 0.1
+// Project: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver, https://developers.google.com/web/updates/2016/10/resizeobserver, https://wicg.github.io/ResizeObserver/
+// Definitions by: Chives <https://github.com/chivesrs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+export class ResizeObserver {
+    constructor(callback: ResizeObserverCallback);
+    disconnect(): void;
+    observe(target: Element): void;
+    unobserve(target: Element): void;
+}
+
+export type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+
+export interface ResizeObserverEntry {
+    readonly target: Element;
+    readonly contentRect: DOMRectReadOnly;
+}

--- a/types/resize-observer-browser/resize-observer-browser-tests.ts
+++ b/types/resize-observer-browser/resize-observer-browser-tests.ts
@@ -1,0 +1,13 @@
+import { ResizeObserver } from "resize-observer-browser";
+
+function resizeObserverCreates(): void {
+    const resizeObserver: ResizeObserver = new ResizeObserver((entries) => {
+        const div = document.getElementById('display-div')!;
+        const rect = entries[0].contentRect;
+        div.textContent = `${rect.left} ${rect.right}`;
+    });
+    const div = document.getElementById('resized-div')!;
+    resizeObserver.observe(div);
+    resizeObserver.unobserve(div);
+    resizeObserver.disconnect();
+}

--- a/types/resize-observer-browser/tsconfig.json
+++ b/types/resize-observer-browser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "resize-observer-tests.ts"
+    ]
+}

--- a/types/resize-observer-browser/tslint.json
+++ b/types/resize-observer-browser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Information on this API is available at https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver, https://developers.google.com/web/updates/2016/10/resizeobserver, and https://wicg.github.io/ResizeObserver/. I've used only the type definitions from the MDN website rather than the full draft spec.