### PR TITLE
Update SQSMessageAttribute in aws-lambda

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -1003,7 +1003,15 @@ const SQSEvent: AWSLambda.SQSEvent = {
                 SenderId: "594035263019",
                 ApproximateFirstReceiveTimestamp: "1529104986230"
             },
-            messageAttributes: {},
+            messageAttributes: {
+                testAttr: {
+                    stringValue: "100",
+                    binaryValue: "base64Str",
+                    stringListValues: [],
+                    binaryListValues: [],
+                    dataType: "Number"
+                }
+            },
             md5OfBody: "9bb58f26192e4ba00f01e2e7b136bbd8",
             eventSource: "aws:sqs",
             eventSourceARN: "arn:aws:sqs:us-west-2:594035263019:NOTFIFOQUEUE",
@@ -1039,6 +1047,10 @@ const SQSMessageNode8AsyncHandler: AWSLambda.SQSHandler = async (
     event;
     str = event.Records[0].messageId;
     anyObj = event.Records[0].body;
+    strOrUndefined = event.Records[0].messageAttributes.testAttr.stringValue;
+    strOrUndefined = event.Records[0].messageAttributes.testAttr.binaryValue;
+    str = event.Records[0].messageAttributes.testAttr.dataType;
+
     // $ExpectType Context
     context;
     str = context.functionName;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -878,11 +878,17 @@ export interface SQSRecordAttributes {
     SenderId: string;
     ApproximateFirstReceiveTimestamp: string;
 }
+
+export type SQSMessageAttributeDataType = 'String' | 'Number' | 'Binary' | string;
+
 export interface SQSMessageAttribute {
-    Name: string;
-    Type: string;
-    Value: string;
+    stringValue?: string;
+    binaryValue?: string;
+    stringListValues: never[]; // Not implemented. Reserved for future use.
+    binaryListValues: never[]; // Not implemented. Reserved for future use.
+    dataType: SQSMessageAttributeDataType;
 }
+
 export interface SQSMessageAttributes {
     [name: string]: SQSMessageAttribute;
 }


### PR DESCRIPTION
Fixes #33514 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Here's a link to `aws-sdk-js` docs for SQS Attributes](https://github.com/aws/aws-sdk-js/blob/master/apis/sqs-2012-11-05.normal.json#L923:L955) and here's an SQS message from one of my services:

```json
{
    "Records": [
        {
            "messageId": "xxx",
            "receiptHandle": "xxx",
            "body": "xxx",
            "attributes": {
                "ApproximateReceiveCount": "1",
                "SentTimestamp": "1551764832218",
                "SenderId": "xxx",
                "ApproximateFirstReceiveTimestamp": "1551765732218"
            },
            "messageAttributes": {
                "retryCnt": {
                    "stringValue": "5",
                    "stringListValues": [],
                    "binaryListValues": [],
                    "dataType": "Number"
                },
                "queueUrl": {
                    "stringValue": "xxx",
                    "stringListValues": [],
                    "binaryListValues": [],
                    "dataType": "String"
                }
            },
            "md5OfMessageAttributes": "xxx",
            "md5OfBody": "xxx",
            "eventSource": "aws:sqs",
            "eventSourceARN": "xxx",
            "awsRegion": "us-west-2"
        }
    ]
}
```

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.