### PR TITLE
[@types/electron-store] Set ElectronStore to be default export

### DIFF
--- a/types/electron-store/electron-store-tests.ts
+++ b/types/electron-store/electron-store-tests.ts
@@ -1,4 +1,4 @@
-import ElectronStore = require('electron-store');
+import ElectronStore from 'electron-store';
 
 new ElectronStore({
     defaults: {}

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -111,4 +111,4 @@ declare class ElectronStore<T = {}> implements Iterable<[string, JSONValue]> {
     [Symbol.iterator](): Iterator<[string, JSONValue]>;
 }
 
-export = ElectronStore;
+export default ElectronStore;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Context below.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Context for changes:

Allows for importing Store in ES6 style and shows typings for functions and properties in text editors/IDEs.

Currently, if imported in ES6 style additions need to be made in tsconfigs and all properties and functions have 'any' types.
