### PR TITLE
Remove GA Beacon from README since it won't work

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -332,5 +332,3 @@ Es más apropiado importar este módulo utilizando la sintaxis `import foo = req
 Este proyecto es licenciado bajo la licencia MIT.
 
 Los derechos de autor de cada archivo de definición son respectivos de cada contribuidor listado al comienzo de cada archivo de definición.
-
-[![Analytics](https://ga-beacon.appspot.com/UA-47495295-4/borisyankov/DefinitelyTyped)](https://github.com/igrigorik/ga-beacon)

--- a/README.ko.md
+++ b/README.ko.md
@@ -334,5 +334,3 @@ NPM 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
 이 프로젝트는 MIT license 가 적용되어 있습니다.
 
 각 자료형 정의(Type definition) 파일들의 저작권은 각 기여자들에게 있으며, 기여자들은 해당 자료형 정의(Type definition) 파일들의 맨 위에 나열되어 있습니다.
-
-[![Analytics](https://ga-beacon.appspot.com/UA-47495295-4/borisyankov/DefinitelyTyped)](https://github.com/igrigorik/ga-beacon)

--- a/README.md
+++ b/README.md
@@ -452,5 +452,3 @@ GitHub doesn't [support](http://stackoverflow.com/questions/5646174/how-to-make-
 This project is licensed under the MIT license.
 
 Copyrights on the definition files are respective of each contributor listed at the beginning of each definition file.
-
-[![Analytics](https://ga-beacon.appspot.com/UA-47495295-4/borisyankov/DefinitelyTyped)](https://github.com/igrigorik/ga-beacon)

--- a/README.ru.md
+++ b/README.ru.md
@@ -346,8 +346,6 @@ GitHub не [поддерживает](http://stackoverflow.com/questions/564617
 
 Авторские права на файлы определений принадлежат каждому участнику, указанному в начале каждого файла определения.
 
-[![Analytics](https://ga-beacon.appspot.com/UA-47495295-4/borisyankov/DefinitelyTyped)](https://github.com/igrigorik/ga-beacon)
-
 [![Build Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.types-publisher-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=13) В среднем пакеты публикуются на npm менее чем за 10000 секунд?
 
 [![Build Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.typescript-bot-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=14) Был ли typescript-bot активным на DefinitelyTyped в последние два часа?


### PR DESCRIPTION
According to [the GA beacon FAQ](https://github.com/igrigorik/ga-beacon#faq), tracking GA from README won't work anymore, so I was thinking if this can be removed from the README.md. Thanks! Let me know if this is OK.

- [x] I'm just editing the readme
