### PR TITLE
Add missing authors.

### DIFF
--- a/types/axe-webdriverjs/index.d.ts
+++ b/types/axe-webdriverjs/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for axe-webdriverjs 2.0
 // Project: https://github.com/dequelabs/axe-webdriverjs#readme
-// Definitions by: My Self <https://github.com/JoshuaKGoldberg>
+// Definitions by: Joshua Goldberg <https://github.com/JoshuaKGoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/basicauth-middleware/index.d.ts
+++ b/types/basicauth-middleware/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for basicauth-middleware 3.1
 // Project: https://github.com/nchaulet/basicauth-middleware
-// Definitions by: My Self <https://github.com/nchaulet>
+// Definitions by: Nicolas Chaulet <https://github.com/nchaulet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/bip32/index.d.ts
+++ b/types/bip32/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for bip32 1.0
 // Project: https://github.com/bitcoinjs/bip32#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: eduhenke <https://github.com/eduhenke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 

--- a/types/braft-editor/index.d.ts
+++ b/types/braft-editor/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for braft-editor 1.9
 // Project: https://github.com/margox/braft#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Jonny Yao <https://github.com/petitspois>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for cli-progress 1.8
 // Project: https://github.com/AndiDittrich/Node.CLI-Progress
-// Definitions by: My Self <https://github.com/mhegazy>
+// Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/config-yaml/index.d.ts
+++ b/types/config-yaml/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for config-yaml 1.1
 // Project: https://github.com/neolao/config-yaml#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Arylo Yeung <https://github.com/Arylo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 2.1

--- a/types/jsreport-html-to-xlsx/index.d.ts
+++ b/types/jsreport-html-to-xlsx/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jsreport-html-to-xlsx 2.0
 // Project: https://github.com/jsreport/jsreport-html-to-xlsx
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Tao Quifeng <https://github.com/taoqf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/jsreport-html-to-xlsx/v1/index.d.ts
+++ b/types/jsreport-html-to-xlsx/v1/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jsreport-html-to-xlsx 1.4
 // Project: https://github.com/jsreport/jsreport-html-to-xlsx
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Tao Quifeng <https://github.com/taoqf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/permit/index.d.ts
+++ b/types/permit/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for permit 0.2
 // Project: https://github.com/ianstormtaylor/permit#readme
-// Definitions by: My Self <https://github.com/jannikkeye>
+// Definitions by: Jannik Keye <https://github.com/jannikkeye>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/pet-finder-api/index.d.ts
+++ b/types/pet-finder-api/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pet-finder-api 1.0
 // Project: https://github.com/drlukeangel/Pet-Finder-API-Javascript-Library
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: ncipollina <https://github.com/ncipollina>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare function petFinder(api_key: string, api_secret: string, options?: any): petFinder.PetFinder;
 

--- a/types/provinces/index.d.ts
+++ b/types/provinces/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for provinces 1.11
 // Project: https://github.com/substack/provinces
-// Definitions by: My Self <https://github.com/gatimus>
+// Definitions by: William Lohan <https://github.com/gatimus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare global {

--- a/types/react-blessed/index.d.ts
+++ b/types/react-blessed/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-blessed 0.3
 // Project: https://github.com/yomguithereal/react-blessed#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Century Guo <https://github.com/guoshencheng>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-native-tab-navigator/index.d.ts
+++ b/types/react-native-tab-navigator/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-native-tab-navigator 0.3
 // Project: https://github.com/exponentjs/react-native-tab-navigator#readme
-// Definitions by: My Self <https://github.com/iRoachie>
+// Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/require-directory/index.d.ts
+++ b/types/require-directory/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for require-directory 2.1
 // Project: https://github.com/troygoode/node-require-directory/
-// Definitions by: My Self <https://github.com/Igmat>
+// Definitions by: Ihor Chulinda <https://github.com/Igmat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 /// <reference types="node" />

--- a/types/urlencode/index.d.ts
+++ b/types/urlencode/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for urlencode 1.1
 // Project: https://github.com/node-modules/urlencode
-// Definitions by: My Self <https://github.com/kimcoder>
+// Definitions by: kimcoder <https://github.com/kimcoder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface charsetParam {

--- a/types/vue-color/index.d.ts
+++ b/types/vue-color/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for vue-color 2.4
 // Project: https://github.com/xiaokaike/vue-color#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Clément Flodrops <https://github.com/mildful>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 


### PR DESCRIPTION
Uncovered by dtslint 0.5.4, which now requires that definitions cannot
be by "My Self", which is the default from dts-gen.