### PR TITLE
add support for getInstance method on react-onclickoutside refs

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -2,10 +2,13 @@
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 //                 Boris Sergeyev <https://github.com/surgeboris>
+//                 Thomas Levy <https://github.com/NilSet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
+
+export {};
 
 export interface HandleClickOutside<T> {
     handleClickOutside: React.MouseEventHandler<T>;
@@ -38,7 +41,25 @@ export interface ClickOutComponentClass<P> extends React.ComponentClass<P> {
 
 export type OnClickOutProps<P> = WithoutInjectedClickOutProps<P> & AdditionalProps;
 
-export default function OnClickOut<P>(
-    component: ComponentConstructor<P> | ClickOutComponentClass<P>,
-    config?: ConfigObject
-): React.ComponentClass<OnClickOutProps<P>>;
+interface WrapperClass<P, C> {
+    new (): WrapperInstance<P, C>;
+}
+
+interface WrapperInstance<P, C>
+    extends React.Component<OnClickOutProps<JSX.LibraryManagedAttributes<C, P>>> {
+    getInstance(): C extends typeof React.Component ? InstanceType<C> : never;
+}
+
+type PropsOf<T> = T extends (
+    props: infer P,
+    context?: any
+) => React.ReactElement | null // Try to infer for SFCs
+    ? P
+    : T extends new (props: infer P, context?: any) => React.Component // Otherwise try to infer for classes
+    ? P
+    : never;
+
+export default function OnClickOut<
+    C extends ComponentConstructor<P> | ClickOutComponentClass<P>,
+    P = PropsOf<C>
+>(component: C, config?: ConfigObject): WrapperClass<P, C>;

--- a/types/react-onclickoutside/react-onclickoutside-tests.tsx
+++ b/types/react-onclickoutside/react-onclickoutside-tests.tsx
@@ -48,6 +48,10 @@ class TestComponent extends React.Component<{ disableOnClickOutside(): void; ena
         console.log('this.handleClickOutside');
     }
 
+    logProps = () => {
+        console.log(this.props);
+    }
+
     render() {
         this.props.disableOnClickOutside();
         this.props.enableOnClickOutside();
@@ -58,12 +62,18 @@ class TestComponent extends React.Component<{ disableOnClickOutside(): void; ena
 }
 
 const WrappedComponent = onClickOutside(TestComponent);
+const wrappedComponentRef: React.RefObject<InstanceType<typeof WrappedComponent>> = React.createRef();
 
 render(
     <WrappedComponent
+        ref={wrappedComponentRef}
         eventTypes="whatever"
         preventDefault
         stopPropagation
     />,
     document.getElementById("main")
 );
+
+if (wrappedComponentRef.current) {
+  wrappedComponentRef.current.getInstance().logProps();
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Pomax/react-onclickoutside#but-how-can-i-access-my-component-it-has-an-api-that-i-rely-on
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
