### PR TITLE
react-maskedinput: validate should return a boolean

### DIFF
--- a/types/react-maskedinput/index.d.ts
+++ b/types/react-maskedinput/index.d.ts
@@ -9,7 +9,7 @@
 import * as React from "react";
 
 export interface FormatCharacter {
-    validate(char: string): string;
+    validate(char: string): boolean;
     transform?(char: string): string;
 }
 


### PR DESCRIPTION
the validations are done by regex tests, which return a boolean.

from the example in the docs :
`validate(char) { return /\w/.test(char ) },`

Is this observation correct ?
otherwise it might change to return : string | boolean 

