### PR TITLE
[react-redux] Fix #33690: improper import of `hoist-non-react-statics`

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -43,7 +43,7 @@ import {
     Store
 } from 'redux';
 
-import { NonReactStatics } from 'hoist-non-react-statics';
+import hoistNonReactStatics = require('hoist-non-react-statics');
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -100,7 +100,7 @@ export type GetProps<C> = C extends ComponentType<infer P> ? P : never;
 export type ConnectedComponentClass<
     C extends ComponentType<any>,
     P
-> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & NonReactStatics<C> & {
+> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & hoistNonReactStatics.NonReactStatics<C> & {
     WrappedComponent: C;
 };
 


### PR DESCRIPTION
**This PR fixes a regression in a popular package (`react-redux`). Please review and merge ASAP.**

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~ Unnecessary.
- [X] ~Increase the version number in the header if appropriate.~ Unnecessary.
- [X] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ Unnecessary.

---

I regressed `react-redux` in 8b1beff94 by importing `hoist-non-react-statics` using the ES6 import syntax, when I should've used the TypeScript namespace/module import syntax.

This PR corrects the mistake, and should be an appropriate fix for #33690.