### PR TITLE
Update paramName to accept callback function

### DIFF
--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -55,7 +55,7 @@ declare namespace Dropzone {
 		retryChunks?: boolean;
 		retryChunksLimit?: number;
 		maxFilesize?: number;
-		paramName?: string;
+		paramName?: string | () => string;
 		createImageThumbnails?: boolean;
 		maxThumbnailFilesize?: number;
 		thumbnailWidth?: number;


### PR DESCRIPTION
The paramName in DropzoneOption should accept both a string and a callback that returns a string as per the library implementation.
