### PR TITLE
Propagate event type to components in react-big-calendar

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -167,7 +167,7 @@ export interface EventWrapperProps<TEvent extends Event = Event> {
     // https://github.com/intljusticemission/react-big-calendar/blob/27a2656b40ac8729634d24376dff8ea781a66d50/src/TimeGridEvent.js#L28
     style?: React.CSSProperties & { xOffset: number };
     className: string;
-    event: T;
+    event: TEvent;
     isRtl: boolean;
     getters: {
         eventProp?: EventPropGetter<TEvent>;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -113,7 +113,7 @@ export interface HeaderProps {
     localizer: DateLocalizer;
 }
 
-export interface Components<T> {
+export interface Components<T extends Event = Event> {
     event?: React.ComponentType<EventProps<T>>;
     eventWrapper?: React.ComponentType<EventWrapperProps<T>>;
     eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -113,9 +113,9 @@ export interface HeaderProps {
     localizer: DateLocalizer;
 }
 
-export interface Components<T extends Event = Event> {
-    event?: React.ComponentType<EventProps<T>>;
-    eventWrapper?: React.ComponentType<EventWrapperProps<T>>;
+export interface Components<TEvent extends Event = Event> {
+    event?: React.ComponentType<EventProps<TEvent>>;
+    eventWrapper?: React.ComponentType<EventWrapperProps<TEvent>>;
     eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dayWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dateCellWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
@@ -158,29 +158,29 @@ export interface ToolbarProps {
     children?: React.ReactNode;
 }
 
-export interface EventProps<T extends Event = Event> {
-    event: T;
+export interface EventProps<TEvent extends Event = Event> {
+    event: TEvent;
     title: string;
 }
 
-export interface EventWrapperProps<T extends Event = Event> {
+export interface EventWrapperProps<TEvent extends Event = Event> {
     // https://github.com/intljusticemission/react-big-calendar/blob/27a2656b40ac8729634d24376dff8ea781a66d50/src/TimeGridEvent.js#L28
     style?: React.CSSProperties & { xOffset: number };
     className: string;
     event: T;
     isRtl: boolean;
     getters: {
-        eventProp?: EventPropGetter<T>;
+        eventProp?: EventPropGetter<TEvent>;
         slotProp?: SlotPropGetter;
         dayProp?: DayPropGetter;
     };
     onClick: (e: React.MouseEvent<HTMLElement>) => void;
     onDoubleClick: (e: React.MouseEvent<HTMLElement>) => void;
     accessors: {
-        title?: (event: T) => string;
-        tooltip?: (event: T) => string;
-        end?: (event: T) => Date;
-        start?: (event: T) => Date;
+        title?: (event: TEvent) => string;
+        tooltip?: (event: TEvent) => string;
+        end?: (event: TEvent) => Date;
+        start?: (event: TEvent) => Date;
     };
     selected: boolean;
     label: string;
@@ -293,7 +293,7 @@ export default class BigCalendar<TEvent extends Event = Event, TResource extends
     components: {
         dateCellWrapper: React.ComponentType,
         dayWrapper: React.ComponentType,
-        eventWrapper: React.ComponentType,
+        eventWrapper: React.ComponentType<TEvent>,
     };
     /**
      * create DateLocalizer from globalize

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -113,9 +113,9 @@ export interface HeaderProps {
     localizer: DateLocalizer;
 }
 
-export interface Components {
-    event?: React.ComponentType<EventProps>;
-    eventWrapper?: React.ComponentType<EventWrapperProps>;
+export interface Components<T> {
+    event?: React.ComponentType<EventProps<T>>;
+    eventWrapper?: React.ComponentType<EventWrapperProps<T>>;
     eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dayWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dateCellWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
@@ -263,7 +263,7 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     scrollToTime?: Date;
     culture?: string;
     formats?: Formats;
-    components?: Components;
+    components?: Components<TEvent>;
     messages?: Messages;
     titleAccessor?: keyof TEvent | ((event: TEvent) => string);
     allDayAccessor?: keyof TEvent | ((event: TEvent) => boolean);

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -93,7 +93,7 @@ class CalendarResource {
     class FullAPIExample extends React.Component<BigCalendarProps<CalendarEvent, CalendarResource>> {
         render() {
             return (
-              <MyCalendar  {...this.props}
+              <MyCalendar<CalendarEvent> {...this.props}
               date={new Date()}
               getNow={() => new Date()}
               view={'day'}
@@ -217,7 +217,7 @@ const customSlotPropGetter = (date: Date) => {
     else return {};
 };
 
-function Event(event: any) {
+function Event(props: EventProps<CalendarEvent>) {
     return (
         <span>
             <strong>{event.title}</strong>
@@ -226,15 +226,13 @@ function Event(event: any) {
     );
 }
 
-class EventWrapper extends React.Component<EventWrapperProps> {
-    render() {
-        const { continuesEarlier, event, label, accessors = {}, style } = this.props;
-        return (
-            <div style={style}>
-                <div>{continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}}</div>
-            </div>
-        );
-    }
+function EventWrapper(props:EventWrapperProps<CalendarEvent>) {
+    const { continuesEarlier, event, label, accessors = {}, style } = props;
+    return (
+        <div style={style}>
+            <div>{continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}}</div>
+        </div>
+    );
 }
 
 class Toolbar extends React.Component<ToolbarProps> {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import BigCalendar, { BigCalendarProps, Navigate, View, DateRange, DateLocalizer, ToolbarProps, EventWrapperProps } from "react-big-calendar";
+import BigCalendar, { BigCalendarProps, Navigate, View, DateRange, DateLocalizer, ToolbarProps, EventProps, EventWrapperProps } from "react-big-calendar";
 import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
 
 // Don't want to add this as a dependency, because it is only used for tests.

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -226,7 +226,7 @@ function Event(props: EventProps<CalendarEvent>) {
     );
 }
 
-function EventWrapper(props:EventWrapperProps<CalendarEvent>) {
+function EventWrapper(props: EventWrapperProps<CalendarEvent>) {
     const { continuesEarlier, event, label, accessors = {}, style } = props;
     return (
         <div style={style}>

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -220,8 +220,8 @@ const customSlotPropGetter = (date: Date) => {
 function Event(props: EventProps<CalendarEvent>) {
     return (
         <span>
-            <strong>{event.title}</strong>
-            {event.desc && ':  ' + event.desc}
+            <strong>{props.event.title}</strong>
+            {props.event.desc && ':  ' + props.event.desc}
         </span>
     );
 }

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -93,7 +93,7 @@ class CalendarResource {
     class FullAPIExample extends React.Component<BigCalendarProps<CalendarEvent, CalendarResource>> {
         render() {
             return (
-              <MyCalendar<CalendarEvent> {...this.props}
+              <MyCalendar {...this.props}
               date={new Date()}
               getNow={() => new Date()}
               view={'day'}


### PR DESCRIPTION
Currently components which accept the event always have its type set to `object` even though the props are already generic because nowhere else in the types is their generic argument actually set.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: **this is about typing generic arguments, not sure what to point to in this case**
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
