### PR TITLE
Disable npm-naming with dt-header

### DIFF
--- a/types/absolute/tslint.json
+++ b/types/absolute/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/acc-wizard/tslint.json
+++ b/types/acc-wizard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ace/tslint.json
+++ b/types/ace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/actioncable/tslint.json
+++ b/types/actioncable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/add2home/tslint.json
+++ b/types/add2home/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/agenda/tslint.json
+++ b/types/agenda/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/alertify/tslint.json
+++ b/types/alertify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/algoliasearch/tslint.json
+++ b/types/algoliasearch/tslint.json
@@ -8,6 +8,7 @@
     "callable-types": false,
     "comment-format": false,
     "dt-header": false,
+        "npm-naming": false,
     "eofline": false,
     "export-just-namespace": false,
     "import-spacing": false,

--- a/types/alt/tslint.json
+++ b/types/alt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/amazon-product-api/tslint.json
+++ b/types/amazon-product-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/amplitude-js/tslint.json
+++ b/types/amplitude-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/amqp-rpc/tslint.json
+++ b/types/amqp-rpc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-agility/tslint.json
+++ b/types/angular-agility/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-animate/tslint.json
+++ b/types/angular-animate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-bootstrap-calendar/tslint.json
+++ b/types/angular-bootstrap-calendar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-bootstrap-lightbox/tslint.json
+++ b/types/angular-bootstrap-lightbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-breadcrumb/tslint.json
+++ b/types/angular-breadcrumb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-clipboard/tslint.json
+++ b/types/angular-clipboard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-cookie/tslint.json
+++ b/types/angular-cookie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-cookies/tslint.json
+++ b/types/angular-cookies/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-deferred-bootstrap/tslint.json
+++ b/types/angular-deferred-bootstrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-dialog-service/tslint.json
+++ b/types/angular-dialog-service/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-dynamic-locale/tslint.json
+++ b/types/angular-dynamic-locale/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-environment/tslint.json
+++ b/types/angular-environment/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-es/tslint.json
+++ b/types/angular-es/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-feature-flags/tslint.json
+++ b/types/angular-feature-flags/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-file-saver/tslint.json
+++ b/types/angular-file-saver/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-formly/tslint.json
+++ b/types/angular-formly/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-fullscreen/tslint.json
+++ b/types/angular-fullscreen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-gettext/tslint.json
+++ b/types/angular-gettext/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-google-analytics/tslint.json
+++ b/types/angular-google-analytics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-growl-v2/tslint.json
+++ b/types/angular-growl-v2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-http-auth/tslint.json
+++ b/types/angular-http-auth/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-httpi/tslint.json
+++ b/types/angular-httpi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-idle/tslint.json
+++ b/types/angular-idle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-jwt/tslint.json
+++ b/types/angular-jwt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-load/tslint.json
+++ b/types/angular-load/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-loading-bar/tslint.json
+++ b/types/angular-loading-bar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-local-storage/tslint.json
+++ b/types/angular-local-storage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-localforage/tslint.json
+++ b/types/angular-localforage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-locker/tslint.json
+++ b/types/angular-locker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-media-queries/tslint.json
+++ b/types/angular-media-queries/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-meteor/tslint.json
+++ b/types/angular-meteor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-modal/tslint.json
+++ b/types/angular-modal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-notifications/tslint.json
+++ b/types/angular-notifications/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-notify/tslint.json
+++ b/types/angular-notify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-odata-resources/tslint.json
+++ b/types/angular-odata-resources/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-permission/tslint.json
+++ b/types/angular-permission/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-promise-tracker/tslint.json
+++ b/types/angular-promise-tracker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-q-spread/tslint.json
+++ b/types/angular-q-spread/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-route/tslint.json
+++ b/types/angular-route/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-sanitize/tslint.json
+++ b/types/angular-sanitize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-scenario/tslint.json
+++ b/types/angular-scenario/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-scroll/tslint.json
+++ b/types/angular-scroll/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-signalr-hub/tslint.json
+++ b/types/angular-signalr-hub/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-spinner/tslint.json
+++ b/types/angular-spinner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-storage/tslint.json
+++ b/types/angular-storage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-toastr/tslint.json
+++ b/types/angular-toastr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-toasty/tslint.json
+++ b/types/angular-toasty/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-translate/tslint.json
+++ b/types/angular-translate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-bootstrap/tslint.json
+++ b/types/angular-ui-bootstrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-notification/tslint.json
+++ b/types/angular-ui-notification/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-router/tslint.json
+++ b/types/angular-ui-router/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-scroll/tslint.json
+++ b/types/angular-ui-scroll/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-sortable/tslint.json
+++ b/types/angular-ui-sortable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-ui-tree/tslint.json
+++ b/types/angular-ui-tree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-wizard/tslint.json
+++ b/types/angular-wizard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular-xeditable/tslint.json
+++ b/types/angular-xeditable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angular.throttle/tslint.json
+++ b/types/angular.throttle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angularfire/tslint.json
+++ b/types/angularfire/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angularlocalstorage/tslint.json
+++ b/types/angularlocalstorage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/angulartics/tslint.json
+++ b/types/angulartics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/animation-frame/tslint.json
+++ b/types/animation-frame/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ansi-styles/tslint.json
+++ b/types/ansi-styles/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ansicolors/tslint.json
+++ b/types/ansicolors/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/any-db-transaction/tslint.json
+++ b/types/any-db-transaction/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/any-db/tslint.json
+++ b/types/any-db/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/aphrodite/tslint.json
+++ b/types/aphrodite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/api-error-handler/tslint.json
+++ b/types/api-error-handler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/apigee-access/tslint.json
+++ b/types/apigee-access/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/app-root-path/tslint.json
+++ b/types/app-root-path/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/appframework/tslint.json
+++ b/types/appframework/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/appletvjs/tslint.json
+++ b/types/appletvjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/arbiter/tslint.json
+++ b/types/arbiter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/arcgis-js-api/tslint.json
+++ b/types/arcgis-js-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/archy/tslint.json
+++ b/types/archy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/argv/tslint.json
+++ b/types/argv/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/array-foreach/tslint.json
+++ b/types/array-foreach/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/asana/tslint.json
+++ b/types/asana/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/asciify/tslint.json
+++ b/types/asciify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/asn1js/tslint.json
+++ b/types/asn1js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/aspnet-identity-pw/tslint.json
+++ b/types/aspnet-identity-pw/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/assertsharp/tslint.json
+++ b/types/assertsharp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/async-polling/tslint.json
+++ b/types/async-polling/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/async-writer/tslint.json
+++ b/types/async-writer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/atmosphere.js/tslint.json
+++ b/types/atmosphere.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/atpl/tslint.json
+++ b/types/atpl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/auth0-angular/tslint.json
+++ b/types/auth0-angular/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/auth0.widget/tslint.json
+++ b/types/auth0.widget/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/auth0/tslint.json
+++ b/types/auth0/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/autolinker/tslint.json
+++ b/types/autolinker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/autoprefixer-core/tslint.json
+++ b/types/autoprefixer-core/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/avoscloud-sdk/tslint.json
+++ b/types/avoscloud-sdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/aws-iot-device-sdk/tslint.json
+++ b/types/aws-iot-device-sdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/aws4/tslint.json
+++ b/types/aws4/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/axel/tslint.json
+++ b/types/axel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/azure-mobile-services-client/tslint.json
+++ b/types/azure-mobile-services-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/azure-sb/tslint.json
+++ b/types/azure-sb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/azure/tslint.json
+++ b/types/azure/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/babelify/tslint.json
+++ b/types/babelify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/babyparse/tslint.json
+++ b/types/babyparse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone-associations/tslint.json
+++ b/types/backbone-associations/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone-fetch-cache/tslint.json
+++ b/types/backbone-fetch-cache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone-relational/tslint.json
+++ b/types/backbone-relational/tslint.json
@@ -4,6 +4,7 @@
         "array-type": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "jsdoc-format": false,
         "max-line-length": false,

--- a/types/backbone.layoutmanager/tslint.json
+++ b/types/backbone.layoutmanager/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone.localstorage/tslint.json
+++ b/types/backbone.localstorage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone.paginator/tslint.json
+++ b/types/backbone.paginator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone.radio/tslint.json
+++ b/types/backbone.radio/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backbone/tslint.json
+++ b/types/backbone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "export-just-namespace": false,
         "interface-name": false,
         "jsdoc-format": false,

--- a/types/backgrid/tslint.json
+++ b/types/backgrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/backlog-js/tslint.json
+++ b/types/backlog-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/baconjs/tslint.json
+++ b/types/baconjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/baidumap-web-sdk/tslint.json
+++ b/types/baidumap-web-sdk/tslint.json
@@ -7,6 +7,7 @@
         "ban-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "max-line-length": false,
         "member-access": false,

--- a/types/barcode/tslint.json
+++ b/types/barcode/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bardjs/tslint.json
+++ b/types/bardjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/base16/tslint.json
+++ b/types/base16/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bases/tslint.json
+++ b/types/bases/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/batch-stream/tslint.json
+++ b/types/batch-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bazinga-translator/tslint.json
+++ b/types/bazinga-translator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bcrypt-nodejs/tslint.json
+++ b/types/bcrypt-nodejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bcrypt/tslint.json
+++ b/types/bcrypt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bcryptjs/tslint.json
+++ b/types/bcryptjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/benchmark/tslint.json
+++ b/types/benchmark/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/better-curry/tslint.json
+++ b/types/better-curry/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bezier-js/tslint.json
+++ b/types/bezier-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bgiframe/tslint.json
+++ b/types/bgiframe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bigint/tslint.json
+++ b/types/bigint/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bignum/tslint.json
+++ b/types/bignum/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bigscreen/tslint.json
+++ b/types/bigscreen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bind-ponyfill/tslint.json
+++ b/types/bind-ponyfill/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bintrees/tslint.json
+++ b/types/bintrees/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bip21/tslint.json
+++ b/types/bip21/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bit-array/tslint.json
+++ b/types/bit-array/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bl/tslint.json
+++ b/types/bl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blazy/tslint.json
+++ b/types/blazy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bleno/tslint.json
+++ b/types/bleno/tslint.json
@@ -2,6 +2,7 @@
 	"extends": "dtslint/dt.json",
 	"rules": {
 		"dt-header": false,
+        "npm-naming": false,
 		"unified-signatures": false
 	}
 }

--- a/types/blessed/tslint.json
+++ b/types/blessed/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blissfuljs/tslint.json
+++ b/types/blissfuljs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blob-stream/tslint.json
+++ b/types/blob-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blocks/tslint.json
+++ b/types/blocks/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blue-tape/tslint.json
+++ b/types/blue-tape/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/blueimp-md5/tslint.json
+++ b/types/blueimp-md5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bookshelf/tslint.json
+++ b/types/bookshelf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/boolify-string/tslint.json
+++ b/types/boolify-string/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootbox/tslint.json
+++ b/types/bootbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootpag/tslint.json
+++ b/types/bootpag/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-datepicker/tslint.json
+++ b/types/bootstrap-datepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-fileinput/tslint.json
+++ b/types/bootstrap-fileinput/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-maxlength/tslint.json
+++ b/types/bootstrap-maxlength/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-notify/tslint.json
+++ b/types/bootstrap-notify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-select/tslint.json
+++ b/types/bootstrap-select/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-switch/tslint.json
+++ b/types/bootstrap-switch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-table/tslint.json
+++ b/types/bootstrap-table/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap-touchspin/tslint.json
+++ b/types/bootstrap-touchspin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap.paginator/tslint.json
+++ b/types/bootstrap.paginator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bootstrap.timepicker/tslint.json
+++ b/types/bootstrap.timepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bounce.js/tslint.json
+++ b/types/bounce.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/box2d/tslint.json
+++ b/types/box2d/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/braintree-web/tslint.json
+++ b/types/braintree-web/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/breeze/tslint.json
+++ b/types/breeze/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/brorand/tslint.json
+++ b/types/brorand/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browser-harness/tslint.json
+++ b/types/browser-harness/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browser-pack/tslint.json
+++ b/types/browser-pack/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browser-report/tslint.json
+++ b/types/browser-report/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browser-resolve/tslint.json
+++ b/types/browser-resolve/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browser-sync/tslint.json
+++ b/types/browser-sync/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/browserify/tslint.json
+++ b/types/browserify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bson/tslint.json
+++ b/types/bson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bucks/tslint.json
+++ b/types/bucks/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/buffer-compare/tslint.json
+++ b/types/buffer-compare/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/buffer-equal/tslint.json
+++ b/types/buffer-equal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/buffers/tslint.json
+++ b/types/buffers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bunyan-config/tslint.json
+++ b/types/bunyan-config/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bunyan-logentries/tslint.json
+++ b/types/bunyan-logentries/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bunyan-prettystream/tslint.json
+++ b/types/bunyan-prettystream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/busboy/tslint.json
+++ b/types/busboy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/business-rules-engine/tslint.json
+++ b/types/business-rules-engine/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bwip-js/tslint.json
+++ b/types/bwip-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/byline/tslint.json
+++ b/types/byline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/bytebuffer/tslint.json
+++ b/types/bytebuffer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cache-manager/tslint.json
+++ b/types/cache-manager/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cal-heatmap/tslint.json
+++ b/types/cal-heatmap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/callsite/tslint.json
+++ b/types/callsite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/calq/tslint.json
+++ b/types/calq/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/camljs/tslint.json
+++ b/types/camljs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/camo/tslint.json
+++ b/types/camo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cannon/tslint.json
+++ b/types/cannon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/canvas-gauges/tslint.json
+++ b/types/canvas-gauges/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cash/tslint.json
+++ b/types/cash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cbor/tslint.json
+++ b/types/cbor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-as-promised/tslint.json
+++ b/types/chai-as-promised/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-datetime/tslint.json
+++ b/types/chai-datetime/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-dom/tslint.json
+++ b/types/chai-dom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-enzyme/tslint.json
+++ b/types/chai-enzyme/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-fuzzy/tslint.json
+++ b/types/chai-fuzzy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-jquery/tslint.json
+++ b/types/chai-jquery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-spies/tslint.json
+++ b/types/chai-spies/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-string/tslint.json
+++ b/types/chai-string/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chai-things/tslint.json
+++ b/types/chai-things/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chance/tslint.json
+++ b/types/chance/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "adjacent-overload-signatures": false,
         "dt-header": false,
