### PR TITLE
fix(auth0-js): extend cross origin login options with missing authorize options

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -179,7 +179,7 @@ webAuth.popup.signupAndLogin({ email: "", password: "", connection: "" }, (err, 
     // do something with data
 });
 
-webAuth.login({username: 'bar', password: 'foo'}, (err, data) => {});
+webAuth.login({username: 'bar', password: 'foo', state: '1234'}, (err, data) => {});
 
 webAuth.crossOriginAuthenticationCallback();
 

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>
+//                 Bartosz Kotrys <https://github.com/bkotrys>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -703,6 +704,7 @@ export interface CrossOriginLoginOptions {
     email?: string;
     password: string;
     realm?: string;
+    state?: string;
 }
 
 export interface LogoutOptions {

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -704,7 +704,15 @@ export interface CrossOriginLoginOptions {
     email?: string;
     password: string;
     realm?: string;
+    domain?: string;
+    clientID?: string;
+    redirectUri?: string;
+    responseType?: string;
+    responseMode?: string;
     state?: string;
+    nonce?: string;
+    scope?: string;
+    audience?: string;
 }
 
 export interface LogoutOptions {


### PR DESCRIPTION
There is wrong type definition for `CrossOriginLoginOptions` interface. Parameter state is missing.
It can be very misleading, because at first glance, it seems that you can not set a custom state for cross origin authentication. Finally it is possible, but the interface is wrong and we need to override it locally. 

**The PR adds missing properties to `CrossOriginLoginOptions` interface:**
- domain?: string;
- clientID?: string;
- redirectUri?: string;
- responseType?: string;
- responseMode?: string;
- state?: string;
- nonce?: string;
- scope?: string;
- audience?: string;

Based on [JSDOC from `auth0-js` source code](https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L639):
> * @param {Object} options options used in the {@link authorize} call after the login_ticket is acquired


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/auth0/auth0.js/issues/917, 
   - https://auth0.com/docs/libraries/auth0js/v9#webauth-login-
   - https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L639
