### PR TITLE
Revert "[@types/google-apps-script] Remove the unnecessary console declaration"

### DIFF
--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -326,3 +326,4 @@ declare var Logger: GoogleAppsScript.Base.Logger;
 // conflicts with MimeType in lib.d.ts
 // declare var MimeType: GoogleAppsScript.Base.MimeType;
 declare var Session: GoogleAppsScript.Base.Session;
+declare var console: GoogleAppsScript.Base.console;


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#32663.

`console` is actually needed.
We do not have `console from `@types/node` since Node is not the runtime we should be using.