+        "npm-naming": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false,
         "no-unnecessary-generics": false,

--- a/types/change-emitter/tslint.json
+++ b/types/change-emitter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chartist/tslint.json
+++ b/types/chartist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/checksum/tslint.json
+++ b/types/checksum/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cheerio/tslint.json
+++ b/types/cheerio/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chocolatechipjs/tslint.json
+++ b/types/chocolatechipjs/tslint.json
@@ -5,6 +5,7 @@
         "adjacent-overload-signatures": false,
         "ban-types": false,
         "dt-header": false,
+        "npm-naming": false,
         "no-any-union": false,
         "unified-signatures": false,
         "no-unnecessary-generics": false,

--- a/types/chrome-apps/tslint.json
+++ b/types/chrome-apps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chrome/tslint.json
+++ b/types/chrome/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/chui/tslint.json
+++ b/types/chui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cldrjs/tslint.json
+++ b/types/cldrjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cli-color/tslint.json
+++ b/types/cli-color/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cli/tslint.json
+++ b/types/cli/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cliff/tslint.json
+++ b/types/cliff/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/clipboard-js/tslint.json
+++ b/types/clipboard-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/clone/tslint.json
+++ b/types/clone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/closure-compiler/tslint.json
+++ b/types/closure-compiler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cloud-env/tslint.json
+++ b/types/cloud-env/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/co-body/tslint.json
+++ b/types/co-body/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/codemirror/tslint.json
+++ b/types/codemirror/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/coffeeify/tslint.json
+++ b/types/coffeeify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/collections/tslint.json
+++ b/types/collections/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/colorbrewer/tslint.json
+++ b/types/colorbrewer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/com.darktalker.cordova.screenshot/tslint.json
+++ b/types/com.darktalker.cordova.screenshot/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/combokeys/tslint.json
+++ b/types/combokeys/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/command-line-commands/tslint.json
+++ b/types/command-line-commands/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/commangular/tslint.json
+++ b/types/commangular/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/compare-version/tslint.json
+++ b/types/compare-version/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/component-emitter/tslint.json
+++ b/types/component-emitter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/compose-function/tslint.json
+++ b/types/compose-function/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/compression/tslint.json
+++ b/types/compression/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/concaveman/tslint.json
+++ b/types/concaveman/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/confidence/tslint.json
+++ b/types/confidence/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/config/tslint.json
+++ b/types/config/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/confit/tslint.json
+++ b/types/confit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-flash/tslint.json
+++ b/types/connect-flash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-livereload/tslint.json
+++ b/types/connect-livereload/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-modrewrite/tslint.json
+++ b/types/connect-modrewrite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-mongo/tslint.json
+++ b/types/connect-mongo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-mongodb-session/tslint.json
+++ b/types/connect-mongodb-session/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-redis/tslint.json
+++ b/types/connect-redis/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-slashes/tslint.json
+++ b/types/connect-slashes/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect-timeout/tslint.json
+++ b/types/connect-timeout/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/connect/tslint.json
+++ b/types/connect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/console-stamp/tslint.json
+++ b/types/console-stamp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/consolidate/tslint.json
+++ b/types/consolidate/tslint.json
@@ -9,6 +9,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/consul/tslint.json
+++ b/types/consul/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/contentful-resolve-response/tslint.json
+++ b/types/contentful-resolve-response/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/contextjs/tslint.json
+++ b/types/contextjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cookie-session/tslint.json
+++ b/types/cookie-session/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cookie_js/tslint.json
+++ b/types/cookie_js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/copy-paste/tslint.json
+++ b/types/copy-paste/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-ionic/tslint.json
+++ b/types/cordova-ionic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-app-version/tslint.json
+++ b/types/cordova-plugin-app-version/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-background-mode/tslint.json
+++ b/types/cordova-plugin-background-mode/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-ble-central/tslint.json
+++ b/types/cordova-plugin-ble-central/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-device-name/tslint.json
+++ b/types/cordova-plugin-device-name/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-email-composer/tslint.json
+++ b/types/cordova-plugin-email-composer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-ibeacon/tslint.json
+++ b/types/cordova-plugin-ibeacon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-insomnia/tslint.json
+++ b/types/cordova-plugin-insomnia/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-keyboard/tslint.json
+++ b/types/cordova-plugin-keyboard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-mapsforge/tslint.json
+++ b/types/cordova-plugin-mapsforge/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-ms-adal/tslint.json
+++ b/types/cordova-plugin-ms-adal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-ouralabs/tslint.json
+++ b/types/cordova-plugin-ouralabs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-qrscanner/tslint.json
+++ b/types/cordova-plugin-qrscanner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-spinner/tslint.json
+++ b/types/cordova-plugin-spinner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-websql/tslint.json
+++ b/types/cordova-plugin-websql/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova-plugin-x-socialsharing/tslint.json
+++ b/types/cordova-plugin-x-socialsharing/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova/tslint.json
+++ b/types/cordova/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordova_app_version_plugin/tslint.json
+++ b/types/cordova_app_version_plugin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cordovarduino/tslint.json
+++ b/types/cordovarduino/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cors/tslint.json
+++ b/types/cors/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/couchbase/tslint.json
+++ b/types/couchbase/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/countdown/tslint.json
+++ b/types/countdown/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cradle/tslint.json
+++ b/types/cradle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/create-error/tslint.json
+++ b/types/create-error/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/createjs-lib/tslint.json
+++ b/types/createjs-lib/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/createjs/tslint.json
+++ b/types/createjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/credential/tslint.json
+++ b/types/credential/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/credit-card-type/tslint.json
+++ b/types/credit-card-type/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cron/tslint.json
+++ b/types/cron/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cross-storage/tslint.json
+++ b/types/cross-storage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/crossfilter/tslint.json
+++ b/types/crossfilter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/crossroads/tslint.json
+++ b/types/crossroads/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/crypto-js/tslint.json
+++ b/types/crypto-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cryptojs/tslint.json
+++ b/types/cryptojs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cson/tslint.json
+++ b/types/cson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/css-modules-require-hook/tslint.json
+++ b/types/css-modules-require-hook/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/css/tslint.json
+++ b/types/css/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cssbeautify/tslint.json
+++ b/types/cssbeautify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/csurf/tslint.json
+++ b/types/csurf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cuid/tslint.json
+++ b/types/cuid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/custom-error-generator/tslint.json
+++ b/types/custom-error-generator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/cybozulabs-md5/tslint.json
+++ b/types/cybozulabs-md5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/d3-box/tslint.json
+++ b/types/d3-box/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/d3-cloud/tslint.json
+++ b/types/d3-cloud/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/d3-tip/tslint.json
+++ b/types/d3-tip/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/d3.slider/tslint.json
+++ b/types/d3.slider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/d3pie/tslint.json
+++ b/types/d3pie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dat.gui/tslint.json
+++ b/types/dat.gui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/data-driven/tslint.json
+++ b/types/data-driven/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/date-arithmetic/tslint.json
+++ b/types/date-arithmetic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/date.format.js/tslint.json
+++ b/types/date.format.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/datejs/tslint.json
+++ b/types/datejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/db-migrate-base/tslint.json
+++ b/types/db-migrate-base/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/db-migrate-pg/tslint.json
+++ b/types/db-migrate-pg/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/db.js/tslint.json
+++ b/types/db.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dc/tslint.json
+++ b/types/dc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/decorum/tslint.json
+++ b/types/decorum/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/defaults/tslint.json
+++ b/types/defaults/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/deku/tslint.json
+++ b/types/deku/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/denodeify/tslint.json
+++ b/types/denodeify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/deoxxa-content-type/tslint.json
+++ b/types/deoxxa-content-type/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/deployjava/tslint.json
+++ b/types/deployjava/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/devexpress-web/tslint.json
+++ b/types/devexpress-web/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/devtools-detect/tslint.json
+++ b/types/devtools-detect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/df-visible/tslint.json
+++ b/types/df-visible/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dhtmlxgantt/tslint.json
+++ b/types/dhtmlxgantt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dhtmlxscheduler/tslint.json
+++ b/types/dhtmlxscheduler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/di-lite/tslint.json
+++ b/types/di-lite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/diff2html/tslint.json
+++ b/types/diff2html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/disposable-email-domains/tslint.json
+++ b/types/disposable-email-domains/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/doccookies/tslint.json
+++ b/types/doccookies/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dock-spawn/tslint.json
+++ b/types/dock-spawn/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/docopt/tslint.json
+++ b/types/docopt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/doctrine/tslint.json
+++ b/types/doctrine/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/documentdb-server/tslint.json
+++ b/types/documentdb-server/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dojo/tslint.json
+++ b/types/dojo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dom4/tslint.json
+++ b/types/dom4/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/domo/tslint.json
+++ b/types/domo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dompurify/tslint.json
+++ b/types/dompurify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/domurl/tslint.json
+++ b/types/domurl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/donna/tslint.json
+++ b/types/donna/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dotdotdot/tslint.json
+++ b/types/dotdotdot/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/doublearray/tslint.json
+++ b/types/doublearray/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/draft-js/tslint.json
+++ b/types/draft-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dragula/tslint.json
+++ b/types/dragula/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dropboxjs/tslint.json
+++ b/types/dropboxjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dropzone/tslint.json
+++ b/types/dropzone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dsv/tslint.json
+++ b/types/dsv/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dts-bundle/tslint.json
+++ b/types/dts-bundle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/durandal/tslint.json
+++ b/types/durandal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dustjs-linkedin/tslint.json
+++ b/types/dustjs-linkedin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dvtng-jss/tslint.json
+++ b/types/dvtng-jss/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dw-bxslider-4/tslint.json
+++ b/types/dw-bxslider-4/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dygraphs/tslint.json
+++ b/types/dygraphs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dymo-label-framework/tslint.json
+++ b/types/dymo-label-framework/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/dynatable/tslint.json
+++ b/types/dynatable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/each/tslint.json
+++ b/types/each/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easeljs/tslint.json
+++ b/types/easeljs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-api-request/tslint.json
+++ b/types/easy-api-request/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-jsend/tslint.json
+++ b/types/easy-jsend/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-session/tslint.json
+++ b/types/easy-session/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-table/tslint.json
+++ b/types/easy-table/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-xapi-utils/tslint.json
+++ b/types/easy-xapi-utils/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/easy-xapi/tslint.json
+++ b/types/easy-xapi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/echarts/tslint.json
+++ b/types/echarts/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/egg.js/tslint.json
+++ b/types/egg.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ejs-locals/tslint.json
+++ b/types/ejs-locals/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ejson/tslint.json
+++ b/types/ejson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/elastic.js/tslint.json
+++ b/types/elastic.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/electron-debug/tslint.json
+++ b/types/electron-debug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/electron-devtools-installer/tslint.json
+++ b/types/electron-devtools-installer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/electron-notifications/tslint.json
+++ b/types/electron-notifications/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/electron-notify/tslint.json
+++ b/types/electron-notify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/electron-window-state/tslint.json
+++ b/types/electron-window-state/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/element-resize-event/tslint.json
+++ b/types/element-resize-event/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/elm/tslint.json
+++ b/types/elm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ember-testing-helpers/tslint.json
+++ b/types/ember-testing-helpers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/emissary/tslint.json
+++ b/types/emissary/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/empower/tslint.json
+++ b/types/empower/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/emscripten/tslint.json
+++ b/types/emscripten/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/encoding-japanese/tslint.json
+++ b/types/encoding-japanese/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/enhanced-resolve/tslint.json
+++ b/types/enhanced-resolve/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ent/tslint.json
+++ b/types/ent/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/envify/tslint.json
+++ b/types/envify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/enzyme/tslint.json
+++ b/types/enzyme/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-duplicate-imports": false,
         "no-unnecessary-generics": false
     }

--- a/types/eonasdan-bootstrap-datetimepicker/tslint.json
+++ b/types/eonasdan-bootstrap-datetimepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/epiceditor/tslint.json
+++ b/types/epiceditor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/epub/tslint.json
+++ b/types/epub/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/eq.js/tslint.json
+++ b/types/eq.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/errorhandler/tslint.json
+++ b/types/errorhandler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/es6-collections/tslint.json
+++ b/types/es6-collections/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/es6-shim/tslint.json
+++ b/types/es6-shim/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/escape-html/tslint.json
+++ b/types/escape-html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/escape-latex/tslint.json
+++ b/types/escape-latex/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/escape-string-regexp/tslint.json
+++ b/types/escape-string-regexp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/escodegen/tslint.json
+++ b/types/escodegen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/esprima-walk/tslint.json
+++ b/types/esprima-walk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/estraverse/tslint.json
+++ b/types/estraverse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/estree/tslint.json
+++ b/types/estree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/event-loop-lag/tslint.json
+++ b/types/event-loop-lag/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/event-stream/tslint.json
+++ b/types/event-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/event-to-promise/tslint.json
+++ b/types/event-to-promise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/evernote/tslint.json
+++ b/types/evernote/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/exit/tslint.json
+++ b/types/exit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/exorcist/tslint.json
+++ b/types/exorcist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/expect.js/tslint.json
+++ b/types/expect.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/expectations/tslint.json
+++ b/types/expectations/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-brute-memcached/tslint.json
+++ b/types/express-brute-memcached/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-brute-mongo/tslint.json
+++ b/types/express-brute-mongo/tslint.json
@@ -4,6 +4,7 @@
         // TODOs
         "ban-types": false,
         "dt-header": false,
+        "npm-naming": false,
         "no-unnecessary-class": false
     }
 }

