### PR TITLE
Add support for matrix property in TransformsStyle

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -666,7 +666,11 @@ type GeolocationError = {
     POSITION_UNAVAILABLE: number;
     TIMEOUT: number;
 };
-
+   
+interface MatrixTransform {
+    matrix: Array<number>;
+}
+    
 interface PerpectiveTransform {
     perspective: number;
 }
@@ -717,6 +721,7 @@ interface SkewYTransform {
 
 export interface TransformsStyle {
     transform?: (
+        | MatrixTransform
         | PerpectiveTransform
         | RotateTransform
         | RotateXTransform

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -666,11 +666,11 @@ type GeolocationError = {
     POSITION_UNAVAILABLE: number;
     TIMEOUT: number;
 };
-   
+
 interface MatrixTransform {
     matrix: Array<number>;
 }
-    
+
 interface PerpectiveTransform {
     perspective: number;
 }


### PR DESCRIPTION
Although there is no reference to the matrix property within the transform style on the wiki (https://facebook.github.io/react-native/docs/transforms) there is mention of transformMatrix which has been deprecated which tells you to use the transform property instead. Perhaps that's an issue with the documentation.

We have currently defined transformMatrix but not within the transform property.
