### PR TITLE
Type check GraphQL args

### DIFF
--- a/types/graphql-relay/graphql-relay-tests.ts
+++ b/types/graphql-relay/graphql-relay-tests.ts
@@ -45,7 +45,7 @@ forwardConnectionArgs.first = { type: GraphQLInt };
 backwardConnectionArgs.before = { type: GraphQLString };
 backwardConnectionArgs.last = { type: GraphQLInt };
 // connectionDefinitions returns a connectionType and its associated edgeType, given a node type.
-const resolve: GraphQLFieldResolver<any, any> = (source, args, context, info) => {
+const resolve: GraphQLFieldResolver<any, any, any> = (source, args, context, info) => {
     context.flag = "f";
 };
 const fields: GraphQLFieldConfigMap<any, any> = {};
@@ -124,8 +124,8 @@ const idFetcher = (id: string, context: any, info: GraphQLResolveInfo) => {
     context.flag = "f";
 };
 const nodeDef = nodeDefinitions<any>(idFetcher, resolver);
-const nodeFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodeField;
-const nodesFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodesField;
+const nodeFieldConfig: GraphQLFieldConfig<any, any, any> = nodeDef.nodeField;
+const nodesFieldConfig: GraphQLFieldConfig<any, any, any> = nodeDef.nodesField;
 const interfaceType: GraphQLInterfaceType = nodeDef.nodeInterface;
 // toGlobalId takes a type name and an ID specific to that type name, and returns a "global ID" that is unique among all types.
 toGlobalId("t", "i").toLowerCase();
@@ -137,10 +137,10 @@ fgi.type.toUpperCase();
 const idFetcher2 = (object: any, context: any, info: GraphQLResolveInfo) => {
     return "";
 };
-const gif: GraphQLFieldConfig<any, any> = globalIdField("t", idFetcher2);
+const gif: GraphQLFieldConfig<any, any, any> = globalIdField("t", idFetcher2);
 // pluralIdentifyingRootField creates a field that accepts a list of non-ID identifiers (like a username) and maps them to their corresponding objects.
 const input: GraphQLInputType = GraphQLString;
-const prf: GraphQLFieldConfig<any, any> = pluralIdentifyingRootField({
+const prf: GraphQLFieldConfig<any, any, any> = pluralIdentifyingRootField({
     argName: "a",
     inputType: input,
     outputType: input,

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -246,14 +246,14 @@ export interface MutationConfig {
  */
 export function mutationWithClientMutationId(
     config: MutationConfig
-): GraphQLFieldConfig<any, any>;
+): GraphQLFieldConfig<any, any, any>;
 
 // node/node.js
 
 export interface GraphQLNodeDefinitions {
     nodeInterface: GraphQLInterfaceType;
-    nodeField: GraphQLFieldConfig<any, any>;
-    nodesField: GraphQLFieldConfig<any, any>;
+    nodeField: GraphQLFieldConfig<any, any, any>;
+    nodesField: GraphQLFieldConfig<any, any, any>;
 }
 
 export type typeResolverFn = ((any: any) => GraphQLObjectType) |
@@ -300,7 +300,7 @@ export function fromGlobalId(globalId: string): ResolvedGlobalId;
 export function globalIdField(
     typeName?: string,
     idFetcher?: (object: any, context: any, info: GraphQLResolveInfo) => string
-): GraphQLFieldConfig<any, any>;
+): GraphQLFieldConfig<any, any, any>;
 
 // node/plural.js
 
@@ -314,4 +314,4 @@ export interface PluralIdentifyingRootFieldConfig {
 
 export function pluralIdentifyingRootField(
     config: PluralIdentifyingRootFieldConfig
-): GraphQLFieldConfig<any, any>;
+): GraphQLFieldConfig<any, any, any>;

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -30,29 +30,29 @@ import {
 // connection/connection.js
 
 /**
- * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * Returns a GraphQLFieldConfigArgumentMap<any> appropriate to include on a field
  * whose return type is a connection type with forward pagination.
  */
 export interface ForwardConnectionArgs {
     after: { type: GraphQLScalarType };
     first: { type: GraphQLScalarType };
 }
-export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap & ForwardConnectionArgs;
+export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap<any> & ForwardConnectionArgs;
 
 /**
- * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * Returns a GraphQLFieldConfigArgumentMap<any> appropriate to include on a field
  * whose return type is a connection type with backward pagination.
  */
 export interface BackwardConnectionArgs {
     before: { type: GraphQLScalarType };
     last: { type: GraphQLScalarType };
 }
-export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap & BackwardConnectionArgs;
+export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap<any> & BackwardConnectionArgs;
 /**
- * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * Returns a GraphQLFieldConfigArgumentMap<any> appropriate to include on a field
  * whose return type is a connection type with bidirectional pagination.
  */
-export const connectionArgs: GraphQLFieldConfigArgumentMap & ForwardConnectionArgs & BackwardConnectionArgs;
+export const connectionArgs: GraphQLFieldConfigArgumentMap<any> & ForwardConnectionArgs & BackwardConnectionArgs;
 
 export type ConnectionConfigNodeTypeNullable =
     | GraphQLScalarType

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -68,8 +68,8 @@ export type ConnectionConfigNodeType =
 export interface ConnectionConfig {
     name?: string | null;
     nodeType: ConnectionConfigNodeType;
-    resolveNode?: GraphQLFieldResolver<any, any> | null;
-    resolveCursor?: GraphQLFieldResolver<any, any> | null;
+    resolveNode?: GraphQLFieldResolver<any, any, any> | null;
+    resolveCursor?: GraphQLFieldResolver<any, any, any> | null;
     edgeFields?: Thunk<GraphQLFieldConfigMap<any, any>> | null;
     connectionFields?: Thunk<GraphQLFieldConfigMap<any, any>> | null;
 }

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -154,9 +154,9 @@ export function buildResolveInfo(
 // function. Returns the result of resolveFn or the abrupt-return Error object.
 export function resolveFieldValueOrError<TSource, TArgs, TContext>(
     exeContext: ExecutionContext,
-    fieldDef: GraphQLField<TSource, TContext, TArgs>,
+    fieldDef: GraphQLField<TSource, TArgs, TContext>,
     fieldNodes: ReadonlyArray<FieldNode>,
-    resolveFn: GraphQLFieldResolver<TSource, TContext, TArgs>,
+    resolveFn: GraphQLFieldResolver<TSource, TArgs, TContext>,
     source: TSource,
     info: GraphQLResolveInfo
 ): Error | any;

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -32,7 +32,7 @@ export interface ExecutionContext {
     contextValue: any;
     operation: OperationDefinitionNode;
     variableValues: { [key: string]: any };
-    fieldResolver: GraphQLFieldResolver<any, any>;
+    fieldResolver: GraphQLFieldResolver<any, any, any>;
     errors: GraphQLError[];
 }
 
@@ -58,7 +58,7 @@ export type ExecutionArgs = {
     contextValue?: any;
     variableValues?: Maybe<{ [key: string]: any }>;
     operationName?: Maybe<string>;
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>;
 };
 
 /**
@@ -81,7 +81,7 @@ export function execute<TData = ExecutionResultDataDefault>(
     contextValue?: any,
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>
 ): MaybePromise<ExecutionResult<TData>>;
 
 /**
@@ -123,7 +123,7 @@ export function buildExecutionContext(
     contextValue: any,
     rawVariableValues: Maybe<{ [key: string]: any }>,
     operationName: Maybe<string>,
-    fieldResolver: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver: Maybe<GraphQLFieldResolver<any, any, any>>
 ): ReadonlyArray<GraphQLError> | ExecutionContext;
 
 /**
@@ -144,7 +144,7 @@ export function collectFields(
 
 export function buildResolveInfo(
     exeContext: ExecutionContext,
-    fieldDef: GraphQLField<any, any>,
+    fieldDef: GraphQLField<any, any, any>,
     fieldNodes: ReadonlyArray<FieldNode>,
     parentType: GraphQLObjectType,
     path: ResponsePath
@@ -152,11 +152,11 @@ export function buildResolveInfo(
 
 // Isolates the "ReturnOrAbrupt" behavior to not de-opt the `resolveField`
 // function. Returns the result of resolveFn or the abrupt-return Error object.
-export function resolveFieldValueOrError<TSource>(
+export function resolveFieldValueOrError<TSource, TArgs, TContext>(
     exeContext: ExecutionContext,
-    fieldDef: GraphQLField<TSource, any>,
+    fieldDef: GraphQLField<TSource, TContext, TArgs>,
     fieldNodes: ReadonlyArray<FieldNode>,
-    resolveFn: GraphQLFieldResolver<TSource, any>,
+    resolveFn: GraphQLFieldResolver<TSource, TContext, TArgs>,
     source: TSource,
     info: GraphQLResolveInfo
 ): Error | any;
@@ -167,7 +167,7 @@ export function resolveFieldValueOrError<TSource>(
  * and returns it as the result, or if it's a function, returns the result
  * of calling that function while passing along args and context.
  */
-export const defaultFieldResolver: GraphQLFieldResolver<any, any>;
+export const defaultFieldResolver: GraphQLFieldResolver<any, any, any>;
 
 /**
  * This method looks up the field on the given type defintion.
@@ -182,4 +182,4 @@ export function getFieldDef(
     schema: GraphQLSchema,
     parentType: GraphQLObjectType,
     fieldName: string
-): Maybe<GraphQLField<any, any>>;
+): Maybe<GraphQLField<any, any, any>>;

--- a/types/graphql/execution/values.d.ts
+++ b/types/graphql/execution/values.d.ts
@@ -34,7 +34,7 @@ export function getVariableValues(
  * Object prototype.
  */
 export function getArgumentValues(
-    def: GraphQLField<any, any> | GraphQLDirective,
+    def: GraphQLField<any, any, any> | GraphQLDirective,
     node: FieldNode | DirectiveNode,
     variableValues?: Maybe<{ [key: string]: any }>
 ): { [key: string]: any };

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -1,4 +1,4 @@
-import { assertInputType, isInputType, isOutputType, GraphQLObjectType, GraphQLString } from 'graphql';
+import { assertInputType, isInputType, isOutputType, GraphQLObjectType, GraphQLFieldConfig, GraphQLString } from 'graphql';
 
 ///////////////////////////
 // graphql               //
@@ -59,14 +59,14 @@ function type_definition_tests() {
             hello: {
                 type: GraphQLString,
                 args: {
-                    id: {
+                    message: {
                         type: GraphQLString
                     }
                 },
-                resolve: (source, context, args: {id: null | "string"}) => {
-                    return "world";
+                resolve: (source, context, args) => {
+                    return args.message || args.message;
                 }
-            }
+            } as GraphQLFieldConfig<any, { message: null | string }, any>
         })
     })
 }

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -66,7 +66,7 @@ function type_definition_tests() {
                     }
                 },
                 resolve: (source, args, context) => {
-                    return args.message || args.message;
+                    return args.message;
                 }
             }
         })

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -1,4 +1,4 @@
-import { assertInputType, isInputType, isOutputType } from 'graphql';
+import { assertInputType, isInputType, isOutputType, GraphQLObjectType, GraphQLString } from 'graphql';
 
 ///////////////////////////
 // graphql               //
