### PR TITLE
[lodash]Tweak `isArray` to keep existing type info

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -391,6 +391,11 @@ declare module "../index" {
         isArray(value?: any): value is any[];
 
         /**
+         * @see _.isArray
+         */
+        isArray<T>(value?: T): value is T extends any[] ? T : never;
+
+        /**
          * DEPRECATED
          */
         isArray<T>(value?: any): value is any[];

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1893,7 +1893,10 @@ declare namespace _ {
     }
     type LodashInvokeMap2x1<TResult> = (collection: object | null | undefined) => TResult[];
     type LodashIsArguments = (value: any) => value is IArguments;
-    type LodashIsArray = (value: any) => value is any[];
+    interface LodashIsArray {
+        (value: any): value is any[];
+        <T>(value: T): value is T extends any[] ? T : never;
+    }
     type LodashIsArrayBuffer = (value: any) => value is ArrayBuffer;
     interface LodashIsArrayLike {
         <T>(value: T & string & number): boolean;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3767,13 +3767,13 @@ fp.now(); // $ExpectType number
     const value: number | string[] | boolean[] = anything;
 
     if (_.isArray(value)) {
-        const result: string[] | boolean[] = value;
+        value; // $ExpectType string[] | boolean[]
     } else {
         value; // $ExpectType number
     }
 
     if (fp.isArray(value)) {
-        const result: string[] | boolean[] = value;
+        value; // $ExpectType string[] | boolean[]
     } else {
         value; // $ExpectType number
     }


### PR DESCRIPTION
```typescript
const value: number | string[] | boolean[] = anything;

if (_.isArray(value)) {
    value; // $ExpectType string[] | boolean[]
} else {
    value; // $ExpectType number
}
```