### PR TITLE
[redis] Added socket_initialdelay prop to ClientOpts

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -39,6 +39,7 @@ export interface ClientOpts {
     return_buffers?: boolean;
     detect_buffers?: boolean;
     socket_keepalive?: boolean;
+    socket_initialdelay?: number;
     no_ready_check?: boolean;
     enable_offline_queue?: boolean;
     retry_max_delay?: number;

--- a/types/redis/ts3.1/index.d.ts
+++ b/types/redis/ts3.1/index.d.ts
@@ -22,6 +22,7 @@ export interface ClientOpts {
     return_buffers?: boolean;
     detect_buffers?: boolean;
     socket_keepalive?: boolean;
+    socket_initialdelay?: number;
     no_ready_check?: boolean;
     enable_offline_queue?: boolean;
     retry_max_delay?: number;


### PR DESCRIPTION
According to the [node_redis docs](https://github.com/NodeRedis/node_redis#options-object-properties) `ClientOpts` interface should have `socket_initialdelay`. [Source code](https://github.com/NodeRedis/node_redis/blob/12265a5079a133d2003bef9cdb0f2deee0251518/index.js#L104) that uses this parameter

Please fill in this template.

Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node_redis/blob/12265a5079a133d2003bef9cdb0f2deee0251518/index.js#L104
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.