### PR TITLE
Fixed property type in @types/jsoneditor

### DIFF
--- a/types/jsoneditor/index.d.ts
+++ b/types/jsoneditor/index.d.ts
@@ -22,7 +22,7 @@ declare module 'jsoneditor' {
     export type JSONEditorMode = 'tree' | 'view' | 'form' | 'code' | 'text';
 
     export interface NodeName {
-        path: string;
+        path: ReadonlyArray<string>;
         type: 'object'|'array';
         size: number;
     }


### PR DESCRIPTION
`NodeName` property `path` used in `JSONEditorOptions.onNodeName` is of type `string[]` according both to [documentation](https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#configuration-options) and my own observations. Since it's not meant to be written into, I changed its type to `ReadonlyArray<string>`;

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#configuration-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.