### PR TITLE
Add type definitions for then-eos

### DIFF
--- a/types/then-eos/index.d.ts
+++ b/types/then-eos/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for then-eos 1.0
+// Project: https://github.com/meoguru/node-then-eos
+// Definitions by: Sean Marvi Oliver Genabe <https://github.com/seangenabe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+type Stream = NodeJS.ReadableStream | NodeJS.WritableStream;
+
+declare function thenEos(stream: Stream): Promise<void>;
+
+export = thenEos;

--- a/types/then-eos/then-eos-tests.ts
+++ b/types/then-eos/then-eos-tests.ts
@@ -1,0 +1,10 @@
+import eos = require("then-eos");
+
+declare const readable: NodeJS.ReadableStream;
+declare const writable: NodeJS.WritableStream;
+
+// $ExpectType Promise<void>
+eos(readable);
+
+// $ExpectType Promise<void>
+eos(writable);

--- a/types/then-eos/tsconfig.json
+++ b/types/then-eos/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "then-eos-tests.ts"
+    ]
+}

--- a/types/then-eos/tslint.json
+++ b/types/then-eos/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
