### PR TITLE
[Mongoose] Improve type of constructor argument - from any to Partial<T>

### DIFF
--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for Mongoose 4.7.2
+// Type definitions for Mongoose 4.7.3
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca>
 //                 horiuchi <https://github.com/horiuchi>
 //                 lukasz-zak <https://github.com/lukasz-zak>
+//                 murbanowicz <https://github.com/murbanowicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -2445,7 +2446,7 @@ declare module "mongoose" {
      *   Model#ensureIndexes. If an error occurred it is passed with the event.
      *   The fields, options, and index name are also passed.
      */
-    new(doc?: any): T;
+    new(doc?: Partial<T>): T;
 
     /**
      * Finds a single document by its _id field. findById(id) is almost*


### PR DESCRIPTION
Type of constructor parameter should be `Partial<T>` to provide better type safety

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
