### PR TITLE
googlemaps - add ImageMapType and StyledMapType properties

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -455,3 +455,36 @@ service.findPlaceFromPhoneNumber({
 const autocomplete = new google.maps.places.Autocomplete(document.createElement('input'));
 const placeResult = autocomplete.getPlace();
 placeResult.name; // $ExpectType string
+
+/***** google.maps.ImageMapType *****/
+const imageMapType = new google.maps.ImageMapType({
+    alt: 'alt',
+    getTileUrl: (tileCoord: google.maps.Point, zoom: number) => 'string',
+    maxZoom: 20,
+    minZoom: 10,
+    name: 'name',
+    opacity: 0.5,
+    tileSize: new google.maps.Size(256, 256),
+});
+imageMapType.alt; // $ExpectType string
+imageMapType.maxZoom; // $ExpectType number
+imageMapType.minZoom; // $ExpectType number
+imageMapType.name; // $ExpectType string
+imageMapType.projection; // $ExpectType Projection
+imageMapType.radius; // $ExpectType number
+imageMapType.tileSize; // $ExpectType Size
+
+/***** google.maps.StyledMapType *****/
+const styledMapType = new google.maps.StyledMapType([], {
+    alt: 'alt',
+    maxZoom: 20,
+    minZoom: 10,
+    name: 'name',
+});
+styledMapType.alt; // $ExpectType string
+styledMapType.maxZoom; // $ExpectType number
+styledMapType.minZoom; // $ExpectType number
+styledMapType.name; // $ExpectType string
+styledMapType.projection; // $ExpectType Projection
+styledMapType.radius; // $ExpectType number
+styledMapType.tileSize; // $ExpectType Size

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1813,6 +1813,13 @@ declare namespace google.maps {
     getTile(tileCoord: Point, zoom: number, ownerDocument: Document): Element;
     releaseTile(tile: Element): void;
     setOpacity(opacity: number): void;
+    alt: string;
+    maxZoom: number;
+    minZoom: number;
+    name: string;
+    projection: Projection;
+    radius: number;
+    tileSize: Size;
   }
 
   export interface ImageMapTypeOptions {
@@ -1822,13 +1829,20 @@ declare namespace google.maps {
     minZoom?: number;
     name?: string;
     opacity?: number;
-    tileSize?: Size;
+    tileSize: Size;
   }
 
   export class StyledMapType extends MVCObject implements MapType {
     constructor(styles: MapTypeStyle[], options?: StyledMapTypeOptions);
     getTile(tileCoord: Point, zoom: number, ownerDocument: Document): Element;
     releaseTile(tile: Element): void;
+    alt: string;
+    maxZoom: number;
+    minZoom: number;
+    name: string;
+    projection: Projection;
+    radius: number;
+    tileSize: Size;
   }
 
   export interface StyledMapTypeOptions {


### PR DESCRIPTION
ImageMapTypeOptions.tileSize is required
add StyledMapType properties

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developers.google.com/maps/documentation/javascript/reference/image-overlay#ImageMapType
https://developers.google.com/maps/documentation/javascript/reference/image-overlay#StyledMapType
https://developers.google.com/maps/documentation/javascript/maptypes#ImageMapTypes
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I've added properties alt, maxZoom, minZoom, name, projection, radius, tileSize to ImageMapType and StyledMapType.
Also google.maps.ImageMapTypeOptions.tileSize is required, see https://developers.google.com/maps/documentation/javascript/maptypes#ImageMapTypes 

> This class, the ImageMapType class, is constructed using an ImageMapTypeOptions object specification defining the following required properties:
> * tileSize 
> * getTileUrl
> 