### PR TITLE
Fabric Polyline pathOffset exposed

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -3642,6 +3642,9 @@ export class Polyline extends Object {
 	 * @param [skipOffset] Whether points offsetting should be skipped
 	 */
 	constructor(points: Array<{ x: number; y: number }>, options?: IPolylineOptions);
+
+    pathOffset: Point;
+
 	/**
 	 * List of attribute names to account for when parsing SVG element (used by `fabric.Polygon.fromElement`)
 	 */


### PR DESCRIPTION
Similar to fabric.Path (however no common ancestor or interface)
It is always set in initializer.
```
initialize: function(points, options) {
  ...
  this.width = calcDim.width;
  this.height = calcDim.height;
  this.pathOffset = {
    x: calcDim.left + this.width / 2,
    y: calcDim.top + this.height / 2
  };
},
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [NA] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [NA] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [NA] Increase the version number in the header if appropriate.
- [NA] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
