### PR TITLE
Update read-pkg to v4.0

### DIFF
--- a/types/read-pkg/index.d.ts
+++ b/types/read-pkg/index.d.ts
@@ -1,15 +1,13 @@
-// Type definitions for read-pkg 3.0
+// Type definitions for read-pkg 4.0
 // Project: https://github.com/sindresorhus/read-pkg
-// Definitions by: Jeff Dickey <https://github.com/jdxcode>
+// Definitions by: Jeff Dickey <https://github.com/jdxcode>, Richard Smith <https://github.com/arichardsmith>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import normalize = require('normalize-package-data');
 
 declare namespace ReadPkg {
-    function sync(path: string, options: Options & {normalize: false}): {[k: string]: any};
     function sync(options: Options & {normalize: false}): {[k: string]: any};
     function sync(options?: Options): normalize.Package;
-    function sync(path?: string, options?: Options): normalize.Package;
 
     interface Options {
         /**
@@ -18,14 +16,18 @@ declare namespace ReadPkg {
          * @default true
          */
         normalize?: boolean;
+        /**
+         * Current working directory
+         *
+         * @default process.cwd()
+         */
+        cwd?: string;
     }
 
     type Package = normalize.Package;
 }
 
-declare function ReadPkg(path: string, options: ReadPkg.Options & {normalize: false}): Promise<{[k: string]: any}>;
 declare function ReadPkg(options: ReadPkg.Options & {normalize: false}): Promise<{[k: string]: any}>;
 declare function ReadPkg(options?: ReadPkg.Options): Promise<normalize.Package>;
-declare function ReadPkg(path?: string, options?: ReadPkg.Options): Promise<normalize.Package>;
 
 export = ReadPkg;

--- a/types/read-pkg/read-pkg-tests.ts
+++ b/types/read-pkg/read-pkg-tests.ts
@@ -3,7 +3,8 @@ import ReadPkg = require('read-pkg');
 ReadPkg().then(pkg => pkg.name); // $ExpectType Promise<string>
 ReadPkg({normalize: true}).then(pkg => pkg.name); // $ExpectType Promise<string>
 ReadPkg({normalize: false}).then(pkg => pkg['name']); // $ExpectType Promise<any>
+ReadPkg({cwd: './foo'}).then(pkg => pkg.name); // $ExpectType Promise<string>
 ReadPkg.sync().name; // $ExpectType string
 ReadPkg.sync({normalize: true}).name; // $ExpectType string
 ReadPkg.sync({normalize: false})['name']; // $ExpectType any
-ReadPkg.sync('package.json', {normalize: false})['name']; // $ExpectType any
+ReadPkg.sync({cwd: './foo'}).name; // $ExpectType string


### PR DESCRIPTION
Updates the read-pkg types to match change in API introduced in v4.0.
v5.0 has same API so types will work for that too.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/read-pkg/commit/0cd09a018be323812eb43c277e17b6ce77526247
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.