### PR TITLE
[cron] Update types to allow system commands

### DIFF
--- a/types/cron/cron-tests.ts
+++ b/types/cron/cron-tests.ts
@@ -46,6 +46,12 @@ var job = new CronJob(moment(), () => {
   timeZone /* Time zone of this job. */
 );
 
+// Another example with system commands
+var job = new CronJob('00 30 11 * * 1-5', 'ls', { command: 'ls', args: ['./'] },
+  true, /* Start the job right now */
+  timeZone /* Time zone of this job. */
+);
+
 // For good measure
 var job = new CronJob({
   cronTime: '00 30 11 * * 1-5',
@@ -59,10 +65,14 @@ var job = new CronJob({
   start: false,
   timeZone: 'America/Los_Angeles'
 });
-console.log(job.lastDate());
-console.log(job.nextDates());// Should be a Moment object
-console.log(job.nextDates(1));// Should be an array of Moment object
-console.log(job.running);
+const ld = job.lastDate(); // $ExpectType Date
+console.log(ld);
+const nd = job.nextDates(); // $ExpectType Moment
+console.log(nd);
+const nds = job.nextDates(1); // $ExpectType Moment | Moment[]
+console.log(nds);// Should be a Moment array
+const ru = job.running // $ExpectType boolean
+console.log(ru);
 job.setTime(new CronTime('00 30 11 * * 1-2'));
 job.start();
 job.stop();

--- a/types/cron/index.d.ts
+++ b/types/cron/index.d.ts
@@ -1,10 +1,15 @@
-// Type definitions for cron 1.6
+// Type definitions for cron 1.7
 // Project: https://www.npmjs.com/package/cron
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi>
 //                 Lundarl Gholoi <https://github.com/winup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 import { Moment } from 'moment';
+import { SpawnOptions } from "child_process";
+
+export declare type CronCommand = (() => void) | string | { command: string, args?: ReadonlyArray<string>, options?: SpawnOptions};
 
 export declare class CronTime {
     /**
@@ -17,10 +22,14 @@ export declare class CronTime {
 
     /**
      * Tells you when ```CronTime``` will be run.
-     * @param i Indicate which turn of run after now. If not given return next run time.
      */
     public sendAt(): Moment;
-    public sendAt(i?: number): Moment[];
+    /**
+     * Tells you when ```CronTime``` will be run.
+     * @param i Indicate which turn of run after now. If not given return next run time.
+     * @returns A `Moment` when the source passed in the constructor is a `Date` or a `Moment` and an array of `Moment` when the source is a string
+     */
+    public sendAt(i?: number): Moment | Moment[];
     /**
      * Get the number of milliseconds in the future at which to fire our callbacks.
      */
@@ -35,11 +44,11 @@ export declare interface CronJobParameters {
     /**
      * The function to fire at the specified time. If an ```onComplete``` callback was provided, ```onTick``` will receive it as an argument. ```onTick``` may call ```onComplete``` when it has finished its work.
      */
-    onTick: () => void;
+    onTick: CronCommand;
     /**
      * A function that will fire when the job is stopped with ```job.stop()```, and may also be called by ```onTick``` at the end of each run.
      */
-    onComplete?: () => void;
+    onComplete?: CronCommand;
     /**
      * Specifies whether to start the job just before exiting the constructor. By default this is set to false. If left at default you will need to call ```job.start()``` in order to start the job (assuming ```job``` is the variable you set the cronjob to). This does not immediately fire your ```onTick``` function, it just gives you more control over the behavior of your jobs.
      */
@@ -88,7 +97,7 @@ export declare class CronJob {
      * @param utcOffset This allows you to specify the offset of your timezone rather than using the ```timeZone``` param. Probably don't use both ```timeZone``` and ```utcOffset``` together or weird things may happen.
      * @param unrefTimeout If you have code that keeps the event loop running and want to stop the node process when that finishes regardless of the state of your cronjob, you can do so making use of this parameter. This is off by default and cron will run as if it needs to control the event loop. For more information take a look at [timers#timers_timeout_unref](https://nodejs.org/api/timers.html#timers_timeout_unref) from the NodeJS docs.
      */
-    constructor(cronTime: string | Date | Moment, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean);
+    constructor(cronTime: string | Date | Moment, onTick: CronCommand, onComplete?: CronCommand, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean);
     /**
      * Create a new ```CronJob```.
      * @param options Job parameters.
@@ -114,10 +123,15 @@ export declare class CronJob {
     public lastDate(): Date;
     /**
      * Tells you when a ```CronTime``` will be run.
-     * @param i Indicate which turn of run after now. If not given return next run time.
      */
+    public nextDate(): Moment;
     public nextDates(): Moment;
-    public nextDates(i?: number): Moment[];
+    /**
+     * Tells you when a ```CronTime``` will be run.
+     * @param i Indicate which turn of run after now. If not given return next run time.
+     * @returns A `Moment` when the cronTime passed in the constructor is a `Date` or a `Moment` and an array of `Moment` when the cronTime is a string
+     */
+    public nextDates(i?: number): Moment | Moment[];
     /**
      * Add another ```onTick``` function.
      * @param callback Target function.
@@ -126,7 +140,7 @@ export declare class CronJob {
 }
 
 export declare var job:
-    ((cronTime: string | Date | Moment, onTick: () => void, onComplete?: () => void, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean) => CronJob)
+    ((cronTime: string | Date | Moment, onTick: () => void, onComplete?: CronCommand, start?: boolean, timeZone?: string, context?: any, runOnInit?: boolean, utcOffset?: string | number, unrefTimeout?: boolean) => CronJob)
     | ((options: CronJobParameters) => CronJob);
 export declare var time: (source: string | Date | Moment, zone?: string) => CronTime;
 export declare var sendAt: (cronTime: string | Date | Moment) => Moment;


### PR DESCRIPTION
After reviewing the code and making some tests, i found that the nextDates() function returns a Moment object when the first parameter of the constructor is a Date or a Moment and the function returns an array of Moment when the parameter is a string. I didn't find a solution to change the return type of a function according to the type of a constructor parameter so the function return an intersection type of the Moment and the Moment array.
I also changed the type of the callback function as it also work with a string or an object that are used to start a system command.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Commands](https://github.com/kelektiv/node-cron/blob/master/lib/cron.js#L518)
[Return type](https://github.com/kelektiv/node-cron/blob/master/lib/cron.js#L151)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
