### PR TITLE
react-redux currently relies on a TS bug (Microsoft/TypeScript#30634) to sucessfully typecheck

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -87,7 +87,7 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  */
 export type Shared<
     InjectedProps,
-    DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
+    DecorationTargetProps
     > = {
         [P in Extract<keyof InjectedProps, keyof DecorationTargetProps>]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never;
     };


### PR DESCRIPTION
This fixes that. The constraint on `Shared`'s second type parameter's constraint seems to be completely unneeded, so I just.... removed it.