### PR TITLE
[toastr] support strictNullChecks and optional parameters as undefined.

### DIFF
--- a/types/toastr/index.d.ts
+++ b/types/toastr/index.d.ts
@@ -225,23 +225,10 @@ interface ToastrDisplayMethod {
 	 * Create a toast
 	 *
 	 * @param message Message to display in toast
-	 */
-	(message: string): JQuery;
-	/**
-	 * Create a toast
-	 *
-	 * @param message Message to display in toast
-	 * @param title Title to display on toast
-	 */
-	(message: string, title: string): JQuery;
-	/**
-	 * Create a toast
-	 *
-	 * @param message Message to display in toast
 	 * @param title Title to display on toast
 	 * @param overrides Option values for toast
 	 */
-	(message: string, title: string, overrides: ToastrOptions): JQuery;
+	(message: string, title?: string, overrides?: ToastrOptions): JQuery;
 }
 
 type ToastrType = 'error'|'info'|'success'|'warning';
@@ -302,22 +289,12 @@ interface Toastr {
 	 */
 	clear: {
 		/**
-		 * Clear all toasts
-		 */
-		(): void;
-		/**
-		 * Clear specific toast
-		 *
-		 * @param toast Toast to clear
-		 */
-		(toast: JQuery): void;
-		/**
 		 * Clear specific toast
 		 *
 		 * @param toast Toast to clear
 		 * @param clearOptions force clearing a toast, ignoring focus
 		 */
-		(toast: JQuery, clearOptions: {force: boolean}): void;
+		(toast?: JQuery, clearOptions?: {force: boolean}): void;
 	};
 	/**
 	 * Removes all toasts (without animation)
@@ -373,9 +350,7 @@ interface Toastr {
 	 *
 	 * @param callback The function which will be passed the event details.
 	 */
-	subscribe: (callback: (response: ToastrResponse) => any) => void;
-
-	[key: string]: any;
+	subscribe: (callback: (response: ToastrResponse) => void) => void;
 }
 
 declare var toastr: Toastr;

--- a/types/toastr/toastr-tests.ts
+++ b/types/toastr/toastr-tests.ts
@@ -1,7 +1,19 @@
 
