### PR TITLE
[angular-material] Add types for $mdUtil

### DIFF
--- a/types/angular-material/angular-material-tests.ts
+++ b/types/angular-material/angular-material-tests.ts
@@ -419,3 +419,14 @@ myApp.controller('StickyController', ($scope: TestScope, $mdSticky: ng.material.
     $mdSticky($scope, stickyElement);
     $mdSticky($scope, stickyElement, cloneStickyElement);
 });
+
+function mdUtil($mdUtil: ng.material.IUtilService) {
+    // $ExpectType void
+    $mdUtil.enableScrolling();
+
+    // $ExpectType () => void
+    $mdUtil.debounce(() => {});
+
+    // $ExpectType () => string
+    $mdUtil.debounce((): string => "");
+}

--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -517,5 +517,11 @@ declare module 'angular' {
             getLastInteractionType(): string|null;
             isUserInvoked(checkDelay?: number): boolean;
         }
+
+        interface IUtilService {
+            // tslint:disable-next-line:ban-types debounce takes in a user provided function
+            debounce<T extends Function>(func: T, wait?: number, scope?: any, invokeApply?: boolean): T;
+            enableScrolling(): void;
+        }
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`$mdUtil` is a utility in the Angular Material library. There is an open issue to create documentation for it at https://github.com/angular/material/issues/6874, and the Angular Material team states there's nothing wrong with using said utility publicly.

I can't figure out how to do the documentation, but at the very least, I'd like to introduce the typings into this repository.

The source code for `debounce` is at https://github.com/angular/material/blob/master/src/core/util/util.js#L427.
The source code for `enableScrolling` is at https://github.com/angular/material/blob/master/src/core/util/util.js#L325.