### PR TITLE
sinon: make calledWith partial

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -29,7 +29,7 @@ declare namespace Sinon {
          * so a call that received the provided arguments (in the same spots) and possibly others as well will return true.
          * @param args
          */
-        calledWith(...args: MatchArguments<TArgs>): boolean;
+        calledWith(...args: Partial<MatchArguments<TArgs>>): boolean;
         /**
          * Returns true if spy was called at least once with the provided arguments and no others.
          */

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -135,16 +135,21 @@ declare namespace Sinon {
          */
         lastArg: any;
 
+        /* tslint:disable:no-unnecessary-generics */
+
         /**
          * Returns true if the spy call occurred before another spy call.
          * @param call
+         *
          */
-        calledBefore(call: SinonSpyCall): boolean;
+        calledBefore<TSpyArgs extends any[]>(call: SinonSpyCall<TSpyArgs>): boolean;
         /**
          * Returns true if the spy call occurred after another spy call.
          * @param call
          */
-        calledAfter(call: SinonSpyCall): boolean;
+        calledAfter<TSpyArgs extends any[]>(call: SinonSpyCall<TSpyArgs>): boolean;
+
+        /* tslint:enable:no-unnecessary-generics */
     }
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
@@ -214,26 +219,32 @@ declare namespace Sinon {
 
         // Methods
         (...args: TArgs): TReturnValue;
+
+        /* tslint:disable:no-unnecessary-generics */
+
         /**
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore(anotherSpy: SinonSpy): boolean;
+        calledBefore<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter(anotherSpy: SinonSpy): boolean;
+        calledAfter<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore(anotherSpy: SinonSpy): boolean;
+        calledImmediatelyBefore<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter(anotherSpy: SinonSpy): boolean;
+        calledImmediatelyAfter<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
+
+        /* tslint:enable:no-unnecessary-generics */
+
         /**
          * Creates a spy that only records calls when the received arguments match those passed to withArgs.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
@@ -628,12 +639,14 @@ declare namespace Sinon {
     }
 
     interface SinonStubStatic {
-        // Disable rule so assignment to typed stub works (see examples in tests).
+        /* tslint:disable:no-unnecessary-generics */
+
         /**
          * Creates an anonymous stub function
          */
-        // tslint:disable-next-line no-unnecessary-generics
-        <TArgs extends any[]= any[], R = any>(): SinonStub<TArgs, R>;
+        <TArgs extends any[] = any[], R = any>(): SinonStub<TArgs, R>;
+
+        /* tslint:enable:no-unnecessary-generics */
 
         /**
          * Stubs all the object’s methods.
@@ -1153,36 +1166,38 @@ declare namespace Sinon {
         pass(assertion: any): void; // Overridable
 
         // Methods
+        /* tslint:disable:no-unnecessary-generics */
+
         /**
          * Passes if spy was never called
          * @param spy
          */
-        notCalled(spy: SinonSpy): void;
+        notCalled<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Passes if spy was called at least once.
          */
-        called(spy: SinonSpy): void;
+        called<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Passes if spy was called once and only once.
          */
-        calledOnce(spy: SinonSpy): void;
+        calledOnce<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Passes if spy was called exactly twice.
          */
-        calledTwice(spy: SinonSpy): void;
+        calledTwice<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Passes if spy was called exactly three times.
          */
-        calledThrice(spy: SinonSpy): void;
+        calledThrice<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Passes if spy was called exactly num times.
          */
-        callCount(spy: SinonSpy, count: number): void;
+        callCount<TArgs extends any[]>(spy: SinonSpy<TArgs>, count: number): void;
         /**
          * Passes if provided spies were called in the specified order.
          * @param spies
          */
-        callOrder(...spies: SinonSpy<any>[]): void;
+        callOrder(...spies: Array<SinonSpy<any>>): void;
         /**
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.
@@ -1191,7 +1206,10 @@ declare namespace Sinon {
         /**
          * Passes if spy was always called with obj as its this value.
          */
-        alwaysCalledOn(spy: SinonSpy, obj: any): void;
+        alwaysCalledOn<TArgs extends any[]>(spy: SinonSpy<TArgs>, obj: any): void;
+
+        /* tslint:enable:no-unnecessary-generics */
+
         /**
          * Passes if spy was called with the provided arguments.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWith(spy.firstCall, arg1, arg2, ...);.
@@ -1268,18 +1286,24 @@ declare namespace Sinon {
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
         threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, exception: any): void;
+
+        /* tslint:disable:no-unnecessary-generics */
+
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy): void;
+        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy, exception: string): void;
+        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>, exception: string): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy, exception: any): void;
+        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>, exception: any): void;
+
+        /* tslint:enable:no-unnecessary-generics */
+
         /**
          * Uses sinon.match to test if the arguments can be considered a match.
          */

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -111,8 +111,7 @@ declare namespace Sinon {
         yieldToOn(property: string, obj: any, ...args: any[]): void;
     }
 
