### PR TITLE
[@types/react-onclickoutside] add `export` to WrapperClass to address compiler error

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -45,7 +45,7 @@ interface WrapperClass<P, C> {
     new (): WrapperInstance<P, C>;
 }
 
-interface WrapperInstance<P, C>
+export interface WrapperInstance<P, C>
     extends React.Component<OnClickOutProps<JSX.LibraryManagedAttributes<C, P>>> {
     getInstance(): C extends typeof React.Component ? InstanceType<C> : never;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

--

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: supporting stack overflow: https://stackoverflow.com/questions/43335336/error-ts4058-return-type-of-exported-function-has-or-is-using-name-x-from-exter

- [ ] Increase the version number in the header if appropriate.

My compiler stopped compiling as a component in my project utilizes the `onClickOut` wrapper function - the error references an interface that was not exported. after adding the `export` the compiler was able to compile and no further errors were encountered.

`Error: /dropdown/index.tsx: semantic error TS4023 Exported variable 'Dropdown' has or is using name 'WrapperClass' from external module node_modules/@types/react-onclickoutside/index" but cannot be named.`
