### PR TITLE
semver: add missing properties and functions, correct some parameter types

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -11,7 +11,7 @@ export type ReleaseType = "major" | "premajor" | "minor" | "preminor" | "patch" 
 
 export interface Options {
     loose?: boolean;
-    includePrerelease?: boolean
+    includePrerelease?: boolean;
 }
 
 /**
@@ -45,7 +45,7 @@ export function patch(v: string | SemVer, optionsOrLoose?: boolean | Options): n
 /**
  * Returns an array of prerelease components, or null if none exist.
  */
-export function prerelease(v: string | SemVer, optionsOrLoose?: boolean | Options): string[] | null;
+export function prerelease(v: string | SemVer, optionsOrLoose?: boolean | Options): ReadonlyArray<string> | null;
 
 // Comparison
 /**
@@ -102,16 +102,16 @@ export function rcompareIdentifiers(a: string | null, b: string | null): 1 | 0 |
 /**
  * Sorts an array of semver entries in ascending order.
  */
-export function sort(list: Array<string | SemVer>, optionsOrLoose?: boolean | Options): Array<string | SemVer>;
+export function sort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
 /**
  * Sorts an array of semver entries in descending order.
  */
-export function rsort(list: Array<string | SemVer>, optionsOrLoose?: boolean | Options): Array<string | SemVer>;
+export function rsort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
 
 /**
  * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
  */
-export function diff(v1: string, v2: string, optionsOrLoose?: boolean | Options): ReleaseType | null;
+export function diff(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): ReleaseType | null;
 
 // Ranges
 /**
@@ -125,15 +125,15 @@ export function satisfies(version: string | SemVer, range: string | Range, optio
 /**
  * Return the highest version in the list that satisfies the range, or null if none of them do.
  */
-export function maxSatisfying(versions: Array<string | SemVer>, range: string | Range, optionsOrLoose?: boolean | Options): string | null;
+export function maxSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
 /**
  * Return the lowest version in the list that satisfies the range, or null if none of them do.
  */
-export function minSatisfying(versions: Array<string | SemVer>, range: string, optionsOrLoose?: boolean | Options): string | null;
+export function minSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
 /**
  * Return the lowest version that can possibly match the given range.
  */
-export function minVersion(range: string | Range, optionsOrLoose?: boolean | Options): SemVer;
+export function minVersion(range: string | Range, optionsOrLoose?: boolean | Options): SemVer | null;
 /**
  * Return true if version is greater than all the versions possible in the range.
  */
