### PR TITLE
[qs] Add 'comma' to parse options

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qs 6.5.1
+// Type definitions for qs 6.5
 // Project: https://github.com/ljharb/qs
 // Definitions by: Roman Korneev <https://github.com/RWander>
 //                 Leon Yu <https://github.com/leonyu>

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qs 6.5.0
+// Type definitions for qs 6.5.1
 // Project: https://github.com/ljharb/qs
 // Definitions by: Roman Korneev <https://github.com/RWander>
 //                 Leon Yu <https://github.com/leonyu>
@@ -6,6 +6,7 @@
 //                 Melvin Lee <https://github.com/zyml>
 //                 Arturs Vonda <https://github.com/artursvonda>
 //                 Carlos Bonetti <https://github.com/CarlosBonetti>
+//                 Dan Smith <https://github.com/dpsmith3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = QueryString;
@@ -30,6 +31,7 @@ declare namespace QueryString {
     }
 
     interface IParseOptions {
+        comma?: boolean;
         delimiter?: string | RegExp;
         depth?: number;
         decoder?: (str: string) => any;

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -239,6 +239,11 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 }
 
 () => {
+    var parsedCommaSeparatedArray = qs.parse('?a=b,c', { comma: true });
+    assert.equal(parsedCommaSeparatedArray, { a: ['b', 'c']});
+}
+
+() => {
     var nullsSkipped = qs.stringify({ a: 'b', c: null }, { skipNulls: true });
     assert.equal(nullsSkipped, 'a=b');
 }

--- a/types/qs/tslint.json
+++ b/types/qs/tslint.json
@@ -7,7 +7,6 @@
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,
-        "dt-header": false,
         "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,


### PR DESCRIPTION
Please fill in this template.

- [y ] Use a meaningful title for the pull request. Include the name of the package modified.
- [y ] Test the change in your own code. (Compile and run.)
- [y ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [y ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [y ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ljharb/qs
"Some people use comma to join array, qs can parse it:"
```
var arraysOfObjects = qs.parse('a=b,c', { comma: true })
assert.deepEqual(arraysOfObjects, { a: ['b', 'c'] })
```
- [ y] Increase the version number in the header if appropriate.
- [n ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.