### PR TITLE
[react-dom] Fix charCode to use number instead of boolean

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -29,7 +29,7 @@ export interface SyntheticEventData extends OptionalEventProperties {
     clientX?: number;
     clientY?: number;
     changedTouches?: TouchList;
-    charCode?: boolean;
+    charCode?: number;
     clipboardData?: DataTransfer;
     ctrlKey?: boolean;
     deltaMode?: number;

--- a/types/react-dom/v15/react-dom-tests.ts
+++ b/types/react-dom/v15/react-dom-tests.ts
@@ -61,7 +61,7 @@ describe('React dom test utils', () => {
 
         node.value = 'giraffe';
         ReactTestUtils.Simulate.change(node);
-        ReactTestUtils.Simulate.keyDown(node, { key: "Enter", keyCode: 13, which: 13 });
+        ReactTestUtils.Simulate.keyDown(node, { key: "Enter", charCode: 13, keyCode: 13, which: 13 });
     });
 
     it('renderIntoDocument', () => {


### PR DESCRIPTION
Changed SyntheticEventData.charCode to number in order to match
the properties listed here:

https://reactjs.org/docs/events.html#keyboard-events

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/events.html#keyboard-events
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
