### PR TITLE
[styled-system] Update ResponsiveValue to accept generic type variables for breakpoints

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -48,9 +48,11 @@ export function style(
     args: LowLevelStylefunctionArguments
 ): { [cssProp: string]: string };
 
-export type TBreakpointAliasStyledSystem<T> = { [key: string]: T };
 export type TLengthStyledSystem = string | 0 | number;
-export type ResponsiveValue<T, B> = T | Array<T | null> | B;
+export interface BreakpointAliasStyledSystem<T> {
+    [key: string]: T;
+}
+export type ResponsiveValue<T, B = BreakpointAliasStyledSystem<TLengthStyledSystem>> = T | Array<T | null> | B;
 
 /**
  * Converts shorthand margin and padding props to margin and padding CSS declarations
@@ -62,35 +64,35 @@ export type ResponsiveValue<T, B> = T | Array<T | null> | B;
  * - Array values are converted into responsive values.
  */
 
-export interface SpaceProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface SpaceProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /** Margin on top, left, bottom and right */
-    m?: ResponsiveValue<CSS.MarginProperty<TLength>, TBreakpoinAlias>;
+    m?: ResponsiveValue<CSS.MarginProperty<TLength>, TBreakpointAlias>;
     /** Margin for the top */
-    mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>, TBreakpoinAlias>;
+    mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>, TBreakpointAlias>;
     /** Margin for the right */
-    mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>, TBreakpoinAlias>;
+    mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>, TBreakpointAlias>;
     /** Margin for the bottom */
-    mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>, TBreakpoinAlias>;
+    mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>, TBreakpointAlias>;
     /** Margin for the left */
-    ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>, TBreakpoinAlias>;
+    ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>, TBreakpointAlias>;
     /** Margin for the left and right */
-    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
+    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpointAlias>;
     /** Margin for the top and bottom */
-    my?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
+    my?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpointAlias>;
     /** Padding on top, left, bottom and right */
-    p?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
+    p?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpointAlias>;
     /** Padding for the top */
-    pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>, TBreakpoinAlias>;
+    pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>, TBreakpointAlias>;
     /** Padding for the right */
-    pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>, TBreakpoinAlias>;
+    pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>, TBreakpointAlias>;
     /** Padding for the bottom */
-    pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>, TBreakpoinAlias>;
+    pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>, TBreakpointAlias>;
     /** Padding for the left */
-    pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>, TBreakpoinAlias>;
+    pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>, TBreakpointAlias>;
     /** Padding for the left and right */
-    px?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
+    px?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpointAlias>;
     /** Padding for the top and bottom */
-    py?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
+    py?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpointAlias>;
 }
 
 export function space(...args: any[]): any;
@@ -135,7 +137,7 @@ export interface Theme extends BaseTheme {
  * Font Size
  */
 
-export interface FontSizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FontSizeProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The fontSize utility parses a component's `fontSize` prop and converts it into a CSS font-size declaration.
      *
@@ -145,7 +147,7 @@ export interface FontSizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = 
      * - And array values are converted into responsive values.
      *
      */
-    fontSize?: ResponsiveValue<CSS.FontSizeProperty<TLength>, TBreakpoinAlias>;
+    fontSize?: ResponsiveValue<CSS.FontSizeProperty<TLength>, TBreakpointAlias>;
 }
 
 export function fontSize(...args: any[]): any;
@@ -154,7 +156,7 @@ export function fontSize(...args: any[]): any;
  * Color
  */
 
-export interface TextColorProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface TextColorProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The color utility parses a component's `color` and `bg` props and converts them into CSS declarations.
      * By default the raw value of the prop is returned.
@@ -164,12 +166,12 @@ export interface TextColorProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<T
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
      */
-    color?: ResponsiveValue<CSS.ColorProperty, TBreakpoinAlias>;
+    color?: ResponsiveValue<CSS.ColorProperty, TBreakpointAlias>;
 }
 
 export function textColor(...args: any[]): any;
 
-export interface BgColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BgColorProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The color utility parses a component's `color` and `bg` props and converts them into CSS declarations.
      * By default the raw value of the prop is returned.
@@ -179,35 +181,36 @@ export interface BgColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = T
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color)
      */
-    bg?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpoinAlias>;
+    bg?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpointAlias>;
 }
 
 export function bgColor(...args: any[]): any;
 
-export interface ColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> extends TextColorProps<TBreakpoinAlias>, BgColorProps<TLength, TBreakpoinAlias> {}
+export interface ColorProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>>
+    extends TextColorProps<TBreakpointAlias>, BgColorProps<TLength, TBreakpointAlias> {}
 
 export function color(...args: any[]): any;
 
 /**
  * Typography
  */
-export interface FontFamilyProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    fontFamily?: ResponsiveValue<CSS.FontFamilyProperty, TBreakpoinAlias>;
+export interface FontFamilyProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    fontFamily?: ResponsiveValue<CSS.FontFamilyProperty, TBreakpointAlias>;
 }
 export function fontFamily(...args: any[]): any;
 
-export interface TextAlignProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface TextAlignProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The text-align CSS property specifies the horizontal alignment of an inline or table-cell box.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
      */
-    textAlign?: ResponsiveValue<CSS.TextAlignProperty, TBreakpoinAlias>;
+    textAlign?: ResponsiveValue<CSS.TextAlignProperty, TBreakpointAlias>;
 }
 
 export function textAlign(...args: any[]): any;
 
-export interface LineHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface LineHeightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The line-height CSS property sets the amount of space used for lines, such as in text. On block-level elements,
      * it specifies the minimum height of line boxes within the element.
@@ -216,11 +219,11 @@ export interface LineHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height)
      */
-    lineHeight?: ResponsiveValue<CSS.LineHeightProperty<TLength>, TBreakpoinAlias>;
+    lineHeight?: ResponsiveValue<CSS.LineHeightProperty<TLength>, TBreakpointAlias>;
 }
 export function lineHeight(...args: any[]): any;
 
-export interface FontWeightProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FontWeightProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The font-weight CSS property specifies the weight (or boldness) of the font.
      *
@@ -228,29 +231,29 @@ export interface FontWeightProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
      */
-    fontWeight?: ResponsiveValue<CSS.FontWeightProperty, TBreakpoinAlias>;
+    fontWeight?: ResponsiveValue<CSS.FontWeightProperty, TBreakpointAlias>;
 }
 
 export function fontWeight(...args: any[]): any;
 
-export interface FontStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FontStyleProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The font-style CSS property specifies whether a font should be styled with a normal, italic,
      * or oblique face from its font-family.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
      */
-    fontStyle?: ResponsiveValue<CSS.FontStyleProperty, TBreakpoinAlias>;
+    fontStyle?: ResponsiveValue<CSS.FontStyleProperty, TBreakpointAlias>;
 }
 export function fontStyle(...args: any[]): any;
 
-export interface LetterSpacingProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface LetterSpacingProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The letter-spacing CSS property sets the spacing behavior between text characters.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing)
      */
-    letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>, TBreakpoinAlias>;
+    letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>, TBreakpointAlias>;
 }
 export function letterSpacing(...args: any[]): any;
 
@@ -258,7 +261,7 @@ export function letterSpacing(...args: any[]): any;
  * Layout
  */
 
-export interface DisplayProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface DisplayProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The display CSS property defines the display type of an element, which consists of the two basic qualities
      * of how an element generates boxes — the outer display type defining how the box participates in flow layout,
@@ -266,36 +269,36 @@ export interface DisplayProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLe
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    display?: ResponsiveValue<CSS.DisplayProperty, TBreakpoinAlias>;
+    display?: ResponsiveValue<CSS.DisplayProperty, TBreakpointAlias>;
 }
 
 export function display(...args: any[]): any;
 
-export interface MaxWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface MaxWidthProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The max-width CSS property sets the maximum width of an element.
      * It prevents the used value of the width property from becoming larger than the value specified by max-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width)
      */
-    maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<TLength>, TBreakpoinAlias>;
+    maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<TLength>, TBreakpointAlias>;
 }
 
 export function maxWidth(...args: any[]): any;
 
-export interface MinWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface MinWidthProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The min-width CSS property sets the minimum width of an element.
      * It prevents the used value of the width property from becoming smaller than the value specified for min-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
      */
-    minWidth?: ResponsiveValue<CSS.MinWidthProperty<TLength>, TBreakpoinAlias>;
+    minWidth?: ResponsiveValue<CSS.MinWidthProperty<TLength>, TBreakpointAlias>;
 }
 
 export function minWidth(...args: any[]): any;
 
-export interface WidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface WidthProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      *   The width utility parses a component's `width` prop and converts it into a CSS width declaration.
      *
@@ -304,87 +307,88 @@ export interface WidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBr
      *   - String values are passed as raw CSS values.
      *   - And arrays are converted to responsive width styles.
      */
-    width?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpoinAlias>;
+    width?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpointAlias>;
 }
 
 export function width(...args: any[]): any;
 
