### PR TITLE
[react-beautiful-dnd] Provide Type-Parameter to React.ReactElement

### DIFF
--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -105,7 +105,7 @@ export interface DroppableProvidedProps {
 }
 export interface DroppableProvided {
     innerRef(element: HTMLElement | null): any;
-    placeholder?: React.ReactElement | null;
+    placeholder?: React.ReactElement<HTMLElement> | null;
     droppableProps: DroppableProvidedProps;
 }
 
@@ -122,7 +122,7 @@ export interface DroppableProps {
     isDropDisabled?: boolean;
     isCombineEnabled?: boolean;
     direction?: 'vertical' | 'horizontal';
-    children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement;
+    children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<HTMLElement>;
 }
 
 export class Droppable extends React.Component<DroppableProps> { }
@@ -176,7 +176,7 @@ export interface DraggableProvided {
 
     // will be removed after move to react 16
     innerRef(element?: HTMLElement | null): any;
-    placeholder?: React.ReactElement | null;
+    placeholder?: React.ReactElement<HTMLElement> | null;
 }
 
 export interface DraggableStateSnapshot {
@@ -205,7 +205,7 @@ export interface DraggableProps {
     index: number;
     isDragDisabled?: boolean;
     disableInteractiveElementBlocking?: boolean;
-    children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement;
+    children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<HTMLElement>;
     type?: TypeId;
     shouldRespectForceTouch?: boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


### More Info
When using the existing `index.d.ts`, I get the following compilation errors:
```
ERROR in /Users/adityas/Projects/skyline/node_modules/@types/react-beautiful-dnd/index.d.ts(108,19):
TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).
ERROR in /Users/adityas/Projects/skyline/node_modules/@types/react-beautiful-dnd/index.d.ts(125,78):
TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).
ERROR in /Users/adityas/Projects/skyline/node_modules/@types/react-beautiful-dnd/index.d.ts(179,19):
TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).
ERROR in /Users/adityas/Projects/skyline/node_modules/@types/react-beautiful-dnd/index.d.ts(208,78):
TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).
```

This PR adds a type argument to `React.ReactElement` to resolve this.