### PR TITLE
Changed ReactElement to ReactNode for consistency with flow types

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -95,7 +95,7 @@ export interface QueryRendererProps<T extends RelayRuntimeTypes.OperationBase = 
     dataFrom?: "NETWORK_ONLY"|"STORE_THEN_NETWORK";
     environment: RelayRuntimeTypes.Environment;
     query?: RelayRuntimeTypes.GraphQLTaggedNode | null;
-    render(readyState: ReadyState<T["response"]>): React.ReactElement | undefined | null;
+    render(readyState: ReadyState<T["response"]>): React.ReactNode;
     variables: T["variables"];
     rerunParamExperimental?: RelayRuntimeTypes.RerunParam;
 }


### PR DESCRIPTION
react-relay [flow types](https://github.com/facebook/relay/blob/master/packages/react-relay/ReactRelayQueryRenderer.js#L66) suggest that React.Node must be the return type of the render function, while typescript uses `ReactElement | undefined | null`

Please fill in this template.

- [/] Use a meaningful title for the pull request. Include the name of the package modified.
- [/] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme] (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). (ran into an issue with CSSTypes not being found, not sure if this is part of a bigger issue)

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/master/packages/react-relay/ReactRelayQueryRenderer.js#L66
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
