### PR TITLE
changelog-parser: switch the callback params

### DIFF
--- a/types/changelog-parser/changelog-parser-tests.ts
+++ b/types/changelog-parser/changelog-parser-tests.ts
@@ -5,7 +5,15 @@ const options = {
     removeMarkdown: false
 };
 
-parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (error, result) => {});
+const fn = (obj: object): void => {};
+
+parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (error, result) => {
+    if (error) {
+        throw error;
+    }
+
+    fn(result);
+});
 
 parseChangelog(options, (error, result) => {});
 

--- a/types/changelog-parser/changelog-parser-tests.ts
+++ b/types/changelog-parser/changelog-parser-tests.ts
@@ -5,12 +5,12 @@ const options = {
     removeMarkdown: false
 };
 
-parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (result, error) => {});
+parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (error, result) => {});
 
-parseChangelog(options, (result, error) => {});
+parseChangelog(options, (error, result) => {});
 
-parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (result) => {});
+parseChangelog({filePath: 'path/to/CHANGELOG.md'}, (error) => {});
 
-parseChangelog(options);
+parseChangelog(options).then((result) => {});
 
-parseChangelog('path/to/CHANGELOG.md');
+parseChangelog('path/to/CHANGELOG.md').then((result) => {});

--- a/types/changelog-parser/index.d.ts
+++ b/types/changelog-parser/index.d.ts
@@ -19,6 +19,7 @@ interface Options {
 /**
  * Change log parser for node.
  */
-declare function parseChangelog(options: Partial<Options>|string, callback?: (result: object, error: string|null) => void): Promise<object>;
+declare function parseChangelog(options: Partial<Options>|string,
+    callback?: (error: string|null, result: object) => void): Promise<object>;
 
 export = parseChangelog;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/hypermodules/changelog-parser
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Doing the ol' switcheroo because it got merged recently before author had chance to put them right.

Also fiddled with one of the tests so we catch this in future (by using the result as an object).

package author is @ungoldman to confirm if possible.

cc types author @adamzerella (sorry if you were already doing this change)