### PR TITLE
update license-checker definitions to 25.0.1

### DIFF
--- a/types/license-checker/index.d.ts
+++ b/types/license-checker/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for license-checker 15.0
+// Type definitions for license-checker 25.0
 // Project: https://github.com/davglass/license-checker
-// Definitions by: Rogier Schouten <https://github.com/rogierschouten>, Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions by: Rogier Schouten <https://github.com/rogierschouten>,
+//                 Daniel Perez Alvarez <https://github.com/unindented>,
+//                 Alec Custer <https://github.com/alechemy>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /**
@@ -28,7 +30,23 @@ export interface InitOpts {
      */
     onlyunknown?: boolean;
     /**
-     * to add a custom Format file in JSON
+     * Output in json format
+     */
+    json?: boolean;
+    /**
+     * Output in csv format
+     */
+    csv?: boolean;
+    /**
+     * Prefix column for component in csv format.
+     */
+    csvComponentPrefix?: string;
+    /**
+     * Write the data to a specific file.
+     */
+    out?: string;
+    /**
+     * To add a custom Format file in JSON
      */
     customPath?: string | ModuleInfo;
     /**
@@ -44,13 +62,29 @@ export interface InitOpts {
      */
     summary?: boolean;
     /**
-     * Fail (exit with code 1) on the first occurrence of the licenses of the comma-separated list
+     * Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
      */
-    failOn?: string[];
+    failOn?: string;
     /**
-     * Use chalk to colorize the licenses member of each returned module info. Unknown licenses become red.
+     * Fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-separated list
      */
-    color?: boolean;
+    onlyAllow?: string;
+    /**
+     * Restrict output to the packages (package@version) in the semicolon-separated list
+     */
+    packages?: string;
+    /**
+     * Restrict output to the packages (package@version) not in the semicolon-separated list
+     */
+    excludePackages?: string;
+    /**
+     * Restrict output to not include any package marked as private
+     */
+    excludePrivatePackages?: boolean;
+    /**
+     * Look for direct dependencies only
+     */
+    direct?: boolean;
 }
 
 /**

--- a/types/license-checker/license-checker-tests.ts
+++ b/types/license-checker/license-checker-tests.ts
@@ -8,7 +8,17 @@ checker.init(
         production: true,
         customPath: {
             licenseText: ""
-        }
+        },
+        json: false,
+        csv: false,
+        csvComponentPrefix: "prefixColumn",
+        out: "/write/to/specific/file",
+        failOn: "impermissible;licenses",
+        onlyAllow: "permissible;licenses",
+        packages: "packages;to;check",
+        excludePackages: "packages;to;exclude",
+        excludePrivatePackages: false,
+        direct: false
     },
     (err: Error, json: checker.ModuleInfos): void => {
         if (err) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davglass/license-checker#readme
- [x] Increase the version number in the header if appropriate.
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~