### PR TITLE
Add linedelimiters property to Hunk in "diff" package 

### DIFF
--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -142,6 +142,7 @@ export interface Hunk {
     newStart: number;
     newLines: number;
     lines: string[];
+    linedelimiters?: string[];
 }
 
 export interface BestPath {

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -142,7 +142,7 @@ export interface Hunk {
     newStart: number;
     newLines: number;
     lines: string[];
-    linedelimiters?: string[];
+    linedelimiters: string[];
 }
 
 export interface BestPath {


### PR DESCRIPTION
Relevant code in source module: https://github.com/kpdecker/jsdiff/blob/2c1a29c0309fef22219bcf2cbb475f20508a955b/src/patch/parse.js#L84-L102
