### PR TITLE
@storybook/addon-knobs: make type of return value of select same with options array element

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -52,6 +52,7 @@ export function object<T>(name: string, value: T, groupId?: string): T;
 export function radios<T>(name: string, options: { [s: string]: T }, value?: T, groupId?: string): string;
 
 export function select<T>(name: string, options: { [s: string]: T }, value: T, groupId?: string): T;
+export function select<T extends string>(name: string, options: ReadonlyArray<T>, value: T, groupId?: string): T;
 export function select(name: string, options: ReadonlyArray<string>, value: string, groupId?: string): string;
 
 export function date(name: string, value?: Date, groupId?: string): Date;

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -94,7 +94,15 @@ stories.add('dynamic knobs', () => {
 });
 
 const readonlyOptionsArray: ReadonlyArray<string> = ['hi'];
-select('With readonly array', readonlyOptionsArray, readonlyOptionsArray[0]);
+select('With readonly string array', readonlyOptionsArray, readonlyOptionsArray[0]);
+
+type StringLiteralType = 'Apple' | 'Banana' | 'Grapes';
+const stringLiteralArray: StringLiteralType[] = ['Apple', 'Banana', 'Grapes'];
+
+let selectedFruit: StringLiteralType;
+
+// type of value returned from `select` must be `StringLiteralType`.
+selectedFruit = select('With string literal array', stringLiteralArray, stringLiteralArray[0]);
 
 const optionsObject = {
   Apple: { taste: 'sweet', color: 'red' },


### PR DESCRIPTION
When select options is an array of string literal union type, select must return the same type of value.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/storybooks/storybook/blob/next/addons/knobs/README.md#select>

As written in the document above, we can pass `string[]` as select `options`. Thus, we can pass an array of value typed string literals union, e.g. `('Apple' | 'Banana' | 'Grapes')[]`. In this case, returned value from `select` should be `'Apple' | 'Banana' | 'Grapes'`.