### PR TITLE
[node] fix static-this lint issues

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -89,14 +89,14 @@ import { readFile } from 'fs';
         }
 
         static test(): void {
-            const cfn = util.callbackify(this.fn);
-            const cfnE = util.callbackify(this.fnE);
-            const cfnT1 = util.callbackify(this.fnT1);
-            const cfnT1E = util.callbackify(this.fnT1E);
-            const cfnTResult = util.callbackify(this.fnTResult);
-            const cfnTResultE = util.callbackify(this.fnTResultE);
-            const cfnT1TResult = util.callbackify(this.fnT1TResult);
-            const cfnT1TResultE = util.callbackify(this.fnT1TResultE);
+            const cfn = util.callbackify(callbackifyTest.fn);
+            const cfnE = util.callbackify(callbackifyTest.fnE);
+            const cfnT1 = util.callbackify(callbackifyTest.fnT1);
+            const cfnT1E = util.callbackify(callbackifyTest.fnT1E);
+            const cfnTResult = util.callbackify(callbackifyTest.fnTResult);
+            const cfnTResultE = util.callbackify(callbackifyTest.fnTResultE);
+            const cfnT1TResult = util.callbackify(callbackifyTest.fnT1TResult);
+            const cfnT1TResultE = util.callbackify(callbackifyTest.fnT1TResultE);
 
             cfn((err: NodeJS.ErrnoException, ...args: string[]) => assert(err === null && args.length === 1 && args[0] === undefined));
             cfnE((err: NodeJS.ErrnoException, ...args: string[]) => assert(err.message === 'fail' && args.length === 0));

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -882,14 +882,14 @@ function bufferTests() {
             }
 
             static test(): void {
-                const cfn = util.callbackify(this.fn);
-                const cfnE = util.callbackify(this.fnE);
-                const cfnT1 = util.callbackify(this.fnT1);
-                const cfnT1E = util.callbackify(this.fnT1E);
-                const cfnTResult = util.callbackify(this.fnTResult);
-                const cfnTResultE = util.callbackify(this.fnTResultE);
-                const cfnT1TResult = util.callbackify(this.fnT1TResult);
-                const cfnT1TResultE = util.callbackify(this.fnT1TResultE);
+                const cfn = util.callbackify(callbackifyTest.fn);
+                const cfnE = util.callbackify(callbackifyTest.fnE);
+                const cfnT1 = util.callbackify(callbackifyTest.fnT1);
+                const cfnT1E = util.callbackify(callbackifyTest.fnT1E);
+                const cfnTResult = util.callbackify(callbackifyTest.fnTResult);
+                const cfnTResultE = util.callbackify(callbackifyTest.fnTResultE);
+                const cfnT1TResult = util.callbackify(callbackifyTest.fnT1TResult);
+                const cfnT1TResultE = util.callbackify(callbackifyTest.fnT1TResultE);
 
                 cfn((err: NodeJS.ErrnoException, ...args: string[]) => assert(err === null && args.length === 1 && args[0] === undefined));
                 cfnE((err: NodeJS.ErrnoException, ...args: string[]) => assert(err.message === 'fail' && args.length === 0));


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Fix lint issues because use of `this` in static context. Most likely an update of tslint caused them to appear without an actual change in code. 

Failure details (see also #33884):
```
Error in node
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/node/test/util.ts:92:42
ERROR: 92:42  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 93:43  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 94:44  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 95:45  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 96:49  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 97:50  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 98:51  static-this  Use the parent class name instead of `this` when in a `static` context.
ERROR: 99:52  static-this  Use the parent class name instead of `this` when in a `static` context.
```
