### PR TITLE
[ramda] Use user type guards for filter and reject

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -822,6 +822,33 @@ R.times(i, 5);
 };
 
 () => {
+    type Prop= 'A' | 'B';
+
+    interface Type<T extends Prop> {
+        prop: T;
+    }
+
+    const a: Type<'A'> = {
+        prop: 'A',
+    };
+
+    const b: Type<'B'> = {
+        prop: 'B',
+    };
+
+    type Things = Type<'A'> | Type<'B'>;
+
+    const things: Things[] = [a, b];
+
+    const isA = (t: Things): t is Type<'A'> => t.prop === 'A';
+
+    const results: Array<Type<'A'>> = R.filter(
+        isA,
+        things
+    );
+};
+
+() => {
     function lastTwo(val: number, idx: number, list: number[]) {
         return list.length - idx <= 2;
     }


### PR DESCRIPTION
The PR add an optional return type to ramda `filter`.

The use case is quite common and is tested [here](https://github.com/guillaumewuip/DefinitelyTyped/blob/6db36294609da72eb4752ffc80ce207d3cb360c3/types/ramda/ramda-tests.ts#L775-L798) : 

```typescript
  type Prop= 'A' | 'B';

  interface Type<T extends Prop> {
    prop: T;
  }

  const a: Type<'A'> = {
    prop: 'A',
  };

  const b: Type<'B'> = {
    prop: 'B',
  };

  type Things = Type<"A"> | Type<"B">;

  const things: Things[] = [a, b]; // Things are Type<'A'> or Type<'B'>

  const isA = (t: Things): t is Type<"A"> => t.prop === 'A';

  // as we are keeping only Type<'A'> here so we want results to be Type<'A'>[] and not Things[]
  const results: Array<Type<'A'>> = R.filter(
    isA,
    things
  );
```

Lodash types allow us to do the same with their `filter` :
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a228c252e2eaa784e046f65c8a81c1ca3bf32f28/types/lodash/common/collection.d.ts#L225-L228

It's important to note that it's breaking for people using `Kind extends 'array'` and `Kind extends 'object'` generics types on filter now as the parameter moves to the 3rd position. I haven't found a way to fix that.


---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (documented in PR description)
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.