### PR TITLE
:sparkles: Add get / set and quit Cluster methods

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -875,10 +875,20 @@ declare namespace IORedis {
 
     type NodeRole = 'master' | 'slave' | 'all';
 
+    type CallbackFunction<T = any> = (err?: NodeJS.ErrnoException | null, result?: T) => void;
+
     interface Cluster extends NodeJS.EventEmitter, Commander {
         connect(callback: () => void): Promise<any>;
         disconnect(): void;
         nodes(role?: NodeRole): Redis[];
+        quit(callback?: CallbackFunction<'OK'>): Promise<'OK'>;
+        get(key: KeyType, callback: (err: Error, res: string | null) => void): void;
+        get(key: KeyType): Promise<string | null>;
+        set(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+        set(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
     }
 
     interface ClusterStatic extends NodeJS.EventEmitter, Commander {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -226,3 +226,32 @@ cluster.nodes().map(node => {
         .exec()
         .then(result => console.log(result));
 });
+cluster.set('foo', 'bar');
+cluster.get('foo', (err, result) => {
+    if (err) {
+        console.error(err);
+    }
+    console.log(result);
+});
+cluster.get('foo')
+    .then(result => console.log(result))
+    .catch(reason => console.error(reason));
+cluster.connect(() => {
+    console.log('connect');
+})
+.then(result => console.log(result))
+.then(reason => console.error(reason));
+cluster.disconnect();
+cluster.quit(result => {
+    console.log(result);
+});
+const getBuiltinCommandsResult = cluster.getBuiltinCommands();
+console.log(getBuiltinCommandsResult);
+const createBuiltinCommandResult = cluster.createBuiltinCommand('createBuiltinCommand');
+console.log(createBuiltinCommandResult);
+const defineCommandResult = cluster.defineCommand('defineCommand', {
+    numberOfKeys: 1,
+    lua: 'lua'
+});
+console.log(defineCommandResult);
+cluster.sendCommand();


### PR DESCRIPTION
I added the get / set methods to the Cluster interface, along with a CallbackFunction type, and the quit Cluster method.

There are still other undocumented functions, such as `cluster.multi()` and `cluster.pipeline()`, but I wanted to help resolve some other people's issues with this type definition quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Cluster get / set methods](
https://github.com/luin/ioredis/blob/6049f6c9aa852c89efdc32dda755ea7f7a7a51fd/README.md#cluster)