### PR TITLE
Add non-singleton version of yargs, and other things used by lerna

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -6,6 +6,7 @@
 //                 Jeff Kenney <https://github.com/jeffkenney>
 //                 Jimi (Dimitris) Charalampidis <https://github.com/JimiC>
 //                 Steffen Viken Valvåg <https://github.com/steffenvv>
+//                 Emily Marigold Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -124,6 +125,8 @@ declare namespace yargs {
 
         example(command: string, description: string): Argv<T>;
 
+        exit(code: number, err: Error): void;
+
         exitProcess(enabled: boolean): Argv<T>;
 
         fail(func: (msg: string, err: Error) => any): Argv<T>;
@@ -168,6 +171,8 @@ declare namespace yargs {
 
         parse(): { [key in keyof Arguments<T>]: Arguments<T>[key] };
         parse(arg: string | ReadonlyArray<string>, context?: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+
+        parsed: DetailedArguments | false;
 
         pkgConf(key: string | ReadonlyArray<string>, cwd?: string): Argv<T>;
 
@@ -261,6 +266,28 @@ declare namespace yargs {
         /** All remaining options */
         [argName: string]: unknown;
     };
+
+    interface DetailedArguments {
+        argv: Arguments;
+        error: Error | null;
+        aliases: {[alias: string]: string[]};
+        newAliases: {[alias: string]: boolean};
+        configuration: Configuration;
+    }
+
+    interface Configuration {
+        'boolean-negation': boolean;
+        'camel-case-expansion': boolean;
+        'combine-arrays': boolean;
+        'dot-notation': boolean;
+        'duplicate-arguments-array': boolean;
+        'flatten-duplicate-arrays': boolean;
+        'negation-prefix': string;
+        'parse-numbers': boolean;
+        'populate--': boolean;
+        'set-placeholder-key': boolean;
+        'short-option-groups': boolean;
+    }
 
     interface RequireDirectoryOptions {
         recurse?: boolean;

--- a/types/yargs/tsconfig.json
+++ b/types/yargs/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "yargs.d.ts",
         "yargs-tests.ts"
     ]
 }

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import yargs = require('yargs');
+import yargsSingleton = require('yargs/yargs');
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -1054,4 +1055,16 @@ function Argv$fallbackToUnknownForUnknownOptions() {
     // $ExpectError
     const x: string = yargs.argv.x;
     return x;
+}
+
+function Argv$exit() {
+    yargs.exit(1, new Error("oh no"));
+}
+
+function Argv$parsed() {
+    const parsedArgs = yargs.parsed;
+}
+
+function makeSingleton() {
+    yargsSingleton(process.argv.slice(2));
 }

--- a/types/yargs/yargs.d.ts
+++ b/types/yargs/yargs.d.ts
@@ -1,0 +1,9 @@
+import { Argv } from '.';
+
+export = Yargs;
+
+declare function Yargs(
+    processArgs?: string[],
+    cwd?: string,
+    parentRequire?: NodeRequireFunction,
+): Argv;

--- a/types/yargs/yargs.d.ts
+++ b/types/yargs/yargs.d.ts
@@ -3,7 +3,7 @@ import { Argv } from '.';
 export = Yargs;
 
 declare function Yargs(
-    processArgs?: string[],
+    processArgs?: ReadonlyArray<string>,
     cwd?: string,
     parentRequire?: NodeRequireFunction,
 ): Argv;


### PR DESCRIPTION
Re-submit of #30594. See also: #31901 . Documentation was added at https://github.com/yargs/yargs/pull/1251

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  [`.parsed`](https://yargs.js.org/docs/#api-parsed)
  [`.exit()`](https://yargs.js.org/docs/#api-exitcode-err)
  [`import 'yargs/yargs'`](https://github.com/yargs/yargs/blob/master/docs/advanced.md#using-the-non-singleton-interface)
- [x] ~~Increase the version number in the header if appropriate.~~