@@ -52,8 +52,23 @@ function language_visitor_tests() {
 function type_definition_tests() {
     isInputType(null);
     isOutputType(null);
-
     assertInputType(null);
+    new GraphQLObjectType({
+        name: "Query",
+        fields: () => ({
+            hello: {
+                type: GraphQLString,
+                args: {
+                    id: {
+                        type: GraphQLString
+                    }
+                },
+                resolve: (source, context, args: {id: null | "string"}) => {
+                    return "world";
+                }
+            }
+        })
+    })
 }
 
 function type_directives_tests() {

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -55,7 +55,7 @@ function type_definition_tests() {
     assertInputType(null);
     new GraphQLObjectType({
         name: "Query",
-        fields: () : {
+        fields: (): {
             hello: GraphQLFieldConfig<any, { message: null | string }, any>
         } => ({
             hello: {

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -55,7 +55,9 @@ function type_definition_tests() {
     assertInputType(null);
     new GraphQLObjectType({
         name: "Query",
-        fields: () => ({
+        fields: () : {
+            hello: GraphQLFieldConfig<any, { message: null | string }, any>
+        } => ({
             hello: {
                 type: GraphQLString,
                 args: {
@@ -63,10 +65,10 @@ function type_definition_tests() {
                         type: GraphQLString
                     }
                 },
-                resolve: (source, context, args) => {
+                resolve: (source, args, context) => {
                     return args.message || args.message;
                 }
-            } as GraphQLFieldConfig<any, { message: null | string }, any>
+            }
         })
     })
 }

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -46,7 +46,7 @@ export interface GraphQLArgs {
     contextValue?: any;
     variableValues?: Maybe<{ [key: string]: any }>;
     operationName?: Maybe<string>;
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>;
 }
 
 export function graphql<TData = ExecutionResultDataDefault>(args: GraphQLArgs): Promise<ExecutionResult<TData>>;
@@ -57,7 +57,7 @@ export function graphql<TData = ExecutionResultDataDefault>(
     contextValue?: any,
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>
 ): Promise<ExecutionResult<TData>>;
 
 /**
@@ -74,5 +74,5 @@ export function graphqlSync<TData = ExecutionResultDataDefault>(
     contextValue?: any,
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>
 ): ExecutionResult<TData>;

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -31,8 +31,8 @@ export function subscribe<TData = ExecutionResultDataDefault>(args: {
     contextValue?: any;
     variableValues?: Maybe<{ [key: string]: any }>;
     operationName?: Maybe<string>;
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>;
+    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>;
 }): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
 export function subscribe<TData = ExecutionResultDataDefault>(
@@ -42,8 +42,8 @@ export function subscribe<TData = ExecutionResultDataDefault>(
     contextValue?: any,
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
-    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>,
+    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>
 ): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
 /**
@@ -71,5 +71,5 @@ export function createSourceEventStream<TData = ExecutionResultDataDefault>(
     contextValue?: any,
     variableValues?: { [key: string]: any },
     operationName?: Maybe<string>,
-    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any, any>>
 ): Promise<AsyncIterable<any> | ExecutionResult<TData>>;

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -344,8 +344,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
  */
 export class GraphQLObjectType<
     TSource = any,
-    TContext = any,
-    TArgs = any
+    TContext = any
 > {
     name: string;
     description: Maybe<string>;
@@ -353,8 +352,8 @@ export class GraphQLObjectType<
     extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
     isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
 
-    constructor(config: GraphQLObjectTypeConfig<TSource, TContext, TArgs>);
-    getFields(): GraphQLFieldMap<any, TContext, TArgs>;
+    constructor(config: GraphQLObjectTypeConfig<TSource, TContext>);
+    getFields(): GraphQLFieldMap<any, TContext>;
     getInterfaces(): GraphQLInterfaceType[];
     toString(): string;
     toJSON(): string;
@@ -363,12 +362,11 @@ export class GraphQLObjectType<
 
 export interface GraphQLObjectTypeConfig<
     TSource,
-    TContext,
-    TArgs = any
+    TContext
 > {
     name: string;
     interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
+    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
     isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
     description?: Maybe<string>;
     astNode?: Maybe<ObjectTypeDefinitionNode>;
@@ -377,13 +375,12 @@ export interface GraphQLObjectTypeConfig<
 
 export type GraphQLTypeResolver<
     TSource,
-    TContext,
-    TArgs = any
+    TContext
 > = (
     value: TSource,
     context: TContext,
     info: GraphQLResolveInfo
-) => MaybePromise<Maybe<GraphQLObjectType<TSource, TContext, TArgs> | string>>;
+) => MaybePromise<Maybe<GraphQLObjectType<TSource, TContext> | string>>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
     source: TSource,
@@ -391,7 +388,7 @@ export type GraphQLIsTypeOfFn<TSource, TContext> = (
     info: GraphQLResolveInfo
 ) => MaybePromise<boolean>;
 
-export type GraphQLFieldResolver<TSource, TContext, TArgs = { [argName: string]: any }> = (
+export type GraphQLFieldResolver<TSource, TArgs, TContext> = (
     source: TSource,
     args: TArgs,
     context: TContext,
@@ -416,11 +413,11 @@ export type ResponsePath = {
     readonly key: string | number;
 };
 
-export interface GraphQLFieldConfig<TSource, TContext, TArgs = { [argName: string]: any }> {
+export interface GraphQLFieldConfig<TSource, TArgs, TContext> {
     type: GraphQLOutputType;
     args?: GraphQLFieldConfigArgumentMap;
-    resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+    resolve?: GraphQLFieldResolver<TSource, TArgs, TContext>;
+    subscribe?: GraphQLFieldResolver<TSource, TArgs, TContext>;
     deprecationReason?: Maybe<string>;
     description?: Maybe<string>;
     astNode?: Maybe<FieldDefinitionNode>;
@@ -435,17 +432,17 @@ export interface GraphQLArgumentConfig {
     astNode?: Maybe<InputValueDefinitionNode>;
 }
 
-export type GraphQLFieldConfigMap<TSource, TContext, TArgs = any> = {
-    [key: string]: GraphQLFieldConfig<TSource, TContext, TArgs>;
+export type GraphQLFieldConfigMap<TSource, TContext> = {
+    [key: string]: GraphQLFieldConfig<TSource, any, TContext>;
 };
 
-export interface GraphQLField<TSource, TContext, TArgs = any> {
+export interface GraphQLField<TSource, TArgs, TContext> {
     name: string;
     description: Maybe<string>;
     type: GraphQLOutputType;
     args: GraphQLArgument[];
-    resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+    resolve?: GraphQLFieldResolver<TSource, TArgs, TContext>;
+    subscribe?: GraphQLFieldResolver<TSource, TArgs, TContext>;
     isDeprecated?: boolean;
     deprecationReason?: Maybe<string>;
     astNode?: Maybe<FieldDefinitionNode>;
@@ -463,10 +460,9 @@ export function isRequiredArgument(arg: GraphQLArgument): boolean;
 
 export type GraphQLFieldMap<
     TSource,
-    TContext,
-    TArgs = any
+    TContext
 > = {
-    [key: string]: GraphQLField<TSource, TContext, TArgs>;
+    [key: string]: GraphQLField<TSource, any, TContext>;
 };
 
 /**
@@ -505,17 +501,16 @@ export class GraphQLInterfaceType {
 
 export interface GraphQLInterfaceTypeConfig<
     TSource,
-    TContext,
-    TArgs = any
+    TContext
 > {
     name: string;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
+    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
     /**
      * Optionally provide a custom type resolver function. If one is not provided,
      * the default implementation will call `isTypeOf` on each implementing
      * Object type.
      */
-    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext, TArgs>>;
+    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
     description?: Maybe<string>;
     astNode?: Maybe<InterfaceTypeDefinitionNode>;
     extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -415,7 +415,7 @@ export type ResponsePath = {
 
 export interface GraphQLFieldConfig<TSource, TArgs, TContext> {
     type: GraphQLOutputType;
-    args?: GraphQLFieldConfigArgumentMap;
+    args?: GraphQLFieldConfigArgumentMap<TArgs>;
     resolve?: GraphQLFieldResolver<TSource, TArgs, TContext>;
     subscribe?: GraphQLFieldResolver<TSource, TArgs, TContext>;
     deprecationReason?: Maybe<string>;
@@ -423,7 +423,7 @@ export interface GraphQLFieldConfig<TSource, TArgs, TContext> {
     astNode?: Maybe<FieldDefinitionNode>;
 }
 
-export type GraphQLFieldConfigArgumentMap = { [key: string]: GraphQLArgumentConfig };
+export type GraphQLFieldConfigArgumentMap<TArgs> = { [K in keyof TArgs]: GraphQLArgumentConfig };
 
 export interface GraphQLArgumentConfig {
     type: GraphQLInputType;

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -345,7 +345,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
 export class GraphQLObjectType<
     TSource = any,
     TContext = any,
-    TArgs = { [key: string]: any }
+    TArgs = any
 > {
     name: string;
     description: Maybe<string>;
@@ -364,7 +364,7 @@ export class GraphQLObjectType<
 export interface GraphQLObjectTypeConfig<
     TSource,
     TContext,
-    TArgs = { [key: string]: any }
+    TArgs = any
 > {
     name: string;
     interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
@@ -378,7 +378,7 @@ export interface GraphQLObjectTypeConfig<
 export type GraphQLTypeResolver<
     TSource,
     TContext,
-    TArgs = { [key: string]: any }
+    TArgs = any
 > = (
     value: TSource,
     context: TContext,
@@ -435,11 +435,11 @@ export interface GraphQLArgumentConfig {
     astNode?: Maybe<InputValueDefinitionNode>;
 }
 
-export type GraphQLFieldConfigMap<TSource, TContext, TArgs = { [key: string]: any }> = {
+export type GraphQLFieldConfigMap<TSource, TContext, TArgs = any> = {
     [key: string]: GraphQLFieldConfig<TSource, TContext, TArgs>;
 };
 
-export interface GraphQLField<TSource, TContext, TArgs = { [key: string]: any }> {
+export interface GraphQLField<TSource, TContext, TArgs = any> {
     name: string;
     description: Maybe<string>;
     type: GraphQLOutputType;
@@ -464,7 +464,7 @@ export function isRequiredArgument(arg: GraphQLArgument): boolean;
 export type GraphQLFieldMap<
     TSource,
     TContext,
-    TArgs = { [key: string]: any }
+    TArgs = any
 > = {
     [key: string]: GraphQLField<TSource, TContext, TArgs>;
 };
@@ -506,7 +506,7 @@ export class GraphQLInterfaceType {
 export interface GraphQLInterfaceTypeConfig<
     TSource,
     TContext,
-    TArgs = { [key: string]: any }
+    TArgs = any
 > {
     name: string;
     fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;

--- a/types/graphql/type/directives.d.ts
+++ b/types/graphql/type/directives.d.ts
@@ -26,7 +26,7 @@ export interface GraphQLDirectiveConfig {
     name: string;
     description?: Maybe<string>;
     locations: DirectiveLocationEnum[];
-    args?: Maybe<GraphQLFieldConfigArgumentMap>;
+    args?: Maybe<GraphQLFieldConfigArgumentMap<any>>;
     astNode?: Maybe<DirectiveDefinitionNode>;
 }
 

--- a/types/graphql/type/introspection.d.ts
+++ b/types/graphql/type/introspection.d.ts
@@ -36,9 +36,9 @@ export const __TypeKind: GraphQLEnumType;
  * so the format for args is different.
  */
 
-export const SchemaMetaFieldDef: GraphQLField<any, any>;
-export const TypeMetaFieldDef: GraphQLField<any, any>;
-export const TypeNameMetaFieldDef: GraphQLField<any, any>;
+export const SchemaMetaFieldDef: GraphQLField<any, any, any>;
+export const TypeMetaFieldDef: GraphQLField<any, any, any>;
+export const TypeNameMetaFieldDef: GraphQLField<any, any, any>;
 
 export const introspectionTypes: ReadonlyArray<any>;
 

--- a/types/graphql/utilities/TypeInfo.d.ts
+++ b/types/graphql/utilities/TypeInfo.d.ts
@@ -33,7 +33,7 @@ export class TypeInfo {
     getParentType(): Maybe<GraphQLCompositeType>;
     getInputType(): Maybe<GraphQLInputType>;
     getParentInputType(): Maybe<GraphQLInputType>;
-    getFieldDef(): GraphQLField<any, Maybe<any>>;
+    getFieldDef(): GraphQLField<any, any, any>;
     getDefaultValue(): Maybe<any>;
     getDirective(): Maybe<GraphQLDirective>;
     getArgument(): Maybe<GraphQLArgument>;
@@ -46,4 +46,4 @@ type getFieldDef = (
     schema: GraphQLSchema,
     parentType: GraphQLType,
     fieldNode: FieldNode
-) => Maybe<GraphQLField<any, any>>;
+) => Maybe<GraphQLField<any, any, any>>;

--- a/types/graphql/utilities/buildASTSchema.d.ts
+++ b/types/graphql/utilities/buildASTSchema.d.ts
@@ -66,7 +66,7 @@ export class ASTDefinitionBuilder {
 
     buildDirective(directiveNode: DirectiveDefinitionNode): GraphQLDirective;
 
-    buildField(field: FieldDefinitionNode): GraphQLFieldConfig<any, any>;
+    buildField(field: FieldDefinitionNode): GraphQLFieldConfig<any, any, any>;
 
     buildInputField(value: InputValueDefinitionNode): GraphQLInputField;
 

--- a/types/graphql/validation/ValidationContext.d.ts
+++ b/types/graphql/validation/ValidationContext.d.ts
@@ -73,7 +73,7 @@ export class ValidationContext extends ASTValidationContext {
 
     getParentInputType(): Maybe<GraphQLInputType>;
 
-    getFieldDef(): Maybe<GraphQLField<any, any>>;
+    getFieldDef(): Maybe<GraphQLField<any, any, any>>;
 
     getDirective(): Maybe<GraphQLDirective>;
 


### PR DESCRIPTION
Having `TArgs` set to `{ [key: string]: any }` in the types produces errors when trying to refine it to a specific type, such as `{id: string}`.

![image](https://user-images.githubusercontent.com/690517/54079477-fc2cdb00-4291-11e9-81d7-b90529f90695.png)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] **N/A** Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] **N/A** Increase the version number in the header if appropriate.
- [ ] **N/A** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

