### PR TITLE
react-csv Extend anchor props on CSVLink

### DIFF
--- a/types/react-csv/components/Link.d.ts
+++ b/types/react-csv/components/Link.d.ts
@@ -1,9 +1,10 @@
 import { Component } from "react";
 import { CommonPropTypes } from "./CommonPropTypes";
 
+// tslint:disable-next-line strict-export-declare-modifiers
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-interface LinkProps
+export interface LinkProps
     extends CommonPropTypes,
         Omit<
             React.DetailedHTMLProps<

--- a/types/react-csv/components/Link.d.ts
+++ b/types/react-csv/components/Link.d.ts
@@ -1,5 +1,15 @@
 import { Component } from "react";
 import { CommonPropTypes } from "./CommonPropTypes";
 
-export default class Link extends Component<CommonPropTypes> {
-}
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+interface LinkProps
+    extends CommonPropTypes,
+        Omit<
+            React.DetailedHTMLProps<
+                React.AnchorHTMLAttributes<HTMLAnchorElement>,
+                HTMLAnchorElement
+            >,
+            "onClick"
+        > {}
+export default class Link extends Component<LinkProps> {}

--- a/types/react-csv/react-csv-tests.tsx
+++ b/types/react-csv/react-csv-tests.tsx
@@ -3,16 +3,16 @@ import { render } from "react-dom";
 import { CSVLink, CSVDownload } from "react-csv";
 
 const headers = [
-    {label: 'First Name', key: 'details.firstName'},
-    {label: 'Last Name', key: 'details.lastName'},
-    {label: 'Job', key: 'job'},
+    { label: "First Name", key: "details.firstName" },
+    { label: "Last Name", key: "details.lastName" },
+    { label: "Job", key: "job" }
 ];
 
-const headersStrings = ['foo', 'bar'];
+const headersStrings = ["foo", "bar"];
 
 const data = [
-    {details: {firstName: 'Ahmed', lastName: 'Tomi'}, job: 'manager'},
-    {details: {firstName: 'John', lastName: 'Jones'}, job: 'developer'},
+    { details: { firstName: "Ahmed", lastName: "Tomi" }, job: "manager" },
+    { details: { firstName: "John", lastName: "Jones" }, job: "developer" }
 ];
 
 const dataString = `firstname,lastname
@@ -21,57 +21,226 @@ Raed,Labes
 Yezzi,Min l3b
 `;
 
-const syncOnClickReturn = (event: React.MouseEventHandler<HTMLAnchorElement>) => {
+const syncOnClickReturn = (
+    event: React.MouseEventHandler<HTMLAnchorElement>
+) => {
     window.console.log(event);
     return true;
 };
-const syncOnClickVoid = (event: React.MouseEventHandler<HTMLAnchorElement>) => window.console.log(event);
-const asyncOnClickReturn = (event: React.MouseEventHandler<HTMLAnchorElement>, done: (proceed?: boolean) => void) => {
+const syncOnClickVoid = (event: React.MouseEventHandler<HTMLAnchorElement>) =>
+    window.console.log(event);
+const asyncOnClickReturn = (
+    event: React.MouseEventHandler<HTMLAnchorElement>,
+    done: (proceed?: boolean) => void
+) => {
     window.console.log(event);
     done(true);
 };
-const asyncOnClickVoid = (event: React.MouseEventHandler<HTMLAnchorElement>, done: (proceed?: boolean) => void) => {
+const asyncOnClickVoid = (
+    event: React.MouseEventHandler<HTMLAnchorElement>,
+    done: (proceed?: boolean) => void
+) => {
     window.console.log(event);
     done();
 };
 
 const node = document.getElementById("main");
 
-render(<CSVLink data={dataString}/>, node);
-render(<CSVLink data={dataString} headers={headersStrings}/>, node);
-render(<CSVLink data={data}/>, node);
-render(<CSVLink data={data} headers={headers}/>, node);
-render(<CSVLink data={data} headers={headers}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true}
-                enclosingCharacter={`'`}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true} enclosingCharacter={`'`}
-                onClick={syncOnClickReturn}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true} enclosingCharacter={`'`}
-                onClick={syncOnClickVoid}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true} enclosingCharacter={`'`}
-                onClick={asyncOnClickReturn} asyncOnClick={true}/>, node);
-render(<CSVLink data={data} headers={headers} separator={','} filename={'bob.csv'} uFEFF={true} enclosingCharacter={`'`}
-                onClick={asyncOnClickVoid} asyncOnClick={true}/>, node);
+render(<CSVLink data={dataString} />, node);
+render(<CSVLink data={dataString} headers={headersStrings} />, node);
+render(<CSVLink data={data} />, node);
+render(<CSVLink data={data} headers={headers} />, node);
+render(<CSVLink data={data} headers={headers} />, node);
+render(<CSVLink data={data} headers={headers} separator={","} />, node);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+        onClick={syncOnClickReturn}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+        onClick={syncOnClickVoid}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+        onClick={asyncOnClickReturn}
+        asyncOnClick={true}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+        onClick={asyncOnClickVoid}
+        asyncOnClick={true}
+    />,
+    node
+);
+render(
+    <CSVLink
+        data={data}
+        headers={headers}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        enclosingCharacter={`'`}
+        onClick={asyncOnClickVoid}
+        asyncOnClick={true}
+        className="test"
+        target="_blank"
+    />,
+    node
+);
 
-render(<CSVDownload data={dataString}/>, node);
-render(<CSVDownload data={dataString} headers={headersStrings}/>, node);
-render(<CSVDownload data={data}/>, node);
-render(<CSVDownload data={data} headers={headers}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'}
-                    uFEFF={true}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'}
-                    uFEFF={true}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'} uFEFF={true}
-                    onClick={syncOnClickReturn}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'} uFEFF={true}
-                    onClick={syncOnClickVoid}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'} uFEFF={true}
-                    onClick={asyncOnClickReturn} asyncOnClick={true}/>, node);
-render(<CSVDownload data={data} headers={headers} target={'_blank'} separator={','} filename={'bob.csv'} uFEFF={true}
-                    onClick={asyncOnClickVoid} asyncOnClick={true}/>, node);
+render(<CSVDownload data={dataString} />, node);
+render(<CSVDownload data={dataString} headers={headersStrings} />, node);
+render(<CSVDownload data={data} />, node);
+render(<CSVDownload data={data} headers={headers} />, node);
+render(<CSVDownload data={data} headers={headers} target={"_blank"} />, node);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        onClick={syncOnClickReturn}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        onClick={syncOnClickVoid}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        onClick={asyncOnClickReturn}
+        asyncOnClick={true}
+    />,
+    node
+);
+render(
+    <CSVDownload
+        data={data}
+        headers={headers}
+        target={"_blank"}
+        separator={","}
+        filename={"bob.csv"}
+        uFEFF={true}
+        onClick={asyncOnClickVoid}
+        asyncOnClick={true}
+    />,
+    node
+);


### PR DESCRIPTION
CSVLink props now extends HTMLAnchorProps as all supported <a> props are passed onwards
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/react-csv/react-csv#1-csvlink-component>