-export interface MaxHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface MaxHeightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The max-height CSS property sets the maximum height of an element. It prevents the used value of the height
      * property from becoming larger than the value specified for max-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height)
      */
-    maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<TLength>, TBreakpoinAlias>;
+    maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function maxHeight(...args: any[]): any;
 
-export interface MinHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface MinHeightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The min-height CSS property sets the minimum height of an element. It prevents the used value of the height
      * property from becoming smaller than the value specified for min-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    minHeight?: ResponsiveValue<CSS.MinHeightProperty<TLength>, TBreakpoinAlias>;
+    minHeight?: ResponsiveValue<CSS.MinHeightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function minHeight(...args: any[]): any;
 
-export interface HeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface HeightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The height CSS property specifies the height of an element. By default, the property defines the height of the
      * content area. If box-sizing is set to border-box, however, it instead determines the height of the border area.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/height)
      */
-    height?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpoinAlias>;
+    height?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function height(...args: any[]): any;
 
 // TODO: Document, I couldn't find any info on these two properties...
 
-export interface SizeWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    size?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpoinAlias>;
+export interface SizeWidthProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    size?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpointAlias>;
 }
 
 export function sizeWidth(...args: any[]): any;
 
-export interface SizeHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    size?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpoinAlias>;
+export interface SizeHeightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    size?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function sizeHeight(...args: any[]): any;
 
-export interface SizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> extends SizeHeightProps<TLength, TBreakpoinAlias>, SizeWidthProps<TLength, TBreakpoinAlias> {}
+export interface SizeProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>>
+    extends SizeHeightProps<TLength, TBreakpointAlias>, SizeWidthProps<TLength, TBreakpointAlias> {}
 
 export function size(...args: any[]): any;
 
-export interface RatioPaddingProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    ratio?: ResponsiveValue<number, TBreakpoinAlias>;
+export interface RatioPaddingProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    ratio?: ResponsiveValue<number, TBreakpointAlias>;
 }
 
 export function ratioPadding(...args: any[]): any;
 
-export interface RatioProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface RatioProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The ration is height: 0 & paddingBottom
      */
-    ratio?: ResponsiveValue<number, TBreakpoinAlias>;
+    ratio?: ResponsiveValue<number, TBreakpointAlias>;
 }
 
 export function ratio(...args: any[]): any;
 
-export interface VerticalAlignProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface VerticalAlignProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The vertical-align CSS property specifies sets vertical alignment of an inline or table-cell box.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
      */
-    verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<TLength>, TBreakpoinAlias>;
+    verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<TLength>, TBreakpointAlias>;
 }
 
 export function verticalAlign(...args: any[]): any;
@@ -393,7 +397,7 @@ export function verticalAlign(...args: any[]): any;
  * Flexbox
  */
 
-export interface AlignItemsProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface AlignItemsProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS align-items property sets the align-self value on all direct children as a group. The align-self
      * property sets the alignment of an item within its containing block.
@@ -403,106 +407,106 @@ export interface AlignItemsProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
      */
-    alignItems?: ResponsiveValue<CSS.AlignItemsProperty, TBreakpoinAlias>;
+    alignItems?: ResponsiveValue<CSS.AlignItemsProperty, TBreakpointAlias>;
 }
 
 export function alignItems(...args: any[]): any;
 
-export interface AlignContentProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface AlignContentProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS align-content property sets how the browser distributes space between and around content items
      * along the cross-axis of a flexbox container, and the main-axis of a grid container.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)
      */
-    alignContent?: ResponsiveValue<CSS.AlignContentProperty, TBreakpoinAlias>;
+    alignContent?: ResponsiveValue<CSS.AlignContentProperty, TBreakpointAlias>;
 }
 
 export function alignContent(...args: any[]): any;
 
-export interface JustifyItemsProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface JustifyItemsProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-items property defines the default justify-self for all items of the box, giving them all
      * a default way of justifying each box along the appropriate axis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
      */
-    justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty, TBreakpoinAlias>;
+    justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty, TBreakpointAlias>;
 }
 
 export function justifyItems(...args: any[]): any;
 
-export interface JustifyContentProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface JustifyContentProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-content property defines how the browser distributes space between and around content items
      * along the main-axis of a flex container, and the inline axis of a grid container.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
      */
-    justifyContent?: ResponsiveValue<CSS.JustifyContentProperty, TBreakpoinAlias>;
+    justifyContent?: ResponsiveValue<CSS.JustifyContentProperty, TBreakpointAlias>;
 }
 
 export function justifyContent(...args: any[]): any;
 
-export interface FlexWrapProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FlexWrapProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex-wrap CSS property sets whether flex items are forced onto one line or can wrap onto multiple lines.
      * If wrapping is allowed, it sets the direction that lines are stacked.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap)
      */
-    flexWrap?: ResponsiveValue<CSS.FlexWrapProperty, TBreakpoinAlias>;
+    flexWrap?: ResponsiveValue<CSS.FlexWrapProperty, TBreakpointAlias>;
 }
 
 export function flexWrap(...args: any[]): any;
 
-export interface FlexBasisProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FlexBasisProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     // TODO: The FlexBasisValue currently really only exists for documentation
     //       purposes, because flex-basis also accepts `Nem` and `Npx` strings.
     //       Not sure there’s a way to still have the union values show up as
     //       auto-completion results.
-    flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>, TBreakpoinAlias>;
+    flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>, TBreakpointAlias>;
 }
 
 export function flexBasis(...args: any[]): any;
 
-export interface FlexDirectionProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FlexDirectionProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex-direction CSS property specifies how flex items are placed in the flex container defining the main
      * axis and the direction (normal or reversed).
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction)
      */
-    flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty, TBreakpoinAlias>;
+    flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty, TBreakpointAlias>;
 }
 
 export function flexDirection(...args: any[]): any;
 
-export interface FlexProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface FlexProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex CSS property specifies how a flex item will grow or shrink so as to fit the space available in
      * its flex container. This is a shorthand property that sets flex-grow, flex-shrink, and flex-basis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex)
      */
-    flex?: ResponsiveValue<CSS.FlexProperty<TLength>, TBreakpoinAlias>;
+    flex?: ResponsiveValue<CSS.FlexProperty<TLength>, TBreakpointAlias>;
 }
 
 export function flex(...args: any[]): any;
 
-export interface JustifySelfProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface JustifySelfProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-self property set the way a box is justified inside its alignment container along
      * the appropriate axis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)
      */
-    justifySelf?: ResponsiveValue<CSS.JustifySelfProperty, TBreakpoinAlias>;
+    justifySelf?: ResponsiveValue<CSS.JustifySelfProperty, TBreakpointAlias>;
 }
 
 export function justifySelf(...args: any[]): any;
 
-export interface AlignSelfProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface AlignSelfProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The align-self CSS property aligns flex items of the current flex line overriding the align-items value.
      *
@@ -511,19 +515,19 @@ export interface AlignSelfProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<T
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
      */
-    alignSelf?: ResponsiveValue<CSS.AlignSelfProperty, TBreakpoinAlias>;
+    alignSelf?: ResponsiveValue<CSS.AlignSelfProperty, TBreakpointAlias>;
 }
 
 export function alignSelf(...args: any[]): any;
 
-export interface OrderProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface OrderProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The order CSS property sets the order to lay out an item in a flex or grid container. Items in a container
      * are sorted by ascending order value and then by their source code order.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/order)
      */
-    order?: ResponsiveValue<CSS.GlobalsNumber, TBreakpoinAlias>;
+    order?: ResponsiveValue<CSS.GlobalsNumber, TBreakpointAlias>;
 }
 
 export function order(...args: any[]): any;
@@ -532,7 +536,7 @@ export function order(...args: any[]): any;
  * Grid Layout
  */
 
-export interface GridGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridGapProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap
      * and column-gap.
@@ -541,12 +545,12 @@ export interface GridGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = T
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
      */
-    gridGap?: ResponsiveValue<CSS.GridGapProperty<TLength>, TBreakpoinAlias>;
+    gridGap?: ResponsiveValue<CSS.GridGapProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridGap(...args: any[]): any;
 
-export interface GridColumnGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridColumnGapProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The column-gap CSS property sets the size of the gap (gutter) between an element's columns.
      *
@@ -554,12 +558,12 @@ export interface GridColumnGapProps<TLength = TLengthStyledSystem, TBreakpoinAli
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap)
      */
-    gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<TLength>, TBreakpoinAlias>;
+    gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridColumnGap(...args: any[]): any;
 
-export interface GridRowGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridRowGapProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The row-gap CSS property sets the size of the gap (gutter) between an element's rows.
      *
@@ -567,12 +571,12 @@ export interface GridRowGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias 
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap)
      */
-    gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<TLength>, TBreakpoinAlias>;
+    gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridRowGap(...args: any[]): any;
 
-export interface GridColumnProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridColumnProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-column CSS property is a shorthand property for grid-column-start and grid-column-end specifying
      * a grid item's size and location within the grid column by contributing a line, a span, or nothing (automatic)
