### PR TITLE
stylelint: correct several interfaces

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -2,36 +2,55 @@
 // Project: https://github.com/stylelint/stylelint, https://stylelint.io
 // Definitions by: Alan Agius <https://github.com/alan-agius4>
 //                 Filips Alpe <https://github.com/filipsalpe>
+//                 James Garbutt <https://github.com/43081j>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export type FormatterType = "json" | "string" | "verbose" | "compact";
+import * as postcss from 'postcss';
 
-export type SyntaxType = "scss" | "sass" | "less" | "sugarss";
+export type FormatterType = "json" | "string" | "verbose" | "compact" | "unix";
+
+export type SyntaxType = "css-in-js"
+    | "html"
+    | "less"
+    | "markdown"
+    | "sass"
+    | "scss"
+    | "sugarss";
+
+export interface Configuration {
+    rules: Record<string, any>;
+    extends: string | string[];
+    plugins: string[];
+    processors: string[];
+    ignoreFiles: string|string[];
+    defaultSeverity: "warning"|"error";
+}
 
 export interface LinterOptions {
-    code?: string;
-    codeFilename?: string;
-    config?: JSON;
-    configBasedir?: string;
-    configFile?: string;
-    configOverrides?: JSON;
-    cache?: boolean;
-    cacheLocation?: string;
-    files?: string | string[];
-    fix?: boolean;
-    formatter?: FormatterType;
-    ignoreDisables?: boolean;
-    reportNeedlessDisables?: boolean;
-    ignorePath?: boolean;
-    syntax?: SyntaxType;
-    customSyntax?: string;
+    cache: boolean;
+    cacheLocation: string;
+    code: string;
+    codeFilename: string;
+    config: Partial<Configuration>;
+    configBasedir: string;
+    configFile: string;
+    configOverrides: Partial<Configuration>;
+    customSyntax: string;
+    disableDefaultIgnores: boolean;
+    files: string | string[];
+    fix: boolean;
+    formatter: FormatterType;
+    ignoreDisables: boolean;
+    ignorePath: string;
+    maxWarnings: number;
+    reportNeedlessDisables: boolean;
+    syntax: SyntaxType;
 }
 
 export interface LinterResult {
     errored: boolean;
     output: string;
-    postcssResults: any[];
     results: LintResult[];
 }
 
@@ -49,9 +68,10 @@ export namespace formatters {
     function string(results: LintResult[]): string;
     function compact(results: LintResult[]): string;
     function verbose(results: LintResult[]): string;
+    function unix(results: LintResult[]): string;
 }
 
