### PR TITLE
[react] Allow children inside React.memo

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -752,9 +752,9 @@ declare namespace React {
     }
 
     function memo<P extends object>(
-        Component: SFC<P>,
+        Component: FunctionComponent<P>,
         propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean
-    ): NamedExoticComponent<P>;
+    ): NamedExoticComponent<PropsWithChildren<P>>;
     function memo<T extends ComponentType<any>>(
         Component: T,
         propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -220,10 +220,11 @@ const Memoized5 = React.memo<{ test: boolean }>(
     (prevProps, nextProps) => nextProps.test ? prevProps.children === nextProps.children : prevProps.test
 );
 
+<Memoized5 test>Content</Memoized5>;
 <Memoized5 test/>;
 
 // for some reason the ExpectType doesn't work if the type is namespaced
-// $ExpectType NamedExoticComponent<{}>
+// $ExpectType NamedExoticComponent<{ children?: ReactNode; }>
 const Memoized6 = React.memo(props => null);
 <Memoized6/>;
 // $ExpectError


### PR DESCRIPTION
Fixes the following issue
```
const Select = React.memo<{ id: string }>(props => 
  (<select id={props.id}>{props.children}</select>)
)

<Select id="foo">
  <option value="dog">Dog</option>
  <option value="cat">Cat</option>
</Select>
```

> Type '{ children: string; id: 'foo'; }' is not assignable to type 'IntrinsicAttributes & { id: string; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & { id: string; }'