### PR TITLE
Use correct npm name for png-async deprecation

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1135,8 +1135,8 @@
             "asOfVersion": "2.15.0"
         },
         {
-            "libraryName": "node-png-async",
-            "typingsPackageName": "node-png-async",
+            "libraryName": "png-async",
+            "typingsPackageName": "png-async",
             "sourceRepoURL": "https://github.com/kanreisa/node-png-async",
             "asOfVersion": "0.9.4"
         },


### PR DESCRIPTION
The CI build doesn't check for correct fields in notNeededPackages.json PRs, so #33579 used the incorrect libraryName and typingsPackageName. This appears to have caused types-publisher to crash.