### PR TITLE
Add overloads to child_process.spawn for better type inference

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -79,7 +79,7 @@ declare module "child_process" {
     }
 
     // return this object when stdio option is undefined or not specified
-    interface ChildProcessWithoutNullStreams {
+    interface ChildProcessWithoutNullStreams extends ChildProcess {
         stdin: Writable;
         stdout: Readable;
         stderr: Readable;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -78,6 +78,20 @@ declare module "child_process" {
         prependOnceListener(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
     }
 
+    // return this object when stdio option is undefined or not specified
+    interface ChildProcessWithoutNullStreams {
+        stdin: Writable;
+        stdout: Readable;
+        stderr: Readable;
+        readonly stdio: [
+            Writable, // stdin
+            Readable, // stdout
+            Readable, // stderr
+            Readable | Writable | null | undefined, // extra, no modification
+            Readable | Writable | null | undefined // extra, no modification
+        ]
+    }
+
     interface MessageOptions {
         keepOpen?: boolean;
     }
@@ -110,7 +124,13 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean;
     }
 
+    interface SpawnOptionsWithoutStdio extends SpawnOptions {
+        stdio?: undefined | undefined[];
+    }
+
+    function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
     function spawn(command: string, options?: SpawnOptions): ChildProcess;
+    function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
     function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -89,7 +89,7 @@ declare module "child_process" {
             Readable, // stderr
             Readable | Writable | null | undefined, // extra, no modification
             Readable | Writable | null | undefined // extra, no modification
-        ]
+        ];
     }
 
     interface MessageOptions {
@@ -125,7 +125,7 @@ declare module "child_process" {
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: undefined | 'pipe' | Array<undefined | 'pipe'>;
+        stdio?: 'pipe' | Array<undefined | 'pipe'>;
     }
 
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -125,7 +125,7 @@ declare module "child_process" {
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: undefined | undefined[];
+        stdio?: undefined | 'pipe' | Array<undefined | 'pipe'>;
     }
 
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -129,9 +129,9 @@ declare module "child_process" {
     }
 
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
-    function spawn(command: string, options?: SpawnOptions): ChildProcess;
+    function spawn(command: string, options: SpawnOptions): ChildProcess;
     function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
-    function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
+    function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {
         shell?: string;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -125,7 +125,7 @@ declare module "child_process" {
     }
 
     interface SpawnOptionsWithoutStdio extends SpawnOptions {
-        stdio?: 'pipe' | Array<undefined | 'pipe'>;
+        stdio?: 'pipe' | Array<null | undefined | 'pipe'>;
     }
 
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -291,11 +291,15 @@ async function testPromisify() {
     expectNonNull(childProcess.spawn('command'));
     expectNonNull(childProcess.spawn('command', {}));
     expectNonNull(childProcess.spawn('command', { stdio: undefined }));
+    expectNonNull(childProcess.spawn('command', { stdio: 'pipe' }));
     expectNonNull(childProcess.spawn('command', { stdio: [undefined, undefined, undefined] }));
+    expectNonNull(childProcess.spawn('command', { stdio: ['pipe', 'pipe', 'pipe'] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c']));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], {}));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: undefined }));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: 'pipe' }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
 }
 {
     process.stdin.setEncoding('utf8');

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -302,6 +302,25 @@ async function testPromisify() {
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
+
+    function expectChildProcess (cp: childProcess.ChildProcess): void {
+        return undefined;
+    }
+
+    expectChildProcess(childProcess.spawn('command'));
+    expectChildProcess(childProcess.spawn('command', {}));
+    expectChildProcess(childProcess.spawn('command', { stdio: undefined }));
+    expectChildProcess(childProcess.spawn('command', { stdio: 'pipe' }));
+    expectChildProcess(childProcess.spawn('command', { stdio: [undefined, undefined, undefined] }));
+    expectChildProcess(childProcess.spawn('command', { stdio: [null, null, null] }));
+    expectChildProcess(childProcess.spawn('command', { stdio: ['pipe', 'pipe', 'pipe'] }));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c']));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], {}));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: undefined }));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: 'pipe' }));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }));
+    expectChildProcess(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
 }
 {
     process.stdin.setEncoding('utf8');

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -303,7 +303,7 @@ async function testPromisify() {
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
 
-    function expectChildProcess (cp: childProcess.ChildProcess): void {
+    function expectChildProcess(cp: childProcess.ChildProcess): void {
         return undefined;
     }
 

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -57,7 +57,7 @@ async function testPromisify() {
 }
 
 {
-    let cp = childProcess.spawn('asd');
+    let cp = childProcess.spawn('asd', { stdio: 'inherit' });
     const _socket: net.Socket = net.createConnection(1);
     const _server: net.Server = net.createServer();
     let _boolean: boolean;
@@ -272,6 +272,30 @@ async function testPromisify() {
         const _message: any = message;
         const _sendHandle: net.Socket | net.Server = sendHandle;
     });
+
+    function expectNonNull(cp: {
+        readonly stdin: Writable;
+        readonly stdout: Readable;
+        readonly stderr: Readable;
+        readonly stdio: [
+            Writable,
+            Readable,
+            Readable,
+            any,
+            any
+        ];
+    }): void {
+        return undefined;
+    }
+
+    expectNonNull(childProcess.spawn('command'));
+    expectNonNull(childProcess.spawn('command', {}));
+    expectNonNull(childProcess.spawn('command', { stdio: undefined }));
+    expectNonNull(childProcess.spawn('command', { stdio: [undefined, undefined, undefined] }));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c']));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], {}));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: undefined }));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }));
 }
 {
     process.stdin.setEncoding('utf8');

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -293,12 +293,14 @@ async function testPromisify() {
     expectNonNull(childProcess.spawn('command', { stdio: undefined }));
     expectNonNull(childProcess.spawn('command', { stdio: 'pipe' }));
     expectNonNull(childProcess.spawn('command', { stdio: [undefined, undefined, undefined] }));
+    expectNonNull(childProcess.spawn('command', { stdio: [null, null, null] }));
     expectNonNull(childProcess.spawn('command', { stdio: ['pipe', 'pipe', 'pipe'] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c']));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], {}));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: undefined }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: 'pipe' }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }));
+    expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
 }
 {


### PR DESCRIPTION
Without `options.stdio`, `cp.{stdin,stdout,stderr}` should not be `null`.

I make this change because I don't want to check for `null` when I am sure `stdout` is not `null`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html#child_process_subprocess_stdout

> If the child was spawned with `stdio[n]` set to anything other than `'pipe'`, then this will be `null`.
