### PR TITLE
Add types for remove-files-webpack-plugin

### DIFF
--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -1,0 +1,110 @@
+// Type definitions for remove-files-webpack-plugin 1.0
+// Project: https://github.com/Amaimersion/remove-files-webpack-plugin
+// Definitions by: Sergey Kuznetsov <https://github.com/Amaimersion>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+
+/**
+ * A plugin for webpack which removes files and folders before and after compilation.
+ */
+declare class RemovePlugin {
+    constructor(parameters: PluginParameters);
+}
+
+
+/**
+ * A parameters for plugin.
+ */
+interface PluginParameters {
+    /**
+     * Removing before compilation.
+     */
+    before: RemoveParameters;
+
+    /**
+     * Removing after compilation.
+     */
+    after: RemoveParameters;
+}
+
+
+/**
+ * A parameters for removing.
+ */
+interface RemoveParameters {
+    /**
+     * A root directory.
+     * Not absolute paths will be appended to this.
+     * Defaults to `.` (from which directory is called).
+     */
+    root: string;
+
+    /**
+     * A folders or files for removing.
+     * Defaults to `[]`.
+     */
+    include: ReadonlyArray<String>;
+
+    /**
+     * A files for excluding.
+     * Defaults to `[]`.
+     */
+    exclude: ReadonlyArray<String>;
+
+    /**
+     * A folders for custom testing.
+     * Defaults to `[]`.
+     */
+    test: ReadonlyArray<TestObject>;
+
+    /**
+     * Print which folders or files has been removed.
+     * Defaults to `true`.
+     */
+    log: boolean;
+
+    /**
+     * Emulate remove process.
+     * Print which folders or files will be removed without actually removing them.
+     * Ignores `log`.
+     * Defaults to `false`.
+     */
+    emulate: boolean;
+
+    /**
+     * Allow remove of a `root` directory or outside the `root` directory.
+     * It's kinda safe mode.
+     * **Don't turn it on, if you don't know what you actually do!**
+     * Defaults to `false`.
+     */
+    allowRootAndOutside: boolean;
+}
+
+
+/**
+ * A folder for custom testing of files that should be removed.
+ */
+interface TestObject {
+    /**
+     * A path to the folder.
+     * Required.
+     */
+    folder: string;
+
+    /**
+     * A method that accepts an absolute file path and must return 
+     * boolean value that indicates should be removed that file or not.
+     * Required.
+     */
+    method: (filePath: string) => boolean;
+
+    /**
+     * Should the method be applied to files in subdirectories.
+     * Defaults to `false`.
+     */
+    recursive: boolean;
+}
+
+
+export = RemovePlugin;

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for remove-files-webpack-plugin 1.0
-// Project: https://github.com/Amaimersion/remove-files-webpack-plugin
+// Project: https://github.com/Amaimersion/remove-files-webpack-plugin/blob/master/README.md
 // Definitions by: Sergey Kuznetsov <https://github.com/Amaimersion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -4,14 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-
 /**
  * A plugin for webpack which removes files and folders before and after compilation.
  */
+// tslint:disable-next-line:no-unnecessary-class
 declare class RemovePlugin {
     constructor(parameters: PluginParameters);
 }
-
 
 /**
  * A parameters for plugin.
@@ -27,7 +26,6 @@ interface PluginParameters {
      */
     after?: RemoveParameters;
 }
-
 
 /**
  * A parameters for removing.
@@ -81,7 +79,6 @@ interface RemoveParameters {
     allowRootAndOutside?: boolean;
 }
 
-
 /**
  * A folder for custom testing of files that should be removed.
  */
@@ -105,6 +102,5 @@ interface TestObject {
      */
     recursive?: boolean;
 }
-
 
 export = RemovePlugin;

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -20,12 +20,12 @@ interface PluginParameters {
     /**
      * Removing before compilation.
      */
-    before: RemoveParameters;
+    before?: RemoveParameters;
 
     /**
      * Removing after compilation.
      */
-    after: RemoveParameters;
+    after?: RemoveParameters;
 }
 
 
