### PR TITLE
Nightly cleanup 06-03-2019

### DIFF
--- a/types/ember/v1/package.json
+++ b/types/ember/v1/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}

--- a/types/ember/v2/package.json
+++ b/types/ember/v2/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}

--- a/types/hbs/package.json
+++ b/types/hbs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}

--- a/types/kafkajs/index.d.ts
+++ b/types/kafkajs/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for kafkajs 1.4
-// Project: https://github.com/tulios/kafkajs
+// Project: https://github.com/tulios/kafkajs, https://kafka.js.org
 // Definitions by: Michal Kaminski <https://github.com/michal-b-kaminski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9

--- a/types/koa-hbs/package.json
+++ b/types/koa-hbs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}

--- a/types/snazzy-info-window/package.json
+++ b/types/snazzy-info-window/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}

--- a/types/swag/package.json
+++ b/types/swag/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "handlebars": "^4.1.0"
+    }
+}


### PR DESCRIPTION
1. Add handlebars dependencies missed in #33518, which deprecated
@types/handlebars now that handlebars ships its own types.
2. Add project homepage for kafkajs.

I recently fixed the dependency analysis of types-publisher. At the time #33518 was opened, it didn't correctly gather dependents of removed packages, so that's why ember/v1 and ember/v2 didn't cause the CI build to fail.