@@ -171,8 +171,8 @@ export class SemVer {
     minor: number;
     patch: number;
     version: string;
-    build: string[];
-    prerelease: string[];
+    build: ReadonlyArray<string>;
+    prerelease: ReadonlyArray<string>;
 
     compare(other: string | SemVer): 1 | 0 | -1;
     compareMain(other: string | SemVer): 1 | 0 | -1;
@@ -204,8 +204,8 @@ export class Range {
     format(): string;
     inspect(): string;
 
-    set: Comparator[][];
-    parseRange(range: string): Comparator[];
+    set: ReadonlyArray<ReadonlyArray<Comparator>>;
+    parseRange(range: string): ReadonlyArray<Comparator>;
     test(version: string | SemVer): boolean;
     intersects(range: Range, optionsOrLoose?: boolean | Options): boolean;
 }

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -9,81 +9,86 @@ export const SEMVER_SPEC_VERSION: "2.0.0";
 
 export type ReleaseType = "major" | "premajor" | "minor" | "preminor" | "patch" | "prepatch" | "prerelease";
 
+export interface Options {
+    loose?: boolean;
+    includePrerelease?: boolean
+}
+
 /**
  * Return the parsed version as a SemVer object, or null if it's not valid.
  */
-export function parse(v: string | SemVer, loose?: boolean): SemVer | null;
+export function parse(v: string | SemVer, optionsOrLoose?: boolean | Options): SemVer | null;
 /**
  * Return the parsed version, or null if it's not valid.
  */
-export function valid(v: string | SemVer, loose?: boolean): string | null;
+export function valid(v: string | SemVer, optionsOrLoose?: boolean | Options): string | null;
 /**
  * Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
  */
-export function clean(version: string, loose?: boolean): string | null;
+export function clean(version: string, optionsOrLoose?: boolean | Options): string | null;
 /**
  * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
  */
-export function inc(v: string | SemVer, release: ReleaseType, loose?: boolean, identifier?: string): string | null;
+export function inc(v: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
 /**
  * Return the major version number.
  */
-export function major(v: string | SemVer, loose?: boolean): number;
+export function major(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
 /**
  * Return the minor version number.
  */
-export function minor(v: string | SemVer, loose?: boolean): number;
+export function minor(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
 /**
  * Return the patch version number.
  */
-export function patch(v: string | SemVer, loose?: boolean): number;
+export function patch(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
 /**
  * Returns an array of prerelease components, or null if none exist.
  */
-export function prerelease(v: string | SemVer, loose?: boolean): string[] | null;
+export function prerelease(v: string | SemVer, optionsOrLoose?: boolean | Options): string[] | null;
 
 // Comparison
 /**
  * v1 > v2
  */
-export function gt(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function gt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 /**
  * v1 >= v2
  */
-export function gte(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function gte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 /**
  * v1 < v2
  */
-export function lt(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function lt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 /**
  * v1 <= v2
  */
-export function lte(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function lte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 /**
  * v1 == v2 This is true if they're logically equivalent, even if they're not the exact same string. You already know how to compare strings.
  */
-export function eq(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function eq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 /**
  * v1 != v2 The opposite of eq.
  */
-export function neq(v1: string | SemVer, v2: string | SemVer, loose?: boolean): boolean;
+export function neq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 
 /**
  * Pass in a comparison string, and it'll call the corresponding semver comparison function.
  * "===" and "!==" do simple string comparison, but are included for completeness.
  * Throws if an invalid comparison string is provided.
  */
-export function cmp(v1: string | SemVer, operator: Operator, v2: string | SemVer, loose?: boolean): boolean;
+export function cmp(v1: string | SemVer, operator: Operator, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 export type Operator = '===' | '!==' | '' | '=' | '==' | '!=' | '>' | '>=' | '<' | '<=';
 
 /**
  * Return 0 if v1 == v2, or 1 if v1 is greater, or -1 if v2 is greater. Sorts in ascending order if passed to Array.sort().
  */
-export function compare(v1: string | SemVer, v2: string | SemVer, loose?: boolean): 1 | 0 | -1;
+export function compare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
 /**
  * The reverse of compare. Sorts an array of versions in descending order when passed to Array.sort().
  */
-export function rcompare(v1: string | SemVer, v2: string | SemVer, loose?: boolean): 1 | 0 | -1;
+export function rcompare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
 
 /**
  * Compares two identifiers, must be numeric strings or truthy/falsy values. Sorts in ascending order if passed to Array.sort().
@@ -97,51 +102,55 @@ export function rcompareIdentifiers(a: string | null, b: string | null): 1 | 0 |
 /**
  * Sorts an array of semver entries in ascending order.
  */
-export function sort(list: Array<string | SemVer>, loose?: boolean): Array<string | SemVer>;
+export function sort(list: Array<string | SemVer>, optionsOrLoose?: boolean | Options): Array<string | SemVer>;
 /**
  * Sorts an array of semver entries in descending order.
  */
-export function rsort(list: Array<string | SemVer>, loose?: boolean): Array<string | SemVer>;
+export function rsort(list: Array<string | SemVer>, optionsOrLoose?: boolean | Options): Array<string | SemVer>;
 
 /**
  * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
  */
-export function diff(v1: string, v2: string, loose?: boolean): ReleaseType | null;
+export function diff(v1: string, v2: string, optionsOrLoose?: boolean | Options): ReleaseType | null;
 
 // Ranges
 /**
  * Return the valid range or null if it's not valid
  */
-export function validRange(range: string | Range, loose?: boolean): string;
+export function validRange(range: string | Range, optionsOrLoose?: boolean | Options): string;
 /**
  * Return true if the version satisfies the range.
  */
-export function satisfies(version: string | SemVer, range: string | Range, loose?: boolean): boolean;
+export function satisfies(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
 /**
  * Return the highest version in the list that satisfies the range, or null if none of them do.
  */
-export function maxSatisfying(versions: Array<string | SemVer>, range: string | Range, loose?: boolean): string;
+export function maxSatisfying(versions: Array<string | SemVer>, range: string | Range, optionsOrLoose?: boolean | Options): string | null;
 /**
  * Return the lowest version in the list that satisfies the range, or null if none of them do.
  */
-export function minSatisfying(versions: Array<string | SemVer>, range: string, loose?: boolean): string;
+export function minSatisfying(versions: Array<string | SemVer>, range: string, optionsOrLoose?: boolean | Options): string | null;
+/**
+ * Return the lowest version that can possibly match the given range.
+ */
+export function minVersion(range: string | Range, optionsOrLoose?: boolean | Options): SemVer;
 /**
  * Return true if version is greater than all the versions possible in the range.
  */
-export function gtr(version: string | SemVer, range: string | Range, loose?: boolean): boolean;
+export function gtr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
 /**
  * Return true if version is less than all the versions possible in the range.
  */
-export function ltr(version: string | SemVer, range: string | Range, loose?: boolean): boolean;
+export function ltr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
 /**
  * Return true if the version is outside the bounds of the range in either the high or low direction.
  * The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
  */
-export function outside(version: string | SemVer, range: string | Range, hilo: '>' | '<', loose?: boolean): boolean;
+export function outside(version: string | SemVer, range: string | Range, hilo: '>' | '<', optionsOrLoose?: boolean | Options): boolean;
 /**
  * Return true if any of the ranges comparators intersect
  */
-export function intersects(range1: string | Range, range2: string | Range, loose?: boolean): boolean;
+export function intersects(range1: string | Range, range2: string | Range, optionsOrLoose?: boolean | Options): boolean;
 
 // Coercion
 /**
@@ -150,10 +159,11 @@ export function intersects(range1: string | Range, range2: string | Range, loose
 export function coerce(version: string | SemVer): SemVer | null;
 
 export class SemVer {
-    constructor(version: string | SemVer, loose?: boolean);
+    constructor(version: string | SemVer, optionsOrLoose?: boolean | Options);
 
     raw: string;
     loose: boolean;
+    options: Options;
     format(): string;
     inspect(): string;
 
@@ -171,27 +181,31 @@ export class SemVer {
 }
 
 export class Comparator {
-    constructor(comp: string | Comparator, loose?: boolean);
+    constructor(comp: string | Comparator, optionsOrLoose?: boolean | Options);
 
     semver: SemVer;
-    operator: string;
-    value: boolean;
+    operator: '' | '=' | '<' | '>' | '<=' | '>=';
+    value: string;
+    loose: boolean;
+    options: Options;
     parse(comp: string): void;
     test(version: string | SemVer): boolean;
-    intersects(comp: Comparator, loose?: boolean): boolean;
+    intersects(comp: Comparator, optionsOrLoose?: boolean | Options): boolean;
 }
 
 export class Range {
-    constructor(range: string | Range, loose?: boolean);
+    constructor(range: string | Range, optionsOrLoose?: boolean | Options);
 
     range: string;
     raw: string;
     loose: boolean;
+    options: Options;
+    includePrerelease: boolean;
     format(): string;
     inspect(): string;
 
     set: Comparator[][];
     parseRange(range: string): Comparator[];
     test(version: string | SemVer): boolean;
-    intersects(range: Range, loose?: boolean): boolean;
+    intersects(range: Range, optionsOrLoose?: boolean | Options): boolean;
 }

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semver 5.7
+// Type definitions for semver 6.0
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>
+//                 Klaus Meinhardt <https://github.com/ajafff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/semver
 
 export const SEMVER_SPEC_VERSION: "2.0.0";

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semver 5.5
+// Type definitions for semver 5.7
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -8,7 +8,7 @@ let diff: semver.ReleaseType | null;
 const op: semver.Operator = '';
 declare const arr: any[];
 declare const exp: RegExp;
-let strArr: string[] | null;
+let strArr: ReadonlyArray<string> | null;
 declare const numArr: string[];
 let comparatorResult: -1 | 0 | 1;
 let versionsArr: Array<string | semver.SemVer>;
@@ -18,7 +18,10 @@ const v2 = '';
 const version = '';
 const versions: string[] = [];
 const loose = true;
-let sem: semver.SemVer | null;
+let sem: semver.SemVer | null = new semver.SemVer(str, {});
+
+sem = new semver.SemVer(str, {includePrerelease: false});
+sem = new semver.SemVer(str, {loose: true});
 
 sem = semver.parse(str);
 strn = semver.valid(str);
@@ -58,12 +61,13 @@ diff = semver.diff(v1, v2, loose);
 // Ranges
 str = semver.validRange(str, loose);
 bool = semver.satisfies(version, str, loose);
-str = semver.maxSatisfying(versions, str, loose);
-str = semver.minSatisfying(versions, str, loose);
+strn = semver.maxSatisfying(versions, str, loose);
+strn = semver.minSatisfying(versions, str, loose);
 bool = semver.gtr(version, str, loose);
 bool = semver.ltr(version, str, loose);
 bool = semver.outside(version, str, '<', loose);
 bool = semver.intersects(str, str, loose);
+sem = semver.minVersion(str, loose);
 
 // Coercion
 sem = semver.coerce(str);
@@ -99,7 +103,7 @@ str = comp.toString();
 
 ver = comp.semver;
 str = comp.operator;
-bool = comp.value;
+str = comp.value;
 comp.parse(str);
 bool = comp.test(ver);
 bool = comp.intersects(new semver.Comparator(str));
@@ -115,8 +119,8 @@ bool = range.test(ver);
 bool = range.intersects(new semver.Range(''));
 bool = range.intersects(new semver.Range(''), bool);
 
-let sets: semver.Comparator[][];
+let sets: ReadonlyArray<ReadonlyArray<semver.Comparator>>;
 sets = range.set;
 
-let lims: semver.Comparator[];
+let lims: ReadonlyArray<semver.Comparator>;
 lims = range.parseRange(str);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I initially only wanted to fix `Comparator.value` and add the `minVersion` function.
I fixed some parameter and return types to match the actual runtime behavior.
I changed mutable Arrays to ReadonlyArray where appropriate.
I also changed `loose?: boolean` to `looseOrOptions?: boolean | Options`:

> All methods and classes take a final options object argument. All options in this object are false by default. The options supported are:
>
>* `loose` Be more forgiving about not-quite-valid semver strings. (Any resulting output will always be 100% strict compliant, of course.) For backwards compatibility reasons, if the options argument is a boolean value instead of an object, it is interpreted to be the loose param.
> * `includePrerelease` Set to suppress the default behavior of excluding prerelease tagged versions from ranges unless they are explicitly opted into.