### PR TITLE
Update @types/stripe with connected account for Connect events

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1850,6 +1850,13 @@ declare namespace Stripe {
              */
             type: string;
         }
+        
+        interface IConnectEvent extends IEvent {
+             /**
+             * The Connect account for whom the webhook is being sent. See https://stripe.com/docs/connect/webhooks
+             */
+            account: string; 
+        }
 
         interface IEventListOptions extends IListOptionsCreated {
             /**


### PR DESCRIPTION
If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/connect/webhooks

Change reason: Missing interface
Details:
Stripe Connect users receive webhooks on behalf of other stripe accounts. When this happens, an event includes an 'account' property with the id of the account that the event occurred on.


