### PR TITLE
Fix return types on several column() functions.

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -615,7 +615,7 @@ dt.columns('.select-filter').eq(0).each((colIdx: any) => {
     // Create the select list and search operation
     const select = $('<select />')
         .appendTo(
-            dt.column(colIdx).footer() as HTMLElement
+            dt.column(colIdx).footer()
         )
         .on('change', () => {
             dt
@@ -656,8 +656,8 @@ $('#listData').html(
 const columns_dataSrc = columns.dataSrc();
 // alert('Data source: ' + dt.columns([0, 1]).dataSrc().join(' '));
 
-const columns_footer: Node = columns.footer();
-const columns_header = columns.header();
+const columns_footer: HTMLElement = columns.footer();
+const columns_header: HTMLElement = columns.header();
 let columns_indexes = columns.indexes();
 columns_indexes = columns.indexes("visibile");
 const columns_nodes = columns.nodes();
@@ -699,7 +699,7 @@ const column_cache = column.cache("order");
 // Create the select list and search operation
 const select = $('<select />')
     .appendTo(
-        dt.column(0).footer() as HTMLElement
+        dt.column(0).footer()
     )
     .on('change', () => {
         dt
@@ -735,7 +735,7 @@ $('#example').on('click', 'tbody td', () => {
     alert('Data source: ' + dt.column(idx).dataSrc());
 });
 
-const column_footer: Node = column.footer();
+const column_footer: HTMLElement = column.footer();
 const column_p = dt.column(0);
 // $(column.footer()).html(
 //    column_p
@@ -745,10 +745,10 @@ const column_p = dt.column(0);
 //    })
 //    );
 
-const column_header = column.header();
+const column_header: HTMLElement = column.header();
 $('#example tbody').on('click', 'td', function() {
     const idx = dt.cell(this).index().column;
-    const title = dt.column(idx).header();
+    const title: HTMLElement = dt.column(idx).header();
 
     alert('Column title clicked on: ' + $(title).html());
 });
@@ -782,7 +782,7 @@ dt.columns('.select-filter').eq(0).each((colIdx: any) => {
     // Create the select list and search operation
     const select = $('<select />')
         .appendTo(
-            dt.column(colIdx).footer() as HTMLElement
+            dt.column(colIdx).footer()
         )
         .on('change', function() {
             dt

--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -615,7 +615,7 @@ dt.columns('.select-filter').eq(0).each((colIdx: any) => {
     // Create the select list and search operation
     const select = $('<select />')
         .appendTo(
-        dt.column(colIdx).footer()
+            dt.column(colIdx).footer() as HTMLElement
         )
         .on('change', () => {
             dt
@@ -656,7 +656,7 @@ $('#listData').html(
 const columns_dataSrc = columns.dataSrc();
 // alert('Data source: ' + dt.columns([0, 1]).dataSrc().join(' '));
 
-const columns_footer = columns.footer();
+const columns_footer: Node = columns.footer();
 const columns_header = columns.header();
 let columns_indexes = columns.indexes();
 columns_indexes = columns.indexes("visibile");
@@ -674,7 +674,7 @@ columns_search_set = columns.search("string", true);
 columns_search_set = columns.search("string", true, false);
 columns_search_set = columns.search("string", true, false, true);
 
-const columns_visible_get = columns.visible();
+const columns_visible_get: boolean = columns.visible();
 let columns_visible_set = columns.visible(false);
 columns_visible_set = columns.visible(false, true);
 // Hide a column
@@ -690,8 +690,8 @@ column = dt.column("selector", modifier);
 dt.column(0).visible(false);
 
 $('#example tbody').on('click', 'td', () => {
-    const visIdx = $(this).index();
-    const dataIdx = dt.column.index('fromVisible', visIdx);
+    const visIdx: number = $(this).index();
+    const dataIdx: number = dt.column.index('fromVisible', visIdx);
     alert('Column data index:');
 });
 
@@ -699,7 +699,7 @@ const column_cache = column.cache("order");
 // Create the select list and search operation
 const select = $('<select />')
     .appendTo(
-    dt.column(0).footer()
+        dt.column(0).footer() as HTMLElement
     )
     .on('change', () => {
         dt
@@ -735,7 +735,7 @@ $('#example').on('click', 'tbody td', () => {
     alert('Data source: ' + dt.column(idx).dataSrc());
 });
 
-const column_footer = column.footer();
+const column_footer: Node = column.footer();
 const column_p = dt.column(0);
 // $(column.footer()).html(
 //    column_p
@@ -753,7 +753,7 @@ $('#example tbody').on('click', 'td', function() {
     alert('Column title clicked on: ' + $(title).html());
 });
 
-let column_index = column.index();
+let column_index: number = column.index();
 column_index = column.index("visibile");
 dt.column(0).visible(false);
 
@@ -762,11 +762,9 @@ alert(idx); // will show 0
 
 dt.column('0:visible').order('asc');
 
-const column_nodes = column.nodes();
-dt.column(-1)
-    .nodes();
-// .to$()      // Convert to a jQuery object
-// .addClass('ready');
+const column_nodes: DataTables.Api = column.nodes();
+column_nodes.to$()      // Convert to a jQuery object
+            .addClass('ready');
 
 const column_search_get = column.search();
 let column_search_set = column.search("string");
@@ -784,7 +782,7 @@ dt.columns('.select-filter').eq(0).each((colIdx: any) => {
     // Create the select list and search operation
     const select = $('<select />')
         .appendTo(
-        dt.column(colIdx).footer()
+            dt.column(colIdx).footer() as HTMLElement
         )
         .on('change', function() {
             dt

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -704,7 +704,7 @@ declare namespace DataTables {
         /**
          * Get the footer th / td cell for the selected column.
          */
-        footer(): any;
+        footer(): Node;
 
         /**
          * Get the header th / td cell for a column.
@@ -766,12 +766,12 @@ declare namespace DataTables {
          *
          * @param t Specify if you want to get the column data index (default) or the visible index (visible).
          */
-        index(t?: string): Api;
+        index(t?: string): number;
 
         /**
          * Obtain the th / td nodes for the selected column
          */
-        nodes(): Api[];
+        nodes(): Api;
     }
 
     interface ColumnsMethodsModel {

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -704,12 +704,12 @@ declare namespace DataTables {
         /**
          * Get the footer th / td cell for the selected column.
          */
-        footer(): Node;
+        footer(): HTMLElement;
 
         /**
          * Get the header th / td cell for a column.
          */
-        header(): Node;
+        header(): HTMLElement;
 
         /**
          * Order the table, in the direction specified, by the column selected by the column()DT selector.


### PR DESCRIPTION
- Fix return type for [column().index()](https://datatables.net/reference/api/column().index()).
- Correct return type of [column().footer()](https://datatables.net/reference/api/column().footer()).
- Correct return type of [column().nodes()](https://datatables.net/reference/api/column().nodes()). 

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: Relevant documentation URLs included in commit and PR comments.
- [ x ] Increase the version number in the header if appropriate.
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
