### PR TITLE
[mongodb] Fixed hasNext() on CommandCursor

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1848,9 +1848,9 @@ export type CommandCursorResult = object | null;
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html */
 export class CommandCursor extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#hasNext */
-    hasNext(): Promise<CommandCursorResult>;
+    hasNext(): Promise<boolean>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#hasNext */
-    hasNext(callback: MongoCallback<CommandCursorResult>): void;
+    hasNext(callback: MongoCallback<boolean>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#batchSize */
     batchSize(value: number): CommandCursor;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#clone */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


A recent change to CommandCursorResult seems to have inadvertently broken the hasNext() method on CommandCursor such that it raises errors when using it correctly. To be fair, the MongoDB documentation implies that the CommandCursorResult can only be an object or null, but if you look at the source code (https://github.com/mongodb/node-mongodb-native/tree/master/lib), it uses the hasNext() implementation from Cursor, which returns a boolean in this case -- and its documentation does indicate that a boolean is valid.

The types for hasNext() on both Cursor and AggregationCursor already return a boolean and this change makes CommandCursor consistent.