### PR TITLE
`react-autocomplete`: fix `renderMenu` param type

### DIFF
--- a/types/react-autocomplete/index.d.ts
+++ b/types/react-autocomplete/index.d.ts
@@ -76,7 +76,7 @@ declare namespace Autocomplete {
          * and the width of the dropdown menu.
          */
         renderMenu?: (
-            items: any[],
+            items: ReactNode[],
             value: string,
             styles: CSSProperties,
         ) => ReactNode;

--- a/types/react-autocomplete/react-autocomplete-tests.tsx
+++ b/types/react-autocomplete/react-autocomplete-tests.tsx
@@ -16,3 +16,8 @@ render(
     />,
     container,
 );
+
+// $ExpectError
+const renderMenu: React.ComponentProps<typeof Autocomplete>['renderMenu'] = (
+    (item: string[]) => <div></div>
+);


### PR DESCRIPTION
`renderMenu` is invoked with the return value of `renderItem`, which is `ReactNode`.

`any` is unsafe because it allows anything and completely disables type checking.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.