--- a/types/express-brute/tslint.json
+++ b/types/express-brute/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-debug/tslint.json
+++ b/types/express-debug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-domain-middleware/tslint.json
+++ b/types/express-domain-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-handlebars/tslint.json
+++ b/types/express-handlebars/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-jwt/tslint.json
+++ b/types/express-jwt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-less/tslint.json
+++ b/types/express-less/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-minify/tslint.json
+++ b/types/express-minify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-mung/tslint.json
+++ b/types/express-mung/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-myconnection/tslint.json
+++ b/types/express-myconnection/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-openapi/tslint.json
+++ b/types/express-openapi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-partials/tslint.json
+++ b/types/express-partials/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-route-fs/tslint.json
+++ b/types/express-route-fs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-unless/tslint.json
+++ b/types/express-unless/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/express-useragent/tslint.json
+++ b/types/express-useragent/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/extjs/tslint.json
+++ b/types/extjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/eyes/tslint.json
+++ b/types/eyes/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/facebook-js-sdk/tslint.json
+++ b/types/facebook-js-sdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/facebook-pixel/tslint.json
+++ b/types/facebook-pixel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/faker/tslint.json
+++ b/types/faker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/falcor-express/tslint.json
+++ b/types/falcor-express/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/falcor-http-datasource/tslint.json
+++ b/types/falcor-http-datasource/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/falcor-json-graph/tslint.json
+++ b/types/falcor-json-graph/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/falcor-router/tslint.json
+++ b/types/falcor-router/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/famous/tslint.json
+++ b/types/famous/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/farbtastic/tslint.json
+++ b/types/farbtastic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fast-levenshtein/tslint.json
+++ b/types/fast-levenshtein/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fast-stats/tslint.json
+++ b/types/fast-stats/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fastclick/tslint.json
+++ b/types/fastclick/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/favico.js/tslint.json
+++ b/types/favico.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fb/tslint.json
+++ b/types/fb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fbemitter/tslint.json
+++ b/types/fbemitter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/featherlight/tslint.json
+++ b/types/featherlight/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fhir/tslint.json
+++ b/types/fhir/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fibers/tslint.json
+++ b/types/fibers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/field/tslint.json
+++ b/types/field/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/filesystem/tslint.json
+++ b/types/filesystem/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/filewriter/tslint.json
+++ b/types/filewriter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fill-pdf/tslint.json
+++ b/types/fill-pdf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/finalhandler/tslint.json
+++ b/types/finalhandler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/finch/tslint.json
+++ b/types/finch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fingerprintjs/tslint.json
+++ b/types/fingerprintjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/firebase-client/tslint.json
+++ b/types/firebase-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/firebase-token-generator/tslint.json
+++ b/types/firebase-token-generator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/firefox/tslint.json
+++ b/types/firefox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fixed-data-table/tslint.json
+++ b/types/fixed-data-table/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flake-idgen/tslint.json
+++ b/types/flake-idgen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flat/tslint.json
+++ b/types/flat/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flexslider/tslint.json
+++ b/types/flexslider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flight/tslint.json
+++ b/types/flight/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flightplan/tslint.json
+++ b/types/flightplan/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flipsnap/tslint.json
+++ b/types/flipsnap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flot/tslint.json
+++ b/types/flot/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/flowjs/tslint.json
+++ b/types/flowjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fluxxor/tslint.json
+++ b/types/fluxxor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fontfaceobserver/tslint.json
+++ b/types/fontfaceobserver/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fontoxml/tslint.json
+++ b/types/fontoxml/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/forge-di/tslint.json
+++ b/types/forge-di/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/form-serializer/tslint.json
+++ b/types/form-serializer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/formidable/tslint.json
+++ b/types/formidable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fossil-delta/tslint.json
+++ b/types/fossil-delta/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/foundation/tslint.json
+++ b/types/foundation/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fpsmeter/tslint.json
+++ b/types/fpsmeter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/freedom/tslint.json
+++ b/types/freedom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/from/tslint.json
+++ b/types/from/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fromjs/tslint.json
+++ b/types/fromjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fromnow/tslint.json
+++ b/types/fromnow/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fs-ext/tslint.json
+++ b/types/fs-ext/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fs-finder/tslint.json
+++ b/types/fs-finder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fs-mock/tslint.json
+++ b/types/fs-mock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ftdomdelegate/tslint.json
+++ b/types/ftdomdelegate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ftp/tslint.json
+++ b/types/ftp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ftpd/tslint.json
+++ b/types/ftpd/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fullname/tslint.json
+++ b/types/fullname/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fullpage.js/tslint.json
+++ b/types/fullpage.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fuzzaldrin-plus/tslint.json
+++ b/types/fuzzaldrin-plus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/fxn/tslint.json
+++ b/types/fxn/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gae.channel.api/tslint.json
+++ b/types/gae.channel.api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gamequery/tslint.json
+++ b/types/gamequery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gandi-livedns/tslint.json
+++ b/types/gandi-livedns/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.analytics/tslint.json
+++ b/types/gapi.analytics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.calendar/tslint.json
+++ b/types/gapi.calendar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.drive/tslint.json
+++ b/types/gapi.drive/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.pagespeedonline/tslint.json
+++ b/types/gapi.pagespeedonline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.people/tslint.json
+++ b/types/gapi.people/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.plus/tslint.json
+++ b/types/gapi.plus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.translate/tslint.json
+++ b/types/gapi.translate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.urlshortener/tslint.json
+++ b/types/gapi.urlshortener/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.youtube/tslint.json
+++ b/types/gapi.youtube/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi.youtubeanalytics/tslint.json
+++ b/types/gapi.youtubeanalytics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gapi/tslint.json
+++ b/types/gapi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/generic-functions/tslint.json
+++ b/types/generic-functions/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gently/tslint.json
+++ b/types/gently/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/geoip-lite/tslint.json
+++ b/types/geoip-lite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/geojson2osm/tslint.json
+++ b/types/geojson2osm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/geometry-dom/tslint.json
+++ b/types/geometry-dom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gijgo/tslint.json
+++ b/types/gijgo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/giraffe/tslint.json
+++ b/types/giraffe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/git-config/tslint.json
+++ b/types/git-config/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/git/tslint.json
+++ b/types/git/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gl-matrix/tslint.json
+++ b/types/gl-matrix/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gldatepicker/tslint.json
+++ b/types/gldatepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/glidejs/tslint.json
+++ b/types/glidejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/glob-expand/tslint.json
+++ b/types/glob-expand/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/glob-stream/tslint.json
+++ b/types/glob-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/globalize-compiler/tslint.json
+++ b/types/globalize-compiler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/globalize/tslint.json
+++ b/types/globalize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/go/tslint.json
+++ b/types/go/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-apps-script/tslint.json
+++ b/types/google-apps-script/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-closure-compiler/tslint.json
+++ b/types/google-closure-compiler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-drive-realtime-api/tslint.json
+++ b/types/google-drive-realtime-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-earth/tslint.json
+++ b/types/google-earth/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-libphonenumber/tslint.json
+++ b/types/google-libphonenumber/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google-maps/tslint.json
+++ b/types/google-maps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google.analytics/tslint.json
+++ b/types/google.analytics/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "dt-header": false,
+        "npm-naming": false,
         "ban-types": false,
         "unified-signatures": false,
         "no-unnecessary-generics": false

--- a/types/google.feeds/tslint.json
+++ b/types/google.feeds/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google.geolocation/tslint.json
+++ b/types/google.geolocation/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google.picker/tslint.json
+++ b/types/google.picker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/google.visualization/tslint.json
+++ b/types/google.visualization/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/googlemaps.infobubble/tslint.json
+++ b/types/googlemaps.infobubble/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/googlemaps/tslint.json
+++ b/types/googlemaps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/graham_scan/tslint.json
+++ b/types/graham_scan/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/graphlib/tslint.json
+++ b/types/graphlib/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/graphviz/tslint.json
+++ b/types/graphviz/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gravatar/tslint.json
+++ b/types/gravatar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gregorian-calendar/tslint.json
+++ b/types/gregorian-calendar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gridfs-stream/tslint.json
+++ b/types/gridfs-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gridstack/tslint.json
+++ b/types/gridstack/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/grunt/tslint.json
+++ b/types/grunt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gsap/tslint.json
+++ b/types/gsap/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // All are TODOs
         "dt-header": false,
+        "npm-naming": false,
         "jsdoc-format": false,
         "max-line-length": false,
         "no-consecutive-blank-lines": false,

--- a/types/gulp-angular-templatecache/tslint.json
+++ b/types/gulp-angular-templatecache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-autoprefixer/tslint.json
+++ b/types/gulp-autoprefixer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-babel/tslint.json
+++ b/types/gulp-babel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-cache/tslint.json
+++ b/types/gulp-cache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-cached/tslint.json
+++ b/types/gulp-cached/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-changed/tslint.json
+++ b/types/gulp-changed/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-cheerio/tslint.json
+++ b/types/gulp-cheerio/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-coffeeify/tslint.json
+++ b/types/gulp-coffeeify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-coffeelint/tslint.json
+++ b/types/gulp-coffeelint/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-concat/tslint.json
+++ b/types/gulp-concat/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-copy/tslint.json
+++ b/types/gulp-copy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-csso/tslint.json
+++ b/types/gulp-csso/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-debug/tslint.json
+++ b/types/gulp-debug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-dtsm/tslint.json
+++ b/types/gulp-dtsm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-espower/tslint.json
+++ b/types/gulp-espower/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-file-include/tslint.json
+++ b/types/gulp-file-include/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-filter/tslint.json
+++ b/types/gulp-filter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-flatten/tslint.json
+++ b/types/gulp-flatten/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-gh-pages/tslint.json
+++ b/types/gulp-gh-pages/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-gzip/tslint.json
+++ b/types/gulp-gzip/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-help-doc/tslint.json
+++ b/types/gulp-help-doc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-help/tslint.json
+++ b/types/gulp-help/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-html-replace/tslint.json
+++ b/types/gulp-html-replace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-htmlmin/tslint.json
+++ b/types/gulp-htmlmin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-if/tslint.json
+++ b/types/gulp-if/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-inject/tslint.json
+++ b/types/gulp-inject/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-insert/tslint.json
+++ b/types/gulp-insert/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-install/tslint.json
+++ b/types/gulp-install/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-istanbul/tslint.json
+++ b/types/gulp-istanbul/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-jade/tslint.json
+++ b/types/gulp-jade/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-jasmine-browser/tslint.json
+++ b/types/gulp-jasmine-browser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-json-editor/tslint.json
+++ b/types/gulp-json-editor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-jspm/tslint.json
+++ b/types/gulp-jspm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-less/tslint.json
+++ b/types/gulp-less/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-load-plugins/tslint.json
+++ b/types/gulp-load-plugins/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-minify-css/tslint.json
+++ b/types/gulp-minify-css/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-minify-html/tslint.json
+++ b/types/gulp-minify-html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-mocha/tslint.json
+++ b/types/gulp-mocha/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-newer/tslint.json
+++ b/types/gulp-newer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-ng-annotate/tslint.json
+++ b/types/gulp-ng-annotate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-nodemon/tslint.json
+++ b/types/gulp-nodemon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-plumber/tslint.json
+++ b/types/gulp-plumber/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-protractor/tslint.json
+++ b/types/gulp-protractor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-remember/tslint.json
+++ b/types/gulp-remember/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-rename/tslint.json
+++ b/types/gulp-rename/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-replace/tslint.json
+++ b/types/gulp-replace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-rev-replace/tslint.json
+++ b/types/gulp-rev-replace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-rev/tslint.json
+++ b/types/gulp-rev/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-ruby-sass/tslint.json
+++ b/types/gulp-ruby-sass/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-sass/tslint.json
+++ b/types/gulp-sass/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-shell/tslint.json
+++ b/types/gulp-shell/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-sort/tslint.json
+++ b/types/gulp-sort/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-sourcemaps/tslint.json
+++ b/types/gulp-sourcemaps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-strip-debug/tslint.json
+++ b/types/gulp-strip-debug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-svg-sprite/tslint.json
+++ b/types/gulp-svg-sprite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-task-listing/tslint.json
+++ b/types/gulp-task-listing/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-tsd/tslint.json
+++ b/types/gulp-tsd/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-useref/tslint.json
+++ b/types/gulp-useref/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp-watch/tslint.json
+++ b/types/gulp-watch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/gulp/tslint.json
+++ b/types/gulp/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-object-literal-type-assertion": false
     }
 }

--- a/types/h2o2/tslint.json
+++ b/types/h2o2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/halfred/tslint.json
+++ b/types/halfred/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hammerjs/tslint.json
+++ b/types/hammerjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hapi-auth-basic/tslint.json
+++ b/types/hapi-auth-basic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hapi-decorators/tslint.json
+++ b/types/hapi-decorators/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/harmony-proxy/tslint.json
+++ b/types/harmony-proxy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hasher/tslint.json
+++ b/types/hasher/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hashids/tslint.json
+++ b/types/hashids/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hashmap/tslint.json
+++ b/types/hashmap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hashset/tslint.json
+++ b/types/hashset/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hashtable/tslint.json
+++ b/types/hashtable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/he/tslint.json
+++ b/types/he/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/headroom/tslint.json
+++ b/types/headroom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/heap/tslint.json
+++ b/types/heap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hellosign-embedded/tslint.json
+++ b/types/hellosign-embedded/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/helmet/tslint.json
+++ b/types/helmet/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/highcharts-ng/tslint.json
+++ b/types/highcharts-ng/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/highland/tslint.json
+++ b/types/highland/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/highlight.js/tslint.json
+++ b/types/highlight.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/history.js/tslint.json
+++ b/types/history.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/history/tslint.json
+++ b/types/history/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hooker/tslint.json
+++ b/types/hooker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hopscotch/tslint.json
+++ b/types/hopscotch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/howler/tslint.json
+++ b/types/howler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/html-entities/tslint.json
+++ b/types/html-entities/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/html-pdf/tslint.json
+++ b/types/html-pdf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/html-to-text/tslint.json
+++ b/types/html-to-text/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/html2canvas/tslint.json
+++ b/types/html2canvas/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/htmlescape/tslint.json
+++ b/types/htmlescape/tslint.json
@@ -3,6 +3,7 @@
 	"rules": {
 		// TODO
 		"dt-header": false,
+        "npm-naming": false,
 		"no-duplicate-imports": false
 	}
 }

