### PR TITLE
react-big-calendar: add missing property `Messages.noEventsInRange`

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -7,6 +7,7 @@
 //                 Paul Potsides <https://github.com/strongpauly>
 //                 janb87 <https://github.com/janb87>
 //                 Daniel Thorne <https://github.com/ldthorne>
+//                 Panagiotis Rikarnto Siavelis <https://github.com/siavelis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { Validator } from 'prop-types';
@@ -204,6 +205,7 @@ export interface Messages {
     today?: string;
     agenda?: string;
     showMore?: (count: number) => string;
+    noEventsInRange?: string;
 }
 
 export type Culture = string | string[];

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -131,7 +131,24 @@ class CalendarResource {
                   agendaDateFormat: (date: Date, culture?: string, localizer?: object) => "some-format",
                   dayRangeHeaderFormat: (range: DateRange, culture?: string, localizer?: object) => "some-format"
               }}
-              messages={{}}
+              messages={{
+                date: 'Date',
+                time: 'Time',
+                event: 'Event',
+                allDay: 'All Day',
+                week: 'Week',
+                work_week: 'Work Week',
+                day: 'Day',
+                month: 'Month',
+                previous: 'Back',
+                next: 'Next',
+                yesterday: 'Yesterday',
+                tomorrow: 'Tomorrow',
+                today: 'Today',
+                agenda: 'Agenda',
+                noEventsInRange: 'There are no events in this range.',
+                showMore: total => `+${total} more`,
+              }}
               timeslots={24}
               defaultView={'month'}
               className={'my-calendar'}


### PR DESCRIPTION
(change related to version [0.20](https://github.com/intljusticemission/react-big-calendar/releases/tag/v0.20.0))
Added missing property `Messages.noEventsInRange`. Also, updated the test case related to this interface.

You can check that this property is defined [here](https://github.com/intljusticemission/react-big-calendar/blob/8fefeee393d7173a37734da7e34af5da64959214/src/Calendar.js#L720), default initialized [here](https://github.com/intljusticemission/react-big-calendar/blob/8fefeee393d7173a37734da7e34af5da64959214/src/utils/messages.js#L17) and most importantly used [here](https://github.com/intljusticemission/react-big-calendar/blob/8fefeee393d7173a37734da7e34af5da64959214/src/Agenda.js#L58).


