### PR TITLE
react-redux dependencies: Semver is a lie and the caret is a bad idea :heart:

### DIFF
--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/hoist-non-react-statics": ">=3.3.0",
         "redux": "^4.0.0"
     }
 }


### PR DESCRIPTION
Over in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33690 people are still having issues with `npm` not installing the required versions of `react-redux`'s dependencies into existing projects - at this point, I believe it's because the caret isn't a strong enough constraint to force a version greater than or equal to `3.3` when an older version in the same major range is installed. In any case, an explicit `>=` requirement should do nicely.
