### PR TITLE
Add definition for the handleKey function within the mousetrap module

### DIFF
--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Mousetrap 1.6.x
 // Project: http://craig.is/killing/mice
-// Definitions by: Dániel Tar <https://github.com/qcz>, Alan Choi <https://github.com/alanhchoi>
+// Definitions by: Dániel Tar <https://github.com/qcz>, Alan Choi <https://github.com/alanhchoi>, Nic Barker <https://github.com/nicbarker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -27,6 +27,7 @@ interface MousetrapInstance {
     bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
     unbind(keys: string|string[], action?: string): void;
     trigger(keys: string, action?: string): void;
+    handleKey(character: string, modifiers: string[], e: ExtendedKeyboardEvent): void;
     reset(): void;
 }
 

--- a/types/mousetrap/test/index.ts
+++ b/types/mousetrap/test/index.ts
@@ -62,6 +62,8 @@ Mousetrap(element).bind('mod+s', function(){ console.log('Factory Saved'); });
 const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
 Mousetrap(element).bind(unionTypeKeys, function() { console.log('Union type test') });
 
+Mousetrap(element).handleKey = (character: string, modifiers: string[], e: KeyboardEvent) => { console.log('Override handleKey test') };
+
 // Test that Mousetrap can be loaded as an external module.
 // Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
 // then everything is working correctly.


### PR DESCRIPTION
This pull request makes the mousetrap extension method "handleKey" available. This method is documented [here](https://craig.is/killing/mice#api.handleKey).

- [✅] Use a meaningful title for the pull request. Include the name of the package modified.
- [✅] Test the change in your own code. (Compile and run.)
- [✅] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✅] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✅] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✅] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [✅] Provide a URL to documentation or source code which provides context for the suggested changes: [https://craig.is/killing/mice#api.handleKey](https://craig.is/killing/mice#api.handleKey)
- [✅] Increase the version number in the header if appropriate.
- [✅] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