-export function lint(options?: LinterOptions): Promise<LinterResult>;
+export function lint(options?: Partial<LinterOptions>): Promise<LinterResult>;
 
 export type RuleOption = {
     actual: any;
@@ -63,25 +83,35 @@ export type RuleOption = {
     optional: true;
 };
 
+export type RuleMessageValue = string | ((...args: any[]) => string);
+
 export namespace utils {
     function report(violation: {
         ruleName: string;
-        result: LintResult;
+        result: postcss.Result;
         message: string;
-        node: any;
+        node: postcss.Node;
         index?: number;
         word?: string;
         line?: number;
     }): void;
 
-    function ruleMessages(ruleName: string, messages: { [key: string]: any; }): typeof messages;
+    function ruleMessages<T extends {[key: string]: RuleMessageValue}>(
+        ruleName: string,
+        messages: T): T;
 
-    function validateOptions(result: LintResult, ruleName: string, ...options: RuleOption[]): boolean;
+    function validateOptions(result: postcss.Result, ruleName: string,
+        ...options: RuleOption[]): boolean;
 
-    function checkAgainstRule(options: { ruleName: string; ruleSettings: any; root: any; }, callback: (warning: string) => void): void;
+    function checkAgainstRule(options: {
+        ruleName: string;
+        ruleSettings: any;
+        root: any;
+    }, callback: (warning: string) => void): void;
 }
 
 export function createPlugin(
     ruleName: string,
-    plugin: (options: RuleOption[]) => (root: any, result: LintResult) => void,
+    plugin: (primaryOption: any, secondaryOptions: RuleOption[]) =>
+        (root: postcss.Root, result: postcss.Result) => void|PromiseLike<void>,
 ): any;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stylelint 9.4
+// Type definitions for stylelint. 10.0
 // Project: https://github.com/stylelint/stylelint, https://stylelint.io
 // Definitions by: Alan Agius <https://github.com/alan-agius4>
 //                 Filips Alpe <https://github.com/filipsalpe>

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -115,3 +115,40 @@ export function createPlugin(
     plugin: (primaryOption: any, secondaryOptions: RuleOption[]) =>
         (root: postcss.Root, result: postcss.Result) => void|PromiseLike<void>,
 ): any;
+
+export interface RuleTesterResult {
+    expected: number;
+    actual: number;
+    description: string;
+}
+
+export interface RuleTesterTest {
+    code: string;
+    description?: string;
+}
+
+export interface RuleTesterTestRejected extends RuleTesterTest {
+    line?: number;
+    column?: number;
+    only?: boolean;
+    message?: string;
+}
+
+export interface RuleTesterSchema {
+    ruleName: string;
+    syntax?: SyntaxType;
+    config?: any;
+    accept?: RuleTesterTest[];
+    reject?: RuleTesterTestRejected[];
+}
+
+export interface RuleTesterContext {
+    comparisonCount: number;
+    completeAssertionDescription: string;
+    caseDescription: string;
+    only?: boolean;
+}
+
+export function createRuleTester(
+    fn: (result: Promise<RuleTesterResult[]>, context: RuleTesterContext) => void
+): (rule: any, schema: RuleTesterSchema) => void;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stylelint. 10.0
+// Type definitions for stylelint 9.10
 // Project: https://github.com/stylelint/stylelint, https://stylelint.io
 // Definitions by: Alan Agius <https://github.com/alan-agius4>
 //                 Filips Alpe <https://github.com/filipsalpe>

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -110,10 +110,12 @@ export namespace utils {
     }, callback: (warning: string) => void): void;
 }
 
