### PR TITLE
[react-map-gl] add geolocate control

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -317,6 +317,18 @@ export interface FullscreenControlProps extends BaseControlProps {
 
 export class FullscreenControl extends BaseControl<FullscreenControlProps> {}
 
+export interface GeolocateControlProps extends BaseControlProps {
+    className?: string;
+    positionOptions?: MapboxGL.PositionOptions;
+    fitBoundsOptions?: MapboxGL.FitBoundsOptions;
+    trackUserLocation?: boolean;
+    showUserLocation?: boolean;
+    onViewStateChange?: (info: ViewStateChangeInfo) => void;
+    onViewportChange?: (viewState: ViewState) => void;
+}
+
+export class GeolocateControl extends BaseControl<GeolocateControlProps> {}
+
 export interface DraggableControlProps extends BaseControlProps {
     draggable?: boolean;
     onDrag?: (event: DragEvent) => void;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -6,6 +6,7 @@ import {
     SVGOverlay,
     HTMLOverlay,
     FullscreenControl,
+    GeolocateControl,
     CanvasRedrawOptions,
     HTMLRedrawOptions,
     SVGRedrawOptions,
@@ -39,6 +40,7 @@ class MyMap extends React.Component<{}, State> {
                     ref={this.setRefInteractive}
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
+                    <GeolocateControl className="test-class" />
                     <CanvasOverlay
                         redraw={opts => {
                             const {


### PR DESCRIPTION
Added `GeolocateControl` according to https://github.com/uber/react-map-gl/blob/master/src/components/geolocate-control.js.
This should bring the types fully up-to-date with the 4.1 release. Fixes #34005