### PR TITLE
[node] Remove allowHTTP1 from http2.ServerOptions

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -424,9 +424,7 @@ declare module "http2" {
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
     export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions { }
 
-    export interface ServerOptions extends ServerSessionOptions {
-        allowHTTP1?: boolean;
-    }
+    export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
         allowHTTP1?: boolean;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -256,8 +256,7 @@ import { URL } from 'url';
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
         selectPadding: (frameLen: number, maxFrameLen: number) => 0,
-        settings,
-        allowHTTP1: true
+        settings
     };
     // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
     const secureServerOptions: SecureServerOptions = Object.assign({}, serverOptions);

--- a/types/node/v10/http2.d.ts
+++ b/types/node/v10/http2.d.ts
@@ -424,9 +424,7 @@ declare module "http2" {
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
     export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions { }
 
-    export interface ServerOptions extends ServerSessionOptions {
-        allowHTTP1?: boolean;
-    }
+    export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
         allowHTTP1?: boolean;

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -4452,8 +4452,7 @@ import * as constants from 'constants';
             paddingStrategy: 0,
             peerMaxConcurrentStreams: 0,
             selectPadding: (frameLen: number, maxFrameLen: number) => 0,
-            settings,
-            allowHTTP1: true
+            settings
         };
         // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
         const secureServerOptions: http2.SecureServerOptions = Object.assign({}, serverOptions);

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -6710,9 +6710,7 @@ declare module "http2" {
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
     export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions { }
 
-    export interface ServerOptions extends ServerSessionOptions {
-        allowHTTP1?: boolean;
-    }
+    export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
         allowHTTP1?: boolean;

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -3686,8 +3686,7 @@ namespace http2_tests {
             paddingStrategy: 0,
             peerMaxConcurrentStreams: 0,
             selectPadding: (frameLen: number, maxFrameLen: number) => 0,
-            settings,
-            allowHTTP1: true
+            settings
         };
         // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
         let secureServerOptions: http2.SecureServerOptions = Object.assign({}, serverOptions);

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -7135,9 +7135,7 @@ declare module "http2" {
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions { }
     export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions { }
 
-    export interface ServerOptions extends ServerSessionOptions {
-        allowHTTP1?: boolean;
-    }
+    export interface ServerOptions extends ServerSessionOptions { }
 
     export interface SecureServerOptions extends SecureServerSessionOptions {
         allowHTTP1?: boolean;

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -3741,8 +3741,7 @@ namespace http2_tests {
             paddingStrategy: 0,
             peerMaxConcurrentStreams: 0,
             selectPadding: (frameLen: number, maxFrameLen: number) => 0,
-            settings,
-            allowHTTP1: true
+            settings
         };
         // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
         let secureServerOptions: http2.SecureServerOptions = Object.assign({}, serverOptions);


### PR DESCRIPTION
Hi, developers! Thank you for your project.

I removed `allowHTTP1` from `http2.ServerOptions`. According to the replies of my question(<https://github.com/nodejs/node/issues/26795>), `allowHTTP1` is only for `Http2SecureServer`. So, I deleted the `allowHTTP1` from `Http2Server` options.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  -  I asked a question about whether node allows HTTP/1 by in non-secure server. The answer is no.: <https://github.com/nodejs/node/issues/26795>
  - Here is a use of `allowHTTP1`. ALPN is used to allow HTTP/1.1, so TLS is needed in current implement because ALPN is an extension of it.: <https://github.com/nodejs/node/blob/296712602b4cba785ccda72623c0cbe3b4584abb/lib/internal/http2/core.js#L2608-L2614>
  - <https://nodejs.org/dist/latest-v10.x/docs/api/http2.html#http2_server_side_example>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.