### PR TITLE
ember-data: In DS.PromiseObject forward the passed in type to sub-objects so .content property gets correct type

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -902,8 +902,8 @@ export namespace DS {
      * it easy to create data bindings with the `PromiseObject` that will
      * be updated when the promise resolves.
      */
-    interface PromiseObject<T>
-        extends ObjectProxy,
+    interface PromiseObject<T extends object>
+        extends ObjectProxy<T>,
             PromiseProxyMixin<T & ObjectProxy> {}
     class PromiseObject<T> {}
     /**

--- a/types/ember-data/test/promises.ts
+++ b/types/ember-data/test/promises.ts
@@ -1,0 +1,20 @@
+import DS from 'ember-data';
+import { assertType } from "./lib/assert";
+
+declare const store: DS.Store;
+
+class Person extends DS.Model {
+    firstName = DS.attr();
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        person: Person;
+    }
+}
+
+const promiseFind = store.findRecord("person", 1);
+
+assertType<Person | undefined>(promiseFind.content);
+
+promiseFind.get("firstName");

--- a/types/ember-data/test/promises.ts
+++ b/types/ember-data/test/promises.ts
@@ -15,6 +15,6 @@ declare module 'ember-data/types/registries/model' {
 
 const promiseFind = store.findRecord("person", 1);
 
-assertType<Person | undefined>(promiseFind.content);
+promiseFind.content; // $ExpectType Person | undefined
 
 promiseFind.get("firstName");

--- a/types/ember-data/tsconfig.json
+++ b/types/ember-data/tsconfig.json
@@ -83,6 +83,7 @@
         "test/belongs-to.ts",
         "test/record-reference.ts",
         "test/injections.ts",
-        "test/error.ts"
+        "test/error.ts",
+        "test/promises.ts"
     ]
 }


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember-data/3.2/classes/DS.PromiseObject

The resolved promise is the result of the `.content` property, which itself is used for proxying.
