### PR TITLE
Fabricjs - cleanup Object.onDeselect

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -2145,12 +2145,6 @@ export class ActiveSelection {
 	 */
 	toGroup(): Group;
 	/**
-	 * If returns true, deselection is cancelled.
-	 * @since 2.0.0
-	 * @return {Boolean} [cancel]
-	 */
-	onDeselect(): boolean;
-	/**
 	 * Returns {@link fabric.ActiveSelection} instance from an object representation
 	 * @memberOf fabric.ActiveSelection
 	 * @param object Object to create a group from
@@ -3501,7 +3495,7 @@ export class Object {
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to deselect this object. If the function returns true, the process is cancelled
 	 */
-	onDeselect(): void;
+	onDeselect(options: { e?: Event, object?: object }): void;
 	/**
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to select this object. If the function returns true, the process is cancelled
@@ -4137,7 +4131,6 @@ export class IText extends Text {
 	 * Initializes all the interactive behavior of IText
 	 */
 	initBehavior(): void;
-	onDeselect(): void;
 	/**
 	 * Initializes "added" event handler
 	 */

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -3494,8 +3494,9 @@ export class Object {
 	/**
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to deselect this object. If the function returns true, the process is cancelled
+     * @return {Boolean} true to cancel selection
 	 */
-	onDeselect(options: { e?: Event, object?: Object }): void;
+	onDeselect(options: { e?: Event, object?: Object }): boolean;
 	/**
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to select this object. If the function returns true, the process is cancelled

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -3495,7 +3495,7 @@ export class Object {
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to deselect this object. If the function returns true, the process is cancelled
 	 */
-	onDeselect(options: { e?: Event, object?: object }): void;
+	onDeselect(options: { e?: Event, object?: Object }): void;
 	/**
 	 * This callback function is called every time _discardActiveObject or _setActiveObject
 	 * try to to select this object. If the function returns true, the process is cancelled


### PR DESCRIPTION
 IText & Group don't need defined as they both extend Object. Group directly and IText through Text.

The call receives an object with 2 optional params. This is the only invocation:
```
    _discardActiveObject: function(e, object) {
      var obj = this._activeObject;
      if (obj) {
        // onDeselect return TRUE to cancel selection;
        if (obj.onDeselect({ e: e, object: object })) {
          return false;
        }
        this._activeObject = null;
      }
      return true;
    },
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [NA] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [NA] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [NA] Increase the version number in the header if appropriate.
- [NA] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
