### PR TITLE
Add type defintion for Profile and fix multiSamlStrategy types.

### DIFF
--- a/types/passport-saml/index.d.ts
+++ b/types/passport-saml/index.d.ts
@@ -41,8 +41,8 @@ export interface SamlConfig {
     path?: string;
     protocol?: string;
     host?: string;
-    entryPoint: string;
-    issuer: string;
+    entryPoint?: string;
+    issuer?: string;
     privateCert?: string;
     cert?: string | string[] | CertCallback;
     decryptionPvk?: string;

--- a/types/passport-saml/index.d.ts
+++ b/types/passport-saml/index.d.ts
@@ -20,9 +20,9 @@ export interface CacheProvider {
     remove(key: string, callback: (err: Error | null, key: string) => void | null): void;
 }
 
-export type VerifiedCallback =	(err: Error | null, user: object, info: object) => void;
+export type VerifiedCallback = (err: Error | null, user?: object, info?: object) => void;
 
-export type VerifyWithRequest = (req: express.Request, profile: object, done: VerifiedCallback) => void;
+export type VerifyWithRequest = (req: express.Request, profile: Profile, done: VerifiedCallback) => void;
 
 export type VerifyWithoutRequest = (profile: object, done: VerifiedCallback) => void;
 
@@ -82,3 +82,20 @@ export interface AuthenticateOptions extends passport.AuthenticateOptions {
 export interface AuthorizeOptions extends AuthenticateOptions {
     samlFallback?: string;
 }
+
+export type Profile = {
+	issuer?: string;
+	sessionIndex?: string;
+	nameID?: string;
+	nameIDFormat?: string;
+	nameQualifier?: string;
+	spNameQualifier?: string;
+	ID?: string;
+	mail?: string;  // InCommon Attribute urn:oid:0.9.2342.19200300.100.1.3
+	email?: string;  // `mail` if not present in the assertion
+	getAssertionXml(): string;  // get the raw assertion XML
+	getAssertion(): object;  // get the assertion XML parsed as a JavaScript object
+	getSamlResponseXml(): string; // get the raw SAML response XML
+} & {
+	[attributeName: string]: string;  // arbitrary `AttributeValue`s
+};

--- a/types/passport-saml/multiSamlStrategy.d.ts
+++ b/types/passport-saml/multiSamlStrategy.d.ts
@@ -1,10 +1,16 @@
 import express = require('express');
 import { Strategy, SamlConfig, VerifyWithRequest, VerifyWithoutRequest } from './index';
 
-export interface MultiSamlConfig extends SamlConfig {
-    getSamlOptions(req: express.Request, callback: (err: Error | null, samlOptions: SamlConfig) => void): void;
+declare namespace MultiSamlStrategy {
+    type SamlOptionsCallback = (err: Error | null, samlOptions?: SamlConfig) => void;
+
+    interface MultiSamlConfig extends SamlConfig {
+        getSamlOptions(req: express.Request, callback: SamlOptionsCallback): void;
+    }
 }
 
-export class MultiSamlStrategy extends Strategy {
-    constructor(config: MultiSamlConfig, verify: VerifyWithRequest | VerifyWithoutRequest);
+declare class MultiSamlStrategy extends Strategy {
+    constructor(config: MultiSamlStrategy.MultiSamlConfig, verify: VerifyWithRequest | VerifyWithoutRequest);
 }
+
+export = MultiSamlStrategy;

--- a/types/passport-saml/passport-saml-tests.ts
+++ b/types/passport-saml/passport-saml-tests.ts
@@ -35,24 +35,26 @@ passport.authenticate('samlCustomName', {failureRedirect: '/', failureFlash: tru
 
 const metadata = samlStrategy.generateServiceProviderMetadata("decryptionCert");
 
-const multiSamlStrategy = new MultiSamlStrategy.MultiSamlStrategy(
+const multiSamlStrategy = new MultiSamlStrategy(
 	{
 		name: 'samlCustomName',
 		path: '/login/callback',
 		entryPoint: 'https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php',
 		issuer: 'passport-saml',
-        getSamlOptions(req: express.Request, callback: (err: Error | null, samlOptions: SamlStrategy.SamlConfig) => void) {
+        getSamlOptions(req: express.Request, callback: MultiSamlStrategy.SamlOptionsCallback) {
             callback(null, {
                 name: 'samlCustomName',
                 path: '/login/callback2',
                 entryPoint: 'https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php',
                 issuer: 'passport-saml',
-            });
+			});
+			callback(new Error("SAML Options Error"));
         }
 	},
-	(profile: {}, done: (err: Error | null, user: {}, info?: {}) => void) => {
+	(profile: {}, done: (err: Error | null, user?: {}, info?: {}) => void) => {
 		const user = {};
 		done(null, user);
+		done(new Error("Verify Request Error"));
 	}
 );
 


### PR DESCRIPTION
Full list of changes:
- Added type definition for Profile.
- Added type definition for SamlOptionsCallback.
- Fixed optional fields in VerifyCallback and getSamlOptions.
- Fixed optional fields in SamlConfig
- Fixed type export from multiSampleConfig to match CommonJS module export.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Profile definition taken from here: https://github.com/bergie/passport-saml#the-profile-object
Version number kept the same to match the passport-saml version.
