### PR TITLE
Fix type of ChildProcess.channel

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -7,7 +7,7 @@ declare module "child_process" {
         stdin: Writable | null;
         stdout: Readable | null;
         stderr: Readable | null;
-        readonly channel?: Pipe | null;
+        readonly channel?: Pipe;
         readonly stdio: [
             Writable | null, // stdin
             Readable | null, // stdout


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html#child_process_subprocess_channel

---

From [the documentation](https://nodejs.org/api/child_process.html#child_process_subprocess_channel):

> If no IPC channel currently exists, this property is `undefined`.
