### PR TITLE
[lolex] make TClock default to Clock

### DIFF
--- a/types/lolex/index.d.ts
+++ b/types/lolex/index.d.ts
@@ -5,6 +5,7 @@
 //                 Rogier Schouten <https://github.com/rogierschouten>
 //                 Yishai Zehavi <https://github.com/zyishai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /**
  * Names of clock methods that may be faked by install.

--- a/types/lolex/index.d.ts
+++ b/types/lolex/index.d.ts
@@ -128,7 +128,7 @@ export interface LolexClock<TTimerId extends TimerId> extends GlobalTimers<TTime
 
     /**
      * Queues the callback to be fired during idle periods to perform background and low priority work on the main event loop.
-     * 
+     *
      * @param callback   Callback to be fired.
      * @param timeout   The maximum number of ticks before the callback must be fired.
      * @remarks Callbacks which have a timeout option will be fired no later than time in milliseconds.
@@ -256,7 +256,7 @@ type InstalledMethods = {
  *
  * @type TClock   type of base clock (e.g BrowserClock).
  */
-type InstalledClock<TClock extends Clock> = TClock & InstalledMethods;
+type InstalledClock<TClock extends Clock = Clock> = TClock & InstalledMethods;
 
 /**
  * Creates a clock.
@@ -268,7 +268,7 @@ type InstalledClock<TClock extends Clock> = TClock & InstalledMethods;
  * @type TClock   Type of clock to create.
  * @remarks The default epoch is 0.
  */
-export declare function createClock<TClock extends Clock>(now?: number | Date, loopLimit?: number): TClock;
+export declare function createClock<TClock extends Clock = Clock>(now?: number | Date, loopLimit?: number): TClock;
 
 export interface LolexInstallOpts {
     /**
@@ -312,12 +312,12 @@ export interface LolexInstallOpts {
  * @param toFake   Names of methods that should be faked.
  * @type TClock   Type of clock to create.
  */
-export declare function install<TClock extends Clock>(opts?: LolexInstallOpts): InstalledClock<TClock>;
+export declare function install<TClock extends Clock = Clock>(opts?: LolexInstallOpts): InstalledClock<TClock>;
 
 export interface LolexWithContext {
     timers: GlobalTimers<TimerId>;
-    createClock: <TClock extends Clock>(now?: number | Date, loopLimit?: number) => TClock;
-    install: <TClock extends Clock>(opts?: LolexInstallOpts) => InstalledClock<TClock>;
+    createClock: <TClock extends Clock = Clock>(now?: number | Date, loopLimit?: number) => TClock;
+    install: <TClock extends Clock = Clock>(opts?: LolexInstallOpts) => InstalledClock<TClock>;
     withGlobal: (global: Object) => LolexWithContext;
 }
 

--- a/types/lolex/lolex-tests.ts
+++ b/types/lolex/lolex-tests.ts
@@ -138,3 +138,8 @@ nodeInstalledClock.uninstall();
 // Clocks should be typed to have unbound method signatures that can be passed around
 const { clearTimeout } = browserClock;
 clearTimeout(0);
+
+// TClock of InstalledClock<TClock> is optional.
+let installedClock: lolex.InstalledClock;
+installedClock = nodeInstalledClock;
+installedClock = browserInstalledClock;


### PR DESCRIPTION
The following expressions no longer require a type annotation:
- `const clock = lolex.createClock(...)`
- `const clock = lolex.install(...)`
- `type Foo = lolex.InstalledClock`

Also, set the minimum version to 2.3 as suggested by `npm run lint lolex`.