### PR TITLE
Update React Leaflet with viewport, VideoOverlay, backport whenReady and DivOverlay 

### DIFF
--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -157,8 +157,8 @@ export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.
     viewport: Viewport;
     createLeafletElement(props: P): E;
     updateLeafletElement(fromProps: P, toProps: P): void;
-    onViewportChange: (viewport: Viewport | null) => void;
-    onViewportChanged: (viewport: Viewport | null) => void;
+    onViewportChange: () => void;
+    onViewportChanged: () => void;
     bindContainer(container: HTMLDivElement | null | undefined): void;
     shouldUpdateCenter(next: Leaflet.LatLngExpression, prev: Leaflet.LatLngExpression): boolean;
     shouldUpdateBounds(next: Leaflet.LatLngBoundsExpression, prev: Leaflet.LatLngBoundsExpression): boolean;

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -47,8 +47,6 @@ export interface MapEvents {
     onlocationerror?(event: Leaflet.ErrorEvent): void;
     onpopupopen?(event: Leaflet.PopupEvent): void;
     onpopupclose?(event: Leaflet.PopupEvent): void;
-    onviewportchange?: (viewport: Viewport | null) => void;
-    onviewportchanged?: (viewport: Viewport | null) => void;
 }
 
 export interface MarkerEvents {
@@ -148,6 +146,8 @@ export interface MapProps extends MapEvents, Leaflet.MapOptions, Leaflet.LocateO
     useFlyTo?: boolean;
     viewport?: Viewport;
     whenReady?: () => void;
+    onViewportChange?: (viewport: Viewport) => void;
+    onViewportChanged?: (viewport: Viewport) => void;
 }
 
 export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.Map> extends MapEvented<P, E> {

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -47,6 +47,8 @@ export interface MapEvents {
     onlocationerror?(event: Leaflet.ErrorEvent): void;
     onpopupopen?(event: Leaflet.PopupEvent): void;
     onpopupclose?(event: Leaflet.PopupEvent): void;
+    onviewportchange?: (viewport: Viewport | null) => void;
+    onviewportchanged?: (viewport: Viewport | null) => void;
 }
 
 export interface MarkerEvents {

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -278,6 +278,19 @@ export class ImageOverlay<P extends ImageOverlayProps = ImageOverlayProps, E ext
     updateLeafletElement(fromProps: P, toProps: P): void;
 }
 
+export interface VideoOverlayProps extends Leaflet.VideoOverlayOptions, MapComponentProps {
+    attribution?: string;
+    bounds: Leaflet.LatLngBoundsExpression;
+    opacity?: number;
+    play?: boolean;
+    url: string | string[] | HTMLVideoElement;
+    zIndex?: number;
+}
+export class VideoOverlay<P extends VideoOverlayProps = VideoOverlayProps, E extends Leaflet.VideoOverlay = Leaflet.VideoOverlay> extends MapLayer<P, E> {
+    createLeafletElement(props: P): E;
+    updateLeafletElement(fromProps: P, toProps: P): void;
+}
+
 export class LayerGroup<P extends MapLayerProps = MapLayerProps, E extends Leaflet.LayerGroup = Leaflet.LayerGroup> extends MapLayer<P, E> {
     createLeafletElement(props: P): E;
 }

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -637,10 +637,10 @@ export class VectorLayersExample extends Component<undefined, undefined> {
 const DEFAULT_VIEWPORT: Viewport = {
     center: [51.505, -0.09],
     zoom: 13,
-}
+};
 
 interface ViewportExampleState {
-    viewport: Viewport
+    viewport: Viewport;
 }
 
 class ViewportExample extends Component<undefined, ViewportExampleState> {

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -634,17 +634,18 @@ export class VectorLayersExample extends Component<undefined, undefined> {
 }
 
 // viewport.js
+const DEFAULT_VIEWPORT: Viewport = {
+    center: [51.505, -0.09],
+    zoom: 13,
+}
 
-const viewportCenter: [number, number] = [51.505, -0.09];
+interface ViewportExampleState {
+    viewport: Viewport
+}
 
-const DEFAULT_VIEWPORT = {
-    center: viewportCenter,
-    zoom: 13
-};
-
-export class ViewportExample extends Component<undefined, { viewport: Viewport }> {
+class ViewportExample extends Component<undefined, ViewportExampleState> {
     state = {
-        viewport: DEFAULT_VIEWPORT
+        viewport: DEFAULT_VIEWPORT,
     };
 
     onClickReset = () => {
@@ -657,15 +658,15 @@ export class ViewportExample extends Component<undefined, { viewport: Viewport }
 
     render() {
         return (
-          <Map
-            onClick={this.onClickReset}
-            onViewportChanged={this.onViewportChanged}
-            viewport={this.state.viewport}>
-            <TileLayer
-              attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            />
-          </Map>
+            <Map
+                onClick={this.onClickReset}
+                onViewportChanged={this.onViewportChanged}
+                viewport={this.state.viewport}>
+                <TileLayer
+                    attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+            </Map>
         );
     }
 }
@@ -811,4 +812,4 @@ class CustomPolygon extends Path<PolygonProps, L.Polygon> {
         );
     }
 }
-const leafletComponent =  withLeaflet<PolygonProps>(CustomPolygon);
+const leafletComponent = withLeaflet<PolygonProps>(CustomPolygon);

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -146,6 +146,7 @@ export interface MapProps extends MapEvents, Leaflet.MapOptions, Leaflet.LocateO
     style?: React.CSSProperties;
     useFlyTo?: boolean;
     viewport?: Viewport;
+    whenReady?: () => void;
     zoom?: number;
 }
 

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -163,6 +163,23 @@ export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.
     onViewportChanged: (viewport: Viewport | null) => void;
 }
 