+declare let displayMethodStr: 'success' | 'info' | 'warning' | 'error';
+declare let undefinedVal: undefined;
+declare let booleanVal: boolean;
+declare let booleanOrUndefinedVal: boolean | undefined;
+declare let stringVal: string;
+declare let stringOrUndefinedVal: string | undefined;
+declare let toastrOptionsVal: ToastrOptions;
+declare let toastrOptionsOrUndefinedVal: ToastrOptions | undefined;
+declare let jQueryVal: JQuery<HTMLElement>;
+declare let jQueryOrUndefinedVal: JQuery<HTMLElement> | undefined;
+declare let clearOptionsVal: {force: boolean};
+declare let clearOptionsOrUndefinedVal: typeof clearOptionsVal | undefined;
 
 function test_basic() {
-    var t: any[] = [];
+    var t: JQuery[] = [];
     t.push(toastr.info('Are you the 6 fingered man?'));
     t.push(toastr.warning('My name is Inigo Montoya. You Killed my father, prepare to die!'));
     t.push(toastr.success('Have fun storming the castle!', 'Miracle Max Says'));
@@ -15,12 +27,52 @@ function test_basic() {
     var overrides = { timeOut: 250 };
     toastr.warning(msg, title, overrides);
     toastr.options.onclick = function () { }
+
+    // Override global options
+    toastr.success('We do have the Kapua suite available.', 'Turtle Bay Resort', {timeOut: 5000})
+
+    // Options from Readme
+    // Escape HTML characters
+    toastr.options.escapeHtml = true;
+    // Close Button
+    toastr.options.closeButton = true;
+    toastr.options.closeHtml = '<button><i class="icon-off"></i></button>';
+    toastr.options.closeMethod = 'fadeOut';
+    toastr.options.closeDuration = 300;
+    toastr.options.closeEasing = 'swing';
+    // Display Sequence
+    toastr.options.newestOnTop = false;
+    // Callbacks
+    toastr.options.onShown = function() { console.log('hello'); }
+    toastr.options.onHidden = function() { console.log('goodbye'); }
+    toastr.options.onclick = function() { console.log('clicked'); }
+    toastr.options.onCloseClick = function() { console.log('close button clicked'); }
+    // Animation Options
+    // Easings
+    toastr.options.showEasing = 'swing';
+    toastr.options.hideEasing = 'linear';
+    toastr.options.closeEasing = 'linear';
+    // Animation method
+    toastr.options.showMethod = 'slideDown';
+    toastr.options.hideMethod = 'slideUp';
+    toastr.options.closeMethod = 'slideUp';
+    // Prevent Duplicates
+    toastr.options.preventDuplicates = true;
+    // Timeouts
+    toastr.options.timeOut = 30; // How long the toast will display without user interaction
+    toastr.options.extendedTimeOut = 60; // How long the toast will display after a user hovers over it
+    // Prevent from Auto Hiding
+    toastr.options.timeOut = 0;
+    toastr.options.extendedTimeOut = 0;
+    // Progress Bar
+    toastr.options.progressBar = true;
+    // rtl
+    toastr.options.rtl = true;
 }
 
 function test_fromdemo() {
     var i = -1,
-        toastCount = 0,
-        $toastlast: any,
+        $toastlast: JQuery,
         getMessage = function () {
             var msgs = ['My name is Inigo Montoya. You killed my father. Prepare to die!',
                 '<div><input class="input-small" value="textbox"/>&nbsp;<a href="http://johnpapa.net" target="_blank">This is a hyperlink</a></div><div><button type="button" id="okBtn" class="btn btn-primary">Close me</button><button type="button" id="surpriseBtn" class="btn" style="margin: 0 8px 0 8px">Surprise me</button></div>',
@@ -37,9 +89,9 @@ function test_fromdemo() {
             return msgs[i];
         };
     $('#showtoast').click(function () {
-		var shortCutFunction = $("#toastTypeGroup input:radio:checked").val() as string,
-			msg = $('#message').val(),
-			title = $('#title').val() || '',
+		var shortCutFunction = $("#toastTypeGroup input:radio:checked").val() as 'success' | 'info' | 'warning' | 'error',
+			msg = $('#message').val() as string,
+			title = $('#title').val() as  string || '',
 			$fadeIn = $('#fadeIn'),
 			$fadeOut = $('#fadeOut'),
 			$timeOut = $('#timeOut'),
@@ -53,16 +105,16 @@ function test_fromdemo() {
             progressBar: true
 		}
         if ((<string> $fadeIn.val()).length) {
-			toastr.options.showDuration = +$fadeIn.val()
+			toastr.options.showDuration = +$fadeIn.val()!
         }
         if ((<string> $fadeOut.val()).length) {
-			toastr.options.hideDuration = +$fadeOut.val()
+			toastr.options.hideDuration = +$fadeOut.val()!
         }
         if ((<string> $timeOut.val()).length) {
-            toastr.options.timeOut = +$timeOut.val()
+            toastr.options.timeOut = +$timeOut.val()!
         }
         if ((<string> $extendedTimeOut.val()).length) {
-            toastr.options.extendedTimeOut = +$extendedTimeOut.val()
+            toastr.options.extendedTimeOut = +$extendedTimeOut.val()!
         }
         var $toast = toastr[shortCutFunction](msg, title)
         if ($toast.find('#okBtn').length) {
@@ -83,4 +135,32 @@ function test_fromdemo() {
     $('#cleartoasts').click(function () {
         toastr.clear();
     });
+}
+
+function test_displayOptions() {
+    // 1st parameter
+    jQueryVal = toastr[displayMethodStr](stringVal);
+
+    // 2nd parameter
+    jQueryVal = toastr[displayMethodStr](stringVal, undefinedVal);
+    jQueryVal = toastr[displayMethodStr](stringVal, stringVal);
+    jQueryVal = toastr[displayMethodStr](stringVal, stringOrUndefinedVal);
+
+    // 3rd parameter
+    jQueryVal = toastr[displayMethodStr](stringVal, stringOrUndefinedVal, undefinedVal);
+    jQueryVal = toastr[displayMethodStr](stringVal, stringOrUndefinedVal, toastrOptionsVal);
+    jQueryVal = toastr[displayMethodStr](stringVal, stringOrUndefinedVal, toastrOptionsOrUndefinedVal);
+}
+
+function test_clearOptions() {
+    // 1st parameter
+    toastr.clear();
+    toastr.clear(undefinedVal);
+    toastr.clear(jQueryVal);
+    toastr.clear(jQueryOrUndefinedVal);
+
+    // 2nd parameter
+    toastr.clear(jQueryOrUndefinedVal, clearOptionsVal);
+    toastr.clear(jQueryOrUndefinedVal, undefinedVal);
+    toastr.clear(jQueryOrUndefinedVal, clearOptionsOrUndefinedVal);
 }

--- a/types/toastr/toastr-tests.ts
+++ b/types/toastr/toastr-tests.ts
@@ -7,8 +7,8 @@ declare let stringVal: string;
 declare let stringOrUndefinedVal: string | undefined;
 declare let toastrOptionsVal: ToastrOptions;
 declare let toastrOptionsOrUndefinedVal: ToastrOptions | undefined;
-declare let jQueryVal: JQuery<HTMLElement>;
-declare let jQueryOrUndefinedVal: JQuery<HTMLElement> | undefined;
+declare let jQueryVal: JQuery;
+declare let jQueryOrUndefinedVal: JQuery | undefined;
 declare let clearOptionsVal: {force: boolean};
 declare let clearOptionsOrUndefinedVal: typeof clearOptionsVal | undefined;
 

--- a/types/toastr/tsconfig.json
+++ b/types/toastr/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
This PR updates the **toastr** types to support the `strictNullChecks` compiler flag.
In particular, when `strictNullChecks` is enabled in a dependent project, you previously couldn't specify toastr options without passing a header. I.e. this would produce an error:

```ts
toastr.success('message', undefined, {/* options */}) // Error with strictNullChecks
```

Detailed explanation of changes:
- Removed the overloads in `ToastrDisplayMethod` and replaced them with optional parameters. This aligns with the [typescript best practices](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#use-optional-parameters).
    - Note: though the first parameter (`message`) can technically be `undefined` without error (showing a blank toast), I chose to not allow `undefined` as a value for it, since passing `undefined` would almost always be a developer error.
- Similar to above, used optional parameters in `clear()`.
    - Allowed the first argument (`toast`) to be undefined even if the second argument (`clearOptions`) is passed. This seems counterintuitive, but it's the most permissive, allowing the `toast` argument to be passed without type narrowing to remove `undefined` from the type. Besides, passing `undefined, options` doesn't produce any errors. [clearToast](https://github.com/CodeSeven/toastr/blob/50092cc604850a16c985520b63df184d3e0b4086/toastr.js#L133). 

In the tests:
- Added more examples from the code on the Readme. 
- Asserted that the toastr display methods return a `JQuery` object.
- Cast JQuery `val()` return values as specific types, in order to comply with `strictNullChecks`, since `val()`'s type says it may return `undefined`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/CodeSeven/toastr/tree/50092cc604850a16c985520b63df184d3e0b4086
https://github.com/CodeSeven/toastr/blob/50092cc604850a16c985520b63df184d3e0b4086/demo.html  
https://github.com/CodeSeven/toastr/blob/50092cc604850a16c985520b63df184d3e0b4086/toastr.js#L352  

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
