### PR TITLE
[activestorage]: make 'delegate' constructor argument optional

### DIFF
--- a/types/activestorage/index.d.ts
+++ b/types/activestorage/index.d.ts
@@ -13,7 +13,7 @@ export class DirectUpload {
     file: File;
     url: string;
 
-    constructor(file: File, url: string, delegate: DirectUploadDelegate)
+    constructor(file: File, url: string, delegate?: DirectUploadDelegate)
 
     create(callback: (error: Error, blob: Blob) => void): void;
 }


### PR DESCRIPTION
Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rails/rails/blob/v5.2.0/activestorage/app/javascript/activestorage/direct_upload.js

Reasoning:

If you look at the active storage code, the delegate is used in the `notify` method, which first checks the existence of the delegate before calling any methods on it. If you look at the Rails docs showing usage of this package, their example omits the delegate: https://edgeguides.rubyonrails.org/active_storage_overview.html#integrating-with-libraries-or-frameworks

Snippet from the RoR guide:
```
...
const uploadFile = (file) => {
  // your form needs the file_field direct_upload: true, which
  //  provides data-direct-upload-url
  const url = input.dataset.directUploadUrl
  const upload = new DirectUpload(file, url)
 
  upload.create((error, blob) => {
    if (error) {
      // Handle the error
    } else {
      // Add an appropriately-named hidden input to the form with a
...
```