### PR TITLE
[moment-timezone] Fixed moment-timezone/moment-timezone import, rearranged exports

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -6,65 +6,6 @@
 //                 Borys Kupar <https://github.com/borys-kupar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import moment = require('moment');
+import moment = require('./moment-timezone');
 
-// require("moment-timezone") === require("moment")
 export = moment;
-
-declare module "moment" {
-    interface MomentZone {
-        name: string;
-        abbrs: string[];
-        untils: number[];
-        offsets: number[];
-        population: number;
-
-        abbr(timestamp: number): string;
-        offset(timestamp: number): number;
-        utcOffset(timestamp: number): number;
-        parse(timestamp: number): number;
-    }
-
-    interface MomentTimezone {
-        (): moment.Moment;
-        (timezone: string): moment.Moment;
-        (date: number, timezone: string): moment.Moment;
-        (date: number[], timezone: string): moment.Moment;
-        (date: string, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, strict: boolean, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, language: string, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, language: string, strict: boolean, timezone: string): moment.Moment;
-        (date: Date, timezone: string): moment.Moment;
-        (date: moment.Moment, timezone: string): moment.Moment;
-        (date: any, timezone: string): moment.Moment;
-
-        zone(timezone: string): MomentZone | null;
-
-        add(packedZoneString: string): void;
-        add(packedZoneString: string[]): void;
-
-        link(packedLinkString: string): void;
-        link(packedLinkString: string[]): void;
-
-        load(data: {
-            version: string;
-            links: string[];
-            zones: string[];
-        }): void;
-
-        names(): string[];
-        guess(ignoreCache?: boolean): string;
-
-        setDefault(timezone?: string): MomentTimezone;
-    }
-
-    interface Moment {
-        tz(): string | undefined;
-        tz(timezone: string, keepLocalTime?: boolean): moment.Moment;
-        zoneAbbr(): string;
-        zoneName(): string;
-    }
-
-    const tz: MomentTimezone;
-}

--- a/types/moment-timezone/moment-timezone.d.ts
+++ b/types/moment-timezone/moment-timezone.d.ts
@@ -1,3 +1,58 @@
 import moment = require('moment');
 
+// require("moment-timezone") === require("moment")
 export = moment;
+
+declare module 'moment' {
+  interface MomentZone {
+    name: string;
+    abbrs: string[];
+    untils: number[];
+    offsets: number[];
+    population: number;
+
+    abbr(timestamp: number): string;
+    offset(timestamp: number): number;
+    utcOffset(timestamp: number): number;
+    parse(timestamp: number): number;
+  }
+
+  interface MomentTimezone {
+    (): moment.Moment;
+    (timezone: string): moment.Moment;
+    (date: number, timezone: string): moment.Moment;
+    (date: number[], timezone: string): moment.Moment;
+    (date: string, timezone: string): moment.Moment;
+    (date: string, format: moment.MomentFormatSpecification, timezone: string): moment.Moment;
+    (date: string, format: moment.MomentFormatSpecification, strict: boolean, timezone: string): moment.Moment;
+    (date: string, format: moment.MomentFormatSpecification, language: string, timezone: string): moment.Moment;
+    (date: string, format: moment.MomentFormatSpecification, language: string, strict: boolean, timezone: string): moment.Moment;
+    (date: Date, timezone: string): moment.Moment;
+    (date: moment.Moment, timezone: string): moment.Moment;
+    (date: any, timezone: string): moment.Moment;
+
+    zone(timezone: string): MomentZone | null;
+
+    add(packedZoneString: string): void;
+    add(packedZoneString: string[]): void;
+
+    link(packedLinkString: string): void;
+    link(packedLinkString: string[]): void;
+
+    load(data: { version: string; links: string[]; zones: string[] }): void;
+
+    names(): string[];
+    guess(ignoreCache?: boolean): string;
+
+    setDefault(timezone?: string): MomentTimezone;
+  }
+
+  interface Moment {
+    tz(): string | undefined;
+    tz(timezone: string, keepLocalTime?: boolean): moment.Moment;
+    zoneAbbr(): string;
+    zoneName(): string;
+  }
+
+  const tz: MomentTimezone;
+}

--- a/types/moment-timezone/tsconfig.json
+++ b/types/moment-timezone/tsconfig.json
@@ -18,7 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "moment-timezone.d.ts",
         "moment-timezone-tests.ts"
     ]
 }


### PR DESCRIPTION
A follow-up fix for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33464 where re-exported moment, didn't include typings for moment-timezone itself.

I rearranged typings, so they replicate original source code:
https://github.com/moment/moment-timezone/blob/develop/index.js


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/moment-timezone/blob/develop/index.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

