### PR TITLE
[is-image] Add type of is-image

### DIFF
--- a/types/is-image/index.d.ts
+++ b/types/is-image/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for is-image 2.0
+// Project: https://github.com/sindresorhus/is-image#readme
+// Definitions by: Denis Frezzato <https://github.com/DenisFrezzato>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = isImage;
+
+declare function isImage(filepath: string): boolean;

--- a/types/is-image/is-image-tests.ts
+++ b/types/is-image/is-image-tests.ts
@@ -1,0 +1,3 @@
+import isImage = require('is-image');
+
+const res: boolean = isImage('/path/to/img.png');

--- a/types/is-image/tsconfig.json
+++ b/types/is-image/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "is-image-tests.ts"]
+}

--- a/types/is-image/tslint.json
+++ b/types/is-image/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
