### PR TITLE
node-forge: add pbkdf2 function definitions with optional parameters

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -584,6 +584,9 @@ declare module "node-forge" {
 
     namespace pkcs5 {
         function pbkdf2(password: string, salt: string, iterations: number, keySize: number): string;
+        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest: md.MessageDigest): string;
+        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, callback: (err: Error | null, dk: string | null) => any): void;
+        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest?: md.MessageDigest, callback?: (err: Error | null, dk: string | null) => any): void;
     }
 
     namespace md {

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -224,7 +224,27 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
 }
 
 {
-    const key: string = forge.pkcs5.pbkdf2("password", "salt", 1000, 32);
+    let md: forge.md.MessageDigest;
+    md = forge.md.sha256.create();
+
+    const key1: string = forge.pkcs5.pbkdf2("password", "salt", 1000, 32);
+    const key2: string = forge.pkcs5.pbkdf2("password", "salt", 1000, 32, md);
+
+    let key3: string;
+    forge.pkcs5.pbkdf2("password", "salt", 1000, 32, function(err: Error | null, dk: null | string) {
+        if (err === null)
+            key3 = dk;
+        else
+            throw Error("pbkdf2 key derivation fail");
+    });
+
+    let key4: string;
+    forge.pkcs5.pbkdf2("password", "salt", 1000, 32, md, function(err: Error | null, dk: null | string) {
+        if (err === null)
+            key4 = dk;
+        else
+            throw Error("pbkdf2 key derivation fail");
+    });
 }
 
 {


### PR DESCRIPTION
The documentation for node-forge shows some optional parameters that are not present in the current definition of the function. Check the comments in the code snippets in the link provided below.

I am not able to run `npm run lint package-name` because it throws some error even without any changes. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge#pkcs5
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
