### PR TITLE
Switch incorrect 'export default' to 'export ='

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -967,7 +967,8 @@ interface Obj {
     }
     const list: Book[] = [{id: "xyz", title: "A"}, {id: "abc", title: "B"}];
     const a1 = R.indexBy(R.prop("id"), list);
-    const a2 = R.indexBy(R.prop("id"))(list);
+    // Typescript 3.3 incorrectly gives `a2: {}`, 3.4 gives an error instead.
+    // const a2 = R.indexBy(R.prop("id"))(list);
     const a3 = R.indexBy<{ id: string }>(R.prop("id"))(list);
     const a4 = R.indexBy(R.prop<"id", string>("id"))(list);
     const a5 = R.indexBy<{ id: string }>(R.prop<"id", string>("id"))(list);

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-table 6.6
+// Type definitions for react-table 6.8
 // Project: https://github.com/react-tools/react-table
 // Definitions by: Roy Xue <https://github.com/royxue>,
 //                 Pavel Sakalo <https://github.com/psakalo>,

--- a/types/riot-route/index.d.ts
+++ b/types/riot-route/index.d.ts
@@ -6,4 +6,4 @@
 
 import route from './lib/index';
 
-export default route;
+export = route;

--- a/types/riot-route/riot-route-tests.ts
+++ b/types/riot-route/riot-route-tests.ts
@@ -1,4 +1,4 @@
-import { default as route } from 'riot-route';
+import route = require('riot-route');
 import routeFromTag from 'riot-route/lib/tag';
 
 /* () */

--- a/types/rollup-plugin-json/index.d.ts
+++ b/types/rollup-plugin-json/index.d.ts
@@ -8,22 +8,25 @@
 /// <reference types="node" />
 import { Plugin } from 'rollup';
 
-export interface Options {
-    /**
-     *  All JSON files will be parsed by default, but you can also specifically include/exclude files
-     */
-    include?: string | string[];
-    exclude?: string | string[];
-    /**
-     *  for tree-shaking, properties will be declared as variables, using either `var` or `const`
-     *  @default false
-     */
-    preferConst?: boolean;
-    /**
-     * specify indentation for the generated default export — defaults to '\t'
-     * @default '\t'
-     */
-    indent?: string;
+declare namespace json {
+    interface Options {
+        /**
+         *  All JSON files will be parsed by default, but you can also specifically include/exclude files
+         */
+        include?: string | string[];
+        exclude?: string | string[];
+        /**
+         *  for tree-shaking, properties will be declared as variables, using either `var` or `const`
+         *  @default false
+         */
+        preferConst?: boolean;
+        /**
+         * specify indentation for the generated default export — defaults to '\t'
+         * @default '\t'
+         */
+        indent?: string;
+    }
 }
 
-export default function json(options?: Options): Plugin;
+declare function json(options?: json.Options): Plugin;
+export = json;

--- a/types/rollup-plugin-json/rollup-plugin-json-tests.ts
+++ b/types/rollup-plugin-json/rollup-plugin-json-tests.ts
@@ -1,4 +1,4 @@
-import json from 'rollup-plugin-json';
+import json = require('rollup-plugin-json');
 
 json(); // $ExpectType Plugin
 


### PR DESCRIPTION
riot-route and rollup-plugin-json don't actually have a `.default` property on the shipped code that you get when say `var r = require('...')`.

Update: Also fix incorrect rollback of react-table to 6.6 when it was already at 6.7. I bumped it to 6.8 to fix the problem. Broken in #30638.

Update: Also remove ramda test that (correctly) fails on TS3.4.