### PR TITLE
Sequelize: add separate type param for attributes required during `create`

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3733,7 +3733,7 @@ declare namespace sequelize {
      * as factory. This class should _not_ be instantiated directly, it is created using `sequelize.define`, and
      * already created models can be loaded using `sequelize.import`
      */
-    interface Model<TInstance, TAttributes> extends Hooks<TInstance>, Associations {
+    interface Model<TInstance, TAttributes, TCreationAttributes = TAttributes> extends Hooks<TInstance>, Associations {
 
         /**
          * The Instance class
@@ -4025,7 +4025,7 @@ declare namespace sequelize {
         /**
          * Builds a new model instance and calls save on it.
          */
-        create(values?: TAttributes, options?: CreateOptions): Promise<TInstance>;
+        create(values?: TCreationAttributes, options?: CreateOptions): Promise<TInstance>;
 
         /**
          * Find a row that matches the query, or build (but don't save) the row if none is found.
@@ -6050,8 +6050,8 @@ declare namespace sequelize {
          * @param options    These options are merged with the default define options provided to the Sequelize
          *                   constructor
          */
-        define<TInstance, TAttributes>(modelName: string, attributes: DefineModelAttributes<TAttributes>,
-            options?: DefineOptions<TInstance>): Model<TInstance, TAttributes>;
+        define<TInstance, TAttributes, TCreationAttributes = TAttributes>(modelName: string, attributes: DefineModelAttributes<TCreationAttributes>,
+            options?: DefineOptions<TInstance>): Model<TInstance, TAttributes, TCreationAttributes>;
 
         /**
          * Fetch a Model which is already defined

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -41,19 +41,26 @@ s.transaction().then( ( a ) => t = a );
 // ~~~~~~~~~~
 //
 
-interface GUserAttributes {
-    id? : number;
+interface GUserCreationAttributes {
+    id? : number
     username? : string;
     email: string;
 }
 
-interface GUserInstance extends Sequelize.Instance<GUserAttributes> {}
-const GUser = s.define<GUserInstance, GUserAttributes>('user', {
+interface GUserAttributes {
+    id : number;
+    username? : string;
+    email: string;
+}
+
+interface GUserInstance extends Sequelize.Instance<GUserAttributes>, GUserAttributes {}
+const GUser = s.define<GUserInstance, GUserAttributes, GUserCreationAttributes>('user', {
     id: Sequelize.INTEGER,
     username: Sequelize.STRING,
     email: Sequelize.STRING
 });
 GUser.create({ id : 1, username : 'one', email: 'one@lol.com' }).then((guser) => guser.save());
+GUser.create({ email: 'two@lol.com' }).then((guser) => guser.save())
 
 var schema : Sequelize.DefineAttributes = {
     key : { type : Sequelize.STRING, primaryKey : true },


### PR DESCRIPTION
A model might have attributes that aren't required during creation, but is guaranteed to exist on any instance. 

An example is an auto-incrementing `id` field. This field shouldn't be required as part of a `create` call, but any instance of the model is expected to have it.

Currently, the an auto-incrementing id attribute would be specified as `id?: string`, which allows `create` calls to work, but results in a type error when trying to access the field on an instance without an unnecessary guard

A model might also have attributes that _must_ be passed in on creation (e.g. password) but will not be available on an instance. Currently the only way to type that, is once again, `password?: string`, which is a terrible compromise

This PR adds a third optional type parameter, `TCreationAttributes`, which defaults to `TAttributes` if not provided

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:

* [x]  Provide a URL to documentation or source code which provides context for the suggested changes:
  - docs for model.create: http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-create
  - docs for model definition: http://docs.sequelizejs.com/manual/models-definition.html
    > // autoIncrement can be used to create auto_incrementing integer columns
    >  incrementMe: { type: Sequelize.INTEGER, autoIncrement: true }