### PR TITLE
[luxon] Refine types further

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.11
+// Type definitions for luxon 1.12
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>

--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -20,20 +20,20 @@ export interface ZoneOptions {
 }
 
 export type ToRelativeUnit =
-    | "year"
-    | "quarter"
-    | "month"
-    | "week"
-    | "day"
-    | "hour"
-    | "minute"
-    | "second";
+    | 'year'
+    | 'quarter'
+    | 'month'
+    | 'week'
+    | 'day'
+    | 'hour'
+    | 'minute'
+    | 'second';
 
 export interface ToRelativeOptions {
     /** The DateTime to use as the basis to which this time is compared. Defaults to now. */
     base?: DateTime;
     locale?: string;
-    style?: "long" | "short" | "narrow";
+    style?: StringUnitLength;
     /** If omitted, the method will pick the unit. */
     unit?: ToRelativeUnit;
     /** Defaults to `true`. */
@@ -45,7 +45,7 @@ export interface ToRelativeOptions {
      */
     padding?: number;
     /** The Intl system may choose not to honor this */
-    numberingSystem?: string;
+    numberingSystem?: NumberingSystem;
 }
 
 export interface ToRelativeCalendarOptions {
@@ -55,7 +55,7 @@ export interface ToRelativeCalendarOptions {
     /** If omitted, the method will pick the unit. */
     unit?: ToRelativeUnit;
     /** The Intl system may choose not to honor this. */
-    numberingSystem?: string;
+    numberingSystem?: NumberingSystem;
 }
 
 export interface ToSQLOptions {
@@ -74,8 +74,8 @@ export type ISOTimeOptions = ToISOTimeOptions;
 
 export interface LocaleOptions {
     locale?: string;
-    outputCalendar?: string;
-    numberingSystem?: string;
+    outputCalendar?: CalendarSystem;
+    numberingSystem?: NumberingSystem;
 }
 
 export interface DateTimeOptions extends LocaleOptions {
@@ -105,8 +105,10 @@ export interface DateObject extends DateObjectUnits, LocaleOptions {
     zone?: string | Zone;
 }
 
+export type ConversionAccuracy = 'casual' | 'longterm';
+
 export interface DiffOptions {
-    conversionAccuracy?: string;
+    conversionAccuracy?: ConversionAccuracy;
 }
 
 export interface ExplainedFormat {
@@ -149,31 +151,19 @@ export class DateTime {
     static fromRFC2822(text: string, options?: DateTimeOptions): DateTime;
     static fromSeconds(seconds: number, options?: DateTimeOptions): DateTime;
     static fromSQL(text: string, options?: DateTimeOptions): DateTime;
-    static fromFormat(
-        text: string,
-        format: string,
-        opts?: DateTimeOptions
-    ): DateTime;
-    static fromFormatExplain(
-        text: string,
-        format: string,
-        opts?: DateTimeOptions
-    ): ExplainedFormat;
+    static fromFormat(text: string, format: string, opts?: DateTimeOptions): DateTime;
+    static fromFormatExplain(text: string, format: string, opts?: DateTimeOptions): ExplainedFormat;
     /**
      * @deprecated since 0.3.0. Use fromFormat instead
      */
-    static fromString(
-        text: string,
-        format: string,
-        options?: DateTimeOptions
-    ): DateTime;
+    static fromString(text: string, format: string, options?: DateTimeOptions): DateTime;
     /**
      * @deprecated 0.3.0. Use fromFormatExplain instead
      */
     static fromStringExplain(
         text: string,
         format: string,
-        options?: DateTimeOptions
+        options?: DateTimeOptions,
     ): ExplainedFormat;
     static invalid(reason: any): DateTime;
     static isDateTime(o: any): o is DateTime;
@@ -184,7 +174,7 @@ export class DateTime {
         hour?: number,
         minute?: number,
         second?: number,
-        millisecond?: number
+        millisecond?: number,
     ): DateTime;
     static max(): undefined;
     static max(...dateTimes: DateTime[]): DateTime;
@@ -197,7 +187,7 @@ export class DateTime {
         hour?: number,
         minute?: number,
         second?: number,
-        millisecond?: number
+        millisecond?: number,
     ): DateTime;
     day: number;
     daysInMonth: number;
@@ -232,15 +222,8 @@ export class DateTime {
     year: number;
     zoneName: string;
     zone: Zone;
-    diff(
-        other: DateTime,
-        unit?: DurationUnit | DurationUnit[],
-        options?: DiffOptions
-    ): Duration;
-    diffNow(
-        unit?: DurationUnit | DurationUnit[],
-        options?: DiffOptions
-    ): Duration;
+    diff(other: DateTime, unit?: DurationUnit | DurationUnit[], options?: DiffOptions): Duration;
+    diffNow(unit?: DurationUnit | DurationUnit[], options?: DiffOptions): Duration;
     endOf(unit: DurationUnit): DateTime;
     equals(other: DateTime): boolean;
     get(unit: keyof DateTime): number;
@@ -248,9 +231,7 @@ export class DateTime {
     minus(duration: Duration | number | DurationObject): DateTime;
     plus(duration: Duration | number | DurationObject): DateTime;
     reconfigure(properties: LocaleOptions): DateTime;
-    resolvedLocaleOpts(
-        options?: DateTimeFormatOptions
-    ): Intl.ResolvedDateTimeFormatOptions;
+    resolvedLocaleOpts(options?: DateTimeFormatOptions): Intl.ResolvedDateTimeFormatOptions;
     set(values: DateObjectUnits): DateTime;
     setLocale(locale: string): DateTime;
     setZone(zone: string | Zone, options?: ZoneOptions): DateTime;
@@ -284,8 +265,8 @@ export class DateTime {
 
 export interface DurationOptions {
     locale?: string;
-    numberingSystem?: string;
-    conversionAccuracy?: string;
+    numberingSystem?: NumberingSystem;
+    conversionAccuracy?: ConversionAccuracy;
 }
 
 export interface DurationObjectUnits {
@@ -356,15 +337,68 @@ export class Duration {
     valueOf(): number;
 }
 
-export type EraLength = "short" | "long";
-export type UnitLength = EraLength | "numeric" | "2-digit" | "narrow";
-export interface UnitOptions extends InfoOptions {
-    numberingSystem?: string;
-    outputCalendar?: string;
-}
+// @deprecated
+export type EraLength = StringUnitLength;
+
+export type NumberingSystem =
+    | 'arab'
+    | 'arabext'
+    | 'bali'
+    | 'beng'
+    | 'deva'
+    | 'fullwide'
+    | 'gujr'
+    | 'guru'
+    | 'hanidec'
+    | 'khmr'
+    | 'knda'
+    | 'laoo'
+    | 'latn'
+    | 'limb'
+    | 'mlym'
+    | 'mong'
+    | 'mymr'
+    | 'orya'
+    | 'tamldec'
+    | 'telu'
+    | 'thai'
+    | 'tibt';
+
+export type CalendarSystem =
+    | 'buddhist'
+    | 'chinese'
+    | 'coptic'
+    | 'ethioaa'
+    | 'ethiopic'
+    | 'gregory'
+    | 'hebrew'
+    | 'indian'
+    | 'islamic'
+    | 'islamicc'
+    | 'iso8601'
+    | 'japanese'
+    | 'persian'
+    | 'roc';
+
+export type HourCycle = 'h11' | 'h12' | 'h23' | 'h24';
+
+export type StringUnitLength = 'narrow' | 'short' | 'long';
+export type NumberUnitLength = 'numeric' | '2-digit';
+export type UnitLength = StringUnitLength | NumberUnitLength;
 
 export interface InfoOptions {
     locale?: string;
+}
+
+export interface InfoUnitOptions extends InfoOptions {
+    numberingSystem?: NumberingSystem;
+}
+
+// @deprecated
+export type UnitOptions = InfoUnitOptions;
+
+export interface InfoCalendarOptions extends InfoUnitOptions {
+    outputCalendar?: CalendarSystem;
 }
 
 export interface Features {
@@ -374,19 +408,16 @@ export interface Features {
 }
 
 export namespace Info {
-    function eras(length?: EraLength, options?: InfoOptions): string[];
+    function eras(length?: StringUnitLength, options?: InfoOptions): string[];
     function features(): Features;
     function hasDST(zone: string | Zone): boolean;
     function isValidIANAZone(zone: string): boolean;
     function normalizeZone(input?: number | string | Zone): Zone;
     function meridiems(options?: InfoOptions): string[];
-    function months(length?: UnitLength, options?: UnitOptions): string[];
-    function monthsFormat(length?: UnitLength, options?: UnitOptions): string[];
-    function weekdays(length?: UnitLength, options?: UnitOptions): string[];
-    function weekdaysFormat(
-        length?: UnitLength,
-        options?: UnitOptions
-    ): string[];
+    function months(length?: UnitLength, options?: InfoCalendarOptions): string[];
+    function monthsFormat(length?: UnitLength, options?: InfoCalendarOptions): string[];
+    function weekdays(length?: StringUnitLength, options?: InfoUnitOptions): string[];
+    function weekdaysFormat(length?: StringUnitLength, options?: InfoUnitOptions): string[];
 }
 
 export interface IntervalObject {
@@ -397,15 +428,15 @@ export interface IntervalObject {
 export class Interval {
     static after(
         start: DateTime | DateObject | Date,
-        duration: Duration | number | DurationObject
+        duration: Duration | number | DurationObject,
     ): Interval;
     static before(
         end: DateTime | DateObject | Date,
-        duration: Duration | number | DurationObject
+        duration: Duration | number | DurationObject,
     ): Interval;
     static fromDateTimes(
         start: DateTime | DateObject | Date,
-        end: DateTime | DateObject | Date
+        end: DateTime | DateObject | Date,
     ): Interval;
     static fromISO(string: string, options?: DateTimeOptions): Interval;
     static invalid(reason?: string): Interval;
@@ -435,15 +466,12 @@ export class Interval {
     set(values: IntervalObject): Interval;
     splitAt(...dateTimes: DateTime[]): Interval[];
     splitBy(duration: Duration | DurationObject | number): Interval[];
-    toDuration(
-        unit?: DurationUnit | DurationUnit[],
-        options?: DiffOptions
-    ): Duration;
+    toDuration(unit?: DurationUnit | DurationUnit[], options?: DiffOptions): Duration;
     toFormat(
         dateFormat: string,
         options?: {
             separator?: string;
-        }
+        },
     ): string;
     toISO(options?: ToISOTimeOptions): string;
     toString(): string;
@@ -463,7 +491,7 @@ export namespace Settings {
 }
 
 export interface ZoneOffsetOptions {
-    format?: "short" | "long";
+    format?: 'short' | 'long';
     localeCode?: string;
 }
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -1,4 +1,13 @@
-import { DateTime, Duration, Interval, Info, Settings, IANAZone, Zone, ZoneOffsetOptions } from 'luxon';
+import {
+    DateTime,
+    Duration,
+    Interval,
+    Info,
+    Settings,
+    IANAZone,
+    Zone,
+    ZoneOffsetOptions,
+} from 'luxon';
 
 /* DateTime */
 const dt = DateTime.local(2017, 5, 15, 8, 30);
@@ -10,12 +19,12 @@ const fromObject = DateTime.fromObject({
     day: 22,
     hour: 12,
     zone: 'America/Los_Angeles',
-    numberingSystem: 'beng'
+    numberingSystem: 'beng',
 });
 
 const ianaZone = new IANAZone('America/Los_Angeles');
 const ianaZoneTest = DateTime.fromObject({
-    zone: ianaZone
+    zone: ianaZone,
 });
 
 const fromIso = DateTime.fromISO('2017-05-15'); // => May 15, 2017 at midnight
@@ -138,8 +147,8 @@ const i = Interval.fromDateTimes(now, later);
 i.length(); // $ExpectType number
 i.length('years'); // $ExpectType number
 i.contains(DateTime.local(2019)); // $ExpectType boolean
-i.set({end: DateTime.local(2020)}); // $ExpectType Interval
-i.mapEndpoints((d) => d); // $ExpectType Interval
+i.set({ end: DateTime.local(2020) }); // $ExpectType Interval
+i.mapEndpoints(d => d); // $ExpectType Interval
 i.intersection(i); // $ExpectType Interval | null
 
 i.toISO(); // $ExpectType string
@@ -153,7 +162,11 @@ if (Interval.isInterval(anything)) {
 
 /* Info */
 Info.months();
+// $ExpectError
+Info.months('2-digit', { outputCalendar: 'unknown' });
 Info.weekdays('long');
+// $ExpectError
+Info.weekdays('2-digit');
 Info.features().intl;
 Info.features().intlTokens;
 Info.features().zones;
@@ -174,33 +187,34 @@ Settings.defaultZone = Settings.defaultZone;
 // http://moment.github.io/luxon/docs/manual/
 
 /* Intl */
-DateTime.local().setLocale("el").toLocaleString(DateTime.DATE_FULL); // $ExpectType string
+// prettier-ignore
+DateTime.local().setLocale('el').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
 dt.locale; // $ExpectType string
-DateTime.local().setLocale("fr").locale; // $ExpectType string
-DateTime.local().reconfigure({ locale: "fr" }).locale; // $ExpectType string
+DateTime.local().setLocale('fr').locale; // $ExpectType string
+DateTime.local().reconfigure({ locale: 'fr' }).locale; // $ExpectType string
 
-Settings.defaultLocale = "fr";
+Settings.defaultLocale = 'fr';
 DateTime.local().locale; // $ExpectType string
 
 Settings.defaultLocale = DateTime.local().resolvedLocaleOpts().locale;
 
-dt.setLocale("fr").toLocaleString(DateTime.DATE_FULL); // $ExpectType string
-dt.toLocaleString({ locale: "es", ...DateTime.DATE_FULL }); // $ExpectType string
-dt.setLocale("fr").toFormat("MMMM dd, yyyy GG"); // $ExpectType string
+dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
+dt.toLocaleString({ locale: 'es', ...DateTime.DATE_FULL }); // $ExpectType string
+dt.setLocale('fr').toFormat('MMMM dd, yyyy GG'); // $ExpectType string
 
-DateTime.fromFormat("septembre 25, 2017 après Jésus-Christ", "MMMM dd, yyyy GG", { locale: "fr" });
+DateTime.fromFormat('septembre 25, 2017 après Jésus-Christ', 'MMMM dd, yyyy GG', { locale: 'fr' });
 
-Info.months("long", { locale: "fr" }); // $ExpectType string[]
-Info.weekdays("long", { locale: "fr" }); // $ExpectType string[]
-Info.eras("long", { locale: "fr" }); // $ExpectType string[]
+Info.months('long', { locale: 'fr' }); // $ExpectType string[]
+Info.weekdays('long', { locale: 'fr' }); // $ExpectType string[]
+Info.eras('long', { locale: 'fr' }); // $ExpectType string[]
 
-DateTime.local().reconfigure({ locale: "it", numberingSystem: "beng" });
-Settings.defaultNumberingSystem = "beng";
+DateTime.local().reconfigure({ locale: 'it', numberingSystem: 'beng' });
+Settings.defaultNumberingSystem = 'beng';
 
 /* Time zones and offsets */
 Info.features().zones; // $ExpectType boolean
 
-const bogus = DateTime.local().setZone("America/Bogus");
+const bogus = DateTime.local().setZone('America/Bogus');
 bogus.isValid; // $ExpectType boolean
 bogus.invalidReason; // $ExpectType string | null
 bogus.invalidExplanation; // $ExpectType string | null
@@ -208,19 +222,20 @@ bogus.invalidExplanation; // $ExpectType string | null
 const local = DateTime.local(2017, 5, 15, 09, 10, 23);
 local.zoneName; // $ExpectType string
 local.toString(); // $ExpectType string
-local.setZone("America/Los_Angeles"); // $ExpectType DateTime
-local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime
+local.setZone('America/Los_Angeles'); // $ExpectType DateTime
+local.setZone('America/Los_Angeles', { keepLocalTime: true }); // $ExpectType DateTime
 
-const iso = DateTime.fromISO("2017-05-15T09:10:23");
+const iso = DateTime.fromISO('2017-05-15T09:10:23');
 iso.zoneName; // $ExpectType string
 iso.toString(); // $ExpectType string
 
-DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime
-DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime
+DateTime.fromISO('2017-05-15T09:10:23', { zone: 'Europe/Paris', setZone: true }); // $ExpectType DateTime
+DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime
 
-Settings.defaultZoneName = "Asia/Tokyo";
+Settings.defaultZoneName = 'Asia/Tokyo';
 
 /* Calendars */
+// prettier-ignore
 DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' });
@@ -245,11 +260,13 @@ DateTime.fromSeconds(1542674993); // $ExpectType DateTime
 DateTime.fromFormat('May 25 1982', 'LLLL dd yyyy'); // $ExpectType DateTime
 DateTime.fromFormat('mai 25 1982', 'LLLL dd yyyy', { locale: 'fr' }); // $ExpectType DateTime
 
-DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy").regex;
+DateTime.fromFormatExplain('Aug 6 1982', 'MMMM d yyyy').regex;
 
 /* Math */
 const d1: DateTime = DateTime.local(2017, 2, 13).plus({ days: 30 });
-const d2: DateTime = DateTime.fromISO('2017-04-30').plus({days: 1}).plus({months: 1});
+const d2: DateTime = DateTime.fromISO('2017-04-30')
+    .plus({ days: 1 })
+    .plus({ months: 1 });
 
 if (d1 < d2 || +d1 === +d2) {
     //
@@ -262,7 +279,8 @@ d1.hasSame(d2, 'year'); // $ExpectType boolean
 dur.toObject().days; // $ExpectType number | undefined
 dur.as('minutes'); // $ExpectType number
 dur.shiftTo('minutes').toObject().minutes; // $ExpectType number | undefined
-DateTime.fromISO("2017-05-15").plus(dur).toISO(); // $ExpectType string
+// prettier-ignore
+DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string
 
 const end = DateTime.fromISO('2017-03-13');
 const start = DateTime.fromISO('2017-02-13');
@@ -290,18 +308,18 @@ i.toDuration(['years', 'months', 'days']); // $ExpectType Duration
 
 /* Sample Zone Implementation */
 class SampleZone extends Zone {
-  readonly isValid = false;
-  readonly name = 'Sample';
-  readonly type = 'Example';
-  readonly universal = true;
+    readonly isValid = false;
+    readonly name = 'Sample';
+    readonly type = 'Example';
+    readonly universal = true;
 
-  offsetName(ts: number, options?: ZoneOffsetOptions) {
-    return 'SampleZone';
-  }
-  equals(other: Zone) {
-    return other.name === this.name;
-  }
-  offset(ts: number) {
-    return 0;
-  }
+    offsetName(ts: number, options?: ZoneOffsetOptions) {
+        return 'SampleZone';
+    }
+    equals(other: Zone) {
+        return other.name === this.name;
+    }
+    offset(ts: number) {
+        return 0;
+    }
 }


### PR DESCRIPTION
to: @mastermatt @uniqueiniquity 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (BELOW)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

-------

We recently had a production issue where this error was being thrown "Value 2-digit out of range for Intl.DateTimeFormat options property weekday". Turns out we were passing `2-digit` to `Info.weekdays()`, which according to the types was accurate, but is actually not.

This PR refines the unit lengths, adds number/calendar system, and other minor polish. Values based on this doc: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat