### PR TITLE
[kintone/kintone-utility] Add a new type definition

### DIFF
--- a/types/kintone-utility/index.d.ts
+++ b/types/kintone-utility/index.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for kintone-utility 0.4
+// Project: https://github.com/kintone/kintoneUtility
+// Definitions by: TAKAHASHI Shuuji <https://github.com/shuuji3>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/types/kintone-utility
+// TypeScript Version: 2.2
+
+export namespace rest {
+    interface File {
+        type: string;
+        url?: string;
+        file?: { fileKey: string };
+    }
+
+    function deleteAllRecords(params: { app: number; ids: ReadonlyArray<number>; isGuest?: boolean }): object;
+
+    function deleteAllRecordsByQuery(params: { app: number; query?: string; isGuest?: boolean }): object;
+
+    function deleteRecords(params: { app: number; ids: ReadonlyArray<number>; revisions?: ReadonlyArray<number>; isGuest?: boolean }): object;
+
+    function downloadFile(params: { fileKey: string; isGuest?: boolean }): object;
+
+    function getAllRecordsByQuery(params: {
+        app: number;
+        query?: string;
+        fields?: ReadonlyArray<string>;
+        isGuest?: boolean;
+    }): object;
+
+    function getAppDeployStatus(params: { apps: ReadonlyArray<number>; isGuest?: boolean }): object;
+
+    function getCustomization(params: { app: number; isPreview?: boolean; isGuest?: boolean }): object;
+
+    function getFormFields(params: { app: number; lang?: string; isGuest?: boolean; isPreview?: boolean }): object;
+
+    function getFormLayout(params: { app: number; isGuest?: boolean; isPreview?: boolean }): object;
+
+    function getRecord(params: { app: number; id: number; isGuest?: boolean }): object;
+
+    function getRecords(params: {
+        app: number;
+        query?: string;
+        fields?: ReadonlyArray<string>;
+        totalCount?: boolean;
+        isGuest?: boolean;
+    }): object;
+
+    function postAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+
+    function postDeployAppSettings(params: {
+        apps: Array<{ app: number; revision?: number }>;
+        revert?: boolean;
+        isGuest?: boolean;
+    }): object;
+
+    function postRecord(params: { app: number; record?: object; isGuest?: boolean }): object;
+
+    function postRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+
+    function putAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+
+    function putRecord(params: {
+        app: number;
+        id?: number;
+        updateKey?: {
+            field: string;
+            value: string;
+        };
+        revision?: number;
+        record?: object;
+        isGuest?: boolean;
+    }): object;
+
+    function putRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+
+    function setApiTokenAuth(apiToken: string): void;
+
+    function setBasicAuth(userName: string, password: string): void;
+
+    function setDomain(domain: string): void;
+
+    function setGuestSpaceId(guestSpaceId: number): void;
+
+    function setUserAuth(loginName: string, password: string): void;
+
+    function updateCustomization(params: {
+        app: number;
+        scope?: string;
+        desktop?: {
+            js?: ReadonlyArray<File>;
+            ccs?: ReadonlyArray<File>;
+        };
+        mobile?: {
+            js?: ReadonlyArray<File>;
+        };
+        revision?: number;
+        isGuest?: boolean;
+    }): object;
+
+    function uploadFile(params: { fileName: string; blob: object; isGuest?: boolean }): object;
+
+    function upsertRecord(params: {
+        app: number;
+        updateKey: {
+            field: string;
+            value: string;
+        };
+        record: object;
+        isGuest?: boolean;
+    }): object;
+
+    function upsertRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+}

--- a/types/kintone-utility/index.d.ts
+++ b/types/kintone-utility/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for kintone-utility 0.4
+// Type definitions for non-npm package kintone-utility 0.4
 // Project: https://github.com/kintone/kintoneUtility
 // Definitions by: TAKAHASHI Shuuji <https://github.com/shuuji3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/types/kintone-utility

--- a/types/kintone-utility/index.d.ts
+++ b/types/kintone-utility/index.d.ts
@@ -11,30 +11,30 @@ export namespace rest {
         file?: { fileKey: string };
     }
 
-    function deleteAllRecords(params: { app: number; ids: ReadonlyArray<number>; isGuest?: boolean }): object;
+    function deleteAllRecords(params: { app: number; ids: ReadonlyArray<number>; isGuest?: boolean }): Promise<object>;
 
