### PR TITLE
underscore: Allow to pass _.List<T> to OOP wrapper

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -105,6 +105,7 @@ declare module _ {
         * @param key First argument to Underscore object functions.
         **/
         <T>(value: _.Dictionary<T>): Underscore<T>;
+        <T>(value: _.List<T>): Underscore<T>;
         <T>(value: Array<T>): Underscore<T>;
         <T>(value: T): Underscore<T>;
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -147,6 +147,10 @@ namespace TestFind {
 		result = _('abc').chain().detect<string>(iterator).value();
 		result = _('abc').chain().detect<string>(iterator, context).value();
 	}
+
+    {
+        _(list).map(x => x.a);
+    }
 }
 
 var evens = _.filter([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/#oop
- [ ] Increase the version number in the header if appropriate **(this isn't a feature introduced in 1.9 so I am not sure if version should be increased)**.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }` **(tslint.json already exists)**.

-----

It is possible to pass first argument to underscore rather than to a function (so called OOP style).

However, the following code fails to compile according to the current d.ts (live js demo: https://codepen.io/awesoon/pen/RdOMYa?editors=1112):

```
const data = [
  {
    id: 1,
    text: 'This'
  },
  {
    id: 2,
    text: 'works'
  },
  {
    id: 3,
    text: 'fine'
  }
];

const groups = _(data).groupBy(x => x.id);
const values = _(groups).values().map(xs => _(xs).map(x => x.text))
console.log(values);
```

Error message is: `Property 'text' does not exist on type 'List<{ id: number; text: string; }>'`

See simplified test case in the test file changes.

This MR fixes the error above by allowing to pass objects of type `_.List<T>` to underscore