### PR TITLE
[seedrandom] State should be serializable, and removing incorrect callbacks

### DIFF
--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for seedrandom 2.4.2
 // Project: https://github.com/davidbau/seedrandom
-// Definitions by: Kern Handa <https://github.com/kernhanda>
+// Definitions by: Kern Handa <https://github.com/kernhanda>, Eugene Zaretskiy <https://github.com/EugeneZ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace seedrandom {

--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -5,7 +5,7 @@
 
 declare namespace seedrandom {
 
-  export type seedrandomStateType = boolean | (() => prng);
+  export type State = {};
 
   interface prng {
     new (seed?: string, options?: seedRandomOptions, callback?: any): prng;
@@ -13,28 +13,28 @@ declare namespace seedrandom {
     quick(): number;
     int32(): number;
     double(): number;
-    state(): () => prng;
+    state(): State;
   }
 
   interface seedrandom_prng {
-    (seed?: string, options?: seedRandomOptions, callback?: any): prng;
-    alea: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    xor128: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    tychei: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    xorwow: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    xor4096: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    xorshift7: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
-    quick: (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback) => prng;
+    (seed?: string, options?: seedRandomOptions, callback?: seedrandomCallback): prng;
+    alea: (seed?: string, options?: seedRandomOptions) => prng;
+    xor128: (seed?: string, options?: seedRandomOptions) => prng;
+    tychei: (seed?: string, options?: seedRandomOptions) => prng;
+    xorwow: (seed?: string, options?: seedRandomOptions) => prng;
+    xor4096: (seed?: string, options?: seedRandomOptions) => prng;
+    xorshift7: (seed?: string, options?: seedRandomOptions) => prng;
+    quick: (seed?: string, options?: seedRandomOptions) => prng;
   }
 
   interface seedrandomCallback {
-    (prng?: prng, shortseed?: string, global?: boolean, state?: seedrandomStateType): prng;
+    (prng?: prng, shortseed?: string, global?: boolean, state?: State): prng;
   }
 
   interface seedRandomOptions {
     entropy?: boolean;
     'global'?: boolean;
-    state?: seedrandomStateType;
+    state?: boolean | State;
     pass?: seedrandomCallback;
   }
 }


### PR DESCRIPTION
`seedrandom`'s state function does not return a function. It returns an object intended to be opaque, which I don't know how to describe in TS. It's serializable (unlike a function), so I made it just be an empty object. It's properties are unpredictable, but always of a similar shape:

`{ [x]: number, [y]: number, [z]: number[] }`

x,y, and z vary from implementation, and users are not intended to know what they are. The important thing is that it can be passed back to the state option when making a new instance of `seedrandom`, and that it be serializable (which the previous implementation was not).

In addition, `seedrandom`'s alternate algorithms do not take a third "callback" argument, so I removed it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/seedrandom (note that the state is not described here, which is why the lib was working before, but the source can be seed here: http://davidbau.com/encode/seedrandom.js )
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.