### PR TITLE
Add type definition of the module format-number

### DIFF
--- a/types/format-number/README.md
+++ b/types/format-number/README.md
@@ -1,1 +1,0 @@
-Type definitions for npm package [format-number](https://www.npmjs.com/package/format-number) version 2.0

--- a/types/format-number/README.md
+++ b/types/format-number/README.md
@@ -1,0 +1,1 @@
+Type definitions for npm package [format-number](https://www.npmjs.com/package/format-number) version 2.0

--- a/types/format-number/format-number-tests.ts
+++ b/types/format-number/format-number-tests.ts
@@ -1,0 +1,5 @@
+import createFormatNumber from "format-number";
+
+createFormatNumber({ round: 2 }); // $ExpectType (number: number, overrideOptions?: { noUnits: boolean; noSeparator: boolean; } | undefined) => string
+
+createFormatNumber({ round: 2 })(12); // $ExpectType string

--- a/types/format-number/index.d.ts
+++ b/types/format-number/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for format-number 2.0
+// Project: https://github.com/componitable/format-number
+// Definitions by: Fedai Kaya <https://github.com/codelovesme>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default function(options?: {
+    negativeType?: "right" | "left" | "brackets" | null;
+    negativeLeftSymbol?: string;
+    negative?: "R" | null;
+    negativeRightSymbol?: string;
+    negativeLeftOut?: boolean;
+    negativeOut?: boolean;
+    prefix?: string;
+    suffix?: string;
+    integerSeparator?: string;
+    separator?: string;
+    decimalsSeparator?: string;
+    decimal?: string;
+    padLeft?: number;
+    padRight?: number;
+    round?: number;
+    truncate?: number;
+    allowedSeparators?: string[];
+}): (
+    number: number,
+    overrideOptions?: {
+        noUnits: boolean;
+        noSeparator: boolean;
+    }
+) => string;

--- a/types/format-number/index.d.ts
+++ b/types/format-number/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Fedai Kaya <https://github.com/codelovesme>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+
 export default function(options?: {
     negativeType?: "right" | "left" | "brackets" | null;
     negativeLeftSymbol?: string;

--- a/types/format-number/index.d.ts
+++ b/types/format-number/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Fedai Kaya <https://github.com/codelovesme>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 export default function(options?: {
     negativeType?: "right" | "left" | "brackets" | null;
     negativeLeftSymbol?: string;

--- a/types/format-number/tsconfig.json
+++ b/types/format-number/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "format-number-tests.ts"]
+}

--- a/types/format-number/tslint.json
+++ b/types/format-number/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add type definition of the module format-number

Amend

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
