### PR TITLE
[@types/react-color] Fix wrong color type on swatch hover

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-color 2.17
+// Type definitions for react-color 3.0
 // Project: https://github.com/casesandberg/react-color/, http://casesandberg.github.io/react-color
 // Definitions by:  Karol Janyst <https://github.com/LKay>,
 //                  Marks Polakovs <https://github.com/markspolakovs>,

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -4,7 +4,8 @@
 //                  Marks Polakovs <https://github.com/markspolakovs>,
 //                  Matthieu Montaudouin <https://github.com/mntdn>,
 //                  Nokogiri <https://github.com/nkgrnkgr>,
-//                  0815Strohhut <https://github.com/0815Strohhut>
+//                  0815Strohhut <https://github.com/0815Strohhut>,
+//                  Daniel Fürst <https://github.com/dnlfrst>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-color/lib/components/block/Block.d.ts
+++ b/types/react-color/lib/components/block/Block.d.ts
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface BlockPickerProps extends ColorPickerProps<BlockPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top';
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class BlockPicker extends Component<BlockPickerProps> {}

--- a/types/react-color/lib/components/circle/Circle.d.ts
+++ b/types/react-color/lib/components/circle/Circle.d.ts
@@ -6,7 +6,7 @@ export interface CirclePickerProps extends ColorPickerProps<CirclePicker> {
     width?: string;
     circleSize?: number;
     circleSpacing?: number;
-    onSwatchHover?(colorResult: ColorResult, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class CirclePicker extends Component<CirclePickerProps> {}

--- a/types/react-color/lib/components/compact/Compact.d.ts
+++ b/types/react-color/lib/components/compact/Compact.d.ts
@@ -1,9 +1,9 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface CompactPickerProps extends ColorPickerProps<CompactPicker> {
     colors?: string[];
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class CompactPicker extends Component<CompactPickerProps> {}

--- a/types/react-color/lib/components/github/Github.d.ts
+++ b/types/react-color/lib/components/github/Github.d.ts
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface GithubPickerProps extends ColorPickerProps<GithubPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class GithubPicker extends Component<GithubPickerProps> {}

--- a/types/react-color/lib/components/sketch/Sketch.d.ts
+++ b/types/react-color/lib/components/sketch/Sketch.d.ts
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface SketchPickerProps extends ColorPickerProps<SketchPicker> {
     disableAlpha?: boolean;
     presetColors?: string[];
     width?: string;
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class SketchPicker extends Component<SketchPickerProps> {}

--- a/types/react-color/lib/components/swatches/Swatches.d.ts
+++ b/types/react-color/lib/components/swatches/Swatches.d.ts
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface SwatchesPickerProps extends ColorPickerProps<SwatchesPicker> {
     colors?: string[][];
     height?: number;
     width?: number;
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class SwatchesPicker extends Component<SwatchesPickerProps> {}

--- a/types/react-color/lib/components/twitter/Twitter.d.ts
+++ b/types/react-color/lib/components/twitter/Twitter.d.ts
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface TwitterPickerProps extends ColorPickerProps<TwitterPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
 export default class TwitterPicker extends Component<TwitterPickerProps> {}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
---
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...dnlfrst:fix-react-color-swatch-hover)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
---
This pull request refers to the same issue as #31393 did, the parameter `color` of the method `onSwatchHover` seemed to be off for [several color pickers](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0dea8d18a4a686fe3b475a1f1dc4ad51621971f8). Since this change breaks existing usages of `onSwatchHover`, I bumped a major version.  
Additionally, for consistency, the hovered color is now named `color` in every `onSwatchHover` (was only different [here](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/7722daf0548749d7827b478d22ca4599e37fffe3)).

Sadly, I was not able to run `npm run tslint react-color` or `tsc` encountering the following issues, respectively:
![tslint-issue](https://user-images.githubusercontent.com/13868083/54565289-17a09000-49ce-11e9-9744-c2d958bfe95c.PNG)
![tsc-issue](https://user-images.githubusercontent.com/13868083/54565295-1a9b8080-49ce-11e9-8be5-3c635205851f.PNG)

I would greatly appreciate any hint on why the above errors could have occurred.