### PR TITLE
ramda: support R.__ in R.propOr

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2332,6 +2332,8 @@ declare namespace R {
          * If the given, non-null object has an own property with the specified name, returns the value of that property.
          * Otherwise returns the provided default value.
          */
+        propOr<T, U>(val: T, __: Placeholder, obj: U): <V>(p: string) => V;
+        propOr<U>(__: Placeholder, p: string, obj: U): <T, V>(val: T) => V;
         propOr<T, U, V>(val: T, p: string, obj: U): V;
         propOr<T>(val: T, p: string): <U, V>(obj: U) => V;
         propOr<T>(val: T): <U, V>(p: string, obj: U) => V;

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1967,6 +1967,8 @@ class Rectangle {
     const favoriteWithDefault = R.propOr("Ramda", "favoriteLibrary");
 
     const s2 = favoriteWithDefault(alice);  // => 'Ramda'
+    R.propOr('Ramda', R.__, alice)('name');  // => 'ALICE'
+    R.propOr(R.__, 'foo', alice)('default');  // => 'default'
 };
 
 () => {


### PR DESCRIPTION
support using `R.__` in `R.propOr`, where currently it doesn't

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://ramdajs.com/docs/#__>>