### PR TITLE
[@types/react] Enable passing children down to "ExoticComponent"s

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -301,7 +301,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement|null);
+        (props: PropsWithChildren<P>): ReactElement | null;
         readonly $$typeof: symbol;
     }
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -229,6 +229,10 @@ const Memoized6 = React.memo(props => null);
 // $ExpectError
 <Memoized6 foo/>;
 
+const BeforeMemoized7: React.FC = ({ children }) => null;
+const Memoized7 = React.memo(BeforeMemoized7);
+<Memoized7>foo</Memoized7>;
+
 // NOTE: this test _requires_ TypeScript 3.1
 // It is passing, for what it's worth.
 // const Memoized7 = React.memo((() => {


### PR DESCRIPTION
The definition of `ExoticComponent<P>` is as follows: 
(please refer to the introduction of `ExoticComponent` to #30054)

```ts
interface ExoticComponent<P = {}> {
    (props: P): ReactElement | null;
    // Other details omitted.
}
```

So it is not possible to pass children down to `ExoticComponent`s using JSX unless the component specifies the `children` property in props. However, the behavior of `FunctionComponent`s is quite different.

```ts
interface FunctionComponent<P = {}> {
    (props: PropsWithChildren<P>, context?: any): ReactElement | null;
    // Other details omitted.
}
```

The props of `FunctionComponent`s automatically contains the optional `children` property. Hence it is able to pass down children to FCs with no regard of whether the `children` property is specified in the component or not. Similar is for class-based components.

It is more confusing when first making a `React.FunctionComponent` and then `memo`ing it:
(TypeScript 3.3.3333)

![image](https://user-images.githubusercontent.com/3102175/53782174-79351900-3f4f-11e9-83c3-f03f9f8baee6.png)

Note that the compiler complains that we cannot pass children down to the memoed component, while we can still pass it down to the original component.

This PR fixes this confusing behavior by using `PropsWithChildren` in `ExoticComponent`, which is the same way already applied to `FunctionComponent`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> https://www.typescriptlang.org/docs/handbook/jsx.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
