### PR TITLE
fix: wrong type definition for "fields" in types/google__maps PlaceDetailsRequest

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -2404,8 +2404,35 @@ export interface PlaceDetailsRequest {
      * parameter from a request, ALL possible fields will be returned, and you will be billed accordingly.
      * This applies only to Place Details requests.
      */
-    fields?: Array<keyof PlaceDetailsResult>;
+    fields?: PlaceDetailsRequestField[];
 }
+
+export type PlaceDetailsRequestField = (
+    "address_component" |
+    "adr_address" |
+    "alt_id" |
+    "formatted_address" |
+    "geometry" |
+    "icon" |
+    "id" |
+    "name" |
+    "permanently_closed" |
+    "photo" |
+    "place_id" |
+    "plus_code" |
+    "scope" |
+    "type" |
+    "url" |
+    "user_ratings_total" |
+    "utc_offset" |
+    "vicinity" |
+    "formatted_phone_number" |
+    "international_phone_number" |
+    "opening_hours" |
+    "website" |
+    "price_level" |
+    "rating" |
+    "review");
 
 export interface PlaceDetailsResponse {
     /** contains metadata on the request. */


### PR DESCRIPTION
fields and response parameters only match partly
see: https://developers.google.com/places/web-service/details#fields

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/places/web-service/details#fields
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

