### PR TITLE
Cleanup from DT nightly run

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Chart.js 2.7
-// Project: https://github.com/nnnick/Chart.js, http://www.chartjs.org
+// Project: https://github.com/nnnick/Chart.js, https://www.chartjs.org
 // Definitions by: Alberto Nuti <https://github.com/anuti>
 //                 Fabien Lavocat <https://github.com/FabienLavocat>
 //                 KentarouTakeda <https://github.com/KentarouTakeda>

--- a/types/jest-in-case/jest-in-case-tests.ts
+++ b/types/jest-in-case/jest-in-case-tests.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 test('array', () => {
     const title = 'add(augend, addend)';
 
-    const tester = jest.fn(opts => {
+    const tester = jest.fn((opts, cb) => {
         expect(add(opts.augend, opts.addend)).toBe(opts.total);
     });
 
@@ -59,7 +59,7 @@ test('object', () => {
 
     const title = 'add(augend, addend)';
 
-    const tester = jest.fn(opts => {
+    const tester = jest.fn((opts, cb) => {
         expect(subtract(opts.minuend, opts.subtrahend)).toBe(opts.difference);
     });
 

--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for @storybook/addon-storyshots 3.4
-// Project: https://github.com/storybooks/storybook/tree/master/addons/storyshots, https://github.com/storybooks/storybook/tree/master/addons/storyshorts/storyshots-core
+// Project: https://github.com/storybooks/storybook/tree/master/addons/storyshots, https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-core
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1


### PR DESCRIPTION
1. A couple of updated project urls. (one typo and one https)
2. Possible bug in ts@next, or at least surprising behaviour: rest params with tuple types have to match length exactly when assigned to normal rest params. This is stricter than normal param list assignability rules. Work around it in jest-in-case. Microsoft/TypeScript#30234