@@ -580,12 +584,12 @@ export interface GridColumnProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column)
      */
-    gridColumn?: ResponsiveValue<CSS.GridColumnProperty, TBreakpoinAlias>;
+    gridColumn?: ResponsiveValue<CSS.GridColumnProperty, TBreakpointAlias>;
 }
 
 export function gridColumn(...args: any[]): any;
 
-export interface GridRowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridRowProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-row CSS property is a shorthand property for grid-row-start and grid-row-end specifying a grid item’s
      * size and location within the grid row by contributing a line, a span, or nothing (automatic) to its grid
@@ -593,46 +597,46 @@ export interface GridRowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLe
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row)
      */
-    gridRow?: ResponsiveValue<CSS.GridRowProperty, TBreakpoinAlias>;
+    gridRow?: ResponsiveValue<CSS.GridRowProperty, TBreakpointAlias>;
 }
 
 export function gridRow(...args: any[]): any;
 
-export interface GridAutoFlowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridAutoFlowProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-flow CSS property controls how the auto-placement algorithm works, specifying exactly
      * how auto-placed items get flowed into the grid.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
      */
-    gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty, TBreakpoinAlias>;
+    gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty, TBreakpointAlias>;
 }
 
 export function gridAutoFlow(...args: any[]): any;
 
-export interface GridAutoColumnsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridAutoColumnsProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-columns CSS property specifies the size of an implicitly-created grid column track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
      */
-    gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<TLength>, TBreakpoinAlias>;
+    gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridAutoColumns(...args: any[]): any;
 
-export interface GridAutoRowsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridAutoRowsProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-rows CSS property specifies the size of an implicitly-created grid row track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)
      */
-    gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<TLength>, TBreakpoinAlias>;
+    gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridAutoRows(...args: any[]): any;
 
-export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-columns CSS property defines the line names and track sizing functions of the grid columns.
      *
@@ -640,35 +644,35 @@ export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem, TBreak
      */
     gridTemplateColumns?: ResponsiveValue<
         CSS.GridTemplateColumnsProperty<TLength>,
-        TBreakpoinAlias
+        TBreakpointAlias
     >;
 }
 
 export function gridTemplateColumns(...args: any[]): any;
 
-export interface GridTemplatesRowsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridTemplatesRowsProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-rows CSS property defines the line names and track sizing functions of the grid rows.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-template-rows)
      */
-    gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<TLength>, TBreakpoinAlias>;
+    gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<TLength>, TBreakpointAlias>;
 }
 
 export function gridTemplateRows(...args: any[]): any;
 
-export interface GridTemplatesAreasProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridTemplatesAreasProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-areas CSS property specifies named grid areas.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)
      */
-    gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty, TBreakpoinAlias>;
+    gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty, TBreakpointAlias>;
 }
 
 export function gridTemplateAreas(...args: any[]): any;
 
-export interface GridAreaProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface GridAreaProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-area CSS property is a shorthand property for grid-row-start, grid-column-start, grid-row-end
      * and grid-column-end, specifying a grid item’s size and location within the grid row by contributing a line,
@@ -676,7 +680,7 @@ export interface GridAreaProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TL
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
      */
-    gridArea?: ResponsiveValue<CSS.GridAreaProperty, TBreakpoinAlias>;
+    gridArea?: ResponsiveValue<CSS.GridAreaProperty, TBreakpointAlias>;
 }
 
 export function gridArea(...args: any[]): any;
@@ -685,98 +689,98 @@ export function gridArea(...args: any[]): any;
  * Borders
  */
 
-export interface BorderProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border CSS property sets an element's border. It's a shorthand for border-width, border-style,
      * and border-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
      */
-    border?: ResponsiveValue<CSS.BorderProperty<TLength>, TBreakpoinAlias>;
+    border?: ResponsiveValue<CSS.BorderProperty<TLength>, TBreakpointAlias>;
 }
 
 export function border(...args: any[]): any;
 
-export interface BorderTopProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderTopProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-top CSS property is a shorthand that sets the values of border-top-width, border-top-style,
      * and border-top-color. These properties describe an element's top border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
      */
-    borderTop?: ResponsiveValue<CSS.BorderTopProperty<TLength>, TBreakpoinAlias>;
+    borderTop?: ResponsiveValue<CSS.BorderTopProperty<TLength>, TBreakpointAlias>;
 }
 
 export function borderTop(...args: any[]): any;
 
-export interface BorderRightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderRightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-right CSS property is a shorthand that sets border-right-width, border-right-style,
      * and border-right-color. These properties set an element's right border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
      */
-    borderRight?: ResponsiveValue<CSS.BorderRightProperty<TLength>, TBreakpoinAlias>;
+    borderRight?: ResponsiveValue<CSS.BorderRightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function borderRight(...args: any[]): any;
 
-export interface BorderBottomProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderBottomProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-bottom CSS property sets an element's bottom border. It's a shorthand for
      * border-bottom-width, border-bottom-style and border-bottom-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
      */
-    borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<TLength>, TBreakpoinAlias>;
+    borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<TLength>, TBreakpointAlias>;
 }
 
 export function borderBottom(...args: any[]): any;
 
-export interface BorderLeftProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderLeftProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-left CSS property is a shorthand that sets the values of border-left-width,
      * border-left-style, and border-left-color. These properties describe an element's left border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
      */
-    borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<TLength>, TBreakpoinAlias>;
+    borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<TLength>, TBreakpointAlias>;
 }
 
 export function borderLeft(...args: any[]): any;
 
-export interface BordersProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>>
-    extends BorderTopProps<TLength, TBreakpoinAlias>,
-        BorderRightProps<TLength, TBreakpoinAlias>,
-        BorderBottomProps<TLength, TBreakpoinAlias>,
-        BorderLeftProps<TLength, TBreakpoinAlias> {}
+export interface BordersProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>>
+    extends BorderTopProps<TLength, TBreakpointAlias>,
+        BorderRightProps<TLength, TBreakpointAlias>,
+        BorderBottomProps<TLength, TBreakpointAlias>,
+        BorderLeftProps<TLength, TBreakpointAlias> {}
 
 export function borders(...args: any[]): any;
 
-export interface BorderColorProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderColorProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-color shorthand CSS property sets the color of all sides of an element's border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
      */
-    borderColor?: ResponsiveValue<CSS.BorderColorProperty, TBreakpoinAlias>;
+    borderColor?: ResponsiveValue<CSS.BorderColorProperty, TBreakpointAlias>;
 }
 
 export function borderColor(...args: any[]): any;
 
-export interface BorderRadiusProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BorderRadiusProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-radius CSS property rounds the corners of an element's outer border edge. You can set a single
      * radius to make circular corners, or two radii to make elliptical corners.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
      */
-    borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<TLength>, TBreakpoinAlias>;
+    borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<TLength>, TBreakpointAlias>;
 }
 
 export function borderRadius(...args: any[]): any;
 
-export interface BoxShadowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BoxShadowProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The box-shadow CSS property adds shadow effects around an element's frame. You can set multiple effects
      * separated by commas. A box shadow is described by X and Y offsets relative to the element, blur and spread
@@ -784,31 +788,31 @@ export interface BoxShadowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<T
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)
      */
-    boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number, TBreakpoinAlias>;
+    boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number, TBreakpointAlias>;
 }
 
 export function boxShadow(...arg: any[]): any;
 
-export interface OpacityProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface OpacityProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The opacity CSS property sets the transparency of an element or the degree to which content
      * behind an element is visible.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity)
      */
-    opacity?: ResponsiveValue<CSS.GlobalsNumber, TBreakpoinAlias>;
+    opacity?: ResponsiveValue<CSS.GlobalsNumber, TBreakpointAlias>;
 }
 
 export function opacity(...arg: any[]): any;
 
-export interface OverflowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface OverflowProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The overflow CSS property sets what to do when an element's content is too big to fit in its block
      * formatting context. It is a shorthand for overflow-x and overflow-y.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
      */
-    overflow?: ResponsiveValue<CSS.OverflowProperty, TBreakpoinAlias>;
+    overflow?: ResponsiveValue<CSS.OverflowProperty, TBreakpointAlias>;
 }
 
 export function overflow(...arg: any[]): any;
@@ -816,42 +820,42 @@ export function overflow(...arg: any[]): any;
  * Background
  */
 
-export interface BackgroundProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BackgroundProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background shorthand CSS property sets all background style properties at once,
      * such as color, image, origin and size, repeat method, and others.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
      */
-    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpoinAlias>;
+    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpointAlias>;
 }
 
 export function background(...args: any[]): any;
 
-export interface BackgroundImageProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BackgroundImageProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-image CSS property sets one or more background images on an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image)
      */
-    backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty, TBreakpoinAlias>;
+    backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty, TBreakpointAlias>;
 }
 
 export function backgroundImage(...args: any[]): any;
 
