### PR TITLE
[next] add `Html` component to `_document` page

### DIFF
--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -111,6 +111,7 @@ export type DocumentComponentType<P = {}, IP = P, C = NextDocumentContext> = Nex
     C
 >;
 
+export class Html extends React.Component<React.HTMLProps<HTMLHtmlElement>> {}
 export class Head extends React.Component<HeadProps> {}
 export class Main extends React.Component {}
 export class NextScript extends React.Component<NextScriptProps> {}

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -1,6 +1,7 @@
 import Document, {
     DocumentProps,
     Enhancer,
+    Html,
     Head,
     Main,
     NextScript,
@@ -21,7 +22,7 @@ class MyDocumentDefault extends Document {
 
     render() {
         return (
-            <html>
+            <Html>
                 <Head>
                     <style>{`body { margin: 0 } /* custom! */`}</style>
                 </Head>
@@ -29,7 +30,7 @@ class MyDocumentDefault extends Document {
                     <Main />
                     <NextScript />
                 </body>
-            </html>
+            </Html>
         );
     }
 }


### PR DESCRIPTION
Fixes #33872.

Adds the new built-in `<Html>` component to the `_document` page.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/canary/packages/next/pages/_document.js#L47-L65
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
