### PR TITLE
Change some libaries to rely less on implicit {} in test output

### DIFF
--- a/types/airbnb-prop-types/airbnb-prop-types-tests.ts
+++ b/types/airbnb-prop-types/airbnb-prop-types-tests.ts
@@ -104,12 +104,13 @@ AirbnbPropTypes.forbidExtraProps<ForbidShape>({
 // $ExpectType Requireable<number>
 AirbnbPropTypes.integer();
 
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.keysOf(PropTypes.number);
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.keysOf(PropTypes.number, 'foo');
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.keysOf(PropTypes.oneOf(['foo', 'bar']));
+const top = (<T>(x?: T): T => x!)();
+type Top = typeof top;
+declare function validateRequireableTop(x: React.Requireable<Top>): void;
+
+validateRequireableTop(AirbnbPropTypes.keysOf(PropTypes.number));
+validateRequireableTop(AirbnbPropTypes.keysOf(PropTypes.number, 'foo'));
+validateRequireableTop(AirbnbPropTypes.keysOf(PropTypes.oneOf(['foo', 'bar'])));
 
 // $ExpectType Requireable<number>
 AirbnbPropTypes.mutuallyExclusiveProps(PropTypes.number);
@@ -156,23 +157,17 @@ AirbnbPropTypes.requiredBy('foo', PropTypes.string);
 // $ExpectType Validator<number>
 AirbnbPropTypes.requiredBy('bar', PropTypes.number, 42).isRequired;
 
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.restrictedProp();
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.restrictedProp(() => 'Error');
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.restrictedProp(() => new Error('Error'));
+validateRequireableTop(AirbnbPropTypes.restrictedProp());
+validateRequireableTop(AirbnbPropTypes.restrictedProp(() => 'Error'));
+validateRequireableTop(AirbnbPropTypes.restrictedProp(() => new Error('Error')));
 
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.sequenceOf({ validator: PropTypes.number });
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.sequenceOf({ validator: PropTypes.number }, { validator: PropTypes.string });
-// $ExpectType Requireable<{}>
-AirbnbPropTypes.sequenceOf(
+validateRequireableTop(AirbnbPropTypes.sequenceOf({ validator: PropTypes.number }));
+validateRequireableTop(AirbnbPropTypes.sequenceOf({ validator: PropTypes.number }, { validator: PropTypes.string }));
+validateRequireableTop(AirbnbPropTypes.sequenceOf(
     { validator: PropTypes.number, min: 0, max: 10 },
     { validator: PropTypes.string },
     { validator: PropTypes.bool },
-);
+));
 
 interface ShapeShape {
     foo: string;

--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -2,8 +2,12 @@ import Ember from 'ember';
 
 // $
 Ember.$; // $ExpectType JQueryStatic
+
+const top = (<T>(x?: T): T => x!)();
+type Top = typeof top;
+declare function expectTypeNativeArrayTop(x: Ember.NativeArray<Top>): void;
 // A
-Ember.A(); // $ExpectType NativeArray<{}>
+expectTypeNativeArrayTop(Ember.A());
 Ember.A([1, 2]); // $ExpectType NativeArray<number>
 // addListener
 Ember.addListener({ a: 'foo' }, 'a', {}, () => {});

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -9,7 +9,7 @@ export interface PropertyBaseDefinition {
     description?: string | DescriptionDefinition;
 }
 
-export class PropertyBase<TDefinition> implements PropertyBaseDefinition {
+export class PropertyBase<TDefinition extends {}> implements PropertyBaseDefinition {
     description?: string | DescriptionDefinition;
 
     constructor(definition?: PropertyBaseDefinition | {info: PropertyBaseDefinition} | string);
@@ -42,7 +42,7 @@ export interface PropertyDefinition extends PropertyBaseDefinition {
     disabled?: boolean;
 }
 
-export class Property<TDefinition> extends PropertyBase<TDefinition> implements PropertyDefinition {
+export class Property<TDefinition extends {}> extends PropertyBase<TDefinition> implements PropertyDefinition {
     disabled: boolean;
     id: string;
     name: string;

--- a/types/promise-timeout/promise-timeout-tests.ts
+++ b/types/promise-timeout/promise-timeout-tests.ts
@@ -7,4 +7,8 @@ acceptError(new TimeoutError());
 timeout();                       // $ExpectError
 timeout(new Promise(() => { })); // $ExpectError
 
-timeout(new Promise(() => { }), 1000); // $ExpectType Promise<{}>
+const top = (<T>(x?: T): T => x!)();
+type Top = typeof top;
+declare function expectPromiseTop(x: Promise<Top>): void;
+
+expectPromiseTop(timeout(new Promise(() => { }), 1000));

--- a/types/react-broadcast/react-broadcast-tests.tsx
+++ b/types/react-broadcast/react-broadcast-tests.tsx
@@ -8,7 +8,7 @@ class ExampleOfUsingReactBroadcast extends React.Component {
       <Broadcast channel="my-channel" value={42}>
         <div>
           <Subscriber channel="my-channel">
-            {state => <div>{state}</div>}
+            {(state: React.ReactNode) => <div>{state}</div>}
           </Subscriber>
         </div>
       </Broadcast>

--- a/types/saywhen/saywhen-tests.ts
+++ b/types/saywhen/saywhen-tests.ts
@@ -13,6 +13,10 @@ const spy: JasmineSpy = jasmine.createSpy('test');
 when(spy); // $ExpectType CallHandler<JasmineSpy>
 when(spy).isCalled; // $ExpectType Proxy<JasmineSpy>
 
-when.captor();	// $ExpectType MatcherProxy<{}>
+const top = (<T>(x?: T): T => x!)();
+type Top = typeof top;
+declare function expectMatcherProxyTop(x: (arg: Top) => boolean): void;
+
+expectMatcherProxyTop(when.captor());
 when.captor(jasmine.any(Number));	// $ExpectType MatcherProxy<Any>
 when.noConflict();	// $ExpectType void

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -383,7 +383,9 @@ arrSchema.min(5, "min");
 arrSchema.min(5, () => "min");
 arrSchema.compact((value, index, array) => value === array[index]);
 
-yup.array(); // $ExpectType ArraySchema<{}>
+const arr = yup.array();
+const top = (<T>(x?: T): T => x!)();
+const validArr: yup.ArraySchema<typeof top> = arr;
 yup.array(yup.string()); // $ExpectType ArraySchema<string>
 yup.array().of(yup.string()); // $ExpectType ArraySchema<string>
 


### PR DESCRIPTION
In anticipation of https://github.com/Microsoft/TypeScript/pull/30637, I've changed the few tests that expressly capture the inference-failure type to not do so, and, in some cases (specifically in `postman-collection`), changed the type parameter to explicitly extend `{}` because the non-null/non-undefined-ness under `strict` was both preferable and desired.