### PR TITLE
`parse`: optional `attrs` argument for `user.Signup()`

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -691,7 +691,7 @@ subscription.on('close', () => {});
         static extend(protoProps?: any, classProps?: any): any;
         static hydrate(userJSON: any): Promise<User>;
 
-        signUp(attrs: any, options?: SignUpOptions): Promise<this>;
+        signUp(attrs?: any, options?: SignUpOptions): Promise<this>;
         logIn(options?: SuccessFailureOptions): Promise<this>;
         authenticated(): boolean;
         isCurrent(): boolean;


### PR DESCRIPTION
According to official doc usage (http://docs.parseplatform.org/js/guide/#signing-up). `attrs` here should be optional.

Followings are done:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.parseplatform.org/js/guide/#signing-up
- [x] Increase the version number in the header if appropriate.(Very minor change, so ignored)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.