### PR TITLE
Mongoose:  fix wrong type of shardKey in schema option

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1045,7 +1045,7 @@ declare module "mongoose" {
     safe?: boolean | { w?: number | string; wtimeout?: number; j?: boolean };
 
     /** defaults to null */
-    shardKey?: boolean;
+    shardKey?: object;
     /** defaults to true */
     strict?: boolean | 'throw';
     /** no default */

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -20,6 +20,7 @@
 //                 Ming Chen <https://github.com/mingchen>
 //                 Olga Isakova <https://github.com/penumbra1>
 //                 Orblazer <https://github.com/orblazer>
+//                 HughKu <https://github.com/HughKu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -2118,6 +2118,15 @@ new mongoose.Schema({ name: String }, {
   }
 });
 
+/**
+ * https://mongoosejs.com/docs/guide.html#shardKey
+ */
+new mongoose.Schema({name: String}, {
+  shardKey: {
+    tag: 1, name: 1
+  }
+})
+
 /* Query helpers: https://mongoosejs.com/docs/guide.html#query-helpers */
 
 interface Animal2 extends mongoose.Document {


### PR DESCRIPTION
Please fill in this template.

- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   https://mongoosejs.com/docs/guide.html#shardKey
https://github.com/Automattic/mongoose/blob/7b92e8dde624ca8b73edd0bdec1d09597ba287ac/test/shard.test.js#L26
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---
Schema option field **shardkey** is actually an `object` type, NOT `boolean`.
Mongoose official documentation is not correct on this subject, as suggested in recent [issue](https://github.com/Automattic/mongoose/issues/7643)