### PR TITLE
[@lingui/core][@lingui/macro] Add MessageDescriptor handling for  2.7.x

### DIFF
--- a/types/lingui__core/i18n.d.ts
+++ b/types/lingui__core/i18n.d.ts
@@ -6,6 +6,13 @@ export interface MessageOptions {
     formats?: object;
 }
 
+export interface MessageDescriptor {
+    id: string;
+    defaults?: string;
+    values?: object;
+    formats?: object;
+}
+
 export interface LanguageData {
     plurals?: (n: number, pluralType?: "cardinal" | "ordinal") => string;
 }
@@ -62,6 +69,7 @@ export class I18n {
     use(language: string): I18n;
 
     _(id: string, values?: object, messageOptions?: MessageOptions): string;
+    _(id: MessageDescriptor): string;
 
     pluralForm(n: number, pluralType?: "cardinal" | "ordinal"): string;
 }

--- a/types/lingui__core/index.d.ts
+++ b/types/lingui__core/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @lingui/core 2.2
+// Type definitions for @lingui/core 2.7
 // Project: https://lingui.github.io/js-lingui/, https://github.com/lingui/js-lingui
 // Definitions by: Jeow Li Huan <https://github.com/huan086>
 // Definitions: https://github.com/huan086/lingui-typings
@@ -9,6 +9,7 @@ export {
     setupI18n,
     Catalog,
     Catalogs,
+    MessageDescriptor,
     MessageOptions,
     LanguageData,
     I18n

--- a/types/lingui__core/lingui__core-tests.ts
+++ b/types/lingui__core/lingui__core-tests.ts
@@ -4,6 +4,7 @@ import {
     Catalog,
     Catalogs,
     MessageOptions,
+    MessageDescriptor,
     LanguageData,
     I18n,
     date,
@@ -15,6 +16,13 @@ const age = 12;
 const templateResult: string = i18n.t`${age} years old`;
 const templateIdResult: string = i18n.t('templateId')`${age} years old`;
 const translateResult: string = i18n._('age', { age }, { defaults: '{age} years old' });
+
+const descriptorBasicResult = i18n._({ id: 'basicDescriptor' });
+const descriptorResult = i18n._({
+    id: 'ageDescriptor',
+    defaults: '{age} years old',
+    values: { age }
+});
 
 const count = 42;
 

--- a/types/lingui__macro/index.d.ts
+++ b/types/lingui__macro/index.d.ts
@@ -4,30 +4,31 @@
 // Definitions: https://github.com/huan086/lingui-typings
 // TypeScript Version: 2.8
 
+import { MessageDescriptor } from '@lingui/core';
 import { ComponentClass } from 'react';
 import { FormatPropsWithoutI18n } from './createFormat';
 import { SelectProps, PluralProps } from "./select";
 
 // JS
-export function t(strings: TemplateStringsArray, ...values: any[]): string;
+export function t(strings: TemplateStringsArray, ...values: any[]): MessageDescriptor;
 
-export function t(id: string): (strings: TemplateStringsArray, ...values: any[]) => string;
+export function t(id: string): (strings: TemplateStringsArray, ...values: any[]) => MessageDescriptor;
 
-export function select(config: SelectProps): string;
+export function select(config: SelectProps): MessageDescriptor;
 
-export function select(id: string, config: SelectProps): string;
+export function select(id: string, config: SelectProps): MessageDescriptor;
 
-export function plural(config: PluralProps): string;
+export function plural(config: PluralProps): MessageDescriptor;
 
-export function plural(id: string, config: PluralProps): string;
+export function plural(id: string, config: PluralProps): MessageDescriptor;
 
-export function selectOrdinal(config: PluralProps): string;
+export function selectOrdinal(config: PluralProps): MessageDescriptor;
 
-export function selectOrdinal(id: string, config: PluralProps): string;
+export function selectOrdinal(id: string, config: PluralProps): MessageDescriptor;
 
-export function date(value: Date, format?: Intl.DateTimeFormatOptions): string;
+export function date(value: Date, format?: Intl.DateTimeFormatOptions): MessageDescriptor;
 
-export function number(value: number, format?: Intl.NumberFormatOptions): string;
+export function number(value: number, format?: Intl.NumberFormatOptions): MessageDescriptor;
 
 // JSX
 export { default as Trans } from './Trans';

--- a/types/lingui__macro/lingui__macro-tests.tsx
+++ b/types/lingui__macro/lingui__macro-tests.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { MessageDescriptor } from '@lingui/core';
 import {
     t,
     select,
@@ -16,25 +17,25 @@ import {
 
 // JS
 const age = 12;
-const templateResult: string = t`${age} years old`;
-const templateIdResult: string = t('templateId')`${age} years old`;
+const templateResult: MessageDescriptor = t`${age} years old`;
+const templateIdResult: MessageDescriptor = t('templateId')`${age} years old`;
 
 const count = 42;
 
-const pluralResult: string = plural({
+const pluralResult: MessageDescriptor = plural({
     value: count,
     0: 'no books',
     one: '# book',
     other: '# books'
 });
-const pluralIdResult: string = plural('pluralId', {
+const pluralIdResult: MessageDescriptor = plural('pluralId', {
     value: count,
     0: 'no books',
     one: '# book',
     other: '# books'
 });
 
-const selectOrdinalResult: string = selectOrdinal({
+const selectOrdinalResult: MessageDescriptor = selectOrdinal({
     value: count,
     0: 'Zeroth book',
     one: '#st book',
@@ -42,7 +43,7 @@ const selectOrdinalResult: string = selectOrdinal({
     few: '#rd book',
     other: '#th book'
 });
-const selectOrdinalIdResult: string = selectOrdinal('selectOrdinalId', {
+const selectOrdinalIdResult: MessageDescriptor = selectOrdinal('selectOrdinalId', {
     value: count,
     0: 'Zeroth book',
     one: '#st book',
@@ -60,10 +61,10 @@ const selectResult = select({
     female: plural({
         value: numOfGuests,
         offset: 1,
-        0: t`${host} does not give a party.`,
-        1: t`${host} invites ${guest} to her party.`,
-        2: t`${host} invites ${guest} and one other person to her party.`,
-        other: t`${host} invites ${guest} and # other people to her party.`
+        0: `${host} does not give a party.`,
+        1: `${host} invites ${guest} to her party.`,
+        2: `${host} invites ${guest} and one other person to her party.`,
+        other: `${host} invites ${guest} and # other people to her party.`
     }),
     male: 'male',
     other: 'other'
@@ -76,8 +77,8 @@ const selectIdResult = select('selectId', {
     other: 'other'
 });
 
-const formattedDate: string = date(new Date(), { timeZone: 'UTC' });
-const formattedNumber: string = number(1234.56, { style: 'currency', currency: 'EUR' });
+const formattedDate: MessageDescriptor = date(new Date(), { timeZone: 'UTC' });
+const formattedNumber: MessageDescriptor = number(1234.56, { style: 'currency', currency: 'EUR' });
 
 // JSX
 const App = () => {

--- a/types/lingui__macro/select.d.ts
+++ b/types/lingui__macro/select.d.ts
@@ -1,11 +1,13 @@
+import { MessageDescriptor } from "@lingui/core";
+
 export interface PluralForms {
-    zero?: string;
-    one?: string;
-    two?: string;
-    few?: string;
-    many?: string;
-    other: string;
-    [exact: number]: string;
+    zero?: string | MessageDescriptor;
+    one?: string | MessageDescriptor;
+    two?: string | MessageDescriptor;
+    few?: string | MessageDescriptor;
+    many?: string | MessageDescriptor;
+    other: string | MessageDescriptor;
+    [exact: number]: string | MessageDescriptor;
 }
 
 export interface PluralProps extends PluralForms {
@@ -15,6 +17,6 @@ export interface PluralProps extends PluralForms {
 
 export interface SelectProps {
     value: string;
-    other: string;
-    [selectForm: string]: string;
+    other: string | MessageDescriptor;
+    [selectForm: string]: string | MessageDescriptor;
 }

--- a/types/lingui__macro/tsconfig.json
+++ b/types/lingui__macro/tsconfig.json
@@ -20,6 +20,9 @@
         "paths": {
             "@lingui/macro": [
                 "lingui__macro"
+            ],
+            "@lingui/core": [
+                "lingui__core"
             ]
         }
     },


### PR DESCRIPTION
Looks like the return types of `@lingui/macro`'s functions was off. This PR adds the `MessageDescriptor` interface to `@lingui/core` (as it's accepted as a prop to `i18n._`), and swaps the return types to use that. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
	- [Changelog](https://github.com/lingui/js-lingui/blob/master/CHANGELOG.md#270-2018-09-10)
	- [i18n._ usage](https://github.com/lingui/js-lingui/blob/9b424d7ee98e8064ab785236f21aa89e5e3c79c3/packages/core/src/i18n.js#L183-L194)
	- [Doc for MessageDescriptor](https://lingui.js.org/ref/macro.html#js-macros)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

