### PR TITLE
Fix node-dogstatsd constructor type definition

### DIFF
--- a/types/node-dogstatsd/index.d.ts
+++ b/types/node-dogstatsd/index.d.ts
@@ -4,7 +4,10 @@
 //                 Michael Mifsud <https://github.com/xzyfer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 declare module "node-dogstatsd" {
+  import * as dgram from 'dgram';
 
   export interface StatsDOptions {
     global_tags?: string[];
@@ -25,7 +28,9 @@ declare module "node-dogstatsd" {
   }
 
   export class StatsD implements StatsDClient {
-    constructor(host: string, port?: number, socket?: string, options?: StatsDOptions);
+    public socket: dgram.Socket
+
+    constructor(host: string, port?: number, socket?: dgram.Socket, options?: StatsDOptions);
 
     timing(stat: string, time: number, sample_rate?: number, tags?: string[]): void;
 

--- a/types/node-dogstatsd/node-dogstatsd-tests.ts
+++ b/types/node-dogstatsd/node-dogstatsd-tests.ts
@@ -1,12 +1,14 @@
+import * as dgram from 'dgram';
 import * as datadog from 'node-dogstatsd';
 
 function test_statsd_client() {
   // can create client with defaults
   let client = new datadog.StatsD('localhost');
   let options: datadog.StatsDOptions = { global_tags: ['environment:definitely_typed']};
+  const socket: dgram.Socket = dgram.createSocket('udp4');
 
   // can create client with all params
-  client = new datadog.StatsD('localhost', 8125, null, options);
+  client = new datadog.StatsD('localhost', 8125, socket, options);
 
   let key: string = 'key';
   let timeValue: number = 99;


### PR DESCRIPTION
As per the documentation the `socket` argument to the constructor
is an optional Socket type not a string type. Using a string would
result in a fatal error.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/mrbar42/node-dogstatsd#error-handling-policy
  - https://github.com/mrbar42/node-dogstatsd/blob/master/lib/statsd.js#L14
  - https://github.com/mrbar42/node-dogstatsd/blob/master/lib/statsd.js#L123
- [x] Increase the version number in the header if appropriate.
