### PR TITLE
DataZoom.Slider: fillColor must be fillerColor

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -6,6 +6,7 @@
 //                 Ovilia <https://github.com/Ovilia>
 //                 Roman <https://github.com/iRON5>
 //                 Bilal <https://github.com/bilalucar>
+//                 TMTron <https://github.com/tmtron>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/echarts/options/data-zoom.d.ts
+++ b/types/echarts/options/data-zoom.d.ts
@@ -66,7 +66,7 @@ declare namespace echarts {
                 show?: boolean;
                 backgroundColor?: string;
                 dataBackground?: object;
-                fillColor?: string;
+                fillerColor?: string;
                 borderColor?: string;
                 handleIcon?: string;
                 handleSize?: number;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://ecomfe.github.io/echarts-doc/public/en/option.html#dataZoom-slider.fillerColor>>

DataZoom.Slider: the correct property is `fillerColor` (not `fillColor`)