### PR TITLE
Cleanup 20190328

### DIFF
--- a/types/glob-parent/index.d.ts
+++ b/types/glob-parent/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for glob-parent 3.1
-// Project: https://github.com/es128/glob-parent
+// Project: https://github.com/gulpjs/glob-parent
 // Definitions by: mrmlnc <https://github.com/mrmlnc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/is-glob/index.d.ts
+++ b/types/is-glob/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for is-glob 4.0
-// Project: https://github.com/jonschlinkert/is-glob
+// Project: https://github.com/micromatch/is-glob
 // Definitions by: mrmlnc <https://github.com/mrmlnc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/protractor-browser-logs/package.json
+++ b/types/protractor-browser-logs/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "protractor": "latest"
+        "protractor": "5.4.2"
     }
 }


### PR DESCRIPTION
The biggest change is a fix to protractor-browser-logs dependency:

Its dependency on protractor was "latest" &mdash; 6.0 &mdash; which doesn't work because protractor has a dependency on selenium-webdriver. In the Definitely Typed repo, selenium-webdriver is treated as a dependency on @types/selenium-webdriver because d.ts overrides .js.  But selenium-webdriver is at 3.0 while @types/selenium-webdriver is at 4.0, meaning that protractor's imports are broken for people (like DT) who have @types/selenium-webdriver installed.

There are three ways to fix this:

1. Update @types/selenium-webdriver to 4.0. This is a big task.
2. Fix protractor-browser-log's protractor dependency to 5.4.2, right before protractor updated to the latest version of selenium-webdriver.  This way the installed version of selenium-webdriver matches the version of @types/selenium-webdriver in DT.
3. ???? Other tsconfig.json/package.jon wizardry? I don't think this is
a worthwhile path to explore.