### PR TITLE
node-forge: fixed local jsbn to use actual jsbn types to fix BigInteger toString options.

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -29,7 +29,7 @@ declare module "node-forge" {
             data: number[];
             t: number;
             s: number;
-            toString(): string;
+            toString(b?: number): string;
         }
     }
 

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -14,7 +14,7 @@
 // TypeScript Version: 2.6
 
 /// <reference types="node" />
-
+import * as jsbn from "jsbn";
 declare module "node-forge" {
     type Byte = number;
     type Bytes = string;
@@ -23,15 +23,6 @@ declare module "node-forge" {
     type Utf8 = string;
     type OID = string;
     type Encoding = "raw" | "utf8";
-
-    namespace jsbn {
-        class BigInteger {
-            data: number[];
-            t: number;
-            s: number;
-            toString(b?: number): string;
-        }
-    }
 
     namespace pem {
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -343,3 +343,7 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     console.log('created TLS client and server, doing handshake...');
     client.handshake();
 }
+
+{
+    keypair.privateKey.e.toString(16);
+}


### PR DESCRIPTION
This removes local jsbn.BigInteger types and uses jsbn module types directly.
⚠️ Please check that this is correctly added as I'm still quite new to modify those types.⚠️

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/andyperlitch/jsbn/blob/master/index.js#L177
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

