### PR TITLE
Cleanup from tslint 5.14

### DIFF
--- a/types/auth-header/index.d.ts
+++ b/types/auth-header/index.d.ts
@@ -7,7 +7,7 @@
 type Params =
     | Array<[string, string | ReadonlyArray<string>]>
     | {[key: string]: string | ReadonlyArray<string>};
-export {Params};
+export { Params };
 
 export interface TokenOptions {
     scheme: string;

--- a/types/jquery.transit/jquery.transit-tests.ts
+++ b/types/jquery.transit/jquery.transit-tests.ts
@@ -20,7 +20,7 @@ class Assert {
 	static passedTests: number = 0;
 
 	static Results() {
-		console.log('Tests succeeded - ' + this.passedTests + '/' + this.totalTests + '; Tests failed - ' + (this.totalTests - this.passedTests) + '/' + this.totalTests);
+		console.log('Tests succeeded - ' + Assert.passedTests + '/' + Assert.totalTests + '; Tests failed - ' + (Assert.totalTests - Assert.passedTests) + '/' + Assert.totalTests);
 	}
 
 	static AssertionFailed(actual: any, expected: any, test: string) {
@@ -28,21 +28,21 @@ class Assert {
 	}
 
 	static Equal(actual: any, expected: any, test?: string) {
-		this.totalTests++;
+		Assert.totalTests++;
 		if (actual === expected) {
-			this.passedTests++;
+			Assert.passedTests++;
 			return;
 		}
-		this.AssertionFailed(actual, expected, test);
+		Assert.AssertionFailed(actual, expected, test);
 	}
 
 	static NotEqual(actual: any, expected: any, test?: string) {
-		this.totalTests++;
+		Assert.totalTests++;
 		if (actual !== expected) {
-			this.passedTests++;
+			Assert.passedTests++;
 			return;
 		}
-		this.AssertionFailed(actual, expected, test);
+		Assert.AssertionFailed(actual, expected, test);
 	}
 }
 

--- a/types/material__base/index.d.ts
+++ b/types/material__base/index.d.ts
@@ -24,4 +24,4 @@
 import MDCFoundation, { MDCNumbers, MDCStrings } from './foundation';
 import MDCComponent from './component';
 
-export {MDCNumbers, MDCStrings, MDCFoundation, MDCComponent};
+export { MDCNumbers, MDCStrings, MDCFoundation, MDCComponent };

--- a/types/material__checkbox/index.d.ts
+++ b/types/material__checkbox/index.d.ts
@@ -27,7 +27,7 @@ import { MDCSelectionControl } from 'material__selection-control';
 import MDCCheckboxFoundation from './foundation';
 import { MDCRipple } from 'material__ripple';
 
-export {MDCCheckboxAdapter, MDCCheckboxFoundation};
+export { MDCCheckboxAdapter, MDCCheckboxFoundation };
 
 export class MDCCheckbox extends MDCComponent<MDCCheckboxAdapter, MDCCheckboxFoundation> implements MDCSelectionControl {
     static attachTo(root: Element): MDCCheckbox;

--- a/types/material__dialog/index.d.ts
+++ b/types/material__dialog/index.d.ts
@@ -25,7 +25,7 @@ import MDCDialogFoundation from './foundation';
 import MDCDialogAdapter from './adapter';
 import * as util from './util';
 
-export {MDCDialogAdapter, MDCDialogFoundation, util};
+export { MDCDialogAdapter, MDCDialogFoundation, util };
 
 export class MDCDialog extends MDCComponent<MDCDialogAdapter, MDCDialogFoundation> {
     static attachTo(root: Element): MDCDialog;

--- a/types/material__dom/index.d.ts
+++ b/types/material__dom/index.d.ts
@@ -29,4 +29,4 @@
 
 import * as ponyfill from './ponyfill';
 
-export {ponyfill};
+export { ponyfill };

--- a/types/material__form-field/index.d.ts
+++ b/types/material__form-field/index.d.ts
@@ -26,7 +26,7 @@ import MDCFormFieldFoundation from './foundation';
 import MDCFormFieldAdapter from './adapter';
 import { MDCSelectionControl } from 'material__selection-control';
 
-export {MDCFormFieldAdapter, MDCFormFieldFoundation};
+export { MDCFormFieldAdapter, MDCFormFieldFoundation };
 
 export class MDCFormField extends MDCComponent<MDCFormFieldAdapter, MDCFormFieldFoundation> {
     static attachTo(root: Element): MDCFormField;

--- a/types/material__icon-toggle/index.d.ts
+++ b/types/material__icon-toggle/index.d.ts
@@ -26,7 +26,7 @@ import MDCIconToggleFoundation from './foundation';
 import MDCIconToggleAdapter from './adapter';
 import { MDCRipple } from 'material__ripple';
 
-export {MDCIconToggleAdapter, MDCIconToggleFoundation};
+export { MDCIconToggleAdapter, MDCIconToggleFoundation };
 
 export class MDCIconToggle extends MDCComponent<MDCIconToggleAdapter, MDCIconToggleFoundation> {
     static attachTo(root: Element): MDCIconToggle;

--- a/types/material__list/index.d.ts
+++ b/types/material__list/index.d.ts
@@ -51,4 +51,4 @@ export class MDCList {
   getDefaultFoundation(): MDCListFoundation;
 }
 
-export { MDCListFoundation};
+export {  MDCListFoundation };

--- a/types/material__radio/index.d.ts
+++ b/types/material__radio/index.d.ts
@@ -27,7 +27,7 @@ import MDCRadioAdapter from './adapter';
 import MDCRadioFoundation from './foundation';
 import { MDCRipple } from 'material__ripple';
 
-export {MDCRadioAdapter, MDCRadioFoundation};
+export { MDCRadioAdapter, MDCRadioFoundation };
 
 export class MDCRadio extends MDCComponent<MDCRadioAdapter, MDCRadioFoundation> implements MDCSelectionControl {
     static attachTo(root: Element): MDCRadio;

--- a/types/material__ripple/index.d.ts
+++ b/types/material__ripple/index.d.ts
@@ -26,7 +26,7 @@ import MDCRippleAdapter from './adapter';
 import MDCRippleFoundation from './foundation';
 import * as util from './util';
 
-export {MDCRippleAdapter, MDCRippleFoundation, util};
+export { MDCRippleAdapter, MDCRippleFoundation, util };
 
 export class MDCRipple extends MDCComponent<MDCRippleAdapter, MDCRippleFoundation> {
     static attachTo(root: Element, options?: { isUnbounded?: boolean; }): MDCRipple;

--- a/types/material__select/index.d.ts
+++ b/types/material__select/index.d.ts
@@ -26,7 +26,7 @@ import MDCSelectAdapter from './adapter';
 import { MDCFloatingLabel } from 'material__floating-label';
 import { MDCLineRipple } from 'material__line-ripple';
 
-export {MDCSelectAdapter, MDCSelectFoundation};
+export { MDCSelectAdapter, MDCSelectFoundation };
 
 export class MDCSelect extends MDCComponent<MDCSelectAdapter, MDCSelectFoundation> {
     static attachTo(root: Element): MDCSelect;

--- a/types/material__slider/index.d.ts
+++ b/types/material__slider/index.d.ts
@@ -25,7 +25,7 @@ import MDCComponent from 'material__base/component';
 import MDCSliderFoundation from './foundation';
 import MDCSliderAdapter from './adapter';
 
-export {MDCSliderAdapter, MDCSliderFoundation};
+export { MDCSliderAdapter, MDCSliderFoundation };
 
 export class MDCSlider extends MDCComponent<MDCSliderAdapter, MDCSliderFoundation> {
     static attachTo(root: Element): MDCSlider;

--- a/types/material__snackbar/index.d.ts
+++ b/types/material__snackbar/index.d.ts
@@ -24,7 +24,7 @@ import { MDCComponent } from 'material__base';
 import MDCSnackbarAdapter from './adapter';
 import MDCSnackbarFoundation, { MDCSnackbarData } from './foundation';
 
-export {MDCSnackbarAdapter, MDCSnackbarFoundation};
+export { MDCSnackbarAdapter, MDCSnackbarFoundation };
 
 export class MDCSnackbar extends MDCComponent<MDCSnackbarAdapter, MDCSnackbarFoundation> {
     static attachTo(root: Element): MDCSnackbar;

--- a/types/material__tabs/tab-bar/index.d.ts
+++ b/types/material__tabs/tab-bar/index.d.ts
@@ -20,7 +20,7 @@ import { MDCTab } from '../tab';
 import MDCTabBarFoundation from './foundation';
 import MDCTabBarAdapter from './adapter';
 
-export {MDCTabBarAdapter, MDCTabBarFoundation};
+export { MDCTabBarAdapter, MDCTabBarFoundation };
 
 export class MDCTabBar extends MDCComponent<MDCTabBarAdapter, MDCTabBarFoundation> {
     static attachTo(root: Element): MDCTabBar;

--- a/types/material__tabs/tab/index.d.ts
+++ b/types/material__tabs/tab/index.d.ts
@@ -18,7 +18,7 @@ import MDCComponent from 'material__base/component';
 import MDCTabFoundation from './foundation';
 import MDCTabAdapter from './adapter';
 
-export {MDCTabAdapter, MDCTabFoundation};
+export { MDCTabAdapter, MDCTabFoundation };
 
 export class MDCTab extends MDCComponent<MDCTabAdapter, MDCTabFoundation> {
     static attachTo(root: Element): MDCTab;

--- a/types/material__textfield/helper-text/index.d.ts
+++ b/types/material__textfield/helper-text/index.d.ts
@@ -20,7 +20,7 @@ import MDCComponent from 'material__base/component';
 import MDCTextFieldHelperTextAdapter from './adapter';
 import MDCTextFieldHelperTextFoundation from './foundation';
 
-export {MDCTextFieldHelperTextAdapter, MDCTextFieldHelperTextFoundation};
+export { MDCTextFieldHelperTextAdapter, MDCTextFieldHelperTextFoundation };
 
 export class MDCTextFieldHelperText extends MDCComponent<MDCTextFieldHelperTextAdapter, MDCTextFieldHelperTextFoundation> {
     static attachTo(root: Element): MDCTextFieldHelperText;

--- a/types/material__toolbar/index.d.ts
+++ b/types/material__toolbar/index.d.ts
@@ -25,7 +25,7 @@ import { MDCComponent } from 'material__base';
 import MDCToolbarFoundation from './foundation';
 import MDCToolbarAdapter from './adapter';
 
-export {MDCToolbarAdapter, MDCToolbarFoundation};
+export { MDCToolbarAdapter, MDCToolbarFoundation };
 
 export class MDCToolbar extends MDCComponent<MDCToolbarAdapter, MDCToolbarFoundation> {
     static attachTo(root: Element): MDCToolbar;

--- a/types/nodal/nodal-tests.ts
+++ b/types/nodal/nodal-tests.ts
@@ -84,7 +84,7 @@ class AccessToken extends Nodal.Model {
 
           new AccessToken({
             user_id: user.get('id'),
-            access_token: this.generateAccessTokenString(user.get('id'), user.get('email'), new Date().valueOf()),
+            access_token: AccessToken.generateAccessTokenString(user.get('id'), user.get('email'), new Date().valueOf()),
             token_type: 'bearer',
             expires_at: (new Date(new Date().valueOf() + (30 * 24 * 60 * 60 * 1000))),
             ip_address: params.ip_address
@@ -94,7 +94,7 @@ class AccessToken extends Nodal.Model {
   }
 
   public static verify (params: any, callback: Function) {
-    this.query()
+    AccessToken.query()
       .join('user')
       .where({
         access_token: params.auth.access_token,
@@ -116,7 +116,7 @@ class AccessToken extends Nodal.Model {
   }
 
   public static logout (params: any, callback: Function) {
-    this.verify(params, (err: Error, accessToken: AccessToken) => {
+    AccessToken.verify(params, (err: Error, accessToken: AccessToken) => {
       if (err) {
         return callback(err);
       }

--- a/types/node-static/index.d.ts
+++ b/types/node-static/index.d.ts
@@ -53,4 +53,4 @@ export class Server {
 }
 
 export const version: [number, number, number];
-export {mime};
+export { mime };

--- a/types/node-xmpp-core/index.d.ts
+++ b/types/node-xmpp-core/index.d.ts
@@ -8,7 +8,7 @@ import { Element } from 'ltx';
 import { EventEmitter } from 'events';
 
 // fixme: not ideal
-export {createElement, Element, escapeXML, escapeXMLText} from 'ltx';
+export { createElement, Element, escapeXML, escapeXMLText } from 'ltx';
 
 export class Connection extends EventEmitter {
     constructor(opts?: any);

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -800,14 +800,14 @@ namespace util_tests {
             }
 
             static test(): void {
-                var cfn = util.callbackify(this.fn);
-                var cfnE = util.callbackify(this.fnE);
-                var cfnT1 = util.callbackify(this.fnT1);
-                var cfnT1E = util.callbackify(this.fnT1E);
-                var cfnTResult = util.callbackify(this.fnTResult);
-                var cfnTResultE = util.callbackify(this.fnTResultE);
-                var cfnT1TResult = util.callbackify(this.fnT1TResult);
-                var cfnT1TResultE = util.callbackify(this.fnT1TResultE);
+                var cfn = util.callbackify(callbackifyTest.fn);
+                var cfnE = util.callbackify(callbackifyTest.fnE);
+                var cfnT1 = util.callbackify(callbackifyTest.fnT1);
+                var cfnT1E = util.callbackify(callbackifyTest.fnT1E);
+                var cfnTResult = util.callbackify(callbackifyTest.fnTResult);
+                var cfnTResultE = util.callbackify(callbackifyTest.fnTResultE);
+                var cfnT1TResult = util.callbackify(callbackifyTest.fnT1TResult);
+                var cfnT1TResultE = util.callbackify(callbackifyTest.fnT1TResultE);
 
                 cfn((err: NodeJS.ErrnoException, ...args: string[]) => assert(err === null && args.length === 1 && args[0] === undefined));
                 cfnE((err: NodeJS.ErrnoException, ...args: string[]) => assert(err.message === 'fail' && args.length === 0));

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -826,14 +826,14 @@ namespace util_tests {
             }
 
             static test(): void {
-                var cfn = util.callbackify(this.fn);
-                var cfnE = util.callbackify(this.fnE);
-                var cfnT1 = util.callbackify(this.fnT1);
-                var cfnT1E = util.callbackify(this.fnT1E);
-                var cfnTResult = util.callbackify(this.fnTResult);
-                var cfnTResultE = util.callbackify(this.fnTResultE);
-                var cfnT1TResult = util.callbackify(this.fnT1TResult);
-                var cfnT1TResultE = util.callbackify(this.fnT1TResultE);
+                var cfn = util.callbackify(callbackifyTest.fn);
+                var cfnE = util.callbackify(callbackifyTest.fnE);
+                var cfnT1 = util.callbackify(callbackifyTest.fnT1);
+                var cfnT1E = util.callbackify(callbackifyTest.fnT1E);
+                var cfnTResult = util.callbackify(callbackifyTest.fnTResult);
+                var cfnTResultE = util.callbackify(callbackifyTest.fnTResultE);
+                var cfnT1TResult = util.callbackify(callbackifyTest.fnT1TResult);
+                var cfnT1TResultE = util.callbackify(callbackifyTest.fnT1TResultE);
 
                 cfn((err: NodeJS.ErrnoException, ...args: string[]) => assert(err === null && args.length === 1 && args[0] === undefined));
                 cfnE((err: NodeJS.ErrnoException, ...args: string[]) => assert(err.message === 'fail' && args.length === 0));

--- a/types/passport-oauth2-client-password/passport-oauth2-client-password-tests.ts
+++ b/types/passport-oauth2-client-password/passport-oauth2-client-password-tests.ts
@@ -17,7 +17,7 @@ class Client implements IClient {
     public clientSecret: string;
 
     static findOne(client: IClient, callback: (err: any, client: Client) => void): void {
-        callback(null, new this);
+        callback(null, new Client);
     }
 }
 //#endregion

--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -331,7 +331,7 @@ declare namespace Q {
 	/**
 	 * Alias for fcall()
 	 */
-	export {fcall as try};
+	export { fcall as try };
 
 	/**
 	 * Returns a promise for the result of calling the named method of an object with the given variadic arguments.


### PR DESCRIPTION
1. Better whitespace checking for export lists.
2. Disallow static `this`.

I turned off 'no-unnecessary-else' because it is buggy and also dumb. I also turned off no-tautology-expression because it flagged some correct test code, and doesn't matter for d.ts files.