### PR TITLE
Remove outdated test

### DIFF
--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -655,19 +655,6 @@ test = (
     />
 );
 
-test = (
-    <VictoryScatter
-        data={[
-          {x: 1, y: 3},
-          {x: 2, y: 5},
-          {x: 3, y: 4},
-          {x: 4, y: 2},
-          {x: 5, y: 5}
-        ]}
-        size={(d, a) => (a ? 5 : 3)}
-    />
-);
-
 // VictoryPie test
 test = (
     <VictoryPie


### PR DESCRIPTION
#33546 Removed the two-parameter function from VictoryScatterProps.size's type, but left in a test that relied on this type.