### PR TITLE
Bump deprecated version of copy-text-to-clipboard

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -304,7 +304,7 @@
             "libraryName": "copy-text-to-clipboard",
             "typingsPackageName": "copy-text-to-clipboard",
             "sourceRepoURL": "https://github.com/sindresorhus/copy-text-to-clipboard",
-            "asOfVersion": "2.0.0"
+            "asOfVersion": "2.0.1"
         },
         {
             "libraryName": "cordova-plugin-battery-status",


### PR DESCRIPTION
Work around bug again. Maybe this happens when a previous deprecation has failed? I'm not sure what causes the initial failure though.