### PR TITLE
[stripe-v3] add fontWeight to StypeOptions

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -7,6 +7,7 @@
 //                 Justin Leider <https://github.com/jleider>
 //                 Kamil Gałuszka <https://github.com/galuszkak>
 //                 Stefan Langeder <https://github.com/slangeder>
+//                 Marlos Borges <https://github.com/marlosin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var Stripe: stripe.StripeStatic;
@@ -382,6 +383,7 @@ declare namespace stripe {
             fontSmoothing?: string;
             fontStyle?: string;
             fontVariant?: string;
+            fontWeight?: string | number;
             iconColor?: string;
             lineHeight?: string;
             letterSpacing?: string;

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -14,6 +14,7 @@ describe("Stripe", () => {
                 fontFamily: 'Roboto, "Helvetica Neue", sans-serif',
                 fontSmoothing: 'antialiased',
                 fontSize: '16px',
+                fontWeight: 'bold',
                 '::placeholder': {
                     color: '#aab7c4'
                 }
@@ -183,6 +184,7 @@ describe("Stripe v2 & v3", () => {
                 fontFamily: 'Roboto, "Helvetica Neue", sans-serif',
                 fontSmoothing: 'antialiased',
                 fontSize: '16px',
+                fontWeight: 500,
                 '::placeholder': {
                     color: '#aab7c4'
                 }


### PR DESCRIPTION
I added `fontWeight` property to the `stripe.elements.StyleOptions` interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/stripe-js/reference#element-options>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.