### PR TITLE
@storybook/addon-info Relaxed React.ComponentType-extending definitions

### DIFF
--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -20,10 +20,10 @@ export interface Options {
   header?: boolean;
   inline?: boolean;
   source?: boolean;
-  propTables?: React.ComponentType[] | false;
-  propTablesExclude?: React.ComponentType[];
+  propTables?: Array<React.ComponentType<any>> | false;
+  propTablesExclude?: Array<React.ComponentType<any>>;
   styles?: object;
-  components?: { [key: string]: React.ComponentType };
+  components?: { [key: string]: React.ComponentType<any> };
   marksyConf?: object;
   maxPropsIntoLine?: number;
   maxPropObjectKeys?: number;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/tree/master/addons/info#options-and-defaults
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Background:
the `propTables`, `propTablesExclude`, and `components` keys on the `Options` type are typed as `React.ComponentType` (or an array thereof). `React.ComponentType` is a generic which takes one type argument and assigns it a default value of "`{}`". If no type argument is provided to these in this package's definition file, TypeScript rejects *any* stateless component with required props assigned to these properties. This is because `React.ComponentType<{}>` resolves to an object with props of the very limited type "`{children? React.ReactNode}`", to which no other props type can be cast if it has a required `children` key or any other required keys.

By providing "`any`" as a generic type argument to `React.ComponentType<>`, components with any props type can be assigned to these properties.
