### PR TITLE
[debug] Override all per-namespace log settings

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -29,3 +29,7 @@ extendedLog("Testing this is also an IDebugger.");
 
 const extendedWithCustomDelimiter: debug1.Debugger = log.extend('with-delim', '.');
 extendedWithCustomDelimiter("Testing this is an IDebugger, too.");
+
+debug2.log = console.error.bind(console);
+const anotherLogger = debug2("DefinitelyTyped:error");
+anotherLogger("This should be printed to stdout");

--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -30,6 +30,6 @@ extendedLog("Testing this is also an IDebugger.");
 const extendedWithCustomDelimiter: debug1.Debugger = log.extend('with-delim', '.');
 extendedWithCustomDelimiter("Testing this is an IDebugger, too.");
 
-debug2.log = console.error.bind(console);
+debug2.log = console.log.bind(console);
 const anotherLogger = debug2("DefinitelyTyped:error");
 anotherLogger("This should be printed to stdout");

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -5,6 +5,7 @@
 //                 John McLaughlin <https://github.com/zamb3zi>
 //                 Brasten Sager <https://github.com/brasten>
 //                 Nicolas Penin <https://github.com/npenin>
+//                 Kristian Brünn <https://github.com/kristianmitk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var debug: debug.Debug & { debug: debug.Debug; default: debug.Debug };

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -7,7 +7,7 @@
 //                 Nicolas Penin <https://github.com/npenin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare var debug: debug.Debug & {debug: debug.Debug, default: debug.Debug};
+declare var debug: debug.Debug & { debug: debug.Debug; default: debug.Debug };
 
 export = debug;
 export as namespace debug;
@@ -19,6 +19,7 @@ declare namespace debug {
         disable: () => string;
         enable: (namespaces: string) => void;
         enabled: (namespaces: string) => boolean;
+        log: (...args: any[]) => any;
 
         names: RegExp[];
         skips: RegExp[];


### PR DESCRIPTION
The `Debug` interface declaration is missing the `log` function, that allows to override all per-namespace log settings. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/visionmedia/debug#output-streams>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.