### PR TITLE
[sinon] Correct comparable type

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -238,22 +238,22 @@ declare namespace Sinon {
          * Returns true if the spy was called before @param anotherSpy
          * @param anotherSpy
          */
-        calledBefore(anotherSpy: SinonSpy): boolean;
+        calledBefore(anotherSpy: SinonInspectable): boolean;
         /**
          * Returns true if the spy was called after @param anotherSpy
          * @param anotherSpy
          */
-        calledAfter(anotherSpy: SinonSpy): boolean;
+        calledAfter(anotherSpy: SinonInspectable): boolean;
         /**
          * Returns true if spy was called before @param anotherSpy, and no spy calls occurred between spy and @param anotherSpy.
          * @param anotherSpy
          */
-        calledImmediatelyBefore(anotherSpy: SinonSpy): boolean;
+        calledImmediatelyBefore(anotherSpy: SinonInspectable): boolean;
         /**
          * Returns true if spy was called after @param anotherSpy, and no spy calls occurred between @param anotherSpy and spy.
          * @param anotherSpy
          */
-        calledImmediatelyAfter(anotherSpy: SinonSpy): boolean;
+        calledImmediatelyAfter(anotherSpy: SinonInspectable): boolean;
         /**
          * Returns true if the spy was always called with @param obj as this.
          * @param obj

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -379,6 +379,7 @@ function testSpy() {
     let fn = (arg: string, arg2: number): boolean => true;
     const obj = class {
         foo() { }
+        foobar(p1?: string) { return p1; }
         set bar(val: number) { }
         get bar() { return 0; }
     };
@@ -387,8 +388,19 @@ function testSpy() {
     const spy = sinon.spy(); // $ExpectType SinonSpy<any[], any>
     const spyTwo = sinon.spy().named('spyTwo');
 
-    const methodSpy = sinon.spy(instance, 'foo');
-    const methodSpy2 = sinon.spy(instance, 'bar', ['set', 'get']);
+    const methodSpy = sinon.spy(instance, 'foo'); // $ExpectType SinonSpy<[], void>
+    const methodSpy2 = sinon.spy(instance, 'bar', ['set', 'get']); // $ExpectType SinonSpy<any[], any>
+    const methodSpy3 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined>
+
+    methodSpy.calledBefore(methodSpy2);
+    methodSpy.calledAfter(methodSpy2);
+    methodSpy.calledImmediatelyBefore(methodSpy2);
+    methodSpy.calledImmediatelyAfter(methodSpy2);
+
+    methodSpy.calledBefore(methodSpy3);
+    methodSpy.calledAfter(methodSpy3);
+    methodSpy.calledImmediatelyBefore(methodSpy3);
+    methodSpy.calledImmediatelyAfter(methodSpy3);
 
     let count = 0;
     count = spy.callCount;


### PR DESCRIPTION
Typescript complains for functions `calledBefore`, `calledAfter`, `calledImmediatelyBefore` and `calledImmediatelyAfter` because it's trying to compare a `SinonInspectable` to a `SinonSpy`. Correct comparison should be done on the same type (i.e. `SinonInspectable`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).