### PR TITLE
[react-native] allow redeclaring require when node typing is present

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9297,9 +9297,11 @@ export const PointPropType: React.Validator<PointPropType>;
 export const ViewPropTypes: React.ValidationMap<ViewProps>;
 
 declare global {
-    type ReactNativeRequireFunction = (name: string) => any;
+    interface NodeRequire {
+        (id: string): any;
+    }
 
-    var require: ReactNativeRequireFunction;
+    var require: NodeRequire;
 
     /**
      * Console polyfill


### PR DESCRIPTION
Fixes
```
Subsequent variable declarations must have the same type.  Variable 'require' must be of type 'NodeRequire', but here has type 'ReactNativeRequireFunction'.
```
Caused by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33302


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/javascript-environment.html#polyfills
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
