### PR TITLE
[btoa] Accept Buffer

### DIFF
--- a/types/btoa/btoa-tests.ts
+++ b/types/btoa/btoa-tests.ts
@@ -1,3 +1,5 @@
 import btoa = require('btoa');
 
 btoa('foo');
+
+btoa(Buffer.from('foo'));

--- a/types/btoa/index.d.ts
+++ b/types/btoa/index.d.ts
@@ -5,6 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-declare function btoa(str: string): string;
+/// <reference types="node" />
+
+declare function btoa(str: string | Buffer): string;
 
 export = btoa;


### PR DESCRIPTION
According to [the source code](https://git.coolaj86.com/coolaj86/btoa.js/src/branch/master/index.js) `btoa` function accepts both `string` and `Buffer`
