### PR TITLE
[react] Make "type" button attribute match W3C spec

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -21,6 +21,7 @@
 //                 Jessica Franco <https://github.com/Jessidhia>
 //                 Paul Sherman <https://github.com/pshrmn>
 //                 Saransh Kataria <https://github.com/saranshkataria>
+//                 Kanitkorn Sujautra <https://github.com/lukyth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -1814,7 +1815,7 @@ declare namespace React {
         formNoValidate?: boolean;
         formTarget?: string;
         name?: string;
-        type?: string;
+        type?: 'submit' | 'reset' | 'button';
         value?: string | string[] | number;
     }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1815,7 +1815,10 @@ declare namespace React {
         formNoValidate?: boolean;
         formTarget?: string;
         name?: string;
-        type?: 'submit' | 'reset' | 'button';
+        // TODO: Should be `'submit' | 'reset' | 'button'`,
+        // see [[react] Make "type" button attribute match W3C spec](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33648).
+        // This is a breaking change that cannot be done for the moment.
+        type?: string;
         value?: string | string[] | number;
     }
 


### PR DESCRIPTION
According to https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#attr-button-type, the `type` button attribute can only be one of the three keywords, `"submit"`, `"reset"`, and `"button"`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#attr-button-type
- [ ] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

I'm not sure how to deal with these two checklist.
> - [ ] Add or edit tests to reflect the change. (Run with `npm test`.)

> - [ ] Increase the version number in the header if appropriate.

This seems like a breaking change, but I don't know if that's appropriate or not. 😅 