### PR TITLE
[express-bunyan-logger] Update Options.

### DIFF
--- a/types/express-bunyan-logger/express-bunyan-logger-tests.ts
+++ b/types/express-bunyan-logger/express-bunyan-logger-tests.ts
@@ -22,3 +22,12 @@ const logger = Bunyan.createLogger({
 const middleware5 = expressBunyan({
     logger
 });
+
+expressBunyan({
+    format: () => "some format",
+    genReqId: req => req.header("foo") || "other",
+    name: "foo_app",
+    parseUA: false,
+    serializers: Bunyan.stdSerializers,
+    streams: [{ level: 'info', stream: process.stdout }]
+});

--- a/types/express-bunyan-logger/index.d.ts
+++ b/types/express-bunyan-logger/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for express-bunyan-logger 1.3
 // Project: https://github.com/villadora/express-bunyan-logger
 // Definitions by: Shrey Jain <https://github.com/shreyjain1994>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -17,7 +18,7 @@ declare namespace Factory {
     type RequestIdGenFunction = (req: express.Request) => string;
     type LevelFunction = (status: number, err: Error | null, meta: any) => string;
 
-    interface Options {
+    interface Options extends Partial<Bunyan.LoggerOptions> {
         logger?: Bunyan;
         format?: string | FormatFunction;
         parseUA?: boolean;
@@ -26,7 +27,6 @@ declare namespace Factory {
         excludes?: string[];
         obfuscate?: string[];
         obfuscatePlaceholder?: string;
-        serializers?: { [field: string]: Bunyan.Serializer };
         immediate?: boolean;
         genReqId?: RequestIdGenFunction;
     }


### PR DESCRIPTION
The options are passed through to bunyan.createLogger so all those
options need to be valid. A `Partial` is used because the only required
option by `createLogger` is `name` but the middleware provides a default.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [options are passed to `createLogger`](https://github.com/villadora/express-bunyan-logger/blob/717e2d82fa892d4b6b83980de93d90bb4bb33ecd/index.js#L84)

