### PR TITLE
next: Add GetInitialProps type

### DIFF
--- a/types/next/error.d.ts
+++ b/types/next/error.d.ts
@@ -10,5 +10,5 @@ export interface DefaultErrorIProps {
 }
 
 export default class Error<P = {}> extends React.Component<P & DefaultErrorIProps> {
-    static getInitialProps: GetInitialProps<NextContext, DefaultErrorIProps>;
+    static getInitialProps: GetInitialProps<DefaultErrorIProps, NextContext>;
 }

--- a/types/next/error.d.ts
+++ b/types/next/error.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { NextContext } from ".";
+import { GetInitialProps, NextContext } from ".";
 
 /**
  * Initial props returned from base Error class.
@@ -10,5 +10,5 @@ export interface DefaultErrorIProps {
 }
 
 export default class Error<P = {}> extends React.Component<P & DefaultErrorIProps> {
-    static getInitialProps(context: NextContext): Promise<DefaultErrorIProps> | DefaultErrorIProps;
+    static getInitialProps: GetInitialProps<NextContext, DefaultErrorIProps>;
 }

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -14,8 +14,8 @@
 
 import * as http from "http";
 import * as url from "url";
-import { Server as NextServer, ServerOptions as NextServerOptions, RenderOptions } from 'next-server';
-import { NextConfig as NextServerConfig } from 'next-server/next-config';
+import { Server as NextServer, ServerOptions as NextServerOptions, RenderOptions } from "next-server";
+import { NextConfig as NextServerConfig } from "next-server/next-config";
 import { Response as NodeResponse } from "node-fetch";
 import { SingletonRouter, DefaultQuery, UrlLike } from "./router";
 
@@ -131,8 +131,16 @@ declare namespace next {
      * @template C Context passed to getInitialProps.
      */
     interface NextStaticLifecycle<IP, C> {
-        getInitialProps?: (ctx: C) => Promise<IP> | IP;
+        getInitialProps?: GetInitialProps<IP, C>;
     }
+
+    /**
+     * Next.js getInitialProps type.
+     *
+     * @template IP Initial props returned from getInitialProps and passed to the component.
+     * @template C Context passed to getInitialProps.
+     */
+    type GetInitialProps<IP, C> = (ctx: C) => Promise<IP> | IP;
 }
 
 declare function next(options?: next.ServerOptions & { dev: true }): next.DevServer;


### PR DESCRIPTION
Add type GetInitialProps<IP, C>. Can be use like the example:

```js
interface IProps extends IInitialProps {}

class Page extends React.Component<IProps, IState> {
    public static getInitialProps: GetInitialProps<
        IInitialProps,
        NextContext
    > = (ctx) => {
        return {};
    };
}
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