--- a/types/htmlhint/tslint.json
+++ b/types/htmlhint/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/htmlparser2/tslint.json
+++ b/types/htmlparser2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/htmltojsx/tslint.json
+++ b/types/htmltojsx/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/http-status/tslint.json
+++ b/types/http-status/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/http-string-parser/tslint.json
+++ b/types/http-string-parser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/httperr/tslint.json
+++ b/types/httperr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hubspot-pace/tslint.json
+++ b/types/hubspot-pace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/humane/tslint.json
+++ b/types/humane/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/humanparser/tslint.json
+++ b/types/humanparser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/humps/tslint.json
+++ b/types/humps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hyperscript/tslint.json
+++ b/types/hyperscript/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/hypertext-application-language/tslint.json
+++ b/types/hypertext-application-language/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/i18next-express-middleware/tslint.json
+++ b/types/i18next-express-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/i18next-node-fs-backend/tslint.json
+++ b/types/i18next-node-fs-backend/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/i18next-sprintf-postprocessor/tslint.json
+++ b/types/i18next-sprintf-postprocessor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/i2c-bus/tslint.json
+++ b/types/i2c-bus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/iban/tslint.json
+++ b/types/iban/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ibm-mobilefirst/tslint.json
+++ b/types/ibm-mobilefirst/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/icepick/tslint.json
+++ b/types/icepick/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/icheck/tslint.json
+++ b/types/icheck/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/iconv/tslint.json
+++ b/types/iconv/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ignite-ui/tslint.json
+++ b/types/ignite-ui/tslint.json
@@ -4,6 +4,7 @@
         // All are TODOs
         "array-type": false,
         "dt-header": false,
+        "npm-naming": false,
         "ban-types": false,
         "callable-types": false,
         "no-empty-interface": false,

--- a/types/imagemagick-native/tslint.json
+++ b/types/imagemagick-native/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imagemagick/tslint.json
+++ b/types/imagemagick/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imagemapster/tslint.json
+++ b/types/imagemapster/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imagesloaded/tslint.json
+++ b/types/imagesloaded/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imap-simple/tslint.json
+++ b/types/imap-simple/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imap/tslint.json
+++ b/types/imap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/imgur-rest-api/tslint.json
+++ b/types/imgur-rest-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/impress/tslint.json
+++ b/types/impress/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/incremental-dom/tslint.json
+++ b/types/incremental-dom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inflected/tslint.json
+++ b/types/inflected/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inflection/tslint.json
+++ b/types/inflection/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inherits/tslint.json
+++ b/types/inherits/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ini/tslint.json
+++ b/types/ini/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/iniparser/tslint.json
+++ b/types/iniparser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inline-css/tslint.json
+++ b/types/inline-css/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inquirer/tslint.json
+++ b/types/inquirer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/insight/tslint.json
+++ b/types/insight/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/intercomjs/tslint.json
+++ b/types/intercomjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/intro.js/tslint.json
+++ b/types/intro.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/invariant/tslint.json
+++ b/types/invariant/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/inversify-devtools/tslint.json
+++ b/types/inversify-devtools/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/irc/tslint.json
+++ b/types/irc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/is-my-json-valid/tslint.json
+++ b/types/is-my-json-valid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/is-url/tslint.json
+++ b/types/is-url/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/is/tslint.json
+++ b/types/is/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/iscroll/tslint.json
+++ b/types/iscroll/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/iso8601-localizer/tslint.json
+++ b/types/iso8601-localizer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/istanbul-middleware/tslint.json
+++ b/types/istanbul-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/istanbul/tslint.json
+++ b/types/istanbul/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ix.js/tslint.json
+++ b/types/ix.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jade/tslint.json
+++ b/types/jade/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jake/tslint.json
+++ b/types/jake/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jasmine-es6-promise-matchers/tslint.json
+++ b/types/jasmine-es6-promise-matchers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jasmine-jquery/tslint.json
+++ b/types/jasmine-jquery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jasmine-matchers/tslint.json
+++ b/types/jasmine-matchers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jasmine-node/tslint.json
+++ b/types/jasmine-node/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jasmine-promise-matchers/tslint.json
+++ b/types/jasmine-promise-matchers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/java-applet/tslint.json
+++ b/types/java-applet/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/java/tslint.json
+++ b/types/java/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/javascript-astar/tslint.json
+++ b/types/javascript-astar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/javascript-bignum/tslint.json
+++ b/types/javascript-bignum/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/javascript-obfuscator/tslint.json
+++ b/types/javascript-obfuscator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jbinary/tslint.json
+++ b/types/jbinary/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jcanvas/tslint.json
+++ b/types/jcanvas/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jdataview/tslint.json
+++ b/types/jdataview/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jdenticon/tslint.json
+++ b/types/jdenticon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jee-jsf/tslint.json
+++ b/types/jee-jsf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jest/tslint.json
+++ b/types/jest/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-mergeable-namespace": false,
         "no-void-expression": false,
         "no-unnecessary-generics": false

--- a/types/jfp/tslint.json
+++ b/types/jfp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jjv/tslint.json
+++ b/types/jjv/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jjve/tslint.json
+++ b/types/jjve/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/johnny-five/tslint.json
+++ b/types/johnny-five/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jpm/tslint.json
+++ b/types/jpm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jqgrid/tslint.json
+++ b/types/jqgrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jqrangeslider/tslint.json
+++ b/types/jqrangeslider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-ajax-chain/tslint.json
+++ b/types/jquery-ajax-chain/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-alertable/tslint.json
+++ b/types/jquery-alertable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-backstretch/tslint.json
+++ b/types/jquery-backstretch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-cropbox/tslint.json
+++ b/types/jquery-cropbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-deparam/tslint.json
+++ b/types/jquery-deparam/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-easy-loading/tslint.json
+++ b/types/jquery-easy-loading/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-fullscreen/tslint.json
+++ b/types/jquery-fullscreen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-galleria/tslint.json
+++ b/types/jquery-galleria/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-handsontable/tslint.json
+++ b/types/jquery-handsontable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-jsonrpcclient/tslint.json
+++ b/types/jquery-jsonrpcclient/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-knob/tslint.json
+++ b/types/jquery-knob/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-mockjax/tslint.json
+++ b/types/jquery-mockjax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-mousewheel/tslint.json
+++ b/types/jquery-mousewheel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-param/tslint.json
+++ b/types/jquery-param/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-sortable/tslint.json
+++ b/types/jquery-sortable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-steps/tslint.json
+++ b/types/jquery-steps/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-timeentry/tslint.json
+++ b/types/jquery-timeentry/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-truncate-html/tslint.json
+++ b/types/jquery-truncate-html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-urlparam/tslint.json
+++ b/types/jquery-urlparam/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery-validation-unobtrusive/tslint.json
+++ b/types/jquery-validation-unobtrusive/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.address/tslint.json
+++ b/types/jquery.address/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.are-you-sure/tslint.json
+++ b/types/jquery.are-you-sure/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.autosize/tslint.json
+++ b/types/jquery.autosize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.base64/tslint.json
+++ b/types/jquery.base64/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.bbq/tslint.json
+++ b/types/jquery.bbq/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.blockui/tslint.json
+++ b/types/jquery.blockui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.bootstrap.wizard/tslint.json
+++ b/types/jquery.bootstrap.wizard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.cleditor/tslint.json
+++ b/types/jquery.cleditor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.clientsidelogging/tslint.json
+++ b/types/jquery.clientsidelogging/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.color/tslint.json
+++ b/types/jquery.color/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.colorbox/tslint.json
+++ b/types/jquery.colorbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.colorpicker/tslint.json
+++ b/types/jquery.colorpicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.contextmenu/tslint.json
+++ b/types/jquery.contextmenu/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.cookie/tslint.json
+++ b/types/jquery.cookie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.customselect/tslint.json
+++ b/types/jquery.customselect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.cycle/tslint.json
+++ b/types/jquery.cycle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.cycle2/tslint.json
+++ b/types/jquery.cycle2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.dropotron/tslint.json
+++ b/types/jquery.dropotron/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.dynatree/tslint.json
+++ b/types/jquery.dynatree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.elang/tslint.json
+++ b/types/jquery.elang/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.fancytree/tslint.json
+++ b/types/jquery.fancytree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.fileupload/tslint.json
+++ b/types/jquery.fileupload/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.filtertable/tslint.json
+++ b/types/jquery.filtertable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.finger/tslint.json
+++ b/types/jquery.finger/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.flagstrap/tslint.json
+++ b/types/jquery.flagstrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.form/tslint.json
+++ b/types/jquery.form/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.fullscreen/tslint.json
+++ b/types/jquery.fullscreen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.gridster/tslint.json
+++ b/types/jquery.gridster/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.highlight-bartaz/tslint.json
+++ b/types/jquery.highlight-bartaz/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.jnotify/tslint.json
+++ b/types/jquery.jnotify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.joyride/tslint.json
+++ b/types/jquery.joyride/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.jsignature/tslint.json
+++ b/types/jquery.jsignature/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.leanmodal/tslint.json
+++ b/types/jquery.leanmodal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.livestampjs/tslint.json
+++ b/types/jquery.livestampjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.menuaim/tslint.json
+++ b/types/jquery.menuaim/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.mmenu/tslint.json
+++ b/types/jquery.mmenu/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.notifybar/tslint.json
+++ b/types/jquery.notifybar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.noty/tslint.json
+++ b/types/jquery.noty/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.payment/tslint.json
+++ b/types/jquery.payment/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.pjax/tslint.json
+++ b/types/jquery.pjax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.placeholder/tslint.json
+++ b/types/jquery.placeholder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.pnotify/tslint.json
+++ b/types/jquery.pnotify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.postmessage/tslint.json
+++ b/types/jquery.postmessage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.prettyphoto/tslint.json
+++ b/types/jquery.prettyphoto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.qrcode/tslint.json
+++ b/types/jquery.qrcode/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.rateit/tslint.json
+++ b/types/jquery.rateit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.rowgrid/tslint.json
+++ b/types/jquery.rowgrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.scrollto/tslint.json
+++ b/types/jquery.scrollto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.simplemodal/tslint.json
+++ b/types/jquery.simplemodal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.simplepagination/tslint.json
+++ b/types/jquery.simplepagination/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.simulate/tslint.json
+++ b/types/jquery.simulate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.slimscroll/tslint.json
+++ b/types/jquery.slimscroll/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.sortelements/tslint.json
+++ b/types/jquery.sortelements/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.superlink/tslint.json
+++ b/types/jquery.superlink/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.tagsmanager/tslint.json
+++ b/types/jquery.tagsmanager/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.tile/tslint.json
+++ b/types/jquery.tile/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.timeago/tslint.json
+++ b/types/jquery.timeago/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.timepicker/tslint.json
+++ b/types/jquery.timepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.timer/tslint.json
+++ b/types/jquery.timer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.tinycarousel/tslint.json
+++ b/types/jquery.tinycarousel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.tinyscrollbar/tslint.json
+++ b/types/jquery.tinyscrollbar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.tipsy/tslint.json
+++ b/types/jquery.tipsy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.total-storage/tslint.json
+++ b/types/jquery.total-storage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.transit/tslint.json
+++ b/types/jquery.transit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.ui.datetimepicker/tslint.json
+++ b/types/jquery.ui.datetimepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.ui.layout/tslint.json
+++ b/types/jquery.ui.layout/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.uniform/tslint.json
+++ b/types/jquery.uniform/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.watermark/tslint.json
+++ b/types/jquery.watermark/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquery.window/tslint.json
+++ b/types/jquery.window/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jquerymobile/tslint.json
+++ b/types/jquerymobile/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jqueryui/tslint.json
+++ b/types/jqueryui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-beautify/tslint.json
+++ b/types/js-beautify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-clipper/tslint.json
+++ b/types/js-clipper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-combinatorics/tslint.json
+++ b/types/js-combinatorics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-data-angular/tslint.json
+++ b/types/js-data-angular/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-fixtures/tslint.json
+++ b/types/js-fixtures/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-git/tslint.json
+++ b/types/js-git/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-money/tslint.json
+++ b/types/js-money/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // All are TODOs
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "no-unnecessary-qualifier": false
     }

