### PR TITLE
[react-jsonschema-form] fix missing `label` property

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-jsonschema-form 1.0.1
+// Type definitions for react-jsonschema-form 1.3
 // Project: https://github.com/mozilla-services/react-jsonschema-form
 // Definitions by: Dan Fox <https://github.com/iamdanfox>
 //                 Ivan Jiang <https://github.com/iplus26>

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -88,6 +88,7 @@ declare module "react-jsonschema-form" {
         formContext: any;
         onBlur: (id: string, value: string) => void;
         onFocus: (id: string, value: string) => void;
+        label: string;
     }
 
     export type Widget =

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -123,12 +123,12 @@ declare module "react-jsonschema-form" {
         id: string;
         classNames: string;
         label: string;
-        description: React.ReactElement;
+        description: React.ReactElement<React.ReactNode>;
         rawDescription: string;
-        children: React.ReactElement;
-        errors: React.ReactElement;
+        children: React.ReactElement<React.ReactNode>;
+        errors: React.ReactElement<React.ReactNode>;
         rawErrors: string[];
-        help: React.ReactElement;
+        help: React.ReactElement<React.ReactNode>;
         rawHelp: string;
         hidden: boolean;
         required: boolean;
@@ -142,14 +142,14 @@ declare module "react-jsonschema-form" {
     };
 
     export type ArrayFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<React.ReactNode> }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         canAdd: boolean;
         className: string;
         disabled: boolean;
         idSchema: IdSchema;
         items: {
-            children: React.ReactElement;
+            children: React.ReactElement<React.ReactNode>;
             className: string;
             disabled: boolean;
             hasMoveDown: boolean;
@@ -175,12 +175,12 @@ declare module "react-jsonschema-form" {
     };
 
     export type ObjectFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<React.ReactNode> }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         title: string;
         description: string;
         properties: {
-            content: React.ReactElement;
+            content: React.ReactElement<React.ReactNode>;
             name: string;
             disabled: boolean;
             readonly: boolean;

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -125,12 +125,12 @@ declare module "react-jsonschema-form" {
         id: string;
         classNames: string;
         label: string;
-        description: React.ReactElement<React.ReactNode>;
+        description: React.ReactElement;
         rawDescription: string;
-        children: React.ReactElement<React.ReactNode>;
-        errors: React.ReactElement<React.ReactNode>;
+        children: React.ReactElement;
+        errors: React.ReactElement;
         rawErrors: string[];
-        help: React.ReactElement<React.ReactNode>;
+        help: React.ReactElement;
         rawHelp: string;
         hidden: boolean;
         required: boolean;
@@ -144,14 +144,14 @@ declare module "react-jsonschema-form" {
     };
 
     export type ArrayFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<React.ReactNode> }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         canAdd: boolean;
         className: string;
         disabled: boolean;
         idSchema: IdSchema;
         items: {
-            children: React.ReactElement<React.ReactNode>;
+            children: React.ReactElement;
             className: string;
             disabled: boolean;
             hasMoveDown: boolean;
@@ -177,12 +177,12 @@ declare module "react-jsonschema-form" {
     };
 
     export type ObjectFieldTemplateProps = {
-        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<React.ReactNode> }>;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement }>;
         TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         title: string;
         description: string;
         properties: {
-            content: React.ReactElement<React.ReactNode>;
+            content: React.ReactElement;
             name: string;
             disabled: boolean;
             readonly: boolean;

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -6,6 +6,7 @@
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>
 //                 Sylvain Thénault <https://github.com/sthenault>
 //                 Sebastian Busch <https://github.com/sbusch>
+//                 Mehdi Lahlou <https://github.com/medfreeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - `React.ReactElement` #33582 
  - Missing `label` property on `WidgetProps` interface -> https://github.com/mozilla-services/react-jsonschema-form/blob/68ab7a4e4932f35afa7cd646e8dedd5c1d579cb6/src/components/widgets/CheckboxWidget.js#L41
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

