### PR TITLE
[react-table] Make exported default props non-nullable

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -51,12 +51,12 @@ export interface SortingRule {
 }
 
 export interface TableProps<D = any, ResolvedData = D> extends
-    Partial<TextProps>,
-    Partial<ComponentDecoratorProps>,
-    Partial<ControlledStateCallbackProps>,
-    Partial<PivotingProps>,
-    Partial<ControlledStateOverrideProps>,
-    Partial<ComponentProps> {
+    TextProps,
+    ComponentDecoratorProps,
+    ControlledStateCallbackProps,
+    PivotingProps,
+    ControlledStateOverrideProps,
+    ComponentProps {
     /** Default: [] */
     data: D[];
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-table/blob/v6/src/defaultProps.js
