### PR TITLE
Update fluent definitions for v0.11

### DIFF
--- a/types/fluent-react/index.d.ts
+++ b/types/fluent-react/index.d.ts
@@ -76,7 +76,7 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  */
 export type Shared<
     InjectedProps,
-    DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
+    DecorationTargetProps
     > = {
         [P in Extract<keyof InjectedProps, keyof DecorationTargetProps>]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never;
     };

--- a/types/fluent-react/index.d.ts
+++ b/types/fluent-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://projectfluent.org
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.4.0-rc
 
 import * as React from 'react';
 import {

--- a/types/fluent-react/index.d.ts
+++ b/types/fluent-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://projectfluent.org
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4.0-rc
+// TypeScript Version: 3.3
 
 import * as React from 'react';
 import {

--- a/types/fluent/fluent-tests.ts
+++ b/types/fluent/fluent-tests.ts
@@ -29,6 +29,7 @@ const bundle4 = new FluentBundle(['en-US'], {
 
 // FluentBundle addMessages examples:
 bundle1.addMessages('foo = Foo');
+bundle2.hasMessage('foo');
 bundle2.getMessage('foo');
 
 // FluentBundle addResource examples:
@@ -42,3 +43,8 @@ bundle1.addMessages('hello = Hello, { $name }!');
 const hello = bundle2.getMessage('hello');
 bundle3.format(hello, { name: 'Jane' }, errors2);
 bundle3.format(hello, undefined, errors2);
+
+for (const [id, message] of bundle1.messages) {
+  bundle1.getMessage(id);
+  bundle1.format(message);
+}

--- a/types/fluent/index.d.ts
+++ b/types/fluent/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for fluent 0.10
+// Type definitions for fluent 0.11
 // Project: http://projectfluent.org
-// Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
+// Definitions by: Huy Nguyen <https://github.com/huy-nguyen>, James Nimlos <https://github.com/jamesnimlos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -28,6 +28,8 @@ export class FluentResource extends Map {
 
 export class FluentBundle {
     constructor(locales: string | string[], options?: FluentBundleContructorOptions);
+    messages: IterableIterator<[string, FluentNode[]]>;
+    hasMessage(source: string): boolean;
     addMessages(source: string): string[];
     getMessage(id: string): FluentNode[];
     format(message: FluentNode[], args?: object, errors?: string[]): string;

--- a/types/fluent/tsconfig.json
+++ b/types/fluent/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/projectfluent/fluent.js/blob/master/fluent/src/bundle.js#L68-L85
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. // done previously

### Note
There is a recursive typedef in the dependent package `fluent-react` which is broken for `typescript@next` in master as well and prevents passing tests. See this reported issue [TypeScript#30188](https://github.com/Microsoft/TypeScript/issues/30188). I'm not sure what the solution for that is, but am willing to fix it
```
Error: /Users/jamesnimlos/dev/DefinitelyTyped/types/fluent-react/index.d.ts:101:49
ERROR: 101:49  expect  TypeScript@next compile error: 
Type instantiation is excessively deep and possibly infinite.
```

### EDIT
I've removed the circular reference in the dependent package that was causing the error and the tests for that package still pass. This is not a package I am using so I don't have good insight as to whether this is a good change or not, but due to the automated systems I need to make it in order to get a real person to review. As a precaution I've updated the noted TypeScript version of that typedef to the TS version where the breaking change was added.

As a critique, I'm surprised this breaking change is in a minor version instead of mandating a major TS version like semver dictates.

Recommended Action: I'd suggest creating a group of maintainers who are willing to inspect errors like this to be called upon when new contributors make PRs where they don't understand the next step to remedy errors. This is definitely an uncomfortable situation for new contributors and feels a bit like gatekeeping?