-export interface BackgroundSizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BackgroundSizeProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-size CSS property sets the size of the element's background image. The
      * image can be left to its natural size, stretched, or constrained to fit the available space.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size)
      */
-    backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<TLength>, TBreakpoinAlias>;
+    backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<TLength>, TBreakpointAlias>;
 }
 
 export function backgroundSize(...args: any[]): any;
 
-export interface BackgroundPositionProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BackgroundPositionProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-position CSS property sets the initial position for each background image. The
      * position is relative to the position layer set by background-origin.
@@ -860,20 +864,20 @@ export interface BackgroundPositionProps<TLength = TLengthStyledSystem, TBreakpo
      */
     backgroundPosition?: ResponsiveValue<
         CSS.BackgroundPositionProperty<TLength>,
-        TBreakpoinAlias
+        TBreakpointAlias
     >;
 }
 
 export function backgroundPosition(...args: any[]): any;
 
-export interface BackgroundRepeatProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BackgroundRepeatProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-repeat CSS property sets how background images are repeated. A background
      * image can be repeated along the horizontal and vertical axes, or not repeated at all.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
      */
-    backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty, TBreakpoinAlias>;
+    backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty, TBreakpointAlias>;
 }
 
 export function backgroundRepeat(...args: any[]): any;
@@ -882,97 +886,97 @@ export function backgroundRepeat(...args: any[]): any;
  * Position
  */
 
-export interface PositionProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface PositionProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The position CSS property specifies how an element is positioned in a document.
      * The top, right, bottom, and left properties determine the final location of positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
      */
-    position?: ResponsiveValue<CSS.PositionProperty, TBreakpoinAlias>;
+    position?: ResponsiveValue<CSS.PositionProperty, TBreakpointAlias>;
 }
 
 export function position(...args: any[]): any;
 
-export interface ZIndexProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface ZIndexProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The z-index CSS property sets the z-order of a positioned element and its descendants or
      * flex items. Overlapping elements with a larger z-index cover those with a smaller one.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
      */
-    zIndex?: ResponsiveValue<CSS.ZIndexProperty, TBreakpoinAlias>;
+    zIndex?: ResponsiveValue<CSS.ZIndexProperty, TBreakpointAlias>;
 }
 
 export function zIndex(...args: any[]): any;
 
-export interface TopProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface TopProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The top CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    top?: ResponsiveValue<CSS.TopProperty<TLength>, TBreakpoinAlias>;
+    top?: ResponsiveValue<CSS.TopProperty<TLength>, TBreakpointAlias>;
 }
 
 export function top(...args: any[]): any;
 
-export interface RightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface RightProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The right CSS property participates in specifying the horizontal position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/right)
      */
-    right?: ResponsiveValue<CSS.RightProperty<TLength>, TBreakpoinAlias>;
+    right?: ResponsiveValue<CSS.RightProperty<TLength>, TBreakpointAlias>;
 }
 
 export function right(...args: any[]): any;
 
-export interface BottomProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface BottomProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The bottom CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    bottom?: ResponsiveValue<CSS.BottomProperty<TLength>, TBreakpoinAlias>;
+    bottom?: ResponsiveValue<CSS.BottomProperty<TLength>, TBreakpointAlias>;
 }
 
 export function bottom(...args: any[]): any;
 
-export interface LeftProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface LeftProps<TLength = TLengthStyledSystem, TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The left CSS property participates in specifying the horizontal position
      * of a positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/left)
      */
-    left?: ResponsiveValue<CSS.LeftProperty<TLength>, TBreakpoinAlias>;
+    left?: ResponsiveValue<CSS.LeftProperty<TLength>, TBreakpointAlias>;
 }
 
 export function left(...args: any[]): any;
 
-export interface TextStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    textStyle?: ResponsiveValue<string, TBreakpoinAlias>;
+export interface TextStyleProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    textStyle?: ResponsiveValue<string, TBreakpointAlias>;
 }
 
 export function textStyle(...args: any[]): any;
 
-export interface ColorStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    colors?: ResponsiveValue<string, TBreakpoinAlias>;
+export interface ColorStyleProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    colors?: ResponsiveValue<string, TBreakpointAlias>;
 }
 
 export function colorStyle(...args: any[]): any;
 
-export interface ButtonStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
-    variant?: ResponsiveValue<string, TBreakpoinAlias>;
+export interface ButtonStyleProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    variant?: ResponsiveValue<string, TBreakpointAlias>;
 }
 
 export function buttonStyle(...args: any[]): any;
 
-export interface MixedProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface MixedProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     key?: any;
     // Defaults to "variant"
     prop?: string;
@@ -980,7 +984,7 @@ export interface MixedProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLeng
 
 export function mixed(...args: any[]): any;
 
-export interface StylesProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+export interface StylesProps<TBreakpointAlias = BreakpointAliasStyledSystem<TLengthStyledSystem>> {
     space: typeof space;
     width: typeof width;
     fontSize: typeof fontSize;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-system 3.2
+// Type definitions for styled-system 3.3
 // Project: https://github.com/jxnblk/styled-system#readme
 // Definitions by: Marshall Bowers <https://github.com/maxdeviant>
 //                 Ben McCormick <https://github.com/phobon>
@@ -11,6 +11,7 @@
 //                 Adam Misiorny <https://github.com/adam187>
 //                 Sara F-P <https://github.com/gretzky>
 //                 Chris LoPresto <https://github.com/chrislopresto>
+//                 Kevin Tran <https://github.com/ktranada>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -47,8 +47,9 @@ export function style(
     args: LowLevelStylefunctionArguments
 ): { [cssProp: string]: string };
 
+export type TBreakpointAliasStyledSystem<T> = { [key: string]: T };
 export type TLengthStyledSystem = string | 0 | number;
-export type ResponsiveValue<T> = T | Array<T | null> | { [key: string]: T };
+export type ResponsiveValue<T, B> = T | Array<T | null> | B;
 
 /**
  * Converts shorthand margin and padding props to margin and padding CSS declarations
@@ -60,35 +61,35 @@ export type ResponsiveValue<T> = T | Array<T | null> | { [key: string]: T };
  * - Array values are converted into responsive values.
  */
 
