### PR TITLE
Fix Slick.EventHandler

### DIFF
--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -93,16 +93,16 @@ declare namespace Slick {
 		* @method subscribe
 		* @param fn {Function} Event handler.
 		*/
-		public subscribe(fn: (e: EventData, data: T) => any): void;
-		public subscribe(fn: (e: DOMEvent, data: T) => any): void;
+		public subscribe(fn: (e: EventData, data: T) => void): void;
+		public subscribe(fn: (e: DOMEvent, data: T) => void): void;
 
 		/***
 		* Removes an event handler added with <code>subscribe(fn)</code>.
 		* @method unsubscribe
 		* @param fn {Function} Event handler to be removed.
 		*/
-		public unsubscribe(fn: (e: EventData, data: T) => any): void;
-		public unsubscribe(fn: (e: DOMEvent, data: T) => any): void;
+		public unsubscribe(fn: (e: EventData, data: T) => void): void;
+		public unsubscribe(fn: (e: DOMEvent, data: T) => void): void;
 
 		/***
 		* Fires an event notifying all subscribers.
@@ -125,11 +125,11 @@ declare namespace Slick {
 	}
 
 	// todo: is this private? there are no comments in the code
-	export class EventHandler {
+	export class EventHandler <T = any> {
 		constructor();
 
-		public subscribe(event: EventData, handler: Function): EventHandler;
-		public unsubscribe(event: EventData, handler: Function): EventHandler;
+		public subscribe(event: Event<T>, handler: (e: EventData, data: T) => void): EventHandler;
+		public unsubscribe(event: Event<T>, handler: (e: EventData, data: T) => void): EventHandler;
 		public unsubscribeAll(): EventHandler;
 	}
 

--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -554,7 +554,7 @@ declare namespace Slick {
 		/**
 		*
 		**/
-		dataItemColumnValueExtractor?: any;
+		dataItemColumnValueExtractor?: (item: any, columnDef: any) => any;
 
 		/**
 		*
@@ -690,6 +690,34 @@ declare namespace Slick {
 		*
 		**/
 		topPanelHeight?: number;
+
+
+        addNewRowCssClass?: string;
+        alwaysAllowHorizontalScroll?: boolean;
+        alwaysShowVerticalScroll?: boolean;
+        asyncPostRenderCleanupDelay?: number;
+        createFooterRow?: boolean;
+        createPreHeaderPanel?: boolean;
+        doPaging?: boolean;
+        editorCellNavOnLRKeys?: boolean;
+        emulatePagingWhenScrolling?: boolean;
+        enableAsyncPostRenderCleanup?: boolean;
+        footerRowHeight?: number;
+        frozenBottom?: boolean;
+        frozenColumn?: number;
+        frozenRow?: number;
+        minRowBuffer?: number;
+        numberedMultiColumnSort?: boolean;
+        preHeaderPanelHeight?: number;
+        preserveCopiedSelectionOnPaste?: boolean;
+        showCellSelection?: boolean;
+        showFooterRow?: boolean;
+        showPreHeaderPanel?: boolean;
+        showTopPanel?: boolean;
+        sortColNumberInSeparateSpan?: boolean;
+        suppressActiveCellChangeOnEdit?: boolean;
+        tristateMultiColumnSort?: boolean;
+        viewportClass?: string;
 	}
 
 	export interface DataProvider<T extends SlickData> {

--- a/types/slickgrid/test/index.ts
+++ b/types/slickgrid/test/index.ts
@@ -1,3 +1,5 @@
+declare const htmlElement: HTMLElement;
+
 interface MyData extends Slick.SlickData {
 	title: string;
 	duration: string;
@@ -62,7 +64,7 @@ $('.newSelection');
 grid.setSelectedRows([0, 1, 2]);
 
 class SingleCellSelectionModel extends Slick.SelectionModel<MyData, Slick.Range[]> {
-	private readonly self: SingleCellSelectionModel = null;
+	private readonly self: SingleCellSelectionModel;
 	private _grid: Slick.Grid<MyData>;
 
 	constructor() {
@@ -121,14 +123,14 @@ grid.canCellBeSelected(5, 10);
 
 grid.editActiveCell(new Slick.Editors.Date<MyData>({
 	column: cols[0],
-	container: undefined,
+	container: htmlElement,
 	grid: grid
 }));
 
 grid.setActiveCell(0, 0);
 grid.editActiveCell(new Slick.Editors.Date<MyData>({
 	column: cols[0],
-	container: undefined,
+	container: htmlElement,
 	grid: grid
 }));
 
@@ -203,7 +205,8 @@ columns.forEach(column => {
 });
 
 grid.onSort.subscribe((e, args) => {
-    var sortCol:string = args.sortCols[0].sortCol.field;
+    if (!args.sortCols) return;
+    var sortCol: string | undefined = args.sortCols[0].sortCol.field;
 });
 
 grid.onMouseEnter.subscribe((e: DOMEvent, args: Slick.OnMouseEnterEventArgs<MyData>) => {

--- a/types/slickgrid/test/index.ts
+++ b/types/slickgrid/test/index.ts
@@ -210,3 +210,12 @@ grid.onMouseEnter.subscribe((e: DOMEvent, args: Slick.OnMouseEnterEventArgs<MyDa
 	let cell: Slick.Cell = args.grid.getCellFromEvent(e);
 	if (!cell) { return; }
 });
+
+// EventHandler tests
+var eventHandler = new Slick.EventHandler();
+var onClickHandlerFn = (e: Slick.EventData, args: Slick.OnClickEventArgs<MyData>): void => {
+    return undefined;
+};
+eventHandler.subscribe(grid.onClick, onClickHandlerFn);
+eventHandler.unsubscribe(grid.onClick, onClickHandlerFn);
+eventHandler.unsubscribeAll();

--- a/types/slickgrid/tsconfig.json
+++ b/types/slickgrid/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
It looks like the existing types for `Slick.EventHandler` were incorrect. They don't match the code: https://github.com/mleibman/SlickGrid/blob/bf4705a96c40fea088216034def4d0256a335e65/slick.core.js#L133

Added tests.
Also enabled strictNullChecks and resolved the resulting errors.
