### PR TITLE
[node] bump inspector types to 7.0 and make generation script more type-safe

### DIFF
--- a/types/node/scripts/generate-inspector/README.md
+++ b/types/node/scripts/generate-inspector/README.md
@@ -8,7 +8,7 @@ What this does is:
 For example, to bump `inspector.d.ts` to what's exposed in v8.4:
 ```sh
 # cwd = types/node
-ts-node scripts/generate-inspector v8.4.0
+ts-node -P scripts/generate-inspector/tsconfig.json scripts/generate-inspector v8.4.0
 ```
 
 Inspector type definitions should be updated every time the V8 version is bumped in a Node.js release.

--- a/types/node/scripts/generate-inspector/devtools-protocol-schema.ts
+++ b/types/node/scripts/generate-inspector/devtools-protocol-schema.ts
@@ -45,18 +45,15 @@ export type Parameter = Field & Documentable & {
 
 export interface Command extends Documentable {
     name: string;
-    description?: string;
     handlers?: string[];
     parameters?: Parameter[];
     returns?: Parameter[];
-    experimental?: boolean;
     redirect?: string;
 }
 
 export interface Event extends Documentable {
     name: string;
     parameters?: Parameter[];
-    description?: string;
 }
 
 // It should be safe to load a devtools-protocol/json file and cast it to
@@ -69,7 +66,7 @@ export interface Schema {
     domains: Array<{
         domain: string,
         types?: Type[],
-        commands: Command[],
+        commands?: Command[],
         events?: Event[],
         dependencies?: string[],
     } & Documentable>;

--- a/types/node/scripts/generate-inspector/event-emitter.ts
+++ b/types/node/scripts/generate-inspector/event-emitter.ts
@@ -76,5 +76,5 @@ export const createListeners = (events: Event[]): string[] => {
             acc.push(next);
             return acc;
         }
-    }, []);
+    }, [] as string[]);
 };

--- a/types/node/scripts/generate-inspector/index.ts
+++ b/types/node/scripts/generate-inspector/index.ts
@@ -1,13 +1,14 @@
 // Usage: node generate-inspector [tag]
 // [tag] corresponds to a tag name in the node-core repository.
+// By default, uses the current Node version.
 
 import { execSync } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import * as https from "https";
+
 import * as schema from "./devtools-protocol-schema";
 import { generateSubstituteArgs } from "./generate-substitute-args";
 import { substitute, trimRight } from "./utils";
-import { string } from "parsimmon";
 
 const httpsGet = (url: string) => new Promise<string>((resolve, reject) => {
     https.get(url, res => {

--- a/types/node/scripts/generate-inspector/tsconfig.json
+++ b/types/node/scripts/generate-inspector/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "typeRoots": ["../.."]
+  }
+}

--- a/types/node/scripts/generate-inspector/utils.ts
+++ b/types/node/scripts/generate-inspector/utils.ts
@@ -25,7 +25,14 @@ export function flattenArgs<T = string>(inBetween?: T): (acc: T[], next: T[]) =>
  * Returns whether an array exists and has elements.
  * @param a The array to check.
  */
-export const hasElements = (a: any[]): boolean => a && a.length > 0;
+export const hasElements = (a?: any[]): boolean => !!a && a.length > 0;
+
+/**
+ * Given an array that might have null elements, return an array with just the
+ * non-null elements.
+ * @param a The array to filter.
+ */
+export const filterNull = <T>(a: Array<T | null>): T[] => a.filter(x => x != null) as T[];
 
 /**
  * Returns the capitalized form of a given string.
@@ -48,16 +55,14 @@ export function isObjectReference(t: Field): t is ObjectReference {
  * @param documentable A Documentable object.
  */
 export const createDocs = ({ deprecated, description, experimental }: Documentable): string[] => {
-    const hasDocs = !!description ||
-        deprecated ||
-        experimental;
-    return hasDocs ? [
+    const hasDocs = !!description || deprecated || experimental;
+    return hasDocs ? filterNull([
         "/**",
         ...(description ? description.split(/\r?\n/).map(l => ` * ${l}`) : []),
-        deprecated && " * @deprecated",
-        experimental && " * @experimental",
+        deprecated ? " * @deprecated" : null,
+        experimental ? " * @experimental" : null,
         " */",
-    ].filter(l => l != null) : [];
+    ]) : [];
 };
 
 /**


### PR DESCRIPTION
1) The generation script for inspector was written without strict null checks, I've enabled null checks for them. No user-visible changes.
2) Add new inspector types in V8 7.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
