### PR TITLE
[ckeditor] Set parameters to optional for filter.applyTo()

### DIFF
--- a/types/ckeditor/ckeditor-tests.ts
+++ b/types/ckeditor/ckeditor-tests.ts
@@ -620,6 +620,7 @@ function test_filter() {
     allowed = filter.allow('rule', 'name', false);
 
     var apply: boolean = filter.applyTo(CKEDITOR.htmlParser.fragment.fromHtml('string'), true, false, 1);
+    apply = filter.applyTo(new CKEDITOR.htmlParser.element('name', null));
     apply = filter.applyTo(new CKEDITOR.htmlParser.element('name', null), true, false, 1);
 
     var checked: boolean = filter.check(style);

--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -1436,7 +1436,7 @@ declare namespace CKEDITOR {
         addFeature(feature: feature): boolean;
         addTransformations(transformations: Array<Array<string | filter.transformation>>): void;
         allow(newRules: filter.allowedContentRules, featureName?: string, overrideCustom?: boolean): boolean;
-        applyTo(fragment: htmlParser.fragment | htmlParser.element, toHrml: boolean, transformOnly: boolean, enterMode: number): boolean;
+        applyTo(fragment: htmlParser.fragment | htmlParser.element, toHtml?: boolean, transformOnly?: boolean, enterMode?: number): boolean;
         check(test: filter.contentRule, applyTransformations?: boolean, strictCheck?: boolean): boolean;
         checkFeature(feature: feature): boolean;
         clone(): filter;


### PR DESCRIPTION
According to the [CKEditor documentation](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_filter.html#method-applyTo) the `applyTo()` method should have optional parameters.  The [source](https://github.com/ckeditor/ckeditor-dev/blob/8b53603e87ac1e1a05d39442b84555c9a76876a5/core/filter.js#L272-L285) supports this and the example in the documentation shows calling it with a single parameter.

There was also a minor typo in `toHrml` (should be `toHtml`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_filter.html#method-applyTo
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