+export type Plugin = (primaryOption: any, secondaryOptions: RuleOption[]) =>
+    (root: postcss.Root, result: postcss.Result) => void|PromiseLike<void>;
+
 export function createPlugin(
     ruleName: string,
-    plugin: (primaryOption: any, secondaryOptions: RuleOption[]) =>
-        (root: postcss.Root, result: postcss.Result) => void|PromiseLike<void>,
+    plugin: Plugin
 ): any;
 
 export interface RuleTesterResult {
@@ -151,4 +153,4 @@ export interface RuleTesterContext {
 
 export function createRuleTester(
     fn: (result: Promise<RuleTesterResult[]>, context: RuleTesterContext) => void
-): (rule: any, schema: RuleTesterSchema) => void;
+): (rule: Plugin, schema: RuleTesterSchema) => void;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -73,7 +73,7 @@ export namespace formatters {
 
 export function lint(options?: Partial<LinterOptions>): Promise<LinterResult>;
 
-export type RuleOption = {
+export type ValidateOptionsAssertion = {
     actual: any;
     possible?: any;
     optional?: false;
@@ -101,7 +101,7 @@ export namespace utils {
         messages: T): T;
 
     function validateOptions(result: postcss.Result, ruleName: string,
-        ...options: RuleOption[]): boolean;
+        ...options: ValidateOptionsAssertion[]): boolean;
 
     function checkAgainstRule(options: {
         ruleName: string;
@@ -110,7 +110,7 @@ export namespace utils {
     }, callback: (warning: string) => void): void;
 }
 
-export type Plugin = (primaryOption: any, secondaryOptions: RuleOption[]) =>
+export type Plugin = (primaryOption: any, secondaryOptions?: object) =>
     (root: postcss.Root, result: postcss.Result) => void|PromiseLike<void>;
 
 export function createPlugin(

--- a/types/stylelint/package.json
+++ b/types/stylelint/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "7.x.x"
+    }
+}

--- a/types/stylelint/stylelint-tests.ts
+++ b/types/stylelint/stylelint-tests.ts
@@ -9,7 +9,8 @@ import {
     utils,
     createRuleTester,
     RuleTesterContext,
-    RuleTesterResult
+    RuleTesterResult,
+    Plugin
 } from "stylelint";
 
 const options: Partial<LinterOptions> = {
@@ -40,7 +41,7 @@ const messages = utils.ruleMessages(ruleName, {
     warning: (reason: string) => `This is not allowed because ${reason}`,
 });
 
-createPlugin(ruleName, options => {
+const testPlugin: Plugin = (options) => {
     return (root, result) => {
         const validOptions = utils.validateOptions(result, ruleName, { actual: options });
         if (!validOptions) {
@@ -63,7 +64,9 @@ createPlugin(ruleName, options => {
             });
         });
     };
-});
+};
+
+createPlugin(ruleName, testPlugin);
 
 const tester = createRuleTester(
     (result: Promise<RuleTesterResult[]>, context: RuleTesterContext) => {
@@ -71,7 +74,7 @@ const tester = createRuleTester(
     }
 );
 
-tester({}, {
+tester(testPlugin, {
     ruleName: 'foo',
     config: [true, 1],
     accept: [

--- a/types/stylelint/stylelint-tests.ts
+++ b/types/stylelint/stylelint-tests.ts
@@ -1,6 +1,6 @@
 import { LinterOptions, FormatterType, SyntaxType, lint, LintResult, LinterResult, createPlugin, utils } from "stylelint";
 
-const options: LinterOptions = {
+const options: Partial<LinterOptions> = {
     code: "div { color: red }",
     files: ["**/**.scss"],
     formatter: "json",
@@ -8,14 +8,13 @@ const options: LinterOptions = {
     cacheLocation: "./stylelint.cache.json",
     ignoreDisables: true,
     reportNeedlessDisables: true,
-    ignorePath: true,
+    ignorePath: 'foo',
     syntax: "scss"
 };
 
 lint(options).then((x: LinterResult) => {
     const err: boolean = x.errored;
     const output: string = x.output;
-    const postcssResults: any[] = x.postcssResults;
     const results: LintResult[] = x.results;
 });
 

--- a/types/stylelint/stylelint-tests.ts
+++ b/types/stylelint/stylelint-tests.ts
@@ -1,4 +1,16 @@
-import { LinterOptions, FormatterType, SyntaxType, lint, LintResult, LinterResult, createPlugin, utils } from "stylelint";
+import {
+    LinterOptions,
+    FormatterType,
+    SyntaxType,
+    lint,
+    LintResult,
+    LinterResult,
+    createPlugin,
+    utils,
+    createRuleTester,
+    RuleTesterContext,
+    RuleTesterResult
+} from "stylelint";
 
 const options: Partial<LinterOptions> = {
     code: "div { color: red }",
@@ -51,4 +63,23 @@ createPlugin(ruleName, options => {
             });
         });
     };
+});
+
+const tester = createRuleTester(
+    (result: Promise<RuleTesterResult[]>, context: RuleTesterContext) => {
+        return;
+    }
+);
+
+tester({}, {
+    ruleName: 'foo',
+    config: [true, 1],
+    accept: [
+        { code: 'test' },
+        { code: 'test2', description: 'testing' }
+    ],
+    reject: [
+        { code: 'testreject', line: 1, column: 1 },
+        { code: 'test2reject', message: 'x', line: 1, column: 1 }
+    ]
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stylelint.io/developer-guide/plugins/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

A few of the types were wrong.

Here's what has been done:

* Introduce postcss types to replace a few `any` (postcss is already a whitelisted dep in types-publisher)
* Add the `unix` formatter
* Use `Partial` for linter configuration (its a bad idea to have a fully optional interface)
* Replace the invalid `JSON` type (which actually refers to `JSON.parse` etc) with a new stylelint configuration interface
* Introduce a couple of missing options
* Change `ignorePath` to a string ([it is](https://stylelint.io/user-guide/node-api/#ignorepath))
* Remove `postcssResults` from linter results (stylelint's docs say this exists, however it does not exist anywhere in their source anymore. I guess it is better to not expose a non-existent thing rather than follow the probably-outdated documentation)
* Fix `createPlugin` which had the wrong interface (two params, to include the primary option)
* Add `createRuleTester` 
* Add `Plugin` interface

You can see more about these things here:
https://stylelint.io/developer-guide/plugins/

However, many of the changes were found by digging through stylelint's docs and much of their source in the spare hour I had.