### PR TITLE
[three] Fixed InstancedBufferAttribute definition

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1477,7 +1477,7 @@ export namespace GeometryUtils {
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/InstancedBufferAttribute.js">src/core/InstancedBufferAttribute.js</a>
  */
 export class InstancedBufferAttribute extends BufferAttribute {
-    constructor(data: ArrayLike<number>, itemSize: number, meshPerAttribute?: number);
+    constructor(array: ArrayLike<number>, itemSize: number, normalized?: boolean, meshPerAttribute?: number);
 
     meshPerAttribute: number;
 }


### PR DESCRIPTION
This fixes an incorrect parameter name in the constructor and a missing parameter. See https://github.com/mrdoob/three.js/pull/15957

