### PR TITLE
[@types/request] HTTP Auth username and password can be null when sending a token

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -227,7 +227,7 @@ declare namespace request {
         json(val: any): Request;
         aws(opts: AWSOptions, now?: boolean): Request;
         hawk(opts: HawkOptions): void;
-        auth(username: string, password: string, sendImmediately?: boolean, bearer?: string): Request;
+        auth(username: string | null, password: string | null, sendImmediately?: boolean, bearer?: string): Request;
         oauth(oauth: OAuthOptions): Request;
         jar(jar: CookieJar): Request;
 

--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -227,7 +227,8 @@ declare namespace request {
         json(val: any): Request;
         aws(opts: AWSOptions, now?: boolean): Request;
         hawk(opts: HawkOptions): void;
-        auth(username: string | null, password: string | null, sendImmediately?: boolean, bearer?: string): Request;
+        auth(username: string, password: string, sendImmediately?: boolean): Request;
+        auth(username: null, password: null, sendImmediately: boolean, bearer: string): Request;
         oauth(oauth: OAuthOptions): Request;
         jar(jar: CookieJar): Request;
 


### PR DESCRIPTION
Documentation for the HTTP Authentication may be found at https://www.npmjs.com/package/request#http-authentication

Note that the example states:
`request.get('http://some.server.com/').auth(null, null, true, 'bearerToken');`

The first two parameters in .auth are username and password, which were previously only allowed to be of type string. Now these parameters are allowed to be set to null.