--- a/types/js-priority-queue/tslint.json
+++ b/types/js-priority-queue/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-schema/tslint.json
+++ b/types/js-schema/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-search/tslint.json
+++ b/types/js-search/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/js-url/tslint.json
+++ b/types/js-url/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsbn/tslint.json
+++ b/types/jsbn/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jscrollpane/tslint.json
+++ b/types/jscrollpane/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsdeferred/tslint.json
+++ b/types/jsdeferred/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsen/tslint.json
+++ b/types/jsen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsend/tslint.json
+++ b/types/jsend/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsesc/tslint.json
+++ b/types/jsesc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsfl/tslint.json
+++ b/types/jsfl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsgraph/tslint.json
+++ b/types/jsgraph/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jshamcrest/tslint.json
+++ b/types/jshamcrest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsmockito/tslint.json
+++ b/types/jsmockito/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-editor/tslint.json
+++ b/types/json-editor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-merge-patch/tslint.json
+++ b/types/json-merge-patch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-patch-gen/tslint.json
+++ b/types/json-patch-gen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-patch/tslint.json
+++ b/types/json-patch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-pointer/tslint.json
+++ b/types/json-pointer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json-socket/tslint.json
+++ b/types/json-socket/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/json5/tslint.json
+++ b/types/json5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsoneditor/tslint.json
+++ b/types/jsoneditor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsoneditoronline/tslint.json
+++ b/types/jsoneditoronline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsonminify/tslint.json
+++ b/types/jsonminify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsonnet/tslint.json
+++ b/types/jsonnet/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsonpath/tslint.json
+++ b/types/jsonpath/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsonstream/tslint.json
+++ b/types/jsonstream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsrender/tslint.json
+++ b/types/jsrender/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jstimezonedetect/tslint.json
+++ b/types/jstimezonedetect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jstorage/tslint.json
+++ b/types/jstorage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jstree/tslint.json
+++ b/types/jstree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsts/tslint.json
+++ b/types/jsts/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsuite/tslint.json
+++ b/types/jsuite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsuri/tslint.json
+++ b/types/jsuri/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsurl/tslint.json
+++ b/types/jsurl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jsx-chai/tslint.json
+++ b/types/jsx-chai/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jug/tslint.json
+++ b/types/jug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jwt-client/tslint.json
+++ b/types/jwt-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/jwt-simple/tslint.json
+++ b/types/jwt-simple/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/karma-chai-sinon/tslint.json
+++ b/types/karma-chai-sinon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/karma-coverage/tslint.json
+++ b/types/karma-coverage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/karma-jasmine/tslint.json
+++ b/types/karma-jasmine/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/katex/tslint.json
+++ b/types/katex/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kefir/tslint.json
+++ b/types/kefir/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kendo-ui/tslint.json
+++ b/types/kendo-ui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/keyboardjs/tslint.json
+++ b/types/keyboardjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/keymaster/tslint.json
+++ b/types/keymaster/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/keymirror/tslint.json
+++ b/types/keymirror/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/keytar/tslint.json
+++ b/types/keytar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kii-cloud-sdk/tslint.json
+++ b/types/kii-cloud-sdk/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-unnecessary-class": false,
         "no-unnecessary-generics": false
     }

--- a/types/kik-browser/tslint.json
+++ b/types/kik-browser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kineticjs/tslint.json
+++ b/types/kineticjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/klaw/tslint.json
+++ b/types/klaw/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockback/tslint.json
+++ b/types/knockback/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout-amd-helpers/tslint.json
+++ b/types/knockout-amd-helpers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout-postbox/tslint.json
+++ b/types/knockout-postbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout-secure-binding/tslint.json
+++ b/types/knockout-secure-binding/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout-transformations/tslint.json
+++ b/types/knockout-transformations/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.deferred.updates/tslint.json
+++ b/types/knockout.deferred.updates/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.editables/tslint.json
+++ b/types/knockout.editables/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.es5/tslint.json
+++ b/types/knockout.es5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.kogrid/tslint.json
+++ b/types/knockout.kogrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.mapper/tslint.json
+++ b/types/knockout.mapper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.mapping/tslint.json
+++ b/types/knockout.mapping/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.projections/tslint.json
+++ b/types/knockout.projections/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.punches/tslint.json
+++ b/types/knockout.punches/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.rx/tslint.json
+++ b/types/knockout.rx/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.validation/tslint.json
+++ b/types/knockout.validation/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout.viewmodel/tslint.json
+++ b/types/knockout.viewmodel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockout/tslint.json
+++ b/types/knockout/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/knockstrap/tslint.json
+++ b/types/knockstrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ko.plus/tslint.json
+++ b/types/ko.plus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-bouncer/tslint.json
+++ b/types/koa-bouncer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-compress/tslint.json
+++ b/types/koa-compress/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-favicon/tslint.json
+++ b/types/koa-favicon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-hbs/tslint.json
+++ b/types/koa-hbs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-json/tslint.json
+++ b/types/koa-json/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-router/tslint.json
+++ b/types/koa-router/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa-session-minimal/tslint.json
+++ b/types/koa-session-minimal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/koa/tslint.json
+++ b/types/koa/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kolite/tslint.json
+++ b/types/kolite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/konami.js/tslint.json
+++ b/types/konami.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/kue/tslint.json
+++ b/types/kue/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lab/tslint.json
+++ b/types/lab/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ladda/tslint.json
+++ b/types/ladda/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/latinize/tslint.json
+++ b/types/latinize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/launchpad/tslint.json
+++ b/types/launchpad/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lazy.js/tslint.json
+++ b/types/lazy.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lazypipe/tslint.json
+++ b/types/lazypipe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ldapjs/tslint.json
+++ b/types/ldapjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/leadfoot/tslint.json
+++ b/types/leadfoot/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/leapmotionts/tslint.json
+++ b/types/leapmotionts/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/less-middleware/tslint.json
+++ b/types/less-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/less/tslint.json
+++ b/types/less/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/level-sublevel/tslint.json
+++ b/types/level-sublevel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/levenshtein/tslint.json
+++ b/types/levenshtein/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lime-js/tslint.json
+++ b/types/lime-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/line-reader/tslint.json
+++ b/types/line-reader/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lls/tslint.json
+++ b/types/lls/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/loader-runner/tslint.json
+++ b/types/loader-runner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lobibox/tslint.json
+++ b/types/lobibox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lockr/tslint.json
+++ b/types/lockr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/locutus/tslint.json
+++ b/types/locutus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/logg/tslint.json
+++ b/types/logg/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/loggly/tslint.json
+++ b/types/loggly/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/logrotate-stream/tslint.json
+++ b/types/logrotate-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lokijs/tslint.json
+++ b/types/lokijs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lolex/tslint.json
+++ b/types/lolex/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/long/tslint.json
+++ b/types/long/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lory.js/tslint.json
+++ b/types/lory.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lowlight/tslint.json
+++ b/types/lowlight/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lscache/tslint.json
+++ b/types/lscache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/luaparse/tslint.json
+++ b/types/luaparse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/lwip/tslint.json
+++ b/types/lwip/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/magic-number/tslint.json
+++ b/types/magic-number/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/magicsuggest/tslint.json
+++ b/types/magicsuggest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mailcheck/tslint.json
+++ b/types/mailcheck/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/maildev/tslint.json
+++ b/types/maildev/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/main-bower-files/tslint.json
+++ b/types/main-bower-files/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mainloop.js/tslint.json
+++ b/types/mainloop.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/maker.js/tslint.json
+++ b/types/maker.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mandrill-api/tslint.json
+++ b/types/mandrill-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mapbox-gl/tslint.json
+++ b/types/mapbox-gl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mapsjs/tslint.json
+++ b/types/mapsjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mariasql/tslint.json
+++ b/types/mariasql/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/markdown-it/tslint.json
+++ b/types/markdown-it/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/marker-animate-unobtrusive/tslint.json
+++ b/types/marker-animate-unobtrusive/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/markitup/tslint.json
+++ b/types/markitup/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/maskedinput/tslint.json
+++ b/types/maskedinput/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/match-media-mock/tslint.json
+++ b/types/match-media-mock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/material-design-lite/tslint.json
+++ b/types/material-design-lite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/material-ui-pagination/tslint.json
+++ b/types/material-ui-pagination/tslint.json
@@ -3,6 +3,7 @@
 	"rules": {
 		// TODOs
 		"dt-header": false,
+        "npm-naming": false,
 		"no-duplicate-imports": false,
 		"use-default-type-parameter": false
 	}

--- a/types/mathjax/tslint.json
+++ b/types/mathjax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/matter-js/tslint.json
+++ b/types/matter-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mcustomscrollbar/tslint.json
+++ b/types/mcustomscrollbar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/md5/tslint.json
+++ b/types/md5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mdns/tslint.json
+++ b/types/mdns/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/medium-editor/tslint.json
+++ b/types/medium-editor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/memory-fs/tslint.json
+++ b/types/memory-fs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/memwatch-next/tslint.json
+++ b/types/memwatch-next/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/menubar/tslint.json
+++ b/types/menubar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meshblu/tslint.json
+++ b/types/meshblu/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mess/tslint.json
+++ b/types/mess/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/messenger/tslint.json
+++ b/types/messenger/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-accounts-phone/tslint.json
+++ b/types/meteor-accounts-phone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-jboulhous-dev/tslint.json
+++ b/types/meteor-jboulhous-dev/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-persistent-session/tslint.json
+++ b/types/meteor-persistent-session/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-prime8consulting-oauth2/tslint.json
+++ b/types/meteor-prime8consulting-oauth2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-publish-composite/tslint.json
+++ b/types/meteor-publish-composite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor-roles/tslint.json
+++ b/types/meteor-roles/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/meteor/tslint.json
+++ b/types/meteor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/method-override/tslint.json
+++ b/types/method-override/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/metric-suffix/tslint.json
+++ b/types/metric-suffix/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/microsoft-ajax/tslint.json
+++ b/types/microsoft-ajax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/microsoft-live-connect/tslint.json
+++ b/types/microsoft-live-connect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/microsoft-sdk-soap/tslint.json
+++ b/types/microsoft-sdk-soap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/milkcocoa/tslint.json
+++ b/types/milkcocoa/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/milliseconds/tslint.json
+++ b/types/milliseconds/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mime-db/tslint.json
+++ b/types/mime-db/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mimos/tslint.json
+++ b/types/mimos/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/minilog/tslint.json
+++ b/types/minilog/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/minimist/tslint.json
+++ b/types/minimist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mitm/tslint.json
+++ b/types/mitm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mixto/tslint.json
+++ b/types/mixto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mkpath/tslint.json
+++ b/types/mkpath/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mmmagic/tslint.json
+++ b/types/mmmagic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mocha-phantomjs/tslint.json
+++ b/types/mocha-phantomjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mock-fs/tslint.json
+++ b/types/mock-fs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mock-require/tslint.json
+++ b/types/mock-require/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mockery/tslint.json
+++ b/types/mockery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mockjs/tslint.json
+++ b/types/mockjs/tslint.json
@@ -2,6 +2,7 @@
   "extends": "dtslint/dt.json",
   "rules": {
     "dt-header": false,
+        "npm-naming": false,
     "export-just-namespace": false,
     "no-bad-reference": true
   }

--- a/types/moment-jalaali/tslint.json
+++ b/types/moment-jalaali/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-auto-increment/tslint.json
+++ b/types/mongoose-auto-increment/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-deep-populate/tslint.json
+++ b/types/mongoose-deep-populate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-mock/tslint.json
+++ b/types/mongoose-mock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-paginate/tslint.json
+++ b/types/mongoose-paginate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-promise/tslint.json
+++ b/types/mongoose-promise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-seeder/tslint.json
+++ b/types/mongoose-seeder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose-sequence/tslint.json
+++ b/types/mongoose-sequence/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mongoose/tslint.json
+++ b/types/mongoose/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/morris.js/tslint.json
+++ b/types/morris.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mousetrap/tslint.json
+++ b/types/mousetrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/moviedb/tslint.json
+++ b/types/moviedb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mpromise/tslint.json
+++ b/types/mpromise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ms/tslint.json
+++ b/types/ms/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/msgpack/tslint.json
+++ b/types/msgpack/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/msgpack5/tslint.json
+++ b/types/msgpack5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/msnodesql/tslint.json
+++ b/types/msnodesql/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/msportalfx-test/tslint.json
+++ b/types/msportalfx-test/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mssql/tslint.json
+++ b/types/mssql/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mu2/tslint.json
+++ b/types/mu2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/multiparty/tslint.json
+++ b/types/multiparty/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/multiplexjs/tslint.json
+++ b/types/multiplexjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/murmurhash-js/tslint.json
+++ b/types/murmurhash-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/murmurhash3js/tslint.json
+++ b/types/murmurhash3js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/musicmetadata/tslint.json
+++ b/types/musicmetadata/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mustache/tslint.json
+++ b/types/mustache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/mz/tslint.json
+++ b/types/mz/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nanoajax/tslint.json
+++ b/types/nanoajax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nanp/tslint.json
+++ b/types/nanp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/natural-sort/tslint.json
+++ b/types/natural-sort/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/natural/tslint.json
+++ b/types/natural/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ncp/tslint.json
+++ b/types/ncp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/neo4j/tslint.json
+++ b/types/neo4j/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nes/tslint.json
+++ b/types/nes/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/netmask/tslint.json
+++ b/types/netmask/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nexpect/tslint.json
+++ b/types/nexpect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-command/tslint.json
+++ b/types/ng-command/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-cordova/tslint.json
+++ b/types/ng-cordova/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-dialog/tslint.json
+++ b/types/ng-dialog/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-facebook/tslint.json
+++ b/types/ng-facebook/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-file-upload/tslint.json
+++ b/types/ng-file-upload/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-flow/tslint.json
+++ b/types/ng-flow/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-grid/tslint.json
+++ b/types/ng-grid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-i18next/tslint.json
+++ b/types/ng-i18next/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ng-notify/tslint.json
+++ b/types/ng-notify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngbootbox/tslint.json
+++ b/types/ngbootbox/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngeohash/tslint.json
+++ b/types/ngeohash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngkookies/tslint.json
+++ b/types/ngkookies/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngmap/tslint.json
+++ b/types/ngmap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngprogress-lite/tslint.json
+++ b/types/ngprogress-lite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngprogress/tslint.json
+++ b/types/ngprogress/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ngreact/tslint.json
+++ b/types/ngreact/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nightmare/tslint.json
+++ b/types/nightmare/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/noble/tslint.json
+++ b/types/noble/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nock/tslint.json
+++ b/types/nock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodal/tslint.json
+++ b/types/nodal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-7z/tslint.json
+++ b/types/node-7z/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-array-ext/tslint.json
+++ b/types/node-array-ext/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-calendar/tslint.json
+++ b/types/node-calendar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-config-manager/tslint.json
+++ b/types/node-config-manager/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-dir/tslint.json
+++ b/types/node-dir/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-dogstatsd/tslint.json
+++ b/types/node-dogstatsd/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-fibers/tslint.json
+++ b/types/node-fibers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-forge/tslint.json
+++ b/types/node-forge/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-gcm/tslint.json
+++ b/types/node-gcm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-getopt/tslint.json
+++ b/types/node-getopt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-hue-api/tslint.json
+++ b/types/node-hue-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-int64/tslint.json
+++ b/types/node-int64/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-jsfl-runner/tslint.json
+++ b/types/node-jsfl-runner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-json-db/tslint.json
+++ b/types/node-json-db/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-mysql-wrapper/tslint.json
+++ b/types/node-mysql-wrapper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-notifier/tslint.json
+++ b/types/node-notifier/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-persist/tslint.json
+++ b/types/node-persist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-polyglot/tslint.json
+++ b/types/node-polyglot/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-powershell/tslint.json
+++ b/types/node-powershell/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-sass-middleware/tslint.json
+++ b/types/node-sass-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-slack/tslint.json
+++ b/types/node-slack/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-snap7/tslint.json
+++ b/types/node-snap7/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-uuid/tslint.json
+++ b/types/node-uuid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node-validator/tslint.json
+++ b/types/node-validator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/node_redis/tslint.json
+++ b/types/node_redis/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodemailer-direct-transport/tslint.json
+++ b/types/nodemailer-direct-transport/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodemailer-pickup-transport/tslint.json
+++ b/types/nodemailer-pickup-transport/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodemailer-smtp-pool/tslint.json
+++ b/types/nodemailer-smtp-pool/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodemailer-smtp-transport/tslint.json
+++ b/types/nodemailer-smtp-transport/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodemailer-stub-transport/tslint.json
+++ b/types/nodemailer-stub-transport/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nodeunit/tslint.json
+++ b/types/nodeunit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/noisejs/tslint.json
+++ b/types/noisejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nomnom/tslint.json
+++ b/types/nomnom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nopt/tslint.json
+++ b/types/nopt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/notie/tslint.json
+++ b/types/notie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/notify/tslint.json
+++ b/types/notify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/notifyjs-browser/tslint.json
+++ b/types/notifyjs-browser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/notifyjs/tslint.json
+++ b/types/notifyjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nouislider/tslint.json
+++ b/types/nouislider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/npm/tslint.json
+++ b/types/npm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nprogress/tslint.json
+++ b/types/nprogress/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/numeral/tslint.json
+++ b/types/numeral/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nunjucks-date/tslint.json
+++ b/types/nunjucks-date/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nvd3/tslint.json
+++ b/types/nvd3/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nw.gui/tslint.json
+++ b/types/nw.gui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/nw.js/tslint.json
+++ b/types/nw.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/o.js/tslint.json
+++ b/types/o.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oauth.js/tslint.json
+++ b/types/oauth.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/object-assign/tslint.json
+++ b/types/object-assign/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/object-diff/tslint.json
+++ b/types/object-diff/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/object-hash/tslint.json
+++ b/types/object-hash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/object-refs/tslint.json
+++ b/types/object-refs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oblo-util/tslint.json
+++ b/types/oblo-util/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oboe/tslint.json
+++ b/types/oboe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/observe-js/tslint.json
+++ b/types/observe-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oclazyload/tslint.json
+++ b/types/oclazyload/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/odata/tslint.json
+++ b/types/odata/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/office-js-preview/tslint.json
+++ b/types/office-js-preview/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "file-name-casing": false,

