### PR TITLE
mui-datatables - Add missing types for arguments of customToolbarSelect

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -123,7 +123,14 @@ export interface MUIDataTableOptions {
     expandableRows?: boolean;
     renderExpandableRow?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
     customToolbar?: () => React.ReactNode;
-    customToolbarSelect?: (selectedRows: {data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean };}, displayData: Array<{ data: any[]; dataIndex: number }>,setSelectedRows: (rows: number[]) => void) => React.ReactNode;
+    customToolbarSelect?: (
+        selectedRows: {
+            data: Array<{ index: number; dataIndex: number }>; 
+            lookup: { [key: number]: boolean };
+        }, 
+        displayData: Array<{ data: any[]; dataIndex: number }>,
+        setSelectedRows: (rows: number[]) => void
+    ) => React.ReactNode;
     customFooter?: () => React.ReactNode;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     elevation?: number;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for mui-datatables 2.0
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
+//                 Ankith Konda <https://github.com/ankithkonda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -122,7 +123,7 @@ export interface MUIDataTableOptions {
     expandableRows?: boolean;
     renderExpandableRow?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
     customToolbar?: () => React.ReactNode;
-    customToolbarSelect?: () => React.ReactNode;
+    customToolbarSelect?: (selectedRows: {data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean };}, displayData: Array<{ data: any[]; dataIndex: number }>,setSelectedRows: (rows: number[]) => void) => React.ReactNode;
     customFooter?: () => React.ReactNode;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     elevation?: number;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -125,9 +125,9 @@ export interface MUIDataTableOptions {
     customToolbar?: () => React.ReactNode;
     customToolbarSelect?: (
         selectedRows: {
-            data: Array<{ index: number; dataIndex: number }>; 
+            data: Array<{ index: number; dataIndex: number }>;
             lookup: { [key: number]: boolean };
-        }, 
+        },
         displayData: Array<{ data: any[]; dataIndex: number }>,
         setSelectedRows: (rows: number[]) => void
     ) => React.ReactNode;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -25,6 +25,9 @@ class MuiCustomTable extends React.Component<Props> {
             separator: ','
         },
         sortFilterList: false,
+        customToolbarSelect:(selectedRows, displayData, setSelectedRows)=>{
+            return <span>Custom Selected Toolbar: {`${selectedRows.data.length} - ${JSON.stringify(displayData[0])}`}<button onClick={()=>{ setSelectedRows([])}}>Set Selected Row to none</button></span>
+        },
         textLabels: {
             body: {
                 noMatch: 'Sorry, no matching records found',

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -25,8 +25,20 @@ class MuiCustomTable extends React.Component<Props> {
             separator: ','
         },
         sortFilterList: false,
-        customToolbarSelect:(selectedRows, displayData, setSelectedRows)=>{
-            return <span>Custom Selected Toolbar: {`${selectedRows.data.length} - ${JSON.stringify(displayData[0])}`}<button onClick={()=>{ setSelectedRows([])}}>Set Selected Row to none</button></span>
+        customToolbarSelect: (selectedRows, displayData, setSelectedRows) => {
+            return (
+                <span>
+                    Custom Selected Toolbar:{' '}
+                    {`${selectedRows.data.length} - ${JSON.stringify(displayData[0])}`}
+                    <button
+                        onClick={() => {
+                            setSelectedRows([]);
+                        }}
+                    >
+                        Set Selected Row to none
+                    </button>
+                </span>
+            );
         },
         textLabels: {
             body: {


### PR DESCRIPTION
changing an existing definition:

changes: 

https://github.com/ankithkonda/DefinitelyTyped/blob/3df231577211f85edd5c03e2512ea2cabac5855a/types/mui-datatables/index.d.ts

https://github.com/ankithkonda/DefinitelyTyped/blob/3df231577211f85edd5c03e2512ea2cabac5855a/types/mui-datatables/mui-datatables-tests.tsx

