### PR TITLE
mdns: add dns_sd static export

### DIFF
--- a/types/mdns/index.d.ts
+++ b/types/mdns/index.d.ts
@@ -118,6 +118,7 @@ declare namespace MDNS {
     var Browser:BrowserStatic;
     var ServiceType:ServiceType;
     var rst:DefaultResolverSequenceTasks;
+    var dns_sd:any;
 
     // static functions
 


### PR DESCRIPTION
A common issue (and recommended fix) with this package is documented [here](https://github.com/agnat/node_mdns/issues/130#issuecomment-94504387).

I'm not familiar with the package so I'm not confident how to type it, but I know `dns_sd` is exported as a named export.