### PR TITLE
[@types/mongoose] Document should be exported as a class instead of an interface

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -3336,6 +3336,8 @@ declare module "mongoose" {
     __v?: number;
   }
 
+  export class Document {}
+
   interface SaveOptions {
     safe?: boolean | WriteConcern;
     validateBeforeSave?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ajsharp/typescript-interface-bug/blob/master/src/Person.ts#L15
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

* * *

Mongoose's `Document` class is an exported module from the [original package](https://github.com/Automattic/mongoose/blob/master/lib/document.js#L3180), but is only declared as an interface here. This is a problem because typescript strips interfaces from the compiled code.

This PR simply declares and exports the existing `Document` interface as a class, using typescript [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).

The main problem I ran into was trying to use the `Document` interface in typescript code via `if (this instanceof Document) { /** ... */ }`. But Typescript strips out interfaces in compiled code, so this is not possible. I realize that I can do the same with the exported `Model` class, but as `Document` is an exported class from the original code, I _should_ be able to do that here too.

There seems to also be a related bug in typescript (see https://github.com/Microsoft/TypeScript/issues/29743) where certain kinds of interface declarations don't cause the compiler to throw the `'Document' only refers to a type, but is being used as a value here` error.