### PR TITLE
Fix glob statCache to use fs.Stats

### DIFF
--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -42,9 +42,9 @@ type GlobOptions = import('glob').IOptions;
 		}
         const file1 = matches[0];
         const stat = options.statCache[file1];
-        if (stat.isFile()) {
+        if (stat && stat.isFile()) {
             console.log("is file");
-        } else if (stat.isDirectory()) {
+        } else if (stat && stat.isDirectory()) {
             console.log("is directory");
         }
 	});

--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -1,5 +1,6 @@
 import glob = require("glob");
 const Glob = glob.Glob;
+type GlobOptions = import('glob').IOptions;
 
 (() => {
 	const pattern = "test/a/**/[cg]/../[cg]";
@@ -25,6 +26,27 @@ const Glob = glob.Glob;
 			return;
 		}
 		console.log("matches", matches);
+	});
+	console.log("after");
+})();
+
+(() => {
+	const pattern = "test/**";
+    let options: GlobOptions = { statCache: {}, stat: true, dot: true };
+	console.log(pattern);
+
+	const mg = new Glob(pattern, options, (er, matches) => {
+		if (er) {
+			console.error(er);
+			return;
+		}
+        const file1 = matches[0];
+        const stat = options.statCache[file1];
+        if (stat.isFile()) {
+            console.log("is file");
+        } else if (stat.isDirectory()) {
+            console.log("is directory");
+        }
 	});
 	console.log("after");
 })();

--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -1,4 +1,5 @@
 import glob = require("glob");
+import fs = require("fs");
 const Glob = glob.Glob;
 type GlobOptions = import('glob').IOptions;
 
@@ -32,7 +33,7 @@ type GlobOptions = import('glob').IOptions;
 
 (() => {
 	const pattern = "test/**";
-    let options: GlobOptions = { statCache: {}, stat: true, dot: true };
+    const options: GlobOptions = { statCache: {}, stat: true, dot: true };
 	console.log(pattern);
 
 	const mg = new Glob(pattern, options, (er, matches) => {
@@ -53,4 +54,5 @@ type GlobOptions = import('glob').IOptions;
 
 declare const ignore: ReadonlyArray<string>;
 glob.sync('/foo/*', {realpath: true, realpathCache: {'/foo/bar': '/bar'}, ignore: '/foo/baz'});
-glob.sync('/*', {ignore, nodir: true, cache: {'/': ['bar', 'baz']}, statCache: {'/foo/bar': false, '/foo/baz': {isDirectory() { return true; }}}});
+const statResult = fs.statSync('/*');
+glob.sync('/*', {ignore, nodir: true, cache: {'/': ['bar', 'baz']}, statCache: {'/foo/bar': false, '/foo/baz': statResult}});

--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -1,7 +1,6 @@
 import glob = require("glob");
 import fs = require("fs");
 const Glob = glob.Glob;
-type GlobOptions = import('glob').IOptions;
 
 (() => {
 	const pattern = "test/a/**/[cg]/../[cg]";
@@ -33,7 +32,7 @@ type GlobOptions = import('glob').IOptions;
 
 (() => {
 	const pattern = "test/**";
-    const options: GlobOptions = { statCache: {}, stat: true, dot: true };
+    const options: glob.IOptions = { statCache: {}, stat: true, dot: true };
 	console.log(pattern);
 
 	const mg = new Glob(pattern, options, (er, matches) => {

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -4,6 +4,7 @@
 //                 voy <https://github.com/voy>
 //                 Klaus Meinhardt <https://github.com/ajafff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 /// <reference types="node" />
 

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -7,6 +7,9 @@
 
 /// <reference types="node" />
 
+import * as fs from "fs";
+import { Stats } = fs;
+
 import events = require("events");
 import minimatch = require("minimatch");
 
@@ -34,7 +37,7 @@ declare namespace G {
         silent?: boolean;
         strict?: boolean;
         cache?: { [path: string]: boolean | 'DIR' | 'FILE' | ReadonlyArray<string> };
-        statCache?: { [path: string]: false | { isDirectory(): boolean} | undefined };
+        statCache?: { [path: string]: false | Stats | undefined };
         symlinks?: { [path: string]: boolean | undefined };
         realpathCache?: { [path: string]: string };
         sync?: boolean;

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="node" />
 
 import * as fs from "fs";
-import { Stats } = fs;
+import Stats = fs.Stats;
 
 import events = require("events");
 import minimatch = require("minimatch");

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -74,7 +74,7 @@ declare namespace G {
         options: IOptions;
         aborted: boolean;
         cache: { [path: string]: boolean | 'DIR' | 'FILE' | ReadonlyArray<string> };
-        statCache: { [path: string]: false | { isDirectory(): boolean; } | undefined };
+        statCache: { [path: string]: false | Stats | undefined };
         symlinks: { [path: string]: boolean | undefined };
         realpathCache: { [path: string]: string };
         found: string[];

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -4,7 +4,6 @@
 //                 voy <https://github.com/voy>
 //                 Klaus Meinhardt <https://github.com/ajafff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
 
 /// <reference types="node" />
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide URL to documentation which provides context for the suggested change: [`statCache` option](https://github.com/isaacs/node-glob/blob/master/README.md#options)

