### PR TITLE
Add compatibility for Waterline v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "definitely-typed",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "definitely-typed",
-    "version": "0.0.4",
+    "version": "0.0.3",
     "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped",
     "repository": {
         "type": "git",

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -11,9 +11,6 @@ declare namespace Waterline {
     type Adapter = Object;
     type Connection = {
         adapter: string;
-    }
-    type ConnectionV3 = {
-        adapter: string;
         url?: string,
         host?: string,
         port?: number,
@@ -22,25 +19,24 @@ declare namespace Waterline {
         password?: string,
         database?: string
     }
+
     interface Config {
         adapters: { [index: string]: Adapter };
-        connections: { [index: string]: Connection }
+        connections?: { [index: string]: Connection }
+        datastores?: { [index: string]: Connection }
     }
-    interface ConfigV3 {
-        adapters: { [index: string]: Adapter };
-        datastores: { [index: string]: ConnectionV3 }
-    }
+
     type Ontology = {
         collections: any;
     }
     interface Waterline {
-        registerModel(collection:  CollectionClass<Waterline.CollectionV3>): void;
-        loadCollection(collection: CollectionClass<Waterline.Collection>): void;
-        initialize: (config: Config | ConfigV3, cb: (err: Error, ontology: Ontology) => any) => any;
+        registerModel(collection:  CollectionClass): void;
+        loadCollection(collection: CollectionClass): void;
+        initialize: (config: Config, cb: (err: Error, ontology: Ontology) => any) => any;
         collections: any;
     }
-    interface CollectionClass<T extends Collection | CollectionV3> {
-        (): T
+    interface CollectionClass {
+        (): Collection
     }
 
     // used this comment https://github.com/balderdashy/waterline/issues/1154#issuecomment-167262575
@@ -57,6 +53,7 @@ declare namespace Waterline {
         attributes?: Attributes;
         connection?: string;
         identity?: string;
+        primaryKey?: string,
         tableName?: string;
         migrate?: "alter" | "drop" | "safe";
         autoPK?: boolean;
@@ -65,64 +62,34 @@ declare namespace Waterline {
         schema?: boolean;
         types?: any;
     }
-    export type CollectionDefinitionV3 = LifecycleCallbacks & {
-        attributes?: AttributesV3;
-        connection?: string;
-        identity?: string;
-        primaryKey?: string,
-        tableName?: string;
-        migrate?: "alter" | "drop" | "safe";
-        autoPK?: boolean;
-        schema?: boolean;
-        types?: any;
-    }
 
-    export type CollectionV3 = CollectionDefinitionV3;
     export type Collection = CollectionDefinition;
     export type Attributes = { [index: string]: Attribute } & {
         toJSON?: () => string;
         toObject?: () => any;
     };
-    export type AttributesV3 = { [index: string]: AttributeV3 } & {
-        toJSON?: () => string;
-        toObject?: () => any;
-    };
+
     export type FunctionAttribute = () => any;
     // Data types https://github.com/balderdashy/waterline-docs/blob/master/models/data-types-attributes.md#data-types
-    export type AttributeType = "string" | "text" | "integer" | "float" | "date" | "time"
-        | "datetime" | "boolean" | "binary" | "array" | "json";
-    export type AttributeTypeV3 = "string" | "number" | "boolean" | "json" | "ref";
+    export type AttributeType = "string" | "text" | "integer" | "number" | "float" | "date" | "time"
+        | "datetime" | "boolean" | "binary" | "array" | "json" | "ref";
 
     export type Attribute = string | StringAttribute | EmailAttribute |
-        IntegerAttribute | FloatAttribute |
+        IntegerAttribute | NumberAttribute| FloatAttribute |
         DateAttribute | TimeAttribute | DatetimeAttribute |
-        BooleanAttribute | BinaryAttribute | ArrayAttribute | JsonAttribute |
+        BooleanAttribute | BinaryAttribute | ArrayAttribute | JsonAttribute | RefAttribute |
         OneToOneAttribute | OneToManyAttribute | ManyToManyAttribute |
         FunctionAttribute;
-
-    export type AttributeV3 = string | StringAttributeV3 | NumberAttributeV3  |
-        BooleanAttributeV3 | JsonAttributeV3 | RefAttributeV3 |
-        OneToOneAttributeV3 | OneToManyAttributeV3 | ManyToManyAttributeV3 |
-        FunctionAttribute;
-
 
     export type DefaultsToFn<T> = () => T;
     export type BaseAttribute<T> = AttributeValidations & {
         type?: string;
         primaryKey?: boolean;
+        autoMigrations?: AutoMigration;
         unique?: boolean;
         required?: boolean;
         enum?: Array<T>;
         size?: number;
-        columnName?: string;
-        index?: boolean;
-        defaultsTo?: T | DefaultsToFn<T>;
-    }
-    export type BaseAttributeV3<T> =  {
-        type?: string;
-        autoMigrations?: AutoMigration;
-        unique?: boolean;
-        required?: boolean;
         columnName?: string;
         index?: boolean;
         allowNull?: boolean;
@@ -141,9 +108,6 @@ declare namespace Waterline {
     export type StringAttribute = BaseAttribute<string> & {
         type: "string";
     }
-    export type StringAttributeV3 = BaseAttributeV3<string> & {
-        type: "string";
-    }
     export type EmailAttribute = BaseAttribute<string> & {
         type: "email"
     }
@@ -154,7 +118,7 @@ declare namespace Waterline {
         type: "integer";
         autoIncrement?: boolean;
     }
-    export type NumberAttributeV3 = BaseAttributeV3<number> & {
+    export type NumberAttribute = BaseAttribute<number> & {
         type: "number";
         autoIncrement?: boolean;
     }
@@ -173,9 +137,6 @@ declare namespace Waterline {
     export type BooleanAttribute = BaseAttribute<boolean> & {
         type: 'boolean';
     }
-    export type BooleanAttributeV3 = BaseAttributeV3<boolean> & {
-        type: "boolean";
-      }
     export type BinaryAttribute = BaseAttribute<any> & {
         type: 'binary';
     }
@@ -185,32 +146,17 @@ declare namespace Waterline {
     export type JsonAttribute = BaseAttribute<any> & {
         type: 'json';
     }
-    export type JsonAttributeV3 = BaseAttributeV3<any> & {
-        type: "json";
-    }
-    export type RefAttributeV3 = BaseAttributeV3<any> & {
+    export type RefAttribute = BaseAttribute<any> & {
         type: 'ref';
     }
     export type OneToOneAttribute = BaseAttribute<any> & {
-        model: string;
-    }
-    export type OneToOneAttributeV3 = BaseAttributeV3<any> & {
         model: string;
     }
     export type OneToManyAttribute = BaseAttribute<any> & {
         collection: string;
         via: string;
     }
-    export type OneToManyAttributeV3 = BaseAttributeV3<any> & {
-        collection: string;
-        via: string;
-    }
     export type ManyToManyAttribute = BaseAttribute<any> & {
-        collection: string;
-        via: string;
-        dominant?: boolean;
-    }
-    export type ManyToManyAttributeV3 = BaseAttributeV3<any> & {
         collection: string;
         via: string;
         dominant?: boolean;
@@ -349,7 +295,7 @@ declare namespace Waterline {
 }
 declare interface WaterlineStatic {
     Collection: {
-        extend: <T extends Waterline.CollectionDefinition | Waterline.CollectionDefinitionV3,K>(params: T) => Waterline.CollectionClass<K>;
+        extend:(params: Waterline.CollectionDefinition) => Waterline.CollectionClass;
     }
     new (): Waterline.Waterline;
 }

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -34,16 +34,13 @@ declare namespace Waterline {
         collections: any;
     }
     interface Waterline {
-        registerModel(collection: CollectionClassV3): void;
-        loadCollection(collection: CollectionClass): void;
+        registerModel(collection:  CollectionClass<Waterline.CollectionV3>): void;
+        loadCollection(collection: CollectionClass<Waterline.Collection>): void;
         initialize: (config: Config | ConfigV3, cb: (err: Error, ontology: Ontology) => any) => any;
         collections: any;
     }
-    interface CollectionClass {
-        (): Collection
-    }
-    interface CollectionClassV3 {
-        (): CollectionV3
+    interface CollectionClass<T extends Collection | CollectionV3> {
+        (): T
     }
 
     // used this comment https://github.com/balderdashy/waterline/issues/1154#issuecomment-167262575
@@ -352,10 +349,7 @@ declare namespace Waterline {
 }
 declare interface WaterlineStatic {
     Collection: {
-        extend: (params: Waterline.CollectionDefinition) => Waterline.CollectionClass;
-    }
-    CollectionV3: {
-        extend: (params: Waterline.CollectionDefinitionV3) => Waterline.CollectionClassV3;
+        extend: <T extends Waterline.CollectionDefinition | Waterline.CollectionDefinitionV3,K>(params: T) => Waterline.CollectionClass<K>;
     }
     new (): Waterline.Waterline;
 }

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -72,6 +72,7 @@ declare namespace Waterline {
         attributes?: AttributesV3;
         connection?: string;
         identity?: string;
+        primaryKey?: string,
         tableName?: string;
         migrate?: "alter" | "drop" | "safe";
         autoPK?: boolean;
@@ -127,7 +128,7 @@ declare namespace Waterline {
         required?: boolean;
         columnName?: string;
         index?: boolean;
-        allowNull?:  boolean;
+        allowNull?: boolean;
         autoCreatedAt?: boolean;
         autoUpdatedAt?: boolean;
         validations?: AttributeValidationsV3;
@@ -158,6 +159,7 @@ declare namespace Waterline {
     }
     export type NumberAttributeV3 = BaseAttributeV3<number> & {
         type: "number";
+        autoIncrement?: boolean;
     }
     export type FloatAttribute = BaseAttribute<number> & {
         type: "float";
@@ -174,8 +176,8 @@ declare namespace Waterline {
     export type BooleanAttribute = BaseAttribute<boolean> & {
         type: 'boolean';
     }
-    export type BooleanAttributeV3 = BaseAttributeV3<number> & {
-        type: "number";
+    export type BooleanAttributeV3 = BaseAttributeV3<boolean> & {
+        type: "boolean";
       }
     export type BinaryAttribute = BaseAttribute<any> & {
         type: 'binary';
@@ -236,7 +238,7 @@ declare namespace Waterline {
         isUUID?: AttributeValidation<boolean>;
         max?: AttributeValidation<number>;
         min?: AttributeValidation<number>;
-        maxlength?: AttributeValidation<number>;
+        maxLength?: AttributeValidation<number>;
         minLength?:  AttributeValidation<number>;
         regex?: AttributeValidation<RegExp>
     }

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -172,7 +172,10 @@ declare namespace Waterline {
         isBoolean?: AttributeValidation<boolean>;
         isEmail?: AttributeValidation<boolean>;
         isCreditCard?:AttributeValidation<boolean>;
+        isHexColor?: AttributeValidation<boolean>;
+        isIn?: AttributeValidation<string[]>;
         isIP?: AttributeValidation<boolean>;
+        isInteger?: AttributeValidation<boolean>;
         isNotEmptyString?:AttributeValidation<boolean>;
         isNotIn?: AttributeValidation<string[]>;
         isNumber?: AttributeValidation<boolean>;

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -12,14 +12,29 @@ declare namespace Waterline {
     type Connection = {
         adapter: string;
     }
+    type ConnectionV3 = {
+        adapter: string;
+        url?: string,
+        host?: string,
+        port?: number,
+        schema?: boolean,
+        user?: string,
+        password?: string,
+        database?: string
+    }
     interface Config {
         adapters: { [index: string]: Adapter };
         connections: { [index: string]: Connection }
+    }
+    interface ConfigV3 {
+        adapters: { [index: string]: Adapter };
+        datastores: { [index: string]: ConnectionV3 }
     }
     type Ontology = {
         collections: any;
     }
     interface Waterline {
+        registerModel(collection: CollectionClassV3): void;
         loadCollection(collection: CollectionClass): void;
         initialize: (config: Config, cb: (err: Error, ontology: Ontology) => any) => any;
         collections: any;
@@ -27,6 +42,10 @@ declare namespace Waterline {
     interface CollectionClass {
         (): Collection
     }
+    interface CollectionClassV3 {
+        (): CollectionV3
+    }
+
     // used this comment https://github.com/balderdashy/waterline/issues/1154#issuecomment-167262575
     export type LifecycleCallbacks = {
         beforeValidate?: { (vaues: any, next: Function): void }[] | { (vaues: any, next: Function): void };
@@ -49,6 +68,18 @@ declare namespace Waterline {
         schema?: boolean;
         types?: any;
     }
+    export type CollectionDefinitionV3 = LifecycleCallbacks & {
+        attributes?: AttributeV3;
+        connection?: string;
+        identity?: string;
+        tableName?: string;
+        migrate?: "alter" | "drop" | "safe";
+        autoPK?: boolean;
+        schema?: boolean;
+        types?: any;
+    }
+
+    export type CollectionV3 = CollectionDefinitionV3;
     export type Collection = CollectionDefinition;
     export type Attributes = { [index: string]: Attribute } & {
         toJSON?: () => string;
@@ -64,6 +95,13 @@ declare namespace Waterline {
         BooleanAttribute | BinaryAttribute | ArrayAttribute | JsonAttribute |
         OneToOneAttribute | OneToManyAttribute | ManyToManyAttribute |
         FunctionAttribute;
+
+    export type AttributeV3 = string | StringAttributeV3 | NumberAttributeV3  |
+        BooleanAttributeV3 | JsonAttributeV3 | RefAttributeV3 |
+        OneToOneAttributeV3 | OneToManyAttributeV3 | ManyToManyAttributeV3 |
+        FunctionAttribute;
+
+
     export type DefaultsToFn<T> = () => T;
     export type BaseAttribute<T> = AttributeValidations & {
         type?: string;
@@ -76,7 +114,30 @@ declare namespace Waterline {
         index?: boolean;
         defaultsTo?: T | DefaultsToFn<T>;
     }
+    export type BaseAttributeV3<T> =  {
+        type?: string;
+        autoMigrations?: AutoMigration;
+        unique?: boolean;
+        required?: boolean;
+        columnName?: string;
+        index?: boolean;
+        allowNull?:  boolean;
+        autoCreatedAt?: boolean;
+        autoUpdatedAt?: boolean;
+        validations?: AttributeValidationsV3;
+        defaultsTo?: T | DefaultsToFn<T>;
+    }
+
+    export interface AutoMigration  {
+        autoIncrement?: boolean;
+        columnType?: string;
+    }
+
+
     export type StringAttribute = BaseAttribute<string> & {
+        type: "string";
+    }
+    export type StringAttributeV3 = BaseAttributeV3<string> & {
         type: "string";
     }
     export type EmailAttribute = BaseAttribute<string> & {
@@ -88,6 +149,9 @@ declare namespace Waterline {
     export type IntegerAttribute = BaseAttribute<number> & {
         type: "integer";
         autoIncrement?: boolean;
+    }
+    export type NumberAttributeV3 = BaseAttributeV3<number> & {
+        type: "number";
     }
     export type FloatAttribute = BaseAttribute<number> & {
         type: "float";
@@ -104,6 +168,9 @@ declare namespace Waterline {
     export type BooleanAttribute = BaseAttribute<boolean> & {
         type: 'boolean';
     }
+    export type BooleanAttributeV3 = BaseAttributeV3<number> & {
+        type: "number";
+      }
     export type BinaryAttribute = BaseAttribute<any> & {
         type: 'binary';
     }
@@ -113,10 +180,23 @@ declare namespace Waterline {
     export type JsonAttribute = BaseAttribute<any> & {
         type: 'json';
     }
+    export type JsonAttributeV3 = BaseAttributeV3<any> & {
+        type: "json";
+    }
+    export type RefAttributeV3 = BaseAttributeV3<any> & {
+        type: 'ref';
+    }
     export type OneToOneAttribute = BaseAttribute<any> & {
         model: string;
     }
+    export type OneToOneAttributeV3 = BaseAttributeV3<any> & {
+        model: string;
+    }
     export type OneToManyAttribute = BaseAttribute<any> & {
+        collection: string;
+        via: string;
+    }
+    export type OneToManyAttributeV3 = BaseAttributeV3<any> & {
         collection: string;
         via: string;
     }
@@ -125,10 +205,34 @@ declare namespace Waterline {
         via: string;
         dominant?: boolean;
     }
+    export type ManyToManyAttributeV3 = BaseAttributeV3<any> & {
+        collection: string;
+        via: string;
+        dominant?: boolean;
+    }
     type AttributeValidationSyncFn<T> = () => T;
     type AttributeValidationAsyncFn<T> = (cb: (value: T) => any) => void;
 
     export type AttributeValidation<T> = T | AttributeValidationSyncFn<T> | AttributeValidationAsyncFn<T>;
+    export interface AttributeValidationsV3 {
+        custom?: AttributeValidationAsyncFn<any>;
+        isAfter?: AttributeValidation<Date>;
+        isBefore?: AttributeValidation<Date>;
+        isBoolean?: AttributeValidation<boolean>;
+        isCreditCard?:AttributeValidation<boolean>;
+        isIP?: AttributeValidation<boolean>;
+        isNotEmptyString?:AttributeValidation<boolean>;
+        isNotIn?: AttributeValidation<string[]>;
+        isNumber?: AttributeValidation<boolean>;
+        isString?:AttributeValidation<boolean>;
+        isURL?: AttributeValidation<boolean>;
+        isUUID?: AttributeValidation<boolean>;
+        max?: AttributeValidation<number>;
+        min?: AttributeValidation<number>;
+        maxlength?: AttributeValidation<number>;
+        minLength?:  AttributeValidation<number>;
+        regex?: AttributeValidation<RegExp>
+    }
     export interface AttributeValidations {
         after?: AttributeValidation<string>;
         alpha?: AttributeValidation<boolean>;

--- a/types/waterline/index.d.ts
+++ b/types/waterline/index.d.ts
@@ -36,7 +36,7 @@ declare namespace Waterline {
     interface Waterline {
         registerModel(collection: CollectionClassV3): void;
         loadCollection(collection: CollectionClass): void;
-        initialize: (config: Config, cb: (err: Error, ontology: Ontology) => any) => any;
+        initialize: (config: Config | ConfigV3, cb: (err: Error, ontology: Ontology) => any) => any;
         collections: any;
     }
     interface CollectionClass {
@@ -69,7 +69,7 @@ declare namespace Waterline {
         types?: any;
     }
     export type CollectionDefinitionV3 = LifecycleCallbacks & {
-        attributes?: AttributeV3;
+        attributes?: AttributesV3;
         connection?: string;
         identity?: string;
         tableName?: string;
@@ -85,10 +85,16 @@ declare namespace Waterline {
         toJSON?: () => string;
         toObject?: () => any;
     };
+    export type AttributesV3 = { [index: string]: AttributeV3 } & {
+        toJSON?: () => string;
+        toObject?: () => any;
+    };
     export type FunctionAttribute = () => any;
     // Data types https://github.com/balderdashy/waterline-docs/blob/master/models/data-types-attributes.md#data-types
     export type AttributeType = "string" | "text" | "integer" | "float" | "date" | "time"
         | "datetime" | "boolean" | "binary" | "array" | "json";
+    export type AttributeTypeV3 = "string" | "number" | "boolean" | "json" | "ref";
+
     export type Attribute = string | StringAttribute | EmailAttribute |
         IntegerAttribute | FloatAttribute |
         DateAttribute | TimeAttribute | DatetimeAttribute |
@@ -219,6 +225,7 @@ declare namespace Waterline {
         isAfter?: AttributeValidation<Date>;
         isBefore?: AttributeValidation<Date>;
         isBoolean?: AttributeValidation<boolean>;
+        isEmail?: AttributeValidation<boolean>;
         isCreditCard?:AttributeValidation<boolean>;
         isIP?: AttributeValidation<boolean>;
         isNotEmptyString?:AttributeValidation<boolean>;
@@ -344,6 +351,9 @@ declare namespace Waterline {
 declare interface WaterlineStatic {
     Collection: {
         extend: (params: Waterline.CollectionDefinition) => Waterline.CollectionClass;
+    }
+    CollectionV3: {
+        extend: (params: Waterline.CollectionDefinitionV3) => Waterline.CollectionClassV3;
     }
     new (): Waterline.Waterline;
 }

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -289,16 +289,11 @@ const validationsV3: Waterline.AttributeV3 = {
     type: "string",
     required: true,
     allowNull: true,
-    autoMigrations: {
-        columnType: '_string',
-        autoIncrement: true,
-
-    },
     validations: {
         isString: true,
         isBoolean: true,
         isAfter: new Date("12/12/2001"),
-        isBefore: new Date("12/12/2019"),
+        isBefore: new Date("12/12/2001"),
         isCreditCard:true,
         regex: /ab+c/,
         max: 24,
@@ -308,6 +303,8 @@ const validationsV3: Waterline.AttributeV3 = {
         isUUID: true,
         isURL: true,
         isNumber: true,
+        isNotEmptyString: true,
+        isIp: true,
     }
 };
 
@@ -369,38 +366,6 @@ const attr1: Waterline.CollectionDefinition = {
         next();
     },
 };
-
-const attr2: Waterline.CollectionDefinitionV3 = {
-    beforeValidate: (values, next) => {
-        next();
-        next("");
-    },
-    beforeCreate: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-    afterCreate: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-    beforeUpdate: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-    afterUpdate: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-    beforeDestroy: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-    afterDestroy: (values, next) => {
-        next(new Error(""));
-        next();
-    },
-};
-
 // Queries https://github.com/balderdashy/waterline-docs/blob/master/queries/query.md
 let User: Waterline.Model = {} as any;
 User.find()

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -295,6 +295,12 @@ const validationsV3: Waterline.Attribute = {
         isAfter: new Date("12/12/2001"),
         isBefore: new Date("12/12/2001"),
         isCreditCard:true,
+        isHexColor: true,
+        isEmail: true,
+        isIn: ['test', 'pass'],
+        isNotIn: ['not', 'fail'],
+        isNotEmptyString: true,
+        isNumber: true,
         regex: /ab+c/,
         max: 24,
         min: 4,
@@ -302,8 +308,6 @@ const validationsV3: Waterline.Attribute = {
         maxLength: 24,
         isUUID: true,
         isURL: true,
-        isNumber: true,
-        isNotEmptyString: true,
         isIp: true,
     }
 };

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -1,6 +1,6 @@
 import Waterline = require("waterline");
 const waterline = new Waterline();
-const userCollection = Waterline.Collection.extend({
+const userCollection = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
     identity: "user",
     connection: "default",
     attributes: {
@@ -15,7 +15,7 @@ const userCollection = Waterline.Collection.extend({
         },
     },
 });
-const userCollectionV3 = Waterline.CollectionV3.extend({
+const userCollectionV3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
     identity: "userv3",
     connection: "default",
     attributes: {
@@ -29,7 +29,7 @@ const userCollectionV3 = Waterline.CollectionV3.extend({
         },
     },
 });
-const petCollection = Waterline.Collection.extend({
+const petCollection = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
     identity: "pet",
     connection: "default",
     attributes: {
@@ -44,7 +44,7 @@ const petCollection = Waterline.Collection.extend({
     },
 });
 
-const petCollectionv3 = Waterline.CollectionV3.extend({
+const petCollectionv3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
     identity: "petv3",
     connection: "default",
     attributes: {
@@ -149,7 +149,7 @@ waterline.initialize(configV3, (err, ontology) => {
     });
 });
 
-const Person = Waterline.Collection.extend({
+const Person = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
     identity: "person",
     connection: "local-postgresql",
 
@@ -187,7 +187,7 @@ const Person = Waterline.Collection.extend({
     }
 });
 
-const PersonV3 = Waterline.CollectionV3.extend({
+const PersonV3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
     identity: "person",
     connection: "local-postgresql",
 

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -1,6 +1,6 @@
 import Waterline = require("waterline");
 const waterline = new Waterline();
-const userCollection = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
+const userCollection = Waterline.Collection.extend({
     identity: "user",
     connection: "default",
     attributes: {
@@ -15,7 +15,7 @@ const userCollection = Waterline.Collection.extend<Waterline.CollectionDefinitio
         },
     },
 });
-const userCollectionV3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
+const userCollectionV3 = Waterline.Collection.extend({
     identity: "userv3",
     connection: "default",
     attributes: {
@@ -29,7 +29,7 @@ const userCollectionV3 = Waterline.Collection.extend<Waterline.CollectionDefinit
         },
     },
 });
-const petCollection = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
+const petCollection = Waterline.Collection.extend({
     identity: "pet",
     connection: "default",
     attributes: {
@@ -44,7 +44,7 @@ const petCollection = Waterline.Collection.extend<Waterline.CollectionDefinition
     },
 });
 
-const petCollectionv3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
+const petCollectionv3 = Waterline.Collection.extend({
     identity: "petv3",
     connection: "default",
     attributes: {
@@ -76,7 +76,7 @@ const config: Waterline.Config = {
     },
 };
 
-const configV3: Waterline.ConfigV3 = {
+const configV3: Waterline.Config = {
     adapters: {
         memory: {},
     },
@@ -149,7 +149,7 @@ waterline.initialize(configV3, (err, ontology) => {
     });
 });
 
-const Person = Waterline.Collection.extend<Waterline.CollectionDefinition, Waterline.Collection>({
+const Person = Waterline.Collection.extend({
     identity: "person",
     connection: "local-postgresql",
 
@@ -187,7 +187,7 @@ const Person = Waterline.Collection.extend<Waterline.CollectionDefinition, Water
     }
 });
 
-const PersonV3 = Waterline.Collection.extend<Waterline.CollectionDefinitionV3, Waterline.CollectionV3>({
+const PersonV3 = Waterline.Collection.extend({
     identity: "person",
     connection: "local-postgresql",
 
@@ -285,7 +285,7 @@ const validations: Waterline.Attribute = {
     maxLength: 24,
 };
 
-const validationsV3: Waterline.AttributeV3 = {
+const validationsV3: Waterline.Attribute = {
     type: "string",
     required: true,
     allowNull: true,

--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -369,6 +369,38 @@ const attr1: Waterline.CollectionDefinition = {
         next();
     },
 };
+
+const attr2: Waterline.CollectionDefinitionV3 = {
+    beforeValidate: (values, next) => {
+        next();
+        next("");
+    },
+    beforeCreate: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+    afterCreate: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+    beforeUpdate: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+    afterUpdate: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+    beforeDestroy: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+    afterDestroy: (values, next) => {
+        next(new Error(""));
+        next();
+    },
+};
+
 // Queries https://github.com/balderdashy/waterline-docs/blob/master/queries/query.md
 let User: Waterline.Model = {} as any;
 User.find()


### PR DESCRIPTION
Add compatibility to waterline v3

Package modified types/waterline Add new types for v3 of waterline

#### Change list
* ConfigV3
* Add registerModel method `registerModel(collection: CollectionClassV3): void`
* CollectionClassV3
* CollectionDefinitionV3
* AttributesV3
* AttributeTypeV3
* BaseAttributeV3<T>
* new interface AutoMigration
* new interface AttributeValidationsV3
* keep old interfaces to maintain compatibility with v2
Select one of these and delete the others:

i added definition for waterline v3 keep consistency with v2 types.