### PR TITLE
[stripe] added missing signatures for paymentIntents

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7339,9 +7339,18 @@ declare namespace Stripe {
             ): Promise<paymentIntents.IPaymentIntent>;
             cancel(
                 paymentIntentId: string,
+                options: HeaderOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            cancel(
+                paymentIntentId: string,
                 data: {
                     cancellation_reason?: paymentIntents.PaymentIntentCancelationReason,
                 },
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            cancel(
+                paymentIntentId: string,
                 response?: IResponseFn<paymentIntents.IPaymentIntent>,
             ): Promise<paymentIntents.IPaymentIntent>;
         }

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3359,6 +3359,15 @@ declare namespace Stripe {
             source?: string;
         }
 
+        interface IPaymentIntentRetrieveOptions {
+            /**
+             * The client secret of the PaymentIntent. Required if a publishable key is used to retrieve the source.
+             *
+             * REQUIRED IF USING PUBLISHABLE KEY!
+             */
+            client_secret: string;
+        }
+
         interface IPaymentIntentCaptureOptions {
             /**
              * The amount to capture (in cents) from the PaymentIntent, which must be less than or equal to the original amount. Any additional amount will be automatically refunded. Defaults to the full `amount_capturable` if not provided.
@@ -7278,6 +7287,17 @@ declare namespace Stripe {
              */
             retrieve(
                 id: string,
+                data: paymentIntents.IPaymentIntentRetrieveOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            retrieve(
+                id: string,
+                data: paymentIntents.IPaymentIntentRetrieveOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            retrieve(
+                id: string,
                 options: HeaderOptions,
                 response?: IResponseFn<paymentIntents.IPaymentIntent>,
             ): Promise<paymentIntents.IPaymentIntent>;
@@ -7304,6 +7324,15 @@ declare namespace Stripe {
                 data: paymentIntents.IPaymentIntentConfirmOptions,
                 response?: IResponseFn<paymentIntents.IPaymentIntent>,
             ): Promise<paymentIntents.IPaymentIntent>;
+            confirm(
+                paymentIntentId: string,
+                options: HeaderOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            confirm(
+                paymentIntentId: string,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
 
             /**
              * Capture the funds of an existing uncaptured PaymentIntent where `required_action="requires_capture"`.
@@ -7320,6 +7349,15 @@ declare namespace Stripe {
             capture(
                 paymentIntentId: string,
                 data: paymentIntents.IPaymentIntentCaptureOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            capture(
+                paymentIntentId: string,
+                options: HeaderOptions,
+                response?: IResponseFn<paymentIntents.IPaymentIntent>,
+            ): Promise<paymentIntents.IPaymentIntent>;
+            capture(
+                paymentIntentId: string,
                 response?: IResponseFn<paymentIntents.IPaymentIntent>,
             ): Promise<paymentIntents.IPaymentIntent>;
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1057,6 +1057,8 @@ stripe.paymentIntents.confirm("pi_Aabcxyz01aDfoo", {}).then((intent) => {});
 stripe.paymentIntents.capture("pi_Aabcxyz01aDfoo", {}, (err, intent) => {});
 stripe.paymentIntents.capture("pi_Aabcxyz01aDfoo", {}).then((intent) => {});
 
+stripe.paymentIntents.cancel("pi_Aabcxyz01aDfoo", (err, intent) => {});
+stripe.paymentIntents.cancel("pi_Aabcxyz01aDfoo").then((intent) => {});
 stripe.paymentIntents.cancel("pi_Aabcxyz01aDfoo", {}, (err, intent) => {});
 stripe.paymentIntents.cancel("pi_Aabcxyz01aDfoo", {}).then((intent) => {});
 stripe.paymentIntents.cancel("pi_Aabcxyz01aDfoo", { cancellation_reason: 'duplicate' }, (err, intent) => {});


### PR DESCRIPTION
Fixes #33663.

Since the online documentation isn't that specific, I looked at the [Java implementation](https://github.com/stripe/stripe-java/blob/master/src/main/java/com/stripe/model/PaymentIntent.java) for help.