--- a/types/office-js/tslint.json
+++ b/types/office-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/offline-js/tslint.json
+++ b/types/offline-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oidc-token-manager/tslint.json
+++ b/types/oidc-token-manager/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/onoff/tslint.json
+++ b/types/onoff/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/open/tslint.json
+++ b/types/open/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/openjscad/tslint.json
+++ b/types/openjscad/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/openpgp/tslint.json
+++ b/types/openpgp/tslint.json
@@ -5,6 +5,7 @@
         "array-type": false,
         "ban-types": false,
         "dt-header": false,
+        "npm-naming": false,
         "jsdoc-format": false,
         "max-line-length": false,
         "no-consecutive-blank-lines": false,

--- a/types/opentok/tslint.json
+++ b/types/opentok/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/openui5/tslint.json
+++ b/types/openui5/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/optimist/tslint.json
+++ b/types/optimist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/oracledb/tslint.json
+++ b/types/oracledb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/orchestrator/tslint.json
+++ b/types/orchestrator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/osmtogeojson/tslint.json
+++ b/types/osmtogeojson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/owlcarousel/tslint.json
+++ b/types/owlcarousel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/p2/tslint.json
+++ b/types/p2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/packery/tslint.json
+++ b/types/packery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/page-icon/tslint.json
+++ b/types/page-icon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/page/tslint.json
+++ b/types/page/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pako/tslint.json
+++ b/types/pako/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/papaparse/tslint.json
+++ b/types/papaparse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/paper/tslint.json
+++ b/types/paper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/paralleljs/tslint.json
+++ b/types/paralleljs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/parcel-env/tslint.json
+++ b/types/parcel-env/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/parse-glob/tslint.json
+++ b/types/parse-glob/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/parse-mockdb/tslint.json
+++ b/types/parse-mockdb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/parse/tslint.json
+++ b/types/parse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-beam/tslint.json
+++ b/types/passport-beam/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-google-oauth/tslint.json
+++ b/types/passport-google-oauth/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-http-bearer/tslint.json
+++ b/types/passport-http-bearer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-jwt/tslint.json
+++ b/types/passport-jwt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-local-mongoose/tslint.json
+++ b/types/passport-local-mongoose/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-local/tslint.json
+++ b/types/passport-local/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-oauth2-client-password/tslint.json
+++ b/types/passport-oauth2-client-password/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-strategy/tslint.json
+++ b/types/passport-strategy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/passport-twitter/tslint.json
+++ b/types/passport-twitter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/password-hash/tslint.json
+++ b/types/password-hash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/path-parse/tslint.json
+++ b/types/path-parse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pathfinding/tslint.json
+++ b/types/pathfinding/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pathjs/tslint.json
+++ b/types/pathjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/paypal-cordova-plugin/tslint.json
+++ b/types/paypal-cordova-plugin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pdfjs-dist/tslint.json
+++ b/types/pdfjs-dist/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pdfkit/tslint.json
+++ b/types/pdfkit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pdfobject/tslint.json
+++ b/types/pdfobject/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pebblekitjs/tslint.json
+++ b/types/pebblekitjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/peerjs/tslint.json
+++ b/types/peerjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pegjs/tslint.json
+++ b/types/pegjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/persona/tslint.json
+++ b/types/persona/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pg-pool/tslint.json
+++ b/types/pg-pool/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pgwmodal/tslint.json
+++ b/types/pgwmodal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phantom/tslint.json
+++ b/types/phantom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phantomcss/tslint.json
+++ b/types/phantomcss/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phantomjs/tslint.json
+++ b/types/phantomjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phone-formatter/tslint.json
+++ b/types/phone-formatter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phone/tslint.json
+++ b/types/phone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phonegap-facebook-plugin/tslint.json
+++ b/types/phonegap-facebook-plugin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phonegap-nfc/tslint.json
+++ b/types/phonegap-nfc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phonegap-plugin-barcodescanner/tslint.json
+++ b/types/phonegap-plugin-barcodescanner/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/phonegap/tslint.json
+++ b/types/phonegap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/photonui/tslint.json
+++ b/types/photonui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/photoswipe/tslint.json
+++ b/types/photoswipe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/physijs/tslint.json
+++ b/types/physijs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pi-spi/tslint.json
+++ b/types/pi-spi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pickadate/tslint.json
+++ b/types/pickadate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pify/tslint.json
+++ b/types/pify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pinkyswear/tslint.json
+++ b/types/pinkyswear/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pinterest-sdk/tslint.json
+++ b/types/pinterest-sdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/piwik-tracker/tslint.json
+++ b/types/piwik-tracker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pixi.js/tslint.json
+++ b/types/pixi.js/tslint.json
@@ -4,6 +4,7 @@
         // TODOs
         "ban-types": false,
         "dt-header": false,
+        "npm-naming": false,
         "interface-name": false,
         "no-any-union": false,
         "no-declare-current-package": false,

--- a/types/pkijs/tslint.json
+++ b/types/pkijs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/platform/tslint.json
+++ b/types/platform/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/playerframework/tslint.json
+++ b/types/playerframework/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pleasejs/tslint.json
+++ b/types/pleasejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/plupload/tslint.json
+++ b/types/plupload/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pluralize/tslint.json
+++ b/types/pluralize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pngjs2/tslint.json
+++ b/types/pngjs2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/podcast/tslint.json
+++ b/types/podcast/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/podium/tslint.json
+++ b/types/podium/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/polyline/tslint.json
+++ b/types/polyline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/polymer-ts/tslint.json
+++ b/types/polymer-ts/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/polymer/tslint.json
+++ b/types/polymer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/popcorn/tslint.json
+++ b/types/popcorn/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/postal/tslint.json
+++ b/types/postal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/power-assert-formatter/tslint.json
+++ b/types/power-assert-formatter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/power-assert/tslint.json
+++ b/types/power-assert/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/precise/tslint.json
+++ b/types/precise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/precond/tslint.json
+++ b/types/precond/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/preloadjs/tslint.json
+++ b/types/preloadjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/prelude-ls/tslint.json
+++ b/types/prelude-ls/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/prettyjson/tslint.json
+++ b/types/prettyjson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/priorityqueuejs/tslint.json
+++ b/types/priorityqueuejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/progress/tslint.json
+++ b/types/progress/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/progressjs/tslint.json
+++ b/types/progressjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/project-oxford/tslint.json
+++ b/types/project-oxford/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/promise-pg/tslint.json
+++ b/types/promise-pg/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/promise-pool/tslint.json
+++ b/types/promise-pool/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/promisify-node/tslint.json
+++ b/types/promisify-node/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/promisify-supertest/tslint.json
+++ b/types/promisify-supertest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/prompt-sync-history/tslint.json
+++ b/types/prompt-sync-history/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/prompt-sync/tslint.json
+++ b/types/prompt-sync/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/promptly/tslint.json
+++ b/types/promptly/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/protractor-helpers/tslint.json
+++ b/types/protractor-helpers/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/protractor-http-mock/tslint.json
+++ b/types/protractor-http-mock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/proxyquire/tslint.json
+++ b/types/proxyquire/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pty.js/tslint.json
+++ b/types/pty.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pubsub-js/tslint.json
+++ b/types/pubsub-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pug/tslint.json
+++ b/types/pug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pure-render-decorator/tslint.json
+++ b/types/pure-render-decorator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/purl/tslint.json
+++ b/types/purl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/pvutils/tslint.json
+++ b/types/pvutils/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/q-io/tslint.json
+++ b/types/q-io/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/q-retry/tslint.json
+++ b/types/q-retry/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/qs/tslint.json
+++ b/types/qs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/qtip2/tslint.json
+++ b/types/qtip2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/quixote/tslint.json
+++ b/types/quixote/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/qunit/tslint.json
+++ b/types/qunit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/quoted-printable/tslint.json
+++ b/types/quoted-printable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/qwest/tslint.json
+++ b/types/qwest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rabbit.js/tslint.json
+++ b/types/rabbit.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ractive/tslint.json
+++ b/types/ractive/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/radium/tslint.json
+++ b/types/radium/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/radius/tslint.json
+++ b/types/radius/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/random-string/tslint.json
+++ b/types/random-string/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/randomcolor/tslint.json
+++ b/types/randomcolor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/randomstring/tslint.json
+++ b/types/randomstring/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rangy/tslint.json
+++ b/types/rangy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rangyinputs/tslint.json
+++ b/types/rangyinputs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/raphael/tslint.json
+++ b/types/raphael/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ratelimiter/tslint.json
+++ b/types/ratelimiter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/raty/tslint.json
+++ b/types/raty/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rbush/tslint.json
+++ b/types/rbush/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rc-select/tslint.json
+++ b/types/rc-select/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rcloader/tslint.json
+++ b/types/rcloader/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-create-fragment/tslint.json
+++ b/types/react-addons-create-fragment/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-css-transition-group/tslint.json
+++ b/types/react-addons-css-transition-group/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-linked-state-mixin/tslint.json
+++ b/types/react-addons-linked-state-mixin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-perf/tslint.json
+++ b/types/react-addons-perf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-pure-render-mixin/tslint.json
+++ b/types/react-addons-pure-render-mixin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-shallow-compare/tslint.json
+++ b/types/react-addons-shallow-compare/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-test-utils/tslint.json
+++ b/types/react-addons-test-utils/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-transition-group/tslint.json
+++ b/types/react-addons-transition-group/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-addons-update/tslint.json
+++ b/types/react-addons-update/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-bootstrap-daterangepicker/tslint.json
+++ b/types/react-bootstrap-daterangepicker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-breadcrumbs/tslint.json
+++ b/types/react-breadcrumbs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-bytesize-icons/tslint.json
+++ b/types/react-bytesize-icons/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-calendar-timeline/tslint.json
+++ b/types/react-calendar-timeline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-codemirror/tslint.json
+++ b/types/react-codemirror/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-css-modules/tslint.json
+++ b/types/react-css-modules/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-css-transition-replace/tslint.json
+++ b/types/react-css-transition-replace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-custom-scrollbars/tslint.json
+++ b/types/react-custom-scrollbars/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-data-grid/tslint.json
+++ b/types/react-data-grid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-datagrid/tslint.json
+++ b/types/react-datagrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-dates/tslint.json
+++ b/types/react-dates/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "file-name-casing": false,

--- a/types/react-dom/tslint.json
+++ b/types/react-dom/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-unnecessary-generics": false,
         "no-unnecessary-type-assertion": false
     }

