### PR TITLE
Same as #34335 but for react-redux v6

### DIFF
--- a/types/react-redux/v6/index.d.ts
+++ b/types/react-redux/v6/index.d.ts
@@ -84,7 +84,7 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  */
 export type Shared<
     InjectedProps,
-    DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
+    DecorationTargetProps
     > = {
         [P in Extract<keyof InjectedProps, keyof DecorationTargetProps>]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never;
     };


### PR DESCRIPTION
I missed the same type in `v6` when making #34335. 😢 