### PR TITLE
[@types/credential] Changed hash type to always be a (JSON encoded) string

### DIFF
--- a/types/credential/credential-tests.ts
+++ b/types/credential/credential-tests.ts
@@ -11,15 +11,20 @@ var newPassword = 'I have a really great password.';
 pw.hash(newPassword, function(err, hash) {
     if (err) { throw err; }
     console.log('Store the password hash.', hash);
+    if (typeof hash === "string") {
+        console.log('The hash is a string, as expected');
+    } else {
+        console.log('The has is NOT a string');
+    }
 });
 
-var storedHash = {
+var storedHash = JSON.stringify({
     "hash": "gNofnhlBl36AdRyktwATxKoqWKa6hsIEzwCmW/YXN//7PtiJwCRbepV9fUKu0L9TJELCKoDiBy6rGM8ov7lg2yLY",
     "salt": "yyN3KUzlr4KrKWMM2K3d2Ddxf8OTq+vkKG+mtnmQVIibxSJz8drfzkYzqcH0EM+PVKR/1nClRr/CPDuJsq+FOcIw",
     "keyLength": 66,
     "hashMethod": "pbkdf2",
     "iterations": 181019
-};
+});
 var userInput = 'I have a really great password.';
 
 pw.verify(storedHash, userInput, function(err, isValid) {

--- a/types/credential/index.d.ts
+++ b/types/credential/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for credential
+// Type definitions for credential 2.0
 // Project: https://github.com/ericelliott/credential
 // Definitions by: Phú <https://github.com/phuvo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,24 +10,16 @@ interface defaultOptions {
     hashMethod: string;
 }
 
-interface hashObject {
-    hash: string;
-    salt: string;
-    keyLength: number;
-    hashMethod: string;
-    iterations: number;
-}
-
-type HashCallback = (err: Error, hash: hashObject) => void;
+type HashCallback = (err: Error, hash: string) => void;
 type VerifyCallback = (err: Error, isValid: boolean) => void;
 
 
 declare function credential(defaultOptions?: defaultOptions): {
     hash(password: string, callback: HashCallback): void;
-    hash(password: string): Promise<hashObject>;
+    hash(password: string): Promise<string>;
     // iterations(work: number, base): number;
-    verify(hash: hashObject | string, password: string, callback: VerifyCallback): void;
-    verify(hash: hashObject | string, password: string): Promise<boolean>;
+    verify(hash: string, password: string, callback: VerifyCallback): void;
+    verify(hash: string, password: string): Promise<boolean>;
     expired(hash: string, days: number): boolean;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ericelliott/credential#pwhashpassword-callback-callbackerr-hashjson
- [x] Increase the version number in the header if appropriate.

