### PR TITLE
[Cesium] - Event listener callbacks can have variable parameters

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -706,8 +706,8 @@ declare namespace Cesium {
 
     class Event {
         numberOfListeners: number;
-        addEventListener(listener: () => void, scope?: any): Event.RemoveCallback;
-        removeEventListener(listener: () => void, scope?: any): boolean;
+        addEventListener(listener: (...args: any[]) => void, scope?: any): Event.RemoveCallback;
+        removeEventListener(listener: (...args: any[]) => void, scope?: any): boolean;
         raiseEvent(...args: any[]): void;
     }
 


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Cesium Event listener function can take arbitrary set of arguments: https://cesiumjs.org/Cesium/Build/Documentation/Event.html

Example, clustering new cluster callback is a Cesium `Event` but take 2 parameters:
https://cesiumjs.org/Cesium/Build/Documentation/EntityCluster.html?classFilter=Cluster#clusterEvent
https://cesiumjs.org/Cesium/Build/Documentation/EntityCluster.html#~newClusterCallback

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
