### PR TITLE
Fix get-value second argument typing not accepting arrays

### DIFF
--- a/types/get-value/get-value-tests.ts
+++ b/types/get-value/get-value-tests.ts
@@ -6,6 +6,9 @@ get(obj, "a");
 get(obj, "a.b");
 get(obj, "a.b.c");
 get(obj, "a.b.c.d");
+get(obj, ['a']);
+get(obj, ['a', 'b', 'c']);
+get(obj, ['a', 'b', 'c', 'd']);
 
 {
     const isEnumerable = Object.prototype.propertyIsEnumerable;

--- a/types/get-value/index.d.ts
+++ b/types/get-value/index.d.ts
@@ -1,13 +1,14 @@
 // Type definitions for get-value 3.0
 // Project: https://github.com/jonschlinkert/get-value
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
+//                 Mathew Allen <https://github.com/TheMallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 export = get;
 
 declare function get<T>(obj: T): T;
-declare function get(obj: object, key: string, options?: get.Options): any;
+declare function get(obj: object, key: string | string[], options?: get.Options): any;
 
 declare namespace get {
     interface Options {


### PR DESCRIPTION
This PR fixes the typing for `get-value`, specifically the second argument type [should accept arrays](https://github.com/jonschlinkert/get-value#supports-arrays)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jonschlinkert/get-value#supports-arrays
- [ ] Increase the version number in the header if appropriate. **(N/A)**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **(N/A)**
