### PR TITLE
Add annotations to ramda tests which contain type inference failures …

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1975,9 +1975,9 @@ class Rectangle {
 };
 
 () => {
-    const a: boolean = R.pathSatisfies(x => x > 0, ["x"], {x: 1, y: 2}); // => true
-    const b: boolean = R.pathSatisfies(x => x > 0, ["x"])({x: 1, y: 2}); // => true
-    const c: boolean = R.pathSatisfies(x => x > 0)(["x"])({x: 1, y: 2}); // => true
+    const a: boolean = R.pathSatisfies((x: number) => x > 0, ["x"], {x: 1, y: 2}); // => true
+    const b: boolean = R.pathSatisfies((x: number) => x > 0, ["x"])({x: 1, y: 2}); // => true
+    const c: boolean = R.pathSatisfies((x: number) => x > 0)(["x"])({x: 1, y: 2}); // => true
 };
 
 () => {
@@ -2091,9 +2091,9 @@ class Rectangle {
 };
 
 () => {
-    const a: boolean = R.propSatisfies(x => x > 0, "x", {x: 1, y: 2}); // => true
-    const b: boolean = R.propSatisfies(x => x > 0, "x")({x: 1, y: 2}); // => true
-    const c: boolean = R.propSatisfies(x => x > 0)("x")({x: 1, y: 2}); // => true
+    const a: boolean = R.propSatisfies((x: number) => x > 0, "x", {x: 1, y: 2}); // => true
+    const b: boolean = R.propSatisfies((x: number) => x > 0, "x")({x: 1, y: 2}); // => true
+    const c: boolean = R.propSatisfies((x: number) => x > 0)("x")({x: 1, y: 2}); // => true
 };
 
 () => {


### PR DESCRIPTION
…which trigger future `unknown` warnings, in preparation for https://github.com/Microsoft/TypeScript/pull/30637. For `unknown`, TS warns on operations like `>`, which TS does not currently for `{}` (for some reason, we probably should). The code _probably_ should have always had an annotation, since there's nowhere other than the annotation to infer the type from.