### PR TITLE
react-tag-autocomplete - Add type for handleValidate prop function

### DIFF
--- a/types/react-tag-autocomplete/index.d.ts
+++ b/types/react-tag-autocomplete/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-tag-autocomplete 5.6
 // Project: https://github.com/i-like-robots/react-tags#readme
 // Definitions by: James Lismore <https://github.com/jlismore>
+//                 Rahul Sagore <https://github.com/Rahul-Sagore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -81,6 +82,10 @@ export interface ReactTagsProps {
      * Optional event handler when the input changes. Receives the current input value.
      */
     handleInputChange?: (input: string) => void;
+    /**
+     * Optional validation function that determines if tag should be added to tags. Receives a tag object. Should return a boolean.
+     */
+    handleValidate?: (tag: Tag) => boolean;
     /**
      * An object containing additional attributes that will be applied to the underlying <input /> field.
      */

--- a/types/react-tag-autocomplete/react-tag-autocomplete-tests.tsx
+++ b/types/react-tag-autocomplete/react-tag-autocomplete-tests.tsx
@@ -30,6 +30,7 @@ class TestAll extends React.Component {
         const onBlur = () => {};
         const onFocus = () => {};
         const onInputChange = (input: string) => {};
+        const onValidate = (tag: { id: string | number; name: string }) => true;
         const inputAttributes = { maxLength: 10 };
         const suggestions = [
             { id: 3, name: "Bananas" },
@@ -55,6 +56,7 @@ class TestAll extends React.Component {
                 handleDelete={onDeleteTag}
                 handleFocus={onFocus}
                 handleInputChange={onInputChange}
+                handleValidate={onValidate}
                 inputAttributes={inputAttributes}
                 maxSuggestionsLength={10}
                 minQueryLength={5}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

`npm run lint react-tag-autocomplete` was already giving error, commented in this [Issue: Cannot find module 'csstype'](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24788#issuecomment-477709690)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/react-tag-autocomplete#handlevalidate-optional>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


More details:
I was using [react-tag-autocomplete](https://www.npmjs.com/package/react-tag-autocomplete#handlevalidate-optional) npm package and had to use `handleValidate` prop method provided by it. But it was giving error:

```js
 Property 'handleValidate' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<ReactTags> & Readonly<PropsWithChildren<ReactTagsProps>>'
```

Then I checked the `@types/react-tag-autocomplete/index.d.ts` and this prop was missing. I have added this change in locally `node_modules/` and it worked, hence creating a PR for this.