### PR TITLE
[graphql-resolvers] make TArgs configurable

### DIFF
--- a/types/graphql-resolvers/graphql-resolvers-tests.ts
+++ b/types/graphql-resolvers/graphql-resolvers-tests.ts
@@ -7,6 +7,7 @@ import {
     isDependee,
     skip
 } from "graphql-resolvers";
+import { IFieldResolver } from "graphql-tools";
 
 const resolverOne = () => skip;
 const resolverTwo = () => skip;
@@ -17,3 +18,12 @@ const all = allResolvers([resolverOne, resolverTwo]);
 const dependee = resolveDependee("resolverOne");
 const dependees = resolveDependees(["resolverOne", "resolverTwo"]);
 const isDependent = isDependee(resolverOne);
+
+interface MyArgs {
+    targetId: number;
+}
+const typedResolver: IFieldResolver<any, any> = () => skip;
+const typedCombined = combineResolvers(
+    typedResolver,
+    (obj: undefined, args: MyArgs, context) => skip
+);

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for graphql-resolvers 0.2
+// Type definitions for graphql-resolvers 0.3
 // Project: https://github.com/lucasconstantino/graphql-resolvers#readme
 // Definitions by: Mike Engel <https://github.com/mike-engel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,30 +8,42 @@ import { IFieldResolver } from "graphql-tools";
 
 export const skip: undefined;
 
-export interface TArgs {
-    [argument: string]: any;
-}
-
-export function combineResolvers<TSource = any, TContext = any>(
+export function combineResolvers<
+    TSource = any,
+    TContext = any,
+    TArgs = Record<string, any>
+>(
     ...resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function pipeResolvers<TSource = any, TContext = any>(
+export function pipeResolvers<
+    TSource = any,
+    TContext = any,
+    TArgs = Record<string, any>
+>(
     ...resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function allResolvers<TSource = any, TContext = any>(
+export function allResolvers<
+    TSource = any,
+    TContext = any,
+    TArgs = Record<string, any>
+>(
     resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function resolveDependee(
+export function resolveDependee<TArgs = Record<string, any>>(
     dependeeName: string
 ): IFieldResolver<any, any, TArgs>;
 
-export function resolveDependees(
+export function resolveDependees<TArgs = Record<string, any>>(
     dependeeNames: string[]
 ): IFieldResolver<any, any, TArgs>;
 
-export function isDependee<TSource = any, TContext = any>(
+export function isDependee<
+    TSource = any,
+    TContext = any,
+    TArgs = Record<string, any>
+>(
     resolver: IFieldResolver<TSource, TContext, TArgs>
 ): IFieldResolver<TSource, TContext, TArgs>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lucasconstantino/graphql-resolvers/blob/master/src/combineResolvers.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR fixes the following case:

```typescript
import { IFieldResolver } from 'graphql-tools'

const resolver1: IFieldResolver<any, any, any> =  // ...
const resolver2 : IFieldResolver<any, any, { id: number }> = // ...

const combined = combineResolvers(
  resolver1,
  resolver2
)
```

The code above doesn't compile since `combineResolvers` lacks a generic parameter for `args`. This PR adds a configurable `TArgs` generic parameter, with a default value equal to the non-configurable value in previous version in order to avoid breaking changes. 