### PR TITLE
[parcel-bunder] added missing definitions for 1.12 functionality

### DIFF
--- a/types/parcel-bundler/index.d.ts
+++ b/types/parcel-bundler/index.d.ts
@@ -1,12 +1,30 @@
-// Type definitions for parcel-bundler 1.10
+// Type definitions for parcel-bundler 1.12
 // Project: https://github.com/parcel-bundler/parcel#readme
 // Definitions by: pinage404 <https://github.com/pinage404>
+//                 Nick Woodward <https://github.com/nick-woodward>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+import * as http from 'http';
+import * as https from 'https';
 import * as express from "express-serve-static-core";
 
 declare namespace ParcelBundler {
+    interface HttpsOptions {
+      /**
+       * Path to custom certificate
+       *
+       * @default "./ssl/c.crt"
+       */
+      cert?: string;
+      /**
+       * Path to custom key
+       *
+       * @default "./ssl/k.key"
+       */
+      key?: string;
+    }
+
     interface ParcelOptions {
         /**
          * The out directory to put the build files in
@@ -74,20 +92,7 @@ declare namespace ParcelBundler {
         https?:
             | true
             | false
-            | {
-                  /**
-                   * Path to custom certificate
-                   *
-                   * @default "./ssl/c.crt"
-                   */
-                  cert?: string;
-                  /**
-                   * Path to custom key
-                   *
-                   * @default "./ssl/k.key"
-                   */
-                  key?: string;
-              };
+            | HttpsOptions;
         /**
          * 3 = log everything, 2 = log warnings & errors, 1 = log errors
          *
@@ -124,6 +129,27 @@ declare namespace ParcelBundler {
          * @default false
          */
         detailedReport?: boolean;
+
+        /**
+         * Expose modules as UMD under this name, disabled by default
+         */
+        global?: string;
+
+        /**
+         * By default, package.json dependencies are not included when using 'node' or 'electron' with the 'target' option.
+         *
+         * Set to true to add them to the bundle.
+         *
+         * @default false
+         */
+        bundleNodeModules?: true | false;
+
+        /**
+         * Enable or disable HMR while watching
+         *
+         * @default false
+         */
+        hmr?: true | false;
     }
 
     type ParcelAsset = any;
@@ -161,6 +187,11 @@ declare namespace ParcelBundler {
          * A Map<Asset, number(line number inside the bundle)> of all the locations of the assets inside the bundle, used to generate accurate source maps
          */
         offsets: Map<ParcelAsset, number>;
+
+        /**
+         * A Set of all child bundles
+         */
+        childBundles: Set<any>;
     }
 }
 
@@ -177,6 +208,15 @@ declare class ParcelBundler {
     bundle(): Promise<ParcelBundler.ParcelBundle>;
 
     middleware(): (req: express.Request, res: express.Response, next: express.NextFunction) => any;
+
+    serve(port?: number, https?: true | false | ParcelBundler.HttpsOptions, host?: string): Promise<http.Server | https.Server>;
+
+    on(name: 'buildEnd', cb: () => void): void;
+    on(name: 'bundled', cb: (bundle: ParcelBundler.ParcelBundle) => void): void;
+    on(name: 'buildStart', cb: (entryPoints: string[]) => void): void;
+    on(name: 'buildError', cb: (error: Error) => void): void;
+
+    off(name: 'buildEnd'| 'bundled'| 'buildStart'| 'buildError', cb: (...any: any[]) => void): void;
 }
 
 export = ParcelBundler;

--- a/types/parcel-bundler/parcel-bundler-tests.ts
+++ b/types/parcel-bundler/parcel-bundler-tests.ts
@@ -6,6 +6,20 @@ const files = ["./index.d.ts"];
 
 const bundler = new ParcelBundler(files, parcelOption);
 
+bundler.on('buildStart', (entryPoints) => {
+    console.log(entryPoints);
+});
+
+bundler.on('bundled', (bundle) => {
+    console.log(bundle);
+});
+
+bundler.on('buildEnd', () => console.log('Parcel bundler finished!'));
+
+const cb = () => {};
+bundler.on('buildEnd', cb);
+bundler.off('buildEnd', cb);
+
 bundler.addAssetType('md', 'markdown-asset');
 
 bundler.addPackager('md', 'markdown-packager');
@@ -13,3 +27,11 @@ bundler.addPackager('md', 'markdown-packager');
 bundler.middleware();
 
 bundler.bundle().then(bundle => bundle.name);
+
+bundler.serve(1234, false, 'localhost').then((server) => server.close());
+
+const otherBundler = new ParcelBundler(['./missing.d.ts'], parcelOption);
+
+otherBundler.on('buildError', (error) => console.log(error));
+
+otherBundler.bundle();


### PR DESCRIPTION
### Changes

- Added the `serve`, `on`, and `off` methods to `ParcelBundler`
  - Opted for writing them manually rather than referencing `EventEmitter`.
- Added the `global`, `bundleNodeModules`, and `hmr` options to `ParcelOptions`.

**Please fill in this template.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Select one of these and delete the others:**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://parceljs.org/api.html#bundler (paragraph below the code snippet)
- [x] Increase the version number in the header if appropriate.
