### PR TITLE
[react-jsonschema-form] fix missing types on `onFocus`

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -86,8 +86,8 @@ declare module "react-jsonschema-form" {
         onChange: (value: any) => void;
         options: object;
         formContext: any;
-        onBlur: (id: string, value: string) => void;
-        onFocus: (id: string, value: string) => void;
+        onBlur: (id: string, value: boolean | number | string | null) => void;
+        onFocus: (id: string, value: boolean | number | string | null) => void;
         label: string;
     }
 

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -109,8 +109,26 @@ export class Example extends React.Component<any, IExampleState> {
     }
 }
 
-export const CustomWidget: React.SFC<WidgetProps> = (props) =>
+export const BooleanCustomWidget: React.SFC<WidgetProps> = (props) =>
+    <input
+        onFocus={()=> props.onFocus('id', true)}
+        onBlur={()=> props.onFocus('id', true)}
+    />
+
+export const NumberCustomWidget: React.SFC<WidgetProps> = (props) =>
+    <input
+        onFocus={()=> props.onFocus('id', 0)}
+        onBlur={()=> props.onFocus('id', 0)}
+    />
+
+export const StringCustomWidget: React.SFC<WidgetProps> = (props) =>
     <input
         onFocus={()=> props.onFocus('id', 'value')}
         onBlur={()=> props.onFocus('id', 'value')}
+    />
+
+export const NullCustomWidget: React.SFC<WidgetProps> = (props) =>
+    <input
+        onFocus={()=> props.onFocus('id', null)}
+        onBlur={()=> props.onFocus('id', null)}
     />


### PR DESCRIPTION
and `onBlur` second argument in `WidgetProps` interface

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
-  https://github.com/mozilla-services/react-jsonschema-form/tree/10a6b64918310576b0d54cdc28848cad016a75ac/src/components/widgets
- 
 https://github.com/DefinitelyTyped/DefinitelyTyped/blob/813999bd2b6b2c75dec22b5bba0b52c853af787c/types/react-jsonschema-form/index.d.ts#L15
-  https://github.com/DefinitelyTyped/DefinitelyTyped/blob/813999bd2b6b2c75dec22b5bba0b52c853af787c/types/json-schema/index.d.ts#L223

Basically the addition corresponds to any widget value possible types, which equals to `JSONSchema6Type` minus `array` and `object`, since a widget only deals with a single value at its scope.

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

