### PR TITLE
Add gtag.js type definitions

### DIFF
--- a/types/gtag.js/gtag.js-tests.ts
+++ b/types/gtag.js/gtag.js-tests.ts
@@ -1,0 +1,12 @@
+gtag('config', 'GA-TRACKING_ID');
+gtag('config', 'GA-TRACKING_ID', {send_page_view: false});
+
+gtag('event', 'login', {
+  method: 'Google'
+});
+
+gtag('set', {currency: 'USD'});
+gtag('set', {
+  country: 'US',
+  currency: 'USD'
+});

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Google gtag.js API
 // Project: https://developers.google.com/gtagjs
-// Definitions by:  Junyoung Choi <https://github.com/rokt33r>,
+// Definitions by:  Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var gtag: Gtag.Gtag;

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for Google gtag.js API
+// Project: https://developers.google.com/gtagjs
+// Definitions by:  Junyoung Choi <https://github.com/rokt33r>,
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var gtag: Gtag.Gtag;
+declare namespace Gtag {
+  interface Gtag {
+    (command: 'config', targetId: string, config?: ControlParams | EventParams | CustomParams): void;
+    (command: 'set', config: CustomParams): void;
+    (command: 'event', eventName: EventNames | string, eventParams?: ControlParams |  EventParams | CustomParams): void;
+  }
+
+  interface CustomParams {
+    [key: string]: any;
+  }
+
+  interface ControlParams {
+    groups?: string | string[];
+    send_to?: string | string[];
+    event_callback?: () => void;
+    event_timeout?: number;
+  }
+
+  type EventNames = 'add_payment_info'
+    | 'add_payment_info'
+    | 'add_to_cart'
+    | 'add_to_wishlist'
+    | 'begin_checkout'
+    | 'checkout_progress'
+    | 'exception'
+    | 'generate_lead'
+    | 'login'
+    | 'page_view'
+    | 'purchase'
+    | 'refund'
+    | 'remove_from_cart'
+    | 'screen_view'
+    | 'search'
+    | 'select_content'
+    | 'set_checkout_option'
+    | 'share'
+    | 'sign_up'
+    | 'timing_complete'
+    | 'view_item'
+    | 'view_item_list'
+    | 'view_promotion'
+    | 'view_search_results';
+
+  interface EventParams {
+    checkout_option?: string;
+    checkout_step?: number;
+    content_id?: string;
+    content_type?: string;
+    coupon?: string;
+    currency?: string;
+    description?: string;
+    fatal?: boolean;
+    items?: Item[];
+    method?: string;
+    number?: string;
+    promotions?: Promotion[];
+    screen_name?: string;
+    search_term?: string;
+    shipping?: Currency;
+    tax?: Currency;
+    transaction_id?: string;
+    value?: number;
+    event_label?: string;
+    event_category: string;
+  }
+
+  type Currency = string | number;
+
+  interface Item {
+    brand?: string;
+    category?: string;
+    creative_name?: string;
+    creative_slot?: string;
+    id?: string;
+    location_id?: string;
+    name?: string;
+    price?: Currency;
+    quantity?: number;
+  }
+
+  interface Promotion {
+    creative_name?: string;
+    creative_slot?: string;
+    id?: string;
+    name?: string;
+  }
+}

--- a/types/gtag.js/tsconfig.json
+++ b/types/gtag.js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6",
+          "dom"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": false,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "gtag.js-tests.ts"
+  ]
+}

--- a/types/gtag.js/tslint.json
+++ b/types/gtag.js/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "dt-header": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23718.