### PR TITLE
Add string type to valid data for PubNub decrypt

### DIFF
--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -116,7 +116,7 @@ declare class Pubnub {
   ): any;
 
   decrypt(
-    data: object,
+    data: string | object,
     customCipherKey?: string,
     options?: Pubnub.CryptoParameters
   ): any;

--- a/types/pubnub/pubnub-tests.ts
+++ b/types/pubnub/pubnub-tests.ts
@@ -113,4 +113,5 @@ const mySecret = {
   message: 'Hi!',
 };
 pubnub.decrypt(mySecret, undefined, cryptoOptions);
+pubnub.decrypt('mySecretString', undefined, cryptoOptions);
 pubnub.encrypt('egrah5rwgrehwqh5eh3hwfwef', undefined, cryptoOptions);


### PR DESCRIPTION
**Question:**
I actually need some input here. The flow types in the repo are using `object` and allow on options parameter. The API docs use `string` as first parameter and don't expose options object. What should I do? 
Here are links to both: 
* https://www.pubnub.com/docs/nodejs-javascript/api-reference-misc#decrypt
* https://github.com/pubnub/javascript/blob/master/src/core/components/cryptography/index.js#L108

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.pubnub.com/docs/nodejs-javascript/api-reference-misc#decrypt
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