-export interface SpaceProps<TLength = TLengthStyledSystem> {
+export interface SpaceProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /** Margin on top, left, bottom and right */
-    m?: ResponsiveValue<CSS.MarginProperty<TLength>>;
+    m?: ResponsiveValue<CSS.MarginProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the top */
-    mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>>;
+    mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the right */
-    mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>>;
+    mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the bottom */
-    mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>>;
+    mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the left */
-    ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>>;
+    ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the left and right */
-    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
     /** Margin for the top and bottom */
-    my?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    my?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
     /** Padding on top, left, bottom and right */
-    p?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    p?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the top */
-    pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>>;
+    pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the right */
-    pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>>;
+    pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the bottom */
-    pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>>;
+    pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the left */
-    pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>>;
+    pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the left and right */
-    px?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    px?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
     /** Padding for the top and bottom */
-    py?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    py?: ResponsiveValue<CSS.PaddingProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function space(...args: any[]): any;
@@ -133,7 +134,7 @@ export interface Theme extends BaseTheme {
  * Font Size
  */
 
-export interface FontSizeProps<TLength = TLengthStyledSystem> {
+export interface FontSizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The fontSize utility parses a component's `fontSize` prop and converts it into a CSS font-size declaration.
      *
@@ -143,7 +144,7 @@ export interface FontSizeProps<TLength = TLengthStyledSystem> {
      * - And array values are converted into responsive values.
      *
      */
-    fontSize?: ResponsiveValue<CSS.FontSizeProperty<TLength>>;
+    fontSize?: ResponsiveValue<CSS.FontSizeProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function fontSize(...args: any[]): any;
@@ -152,7 +153,7 @@ export function fontSize(...args: any[]): any;
  * Color
  */
 
-export interface TextColorProps {
+export interface TextColorProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The color utility parses a component's `color` and `bg` props and converts them into CSS declarations.
      * By default the raw value of the prop is returned.
@@ -162,12 +163,12 @@ export interface TextColorProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
      */
-    color?: ResponsiveValue<CSS.ColorProperty>;
+    color?: ResponsiveValue<CSS.ColorProperty, TBreakpoinAlias>;
 }
 
 export function textColor(...args: any[]): any;
 
-export interface BgColorProps<TLength = TLengthStyledSystem> {
+export interface BgColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The color utility parses a component's `color` and `bg` props and converts them into CSS declarations.
      * By default the raw value of the prop is returned.
@@ -177,7 +178,7 @@ export interface BgColorProps<TLength = TLengthStyledSystem> {
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color)
      */
-    bg?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
+    bg?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function bgColor(...args: any[]): any;
@@ -189,23 +190,23 @@ export function color(...args: any[]): any;
 /**
  * Typography
  */
-export interface FontFamilyProps {
-    fontFamily?: ResponsiveValue<CSS.FontFamilyProperty>;
+export interface FontFamilyProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    fontFamily?: ResponsiveValue<CSS.FontFamilyProperty, TBreakpoinAlias>;
 }
 export function fontFamily(...args: any[]): any;
 
-export interface TextAlignProps {
+export interface TextAlignProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The text-align CSS property specifies the horizontal alignment of an inline or table-cell box.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
      */
-    textAlign?: ResponsiveValue<CSS.TextAlignProperty>;
+    textAlign?: ResponsiveValue<CSS.TextAlignProperty, TBreakpoinAlias>;
 }
 
 export function textAlign(...args: any[]): any;
 
-export interface LineHeightProps<TLength = TLengthStyledSystem> {
+export interface LineHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The line-height CSS property sets the amount of space used for lines, such as in text. On block-level elements,
      * it specifies the minimum height of line boxes within the element.
@@ -214,11 +215,11 @@ export interface LineHeightProps<TLength = TLengthStyledSystem> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height)
      */
-    lineHeight?: ResponsiveValue<CSS.LineHeightProperty<TLength>>;
+    lineHeight?: ResponsiveValue<CSS.LineHeightProperty<TLength>, TBreakpoinAlias>;
 }
 export function lineHeight(...args: any[]): any;
 
-export interface FontWeightProps {
+export interface FontWeightProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The font-weight CSS property specifies the weight (or boldness) of the font.
      *
@@ -226,29 +227,29 @@ export interface FontWeightProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
      */
-    fontWeight?: ResponsiveValue<CSS.FontWeightProperty>;
+    fontWeight?: ResponsiveValue<CSS.FontWeightProperty, TBreakpoinAlias>;
 }
 
 export function fontWeight(...args: any[]): any;
 
-export interface FontStyleProps {
+export interface FontStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The font-style CSS property specifies whether a font should be styled with a normal, italic,
      * or oblique face from its font-family.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
      */
-    fontStyle?: ResponsiveValue<CSS.FontStyleProperty>;
+    fontStyle?: ResponsiveValue<CSS.FontStyleProperty, TBreakpoinAlias>;
 }
 export function fontStyle(...args: any[]): any;
 
-export interface LetterSpacingProps<TLength = TLengthStyledSystem> {
+export interface LetterSpacingProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The letter-spacing CSS property sets the spacing behavior between text characters.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing)
      */
-    letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>>;
+    letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>, TBreakpoinAlias>;
 }
 export function letterSpacing(...args: any[]): any;
 
@@ -256,7 +257,7 @@ export function letterSpacing(...args: any[]): any;
  * Layout
  */
 
-export interface DisplayProps {
+export interface DisplayProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The display CSS property defines the display type of an element, which consists of the two basic qualities
      * of how an element generates boxes — the outer display type defining how the box participates in flow layout,
@@ -264,36 +265,36 @@ export interface DisplayProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    display?: ResponsiveValue<CSS.DisplayProperty>;
+    display?: ResponsiveValue<CSS.DisplayProperty, TBreakpoinAlias>;
 }
 
 export function display(...args: any[]): any;
 
-export interface MaxWidthProps<TLength = TLengthStyledSystem> {
+export interface MaxWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The max-width CSS property sets the maximum width of an element.
      * It prevents the used value of the width property from becoming larger than the value specified by max-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width)
      */
-    maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<TLength>>;
+    maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function maxWidth(...args: any[]): any;
 
-export interface MinWidthProps<TLength = TLengthStyledSystem> {
+export interface MinWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The min-width CSS property sets the minimum width of an element.
      * It prevents the used value of the width property from becoming smaller than the value specified for min-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
      */
-    minWidth?: ResponsiveValue<CSS.MinWidthProperty<TLength>>;
+    minWidth?: ResponsiveValue<CSS.MinWidthProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function minWidth(...args: any[]): any;
 
-export interface WidthProps<TLength = TLengthStyledSystem> {
+export interface WidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      *   The width utility parses a component's `width` prop and converts it into a CSS width declaration.
      *
@@ -302,57 +303,57 @@ export interface WidthProps<TLength = TLengthStyledSystem> {
      *   - String values are passed as raw CSS values.
      *   - And arrays are converted to responsive width styles.
      */
-    width?: ResponsiveValue<CSS.WidthProperty<TLength>>;
+    width?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function width(...args: any[]): any;
 
-export interface MaxHeightProps<TLength = TLengthStyledSystem> {
+export interface MaxHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The max-height CSS property sets the maximum height of an element. It prevents the used value of the height
      * property from becoming larger than the value specified for max-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height)
      */
-    maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<TLength>>;
+    maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function maxHeight(...args: any[]): any;
 
-export interface MinHeightProps<TLength = TLengthStyledSystem> {
+export interface MinHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The min-height CSS property sets the minimum height of an element. It prevents the used value of the height
      * property from becoming smaller than the value specified for min-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    minHeight?: ResponsiveValue<CSS.MinHeightProperty<TLength>>;
+    minHeight?: ResponsiveValue<CSS.MinHeightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function minHeight(...args: any[]): any;
 
-export interface HeightProps<TLength = TLengthStyledSystem> {
+export interface HeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The height CSS property specifies the height of an element. By default, the property defines the height of the
      * content area. If box-sizing is set to border-box, however, it instead determines the height of the border area.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/height)
      */
-    height?: ResponsiveValue<CSS.HeightProperty<TLength>>;
+    height?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function height(...args: any[]): any;
 
 // TODO: Document, I couldn't find any info on these two properties...
 
-export interface SizeWidthProps<TLength = TLengthStyledSystem> {
-    size?: ResponsiveValue<CSS.WidthProperty<TLength>>;
+export interface SizeWidthProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    size?: ResponsiveValue<CSS.WidthProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function sizeWidth(...args: any[]): any;
 
-export interface SizeHeightProps<TLength = TLengthStyledSystem> {
-    size?: ResponsiveValue<CSS.HeightProperty<TLength>>;
+export interface SizeHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    size?: ResponsiveValue<CSS.HeightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function sizeHeight(...args: any[]): any;
@@ -361,28 +362,28 @@ export interface SizeProps extends SizeHeightProps, SizeWidthProps {}
 
 export function size(...args: any[]): any;
 
-export interface RatioPaddingProps<TLength = TLengthStyledSystem> {
-    ratio?: ResponsiveValue<number>;
+export interface RatioPaddingProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    ratio?: ResponsiveValue<number, TBreakpoinAlias>;
 }
 
 export function ratioPadding(...args: any[]): any;
 
-export interface RatioProps {
+export interface RatioProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The ration is height: 0 & paddingBottom
      */
-    ratio?: ResponsiveValue<number>;
+    ratio?: ResponsiveValue<number, TBreakpoinAlias>;
 }
 
 export function ratio(...args: any[]): any;
 
-export interface VerticalAlignProps<TLength = TLengthStyledSystem> {
+export interface VerticalAlignProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The vertical-align CSS property specifies sets vertical alignment of an inline or table-cell box.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
      */
-    verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<TLength>>;
+    verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function verticalAlign(...args: any[]): any;
@@ -391,7 +392,7 @@ export function verticalAlign(...args: any[]): any;
  * Flexbox
  */
 
-export interface AlignItemsProps {
+export interface AlignItemsProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS align-items property sets the align-self value on all direct children as a group. The align-self
      * property sets the alignment of an item within its containing block.
@@ -401,106 +402,106 @@ export interface AlignItemsProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
      */
-    alignItems?: ResponsiveValue<CSS.AlignItemsProperty>;
+    alignItems?: ResponsiveValue<CSS.AlignItemsProperty, TBreakpoinAlias>;
 }
 
 export function alignItems(...args: any[]): any;
 
-export interface AlignContentProps {
+export interface AlignContentProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS align-content property sets how the browser distributes space between and around content items
      * along the cross-axis of a flexbox container, and the main-axis of a grid container.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)
      */
-    alignContent?: ResponsiveValue<CSS.AlignContentProperty>;
+    alignContent?: ResponsiveValue<CSS.AlignContentProperty, TBreakpoinAlias>;
 }
 
 export function alignContent(...args: any[]): any;
 
-export interface JustifyItemsProps {
+export interface JustifyItemsProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-items property defines the default justify-self for all items of the box, giving them all
      * a default way of justifying each box along the appropriate axis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
      */
-    justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty>;
+    justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty, TBreakpoinAlias>;
 }
 
 export function justifyItems(...args: any[]): any;
 
-export interface JustifyContentProps {
+export interface JustifyContentProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-content property defines how the browser distributes space between and around content items
      * along the main-axis of a flex container, and the inline axis of a grid container.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
      */
-    justifyContent?: ResponsiveValue<CSS.JustifyContentProperty>;
+    justifyContent?: ResponsiveValue<CSS.JustifyContentProperty, TBreakpoinAlias>;
 }
 
 export function justifyContent(...args: any[]): any;
 
-export interface FlexWrapProps {
+export interface FlexWrapProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex-wrap CSS property sets whether flex items are forced onto one line or can wrap onto multiple lines.
      * If wrapping is allowed, it sets the direction that lines are stacked.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap)
      */
-    flexWrap?: ResponsiveValue<CSS.FlexWrapProperty>;
+    flexWrap?: ResponsiveValue<CSS.FlexWrapProperty, TBreakpoinAlias>;
 }
 
 export function flexWrap(...args: any[]): any;
 
-export interface FlexBasisProps<TLength = TLengthStyledSystem> {
+export interface FlexBasisProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     // TODO: The FlexBasisValue currently really only exists for documentation
     //       purposes, because flex-basis also accepts `Nem` and `Npx` strings.
     //       Not sure there’s a way to still have the union values show up as
     //       auto-completion results.
-    flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>>;
+    flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function flexBasis(...args: any[]): any;
 
-export interface FlexDirectionProps {
+export interface FlexDirectionProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex-direction CSS property specifies how flex items are placed in the flex container defining the main
      * axis and the direction (normal or reversed).
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction)
      */
-    flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty>;
+    flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty, TBreakpoinAlias>;
 }
 
 export function flexDirection(...args: any[]): any;
 
-export interface FlexProps<TLength = TLengthStyledSystem> {
+export interface FlexProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The flex CSS property specifies how a flex item will grow or shrink so as to fit the space available in
      * its flex container. This is a shorthand property that sets flex-grow, flex-shrink, and flex-basis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex)
      */
-    flex?: ResponsiveValue<CSS.FlexProperty<TLength>>;
+    flex?: ResponsiveValue<CSS.FlexProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function flex(...args: any[]): any;
 
-export interface JustifySelfProps {
+export interface JustifySelfProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The CSS justify-self property set the way a box is justified inside its alignment container along
      * the appropriate axis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)
      */
-    justifySelf?: ResponsiveValue<CSS.JustifySelfProperty>;
+    justifySelf?: ResponsiveValue<CSS.JustifySelfProperty, TBreakpoinAlias>;
 }
 
 export function justifySelf(...args: any[]): any;
 
-export interface AlignSelfProps {
+export interface AlignSelfProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The align-self CSS property aligns flex items of the current flex line overriding the align-items value.
      *
@@ -509,19 +510,19 @@ export interface AlignSelfProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
      */
-    alignSelf?: ResponsiveValue<CSS.AlignSelfProperty>;
+    alignSelf?: ResponsiveValue<CSS.AlignSelfProperty, TBreakpoinAlias>;
 }
 
 export function alignSelf(...args: any[]): any;
 
-export interface OrderProps {
+export interface OrderProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The order CSS property sets the order to lay out an item in a flex or grid container. Items in a container
      * are sorted by ascending order value and then by their source code order.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/order)
      */
-    order?: ResponsiveValue<CSS.GlobalsNumber>;
+    order?: ResponsiveValue<CSS.GlobalsNumber, TBreakpoinAlias>;
 }
 
 export function order(...args: any[]): any;
@@ -530,7 +531,7 @@ export function order(...args: any[]): any;
  * Grid Layout
  */
 
-export interface GridGapProps<TLength = TLengthStyledSystem> {
+export interface GridGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap
      * and column-gap.
@@ -539,12 +540,12 @@ export interface GridGapProps<TLength = TLengthStyledSystem> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
      */
-    gridGap?: ResponsiveValue<CSS.GridGapProperty<TLength>>;
+    gridGap?: ResponsiveValue<CSS.GridGapProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridGap(...args: any[]): any;
 
-export interface GridColumnGapProps<TLength = TLengthStyledSystem> {
+export interface GridColumnGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The column-gap CSS property sets the size of the gap (gutter) between an element's columns.
      *
@@ -552,12 +553,12 @@ export interface GridColumnGapProps<TLength = TLengthStyledSystem> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap)
      */
-    gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<TLength>>;
+    gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridColumnGap(...args: any[]): any;
 
-export interface GridRowGapProps<TLength = TLengthStyledSystem> {
+export interface GridRowGapProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The row-gap CSS property sets the size of the gap (gutter) between an element's rows.
      *
@@ -565,12 +566,12 @@ export interface GridRowGapProps<TLength = TLengthStyledSystem> {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap)
      */
-    gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<TLength>>;
+    gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridRowGap(...args: any[]): any;
 
-export interface GridColumnProps {
+export interface GridColumnProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-column CSS property is a shorthand property for grid-column-start and grid-column-end specifying
      * a grid item's size and location within the grid column by contributing a line, a span, or nothing (automatic)
@@ -578,12 +579,12 @@ export interface GridColumnProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column)
      */
-    gridColumn?: ResponsiveValue<CSS.GridColumnProperty>;
+    gridColumn?: ResponsiveValue<CSS.GridColumnProperty, TBreakpoinAlias>;
 }
 
 export function gridColumn(...args: any[]): any;
 
-export interface GridRowProps {
+export interface GridRowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-row CSS property is a shorthand property for grid-row-start and grid-row-end specifying a grid item’s
      * size and location within the grid row by contributing a line, a span, or nothing (automatic) to its grid
@@ -591,81 +592,82 @@ export interface GridRowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row)
      */
-    gridRow?: ResponsiveValue<CSS.GridRowProperty>;
+    gridRow?: ResponsiveValue<CSS.GridRowProperty, TBreakpoinAlias>;
 }
 
 export function gridRow(...args: any[]): any;
 
-export interface GridAutoFlowProps {
+export interface GridAutoFlowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-flow CSS property controls how the auto-placement algorithm works, specifying exactly
      * how auto-placed items get flowed into the grid.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
      */
-    gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty>;
+    gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty, TBreakpoinAlias>;
 }
 
 export function gridAutoFlow(...args: any[]): any;
 
-export interface GridAutoColumnsProps<TLength = TLengthStyledSystem> {
+export interface GridAutoColumnsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-columns CSS property specifies the size of an implicitly-created grid column track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
      */
-    gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<TLength>>;
+    gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridAutoColumns(...args: any[]): any;
 
-export interface GridAutoRowsProps<TLength = TLengthStyledSystem> {
+export interface GridAutoRowsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-auto-rows CSS property specifies the size of an implicitly-created grid row track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)
      */
-    gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<TLength>>;
+    gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridAutoRows(...args: any[]): any;
 
-export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem> {
+export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-columns CSS property defines the line names and track sizing functions of the grid columns.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
      */
     gridTemplateColumns?: ResponsiveValue<
-        CSS.GridTemplateColumnsProperty<TLength>
+        CSS.GridTemplateColumnsProperty<TLength>,
+        TBreakpoinAlias
     >;
 }
 
 export function gridTemplateColumns(...args: any[]): any;
 
-export interface GridTemplatesRowsProps<TLength = TLengthStyledSystem> {
+export interface GridTemplatesRowsProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-rows CSS property defines the line names and track sizing functions of the grid rows.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-template-rows)
      */
-    gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<TLength>>;
+    gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function gridTemplateRows(...args: any[]): any;
 
-export interface GridTemplatesAreasProps {
+export interface GridTemplatesAreasProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-template-areas CSS property specifies named grid areas.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)
      */
-    gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty>;
+    gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty, TBreakpoinAlias>;
 }
 
 export function gridTemplateAreas(...args: any[]): any;
 
-export interface GridAreaProps {
+export interface GridAreaProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The grid-area CSS property is a shorthand property for grid-row-start, grid-column-start, grid-row-end
      * and grid-column-end, specifying a grid item’s size and location within the grid row by contributing a line,
@@ -673,7 +675,7 @@ export interface GridAreaProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
      */
-    gridArea?: ResponsiveValue<CSS.GridAreaProperty>;
+    gridArea?: ResponsiveValue<CSS.GridAreaProperty, TBreakpoinAlias>;
 }
 
 export function gridArea(...args: any[]): any;
@@ -682,62 +684,62 @@ export function gridArea(...args: any[]): any;
  * Borders
  */
 
-export interface BorderProps<TLength = TLengthStyledSystem> {
+export interface BorderProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border CSS property sets an element's border. It's a shorthand for border-width, border-style,
      * and border-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
      */
-    border?: ResponsiveValue<CSS.BorderProperty<TLength>>;
+    border?: ResponsiveValue<CSS.BorderProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function border(...args: any[]): any;
 
-export interface BorderTopProps<TLength = TLengthStyledSystem> {
+export interface BorderTopProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-top CSS property is a shorthand that sets the values of border-top-width, border-top-style,
      * and border-top-color. These properties describe an element's top border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
      */
-    borderTop?: ResponsiveValue<CSS.BorderTopProperty<TLength>>;
+    borderTop?: ResponsiveValue<CSS.BorderTopProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function borderTop(...args: any[]): any;
 
-export interface BorderRightProps<TLength = TLengthStyledSystem> {
+export interface BorderRightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-right CSS property is a shorthand that sets border-right-width, border-right-style,
      * and border-right-color. These properties set an element's right border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
      */
-    borderRight?: ResponsiveValue<CSS.BorderRightProperty<TLength>>;
+    borderRight?: ResponsiveValue<CSS.BorderRightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function borderRight(...args: any[]): any;
 
-export interface BorderBottomProps<TLength = TLengthStyledSystem> {
+export interface BorderBottomProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-bottom CSS property sets an element's bottom border. It's a shorthand for
      * border-bottom-width, border-bottom-style and border-bottom-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
      */
-    borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<TLength>>;
+    borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function borderBottom(...args: any[]): any;
 
-export interface BorderLeftProps<TLength = TLengthStyledSystem> {
+export interface BorderLeftProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-left CSS property is a shorthand that sets the values of border-left-width,
      * border-left-style, and border-left-color. These properties describe an element's left border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
      */
-    borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<TLength>>;
+    borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function borderLeft(...args: any[]): any;
@@ -750,30 +752,30 @@ export interface BordersProps
 
 export function borders(...args: any[]): any;
 
-export interface BorderColorProps {
+export interface BorderColorProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-color shorthand CSS property sets the color of all sides of an element's border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
      */
-    borderColor?: ResponsiveValue<CSS.BorderColorProperty>;
+    borderColor?: ResponsiveValue<CSS.BorderColorProperty, TBreakpoinAlias>;
 }
 
 export function borderColor(...args: any[]): any;
 
-export interface BorderRadiusProps<TLength = TLengthStyledSystem> {
+export interface BorderRadiusProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The border-radius CSS property rounds the corners of an element's outer border edge. You can set a single
      * radius to make circular corners, or two radii to make elliptical corners.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
      */
-    borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<TLength>>;
+    borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function borderRadius(...args: any[]): any;
 
-export interface BoxShadowProps {
+export interface BoxShadowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The box-shadow CSS property adds shadow effects around an element's frame. You can set multiple effects
      * separated by commas. A box shadow is described by X and Y offsets relative to the element, blur and spread
@@ -781,31 +783,31 @@ export interface BoxShadowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)
      */
-    boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number>;
+    boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number, TBreakpoinAlias>;
 }
 
 export function boxShadow(...arg: any[]): any;
 
-export interface OpacityProps {
+export interface OpacityProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The opacity CSS property sets the transparency of an element or the degree to which content
      * behind an element is visible.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity)
      */
-    opacity?: ResponsiveValue<CSS.GlobalsNumber>;
+    opacity?: ResponsiveValue<CSS.GlobalsNumber, TBreakpoinAlias>;
 }
 
 export function opacity(...arg: any[]): any;
 
-export interface OverflowProps {
+export interface OverflowProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The overflow CSS property sets what to do when an element's content is too big to fit in its block
      * formatting context. It is a shorthand for overflow-x and overflow-y.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
      */
-    overflow?: ResponsiveValue<CSS.OverflowProperty>;
+    overflow?: ResponsiveValue<CSS.OverflowProperty, TBreakpoinAlias>;
 }
 
 export function overflow(...arg: any[]): any;
@@ -813,42 +815,42 @@ export function overflow(...arg: any[]): any;
  * Background
  */
 
-export interface BackgroundProps<TLength = TLengthStyledSystem> {
+export interface BackgroundProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background shorthand CSS property sets all background style properties at once,
      * such as color, image, origin and size, repeat method, and others.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
      */
-    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
+    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function background(...args: any[]): any;
 
-export interface BackgroundImageProps {
+export interface BackgroundImageProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-image CSS property sets one or more background images on an element.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image)
      */
-    backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty>;
+    backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty, TBreakpoinAlias>;
 }
 
 export function backgroundImage(...args: any[]): any;
 
-export interface BackgroundSizeProps<TLength = TLengthStyledSystem> {
+export interface BackgroundSizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-size CSS property sets the size of the element's background image. The
      * image can be left to its natural size, stretched, or constrained to fit the available space.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size)
      */
-    backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<TLength>>;
+    backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function backgroundSize(...args: any[]): any;
 
-export interface BackgroundPositionProps<TLength = TLengthStyledSystem> {
+export interface BackgroundPositionProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-position CSS property sets the initial position for each background image. The
      * position is relative to the position layer set by background-origin.
@@ -856,20 +858,21 @@ export interface BackgroundPositionProps<TLength = TLengthStyledSystem> {
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)
      */
     backgroundPosition?: ResponsiveValue<
-        CSS.BackgroundPositionProperty<TLength>
+        CSS.BackgroundPositionProperty<TLength>,
+        TBreakpoinAlias
     >;
 }
 
 export function backgroundPosition(...args: any[]): any;
 
-export interface BackgroundRepeatProps {
+export interface BackgroundRepeatProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The background-repeat CSS property sets how background images are repeated. A background
      * image can be repeated along the horizontal and vertical axes, or not repeated at all.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
      */
-    backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty>;
+    backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty, TBreakpoinAlias>;
 }
 
 export function backgroundRepeat(...args: any[]): any;
@@ -878,97 +881,97 @@ export function backgroundRepeat(...args: any[]): any;
  * Position
  */
 
-export interface PositionProps {
+export interface PositionProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The position CSS property specifies how an element is positioned in a document.
      * The top, right, bottom, and left properties determine the final location of positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
      */
-    position?: ResponsiveValue<CSS.PositionProperty>;
+    position?: ResponsiveValue<CSS.PositionProperty, TBreakpoinAlias>;
 }
 
 export function position(...args: any[]): any;
 
-export interface ZIndexProps {
+export interface ZIndexProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The z-index CSS property sets the z-order of a positioned element and its descendants or
      * flex items. Overlapping elements with a larger z-index cover those with a smaller one.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
      */
-    zIndex?: ResponsiveValue<CSS.ZIndexProperty>;
+    zIndex?: ResponsiveValue<CSS.ZIndexProperty, TBreakpoinAlias>;
 }
 
 export function zIndex(...args: any[]): any;
 
-export interface TopProps<TLength = TLengthStyledSystem> {
+export interface TopProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The top CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    top?: ResponsiveValue<CSS.TopProperty<TLength>>;
+    top?: ResponsiveValue<CSS.TopProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function top(...args: any[]): any;
 
-export interface RightProps<TLength = TLengthStyledSystem> {
+export interface RightProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The right CSS property participates in specifying the horizontal position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/right)
      */
-    right?: ResponsiveValue<CSS.RightProperty<TLength>>;
+    right?: ResponsiveValue<CSS.RightProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function right(...args: any[]): any;
 
-export interface BottomProps<TLength = TLengthStyledSystem> {
+export interface BottomProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The bottom CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    bottom?: ResponsiveValue<CSS.BottomProperty<TLength>>;
+    bottom?: ResponsiveValue<CSS.BottomProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function bottom(...args: any[]): any;
 
-export interface LeftProps<TLength = TLengthStyledSystem> {
+export interface LeftProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     /**
      * The left CSS property participates in specifying the horizontal position
      * of a positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/left)
      */
-    left?: ResponsiveValue<CSS.LeftProperty<TLength>>;
+    left?: ResponsiveValue<CSS.LeftProperty<TLength>, TBreakpoinAlias>;
 }
 
 export function left(...args: any[]): any;
 
-export interface TextStyleProps {
-    textStyle?: ResponsiveValue<string>;
+export interface TextStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    textStyle?: ResponsiveValue<string, TBreakpoinAlias>;
 }
 
 export function textStyle(...args: any[]): any;
 
-export interface ColorStyleProps {
-    colors?: ResponsiveValue<string>;
+export interface ColorStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    colors?: ResponsiveValue<string, TBreakpoinAlias>;
 }
 
 export function colorStyle(...args: any[]): any;
 
-export interface ButtonStyleProps {
-    variant?: ResponsiveValue<string>;
+export interface ButtonStyleProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
+    variant?: ResponsiveValue<string, TBreakpoinAlias>;
 }
 
 export function buttonStyle(...args: any[]): any;
 
-export interface MixedProps {
+export interface MixedProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     key?: any;
     // Defaults to "variant"
     prop?: string;
@@ -976,7 +979,7 @@ export interface MixedProps {
 
 export function mixed(...args: any[]): any;
 
-export interface StylesProps {
+export interface StylesProps<TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> {
     space: typeof space;
     width: typeof width;
     fontSize: typeof fontSize;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -183,7 +183,7 @@ export interface BgColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = T
 
 export function bgColor(...args: any[]): any;
 
-export interface ColorProps extends TextColorProps, BgColorProps {}
+export interface ColorProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> extends TextColorProps<TBreakpoinAlias>, BgColorProps<TLength, TBreakpoinAlias> {}
 
 export function color(...args: any[]): any;
 
@@ -358,7 +358,7 @@ export interface SizeHeightProps<TLength = TLengthStyledSystem, TBreakpoinAlias 
 
 export function sizeHeight(...args: any[]): any;
 
-export interface SizeProps extends SizeHeightProps, SizeWidthProps {}
+export interface SizeProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>> extends SizeHeightProps<TLength, TBreakpoinAlias>, SizeWidthProps<TLength, TBreakpoinAlias> {}
 
 export function size(...args: any[]): any;
 
@@ -744,11 +744,11 @@ export interface BorderLeftProps<TLength = TLengthStyledSystem, TBreakpoinAlias 
 
 export function borderLeft(...args: any[]): any;
 
-export interface BordersProps
-    extends BorderTopProps,
-        BorderRightProps,
-        BorderBottomProps,
-        BorderLeftProps {}
+export interface BordersProps<TLength = TLengthStyledSystem, TBreakpoinAlias = TBreakpointAliasStyledSystem<TLengthStyledSystem>>
+    extends BorderTopProps<TLength, TBreakpoinAlias>,
+        BorderRightProps<TLength, TBreakpoinAlias>,
+        BorderBottomProps<TLength, TBreakpoinAlias>,
+        BorderLeftProps<TLength, TBreakpoinAlias> {}
 
 export function borders(...args: any[]): any;
 

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -128,8 +128,7 @@ import {
     verticalAlign,
     px,
     createMediaQuery,
-    styles,
-    TLengthStyledSystem
+    styles
 } from "styled-system";
 
 // tslint:disable-next-line:strict-export-declare-modifiers
@@ -146,49 +145,43 @@ const boxStyle = variant({
     key: 'box',
 });
 
-interface BreakpointAlias {
-    sm?: TLengthStyledSystem;
-    md?: TLengthStyledSystem;
-    lg?: TLengthStyledSystem;
-}
-
-
 interface BoxProps
-    extends SpaceProps<TLengthStyledSystem, BreakpointAlias>,
-        WidthProps<TLengthStyledSystem, BreakpointAlias>,
-        FontSizeProps<TLengthStyledSystem, BreakpointAlias>,
+    extends SpaceProps,
+        WidthProps,
+        FontSizeProps,
         ColorProps,
-        DisplayProps<BreakpointAlias>,
-        BackgroundProps<TLengthStyledSystem, BreakpointAlias>,
-        MaxWidthProps<TLengthStyledSystem, BreakpointAlias>,
-        MinWidthProps<TLengthStyledSystem, BreakpointAlias>,
-        HeightProps<TLengthStyledSystem, BreakpointAlias>,
-        MaxHeightProps<TLengthStyledSystem, BreakpointAlias>,
-        MinHeightProps<TLengthStyledSystem, BreakpointAlias>,
+        DisplayProps,
+        BackgroundProps,
+        BgColorProps,
+        MaxWidthProps,
+        MinWidthProps,
+        HeightProps,
+        MaxHeightProps,
+        MinHeightProps,
         SizeProps,
-        RatioProps< BreakpointAlias>,
-        BorderColorProps< BreakpointAlias>,
-        FlexProps<TLengthStyledSystem, BreakpointAlias>,
-        JustifySelfProps<BreakpointAlias>,
-        AlignSelfProps<BreakpointAlias>,
-        BorderProps<TLengthStyledSystem, BreakpointAlias>,
+        RatioProps,
+        BorderColorProps,
+        FlexProps,
+        JustifySelfProps,
+        AlignSelfProps,
+        BorderProps,
         BordersProps,
-        BorderRadiusProps<TLengthStyledSystem, BreakpointAlias>,
-        PositionProps<BreakpointAlias>,
-        ZIndexProps<BreakpointAlias>,
-        TopProps<TLengthStyledSystem, BreakpointAlias>,
-        BottomProps<TLengthStyledSystem, BreakpointAlias>,
-        LeftProps<TLengthStyledSystem, BreakpointAlias>,
-        RightProps<TLengthStyledSystem, BreakpointAlias>,
-        BoxShadowProps<BreakpointAlias>,
-        BackgroundImageProps<BreakpointAlias>,
-        BackgroundPositionProps<TLengthStyledSystem, BreakpointAlias>,
-        BackgroundRepeatProps<BreakpointAlias>,
-        BackgroundSizeProps<TLengthStyledSystem, BreakpointAlias>,
-        ColorStyleProps<BreakpointAlias>,
-        TextStyleProps<BreakpointAlias>,
-        MixedProps<BreakpointAlias>,
-        VerticalAlignProps<TLengthStyledSystem, BreakpointAlias> {
+        BorderRadiusProps,
+        PositionProps,
+        ZIndexProps,
+        TopProps,
+        BottomProps,
+        LeftProps,
+        RightProps,
+        BoxShadowProps,
+        BackgroundImageProps,
+        BackgroundPositionProps,
+        BackgroundRepeatProps,
+        BackgroundSizeProps,
+        ColorStyleProps,
+        TextStyleProps,
+        MixedProps,
+        VerticalAlignProps {
             boxStyle?: string;
         }
 const Box: React.ComponentType<BoxProps> = styled`

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -128,7 +128,8 @@ import {
     verticalAlign,
     px,
     createMediaQuery,
-    styles
+    styles,
+    TLengthStyledSystem
 } from "styled-system";
 
 // tslint:disable-next-line:strict-export-declare-modifiers
@@ -145,43 +146,49 @@ const boxStyle = variant({
     key: 'box',
 });
 
+interface BreakpointAlias {
+    sm?: TLengthStyledSystem;
+    md?: TLengthStyledSystem;
+    lg?: TLengthStyledSystem;
+}
+
+
 interface BoxProps
-    extends SpaceProps,
-        WidthProps,
-        FontSizeProps,
+    extends SpaceProps<TLengthStyledSystem, BreakpointAlias>,
+        WidthProps<TLengthStyledSystem, BreakpointAlias>,
+        FontSizeProps<TLengthStyledSystem, BreakpointAlias>,
         ColorProps,
-        DisplayProps,
-        BackgroundProps,
-        BgColorProps,
-        MaxWidthProps,
-        MinWidthProps,
-        HeightProps,
-        MaxHeightProps,
-        MinHeightProps,
+        DisplayProps<BreakpointAlias>,
+        BackgroundProps<TLengthStyledSystem, BreakpointAlias>,
+        MaxWidthProps<TLengthStyledSystem, BreakpointAlias>,
+        MinWidthProps<TLengthStyledSystem, BreakpointAlias>,
+        HeightProps<TLengthStyledSystem, BreakpointAlias>,
+        MaxHeightProps<TLengthStyledSystem, BreakpointAlias>,
+        MinHeightProps<TLengthStyledSystem, BreakpointAlias>,
         SizeProps,
-        RatioProps,
-        BorderColorProps,
-        FlexProps,
-        JustifySelfProps,
-        AlignSelfProps,
-        BorderProps,
+        RatioProps< BreakpointAlias>,
+        BorderColorProps< BreakpointAlias>,
+        FlexProps<TLengthStyledSystem, BreakpointAlias>,
+        JustifySelfProps<BreakpointAlias>,
+        AlignSelfProps<BreakpointAlias>,
+        BorderProps<TLengthStyledSystem, BreakpointAlias>,
         BordersProps,
-        BorderRadiusProps,
-        PositionProps,
-        ZIndexProps,
-        TopProps,
-        BottomProps,
-        LeftProps,
-        RightProps,
-        BoxShadowProps,
-        BackgroundImageProps,
-        BackgroundPositionProps,
-        BackgroundRepeatProps,
-        BackgroundSizeProps,
-        ColorStyleProps,
-        TextStyleProps,
-        MixedProps,
-        VerticalAlignProps {
+        BorderRadiusProps<TLengthStyledSystem, BreakpointAlias>,
+        PositionProps<BreakpointAlias>,
+        ZIndexProps<BreakpointAlias>,
+        TopProps<TLengthStyledSystem, BreakpointAlias>,
+        BottomProps<TLengthStyledSystem, BreakpointAlias>,
+        LeftProps<TLengthStyledSystem, BreakpointAlias>,
+        RightProps<TLengthStyledSystem, BreakpointAlias>,
+        BoxShadowProps<BreakpointAlias>,
+        BackgroundImageProps<BreakpointAlias>,
+        BackgroundPositionProps<TLengthStyledSystem, BreakpointAlias>,
+        BackgroundRepeatProps<BreakpointAlias>,
+        BackgroundSizeProps<TLengthStyledSystem, BreakpointAlias>,
+        ColorStyleProps<BreakpointAlias>,
+        TextStyleProps<BreakpointAlias>,
+        MixedProps<BreakpointAlias>,
+        VerticalAlignProps<TLengthStyledSystem, BreakpointAlias> {
             boxStyle?: string;
         }
 const Box: React.ComponentType<BoxProps> = styled`


### PR DESCRIPTION
**Context**:
I am using an object to define my breakpoints.

**Issue**:
As it currently stands, `ResponsiveValue` utilizes an index signature - accepting any/all propertiets.

**Proposal**:
Update `type ResponsiveValue<T>` to take in an additional generic type variable for breakpoints, while also providing a default (string index signature) - which was previously hardcoded. In doing so, type consumers will have the ability to extend and have their breakpoint objects be strongly typed.

--- 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Defining breakpoints as an object and then passing an object to configure responsive styles](https://styled-system.com/responsive-styles#using-objects)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
