### PR TITLE
Update react-jsonschema-form types to declare lib/validate and support all onChange arguments

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -7,12 +7,18 @@
 //                 Sylvain Thénault <https://github.com/sthenault>
 //                 Sebastian Busch <https://github.com/sbusch>
 //                 Mehdi Lahlou <https://github.com/medfreeman>
+//                 Saad Tazi <https://github.com/saadtazi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
+
 
 declare module "react-jsonschema-form" {
     import * as React from "react";
     import { JSONSchema6 } from "json-schema";
+
+    type ErrorSchema = {
+        [k: string]: ErrorSchema
+    };
 
     export interface FormProps<T> {
         schema: JSONSchema6;
@@ -27,7 +33,7 @@ declare module "react-jsonschema-form" {
         showErrorList?: boolean;
         ErrorList?: React.StatelessComponent<ErrorListProps>;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
-        onChange?: (e: IChangeEvent<T>) => any;
+        onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
         onSubmit?: (e: ISubmitEvent<T>) => any;
         liveValidate?: boolean;
@@ -95,13 +101,13 @@ declare module "react-jsonschema-form" {
         | React.StatelessComponent<WidgetProps>
         | React.ComponentClass<WidgetProps>;
 
-    export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
+    export interface FieldProps<T = any> extends React.HTMLAttributes<HTMLElement> {
         schema: JSONSchema6;
         uiSchema: UiSchema;
         idSchema: IdSchema;
-        formData: any;
-        errorSchema: object;
-        onChange: (value: any) => void;
+        formData: T;
+        errorSchema: ErrorSchema;
+        onChange: (e: IChangeEvent<T> | any, es?: ErrorSchema) => any;
         registry: {
             fields: { [name: string]: Field };
             widgets: { [name: string]: Widget };
@@ -241,7 +247,8 @@ declare module "react-jsonschema-form" {
 }
 
 declare module "react-jsonschema-form/lib/utils" {
-    import { JSONSchema6 } from "json-schema";
+    import { JSONSchema6, JSONSchema6Definition } from "json-schema";
+    import { FieldProps } from "react-jsonschema-form";
 
     export interface IRangeSpec {
         min?: number;
@@ -250,4 +257,20 @@ declare module "react-jsonschema-form/lib/utils" {
     }
 
     export function rangeSpec(schema: JSONSchema6): IRangeSpec;
+
+    export function resolveSchema(
+        schema: JSONSchema6Definition,
+        definitions: FieldProps["registry"]["definitions"],
+        formData: object
+      ): JSONSchema6;
+}
+
+declare module "react-jsonschema-form/lib/validate" {
+    import { JSONSchema6Definition } from "json-schema";
+    import { AjvError } from "react-jsonschema-form";
+
+    export default function validateFormData<T>(
+        formData: T,
+        schema: JSONSchema6Definition
+    ): AjvError[];
 }

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Form, { UiSchema, ErrorListProps, WidgetProps } from "react-jsonschema-form";
+import Form, { UiSchema, ErrorListProps, WidgetProps, ErrorSchema } from "react-jsonschema-form";
 import { JSONSchema6 } from "json-schema";
 
 // example taken from the react-jsonschema-form playground:
@@ -108,6 +108,31 @@ export class Example extends React.Component<any, IExampleState> {
         );
     }
 }
+
+interface FuncExampleProps {
+    formData: object;
+    onError: (e: ErrorSchema) => void;
+    onChange: (e: any) => void;
+}
+
+export const FuncExample = (props: FuncExampleProps) => {
+    const { formData, onChange, onError } = props;
+    return (
+        <Form
+            schema={schema}
+            uiSchema={uiSchema}
+            showErrorList={false}
+            noValidate={false}
+            noHtml5Validate={false}
+            formData={formData}
+            ErrorList={ErrorListExample}
+            onChange={(formData, errorSchema) => {
+                onChange(formData);
+                onError(errorSchema)
+            }}
+        />
+    );
+};
 
 export const BooleanCustomWidget: React.SFC<WidgetProps> = (props) =>
     <input


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [onChange second param](https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/components/fields/ArrayField.js#L252) (and other places as well...), [exported `validateFormData()`](https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/validate.js#L165), [exported `resolveSchema()`](https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/utils.js#L473)
- [ ] Increase the version number in the header if appropriate. **=> not needed: still 1.3.0 at npmjs.org**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