-    function deleteAllRecordsByQuery(params: { app: number; query?: string; isGuest?: boolean }): object;
+    function deleteAllRecordsByQuery(params: { app: number; query?: string; isGuest?: boolean }): Promise<object>;
 
-    function deleteRecords(params: { app: number; ids: ReadonlyArray<number>; revisions?: ReadonlyArray<number>; isGuest?: boolean }): object;
+    function deleteRecords(params: { app: number; ids: ReadonlyArray<number>; revisions?: ReadonlyArray<number>; isGuest?: boolean }): Promise<object>;
 
-    function downloadFile(params: { fileKey: string; isGuest?: boolean }): object;
+    function downloadFile(params: { fileKey: string; isGuest?: boolean }): Promise<object>;
 
     function getAllRecordsByQuery(params: {
         app: number;
         query?: string;
         fields?: ReadonlyArray<string>;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function getAppDeployStatus(params: { apps: ReadonlyArray<number>; isGuest?: boolean }): object;
+    function getAppDeployStatus(params: { apps: ReadonlyArray<number>; isGuest?: boolean }): Promise<object>;
 
-    function getCustomization(params: { app: number; isPreview?: boolean; isGuest?: boolean }): object;
+    function getCustomization(params: { app: number; isPreview?: boolean; isGuest?: boolean }): Promise<object>;
 
-    function getFormFields(params: { app: number; lang?: string; isGuest?: boolean; isPreview?: boolean }): object;
+    function getFormFields(params: { app: number; lang?: string; isGuest?: boolean; isPreview?: boolean }): Promise<object>;
 
-    function getFormLayout(params: { app: number; isGuest?: boolean; isPreview?: boolean }): object;
+    function getFormLayout(params: { app: number; isGuest?: boolean; isPreview?: boolean }): Promise<object>;
 
-    function getRecord(params: { app: number; id: number; isGuest?: boolean }): object;
+    function getRecord(params: { app: number; id: number; isGuest?: boolean }): Promise<object>;
 
     function getRecords(params: {
         app: number;
@@ -42,21 +42,21 @@ export namespace rest {
         fields?: ReadonlyArray<string>;
         totalCount?: boolean;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function postAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+    function postAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): Promise<object>;
 
     function postDeployAppSettings(params: {
         apps: Array<{ app: number; revision?: number }>;
         revert?: boolean;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function postRecord(params: { app: number; record?: object; isGuest?: boolean }): object;
+    function postRecord(params: { app: number; record?: object; isGuest?: boolean }): Promise<object>;
 
-    function postRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+    function postRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): Promise<object>;
 
-    function putAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+    function putAllRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): Promise<object>;
 
     function putRecord(params: {
         app: number;
@@ -68,9 +68,9 @@ export namespace rest {
         revision?: number;
         record?: object;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function putRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+    function putRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): Promise<object>;
 
     function setApiTokenAuth(apiToken: string): void;
 
@@ -94,9 +94,9 @@ export namespace rest {
         };
         revision?: number;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function uploadFile(params: { fileName: string; blob: object; isGuest?: boolean }): object;
+    function uploadFile(params: { fileName: string; blob: object; isGuest?: boolean }): Promise<object>;
 
     function upsertRecord(params: {
         app: number;
@@ -106,7 +106,7 @@ export namespace rest {
         };
         record: object;
         isGuest?: boolean;
-    }): object;
+    }): Promise<object>;
 
-    function upsertRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): object;
+    function upsertRecords(params: { app: number; records: ReadonlyArray<object>; isGuest?: boolean }): Promise<object>;
 }

--- a/types/kintone-utility/kintone-utility-tests.ts
+++ b/types/kintone-utility/kintone-utility-tests.ts
@@ -16,13 +16,13 @@ const record = {id: 1, field1: {value: 1}};
 const records = [{id: 1, field1: {value: 1}, field2: {value: 2}}];
 
 // deleteAllRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteAllRecords({
     app,
     ids,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteAllRecords({
     app,
     ids,
@@ -30,12 +30,12 @@ kintoneUtility.rest.deleteAllRecords({
 });
 
 // deleteAllRecordsByQuery
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteAllRecordsByQuery({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteAllRecordsByQuery({
     app,
     query,
@@ -43,13 +43,13 @@ kintoneUtility.rest.deleteAllRecordsByQuery({
 });
 
 // deleteRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteRecords({
     app,
     ids
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.deleteRecords({
     app,
     ids,
@@ -58,24 +58,24 @@ kintoneUtility.rest.deleteRecords({
 });
 
 // downloadFile
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.downloadFile({
     fileKey,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.downloadFile({
     fileKey,
     isGuest: true,
 });
 
 // getAllRecordsByQuery
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getAllRecordsByQuery({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getAllRecordsByQuery({
     app,
     query,
@@ -84,31 +84,31 @@ kintoneUtility.rest.getAllRecordsByQuery({
 });
 
 // getAppDeployStatus
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getAppDeployStatus({
     apps,
     isGuest: true,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getAppDeployStatus({
     apps,
 });
 
 // getCustomization
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getCustomization({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getCustomization({
     app,
     isPreview: true,
     isGuest: true,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getFormFields({
     app,
     lang: 'ja',
@@ -116,7 +116,7 @@ kintoneUtility.rest.getFormFields({
     isPreview: true,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getFormLayout({
     app,
     isGuest: true,
@@ -124,13 +124,13 @@ kintoneUtility.rest.getFormLayout({
 });
 
 // getRecord
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getRecord({
     app,
     id,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getRecord({
     app,
     id,
@@ -138,12 +138,12 @@ kintoneUtility.rest.getRecord({
 });
 
 // getRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getRecords({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.getRecords({
     app,
     query,
@@ -153,13 +153,13 @@ kintoneUtility.rest.getRecords({
 });
 
 // postAllRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postAllRecords({
     app,
     records,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postAllRecords({
     app,
     records,
@@ -167,7 +167,7 @@ kintoneUtility.rest.postAllRecords({
 });
 
 // postDeployAppSettings
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postDeployAppSettings({
     apps: [
         {app: 1, revision: 1},
@@ -175,7 +175,7 @@ kintoneUtility.rest.postDeployAppSettings({
     ],
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postDeployAppSettings({
     apps: [
         {app: 1, revision: 1},
@@ -186,12 +186,12 @@ kintoneUtility.rest.postDeployAppSettings({
 });
 
 // postRecord
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postRecord({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postRecord({
     app,
     record,
@@ -199,7 +199,7 @@ kintoneUtility.rest.postRecord({
 });
 
 // postRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.postRecords({
     app,
     records,
@@ -207,13 +207,13 @@ kintoneUtility.rest.postRecords({
 });
 
 // putAllRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putAllRecords({
     app,
     records,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putAllRecords({
     app,
     records,
@@ -221,12 +221,12 @@ kintoneUtility.rest.putAllRecords({
 });
 
 // putRecord
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putRecord({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putRecord({
     app,
     id,
@@ -240,13 +240,13 @@ kintoneUtility.rest.putRecord({
 });
 
 // putRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putRecords({
     app,
     records,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.putRecords({
     app,
     records,
@@ -274,12 +274,12 @@ kintoneUtility.rest.setGuestSpaceId(1);
 kintoneUtility.rest.setUserAuth('alice', 'bob');
 
 // updateCustomization
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.updateCustomization({
     app,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.updateCustomization({
     app,
     scope: '',
@@ -295,21 +295,21 @@ kintoneUtility.rest.updateCustomization({
 });
 
 // uploadFile
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.uploadFile({
     fileName: 'image.png',
     blob: {},
     isGuest: true,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.uploadFile({
     fileName: 'image.png',
     blob: {},
 });
 
 // upsertRecord
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.upsertRecord({
     app,
     updateKey: {
@@ -319,7 +319,7 @@ kintoneUtility.rest.upsertRecord({
     record,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.upsertRecord({
     app,
     updateKey: {
@@ -331,13 +331,13 @@ kintoneUtility.rest.upsertRecord({
 });
 
 // upsertRecords
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.upsertRecords({
     app,
     records,
 });
 
-// $ExpectType object
+// $ExpectType Promise<object>
 kintoneUtility.rest.upsertRecords({
     app,
     records,

--- a/types/kintone-utility/kintone-utility-tests.ts
+++ b/types/kintone-utility/kintone-utility-tests.ts
@@ -1,0 +1,345 @@
+import kintoneUtility = require('kintone-utility');
+
+const query = 'field = "value"';
+const app = 1;
+const apps = [1, 2, 3];
+const id = 1;
+const ids = [1, 2, 3];
+const fileKey = 'image.png';
+const fields = ['field1', 'field2', 'field3'];
+const Files = [
+    {type: 'js'},
+    {type: 'js', url: 'https://google.com/search.js'},
+    {type: 'js', file: {fileKey: 'abc_xyz_1234567'}},
+];
+const record = {id: 1, field1: {value: 1}};
+const records = [{id: 1, field1: {value: 1}, field2: {value: 2}}];
+
+// deleteAllRecords
+// $ExpectType object
+kintoneUtility.rest.deleteAllRecords({
+    app,
+    ids,
+});
+
+// $ExpectType object
+kintoneUtility.rest.deleteAllRecords({
+    app,
+    ids,
+    isGuest: true,
+});
+
+// deleteAllRecordsByQuery
+// $ExpectType object
+kintoneUtility.rest.deleteAllRecordsByQuery({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.deleteAllRecordsByQuery({
+    app,
+    query,
+    isGuest: true,
+});
+
+// deleteRecords
+// $ExpectType object
+kintoneUtility.rest.deleteRecords({
+    app,
+    ids
+});
+
+// $ExpectType object
+kintoneUtility.rest.deleteRecords({
+    app,
+    ids,
+    revisions: [1, 2, 3],
+    isGuest: true,
+});
+
+// downloadFile
+// $ExpectType object
+kintoneUtility.rest.downloadFile({
+    fileKey,
+});
+
+// $ExpectType object
+kintoneUtility.rest.downloadFile({
+    fileKey,
+    isGuest: true,
+});
+
+// getAllRecordsByQuery
+// $ExpectType object
+kintoneUtility.rest.getAllRecordsByQuery({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getAllRecordsByQuery({
+    app,
+    query,
+    fields,
+    isGuest: true,
+});
+
+// getAppDeployStatus
+// $ExpectType object
+kintoneUtility.rest.getAppDeployStatus({
+    apps,
+    isGuest: true,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getAppDeployStatus({
+    apps,
+});
+
+// getCustomization
+// $ExpectType object
+kintoneUtility.rest.getCustomization({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getCustomization({
+    app,
+    isPreview: true,
+    isGuest: true,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getFormFields({
+    app,
+    lang: 'ja',
+    isGuest: true,
+    isPreview: true,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getFormLayout({
+    app,
+    isGuest: true,
+    isPreview: true,
+});
+
+// getRecord
+// $ExpectType object
+kintoneUtility.rest.getRecord({
+    app,
+    id,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getRecord({
+    app,
+    id,
+    isGuest: true,
+});
+
+// getRecords
+// $ExpectType object
+kintoneUtility.rest.getRecords({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.getRecords({
+    app,
+    query,
+    fields,
+    totalCount: true,
+    isGuest: true,
+});
+
+// postAllRecords
+// $ExpectType object
+kintoneUtility.rest.postAllRecords({
+    app,
+    records,
+});
+
+// $ExpectType object
+kintoneUtility.rest.postAllRecords({
+    app,
+    records,
+    isGuest: true,
+});
+
+// postDeployAppSettings
+// $ExpectType object
+kintoneUtility.rest.postDeployAppSettings({
+    apps: [
+        {app: 1, revision: 1},
+        {app: 2, revision: 2},
+    ],
+});
+
+// $ExpectType object
+kintoneUtility.rest.postDeployAppSettings({
+    apps: [
+        {app: 1, revision: 1},
+        {app: 2, revision: 2},
+    ],
+    revert: true,
+    isGuest: true,
+});
+
+// postRecord
+// $ExpectType object
+kintoneUtility.rest.postRecord({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.postRecord({
+    app,
+    record,
+    isGuest: true,
+});
+
+// postRecords
+// $ExpectType object
+kintoneUtility.rest.postRecords({
+    app,
+    records,
+    isGuest: true,
+});
+
+// putAllRecords
+// $ExpectType object
+kintoneUtility.rest.putAllRecords({
+    app,
+    records,
+});
+
+// $ExpectType object
+kintoneUtility.rest.putAllRecords({
+    app,
+    records,
+    isGuest: true,
+});
+
+// putRecord
+// $ExpectType object
+kintoneUtility.rest.putRecord({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.putRecord({
+    app,
+    id,
+    updateKey: {
+        field: 'field1',
+        value: 'value1'
+    },
+    revision: 1,
+    record,
+    isGuest: true,
+});
+
+// putRecords
+// $ExpectType object
+kintoneUtility.rest.putRecords({
+    app,
+    records,
+});
+
+// $ExpectType object
+kintoneUtility.rest.putRecords({
+    app,
+    records,
+    isGuest: true,
+});
+
+// setApiTokenAuth
+// $ExpectType void
+kintoneUtility.rest.setApiTokenAuth('token123');
+
+// setBasicAuth
+// $ExpectType void
+kintoneUtility.rest.setBasicAuth('alice', 'bob');
+
+// setDomain
+// $ExpectType void
+kintoneUtility.rest.setDomain('google.com');
+
+// setGuestSpaceId
+// $ExpectType void
+kintoneUtility.rest.setGuestSpaceId(1);
+
+// setUserAuth
+// $ExpectType void
+kintoneUtility.rest.setUserAuth('alice', 'bob');
+
+// updateCustomization
+// $ExpectType object
+kintoneUtility.rest.updateCustomization({
+    app,
+});
+
+// $ExpectType object
+kintoneUtility.rest.updateCustomization({
+    app,
+    scope: '',
+    desktop: {
+        js: Files,
+        ccs: Files,
+    },
+    mobile: {
+        js: Files,
+    },
+    revision: 1,
+    isGuest: true,
+});
+
+// uploadFile
+// $ExpectType object
+kintoneUtility.rest.uploadFile({
+    fileName: 'image.png',
+    blob: {},
+    isGuest: true,
+});
+
+// $ExpectType object
+kintoneUtility.rest.uploadFile({
+    fileName: 'image.png',
+    blob: {},
+});
+
+// upsertRecord
+// $ExpectType object
+kintoneUtility.rest.upsertRecord({
+    app,
+    updateKey: {
+        field: 'field1',
+        value: 'value1'
+    },
+    record,
+});
+
+// $ExpectType object
+kintoneUtility.rest.upsertRecord({
+    app,
+    updateKey: {
+        field: 'field1',
+        value: 'value1'
+    },
+    record,
+    isGuest: true,
+});
+
+// upsertRecords
+// $ExpectType object
+kintoneUtility.rest.upsertRecords({
+    app,
+    records,
+});
+
+// $ExpectType object
+kintoneUtility.rest.upsertRecords({
+    app,
+    records,
+    isGuest: true,
+});

--- a/types/kintone-utility/tsconfig.json
+++ b/types/kintone-utility/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "kintone-utility-tests.ts"
+    ]
+}

--- a/types/kintone-utility/tslint.json
+++ b/types/kintone-utility/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Hello, DefinitelyTyped team 

I created a new type definition for the `kintone-utility` package.

## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  - **Note:** Yes, I read the advice but the definition has many `object` in it because the original code only promises the object type. It's because the nature of the target library which is a wrapper for RESTful API of the web service mainly returning the result as a JSON object changing depended on context.
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
  - **Note:** Because the original js code has JSDoc, I used [tsd-jsdoc](https://github.com/englercj/tsd-jsdoc) to create the base and modified the d.ts code.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## Additional Information for a reviewer

Though I typed `Promise<object>` in many functions, JSDoc of codes in kintone/kintone-utility does not have this type. Although JSDoc tell us that `kintone.api` returns `object` not `Promise`, I think this is wrong. Because every function of the type result in `sendRequest` function in `src/js/rest/common/sendRequest.js` and this function returns from either of `kintone.api` or `useXMLHttp`. `useXMLHttp` returns `new Promise()`. And another library published by the official developer has the type definition <https://github.com/kintone/dts-gen/blob/master/kintone.d.ts> which indicate the return value of `kintone.api` is `Promise<any>`. Also from my experience for a year in this kintone platform, this function should return `Promise<any>` and the official documentation says that, too.