### PR TITLE
[css-modules-loader-core] add type definitions for css-modules-loader-core

### DIFF
--- a/types/css-modules-loader-core/css-modules-loader-core-tests.ts
+++ b/types/css-modules-loader-core/css-modules-loader-core-tests.ts
@@ -1,0 +1,24 @@
+/// <reference types="node" />
+
+import Core, { Source } from "css-modules-loader-core";
+
+const core = new Core();
+const emptyPlugins = new Core([]);
+const withPlugins = new Core([
+    Core.values,
+    Core.localByDefault,
+    Core.extractImports,
+    Core.scope
+]);
+const withDefaultPlugins = new Core(Core.defaultPlugins);
+
+// $ExpectError
+const noArray = new Core(Core.values);
+
+// Validating the source can be anything that has toString() defined
+const bufferSource: Source = new Buffer("str");
+
+core.load("str").then(({ injectableSource, exportTokens }) => {
+    const str: string = injectableSource;
+    exportTokens["key"] = "value";
+});

--- a/types/css-modules-loader-core/index.d.ts
+++ b/types/css-modules-loader-core/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for css-modules-loader-core 1.1
+// Project: https://github.com/css-modules/css-modules-loader-core
+// Definitions by: Spencer Miskoviak <https://github.com/skovy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Plugin } from "postcss";
+
+declare namespace Core {
+    type Source =
+        | string
+        | {
+              toString(): string;
+          };
+
+    type PathFetcher = (
+        file: string,
+        relativeTo: string,
+        depTrace: string
+    ) => void;
+
+    interface ExportTokens {
+        [index: string]: string;
+    }
+
+    interface Result {
+        injectableSource: string;
+        exportTokens: ExportTokens;
+    }
+}
+
+declare class Core {
+    static values: Plugin<{}>;
+    static localByDefault: Plugin<{}>;
+    static extractImports: Plugin<{}>;
+    static scope: Plugin<{}>;
+    static defaultPlugins: Array<Plugin<{}>>;
+
+    constructor(plugins?: Array<Plugin<any>>);
+
+    load(
+        source: Core.Source,
+        sourcePath?: string,
+        trace?: string,
+        pathFetcher?: Core.PathFetcher
+    ): Promise<Core.Result>;
+}
+
+export = Core;
+export as namespace Core;

--- a/types/css-modules-loader-core/package.json
+++ b/types/css-modules-loader-core/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "postcss": "7.x.x"
+  }
+}

--- a/types/css-modules-loader-core/tsconfig.json
+++ b/types/css-modules-loader-core/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,        
+        "esModuleInterop": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-modules-loader-core-tests.ts"
+    ]
+}

--- a/types/css-modules-loader-core/tslint.json
+++ b/types/css-modules-loader-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.