### PR TITLE
@storybook/addon-knobs: update select options type to accept all types <option> tag's value attribute can take

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -52,8 +52,12 @@ export function object<T>(name: string, value: T, groupId?: string): T;
 export function radios<T>(name: string, options: { [s: string]: T }, value?: T, groupId?: string): string;
 
 export function select<T>(name: string, options: { [s: string]: T }, value: T, groupId?: string): T;
-export function select<T extends string>(name: string, options: ReadonlyArray<T>, value: T, groupId?: string): T;
-export function select(name: string, options: ReadonlyArray<string>, value: string, groupId?: string): string;
+export function select<
+    T extends Exclude<
+        React.OptionHTMLAttributes<HTMLOptionElement>['value'],
+        undefined
+    >
+>(name: string, options: ReadonlyArray<T>, value: T, groupId?: string): T;
 
 export function date(name: string, value?: Date, groupId?: string): Date;
 

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -93,16 +93,17 @@ stories.add('dynamic knobs', () => {
   );
 });
 
-const readonlyOptionsArray: ReadonlyArray<string> = ['hi'];
-select('With readonly string array', readonlyOptionsArray, readonlyOptionsArray[0]);
+// readonly option array: element can be typed string | number | string[]
+select('With readonly string array', ['hi'], 'hi');
+select('With readonly number array', [1, 2, 3, 4], 1);
+select('With readonly string[] array', [['a'], ['b', 'c']], ['a']);
+select('With mixed-typed element array', [1, 'hi', ['a']], 1);
 
 type StringLiteralType = 'Apple' | 'Banana' | 'Grapes';
 const stringLiteralArray: StringLiteralType[] = ['Apple', 'Banana', 'Grapes'];
 
-let selectedFruit: StringLiteralType;
-
 // type of value returned from `select` must be `StringLiteralType`.
-selectedFruit = select('With string literal array', stringLiteralArray, stringLiteralArray[0]);
+const _: StringLiteralType = select('With string literal array', stringLiteralArray, stringLiteralArray[0]);
 
 const optionsObject = {
   Apple: { taste: 'sweet', color: 'red' },
@@ -112,7 +113,7 @@ select('With object', optionsObject, optionsObject.Apple);
 
 const genericArray = array('With regular array', ['hi', 'there']);
 
-const userInputArray = array('With readonly array', readonlyOptionsArray);
+const userInputArray = array('With readonly array', ['hi']);
 userInputArray.push('Make sure that the output is still mutable although the input need not be!');
 
 // groups


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/storybooks/storybook/blob/next/addons/knobs/src/components/types/Select.js#L24>

When an array is passed as `options` parameter of `select` function, each element of the array is used as a `value` attribute of an `<option>` HTML element. `value` can take `string`, `number`, `string[]` or `undefined` by the definition. So I updated type of `options` parameter to be either `ReadonlyArray<string>`, `ReadonlyArray<number>`, or `<ReadonlyArray<string[]>`.

Thank you @akameco for pointing it out in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33670#discussion_r264516189