-    interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>
-        extends SinonSpyCallApi<TArgs, TReturnValue> {
+    interface SinonSpyCallLike {
         /**
          * The call’s this value.
          */
@@ -124,7 +123,7 @@ declare namespace Sinon {
         /**
          * Return value.
          */
-        returnValue: TReturnValue;
+        returnValue: any;
         /**
          * This property is a convenience for a call’s callback.
          * When the last argument in a call is a Function, then callback will reference that. Otherwise it will be undefined.
@@ -139,44 +138,23 @@ declare namespace Sinon {
          * Returns true if the spy call occurred before another spy call.
          * @param call
          */
-        calledBefore(call: SinonSpyCall): boolean;
+        calledBefore(call: SinonSpyCallLike): boolean;
         /**
          * Returns true if the spy call occurred after another spy call.
          * @param call
          */
-        calledAfter(call: SinonSpyCall): boolean;
+        calledAfter(call: SinonSpyCallLike): boolean;
     }
 
-    /**
-     * A test spy is a function that records arguments, return value,
-     * the value of this and exception thrown (if any) for all its calls.
-     */
-    interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any> extends SinonInspectable<TArgs, TReturnValue> {
-        // Methods
-        (...args: TArgs): TReturnValue;
-
+    interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>
+        extends SinonSpyCallLike, SinonSpyCallApi<TArgs, TReturnValue> {
         /**
-         * Creates a spy that only records calls when the received arguments match those passed to withArgs.
-         * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
-         * @param args Expected args
+         * @inheritdoc
          */
-        withArgs(...args: MatchArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
-
-        /**
-         * Set the displayName of the spy or stub.
-         * @param name
-         */
-        named(name: string): SinonSpy<TArgs, TReturnValue>;
+        returnValue: TReturnValue;
     }
 
-    /**
-     * The part of the spy API that allows inspecting the calls made on a spy.
-     */
-    interface SinonInspectable<TArgs extends any[] = any[], TReturnValue = any>
-        extends Pick<
-                SinonSpyCallApi<TArgs, TReturnValue>,
-                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-            > {
+    interface SinonSpyLike {
         // Properties
         /**
          * The number of recorded calls.
@@ -205,19 +183,19 @@ declare namespace Sinon {
         /**
          * The first call
          */
-        firstCall: SinonSpyCall<TArgs, TReturnValue>;
+        firstCall: SinonSpyCallLike;
         /**
          * The second call
          */
-        secondCall: SinonSpyCall<TArgs, TReturnValue>;
+        secondCall: SinonSpyCallLike;
         /**
          * The third call
          */
-        thirdCall: SinonSpyCall<TArgs, TReturnValue>;
+        thirdCall: SinonSpyCallLike;
         /**
          * The last call
          */
-        lastCall: SinonSpyCall<TArgs, TReturnValue>;
+        lastCall: SinonSpyCallLike;
         /**
          * Array of this objects, spy.thisValues[0] is the this object for the first call.
          */
@@ -225,7 +203,7 @@ declare namespace Sinon {
         /**
          * Array of arguments received, spy.args[0] is an array of arguments received in the first call.
          */
-        args: TArgs[];
+        args: any[];
         /**
          * Array of exception objects thrown, spy.exceptions[0] is the exception thrown by the first call.
          * If the call did not throw an error, the value at the call’s location in .exceptions will be undefined.
@@ -235,27 +213,36 @@ declare namespace Sinon {
          * Array of return values, spy.returnValues[0] is the return value of the first call.
          * If the call did not explicitly return a value, the value at the call’s location in .returnValues will be undefined.
          */
-        returnValues: TReturnValue[];
+        returnValues: any[];
+
+        // Methods
+        (...args: any[]): any;
         /**
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore(anotherSpy: SinonInspectable): boolean;
+        calledBefore(anotherSpy: SinonSpyLike): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter(anotherSpy: SinonInspectable): boolean;
+        calledAfter(anotherSpy: SinonSpyLike): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore(anotherSpy: SinonInspectable): boolean;
+        calledImmediatelyBefore(anotherSpy: SinonSpyLike): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter(anotherSpy: SinonInspectable): boolean;
+        calledImmediatelyAfter(anotherSpy: SinonSpyLike): boolean;
+        /**
+         * Creates a spy that only records calls when the received arguments match those passed to withArgs.
+         * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
+         * @param args Expected args
+         */
+        withArgs(...args: MatchArguments<any[]>): SinonSpyLike;
         /**
          * Returns true if the spy was always called with @param obj as this.
          * @param obj
@@ -264,29 +251,29 @@ declare namespace Sinon {
         /**
          * Returns true if spy was always called with the provided arguments (and possibly others).
          */
-        alwaysCalledWith(...args: MatchArguments<TArgs>): boolean;
+        alwaysCalledWith(...args: MatchArguments<any[]>): boolean;
         /**
          * Returns true if spy was always called with the exact provided arguments.
          * @param args
          */
-        alwaysCalledWithExactly(...args: MatchArguments<TArgs>): boolean;
+        alwaysCalledWithExactly(...args: MatchArguments<any[]>): boolean;
         /**
          * Returns true if spy was always called with matching arguments (and possibly others).
          * This behaves the same as spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        alwaysCalledWithMatch(...args: TArgs): boolean;
+        alwaysCalledWithMatch(...args: any[]): boolean;
         /**
          * Returns true if the spy/stub was never called with the provided arguments.
          * @param args
          */
-        neverCalledWith(...args: MatchArguments<TArgs>): boolean;
+        neverCalledWith(...args: MatchArguments<any[]>): boolean;
         /**
          * Returns true if the spy/stub was never called with matching arguments.
          * This behaves the same as spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        neverCalledWithMatch(...args: TArgs): boolean;
+        neverCalledWithMatch(...args: any[]): boolean;
         /**
          * Returns true if spy always threw an exception.
          */
@@ -309,17 +296,22 @@ declare namespace Sinon {
          * If the stub was never called with a function argument, yield throws an error.
          * Returns an Array with all callbacks return values in the order they were called, if no error is thrown.
          */
-        invokeCallback(...args: TArgs): void;
+        invokeCallback(...args: any[]): void;
+        /**
+         * Set the displayName of the spy or stub.
+         * @param name
+         */
+        named(name: string): SinonSpyLike;
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
          * @param n
          */
-        getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
+        getCall(n: number): SinonSpyCallLike;
         /**
          * Returns an Array of all calls recorded by the spy.
          */
-        getCalls(): Array<SinonSpyCall<TArgs, TReturnValue>>;
+        getCalls(): SinonSpyCallLike[];
         /**
          * Resets the state of a spy.
          */
@@ -341,6 +333,80 @@ declare namespace Sinon {
          * Replaces the spy with the original method. Only available if the spy replaced an existing method.
          */
         restore(): void;
+    }
+
+    interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
+        extends SinonSpyLike, Pick<
+                SinonSpyCallApi<TArgs, TReturnValue>,
+                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+            > {
+        /**
+         * @inheritdoc
+         */
+        firstCall: SinonSpyCall<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        secondCall: SinonSpyCall<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        thirdCall: SinonSpyCall<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        lastCall: SinonSpyCall<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        args: TArgs[];
+        /**
+         * @inheritdoc
+         */
+        returnValues: TReturnValue[];
+
+        // Methods
+        (...args: TArgs): TReturnValue;
+        /**
+         * @inheritdoc
+         */
+        withArgs(...args: MatchArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        alwaysCalledWith(...args: MatchArguments<TArgs>): boolean;
+        /**
+         * @inheritdoc
+         */
+        alwaysCalledWithExactly(...args: MatchArguments<TArgs>): boolean;
+        /**
+         * @inheritdoc
+         */
+        alwaysCalledWithMatch(...args: TArgs): boolean;
+        /**
+         * @inheritdoc
+         */
+        neverCalledWith(...args: MatchArguments<TArgs>): boolean;
+        /**
+         * @inheritdoc
+         */
+        neverCalledWithMatch(...args: TArgs): boolean;
+        /**
+         * @inheritdoc
+         */
+        invokeCallback(...args: TArgs): void;
+        /**
+         * @inheritdoc
+         */
+        named(name: string): SinonSpy<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
+        /**
+         * @inheritdoc
+         */
+        getCalls(): Array<SinonSpyCall<TArgs, TReturnValue>>;
     }
 
     interface SinonSpyStatic {
@@ -1168,60 +1234,60 @@ declare namespace Sinon {
          * Passes if spy was never called
          * @param spy
          */
-        notCalled(spy: SinonInspectable): void;
+        notCalled(spy: SinonSpyLike): void;
         /**
          * Passes if spy was called at least once.
          */
-        called(spy: SinonInspectable): void;
+        called(spy: SinonSpyLike): void;
         /**
          * Passes if spy was called once and only once.
          */
-        calledOnce(spy: SinonInspectable): void;
+        calledOnce(spy: SinonSpyLike): void;
         /**
          * Passes if spy was called exactly twice.
          */
-        calledTwice(spy: SinonInspectable): void;
+        calledTwice(spy: SinonSpyLike): void;
         /**
          * Passes if spy was called exactly three times.
          */
-        calledThrice(spy: SinonInspectable): void;
+        calledThrice(spy: SinonSpyLike): void;
         /**
          * Passes if spy was called exactly num times.
          */
-        callCount(spy: SinonInspectable, count: number): void;
+        callCount(spy: SinonSpyLike, count: number): void;
         /**
          * Passes if provided spies were called in the specified order.
          * @param spies
          */
-        callOrder(...spies: SinonInspectable[]): void;
+        callOrder(...spies: SinonSpyLike[]): void;
         /**
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.
          */
-        calledOn(spyOrSpyCall: SinonInspectable | SinonSpyCall, obj: any): void;
+        calledOn(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, obj: any): void;
         /**
          * Passes if spy was always called with obj as its this value.
          */
-        alwaysCalledOn(spy: SinonInspectable, obj: any): void;
+        alwaysCalledOn(spy: SinonSpyLike, obj: any): void;
         /**
          * Passes if spy was called with the provided arguments.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWith(spy.firstCall, arg1, arg2, ...);.
          * @param spyOrSpyCall
          * @param args
          */
-        calledWith<TArgs extends any[]>(spyOrSpyCall: SinonInspectable<TArgs> | SinonSpyCall<TArgs>, ...args: MatchArguments<TArgs>): void;
+        calledWith<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: MatchArguments<TArgs>): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
          * @param args
          */
-        alwaysCalledWith<TArgs extends any[]>(spy: SinonInspectable<TArgs>, ...args: MatchArguments<TArgs>): void;
+        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
         /**
          * Passes if spy was never called with the provided arguments.
          * @param spy
          * @param args
          */
-        neverCalledWith<TArgs extends any[]>(spy: SinonInspectable<TArgs>, ...args: MatchArguments<TArgs>): void;
+        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
         /**
          * Passes if spy was called with the provided arguments and no others.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);.
@@ -1229,68 +1295,68 @@ declare namespace Sinon {
          * @param args
          */
         calledWithExactly<TArgs extends any[]>(
-            spyOrSpyCall: SinonInspectable<TArgs> | SinonSpyCall<TArgs>,
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
             ...args: MatchArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments and no others.
          */
-        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonInspectable<TArgs>, ...args: MatchArguments<TArgs>): void;
+        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
         /**
          * Passes if spy was called with matching arguments.
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
         calledWithMatch<TArgs extends any[]>(
-            spyOrSpyCall: SinonInspectable<TArgs> | SinonSpyCall<TArgs>,
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
             ...args: TArgs
         ): void;
         /**
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          */
-        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonInspectable<TArgs>, ...args: TArgs): void;
+        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: TArgs): void;
         /**
          * Passes if spy was never called with matching arguments.
          * This behaves the same way as sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * @param spy
          * @param args
          */
-        neverCalledWithMatch<TArgs extends any[]>(spy: SinonInspectable<TArgs>, ...args: TArgs): void;
+        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: TArgs): void;
         /**
          * Passes if spy was called with the new operator.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.
          * @param spyOrSpyCall
          */
-        calledWithNew(spyOrSpyCall: SinonInspectable | SinonSpyCall): void;
+        calledWithNew(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike): void;
         /**
          * Passes if spy threw any exception.
          */
-        threw(spyOrSpyCall: SinonInspectable | SinonSpyCall): void;
+        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is an actual object.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw(spyOrSpyCall: SinonInspectable | SinonSpyCall, exception: string): void;
+        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, exception: string): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is a String denoting its type.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw(spyOrSpyCall: SinonInspectable | SinonSpyCall, exception: any): void;
+        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, exception: any): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonInspectable): void;
+        alwaysThrew(spy: SinonSpyLike): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonInspectable, exception: string): void;
+        alwaysThrew(spy: SinonSpyLike, exception: string): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonInspectable, exception: any): void;
+        alwaysThrew(spy: SinonSpyLike, exception: any): void;
         /**
          * Uses sinon.match to test if the arguments can be considered a match.
          */

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -111,7 +111,8 @@ declare namespace Sinon {
         yieldToOn(property: string, obj: any, ...args: any[]): void;
     }
 
-    interface SinonSpyCallLike {
+    interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>
+        extends SinonSpyCallApi<TArgs, TReturnValue> {
         /**
          * The call’s this value.
          */
@@ -123,7 +124,7 @@ declare namespace Sinon {
         /**
          * Return value.
          */
-        returnValue: any;
+        returnValue: TReturnValue;
         /**
          * This property is a convenience for a call’s callback.
          * When the last argument in a call is a Function, then callback will reference that. Otherwise it will be undefined.
@@ -138,23 +139,19 @@ declare namespace Sinon {
          * Returns true if the spy call occurred before another spy call.
          * @param call
          */
-        calledBefore(call: SinonSpyCallLike): boolean;
+        calledBefore(call: SinonSpyCall<any[]>): boolean;
         /**
          * Returns true if the spy call occurred after another spy call.
          * @param call
          */
-        calledAfter(call: SinonSpyCallLike): boolean;
+        calledAfter(call: SinonSpyCall<any[]>): boolean;
     }
 
-    interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>
-        extends SinonSpyCallLike, SinonSpyCallApi<TArgs, TReturnValue> {
-        /**
-         * @inheritdoc
-         */
-        returnValue: TReturnValue;
-    }
-
-    interface SinonSpyLike {
+    interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
+        extends Pick<
+                SinonSpyCallApi<TArgs, TReturnValue>,
+                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+            > {
         // Properties
         /**
          * The number of recorded calls.
@@ -183,19 +180,19 @@ declare namespace Sinon {
         /**
          * The first call
          */
-        firstCall: SinonSpyCallLike;
+        firstCall: SinonSpyCall<TArgs, TReturnValue>;
         /**
          * The second call
          */
-        secondCall: SinonSpyCallLike;
+        secondCall: SinonSpyCall<TArgs, TReturnValue>;
         /**
          * The third call
          */
-        thirdCall: SinonSpyCallLike;
+        thirdCall: SinonSpyCall<TArgs, TReturnValue>;
         /**
          * The last call
          */
-        lastCall: SinonSpyCallLike;
+        lastCall: SinonSpyCall<TArgs, TReturnValue>;
         /**
          * Array of this objects, spy.thisValues[0] is the this object for the first call.
          */
@@ -203,7 +200,7 @@ declare namespace Sinon {
         /**
          * Array of arguments received, spy.args[0] is an array of arguments received in the first call.
          */
-        args: any[];
+        args: TArgs[];
         /**
          * Array of exception objects thrown, spy.exceptions[0] is the exception thrown by the first call.
          * If the call did not throw an error, the value at the call’s location in .exceptions will be undefined.
@@ -213,36 +210,36 @@ declare namespace Sinon {
          * Array of return values, spy.returnValues[0] is the return value of the first call.
          * If the call did not explicitly return a value, the value at the call’s location in .returnValues will be undefined.
          */
-        returnValues: any[];
+        returnValues: TReturnValue[];
 
         // Methods
-        (...args: any[]): any;
+        (...args: TArgs): TReturnValue;
         /**
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore(anotherSpy: SinonSpyLike): boolean;
+        calledBefore(anotherSpy: SinonSpy<any[]>): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter(anotherSpy: SinonSpyLike): boolean;
+        calledAfter(anotherSpy: SinonSpy<any[]>): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore(anotherSpy: SinonSpyLike): boolean;
+        calledImmediatelyBefore(anotherSpy: SinonSpy<any[]>): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter(anotherSpy: SinonSpyLike): boolean;
+        calledImmediatelyAfter(anotherSpy: SinonSpy<any[]>): boolean;
         /**
          * Creates a spy that only records calls when the received arguments match those passed to withArgs.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
          * @param args Expected args
          */
-        withArgs(...args: MatchArguments<any[]>): SinonSpyLike;
+        withArgs(...args: MatchArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
         /**
          * Returns true if the spy was always called with @param obj as this.
          * @param obj
@@ -251,29 +248,29 @@ declare namespace Sinon {
         /**
          * Returns true if spy was always called with the provided arguments (and possibly others).
          */
-        alwaysCalledWith(...args: MatchArguments<any[]>): boolean;
+        alwaysCalledWith(...args: MatchArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with the exact provided arguments.
          * @param args
          */
-        alwaysCalledWithExactly(...args: MatchArguments<any[]>): boolean;
+        alwaysCalledWithExactly(...args: MatchArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with matching arguments (and possibly others).
          * This behaves the same as spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        alwaysCalledWithMatch(...args: any[]): boolean;
+        alwaysCalledWithMatch(...args: TArgs): boolean;
         /**
          * Returns true if the spy/stub was never called with the provided arguments.
          * @param args
          */
-        neverCalledWith(...args: MatchArguments<any[]>): boolean;
+        neverCalledWith(...args: MatchArguments<TArgs>): boolean;
         /**
          * Returns true if the spy/stub was never called with matching arguments.
          * This behaves the same as spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        neverCalledWithMatch(...args: any[]): boolean;
+        neverCalledWithMatch(...args: TArgs): boolean;
         /**
          * Returns true if spy always threw an exception.
          */
@@ -296,22 +293,22 @@ declare namespace Sinon {
          * If the stub was never called with a function argument, yield throws an error.
          * Returns an Array with all callbacks return values in the order they were called, if no error is thrown.
          */
-        invokeCallback(...args: any[]): void;
+        invokeCallback(...args: TArgs): void;
         /**
          * Set the displayName of the spy or stub.
          * @param name
          */
-        named(name: string): SinonSpyLike;
+        named(name: string): SinonSpy<TArgs, TReturnValue>;
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
          * @param n
          */
-        getCall(n: number): SinonSpyCallLike;
+        getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
         /**
          * Returns an Array of all calls recorded by the spy.
          */
-        getCalls(): SinonSpyCallLike[];
+        getCalls(): Array<SinonSpyCall<TArgs, TReturnValue>>;
         /**
          * Resets the state of a spy.
          */
@@ -333,80 +330,6 @@ declare namespace Sinon {
          * Replaces the spy with the original method. Only available if the spy replaced an existing method.
          */
         restore(): void;
-    }
-
-    interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
-        extends SinonSpyLike, Pick<
-                SinonSpyCallApi<TArgs, TReturnValue>,
-                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-            > {
-        /**
-         * @inheritdoc
-         */
-        firstCall: SinonSpyCall<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        secondCall: SinonSpyCall<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        thirdCall: SinonSpyCall<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        lastCall: SinonSpyCall<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        args: TArgs[];
-        /**
-         * @inheritdoc
-         */
-        returnValues: TReturnValue[];
-
-        // Methods
-        (...args: TArgs): TReturnValue;
-        /**
-         * @inheritdoc
-         */
-        withArgs(...args: MatchArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        alwaysCalledWith(...args: MatchArguments<TArgs>): boolean;
-        /**
-         * @inheritdoc
-         */
-        alwaysCalledWithExactly(...args: MatchArguments<TArgs>): boolean;
-        /**
-         * @inheritdoc
-         */
-        alwaysCalledWithMatch(...args: TArgs): boolean;
-        /**
-         * @inheritdoc
-         */
-        neverCalledWith(...args: MatchArguments<TArgs>): boolean;
-        /**
-         * @inheritdoc
-         */
-        neverCalledWithMatch(...args: TArgs): boolean;
-        /**
-         * @inheritdoc
-         */
-        invokeCallback(...args: TArgs): void;
-        /**
-         * @inheritdoc
-         */
-        named(name: string): SinonSpy<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
-        /**
-         * @inheritdoc
-         */
-        getCalls(): Array<SinonSpyCall<TArgs, TReturnValue>>;
     }
 
     interface SinonSpyStatic {
@@ -1234,41 +1157,41 @@ declare namespace Sinon {
          * Passes if spy was never called
          * @param spy
          */
-        notCalled(spy: SinonSpyLike): void;
+        notCalled(spy: SinonSpy<any[]>): void;
         /**
          * Passes if spy was called at least once.
          */
-        called(spy: SinonSpyLike): void;
+        called(spy: SinonSpy<any[]>): void;
         /**
          * Passes if spy was called once and only once.
          */
-        calledOnce(spy: SinonSpyLike): void;
+        calledOnce(spy: SinonSpy<any[]>): void;
         /**
          * Passes if spy was called exactly twice.
          */
-        calledTwice(spy: SinonSpyLike): void;
+        calledTwice(spy: SinonSpy<any[]>): void;
         /**
          * Passes if spy was called exactly three times.
          */
-        calledThrice(spy: SinonSpyLike): void;
+        calledThrice(spy: SinonSpy<any[]>): void;
         /**
          * Passes if spy was called exactly num times.
          */
-        callCount(spy: SinonSpyLike, count: number): void;
+        callCount(spy: SinonSpy<any[]>, count: number): void;
         /**
          * Passes if provided spies were called in the specified order.
          * @param spies
          */
-        callOrder(...spies: SinonSpyLike[]): void;
+        callOrder(...spies: Array<SinonSpy<any>>): void;
         /**
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.
          */
-        calledOn(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, obj: any): void;
+        calledOn<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, obj: any): void;
         /**
          * Passes if spy was always called with obj as its this value.
          */
-        alwaysCalledOn(spy: SinonSpyLike, obj: any): void;
+        alwaysCalledOn(spy: SinonSpy<any[]>, obj: any): void;
         /**
          * Passes if spy was called with the provided arguments.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWith(spy.firstCall, arg1, arg2, ...);.
@@ -1328,35 +1251,35 @@ declare namespace Sinon {
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.
          * @param spyOrSpyCall
          */
-        calledWithNew(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike): void;
+        calledWithNew<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>): void;
         /**
          * Passes if spy threw any exception.
          */
-        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike): void;
+        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is an actual object.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, exception: string): void;
+        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, exception: string): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is a String denoting its type.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw(spyOrSpyCall: SinonSpyLike | SinonSpyCallLike, exception: any): void;
+        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, exception: any): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpyLike): void;
+        alwaysThrew(spy: SinonSpy<any[]>): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpyLike, exception: string): void;
+        alwaysThrew(spy: SinonSpy<any[]>, exception: string): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpyLike, exception: any): void;
+        alwaysThrew(spy: SinonSpy<any[]>, exception: any): void;
         /**
          * Uses sinon.match to test if the arguments can be considered a match.
          */

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -135,21 +135,17 @@ declare namespace Sinon {
          */
         lastArg: any;
 
-        /* tslint:disable:no-unnecessary-generics */
-
         /**
          * Returns true if the spy call occurred before another spy call.
          * @param call
          *
          */
-        calledBefore<TSpyArgs extends any[]>(call: SinonSpyCall<TSpyArgs>): boolean;
+        calledBefore(call: SinonSpyCall<any>): boolean;
         /**
          * Returns true if the spy call occurred after another spy call.
          * @param call
          */
-        calledAfter<TSpyArgs extends any[]>(call: SinonSpyCall<TSpyArgs>): boolean;
-
-        /* tslint:enable:no-unnecessary-generics */
+        calledAfter(call: SinonSpyCall<any>): boolean;
     }
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
@@ -220,30 +216,26 @@ declare namespace Sinon {
         // Methods
         (...args: TArgs): TReturnValue;
 
-        /* tslint:disable:no-unnecessary-generics */
-
         /**
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
+        calledBefore(anotherSpy: SinonSpy<any>): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
+        calledAfter(anotherSpy: SinonSpy<any>): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
+        calledImmediatelyBefore(anotherSpy: SinonSpy<any>): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter<TSpyArgs extends any[]>(anotherSpy: SinonSpy<TSpyArgs>): boolean;
-
-        /* tslint:enable:no-unnecessary-generics */
+        calledImmediatelyAfter(anotherSpy: SinonSpy<any>): boolean;
 
         /**
          * Creates a spy that only records calls when the received arguments match those passed to withArgs.
@@ -1166,33 +1158,32 @@ declare namespace Sinon {
         pass(assertion: any): void; // Overridable
 
         // Methods
-        /* tslint:disable:no-unnecessary-generics */
 
         /**
          * Passes if spy was never called
          * @param spy
          */
-        notCalled<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        notCalled(spy: SinonSpy<any>): void;
         /**
          * Passes if spy was called at least once.
          */
-        called<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        called(spy: SinonSpy<any>): void;
         /**
          * Passes if spy was called once and only once.
          */
-        calledOnce<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        calledOnce(spy: SinonSpy<any>): void;
         /**
          * Passes if spy was called exactly twice.
          */
-        calledTwice<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        calledTwice(spy: SinonSpy<any>): void;
         /**
          * Passes if spy was called exactly three times.
          */
-        calledThrice<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        calledThrice(spy: SinonSpy<any>): void;
         /**
          * Passes if spy was called exactly num times.
          */
-        callCount<TArgs extends any[]>(spy: SinonSpy<TArgs>, count: number): void;
+        callCount(spy: SinonSpy<any>, count: number): void;
         /**
          * Passes if provided spies were called in the specified order.
          * @param spies
@@ -1202,13 +1193,11 @@ declare namespace Sinon {
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.
          */
-        calledOn<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, obj: any): void;
+        calledOn(spyOrSpyCall: SinonSpy<any> | SinonSpyCall<any>, obj: any): void;
         /**
          * Passes if spy was always called with obj as its this value.
          */
-        alwaysCalledOn<TArgs extends any[]>(spy: SinonSpy<TArgs>, obj: any): void;
-
-        /* tslint:enable:no-unnecessary-generics */
+        alwaysCalledOn(spy: SinonSpy<any>, obj: any): void;
 
         /**
          * Passes if spy was called with the provided arguments.
@@ -1269,40 +1258,36 @@ declare namespace Sinon {
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.
          * @param spyOrSpyCall
          */
-        calledWithNew<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>): void;
+        calledWithNew(spyOrSpyCall: SinonSpy<any> | SinonSpyCall<any>): void;
         /**
          * Passes if spy threw any exception.
          */
-        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>): void;
+        threw(spyOrSpyCall: SinonSpy<any> | SinonSpyCall<any>): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is an actual object.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, exception: string): void;
+        threw(spyOrSpyCall: SinonSpy<any> | SinonSpyCall<any>, exception: string): void;
         /**
          * Passes if spy threw the given exception.
          * The exception is a String denoting its type.
          * It’s possible to assert on a dedicated spy call: sinon.assert.threw(spy.thirdCall, exception);.
          */
-        threw<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, exception: any): void;
-
-        /* tslint:disable:no-unnecessary-generics */
+        threw(spyOrSpyCall: SinonSpy<any> | SinonSpyCall<any>, exception: any): void;
 
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>): void;
+        alwaysThrew(spy: SinonSpy<any>): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>, exception: string): void;
+        alwaysThrew(spy: SinonSpy<any>, exception: string): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew<TArgs extends any[]>(spy: SinonSpy<TArgs>, exception: any): void;
-
-        /* tslint:enable:no-unnecessary-generics */
+        alwaysThrew(spy: SinonSpy<any>, exception: any): void;
 
         /**
          * Uses sinon.match to test if the arguments can be considered a match.

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -139,12 +139,12 @@ declare namespace Sinon {
          * Returns true if the spy call occurred before another spy call.
          * @param call
          */