--- a/types/react-dropzone/tslint.json
+++ b/types/react-dropzone/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-easy-chart/tslint.json
+++ b/types/react-easy-chart/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-file-input/tslint.json
+++ b/types/react-file-input/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-flex/tslint.json
+++ b/types/react-flex/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-flexr/tslint.json
+++ b/types/react-flexr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-helmet/tslint.json
+++ b/types/react-helmet/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-holder/tslint.json
+++ b/types/react-holder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-imageloader/tslint.json
+++ b/types/react-imageloader/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-infinite/tslint.json
+++ b/types/react-infinite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-input-calendar/tslint.json
+++ b/types/react-input-calendar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-intl-redux/tslint.json
+++ b/types/react-intl-redux/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-is-deprecated/tslint.json
+++ b/types/react-is-deprecated/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-jsonschema-form/tslint.json
+++ b/types/react-jsonschema-form/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-mdl/tslint.json
+++ b/types/react-mdl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-mixin/tslint.json
+++ b/types/react-mixin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-motion-slider/tslint.json
+++ b/types/react-motion-slider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-motion/tslint.json
+++ b/types/react-motion/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-native-orientation/tslint.json
+++ b/types/react-native-orientation/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-native-sortable-list/tslint.json
+++ b/types/react-native-sortable-list/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-native-touch-id/tslint.json
+++ b/types/react-native-touch-id/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-notification-system/tslint.json
+++ b/types/react-notification-system/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-props-decorators/tslint.json
+++ b/types/react-props-decorators/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-redux-i18n/tslint.json
+++ b/types/react-redux-i18n/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-redux-toastr/tslint.json
+++ b/types/react-redux-toastr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-router-bootstrap/tslint.json
+++ b/types/react-router-bootstrap/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-scrollbar/tslint.json
+++ b/types/react-scrollbar/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-spinkit/tslint.json
+++ b/types/react-spinkit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-swf/tslint.json
+++ b/types/react-swf/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-tagcloud/tslint.json
+++ b/types/react-tagcloud/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-tap-event-plugin/tslint.json
+++ b/types/react-tap-event-plugin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-test-renderer/tslint.json
+++ b/types/react-test-renderer/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "dt-header": false,
+        "npm-naming": false,
         "no-unnecessary-generics": false
     }
 }

--- a/types/react-textarea-autosize/tslint.json
+++ b/types/react-textarea-autosize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react-user-tour/tslint.json
+++ b/types/react-user-tour/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/react/tslint.json
+++ b/types/react/tslint.json
@@ -3,6 +3,7 @@
 	"rules": {
 		// TODOs
 		"dt-header": false,
+        "npm-naming": false,
 		"no-any-union": false,
 		"no-empty-interface": false,
 		"no-object-literal-type-assertion": false,

--- a/types/reactcss/tslint.json
+++ b/types/reactcss/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/read/tslint.json
+++ b/types/read/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/readdir-stream/tslint.json
+++ b/types/readdir-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/recompose/tslint.json
+++ b/types/recompose/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redis-scripto/tslint.json
+++ b/types/redis-scripto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-action-utils/tslint.json
+++ b/types/redux-action-utils/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-debounced/tslint.json
+++ b/types/redux-debounced/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-devtools-dock-monitor/tslint.json
+++ b/types/redux-devtools-dock-monitor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-devtools-log-monitor/tslint.json
+++ b/types/redux-devtools-log-monitor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-devtools/tslint.json
+++ b/types/redux-devtools/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-immutable/tslint.json
+++ b/types/redux-immutable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-mock-store/tslint.json
+++ b/types/redux-mock-store/tslint.json
@@ -3,6 +3,7 @@
 	"rules": {
 		// TODO
 		"dt-header": false,
+        "npm-naming": false,
 		"no-unnecessary-generics": false
 	}
 }

--- a/types/redux-optimistic-ui/tslint.json
+++ b/types/redux-optimistic-ui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-promise-middleware/tslint.json
+++ b/types/redux-promise-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-promise/tslint.json
+++ b/types/redux-promise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-recycle/tslint.json
+++ b/types/redux-recycle/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-router/tslint.json
+++ b/types/redux-router/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/redux-storage/tslint.json
+++ b/types/redux-storage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-array-di/tslint.json
+++ b/types/ref-array-di/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-array/tslint.json
+++ b/types/ref-array/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-napi/tslint.json
+++ b/types/ref-napi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-struct-di/tslint.json
+++ b/types/ref-struct-di/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-struct/tslint.json
+++ b/types/ref-struct/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-union-di/tslint.json
+++ b/types/ref-union-di/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref-union/tslint.json
+++ b/types/ref-union/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ref/tslint.json
+++ b/types/ref/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/relateurl/tslint.json
+++ b/types/relateurl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/replace-ext/tslint.json
+++ b/types/replace-ext/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/request-ip/tslint.json
+++ b/types/request-ip/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/requirejs-domready/tslint.json
+++ b/types/requirejs-domready/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/requirejs/tslint.json
+++ b/types/requirejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/resemblejs/tslint.json
+++ b/types/resemblejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/resolve/tslint.json
+++ b/types/resolve/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/response-time/tslint.json
+++ b/types/response-time/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rest/tslint.json
+++ b/types/rest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/restangular/tslint.json
+++ b/types/restangular/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/restful.js/tslint.json
+++ b/types/restful.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/restler/tslint.json
+++ b/types/restler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/resumablejs/tslint.json
+++ b/types/resumablejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rethinkdb/tslint.json
+++ b/types/rethinkdb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/revalidator/tslint.json
+++ b/types/revalidator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/reveal/tslint.json
+++ b/types/reveal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rickshaw/tslint.json
+++ b/types/rickshaw/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/riot-api-nodejs/tslint.json
+++ b/types/riot-api-nodejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/riot-games-api/tslint.json
+++ b/types/riot-games-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/riotcontrol/tslint.json
+++ b/types/riotcontrol/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/riotjs/tslint.json
+++ b/types/riotjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rison/tslint.json
+++ b/types/rison/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rosie/tslint.json
+++ b/types/rosie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/roslib/tslint.json
+++ b/types/roslib/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/routie/tslint.json
+++ b/types/routie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/royalslider/tslint.json
+++ b/types/royalslider/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rpio/tslint.json
+++ b/types/rpio/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rsmq-worker/tslint.json
+++ b/types/rsmq-worker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rsmq/tslint.json
+++ b/types/rsmq/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rss/tslint.json
+++ b/types/rss/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rsvp/tslint.json
+++ b/types/rsvp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rsync/tslint.json
+++ b/types/rsync/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rtree/tslint.json
+++ b/types/rtree/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/run-sequence/tslint.json
+++ b/types/run-sequence/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rx-angular/tslint.json
+++ b/types/rx-angular/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rx-core-binding/tslint.json
+++ b/types/rx-core-binding/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-declare-current-package": false,
         "no-empty-interface": false,
         "interface-name": false,

--- a/types/rx-core/tslint.json
+++ b/types/rx-core/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "unified-signatures": false,
         "no-declare-current-package": false,
         "no-empty-interface": false,

--- a/types/rx-jquery/tslint.json
+++ b/types/rx-jquery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rx-lite-aggregates/tslint.json
+++ b/types/rx-lite-aggregates/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODO
         "dt-header": false,
+        "npm-naming": false,
         "unified-signatures": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false

--- a/types/rx-lite-coincidence/tslint.json
+++ b/types/rx-lite-coincidence/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "unified-signatures": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false,

--- a/types/rx-lite-time/tslint.json
+++ b/types/rx-lite-time/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "unified-signatures": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false,

--- a/types/rx-lite-virtualtime/tslint.json
+++ b/types/rx-lite-virtualtime/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "interface-name": false,
         "no-declare-current-package": false,
         "no-empty-interface": false,

--- a/types/rx-lite/tslint.json
+++ b/types/rx-lite/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "unified-signatures": false,
         "no-declare-current-package": false,
         "no-empty-interface": false,

--- a/types/rx-node/tslint.json
+++ b/types/rx-node/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rx.wamp/tslint.json
+++ b/types/rx.wamp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/rx/tslint.json
+++ b/types/rx/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false
     }

--- a/types/s3-uploader/tslint.json
+++ b/types/s3-uploader/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/s3rver/tslint.json
+++ b/types/s3rver/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/safari-extension-content/tslint.json
+++ b/types/safari-extension-content/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/safari-extension/tslint.json
+++ b/types/safari-extension/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sails.io.js/tslint.json
+++ b/types/sails.io.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/saml2-js/tslint.json
+++ b/types/saml2-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/samlp/tslint.json
+++ b/types/samlp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sammy/tslint.json
+++ b/types/sammy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sandboxed-module/tslint.json
+++ b/types/sandboxed-module/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sanitize-filename/tslint.json
+++ b/types/sanitize-filename/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sanitize-html/tslint.json
+++ b/types/sanitize-html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sanitizer/tslint.json
+++ b/types/sanitizer/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sass-graph/tslint.json
+++ b/types/sass-graph/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sat/tslint.json
+++ b/types/sat/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/satnav/tslint.json
+++ b/types/satnav/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sax/tslint.json
+++ b/types/sax/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/scalike/tslint.json
+++ b/types/scalike/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/screeps/tslint.json
+++ b/types/screeps/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "no-redundant-jsdoc-2": false,
         "dt-header": false,
+        "npm-naming": false,
         "no-empty-interface": false,
         "no-unnecessary-generics": false,
         "no-misused-new": false,

--- a/types/scriptjs/tslint.json
+++ b/types/scriptjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/scroll-into-view/tslint.json
+++ b/types/scroll-into-view/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/scrollreveal/tslint.json
+++ b/types/scrollreveal/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/scrolltofixed/tslint.json
+++ b/types/scrolltofixed/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/scrypt-async/tslint.json
+++ b/types/scrypt-async/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/seamless/tslint.json
+++ b/types/seamless/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/seedrandom/tslint.json
+++ b/types/seedrandom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/segment-analytics/tslint.json
+++ b/types/segment-analytics/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/selectize/tslint.json
+++ b/types/selectize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/semaphore/tslint.json
+++ b/types/semaphore/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sencha_touch/tslint.json
+++ b/types/sencha_touch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/send/tslint.json
+++ b/types/send/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/seneca/tslint.json
+++ b/types/seneca/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sequelize-fixtures/tslint.json
+++ b/types/sequelize-fixtures/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sequelize/tslint.json
+++ b/types/sequelize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sequester/tslint.json
+++ b/types/sequester/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/serve-favicon/tslint.json
+++ b/types/serve-favicon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/serve-index/tslint.json
+++ b/types/serve-index/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/serve-static/tslint.json
+++ b/types/serve-static/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/set-cookie-parser/tslint.json
+++ b/types/set-cookie-parser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sharedworker/tslint.json
+++ b/types/sharedworker/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sharepoint/tslint.json
+++ b/types/sharepoint/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "jsdoc-format": false,
         "max-line-length": false,
         "no-any-union": false,

--- a/types/shopify-buy/tslint.json
+++ b/types/shopify-buy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/shortid/tslint.json
+++ b/types/shortid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/showdown/tslint.json
+++ b/types/showdown/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/shuffle-array/tslint.json
+++ b/types/shuffle-array/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/siesta/tslint.json
+++ b/types/siesta/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sigmajs/tslint.json
+++ b/types/sigmajs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/signalr/tslint.json
+++ b/types/signalr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/signature_pad/tslint.json
+++ b/types/signature_pad/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simple-assign/tslint.json
+++ b/types/simple-assign/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simple-cw-node/tslint.json
+++ b/types/simple-cw-node/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simple-mock/tslint.json
+++ b/types/simple-mock/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simple-url-cache/tslint.json
+++ b/types/simple-url-cache/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simplemde/tslint.json
+++ b/types/simplemde/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simplesmtp/tslint.json
+++ b/types/simplesmtp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/simplestorage.js/tslint.json
+++ b/types/simplestorage.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sinon-as-promised/tslint.json
+++ b/types/sinon-as-promised/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sinon-chai/tslint.json
+++ b/types/sinon-chai/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sinon-chrome/tslint.json
+++ b/types/sinon-chrome/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sinon-mongoose/tslint.json
+++ b/types/sinon-mongoose/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sinon-stub-promise/tslint.json
+++ b/types/sinon-stub-promise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sipml/tslint.json
+++ b/types/sipml/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sjcl/tslint.json
+++ b/types/sjcl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ski/tslint.json
+++ b/types/ski/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/skyway/tslint.json
+++ b/types/skyway/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slack-node/tslint.json
+++ b/types/slack-node/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slackify-html/tslint.json
+++ b/types/slackify-html/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slate-irc/tslint.json
+++ b/types/slate-irc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sleep/tslint.json
+++ b/types/sleep/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slick-carousel/tslint.json
+++ b/types/slick-carousel/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slickgrid/tslint.json
+++ b/types/slickgrid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/slideout/tslint.json
+++ b/types/slideout/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/smart-fox-server/tslint.json
+++ b/types/smart-fox-server/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/smtpapi/tslint.json
+++ b/types/smtpapi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/snapsvg/tslint.json
+++ b/types/snapsvg/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/socket.io-client/tslint.json
+++ b/types/socket.io-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/socket.io-redis/tslint.json
+++ b/types/socket.io-redis/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/socket.io.users/tslint.json
+++ b/types/socket.io.users/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/socket.io/tslint.json
+++ b/types/socket.io/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/socketty/tslint.json
+++ b/types/socketty/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/solution-center-communicator/tslint.json
+++ b/types/solution-center-communicator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sortablejs/tslint.json
+++ b/types/sortablejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/soundjs/tslint.json
+++ b/types/soundjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/source-list-map/tslint.json
+++ b/types/source-list-map/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/space-pen/tslint.json
+++ b/types/space-pen/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/spectrum/tslint.json
+++ b/types/spectrum/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/split/tslint.json
+++ b/types/split/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/split2/tslint.json
+++ b/types/split2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/spotify-api/tslint.json
+++ b/types/spotify-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sql.js/tslint.json
+++ b/types/sql.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sqs-consumer/tslint.json
+++ b/types/sqs-consumer/tslint.json
@@ -4,6 +4,7 @@
         // TODOs
         "ban-types": false,
         "dt-header": false,
+        "npm-naming": false,
         "strict-export-declare-modifiers": false
     }
 }

