### PR TITLE
Fix ramda evolvable type for ts@next

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -609,10 +609,13 @@ declare namespace R {
 
     // Represents all objects evolvable with Evolver E
     type Evolvable<E extends Evolver> = {
-        [P in keyof E]?: E[P] extends (value: infer V) => any ? V :
-            E[P] extends Evolver ? Evolvable<E[P]> :
-            never
+        [P in keyof E]?: Evolved<E[P]>;
     };
+
+    type Evolved<T> =
+        T extends (value: infer V) => any ? V :
+        T extends Evolver ? Evolvable<T> :
+        never;
 
     interface Placeholder { __isRamdaPlaceholder__: true; }
 


### PR DESCRIPTION
Fixes one of the new errors in ramda's tests, per [this comment](https://github.com/Microsoft/TypeScript/pull/30215#issuecomment-470715781). One of the other issues is now tracked on TS by https://github.com/Microsoft/TypeScript/issues/30324 - I suspect it's actually the same root cause for all 3 of the other test failures.