-        calledBefore(call: SinonSpyCall<any[]>): boolean;
+        calledBefore(call: SinonSpyCall): boolean;
         /**
          * Returns true if the spy call occurred after another spy call.
          * @param call
          */
-        calledAfter(call: SinonSpyCall<any[]>): boolean;
+        calledAfter(call: SinonSpyCall): boolean;
     }
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -1182,7 +1182,7 @@ declare namespace Sinon {
          * Passes if provided spies were called in the specified order.
          * @param spies
          */
-        callOrder(...spies: SinonSpy[]): void;
+        callOrder(...spies: SinonSpy<any>[]): void;
         /**
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -218,22 +218,22 @@ declare namespace Sinon {
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore(anotherSpy: SinonSpy<any[]>): boolean;
+        calledBefore(anotherSpy: SinonSpy): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter(anotherSpy: SinonSpy<any[]>): boolean;
+        calledAfter(anotherSpy: SinonSpy): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore(anotherSpy: SinonSpy<any[]>): boolean;
+        calledImmediatelyBefore(anotherSpy: SinonSpy): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter(anotherSpy: SinonSpy<any[]>): boolean;
+        calledImmediatelyAfter(anotherSpy: SinonSpy): boolean;
         /**
          * Creates a spy that only records calls when the received arguments match those passed to withArgs.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
@@ -1157,32 +1157,32 @@ declare namespace Sinon {
          * Passes if spy was never called
          * @param spy
          */
-        notCalled(spy: SinonSpy<any[]>): void;
+        notCalled(spy: SinonSpy): void;
         /**
          * Passes if spy was called at least once.
          */
-        called(spy: SinonSpy<any[]>): void;
+        called(spy: SinonSpy): void;
         /**
          * Passes if spy was called once and only once.
          */
-        calledOnce(spy: SinonSpy<any[]>): void;
+        calledOnce(spy: SinonSpy): void;
         /**
          * Passes if spy was called exactly twice.
          */
-        calledTwice(spy: SinonSpy<any[]>): void;
+        calledTwice(spy: SinonSpy): void;
         /**
          * Passes if spy was called exactly three times.
          */
-        calledThrice(spy: SinonSpy<any[]>): void;
+        calledThrice(spy: SinonSpy): void;
         /**
          * Passes if spy was called exactly num times.
          */
-        callCount(spy: SinonSpy<any[]>, count: number): void;
+        callCount(spy: SinonSpy, count: number): void;
         /**
          * Passes if provided spies were called in the specified order.
          * @param spies
          */
-        callOrder(...spies: Array<SinonSpy<any>>): void;
+        callOrder(...spies: SinonSpy[]): void;
         /**
          * Passes if spy was ever called with obj as its this value.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledOn(spy.firstCall, arg1, arg2, ...);.
@@ -1191,7 +1191,7 @@ declare namespace Sinon {
         /**
          * Passes if spy was always called with obj as its this value.
          */
-        alwaysCalledOn(spy: SinonSpy<any[]>, obj: any): void;
+        alwaysCalledOn(spy: SinonSpy, obj: any): void;
         /**
          * Passes if spy was called with the provided arguments.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWith(spy.firstCall, arg1, arg2, ...);.
@@ -1271,15 +1271,15 @@ declare namespace Sinon {
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy<any[]>): void;
+        alwaysThrew(spy: SinonSpy): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy<any[]>, exception: string): void;
+        alwaysThrew(spy: SinonSpy, exception: string): void;
         /**
          * Like threw, only required for all calls to the spy.
          */
-        alwaysThrew(spy: SinonSpy<any[]>, exception: any): void;
+        alwaysThrew(spy: SinonSpy, exception: any): void;
         /**
          * Uses sinon.match to test if the arguments can be considered a match.
          */

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -6,7 +6,9 @@ interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
     type MatchArguments<T> = {
-        [K in keyof T]: SinonMatcher | MatchArguments<T[K]> | T[K];
+        [K in keyof T]: SinonMatcher
+            | (T[K] extends object ? MatchArguments<T[K]> : never)
+            | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -82,6 +82,7 @@ function testSandbox() {
     const stubInstance = sb.createStubInstance(cls);
     const privateFooStubbedInstance = sb.createStubInstance(PrivateFoo);
     stubInstance.foo.calledWith('foo', 1);
+    stubInstance.foo.calledWith('foo');
     privateFooStubbedInstance.foo.calledWith();
     const clsFoo: sinon.SinonStub<[string, number], number> = stubInstance.foo;
     const privateFooFoo: sinon.SinonStub<[], void> = privateFooStubbedInstance.foo;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v7.3.0/spies/

---

Fixes #33839

Summary of the mass of posts below & the changes here:

* `SinonInspectable` isn't a real thing, sinon has no such interface/concept, it has been removed from the types
* `SinonSpy` when used in spread has been changed to use `any` as `TArgs` (rather than `any[]`, the default) to allow having a collection of spies (trade-off we must make to avoid introducing a workaround interface like the whole `SinonInspectable` thing did)
* `calledWith` is partial, so can accept _some_ of the arguments rather than requiring them all
* the inspectable changes introduced a breaking change we overlooked (a big one which caused thousands of type errors in my case), removing it and breaking whoever uses it is a safer play than leaving everyone else broken