### PR TITLE
[cacheable-request] Include type alias for cache adapter

### DIFF
--- a/types/cacheable-request/index.d.ts
+++ b/types/cacheable-request/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for cacheable-request 6.0
 // Project: https://github.com/lukechilds/cacheable-request#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
+//                 Paul Melnikow <https://github.com/paulmelnikow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -19,8 +20,10 @@ declare const CacheableRequest: CacheableRequest;
 
 type RequestFn = typeof request;
 
+export type StorageAdapter = Store<any>
+
 interface CacheableRequest {
-    new (requestFn: RequestFn, storageAdapter?: string | Store<any>): (
+    new (requestFn: RequestFn, storageAdapter?: string | StorageAdapter): (
         opts: string | URL | (RequestOptions & CacheSemanticsOptions),
         cb?: (response: ServerResponse | ResponseLike) => void
     ) => CacheableRequest.Emitter;

--- a/types/cacheable-request/index.d.ts
+++ b/types/cacheable-request/index.d.ts
@@ -20,10 +20,8 @@ declare const CacheableRequest: CacheableRequest;
 
 type RequestFn = typeof request;
 
-export type StorageAdapter = Store<any>;
-
 interface CacheableRequest {
-    new (requestFn: RequestFn, storageAdapter?: string | StorageAdapter): (
+    new (requestFn: RequestFn, storageAdapter?: string | CacheableRequest.StorageAdapter): (
         opts: string | URL | (RequestOptions & CacheSemanticsOptions),
         cb?: (response: ServerResponse | ResponseLike) => void
     ) => CacheableRequest.Emitter;
@@ -33,6 +31,8 @@ interface CacheableRequest {
 }
 
 declare namespace CacheableRequest {
+    type StorageAdapter = Store<any>;
+
     interface Options {
         /**
          * If the cache should be used. Setting this to `false` will completely bypass the cache for the current request.

--- a/types/cacheable-request/index.d.ts
+++ b/types/cacheable-request/index.d.ts
@@ -20,7 +20,7 @@ declare const CacheableRequest: CacheableRequest;
 
 type RequestFn = typeof request;
 
-export type StorageAdapter = Store<any>
+export type StorageAdapter = Store<any>;
 
 interface CacheableRequest {
     new (requestFn: RequestFn, storageAdapter?: string | StorageAdapter): (


### PR DESCRIPTION
This allows easily declaring a parameter that will be passed into the
constructor.

Ref https://github.com/sindresorhus/got/pull/760#discussion_r268277506

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Did not add a test because existing tests seem to cover this behavior.

Lint is failing, but I don't understand why:

```
> definitely-typed@0.0.3 lint /Users/pnm/code/DefinitelyTyped
> dtslint types "cacheable-request"

/Users/pnm/code/DefinitelyTyped/node_modules/.bin/dtslint: line 1: use strict: command not found
/Users/pnm/code/DefinitelyTyped/node_modules/.bin/dtslint: line 2: syntax error near unexpected token `('
/Users/pnm/code/DefinitelyTyped/node_modules/.bin/dtslint: line 2: `var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {'
```

Tests will not run on my machine either:

```
index.d.ts:17:1 - error TS2309: An export assignment cannot be used in a module with other exported elements.

17 export = CacheableRequest;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.