### PR TITLE
Add type definitions to webpack-plugin-serve

### DIFF
--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -34,5 +34,4 @@ declare namespace historyApiFallback {
         from: RegExp;
         to: string | RegExp | RewriteTo;
     }
-
 }

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -10,26 +10,29 @@ import { Url } from 'url';
 
 import * as core from "express-serve-static-core";
 
-declare function historyApiFallback(options?: Options): core.RequestHandler;
-declare namespace historyApiFallback {}
 export = historyApiFallback;
 
-interface Options {
-    disableDotRule?: true;
-    htmlAcceptHeaders?: string[];
-    index?: string;
-    logger?: typeof console.log;
-    rewrites?: Rewrite[];
-    verbose?: boolean;
-}
+declare function historyApiFallback(options?: historyApiFallback.Options): core.RequestHandler;
 
-interface Context {
-    match: RegExpMatchArray;
-    parsedUrl: Url;
-}
-type RewriteTo = (context: Context) => string;
+declare namespace historyApiFallback {
+    interface Options {
+        disableDotRule?: true;
+        htmlAcceptHeaders?: string[];
+        index?: string;
+        logger?: typeof console.log;
+        rewrites?: Rewrite[];
+        verbose?: boolean;
+    }
 
-interface Rewrite {
-    from: RegExp;
-    to: string | RegExp | RewriteTo;
+    interface Context {
+        match: RegExpMatchArray;
+        parsedUrl: Url;
+    }
+    type RewriteTo = (context: Context) => string;
+
+    interface Rewrite {
+        from: RegExp;
+        to: string | RegExp | RewriteTo;
+    }
+
 }

--- a/types/koa-compress/index.d.ts
+++ b/types/koa-compress/index.d.ts
@@ -16,12 +16,18 @@
 /// <reference types="node" />
 /// <reference types="koa" />
 
-declare module "koa-compress" {
+import * as Koa from "koa";
+import * as zlib from "zlib";
 
-    import * as Koa from "koa";
-    import * as zlib from "zlib";
+/**
+ * Compress middleware for Koa
+ */
+declare function koaCompress(options?: koaCompress.CompressOptions): Koa.Middleware;
 
-    interface CompressOptions extends zlib.ZlibOptions {
+export = koaCompress;
+
+declare namespace koaCompress {
+    export interface CompressOptions extends zlib.ZlibOptions {
         /**
          * An optional function that checks the response content type to decide whether to compress. By default, it uses compressible.
          */
@@ -32,12 +38,4 @@ declare module "koa-compress" {
          */
         threshold?: number
     }
-
-    /**
-     * Compress middleware for Koa
-     */
-    function compress(options?: CompressOptions): Koa.Middleware;
-
-    namespace compress {}
-    export = compress;
 }

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -93,7 +93,7 @@ export interface WebpackPluginServeOptions {
     waitForBuild?: boolean;
 }
 
-export declare class WebpackPluginServe {
+export class WebpackPluginServe {
     constructor(opts?: WebpackPluginServeOptions);
     attach(): {
         apply(compiler: Compiler): void;

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -16,93 +16,88 @@ import { ServerOptions as HttpsServerOptions } from 'https';
 import { ZlibOptions } from 'zlib';
 import { Compiler } from 'webpack';
 
-declare namespace WebpackPluginServe {
-
-    export interface CompressOptions extends ZlibOptions {
-        filter?: (content_type: string) => boolean;
-        threshold?: number;
-    }
-
-    export interface KoaStaticOptions {
-        maxage?: number;
-        hidden?: boolean;
-        index?: string;
-        defer?: boolean;
-        gzip?: boolean;
-        br?: boolean;
-        setHeaders?: (res: any, path: any, stats: any) => any;
-        extensions?: string[] | boolean;
-    }
-
-    export type RewriteTo = (context: Context) => string;
-
-    export interface Context {
-        match: RegExpMatchArray;
-        parsedUrl: Url;
-    }
-
-    export interface Rewrite {
-        from: RegExp;
-        to: string | RegExp | RewriteTo;
-    }
-
-    export interface HistoryApiFallbackOptions {
-        disableDotRule?: true;
-        htmlAcceptHeaders?: string[];
-        index?: string;
-        logger?: typeof console.log;
-        rewrites?: Rewrite[];
-        verbose?: boolean;
-    }
-
-    export interface Builtins {
-        proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
-        compress: (opts: CompressOptions) => void;
-        static: (paths: string[], opts?: KoaStaticOptions) => void;
-        historyFallback: (opts: HistoryApiFallbackOptions) => void;
-        websocket: () => void;
-        four0four: (fn?: (ctx: Koa.Context) => void) => void;
-    }
-
-    export interface WebpackPluginServeOptions {
-        client?: {
-            address?: string;
-            retry?: boolean;
-            silent?: boolean;
-        };
-        compress?: boolean;
-        historyFallback?: boolean | HistoryApiFallbackOptions;
-        hmr?: boolean;
-        host?: string | Promise<string>;
-        http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
-        https?: HttpsServerOptions;
-        liveReload?: boolean;
-        log?: {
-            level: string;
-            timestamp?: boolean;
-        };
-        middleware?: (app: Koa, builtins: Builtins) => void;
-        open?:
-        | boolean
-        | {
-            wait?: boolean;
-            app?: string | ReadonlyArray<string>;
-        };
-        port?: number | Promise<number>;
-        progress?: boolean | 'minimal';
-        static?: string | string[];
-        status?: boolean;
-        waitForBuild?: boolean;
-    }
-
-    class WebpackPluginServe {
-        constructor(opts?: WebpackPluginServeOptions);
-        attach(): {
-            apply(compiler: Compiler): void;
-        };
-        hook(compiler: Compiler): void;
-        apply(compiler: Compiler): void;
-    }
+export interface CompressOptions extends ZlibOptions {
+    filter?: (content_type: string) => boolean;
+    threshold?: number;
 }
 
-export = WebpackPluginServe;
+export interface KoaStaticOptions {
+    maxage?: number;
+    hidden?: boolean;
+    index?: string;
+    defer?: boolean;
+    gzip?: boolean;
+    br?: boolean;
+    setHeaders?: (res: any, path: any, stats: any) => any;
+    extensions?: string[] | boolean;
+}
+
+export type RewriteTo = (context: Context) => string;
+
+export interface Context {
+    match: RegExpMatchArray;
+    parsedUrl: Url;
+}
+
+export interface Rewrite {
+    from: RegExp;
+    to: string | RegExp | RewriteTo;
+}
+
+export interface HistoryApiFallbackOptions {
+    disableDotRule?: true;
+    htmlAcceptHeaders?: string[];
+    index?: string;
+    logger?: typeof console.log;
+    rewrites?: Rewrite[];
+    verbose?: boolean;
+}
+
+export interface Builtins {
+    proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
+    compress: (opts: CompressOptions) => void;
+    static: (paths: string[], opts?: KoaStaticOptions) => void;
+    historyFallback: (opts: HistoryApiFallbackOptions) => void;
+    websocket: () => void;
+    four0four: (fn?: (ctx: Koa.Context) => void) => void;
+}
+
+export interface WebpackPluginServeOptions {
+    client?: {
+        address?: string;
+        retry?: boolean;
+        silent?: boolean;
+    };
+    compress?: boolean;
+    historyFallback?: boolean | HistoryApiFallbackOptions;
+    hmr?: boolean;
+    host?: string | Promise<string>;
+    http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
+    https?: HttpsServerOptions;
+    liveReload?: boolean;
+    log?: {
+        level: string;
+        timestamp?: boolean;
+    };
+    middleware?: (app: Koa, builtins: Builtins) => void;
+    open?:
+    | boolean
+    | {
+        wait?: boolean;
+        app?: string | ReadonlyArray<string>;
+    };
+    port?: number | Promise<number>;
+    progress?: boolean | 'minimal';
+    static?: string | string[];
+    status?: boolean;
+    waitForBuild?: boolean;
+}
+
+export declare class WebpackPluginServe {
+    constructor(opts?: WebpackPluginServeOptions);
+    attach(): {
+        apply(compiler: Compiler): void;
+    };
+    hook(compiler: Compiler): void;
+    apply(compiler: Compiler): void;
+}

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -76,7 +76,7 @@ export interface WebpackPluginServeOptions {
     https?: HttpsServerOptions;
     liveReload?: boolean;
     log?: {
-        level: string;
+        level: 'trace' | 'debug' | 'info' | 'warn' | 'error';
         timestamp?: boolean;
     };
     middleware?: (app: Koa, builtins: Builtins) => void;

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -10,95 +10,101 @@ import { Url } from 'url';
 import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
 import * as Koa from 'koa';
 import {
-  ServerOptions as Http2ServerOptions,
-  SecureServerOptions as Http2SecureServerOptions,
+    ServerOptions as Http2ServerOptions,
+    SecureServerOptions as Http2SecureServerOptions,
 } from 'http2';
 import { ServerOptions as HttpsServerOptions } from 'https';
 import { ZlibOptions } from 'zlib';
 import { Compiler } from 'webpack';
 
-export interface CompressOptions extends ZlibOptions {
-  filter?: (content_type: string) => boolean;
-  threshold?: number;
+
+declare namespace WebpackPluginServe {
+
+    export interface CompressOptions extends ZlibOptions {
+        filter?: (content_type: string) => boolean;
+        threshold?: number;
+    }
+
+    export interface KoaStaticOptions {
+        maxage?: number;
+        hidden?: boolean;
+        index?: string;
+        defer?: boolean;
+        gzip?: boolean;
+        br?: boolean;
+        setHeaders?: (res: any, path: any, stats: any) => any;
+        extensions?: string[] | boolean;
+    }
+
+    export type RewriteTo = (context: Context) => string;
+
+    export interface Context {
+        match: RegExpMatchArray;
+        parsedUrl: Url;
+    }
+
+    export interface Rewrite {
+        from: RegExp;
+        to: string | RegExp | RewriteTo;
+    }
+
+    export interface HistoryApiFallbackOptions {
+        disableDotRule?: true;
+        htmlAcceptHeaders?: string[];
+        index?: string;
+        logger?: typeof console.log;
+        rewrites?: Rewrite[];
+        verbose?: boolean;
+    }
+
+    export interface Builtins {
+        proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
+        compress: (opts: CompressOptions) => void;
+        static: (paths: string[], opts?: KoaStaticOptions) => void;
+        historyFallback: (opts: HistoryApiFallbackOptions) => void;
+        websocket: () => void;
+        four0four: (fn?: (ctx: Koa.Context) => void) => void;
+    }
+
+    export interface WebpackPluginServeOptions {
+        client?: {
+            address?: string;
+            retry?: boolean;
+            silent?: boolean;
+        };
+        compress?: boolean;
+        historyFallback?: boolean | HistoryApiFallbackOptions;
+        hmr?: boolean;
+        host?: string | Promise<string>;
+        http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
+        https?: HttpsServerOptions;
+        liveReload?: boolean;
+        log?: {
+            level: string;
+            timestamp?: boolean;
+        };
+        middleware?: (app: Koa, builtins: Builtins) => void;
+        open?:
+        | boolean
+        | {
+            wait?: boolean;
+            app?: string | ReadonlyArray<string>;
+        };
+        port?: number | Promise<number>;
+        progress?: boolean | 'minimal';
+        static?: string | string[];
+        status?: boolean;
+        waitForBuild?: boolean;
+    }
+
+    class WebpackPluginServe {
+        constructor(opts?: WebpackPluginServeOptions);
+        attach(): {
+            apply(compiler: Compiler): void;
+        };
+        hook(compiler: Compiler): void;
+        apply(compiler: Compiler): void;
+    }
 }
 
-export interface KoaStaticOptions {
-  maxage?: number;
-  hidden?: boolean;
-  index?: string;
-  defer?: boolean;
-  gzip?: boolean;
-  br?: boolean;
-  setHeaders?: (res: any, path: any, stats: any) => any;
-  extensions?: string[] | boolean;
-}
-
-export type RewriteTo = (context: Context) => string;
-
-export interface Context {
-  match: RegExpMatchArray;
-  parsedUrl: Url;
-}
-
-export interface Rewrite {
-  from: RegExp;
-  to: string | RegExp | RewriteTo;
-}
-
-export interface HistoryApiFallbackOptions {
-  disableDotRule?: true;
-  htmlAcceptHeaders?: string[];
-  index?: string;
-  logger?: typeof console.log;
-  rewrites?: Rewrite[];
-  verbose?: boolean;
-}
-
-export interface Builtins {
-  proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
-  compress: (opts: CompressOptions) => void;
-  static: (paths: string[], opts?: KoaStaticOptions) => void;
-  historyFallback: (opts: HistoryApiFallbackOptions) => void;
-  websocket: () => void;
-  four0four: (fn?: (ctx: Koa.Context) => void) => void;
-}
-
-export interface WebpackPluginServeOptions {
-  client?: {
-    address?: string;
-    retry?: boolean;
-    silent?: boolean;
-  };
-  compress?: boolean;
-  historyFallback?: boolean | HistoryApiFallbackOptions;
-  hmr?: boolean;
-  host?: string | Promise<string>;
-  http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
-  https?: HttpsServerOptions;
-  liveReload?: boolean;
-  log?: {
-    level: string;
-    timestamp?: boolean;
-  };
-  middleware?: (app: Koa, builtins: Builtins) => void;
-  open?:
-    | boolean
-    | {
-        wait?: boolean;
-        app?: string | ReadonlyArray<string>;
-      };
-  port?: number | Promise<number>;
-  progress?: boolean | 'minimal';
-  static?: string | string[];
-  status?: boolean;
-  waitForBuild?: boolean;
-}
-
-export class WebpackPluginServe {
-  constructor(opts?: WebpackPluginServeOptions);
-  attach(): {
-    apply(compiler: Compiler): void;
-  };
-  hook(compiler: Compiler): void;
-  apply(compiler: Compiler): void;
-}
+export = WebpackPluginServe;

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -5,7 +5,6 @@
 // TypeScript Version: 2.3
 /// <reference types="node" />
 
-
 import { Url } from 'url';
 import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
 import * as Koa from 'koa';
@@ -16,7 +15,6 @@ import {
 import { ServerOptions as HttpsServerOptions } from 'https';
 import { ZlibOptions } from 'zlib';
 import { Compiler } from 'webpack';
-
 
 declare namespace WebpackPluginServe {
 

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -1,0 +1,104 @@
+// Type definitions for webpack-plugin-serve 0.7
+// Project: https://github.com/shellscape/webpack-plugin-serve
+// Definitions by: Matheus Gonçalves da Silva <https://github.com/PlayMa256>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+/// <reference types="node" />
+
+
+import { Url } from 'url';
+import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
+import * as Koa from 'koa';
+import {
+  ServerOptions as Http2ServerOptions,
+  SecureServerOptions as Http2SecureServerOptions,
+} from 'http2';
+import { ServerOptions as HttpsServerOptions } from 'https';
+import { ZlibOptions } from 'zlib';
+import { Compiler } from 'webpack';
+
+export interface CompressOptions extends ZlibOptions {
+  filter?: (content_type: string) => boolean;
+  threshold?: number;
+}
+
+export interface KoaStaticOptions {
+  maxage?: number;
+  hidden?: boolean;
+  index?: string;
+  defer?: boolean;
+  gzip?: boolean;
+  br?: boolean;
+  setHeaders?: (res: any, path: any, stats: any) => any;
+  extensions?: string[] | boolean;
+}
+
+export type RewriteTo = (context: Context) => string;
+
+export interface Context {
+  match: RegExpMatchArray;
+  parsedUrl: Url;
+}
+
+export interface Rewrite {
+  from: RegExp;
+  to: string | RegExp | RewriteTo;
+}
+
+export interface HistoryApiFallbackOptions {
+  disableDotRule?: true;
+  htmlAcceptHeaders?: string[];
+  index?: string;
+  logger?: typeof console.log;
+  rewrites?: Rewrite[];
+  verbose?: boolean;
+}
+
+export interface Builtins {
+  proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
+  compress: (opts: CompressOptions) => void;
+  static: (paths: string[], opts?: KoaStaticOptions) => void;
+  historyFallback: (opts: HistoryApiFallbackOptions) => void;
+  websocket: () => void;
+  four0four: (fn?: (ctx: Koa.Context) => void) => void;
+}
+
+export interface WebpackPluginServeOptions {
+  client?: {
+    address?: string;
+    retry?: boolean;
+    silent?: boolean;
+  };
+  compress?: boolean;
+  historyFallback?: boolean | HistoryApiFallbackOptions;
+  hmr?: boolean;
+  host?: string | Promise<string>;
+  http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
+  https?: HttpsServerOptions;
+  liveReload?: boolean;
+  log?: {
+    level: string;
+    timestamp?: boolean;
+  };
+  middleware?: (app: Koa, builtins: Builtins) => void;
+  open?:
+    | boolean
+    | {
+        wait?: boolean;
+        app?: string | ReadonlyArray<string>;
+      };
+  port?: number | Promise<number>;
+  progress?: boolean | 'minimal';
+  static?: string | string[];
+  status?: boolean;
+  waitForBuild?: boolean;
+}
+
+export class WebpackPluginServe {
+  constructor(opts?: WebpackPluginServeOptions);
+  attach(): {
+    apply(compiler: Compiler): void;
+  };
+  hook(compiler: Compiler): void;
+  apply(compiler: Compiler): void;
+}

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -15,43 +15,9 @@ import {
 import { ServerOptions as HttpsServerOptions } from 'https';
 import { ZlibOptions } from 'zlib';
 import { Compiler } from 'webpack';
-
-export interface CompressOptions extends ZlibOptions {
-    filter?: (content_type: string) => boolean;
-    threshold?: number;
-}
-
-export interface KoaStaticOptions {
-    maxage?: number;
-    hidden?: boolean;
-    index?: string;
-    defer?: boolean;
-    gzip?: boolean;
-    br?: boolean;
-    setHeaders?: (res: any, path: any, stats: any) => any;
-    extensions?: string[] | boolean;
-}
-
-export type RewriteTo = (context: Context) => string;
-
-export interface Context {
-    match: RegExpMatchArray;
-    parsedUrl: Url;
-}
-
-export interface Rewrite {
-    from: RegExp;
-    to: string | RegExp | RewriteTo;
-}
-
-export interface HistoryApiFallbackOptions {
-    disableDotRule?: true;
-    htmlAcceptHeaders?: string[];
-    index?: string;
-    logger?: typeof console.log;
-    rewrites?: Rewrite[];
-    verbose?: boolean;
-}
+import { Options as HistoryApiFallbackOptions } from 'connect-history-api-fallback';
+import { CompressOptions } from 'koa-compress';
+import { Options as KoaStaticOptions } from 'koa-static';
 
 export interface Builtins {
     proxy: (args: HttpProxyMiddlewareConfig) => Proxy;

--- a/types/webpack-plugin-serve/tsconfig.json
+++ b/types/webpack-plugin-serve/tsconfig.json
@@ -11,7 +11,7 @@
         "typeRoots": [
             "../"
         ],
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/webpack-plugin-serve/tsconfig.json
+++ b/types/webpack-plugin-serve/tsconfig.json
@@ -11,6 +11,7 @@
         "typeRoots": [
             "../"
         ],
+        "strictFunctionTypes": false,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/webpack-plugin-serve/tsconfig.json
+++ b/types/webpack-plugin-serve/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-plugin-serve-tests.ts"
+    ]
+}

--- a/types/webpack-plugin-serve/tslint.json
+++ b/types/webpack-plugin-serve/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
+++ b/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
@@ -1,0 +1,39 @@
+import { WebpackPluginServe } from 'webpack-plugin-serve';
+import { Configuration } from 'webpack';
+
+const usage = (config: Configuration) => {
+  (config.entry as string[]).push('webpack-plugin-serve/client');
+
+  config.watch = true;
+
+  config.plugins!.push(
+    new WebpackPluginServe({
+      compress: true,
+      historyFallback: true,
+      host: '0.0.0.0',
+      port: 3808,
+      liveReload: true,
+      middleware: (app: any, builtins: any) =>
+        app.use(async (ctx: any, next: any) => {
+          await next();
+          ctx.set('Access-Control-Allow-Headers', '*');
+          ctx.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+          ctx.set('Access-Control-Allow-Origin', '*');
+        }),
+      static: '/',
+
+      status: true,
+      progress: true,
+    }),
+  );
+
+  config.output!.publicPath = '/';
+
+  return config;
+}
+
+const baseConfig = {
+    entry: 'index.js'
+};
+
+const configWithServer = usage(baseConfig);

--- a/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
+++ b/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
@@ -30,7 +30,7 @@ const usage = (config: Configuration) => {
   config.output!.publicPath = '/';
 
   return config;
-}
+};
 
 const baseConfig = {
     entry: 'index.js'


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). 

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.