### PR TITLE
fix(sharp): add missing linear, recomb, modulate types

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -424,7 +424,15 @@ declare namespace sharp {
          * @throws {Error} Invalid parameters
          * @returns A sharp instance that can be used to chain operations
          */
-        linear(a?: number, b?: number): Sharp;
+        linear(a?: number | null, b?: number): Sharp;
+
+        /**
+         * Recomb the image with the specified matrix.
+         * @param inputMatrix 3x3 Recombination matrix
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        recomb(inputMatrix: Matrix3x3): Sharp;
 
         //#endregion
 
@@ -1028,6 +1036,12 @@ declare namespace sharp {
         files: { current: number; max: number; };
         items: { current: number; max: number; };
     }
+
+    type Matrix3x3 = [
+        [number, number, number],
+        [number, number, number],
+        [number, number, number]
+    ];
 }
 
 export = sharp;

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -233,3 +233,15 @@ const vipsVersion: string = sharp.versions.vips;
 if (sharp.versions.cairo) {
     const cairoVersion: string = sharp.versions.cairo;
 }
+
+sharp('input.gif')
+    .linear(1)
+    .linear(1, 0)
+    .linear(null, 0)
+
+    .recomb([
+        [0.3588, 0.7044, 0.1368],
+        [0.2990, 0.5870, 0.1140],
+        [0.2392, 0.4696, 0.0912],
+    ])
+;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). (via `node node_modules/.bin/dtslint types sharp` because https://github.com/Microsoft/dtslint/issues/219)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

* `linear` [docs](https://github.com/lovell/sharp/blob/master/docs/api-operation.md#linear) , [allowing null as first param](https://github.com/lovell/sharp/blob/1999c7103ccc293d4414e1d2c3726fb601079e2d/test/unit/linear.js#L61)
* `recomb` [docs](https://github.com/lovell/sharp/blob/master/docs/api-operation.md#recomb)
* `modulate` [docs](https://github.com/lovell/sharp/blob/master/docs/api-operation.md#modulate)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note: `modulate` is part of the next sharp release and not yet released. I'm not sure if we should already ship it in the type definition, see https://github.com/lovell/sharp/commit/fc178de309d8e4055e86ffe1bbcfcf40754c885b#diff-343723a0cb380f664aedf0dfed5c1c2f
