### PR TITLE
Fix Kefir#fromNodeCallback

### DIFF
--- a/types/kefir/index.d.ts
+++ b/types/kefir/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Kefir 3.8.0
+// Type definitions for Kefir 3.8.1
 // Project: http://rpominov.github.io/kefir/
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 //                 Piotr Hitori Bosak <https://github.com/HitoriSensei>
@@ -162,7 +162,7 @@ export function sequentially<T>(interval: number, values: T[]): Stream<T, never>
 export function fromPoll<T>(interval: number, fn: () => T): Stream<T, never>;
 export function withInterval<T, S>(interval: number, handler: (emitter: Emitter<T, S>) => void): Stream<T, S>;
 export function fromCallback<T>(fn: (callback: (value: T) => void) => void): Stream<T, never>;
-export function fromNodeCallback<T, S>(fn: (callback: (error: S, result: T) => void) => void): Stream<T, S>;
+export function fromNodeCallback<T, S>(fn: (callback: (error: S | null, result: T) => void) => void): Stream<T, S>;
 export function fromEvents<T, S>(target: EventTarget | NodeJS.EventEmitter | { on: Function, off: Function }, eventName: string, transform?: (value: T) => S): Stream<T, S>;
 export function stream<T, S>(subscribe: (emitter: Emitter<T, S>) => Function | void): Stream<T, S>;
 export function fromESObservable<T, S>(observable: any): Stream<T, S>

--- a/types/kefir/kefir-tests.ts
+++ b/types/kefir/kefir-tests.ts
@@ -24,7 +24,7 @@ import { Observable, Pool, Stream, Property, Event, Emitter } from 'kefir';
 		});
 	}
 	let stream07: Stream<number, void> = Kefir.fromCallback<number>(callback => setTimeout(() => callback(1), 1000));
-	let stream08: Stream<number, void> = Kefir.fromNodeCallback<number, void>(callback => setTimeout(() => callback(null, 1), 1000));
+	let stream08: Stream<number, Error> = Kefir.fromNodeCallback<number, Error>(callback => setTimeout(() => callback(null, 1), 1000));
 	let stream09: Stream<MouseEvent, void> = Kefir.fromEvents<MouseEvent, void>(document.body, 'click');
 	let stream10: Stream<number, void> = Kefir.stream<number, void>(emitter => {
 		let count = 0;

--- a/types/kefir/tsconfig.json
+++ b/types/kefir/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Most nodebacks use `null` there to indicate no error, so the
types for `fromNodeCallback` should allow `null`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://kefirjs.github.io/kefir/#from-node-callback
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.