### PR TITLE
[node] crypto.Verify and Signer should be classes

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -268,21 +268,23 @@ declare module "crypto" {
 
     type KeyLike = string | Buffer | KeyObject;
 
-    interface Signer extends NodeJS.WritableStream {
+    class Signer extends stream.Writable {
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
         sign(private_key: SignPrivateKeyInput | KeyLike): Buffer;
         sign(private_key: SignPrivateKeyInput | KeyLike, output_format: HexBase64Latin1Encoding): string;
+        private constructor();
     }
 
     function createVerify(algorith: string, options?: stream.WritableOptions): Verify;
-    interface Verify extends NodeJS.WritableStream {
+    class Verify extends stream.Writable {
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
         verify(object: Object | KeyLike, signature: Binary): boolean;
-        verify(object: Object | KeyLike, signature: string, signature_format: HexBase64Latin1Encoding): boolean;
+        verify(object: Object | KeyLike, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
+        private constructor();
     }
     function createDiffieHellman(prime_length: number, generator?: number | Binary): DiffieHellman;
     function createDiffieHellman(prime: Binary): DiffieHellman;

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -118,13 +118,15 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    interface Hash extends NodeJS.ReadWriteStream {
+    class Hash extends stream.Duplex {
+        private constructor();
         update(data: BinaryLike): Hash;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    interface Hmac extends NodeJS.ReadWriteStream {
+    class Hmac extends stream.Duplex {
+        private constructor();
         update(data: BinaryLike): Hmac;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
         digest(): Buffer;
@@ -133,7 +135,8 @@ declare module "crypto" {
 
     export type KeyObjectType = 'secret' | 'public' | 'private';
 
-    interface KeyObject {
+    class KeyObject {
+        private constructor();
         asymmetricKeyType?: KeyType;
         export(options?: {
             type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1',
@@ -182,7 +185,8 @@ declare module "crypto" {
         algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
     ): Cipher;
 
-    interface Cipher extends NodeJS.ReadWriteStream {
+    class Cipher extends stream.Duplex {
+        private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Binary, input_encoding: undefined, output_encoding: HexBase64BinaryEncoding): string;
@@ -222,7 +226,8 @@ declare module "crypto" {
     ): DecipherGCM;
     function createDecipheriv(algorithm: string, key: BinaryLike, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
 
-    interface Decipher extends NodeJS.ReadWriteStream {
+    class Decipher extends stream.Duplex {
+        private constructor();
         update(data: Binary): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Binary, input_encoding: undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
@@ -269,29 +274,32 @@ declare module "crypto" {
     type KeyLike = string | Buffer | KeyObject;
 
     class Signer extends stream.Writable {
+        private constructor();
+
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
         sign(private_key: SignPrivateKeyInput | KeyLike): Buffer;
         sign(private_key: SignPrivateKeyInput | KeyLike, output_format: HexBase64Latin1Encoding): string;
-        private constructor();
     }
 
     function createVerify(algorith: string, options?: stream.WritableOptions): Verify;
     class Verify extends stream.Writable {
+        private constructor();
+
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
         verify(object: Object | KeyLike, signature: Binary): boolean;
         verify(object: Object | KeyLike, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
-        private constructor();
     }
     function createDiffieHellman(prime_length: number, generator?: number | Binary): DiffieHellman;
     function createDiffieHellman(prime: Binary): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | Binary): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    interface DiffieHellman {
+    class DiffieHellman {
+        private constructor();
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding): string;
         computeSecret(other_public_key: Binary): Buffer;
@@ -370,6 +378,7 @@ declare module "crypto" {
     function getCurves(): string[];
     function getHashes(): string[];
     class ECDH {
+        private constructor();
         static convertKey(
             key: BinaryLike,
             curve: string,

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -487,6 +487,41 @@ import { promisify } from 'util';
 }
 
 {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
+        namedCurve: 'sect239k1'
+    });
+
+    const sign: crypto.Signer = crypto.createSign('SHA256');
+    sign.write('some data to sign');
+    sign.end();
+    const signature: string = sign.sign(privateKey, 'hex');
+
+    const verify: crypto.Verify = crypto.createVerify('SHA256');
+    verify.write('some data to sign');
+    verify.end();
+    verify.verify(publicKey, signature);    // $ExpectType boolean
+
+    verify instanceof crypto.Verify;        // $ExpectType boolean
+    sign instanceof crypto.Signer;          // $ExpectType boolean
+}
+
+{
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+    });
+
+    const sign: crypto.Signer = crypto.createSign('SHA256');
+    sign.update('some data to sign');
+    sign.end();
+    const signature: Buffer = sign.sign(privateKey);
+
+    const verify: crypto.Verify = crypto.createVerify('SHA256');
+    verify.update('some data to sign');
+    verify.end();
+    verify.verify(publicKey, signature);    // $ExpectType boolean
+}
+
+{
     // crypto_constants_test
     let num: number;
     let str: string;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -501,8 +501,9 @@ import { promisify } from 'util';
     verify.end();
     verify.verify(publicKey, signature);    // $ExpectType boolean
 
-    verify instanceof crypto.Verify;        // $ExpectType boolean
-    sign instanceof crypto.Signer;          // $ExpectType boolean
+    // ensure that instanceof works
+    verify instanceof crypto.Verify;
+    sign instanceof crypto.Signer;
 }
 
 {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://nodejs.org/api/crypto.html#crypto_class_verify
https://nodejs.org/api/crypto.html#crypto_class_sign
https://nodejs.org/api/crypto.html#crypto_verify_verify_object_signature_signatureencoding
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Besides converting `Verify` and `Signer` to classes with private constructor I made also `signature_format` in `Verify.verify` optional otherwise the sample in node docs won't work.

fixes: #34128
fyi @everett1992
