### PR TITLE
[nodemailer] add messageId() method to MimeNode

### DIFF
--- a/types/nodemailer/lib/mime-node.d.ts
+++ b/types/nodemailer/lib/mime-node.d.ts
@@ -125,7 +125,7 @@ declare class MimeNode {
 
     /** Generates and returns SMTP envelope with the sender address and a list of recipients addresses */
     getEnvelope(): MimeNode.Envelope;
-    
+
     /** Generates and returns the Message-Id value */
     messageId(): string;
 

--- a/types/nodemailer/lib/mime-node.d.ts
+++ b/types/nodemailer/lib/mime-node.d.ts
@@ -126,7 +126,7 @@ declare class MimeNode {
     /** Generates and returns SMTP envelope with the sender address and a list of recipients addresses */
     getEnvelope(): MimeNode.Envelope;
 
-    /** Generates and returns the Message-Id value */
+    /** Returns Message-Id value. If it does not exist, then creates one */
     messageId(): string;
 
     /** Sets pregenerated content that will be used as the output of this node */

--- a/types/nodemailer/lib/mime-node.d.ts
+++ b/types/nodemailer/lib/mime-node.d.ts
@@ -125,6 +125,9 @@ declare class MimeNode {
 
     /** Generates and returns SMTP envelope with the sender address and a list of recipients addresses */
     getEnvelope(): MimeNode.Envelope;
+    
+    /** Generates and returns the Message-Id value */
+    messageId(): string;
 
     /** Sets pregenerated content that will be used as the output of this node */
     setRaw(raw: string | Buffer | Readable): this;


### PR DESCRIPTION
The [example transport plugin](https://nodemailer.com/plugins/create/#transport-send-mail-callback) currently fails to compile in TypeScript because of the missing `messageId()` method on `MimeNode`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodemailer.com/plugins/create/#transport-send-mail-callback
