### PR TITLE
webpack: Fix startTime and endTime in Stats

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1131,8 +1131,8 @@ declare namespace webpack {
     abstract class Stats {
         compilation: compilation.Compilation;
         hash?: string;
-        startTime?: Date;
-        endTime?: Date;
+        startTime?: number;
+        endTime?: number;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;
         /** Returns true if there were warnings while compiling. */

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -895,3 +895,11 @@ profiling = new webpack.debug.ProfilingPlugin({ outputPath: './path.json' });
 configuration = {
     plugins: [profiling]
 };
+
+compiler.hooks.done.tap('foo', stats => {
+  if (stats.startTime === undefined || stats.endTime === undefined) {
+    throw new Error('Well, this is odd');
+  }
+
+  console.log(`Compiled in ${stats.endTime - stats.startTime}ms`);
+});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/6389e41e4c65bf32a916e6fffa5d65f66538d483/lib/Compiler.js#L223-L233
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Just realized that I typed `startTime` and `endTime` incorrectly in #27497. Quite embarrassing, considering that they were the main reason for the whole PR :slightly_smiling_face: Haven't noticed the problem in my own code until now because was casting `stats` to `any` all the time, out of habit.