### PR TITLE
egg-mock: set noImplicitAny: false

### DIFF
--- a/types/egg-mock/tsconfig.json
+++ b/types/egg-mock/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": true,
+        "noImplicitAny": false,
         "noImplicitThis": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,


### PR DESCRIPTION
egg-mock 3.* has a dependency on egg-logger 1.7.1, which has an implicit-any error in its d.ts.

Until somebody updates egg-mock types, I think it's fine to change this package to not give implicit-any errors.