### PR TITLE
[@types/sequelize] Fix import cases for esNext

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5941,7 +5941,7 @@ declare namespace sequelize {
         /**
          * Default export for `import Sequelize from 'sequelize';` kind of imports
          */
-        // default: SequelizeStatic;
+        default: SequelizeStatic;
 
         /**
          * Export sequelize static on the instance for `import Sequelize from 'sequelize';` kind of imports

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1379,7 +1379,7 @@ declare namespace sequelize {
          * Should the join model have timestamps
          */
         timestamps?: boolean;
-         
+
         /**
          * Belongs-To-Many creates a unique key when primary key is not present on through model. This unique key name can be overridden using uniqueKey option.
          */
@@ -5938,6 +5938,15 @@ declare namespace sequelize {
         cls: any;
         useCLS(namespace:cls.Namespace): Sequelize;
 
+        /**
+         * Default export for `import Sequelize from 'sequelize';` kind of imports
+         */
+        default: SequelizeStatic;
+
+        /**
+         * Export sequelize static on the instance for `import Sequelize from 'sequelize';` kind of imports
+         */
+        Sequelize: SequelizeStatic;
     }
 
     interface QueryOptionsTransactionRequired { }

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5941,7 +5941,7 @@ declare namespace sequelize {
         /**
          * Default export for `import Sequelize from 'sequelize';` kind of imports
          */
-        default: SequelizeStatic;
+        // default: SequelizeStatic;
 
         /**
          * Export sequelize static on the instance for `import Sequelize from 'sequelize';` kind of imports

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -5,6 +5,14 @@ import SequelizeAsDefault from 'sequelize';
 import { Sequelize as SequelizeAsIndividualExport } from 'sequelize';
 
 //
+// Import checks
+// ~~~~~~~~~~~~~
+//
+Sequelize.Model.Instance
+SequelizeAsDefault.Model.Instance
+SequelizeAsIndividualExport.Model.Instance
+
+//
 //  Fixtures
 // ~~~~~~~~~~
 //
@@ -27,7 +35,6 @@ var Comment   = s.define<AnyInstance, AnyAttributes>( 'comment', {} );
 var Post      = s.define<AnyInstance, AnyAttributes>( 'post', {} );
 var t : Sequelize.Transaction = null;
 s.transaction().then( ( a ) => t = a );
-
 
 //
 //  Generics

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -26,6 +26,9 @@ var Post      = s.define<AnyInstance, AnyAttributes>( 'post', {} );
 var t : Sequelize.Transaction = null;
 s.transaction().then( ( a ) => t = a );
 
+var sequelizeAsDefaultImport = Sequelize.default;
+var sequelizeAsExportClause  = Sequelize.Sequelize;
+
 //
 //  Generics
 // ~~~~~~~~~~

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1,6 +1,8 @@
 import Sequelize = require("sequelize");
 import Q = require('q');
 import Bluebird = require('bluebird');
+import SequelizeAsDefault from 'sequelize';
+import { Sequelize as SequelizeAsIndividualExport } from 'sequelize';
 
 //
 //  Fixtures
@@ -26,8 +28,6 @@ var Post      = s.define<AnyInstance, AnyAttributes>( 'post', {} );
 var t : Sequelize.Transaction = null;
 s.transaction().then( ( a ) => t = a );
 
-var sequelizeAsDefaultImport = Sequelize.default;
-var sequelizeAsExportClause  = Sequelize.Sequelize;
 
 //
 //  Generics


### PR DESCRIPTION
Fix imports cases according to the source code of sequelize to allow for different import syntaxes other than `require()`

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sequelize/sequelize/blob/v4/lib/sequelize.js#L1269-L1271
- [?] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