@@ -38,31 +38,31 @@ interface RemoveParameters {
      * Not absolute paths will be appended to this.
      * Defaults to `.` (from which directory is called).
      */
-    root: string;
+    root?: string;
 
     /**
      * A folders or files for removing.
      * Defaults to `[]`.
      */
-    include: ReadonlyArray<String>;
+    include?: ReadonlyArray<String>;
 
     /**
      * A files for excluding.
      * Defaults to `[]`.
      */
-    exclude: ReadonlyArray<String>;
+    exclude?: ReadonlyArray<String>;
 
     /**
      * A folders for custom testing.
      * Defaults to `[]`.
      */
-    test: ReadonlyArray<TestObject>;
+    test?: ReadonlyArray<TestObject>;
 
     /**
      * Print which folders or files has been removed.
      * Defaults to `true`.
      */
-    log: boolean;
+    log?: boolean;
 
     /**
      * Emulate remove process.
@@ -70,7 +70,7 @@ interface RemoveParameters {
      * Ignores `log`.
      * Defaults to `false`.
      */
-    emulate: boolean;
+    emulate?: boolean;
 
     /**
      * Allow remove of a `root` directory or outside the `root` directory.
@@ -78,7 +78,7 @@ interface RemoveParameters {
      * **Don't turn it on, if you don't know what you actually do!**
      * Defaults to `false`.
      */
-    allowRootAndOutside: boolean;
+    allowRootAndOutside?: boolean;
 }
 
 
@@ -103,7 +103,7 @@ interface TestObject {
      * Should the method be applied to files in subdirectories.
      * Defaults to `false`.
      */
-    recursive: boolean;
+    recursive?: boolean;
 }
 
 

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -44,13 +44,13 @@ interface RemoveParameters {
      * A folders or files for removing.
      * Defaults to `[]`.
      */
-    include?: ReadonlyArray<String>;
+    include?: ReadonlyArray<string>;
 
     /**
      * A files for excluding.
      * Defaults to `[]`.
      */
-    exclude?: ReadonlyArray<String>;
+    exclude?: ReadonlyArray<string>;
 
     /**
      * A folders for custom testing.
@@ -93,7 +93,7 @@ interface TestObject {
     folder: string;
 
     /**
-     * A method that accepts an absolute file path and must return 
+     * A method that accepts an absolute file path and must return
      * boolean value that indicates should be removed that file or not.
      * Required.
      */

--- a/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
+++ b/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
@@ -1,6 +1,5 @@
 import RemovePlugin = require("remove-files-webpack-plugin");
 
-
 new RemovePlugin({
     before: {
         root: ".",

--- a/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
+++ b/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
@@ -1,0 +1,24 @@
+import RemovePlugin = require("remove-files-webpack-plugin");
+
+
+new RemovePlugin({
+    before: {
+        root: ".",
+        include: ["./path/to/file/include.ts"],
+        exclude: ["./path/to/file/exclude.ts"],
+        test: [
+            {
+                folder: "./path/to/folder",
+                method: (filePath) => {
+                    return filePath.length > 15;
+                },
+                recursive: true
+            }
+        ]
+    },
+    after: {
+        log: false,
+        emulate: false,
+        allowRootAndOutside: true
+    }
+});

--- a/types/remove-files-webpack-plugin/tsconfig.json
+++ b/types/remove-files-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "remove-files-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/remove-files-webpack-plugin/tslint.json
+++ b/types/remove-files-webpack-plugin/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/remove-files-webpack-plugin/tslint.json
+++ b/types/remove-files-webpack-plugin/tslint.json
@@ -1,3 +1,5 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "no-consecutive-blank-lines": false,
+    "no-unnecessary-class": "allow-constructor-only"
 }

--- a/types/remove-files-webpack-plugin/tslint.json
+++ b/types/remove-files-webpack-plugin/tslint.json
@@ -1,5 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "no-consecutive-blank-lines": false,
-    "no-unnecessary-class": "allow-constructor-only"
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Hello.

Here is a types for `remove-files-webpack-plugin`.
GitHub – https://github.com/Amaimersion/remove-files-webpack-plugin
NPM – https://www.npmjs.com/package/remove-files-webpack-plugin


# Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
  - **Note**: current JSDoc types right in the plugin file cannot be treated as a providing of it's own types. I created it only for local usage and, probably, not all editors or IDE's can treat it as a truly type.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
