### PR TITLE
Add a description about asOfVersion in "Removing a package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ When a package [bundles](http://www.typescriptlang.org/docs/handbook/declaration
 
 You can remove it by running `npm run not-needed -- typingsPackageName asOfVersion sourceRepoURL [libraryName]`.
 - `typingsPackageName`: This is the name of the directory to delete.
-- `asOfVersion`: A stub will be published to `@types/foo` with this version. Should be higher than any currently published version.
+- `asOfVersion`: A stub will be published to `@types/foo` with this version. Should be higher than any currently published version, and should be a version of `foo` on npm.
 - `sourceRepoURL`: This should point to the repository that contains the typings.
 - `libraryName`: Name of npm package that replaces the Definitely Typed types. Usually this is identical to "typingsPackageName", in which case you can omit it.
 


### PR DESCRIPTION
Hi, developers. Thank you for a wonderful project!

This PR is for **very small improvement of README**, **not for type definition**.

### Background

In the "Removing a package" section, you have the following command to remove.
`npm run not-needed -- typingsPackageName asOfVersion sourceRepoURL [libraryName]`

I don't think that the description of `asOfVersion` is enough. 
**The `asOfVersion` should be a version on `foo` package on npm.** In other word, `foo@asOfVersion` should exist on npm. If not, you have an error like the following.

```txt
{ AssertionError [ERR_ASSERTION]: The specified version 4.0.2 of get-port is not on npm.
```

So, I added a sentence to clarify `asOfVersion` for people to remove a package. (Actually, at first, I had the error above.)

This PR is related to English. I'm not an English native speaker. Please correct the sentence more natural if this PR is meaningful 🙏  

<!--
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
-->