### PR TITLE
[React] Fix optionality of inferred props

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2732,18 +2732,21 @@ declare namespace React {
 // so boolean is only resolved for T = any
 type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false;
 
-// Pick properties for which the value is `any`
-type PickAny<T> = Pick<T, { [K in keyof T]: IsExactlyAny<T[K]> extends true ? K : never }[keyof T]>;
+type ExactlyAnyPropertyKeys<T> = { [K in keyof T]: IsExactlyAny<T[K]> extends true ? K : never }[keyof T];
+type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
 
 // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
-// If props is type any, use propTypes definitions, otherwise for each `any` property of props, use the propTypes type
-// If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
-type MergePropTypes<P, T> = IsExactlyAny<P> extends true ? T : string extends keyof P ? P : (
-    // From declared props, pick properties which are either not `any` or are missing on `propTypes`.
-    & Pick<P, Exclude<keyof P, keyof PickAny<P>> | Exclude<keyof P, keyof T>>
-    // From inferred props, pick all properties except those which are not `any` on `Props`
-    & Pick<T, Exclude<keyof T, Exclude<keyof P, keyof PickAny<P>>>>
-);
+type MergePropTypes<P, T> =
+    // If props is type any, use propTypes definitions
+    IsExactlyAny<P> extends true ? T :
+        // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+        string extends keyof P ? P :
+            // Prefer declared types which are not exactly any
+            & Pick<P, NotExactlyAnyPropertyKeys<P>>
+            // For props which are exactly any, use the type inferred from propTypes if present
+            & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
+            // Keep leftover props not specified in propTypes
+            & Pick<P, Exclude<keyof P, keyof T>>;
 
 // Any prop that has a default prop becomes optional, but its type is unchanged
 // Undeclared default props are augmented into the resulting allowable attributes

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -235,17 +235,40 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     foo: string;
 //     bar: any;
 // }
+// interface WeakComponentProps3 {
+//     foo: any;
+//     bar: any;
+// }
 
 // // $ExpectType true
 // type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
 //     foo?: string | null
 //     bar: boolean
 // } ? true : false;
+// // $ExpectType true
 // type weakComponentTest2 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
 //     foo?: string | null
 //     bar: number
 // } ? true : false;
+// // $ExpectType true
 // type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
 //     foo: string
 //     bar: boolean
 // } ? true : false;
+
+// // $ExpectError
+// const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
+// const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
+
+// interface IndexedComponentProps {
+//     [K: string]: boolean;
+// }
+// interface WeakIndexedComponentProps {
+//     [K: string]: any;
+// }
+
+// const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
+// // $ExpectError
+// const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
+// const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
+// const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };


### PR DESCRIPTION
Please fill in this template.

-   [x] Use a meaningful title for the pull request. Include the name of the package modified.
-   [X] Test the change in your own code. (Compile and run.)
-   [X] Add or edit tests to reflect the change. (Run with `npm test`.)
-   [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
-   [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
-   [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

-   [x] Provide a URL to documentation or source code which provides context for the suggested changes: Fixes #33742
-   [ ] ~~Increase the version number in the header if appropriate.~~
-   [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

This change ensures that the optional modifier (`?`) is copied when using inferred properties from `propTypes`.
