### PR TITLE
 Fix createConnection params in node/http2.d.ts

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -415,7 +415,7 @@ declare module "http2" {
         peerMaxConcurrentStreams?: number;
         selectPadding?: (frameLen: number, maxFrameLen: number) => number;
         settings?: Settings;
-        createConnection?: (option: SessionOptions) => stream.Duplex;
+        createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
     }
 
     export type ClientSessionOptions = SessionOptions;

--- a/types/node/v10/http2.d.ts
+++ b/types/node/v10/http2.d.ts
@@ -415,7 +415,7 @@ declare module "http2" {
         peerMaxConcurrentStreams?: number;
         selectPadding?: (frameLen: number, maxFrameLen: number) => number;
         settings?: Settings;
-        createConnection?: (option: SessionOptions) => stream.Duplex;
+        createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
     }
 
     export type ClientSessionOptions = SessionOptions;


### PR DESCRIPTION
[NodeJS calls `createConnection` with 2 arguments: `authority` and `options`](https://github.com/nodejs/node/blob/107c95da0dd8cb4c9024d762b61b62630bfb7bba/lib/internal/http2/core.js#L2778)

[Documentation says the same (`createConnection` param)](https://nodejs.org/api/http2.html#http2_http2_connect_authority_options_listener)

[There are no tests for such case in tests folder](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/test/http2.ts)

[Previous pull request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33884)