--- a/types/squirejs/tslint.json
+++ b/types/squirejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/srp/tslint.json
+++ b/types/srp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ssh2-streams/tslint.json
+++ b/types/ssh2-streams/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ssh2/tslint.json
+++ b/types/ssh2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stack-mapper/tslint.json
+++ b/types/stack-mapper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stack-trace/tslint.json
+++ b/types/stack-trace/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stacktrace-js/tslint.json
+++ b/types/stacktrace-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/static-eval/tslint.json
+++ b/types/static-eval/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stats.js/tslint.json
+++ b/types/stats.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/statsd-client/tslint.json
+++ b/types/statsd-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/steam/tslint.json
+++ b/types/steam/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stompjs/tslint.json
+++ b/types/stompjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/store/tslint.json
+++ b/types/store/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stream-meter/tslint.json
+++ b/types/stream-meter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stream-series/tslint.json
+++ b/types/stream-series/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/streamjs/tslint.json
+++ b/types/streamjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/strftime/tslint.json
+++ b/types/strftime/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/string-hash/tslint.json
+++ b/types/string-hash/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/string-template/tslint.json
+++ b/types/string-template/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/string/tslint.json
+++ b/types/string/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/string_score/tslint.json
+++ b/types/string_score/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/strip-json-comments/tslint.json
+++ b/types/strip-json-comments/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/stripe-v3/tslint.json
+++ b/types/stripe-v3/tslint.json
@@ -3,6 +3,7 @@
 	"rules": {
 		// TODOs
 		"dt-header": false,
+        "npm-naming": false,
         "no-angle-bracket-type-assertion": false,
 		"no-any-union": false
 	}

--- a/types/strophe/tslint.json
+++ b/types/strophe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/succinct/tslint.json
+++ b/types/succinct/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/suitescript/tslint.json
+++ b/types/suitescript/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/supertest/tslint.json
+++ b/types/supertest/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/svg-injector/tslint.json
+++ b/types/svg-injector/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/svg-sprite/tslint.json
+++ b/types/svg-sprite/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/svgjs.draggable/tslint.json
+++ b/types/svgjs.draggable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/svgjs.resize/tslint.json
+++ b/types/svgjs.resize/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swag/tslint.json
+++ b/types/swag/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swagger-express-middleware/tslint.json
+++ b/types/swagger-express-middleware/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swagger-jsdoc/tslint.json
+++ b/types/swagger-jsdoc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swaggerize-express/tslint.json
+++ b/types/swaggerize-express/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swfobject/tslint.json
+++ b/types/swfobject/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swiftclick/tslint.json
+++ b/types/swiftclick/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swig/tslint.json
+++ b/types/swig/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swipe/tslint.json
+++ b/types/swipe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swipeview/tslint.json
+++ b/types/swipeview/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/switchery/tslint.json
+++ b/types/switchery/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/swiz/tslint.json
+++ b/types/swiz/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/sylvester/tslint.json
+++ b/types/sylvester/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/synaptic/tslint.json
+++ b/types/synaptic/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tabtab/tslint.json
+++ b/types/tabtab/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tapable/tslint.json
+++ b/types/tapable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tape/tslint.json
+++ b/types/tape/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tea-merge/tslint.json
+++ b/types/tea-merge/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tedious/tslint.json
+++ b/types/tedious/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/teechart/tslint.json
+++ b/types/teechart/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/temp-fs/tslint.json
+++ b/types/temp-fs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/terminal-menu/tslint.json
+++ b/types/terminal-menu/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tesseract.js/tslint.json
+++ b/types/tesseract.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tether-drop/tslint.json
+++ b/types/tether-drop/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tether-shepherd/tslint.json
+++ b/types/tether-shepherd/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tether/tslint.json
+++ b/types/tether/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/text-encoding/tslint.json
+++ b/types/text-encoding/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/three/tslint.json
+++ b/types/three/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/through/tslint.json
+++ b/types/through/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/through2/tslint.json
+++ b/types/through2/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tile-reduce/tslint.json
+++ b/types/tile-reduce/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tilebelt/tslint.json
+++ b/types/tilebelt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/timelinejs/tslint.json
+++ b/types/timelinejs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/timelinejs3/tslint.json
+++ b/types/timelinejs3/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/timezone-js/tslint.json
+++ b/types/timezone-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tinder/tslint.json
+++ b/types/tinder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tinycopy/tslint.json
+++ b/types/tinycopy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/title/tslint.json
+++ b/types/title/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tldjs/tslint.json
+++ b/types/tldjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/to-title-case-gouch/tslint.json
+++ b/types/to-title-case-gouch/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/toastr/tslint.json
+++ b/types/toastr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tooltipster/tslint.json
+++ b/types/tooltipster/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/torrent-stream/tslint.json
+++ b/types/torrent-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/touch-events/tslint.json
+++ b/types/touch-events/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/traceback/tslint.json
+++ b/types/traceback/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tracking/tslint.json
+++ b/types/tracking/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/traverse/tslint.json
+++ b/types/traverse/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/traverson/tslint.json
+++ b/types/traverson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/trayballoon/tslint.json
+++ b/types/trayballoon/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/trim/tslint.json
+++ b/types/trim/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/trunk8/tslint.json
+++ b/types/trunk8/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tspromise/tslint.json
+++ b/types/tspromise/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tv4/tslint.json
+++ b/types/tv4/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tweenjs/tslint.json
+++ b/types/tweenjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twilio/tslint.json
+++ b/types/twilio/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twit/tslint.json
+++ b/types/twit/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twitter-for-web/tslint.json
+++ b/types/twitter-for-web/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twitter-stream-channels/tslint.json
+++ b/types/twitter-stream-channels/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twitter-text/tslint.json
+++ b/types/twitter-text/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/twix/tslint.json
+++ b/types/twix/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/type-check/tslint.json
+++ b/types/type-check/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/type-detect/tslint.json
+++ b/types/type-detect/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/type-name/tslint.json
+++ b/types/type-name/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/typeahead/tslint.json
+++ b/types/typeahead/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/typedarray-pool/tslint.json
+++ b/types/typedarray-pool/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/typescript-deferred/tslint.json
+++ b/types/typescript-deferred/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/tz-format/tslint.json
+++ b/types/tz-format/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ua-parser-js/tslint.json
+++ b/types/ua-parser-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uglifycss/tslint.json
+++ b/types/uglifycss/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ui-grid/tslint.json
+++ b/types/ui-grid/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ui-select/tslint.json
+++ b/types/ui-select/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uid-safe/tslint.json
+++ b/types/uid-safe/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/umbraco/tslint.json
+++ b/types/umbraco/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/umd/tslint.json
+++ b/types/umd/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/umzug/tslint.json
+++ b/types/umzug/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/underscore-ko/tslint.json
+++ b/types/underscore-ko/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/underscore.string/tslint.json
+++ b/types/underscore.string/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/underscore/tslint.json
+++ b/types/underscore/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uniq/tslint.json
+++ b/types/uniq/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/unique-random/tslint.json
+++ b/types/unique-random/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/unity-webapi/tslint.json
+++ b/types/unity-webapi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/unorm/tslint.json
+++ b/types/unorm/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/urbanairship-cordova/tslint.json
+++ b/types/urbanairship-cordova/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uri-templates/tslint.json
+++ b/types/uri-templates/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/urijs/tslint.json
+++ b/types/urijs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/url-template/tslint.json
+++ b/types/url-template/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/urlrouter/tslint.json
+++ b/types/urlrouter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/urlsafe-base64/tslint.json
+++ b/types/urlsafe-base64/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/usage/tslint.json
+++ b/types/usage/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/useragent/tslint.json
+++ b/types/useragent/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/username/tslint.json
+++ b/types/username/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/utf8/tslint.json
+++ b/types/utf8/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/utils-merge/tslint.json
+++ b/types/utils-merge/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uuid-1345/tslint.json
+++ b/types/uuid-1345/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/uws/tslint.json
+++ b/types/uws/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/v8-profiler/tslint.json
+++ b/types/v8-profiler/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/valdr-message/tslint.json
+++ b/types/valdr-message/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/valdr/tslint.json
+++ b/types/valdr/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/valerie/tslint.json
+++ b/types/valerie/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/valid-url/tslint.json
+++ b/types/valid-url/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/validator/tslint.json
+++ b/types/validator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/validatorjs/tslint.json
+++ b/types/validatorjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vec3/tslint.json
+++ b/types/vec3/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vectorious/tslint.json
+++ b/types/vectorious/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/velocity-animate/tslint.json
+++ b/types/velocity-animate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vex-js/tslint.json
+++ b/types/vex-js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vexflow/tslint.json
+++ b/types/vexflow/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/victor/tslint.json
+++ b/types/victor/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/viewporter/tslint.json
+++ b/types/viewporter/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vimeo/tslint.json
+++ b/types/vimeo/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vinyl-paths/tslint.json
+++ b/types/vinyl-paths/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vinyl-source-stream/tslint.json
+++ b/types/vinyl-source-stream/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/virtual-dom/tslint.json
+++ b/types/virtual-dom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vitalsigns/tslint.json
+++ b/types/vitalsigns/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vivus/tslint.json
+++ b/types/vivus/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/voronoi-diagram/tslint.json
+++ b/types/voronoi-diagram/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vortex-web-client/tslint.json
+++ b/types/vortex-web-client/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/voximplant-websdk/tslint.json
+++ b/types/voximplant-websdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/vue-resource/tslint.json
+++ b/types/vue-resource/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/w2ui/tslint.json
+++ b/types/w2ui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/w3c-gamepad/tslint.json
+++ b/types/w3c-gamepad/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/waitme/tslint.json
+++ b/types/waitme/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wake_on_lan/tslint.json
+++ b/types/wake_on_lan/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wallabyjs/tslint.json
+++ b/types/wallabyjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wampy/tslint.json
+++ b/types/wampy/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/warning/tslint.json
+++ b/types/warning/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/watchify/tslint.json
+++ b/types/watchify/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/waterline/tslint.json
+++ b/types/waterline/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/weapp-api/tslint.json
+++ b/types/weapp-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/web-bluetooth/tslint.json
+++ b/types/web-bluetooth/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webassembly-js-api/tslint.json
+++ b/types/webassembly-js-api/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         // TODOs
         "dt-header": false,
+        "npm-naming": false,
         "no-unnecessary-class": false
     }
 }

--- a/types/webcl/tslint.json
+++ b/types/webcl/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webcrypto/tslint.json
+++ b/types/webcrypto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webfontloader/tslint.json
+++ b/types/webfontloader/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webgl-ext/tslint.json
+++ b/types/webgl-ext/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webgl2/tslint.json
+++ b/types/webgl2/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "dt-header": false,
+        "npm-naming": false,
         "align": false,
         "adjacent-overload-signatures": false,
         "comment-format": false,

--- a/types/webpack-env/tslint.json
+++ b/types/webpack-env/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webpack-fail-plugin/tslint.json
+++ b/types/webpack-fail-plugin/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webpack-validator/tslint.json
+++ b/types/webpack-validator/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webrtc/tslint.json
+++ b/types/webrtc/tslint.json
@@ -6,6 +6,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "no-empty-interface": false,
         "no-useless-files": false,
         "prefer-method-signature": false

--- a/types/website-scraper/tslint.json
+++ b/types/website-scraper/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/websocket/tslint.json
+++ b/types/websocket/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/websql/tslint.json
+++ b/types/websql/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/webvr-api/tslint.json
+++ b/types/webvr-api/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/weighted/tslint.json
+++ b/types/weighted/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/whatwg-streams/tslint.json
+++ b/types/whatwg-streams/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/when/tslint.json
+++ b/types/when/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/which/tslint.json
+++ b/types/which/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/why-did-you-update/tslint.json
+++ b/types/why-did-you-update/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wiiu/tslint.json
+++ b/types/wiiu/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/window-size/tslint.json
+++ b/types/window-size/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/windows-1251/tslint.json
+++ b/types/windows-1251/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/windows-service/tslint.json
+++ b/types/windows-service/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/winjs/tslint.json
+++ b/types/winjs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/winreg/tslint.json
+++ b/types/winreg/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/winrt-uwp/tslint.json
+++ b/types/winrt-uwp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/winrt/tslint.json
+++ b/types/winrt/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/winston-dynamodb/tslint.json
+++ b/types/winston-dynamodb/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wiredep/tslint.json
+++ b/types/wiredep/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wiring-pi/tslint.json
+++ b/types/wiring-pi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wonder.js/tslint.json
+++ b/types/wonder.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wrap-ansi/tslint.json
+++ b/types/wrap-ansi/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wreck/tslint.json
+++ b/types/wreck/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/wrench/tslint.json
+++ b/types/wrench/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/x-editable/tslint.json
+++ b/types/x-editable/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xdate/tslint.json
+++ b/types/xdate/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xdomain/tslint.json
+++ b/types/xdomain/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xml-parser/tslint.json
+++ b/types/xml-parser/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xmlbuilder/tslint.json
+++ b/types/xmlbuilder/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xmldom/tslint.json
+++ b/types/xmldom/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xmlpoke/tslint.json
+++ b/types/xmlpoke/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xmlrpc/tslint.json
+++ b/types/xmlrpc/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xmltojson/tslint.json
+++ b/types/xmltojson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xregexp/tslint.json
+++ b/types/xregexp/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xsockets/tslint.json
+++ b/types/xsockets/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xss-filters/tslint.json
+++ b/types/xss-filters/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/xtend/tslint.json
+++ b/types/xtend/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/yamljs/tslint.json
+++ b/types/yamljs/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/yandex-money-sdk/tslint.json
+++ b/types/yandex-money-sdk/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/yayson/tslint.json
+++ b/types/yayson/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/ydn-db/tslint.json
+++ b/types/ydn-db/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/yosay/tslint.json
+++ b/types/yosay/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/youtube/tslint.json
+++ b/types/youtube/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/yui/tslint.json
+++ b/types/yui/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/z-schema/tslint.json
+++ b/types/z-schema/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/zepto/tslint.json
+++ b/types/zepto/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/zeroclipboard/tslint.json
+++ b/types/zeroclipboard/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/zip.js/tslint.json
+++ b/types/zip.js/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,

--- a/types/zmq/tslint.json
+++ b/types/zmq/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,


### PR DESCRIPTION
npm-naming is a new rule but the code it runs was already disabled whenever dt-header was disabled. This change keeps the behaviour the same.

Changing 1655 packages should be fine!