### PR TITLE
[@types/ramda] fix returning value for split to match the expected value for fromEntries func

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2712,8 +2712,8 @@ declare namespace R {
          * Splits a string into an array of strings based on the given
          * separator.
          */
-        split<T>(sep: string | RegExp): (str: string) => T;
-        split<T>(sep: string | RegExp, str: string): T;
+        split<T = string[]>(sep: string | RegExp): (str: string) => T;
+        split<T = string[]>(sep: string | RegExp, str: string): T;
 
         /**
          * Splits a given list or string at a given index.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -28,6 +28,7 @@
 //                 Nitesh Phadatare <https://github.com/minitesh>
 //                 Krantisinh Deshmukh <https://github.com/krantisinh>
 //                 Pierre-Antoine Mills <https://github.com/pirix-gh>
+//                 Artem Korchunov <https://github.com/ArtemKorchunov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
@@ -2711,8 +2712,8 @@ declare namespace R {
          * Splits a string into an array of strings based on the given
          * separator.
          */
-        split(sep: string | RegExp): (str: string) => string[];
-        split(sep: string | RegExp, str: string): string[];
+        split<T>(sep: string | RegExp): (str: string) => T;
+        split<T>(sep: string | RegExp, str: string): T;
 
         /**
          * Splits a given list or string at a given index.


### PR DESCRIPTION
Problem:
Type 'string[]' in returning value of `split('=')` is missing the following properties from type 'KeyValuePair<number, {}>': 0, 1 that is an argument for fromPairs function


When trying to
```
const queryString = "?item=2&page=10&total=90";

compose(
  fromPairs,
  map(split("=")),
  split("&"),
  tail
);
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.

- [x] Test the change in your own code. (Compile and run.)

- [ ] Add or edit tests to reflect the change. (Run with npm test.)

- [x] Follow the advice from the readme.

- [x] Avoid common mistakes.