### PR TITLE
bn.js: Adds Uint8Array as a valid constructor argument.

### DIFF
--- a/types/bn.js/bn.js-tests.ts
+++ b/types/bn.js/bn.js-tests.ts
@@ -16,3 +16,8 @@ const red = bn.toRed(ctx);
 const newRed = red.redAdd(new BN(1));
 newRed.cmp(bn);
 newRed.fromRed();
+
+const expected = new BN(0x4020);
+const actualArray = new BN([0x40, 0x20]);
+const actualUint8Array =  new BN(new Uint8Array([0x40, 0x20]));
+const actualString = new BN('0x4020');

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -25,12 +25,12 @@ interface ReductionContext {
 
 declare class BN {
     constructor(
-        number: number | string | number[] | Buffer | BN,
+        number: number | string | number[] | Uint8Array | Buffer | BN,
         base?: number | 'hex',
         endian?: Endianness
     );
     constructor(
-        number: number | string | number[] | Buffer | BN,
+        number: number | string | number[] | Uint8Array | Buffer | BN,
         endian?: Endianness
     )
 


### PR DESCRIPTION
Only thing I'm uncertain on is whether `Uint8Array` is safe to include in definitions yet.  It has been around for years and bn.js supports it, though [indirectly](https://github.com/indutny/bn.js/blob/master/lib/bn.js#L144).

```
> new BigNumber(new Uint8Array([0x40, 0x20])).toString(16)
'4020'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/indutny/bn.js/blob/master/lib/bn.js#L144>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
