### PR TITLE
[duplexify] add 'default' to DuplexifyConstructor

### DIFF
--- a/types/duplexify/index.d.ts
+++ b/types/duplexify/index.d.ts
@@ -14,6 +14,7 @@ interface DuplexifyConstructor {
   new (writable?: stream.Writable, readable?: stream.Readable, streamOptions?: stream.DuplexOptions): duplexify.Duplexify;
 
   obj(writable?: stream.Writable, readable?: stream.Readable, streamOptions?: stream.DuplexOptions): duplexify.Duplexify;
+  default: DuplexifyConstructor;
 }
 declare var duplexify: DuplexifyConstructor;
 declare namespace duplexify {


### PR DESCRIPTION
In its current form, using `duplexify` in Typescript apps
with a tsconfig that has esModuleInterop set to `true` where the
code has a class that extends `Duplexify` causes a compliation
error.

This is because if esModuleInterop is set to `true`, the
`Duplexify` constructor is accessed through the synthesized
default export of `duplexify`.

By having the `DuplexifyConstructor` have a `default` property
that is itself a `DuplexifyConstrutor`, users can use
`duplexify` with esModuleInterop set to `true` or `false`.

See issue
https://github.com/googleapis/nodejs-logging-bunyan/issues/241
for more context.