### PR TITLE
algoliasearch: Added "clickAnalytics" boolean option

### DIFF
--- a/types/algoliasearch/algoliasearch-tests.ts
+++ b/types/algoliasearch/algoliasearch-tests.ts
@@ -148,6 +148,7 @@ let _algoliaQueryParameters: QueryParameters = {
   tagFilters: [''],
   facetFilters: [''],
   analytics: false,
+  clickAnalytics: true,
   analyticsTags: [''],
   synonyms: true,
   replaceSynonymsInHighlight: false,

--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for algoliasearch-client-js 3.30.0
+// Type definitions for algoliasearch-client-js 3.30.1
 // Project: https://github.com/algolia/algoliasearch-client-js
 // Definitions by: Baptiste Coquelle <https://github.com/cbaptiste>
 //                 Haroen Viaene <https://github.com/haroenv>

--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1427,6 +1427,12 @@ declare namespace algoliasearch {
      */
     analytics?: boolean;
     /**
+     * If set to true, enables the Click Analytics feature
+     * default false
+     * https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/
+     */
+    clickAnalytics?: boolean;
+    /**
      * If set, tag your query with the specified identifiers
      * default: []
      * https://www.algolia.com/doc/api-reference/api-parameters/analyticsTags/

--- a/types/algoliasearch/lite/index.d.ts
+++ b/types/algoliasearch/lite/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for algoliasearch-client-js 3.30.0
+// Type definitions for algoliasearch-client-js 3.30.1
 // Project: https://github.com/algolia/algoliasearch-client-js
 // Definitions by: Baptiste Coquelle <https://github.com/cbaptiste>
 //                 Haroen Viaene <https://github.com/haroenv>

--- a/types/algoliasearch/lite/index.d.ts
+++ b/types/algoliasearch/lite/index.d.ts
@@ -507,6 +507,12 @@ declare namespace algoliasearch {
      */
     analytics?: boolean;
     /**
+     * If set to true, enables the Click Analytics feature
+     * default false
+     * https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/
+     */
+    clickAnalytics?: boolean;
+    /**
      * If set, tag your query with the specified identifiers
      * default: []
      * https://www.algolia.com/doc/api-reference/api-parameters/analyticsTags/


### PR DESCRIPTION
The clickAnalytics definition allows us to track clicks using
"search-insights". See: https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