+export interface DivOverlayProps extends Leaflet.DivOverlayOptions {
+    children: Children;
+    onClose?: () => void;
+    onOpen?: () => void;
+}
+
+export interface DivOverlayTypes extends Leaflet.Evented {
+    isOpen: () => boolean;
+    update: () => void;
+}
+
+export class DivOverlay<P extends DivOverlayProps, E extends DivOverlayTypes> extends MapComponent<P, E> {
+    onClose: () => void;
+    onOpen: () => void;
+    onRender: () => void;
+}
+
 export interface PaneProps {
     name?: string;
     children?: Children;
@@ -293,10 +310,10 @@ export interface RectangleProps extends PathEvents, Leaflet.PolylineOptions {
 }
 export class Rectangle<P extends RectangleProps = RectangleProps, E extends Leaflet.Rectangle = Leaflet.Rectangle> extends Path<P, E> { }
 
-export interface PopupProps extends Leaflet.PopupOptions {
-    children?: Children;
+export interface PopupProps extends DivOverlayProps, Leaflet.PopupOptions {
     position?: Leaflet.LatLngExpression;
 }
+
 export class Popup<P extends PopupProps = PopupProps, E extends Leaflet.Popup = Leaflet.Popup> extends MapComponent<P, E> {
     onPopupOpen(arg: { popup: E }): void;
     onPopupClose(arg: { popup: E }): void;
@@ -304,9 +321,9 @@ export class Popup<P extends PopupProps = PopupProps, E extends Leaflet.Popup = 
     removePopupContent(): void;
 }
 
-export interface TooltipProps extends Leaflet.TooltipOptions {
-    children?: Children;
+export interface TooltipProps extends DivOverlayProps, Leaflet.TooltipOptions {
 }
+
 export class Tooltip<P extends TooltipProps = TooltipProps, E extends Leaflet.Tooltip = Leaflet.Tooltip> extends MapComponent<P, E> {
     onTooltipOpen(arg: { tooltip: E }): void;
     onTooltipClose(arg: { tooltip: E }): void;

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-leaflet 1.9.1
+// Type definitions for react-leaflet 1.9
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>, David Schneider <https://github.com/davschne>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-leaflet 1.1
+// Type definitions for react-leaflet 1.9.1
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>, David Schneider <https://github.com/davschne>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,6 +11,11 @@ import * as React from 'react';
 // which already declares things with some of the same names
 
 export type Children = React.ReactNode | React.ReactNode[];
+
+export interface Viewport {
+    center: [number, number] | null | undefined;
+    zoom: number | null | undefined;
+}
 
 export interface MapEvents {
     onclick?(event: Leaflet.LeafletMouseEvent): void;
@@ -140,18 +145,22 @@ export interface MapProps extends MapEvents, Leaflet.MapOptions, Leaflet.LocateO
     minZoom?: number;
     style?: React.CSSProperties;
     useFlyTo?: boolean;
+    viewport?: Viewport;
     zoom?: number;
 }
 
 export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.Map> extends MapComponent<P, E> {
     className?: string;
     container: HTMLDivElement;
+    viewport: Viewport;
     getChildContext(): { layerContainer: E, map: E };
     createLeafletElement(props: P): E;
     updateLeafletElement(fromProps: P, toProps: P): void;
     bindContainer(container: HTMLDivElement): void;
     shouldUpdateCenter(next: Leaflet.LatLngExpression, prev: Leaflet.LatLngExpression): boolean;
     shouldUpdateBounds(next: Leaflet.LatLngBoundsExpression, prev: Leaflet.LatLngBoundsExpression): boolean;
+    onViewportChange: (viewport: Viewport | null) => void;
+    onViewportChanged: (viewport: Viewport | null) => void;
 }
 
 export interface PaneProps {

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -240,6 +240,19 @@ export class ImageOverlay<P extends ImageOverlayProps = ImageOverlayProps, E ext
     getChildContext(): { popupContainer: E };
 }
 
+export interface VideoOverlayProps extends Leaflet.VideoOverlayOptions {
+    attribution?: string;
+    children?: Children;
+    bounds: Leaflet.LatLngBoundsExpression;
+    opacity?: number;
+    play?: boolean;
+    url: string | string[] | HTMLVideoElement;
+    zIndex?: number;
+}
+export class VideoOverlay<P extends VideoOverlayProps = VideoOverlayProps, E extends Leaflet.VideoOverlay = Leaflet.VideoOverlay> extends MapLayer<P, E> {
+    getChildContext(): { popupContainer: E };
+}
+
 export interface LayerGroupProps {
     children?: Children;
 }

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -148,6 +148,8 @@ export interface MapProps extends MapEvents, Leaflet.MapOptions, Leaflet.LocateO
     viewport?: Viewport;
     whenReady?: () => void;
     zoom?: number;
+    onViewportChange?: (viewport: Viewport) => void;
+    onViewportChanged?: (viewport: Viewport) => void;
 }
 
 export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.Map> extends MapComponent<P, E> {

--- a/types/react-leaflet/v1/index.d.ts
+++ b/types/react-leaflet/v1/index.d.ts
@@ -162,8 +162,8 @@ export class Map<P extends MapProps = MapProps, E extends Leaflet.Map = Leaflet.
     bindContainer(container: HTMLDivElement): void;
     shouldUpdateCenter(next: Leaflet.LatLngExpression, prev: Leaflet.LatLngExpression): boolean;
     shouldUpdateBounds(next: Leaflet.LatLngBoundsExpression, prev: Leaflet.LatLngBoundsExpression): boolean;
-    onViewportChange: (viewport: Viewport | null) => void;
-    onViewportChanged: (viewport: Viewport | null) => void;
+    onViewportChange: () => void;
+    onViewportChanged: () => void;
 }
 
 export interface DivOverlayProps extends Leaflet.DivOverlayOptions {

--- a/types/react-leaflet/v1/react-leaflet-tests.tsx
+++ b/types/react-leaflet/v1/react-leaflet-tests.tsx
@@ -24,6 +24,8 @@ import {
     Rectangle,
     TileLayer,
     Tooltip,
+    Viewport,
+    VideoOverlay,
     WMSTileLayer,
     ZoomControl
 } from 'react-leaflet';
@@ -623,6 +625,75 @@ export class VectorLayersExample extends Component<undefined, undefined> {
                 <Polygon color='purple' positions={polygon} />
                 <Polygon color='purple' positions={multiPolygon} />
                 <Rectangle bounds={rectangle} color='black' />
+            </Map>
+        );
+    }
+}
+
+// viewport.js
+const DEFAULT_VIEWPORT: Viewport = {
+    center: [51.505, -0.09],
+    zoom: 13,
+}
+
+interface ViewportExampleState {
+    viewport: Viewport
+}
+
+class ViewportExample extends Component<undefined, ViewportExampleState> {
+    state = {
+        viewport: DEFAULT_VIEWPORT,
+    };
+
+    onClickReset = () => {
+        this.setState({ viewport: DEFAULT_VIEWPORT });
+    }
+
+    onViewportChanged = (viewport: Viewport) => {
+        this.setState({ viewport });
+    }
+
+    render() {
+        return (
+            <Map
+                onClick={this.onClickReset}
+                onViewportChanged={this.onViewportChanged}
+                viewport={this.state.viewport}>
+                <TileLayer
+                    attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+            </Map>
+        );
+    }
+}
+
+// video-overlay.js
+interface VideoOverlayExampleState {
+    play: boolean
+}
+
+class VideoOverlayExample extends Component<undefined, VideoOverlayExampleState> {
+    state = {
+        play: true,
+    };
+
+    onTogglePlay = () => {
+        this.setState({ play: !this.state.play });
+    }
+
+    render() {
+        return (
+            <Map center={[25, -100]} onClick={this.onTogglePlay} zoom={4}>
+                <TileLayer
+                    attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                <VideoOverlay
+                    bounds={[[32, -130], [13, -100]]}
+                    play={this.state.play}
+                    url="https://www.mapbox.com/bites/00188/patricia_nasa.webm"
+                />
             </Map>
         );
     }

--- a/types/react-leaflet/v1/react-leaflet-tests.tsx
+++ b/types/react-leaflet/v1/react-leaflet-tests.tsx
@@ -634,13 +634,13 @@ export class VectorLayersExample extends Component<undefined, undefined> {
 const DEFAULT_VIEWPORT: Viewport = {
     center: [51.505, -0.09],
     zoom: 13,
-}
+};
 
 interface ViewportExampleState {
-    viewport: Viewport
+    viewport: Viewport;
 }
 
-class ViewportExample extends Component<undefined, ViewportExampleState> {
+export class ViewportExample extends Component<undefined, ViewportExampleState> {
     state = {
         viewport: DEFAULT_VIEWPORT,
     };
@@ -670,10 +670,10 @@ class ViewportExample extends Component<undefined, ViewportExampleState> {
 
 // video-overlay.js
 interface VideoOverlayExampleState {
-    play: boolean
+    play: boolean;
 }
 
-class VideoOverlayExample extends Component<undefined, VideoOverlayExampleState> {
+export class VideoOverlayExample extends Component<undefined, VideoOverlayExampleState> {
     state = {
         play: true,
     };


### PR DESCRIPTION
Add missing viewport events which were left out of #33367 for React Leaflet v2, and VideoOverlay from v1.4 which were left out. Also backported these changes to the v1 types. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - VideoOverlay: v1.4.0 https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md#v140-2017-06-28
    - whenReady: v1.2.0 https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md#v120-2017-05-24
    - viewport: v1.3.0 https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md#v130-2017-06-11


- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
