### PR TITLE
Adjust @babel/traverse to not rely on the exact string of the nodepath type

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -1,17 +1,15 @@
-import traverse, { Visitor } from "@babel/traverse";
+import traverse, { Visitor, NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
 // Examples from: https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md
 const MyVisitor: Visitor = {
     Identifier: {
         enter(path) {
-            // $ExpectType NodePath<Identifier>
-            path;
+            const x: NodePath<t.Identifier> = path;
             console.log("Entered!");
         },
         exit(path) {
-            // $ExpectType NodePath<Identifier>
-            path;
+            const x: NodePath<t.Identifier> = path;
             console.log("Exited!");
         }
     }


### PR DESCRIPTION
in its test to fixup test with ts@next
