### PR TITLE
[airtable] new package - airtable npm module (Airtable JS API)

### DIFF
--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -1,15 +1,15 @@
-import Airtable, { Attachment, Table, FieldSet } from "airtable";
+import * as Airtable from 'airtable';
 
-interface Row extends FieldSet {
+interface Row extends Airtable.FieldSet {
   field1: string;
-  attachments: Attachment[];
+  attachments: Airtable.Attachment[];
 }
 
 const airtable = new Airtable();
 
 const base = airtable.base('app id');
 
-const table = base('table name') as Table<Row>;
+const table = base('table name') as Airtable.Table<Row>;
 
 async () => {
     const query = table.select();

--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -1,0 +1,43 @@
+import Airtable, { Attachment, Table } from "airtable";
+
+interface Row {
+  field1: string;
+  attachments: Attachment[];
+}
+
+const airtable = new Airtable();
+
+const base = airtable.base('app id');
+
+const table = base('table name') as Table<Row>;
+
+async () => {
+    const query = table.select();
+    {
+        const rows = await query.all();
+        for (const row of rows) {
+            row.id; // $ExpectType string
+            row.fields.field1; // $ExpectType string
+            for (const attachment of row.fields.attachments) {
+                attachment.id; // $ExpectType string
+                attachment.filename; // $ExpectType string
+                attachment.size; // $ExpectType number
+                attachment.type; // $ExpectType string
+                attachment.url; // $ExpectType string
+                if (attachment.thumbnails) {
+                  attachment.thumbnails.full.height; // $ExpectType number
+                  attachment.thumbnails.full.width; // $ExpectType number
+                  attachment.thumbnails.full.url; // $ExpectType string
+
+                  attachment.thumbnails.large.height; // $ExpectType number
+                  attachment.thumbnails.large.width; // $ExpectType number
+                  attachment.thumbnails.large.url; // $ExpectType string
+
+                  attachment.thumbnails.small.height; // $ExpectType number
+                  attachment.thumbnails.small.width; // $ExpectType number
+                  attachment.thumbnails.small.url; // $ExpectType string
+                }
+            }
+        }
+    }
+};

--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -1,6 +1,6 @@
-import Airtable, { Attachment, Table } from "airtable";
+import Airtable, { Attachment, Table, FieldSet } from "airtable";
 
-interface Row {
+interface Row extends FieldSet {
   field1: string;
   attachments: Attachment[];
 }

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -4,53 +4,59 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export default class Airtable {
-    base(appId: string): Base;
-}
+export = Airtable;
 
-export interface Base {
-    (tableName: string): Table<{}>;
-}
+declare global {
+    class Airtable {
+        base(appId: string): Airtable.Base;
+    }
 
-export interface FieldSet {
-    [ key: string ]: undefined | string | ReadonlyArray<Attachment>;
-}
+    namespace Airtable {
+        interface FieldSet {
+            [ key: string ]: undefined | string | ReadonlyArray<Attachment>;
+        }
 
-export interface Table<TFields extends FieldSet> {
-    select(opt?: SelectOptions): Query<TFields>;
-}
+        interface Base {
+            (tableName: string): Table<{}>;
+        }
 
-export interface SelectOptions {
-    view?: string;
-}
+        interface Table<TFields extends FieldSet> {
+            select(opt?: SelectOptions): Query<TFields>;
+        }
 
-export interface Query<TFields extends object> {
-    all(): Promise<Response<TFields>>;
-    firstPage(): Promise<Response<TFields>>;
-}
+        interface SelectOptions {
+            view?: string;
+        }
 
-export type Response<TFields> = ReadonlyArray<Row<TFields>>;
+        interface Query<TFields extends object> {
+            all(): Promise<Response<TFields>>;
+            firstPage(): Promise<Response<TFields>>;
+        }
 
-export interface Row<TFields> {
-    id: string;
-    fields: TFields;
-}
+        type Response<TFields> = ReadonlyArray<Row<TFields>>;
 
-export interface Attachment {
-    id: string;
-    url: string;
-    filename: string;
-    size: number;
-    type: string;
-    thumbnails?: {
-        small: Thumbnail;
-        large: Thumbnail;
-        full: Thumbnail;
-    };
-}
+        interface Row<TFields> {
+            id: string;
+            fields: TFields;
+        }
 
-export interface Thumbnail {
-    url: string;
-    width: number;
-    height: number;
+        interface Attachment {
+            id: string;
+            url: string;
+            filename: string;
+            size: number;
+            type: string;
+            thumbnails?: {
+                small: Thumbnail;
+                large: Thumbnail;
+                full: Thumbnail;
+            };
+        }
+
+        interface Thumbnail {
+            url: string;
+            width: number;
+            height: number;
+        }
+    }
 }

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -12,7 +12,11 @@ export interface Base {
     (tableName: string): Table<{}>;
 }
 
-export interface Table<TFields extends object> {
+export interface FieldSet {
+    [ key: string ]: undefined | string | ReadonlyArray<Attachment>;
+}
+
+export interface Table<TFields extends FieldSet> {
     select(opt?: SelectOptions): Query<TFields>;
 }
 

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for airtable 0.5
+// Project: https://github.com/airtable/airtable.js
+// Definitions by: Brandon Valosek <https://github.com/bvalosek>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export default class Airtable {
+    base(appId: string): Base;
+}
+
+export interface Base {
+    (tableName: string): Table<{}>;
+}
+
+export interface Table<TFields extends object> {
+    select(opt?: SelectOptions): Query<TFields>;
+}
+
+export interface SelectOptions {
+    view?: string;
+}
+
+export interface Query<TFields extends object> {
+    all(): Promise<Response<TFields>>;
+    firstPage(): Promise<Response<TFields>>;
+}
+
+export type Response<TFields> = ReadonlyArray<Row<TFields>>;
+
+export interface Row<TFields> {
+    id: string;
+    fields: TFields;
+}
+
+export interface Attachment {
+    id: string;
+    url: string;
+    filename: string;
+    size: number;
+    type: string;
+    thumbnails?: {
+        small: Thumbnail;
+        large: Thumbnail;
+        full: Thumbnail;
+    };
+}
+
+export interface Thumbnail {
+    url: string;
+    width: number;
+    height: number;
+}

--- a/types/airtable/tsconfig.json
+++ b/types/airtable/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "airtable-tests.ts"
+    ]
+}

--- a/types/airtable/tslint.json
+++ b/types/airtable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds typings to the [airtable](https://github.com/airtable/airtable.js/) npm module.

A maintainer of that repo (@EvanHahn) [explicitly requested to go the DefinitelyTyped route rather than have types in the repo](https://github.com/Airtable/airtable.js/issues/34#issuecomment-468039966)

Currently this only represents a small subset of the Airtable API.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.