### PR TITLE
[@types/google__maps] fix: PlaceSearchResult vicinity is a string

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1687,7 +1687,7 @@ export interface PlaceSearchResult {
      * contains a feature name of a nearby location. Often this feature refers to a street or neighborhood within the given results.
      * The `vicinity` property is only returned for a Nearby Search.
      */
-    vicinity: number;
+    vicinity?: string;
     /**
      * is a string containing the human-readable address of this place. Often this address is equivalent to the "postal address".
      * The `formatted_address` property is only returned for a Text Search.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/places/web-service/search#nearby-search-and-text-search-responses
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


