### PR TITLE
Add type definition for domelementtype

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,26 @@
 Please fill in this template.
 
-- [x] Use a meaningful title for the pull request. Include the name of the package modified.
-- [x] Test the change in your own code. (Compile and run.)
-- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
-- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
-- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
-- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
+- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
+- [ ] Test the change in your own code. (Compile and run.)
+- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
+- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
+- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
+- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
 
 Select one of these and delete the others:
 
 If adding a new definition:
-- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
-- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
-- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
-- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
+- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
+- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
+- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
+- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
+
+If changing an existing definition:
+- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
+- [ ] Increase the version number in the header if appropriate.
+- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
+
+If removing a declaration:
+- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
+- [ ] Delete the package's directory.
+- [ ] Add it to `notNeededPackages.json`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,16 @@
 Please fill in this template.
 
-- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
-- [ ] Test the change in your own code. (Compile and run.)
-- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
-- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
-- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
-- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
+- [x] Use a meaningful title for the pull request. Include the name of the package modified.
+- [x] Test the change in your own code. (Compile and run.)
+- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
+- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
+- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
+- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
 
 Select one of these and delete the others:
 
 If adding a new definition:
-- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
-- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
-- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
-- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
-
-If changing an existing definition:
-- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
-- [ ] Increase the version number in the header if appropriate.
-- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
-
-If removing a declaration:
-- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
-- [ ] Delete the package's directory.
-- [ ] Add it to `notNeededPackages.json`.
+- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
+- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
+- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
+- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

--- a/types/domelementtype/domelementtype-tests.ts
+++ b/types/domelementtype/domelementtype-tests.ts
@@ -1,0 +1,12 @@
+import { DomElementType } from "domelementtype";
+
+console.log(DomElementType.Text === 'text');
+console.log(DomElementType.Directive === 'directive');
+console.log(DomElementType.Comment === 'comment');
+console.log(DomElementType.Script === 'script');
+console.log(DomElementType.Style === 'style');
+console.log(DomElementType.Tag === 'tag');
+console.log(DomElementType.CDATA === 'cdata');
+console.log(DomElementType.Doctype === 'doctype');
+console.log(DomElementType.isTag({ type: DomElementType.Tag }));
+console.log(DomElementType.isTag({ type: DomElementType.Doctype }));

--- a/types/domelementtype/index.d.ts
+++ b/types/domelementtype/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for domelementtype 1.3
+// Project: https://github.com/fb55/domelementtype#readme
+// Definitions by: Johan Davidsson <https://github.com/johandavidson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export namespace DomElementType {
+    /***
+     * Text
+     */
+    const Text = "text";
+    /***
+     * <? ... ?>
+     */
+    const Directive = "directive";
+    /***
+     * <!-- ... -->
+     */
+    const Comment = "comment";
+    /***
+     * <script> tags
+     */
+    const Script = "script";
+    /***
+     * <style> tags
+     */
+    const Style = "style";
+    /***
+     * Any tag
+     */
+    const Tag = "tag";
+    /***
+     * <![CDATA[ ... ]]>
+     */
+    const CDATA = "cdata";
+    /***
+     * <!DOCTYPE ... >
+     */
+    const Doctype = "doctype";
+
+    /***
+     * Checks whether element object is a tag
+     */
+    function isTag(elem: { type: string}): boolean;
+}

--- a/types/domelementtype/tsconfig.json
+++ b/types/domelementtype/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "domelementtype-tests.ts"
+    ]
+}

--- a/types/domelementtype/tslint.json
+++ b/types/domelementtype/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
