### PR TITLE
JQuery/v2: Improve typings of value parameter JQueryDeferred

### DIFF
--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -37,7 +37,7 @@ MERCHANTABLITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
-
+// TypeScript Version: 3.2
 
 /**
  * Interface for the AJAX setting that will configure the AJAX request
@@ -321,7 +321,7 @@ interface JQueryGenericPromise<T> {
      * @param failFilter An optional function that is called when the Deferred is rejected.
      * @see {@link https://api.jquery.com/deferred.then/#deferred-then-doneFilter-failFilter-progressFilter}
      */
-    then<U>(doneFilter: (value?: T, ...values: any[]) => U|JQueryPromise<U>, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(doneFilter: (value: T, ...values: any[]) => U|JQueryPromise<U>, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
 
     /**
      * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
@@ -330,7 +330,7 @@ interface JQueryGenericPromise<T> {
      * @param failFilter An optional function that is called when the Deferred is rejected.
      * @see {@link https://api.jquery.com/deferred.then/#deferred-then-doneFilter-failFilter-progressFilter}
      */
-    then(doneFilter: (value?: T, ...values: any[]) => void, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<void>;
+    then(doneFilter: (value: T, ...values: any[]) => void, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<void>;
 }
 
 /**
@@ -482,7 +482,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      * @param args Optional subsequent arguments that are passed to the doneCallbacks.
      * @see {@link https://api.jquery.com/deferred.resolve/}
      */
-    resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
+    resolve(value: T, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given context and args.

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -37,6 +37,7 @@ MERCHANTABLITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
+// TypeScript Version: 3.2
 
 /**
  * Interface for the AJAX setting that will configure the AJAX request

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -37,7 +37,6 @@ MERCHANTABLITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
-// TypeScript Version: 3.2
 
 /**
  * Interface for the AJAX setting that will configure the AJAX request

--- a/types/jquery/v2/jquery-tests.ts
+++ b/types/jquery/v2/jquery-tests.ts
@@ -3534,7 +3534,7 @@ function test_promise_then_change_type() {
 function test_promise_then_not_return_deferred() {
   var state: string;
 
-  var deferred: JQueryDeferred<any> = $.Deferred();
+  var deferred = $.Deferred<void>();
   state = deferred.state();
   deferred = deferred.progress();
   deferred = deferred.done();
@@ -3546,7 +3546,7 @@ function test_promise_then_not_return_deferred() {
   promise = deferred.promise();
   promise = deferred.then(function () { });
 
-  var promise: JQueryPromise<any> = $.Deferred().promise();
+  var promise = $.Deferred<void>().promise();
   state = promise.state();
   promise = promise.then(function () { });
   promise = promise.progress();


### PR DESCRIPTION
const d = $.Deferred<number>().resolve(3).then(result => {...});
Type of 'result' should not be 'number | undefined' but should be 'number'.

const d3 = $.Deferred<number | undefined>().resolve(3).then(result =>
{...});
Type of 'result' should be 'number | undefined'

Fixes DefinitelyTyped/DefinitelyTyped#34022

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/jquery.deferred/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

