### PR TITLE
[slate-react] Expose setDecorations method on CoreEditor

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -9,6 +9,7 @@
 //                 Hanna Greaves <https://github.com/sgreav>
 //                 Francesco Agnoletto <https://github.com/Kornil>
 //                 Jack Allen <https://github.com/jackall3n>
+//                 Benjamin Evenson <https://github.com/benjiro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import {
@@ -331,6 +332,7 @@ export class Editor extends React.Component<EditorProps, EditorState> implements
     replaceNodeByPath: CoreEditor['replaceNodeByPath'];
     removeTextByKey: CoreEditor['removeTextByKey'];
     removeTextByPath: CoreEditor['removeTextByPath'];
+    setDecorations: CoreEditor['setDecorations'];
     setMarkByKey: CoreEditor['setMarkByKey'];
     setMarksByPath: CoreEditor['setMarksByPath'];
     setNodeByKey: CoreEditor['setNodeByKey'];

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -1,5 +1,5 @@
 import { Editor, Plugin, EditorProps, RenderNodeProps } from "slate-react";
-import { Value, Editor as Controller, Operation, Point, Range, Inline, Mark, Document } from "slate";
+import { Value, Editor as Controller, Operation, Point, Range, Inline, Mark, Document, Decoration } from "slate";
 import * as React from "react";
 import * as Immutable from "immutable";
 
@@ -50,6 +50,8 @@ const point = Point.create({ key: "a", offset: 0 });
 const range = Range.create({ anchor: point, focus: point });
 const inline = Inline.create("text");
 const mark = Mark.create("bold");
+const decorations = Decoration.createList([{ anchor: Point.create({ key: "a", offset: 0 }), focus: Point.create({ key: "a", offset: 0 }), mark }]);
+
 const doc = Document.fromJSON({
 	object: "document",
 	data: {},
@@ -248,6 +250,7 @@ editor
 .replaceNodeByKey("a", inline)
 .replaceNodeByPath("a", inline)
 .select(range)
+.setDecorations(decorations)
 .setBlocks("paragraph")
 .setBlocksAtRange(range, "paragraph")
 .setInlines("paragraph")


### PR DESCRIPTION
This change is in accordance with the following pull-request for slate-js https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34174

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34174
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
