### PR TITLE
Use export assignment for caseless

### DIFF
--- a/types/caseless/caseless-tests.ts
+++ b/types/caseless/caseless-tests.ts
@@ -1,9 +1,9 @@
-import caseless, { Caseless, httpify, Httpified } from "caseless";
+import caseless = require("caseless");
 
-new Caseless(); // $ExpectError
+new caseless.Caseless(); // $ExpectError
 
 // tslint:disable-next-line: prefer-const
-let c1: Caseless;
+let c1: caseless.Caseless;
 
 caseless(); // $ExpectType Caseless
 caseless({}); // $ExpectType Caseless
@@ -30,16 +30,16 @@ c2.swap(10); // $ExpectError
 
 c2.del('foo'); // $ExpectType boolean
 
-httpify(null, {}); // $ExpectError
-httpify(1, {}); // $ExpectError
-httpify("2", {}); // $ExpectError
-httpify({}, null); // $ExpectError
-httpify({}, 1); // $ExpectError
-httpify({}, "2"); // $ExpectError
+caseless.httpify(null, {}); // $ExpectError
+caseless.httpify(1, {}); // $ExpectError
+caseless.httpify("2", {}); // $ExpectError
+caseless.httpify({}, null); // $ExpectError
+caseless.httpify({}, 1); // $ExpectError
+caseless.httpify({}, "2"); // $ExpectError
 
-httpify({}, {}); // $ExpectType Caseless
+caseless.httpify({}, {}); // $ExpectType Caseless
 
-const request: Httpified = {}; // $ExpectError
+const request: caseless.Httpified = {}; // $ExpectError
 
 request.setHeader({}); // $ExpectType void
 request.setHeader('foo', 'bar'); // $ExpectType string | false

--- a/types/caseless/index.d.ts
+++ b/types/caseless/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mikeal/caseless
 // Definitions by: downace <https://github.com/downace>
 //                 Matt R. Wilson <https://github.com/mastermatt>
+//                 Emily Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -9,26 +10,28 @@ type KeyType = string;
 type ValueType = any;
 type RawDict = object;
 
-export interface Caseless {
-    set(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
-    set(dict: RawDict): void;
-    has(name: KeyType): KeyType | false;
-    get(name: KeyType): ValueType | undefined;
-    swap(name: KeyType): void;
-    del(name: KeyType): boolean;
+declare function caseless(dict?: RawDict): caseless.Caseless;
+
+declare namespace caseless {
+    function httpify(resp: object, headers: RawDict): Caseless;
+
+    interface Caseless {
+        set(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
+        set(dict: RawDict): void;
+        has(name: KeyType): KeyType | false;
+        get(name: KeyType): ValueType | undefined;
+        swap(name: KeyType): void;
+        del(name: KeyType): boolean;
+    }
+
+    interface Httpified {
+      headers: RawDict;
+      setHeader(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
+      setHeader(dict: RawDict): void;
+      hasHeader(name: KeyType): KeyType | false;
+      getHeader(name: KeyType): ValueType | undefined;
+      removeHeader(name: KeyType): boolean;
+    }
 }
 
-export interface Httpified {
-  headers: RawDict;
-  setHeader(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
-  setHeader(dict: RawDict): void;
-  hasHeader(name: KeyType): KeyType | false;
-  getHeader(name: KeyType): ValueType | undefined;
-  removeHeader(name: KeyType): boolean;
-}
-
-export function httpify(resp: object, headers: RawDict): Caseless;
-
-declare function caseless(dict?: RawDict): Caseless;
-
-export default caseless;
+export = caseless;


### PR DESCRIPTION
`caseless` doesn't provide a `default` export, so the current typedef file doesn't work

<!-- Please fill in this template. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

<!-- Select one of these and delete the others: -->

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: my best guess is that [the `esModuleInterop` option was allowing this to work, and it was removed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23658). I don't use that option, so, caseless does not work with this definition file, as caseless doesn't provide a `default` export https://github.com/request/caseless/blob/master/index.js
- [ ] ~~Increase the version number in the header if appropriate.~~ N/A