### PR TITLE
@types/storybook__addon-a11y: Deprecate checkA11y in favor of withA11y

### DIFF
--- a/types/storybook__addon-a11y/index.d.ts
+++ b/types/storybook__addon-a11y/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/addon-a11y 3.3
+// Type definitions for @storybook/addon-a11y 5.0
 // Project: https://github.com/storybooks/storybook
 // Definitions by: HyunSeob <https://github.com/hyunseob>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,4 +6,5 @@
 
 import { StoryDecorator } from '@storybook/react';
 
-export const checkA11y: StoryDecorator;
+export const checkA11y: StoryDecorator; // Deprecated
+export const withA11y: StoryDecorator;


### PR DESCRIPTION
See [`storybook/addons/a11y/src/index.js#L66-L70`](https://github.com/storybooks/storybook/blob/f2b625bab05720c4c323af3e612e7d03adbd3b92/addons/a11y/src/index.js#L66-L70) and [`storybook/MIGRATION.md#addon-a11y-uses-parameters-decorator-renamed`](https://github.com/storybooks/storybook/blob/next/MIGRATION.md#addon-a11y-uses-parameters-decorator-renamed).