### PR TITLE
refactor(shelljs): Refactor ShellJS types to be more correct

### DIFF
--- a/types/shelljs/.editorconfig
+++ b/types/shelljs/.editorconfig
@@ -1,0 +1,3 @@
+# This package uses tabs
+[*]
+indent_style = tab

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -139,8 +139,8 @@ export interface RemoveFunction {
 	 * Removes files. The wildcard `*` is accepted.
 	 *
 	 * @param options Available options:
-	 *        - `-f`: (force),
-	 *        - `-r`, `-R`: (recursive)
+	 *        - `-f`: force
+	 *        - `-r`, `-R`: recursive
 	 * @param files   Files to remove.
 	 * @return        Object with shell exit code, stderr and stdout.
 	 */
@@ -208,7 +208,7 @@ export interface MkdirFunction {
 	 * Creates directories.
 	 *
 	 * @param options Available options:
-	 *        - `-p`: (full paths, will create intermediate dirs if necessary)
+	 *        - `-p`: full paths, will create intermediate dirs if necessary
 	 * @param dir     The directories to create.
 	 * @return        Object with shell exit code, stderr and stdout.
 	 */
@@ -229,7 +229,7 @@ export interface MkdirFunction {
  * Creates directories.
  *
  * @param options Available options:
- *        - `-p`: (full paths, will create intermediate dirs if necessary)
+ *        - `-p`: full paths, will create intermediate dirs if necessary
  * @param dir     The directories to create.
  * @return        Object with shell exit code, stderr and stdout.
  */
@@ -287,17 +287,23 @@ export interface SedFunction {
 	 * on the input using the given search regex and replacement string or function.
 	 *
 	 * @param options Available options:
-	 *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+	 *        - `-i`: Replace contents of 'file' in-place. Note that no backups will be created!
 	 * @param searchRegex The regular expression to use for search.
 	 * @param replacement The replacement.
-	 * @param file        The file to process.
+	 * @param files       The files to process.
 	 * @return            The new string after replacement.
 	 */
 	(
 		options: string,
 		searchRegex: string | RegExp,
 		replacement: string,
-		file: string
+		files: string[]
+	): ShellString;
+	(
+		options: string,
+		searchRegex: string | RegExp,
+		replacement: string,
+		...files: string[]
 	): ShellString;
 
 	/**
@@ -306,13 +312,18 @@ export interface SedFunction {
 	 *
 	 * @param searchRegex The regular expression to use for search.
 	 * @param replacement The replacement.
-	 * @param file        The file to process.
+	 * @param files       The files to process.
 	 * @return            The new string after replacement.
 	 */
 	(
 		searchRegex: string | RegExp,
 		replacement: string,
-		file: string
+		files: string[]
+	): ShellString;
+	(
+		searchRegex: string | RegExp,
+		replacement: string,
+		...files: string[]
 	): ShellString;
 }
 
@@ -321,10 +332,10 @@ export interface SedFunction {
  * on the input using the given search regex and replacement string or function.
  *
  * @param options Available options:
- *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+ *        - `-i`: Replace contents of 'file' in-place. Note that no backups will be created!
  * @param searchRegex The regular expression to use for search.
  * @param replacement The replacement.
- * @param file        The file to process.
+ * @param files       The files to process.
  * @return            The new string after replacement.
  */
 export const sed: SedFunction;
@@ -335,8 +346,8 @@ export interface GrepFunction {
 	 * of the file that match the given `regex_filter`. Wildcard `*` accepted.
 	 *
 	 * @param options Available options:
-	 *        - `-v`: (Inverse the sense of the regex and print
-	 *                 the lines not matching the criteria.)
+	 *        - `-v`: Inverse the sense of the regex and print
+	 *                the lines not matching the criteria.
 	 *        - `-l`: Print only filenames of matching files
 	 * @param regex_filter The regular expression to use.
 	 * @param files The files to process.
@@ -370,8 +381,8 @@ export interface GrepFunction {
  * of the file that match the given `regex_filter`. Wildcard `*` accepted.
  *
  * @param options Available options:
- *        - `-v`: (Inverse the sense of the regex and print
- *                 the lines not matching the criteria.)
+ *        - `-v`: Inverse the sense of the regex and print
+ *                the lines not matching the criteria.
  *        - `-l`: Print only filenames of matching files
  * @param regex_filter The regular expression to use.
  * @param files        The files to process.
@@ -408,16 +419,25 @@ export interface EchoFunction {
 	(...text: string[]): ShellString;
 }
 
+/**
+ * Prints string to stdout, and returns string with additional utility methods like .to().
+ *
+ * @param options Available options:
+ *        - `-e`: interpret backslash escapes (default)
+ *        - `-n`: remove trailing newline from output
+ * @param text The text to print.
+ * @return     Returns the string that was passed as argument.
+ */
 export const echo: EchoFunction;
 
 export interface PushDirFunction {
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when adding directories
-	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when adding directories
+	 *                to the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     Brings the Nth directory (counting from the left of the list printed by dirs,
 	 *                starting with zero) to the top of the list by rotating the stack.
@@ -426,12 +446,12 @@ export interface PushDirFunction {
 	(options: string, dir: "+N"): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when adding directories
-	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when adding directories
+	 *                to the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     Brings the Nth directory (counting from the right of the list printed by dirs,
 	 *                starting with zero) to the top of the list by rotating the stack.
@@ -440,12 +460,12 @@ export interface PushDirFunction {
 	(options: string, dir: "-N"): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when adding directories
-	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when adding directories
+	 *                to the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     Makes the current working directory be the top of the stack,
 	 *                and then executes the equivalent of `cd dir`.
@@ -454,7 +474,7 @@ export interface PushDirFunction {
 	(options: string, dir: string): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param dir Brings the Nth directory (counting from the left of the list printed by dirs,
@@ -464,7 +484,7 @@ export interface PushDirFunction {
 	(dir: "+N"): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param dir Brings the Nth directory (counting from the right of the list printed by dirs,
@@ -474,7 +494,7 @@ export interface PushDirFunction {
 	(dir: "-N"): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
 	 * @param dir Makes the current working directory be the top of the stack,
@@ -484,21 +504,21 @@ export interface PushDirFunction {
 	(dir: string): ShellArray;
 
 	/**
-	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * Saves the current directory on the top of the directory stack and then cd to dir.
 	 * With no arguments, `pushd` exchanges the top two directories.
 	 *
-	 * @return        Returns an array of paths in the stack.
+	 * @return Returns an array of paths in the stack.
 	 */
 	(): ShellArray;
 }
 
 /**
- * Save the current directory on the top of the directory stack and then cd to dir.
+ * Saves the current directory on the top of the directory stack and then cd to dir.
  * With no arguments, `pushd` exchanges the top two directories.
  *
  * @param options Available options:
- *        - `-n`: (Suppresses the normal change of directory when adding directories
- *                 to the stack, so that only the stack is manipulated)
+ *        - `-n`: Suppresses the normal change of directory when adding directories
+ *                to the stack, so that only the stack is manipulated
  *        - `-q`: Suppresses output to the console.
  * @param dir     Makes the current working directory be the top of the stack,
  *                and then executes the equivalent of `cd dir`.
@@ -515,8 +535,8 @@ export interface PopDirFunction {
 	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when removing directories
-	 *                from the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when removing directories
+	 *                from the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     Removes the Nth directory (counting from the left of the list printed by dirs), starting with zero.
 	 * @return        Returns an array of paths in the stack.
@@ -531,8 +551,8 @@ export interface PopDirFunction {
 	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when removing directories
-	 *                from the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when removing directories
+	 *                from the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     Removes the Nth directory (counting from the right of the list printed by dirs), starting with zero.
 	 * @return        Returns an array of paths in the stack.
@@ -547,8 +567,8 @@ export interface PopDirFunction {
 	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
 	 *
 	 * @param options Available options:
-	 *        - `-n`: (Suppresses the normal change of directory when removing directories
-	 *                 from the stack, so that only the stack is manipulated)
+	 *        - `-n`: Suppresses the normal change of directory when removing directories
+	 *                from the stack, so that only the stack is manipulated
 	 *        - `-q`: Suppresses output to the console.
 	 * @param dir     You can only use -N and +N.
 	 * @return        Returns an array of paths in the stack.
@@ -611,8 +631,8 @@ export interface PopDirFunction {
  * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
  *
  * @param options Available options:
- *        - `-n`: (Suppresses the normal change of directory when removing directories
- *                 from the stack, so that only the stack is manipulated)
+ *        - `-n`: Suppresses the normal change of directory when removing directories
+ *                from the stack, so that only the stack is manipulated
  *        - `-q`: Suppresses output to the console.
  * @param dir     You can only use -N and +N.
  * @return        Returns an array of paths in the stack.
@@ -629,7 +649,7 @@ export interface DirsFunction {
 	(options: "-c"): ShellArray;
 
 	/**
-	 * Display the list of currently remembered directories.
+	 * Displays the list of currently remembered directories.
 	 *
 	 * @param options Displays the Nth directory (counting from the left of the list
 	 *                printed by dirs when invoked without options), starting with zero.
@@ -638,7 +658,7 @@ export interface DirsFunction {
 	(options: "+N"): ShellString;
 
 	/**
-	 * Display the list of currently remembered directories.
+	 * Displays the list of currently remembered directories.
 	 *
 	 * @param options Displays the Nth directory (counting from the right of the list
 	 *                printed by dirs when invoked without options), starting with zero.
@@ -647,7 +667,7 @@ export interface DirsFunction {
 	(options: "-N"): ShellString;
 
 	/**
-	 * Display the list of currently remembered directories.
+	 * Displays the list of currently remembered directories.
 	 *
 	 * @param options Available options:
 	 *        - `-c`: Clears the directory stack by deleting all of the elements.
@@ -661,7 +681,7 @@ export interface DirsFunction {
 }
 
 /**
- * Display the list of currently remembered directories.
+ * Displays the list of currently remembered directories.
  *
  * @param options Available options:
  *        - `-c`: Clears the directory stack by deleting all of the elements.
@@ -810,7 +830,7 @@ export type ExecCallback = (
 
 export interface ExecOptions extends child.ExecOptions {
 	/**
-	 * Do not echo program output to console.
+	 * Do not echo program output to the console.
 	 *
 	 * @default false
 	 */
@@ -867,14 +887,13 @@ export interface ShellReturnValue extends ExecOutputReturnValue {
 	toEnd(file: string): void;
 
 	/**
-	 * Returns a string containing the given file, or a concatenated string
-	 * containing the files if more than one file is given (a new line character
-	 * is introduced between each file).
+	 * Returns a string containing the given pipeline, or a concatenated string
+	 * containing the pipelines if more than one input stream is given
+	 * (a new line character is introduced between each input).
 	 *
-	 * @param files Files to use. Wildcard `*` accepted.
-	 * @return A string containing the given file, or a concatenated string
-	 *         containing the files if more than one file is given
-	 *         (a new line character is introduced between each file).
+	 * @return A string containing the given pipeline, or a concatenated string
+	 *         containing the pipelines if more than one input stream is given
+	 *         (a new line character is introduced between each input).
 	 */
 	cat: CatFunction;
 
@@ -890,7 +909,7 @@ export interface ShellReturnValue extends ExecOutputReturnValue {
 	exec: ExecFunction;
 
 	/**
-	 * Read the start of a file.
+	 * Read the start of a pipeline input.
 	 */
 	head: HeadFunction;
 
@@ -899,31 +918,28 @@ export interface ShellReturnValue extends ExecOutputReturnValue {
 	 * of the file that match the given `regex_filter`. Wildcard `*` accepted.
 	 *
 	 * @param options Available options:
-	 *        - `-v`: (Inverse the sense of the regex and print
-	 *                 the lines not matching the criteria.)
+	 *        - `-v`: Inverse the sense of the regex and print
+	 *                the lines not matching the criteria.
 	 *        - `-l`: Print only filenames of matching files
 	 * @param regex_filter The regular expression to use.
-	 * @param files        The files to process.
 	 * @return Returns a string containing all lines of the file that match the given `regex_filter`.
 	 */
 	grep: GrepFunction;
 
 	/**
-	 * Reads an input string from file and performs a JavaScript `replace()`
+	 * Reads an input string from pipeline and performs a JavaScript `replace()`
 	 * on the input using the given search regex and replacement string or function.
 	 *
 	 * @param options Available options:
-	 *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+	 *        - `-i`: Replace contents of 'file' in-place. Note that no backups will be created!
 	 * @param searchRegex The regular expression to use for search.
 	 * @param replacement The replacement.
-	 * @param file        The file to process.
 	 * @return            The new string after replacement.
 	 */
 	sed: SedFunction;
 
 	/**
-	 * Return the contents of the files, sorted line-by-line.
-	 * Sorting multiple files mixes their content (just as unix sort does).
+	 * Return the contents of the pipeline, sorted line-by-line.
 	 *
 	 * @param options Available options:
 	 *        - `-r`: Reverse the results
@@ -932,7 +948,7 @@ export interface ShellReturnValue extends ExecOutputReturnValue {
 	sort: SortFunction;
 
 	/**
-	 * Read the end of a file.
+	 * Read the end of a pipeline input.
 	 */
 	tail: TailFunction;
 
@@ -963,9 +979,9 @@ export interface ChmodFunction {
 	 * - There is no "quiet" option since default behavior is to run silent.
 	 *
 	 * @param options Available options:
-	 *        - `-v`: (output a diagnostic for every file processed),
-	 *        - `-c`: (like -v but report only when a change is made),
-	 *        - `-R`: (change files and directories recursively)
+	 *        - `-v`: output a diagnostic for every file processed
+	 *        - `-c`: like -v but report only when a change is made
+	 *        - `-R`: change files and directories recursively
 	 * @param mode    The access mode. Can be an octal string or a symbolic mode string.
 	 * @param file    The file to use.
 	 * @return        Object with shell exit code, stderr and stdout.
@@ -1000,9 +1016,9 @@ export interface ChmodFunction {
  * - There is no "quiet" option since default behavior is to run silent.
  *
  * @param options Available options:
- *        - `-v`: (output a diagnostic for every file processed),
- *        - `-c`: (like -v but report only when a change is made),
- *        - `-R`: (change files and directories recursively)
+ *        - `-v`: output a diagnostic for every file processed
+ *        - `-c`: like -v but report only when a change is made
+ *        - `-R`: change files and directories recursively
  * @param mode    The access mode. Can be an octal string or a symbolic mode string.
  * @param file    The file to use.
  * @return        Object with shell exit code, stderr and stdout.
@@ -1059,15 +1075,9 @@ export interface HeadOptions {
 }
 
 export interface HeadFunction {
-	/**
-	 * Read the start of a file.
-	 */
 	(options: HeadOptions, files: string[]): ShellString;
 	(options: HeadOptions, ...files: string[]): ShellString;
 
-	/**
-	 * Read the start of a file.
-	 */
 	(files: string[]): ShellString;
 	(...files: string[]): ShellString;
 }
@@ -1113,15 +1123,9 @@ export interface TailOptions {
 }
 
 export interface TailFunction {
-	/**
-	 * Read the end of a file.
-	 */
 	(options: TailOptions, files: string[]): ShellString;
 	(options: TailOptions, ...files: string[]): ShellString;
 
-	/**
-	 * Read the end of a file.
-	 */
 	(files: string[]): ShellString;
 	(...files: string[]): ShellString;
 }

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -836,7 +836,7 @@ export interface ExecOptions extends child.ExecOptions {
 	encoding?: string;
 }
 
-export interface ShellReturnValue {
+export interface ExecOutputReturnValue {
 	/** The process exit code. */
 	code: number;
 
@@ -845,7 +845,9 @@ export interface ShellReturnValue {
 
 	/** The process standard error output. */
 	stderr: string;
+}
 
+export interface ShellReturnValue extends ExecOutputReturnValue {
 	/**
 	 * Analogous to the redirection operator `>` in Unix, but works with JavaScript strings
 	 * (such as those returned by `cat`, `grep`, etc).

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -5,6 +5,7 @@
 //                 George Kalpakas <https://github.com/gkalpak>
 //                 Paul Huynh <https://github.com/pheromonez>
 //                 Alexander Futász <https://github.com/aldafu>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -12,9 +13,13 @@
 import child = require("child_process");
 import glob = require("glob");
 
+export as namespace shelljs;
+
 /**
- * Changes to directory dir for the duration of the script. Changes to home directory if no argument is supplied.
- * @param dir Directory to change in.
+ * Changes the current working directory dir for the duration of the script.
+ * Changes to the home directory if no argument is supplied.
+ *
+ * @param dir Directory to change to.
  * @return    Object with shell exit code, stderr and stdout.
  */
 export function cd(dir?: string): ShellString;
@@ -25,537 +30,1173 @@ export function cd(dir?: string): ShellString;
  */
 export function pwd(): ShellString;
 
-/**
- * Returns array of files in the given path, or in current directory if no path provided.
- * @param  ...paths Paths to search.
- * @return          An array of files in the given path(s).
- */
-export function ls(...paths: Array<string | string[]>): ShellArray;
+export interface ListFunction {
+	/**
+	 * Returns array of files in the given path, or in current directory if no path provided.
+	 *
+	 * @param options Available options:
+	 *        - `-R`: recursive
+	 *        - `-A`: all files (include files beginning with ., except for . and ..)
+	 *        - `-L`: follow symlinks
+	 *        - `-d`: list directories themselves, not their contents
+	 *        - `-l`: list objects representing each file, each with fields containing
+	 *                `ls -l` output fields. See fs.Stats for more info
+	 * @param paths   Paths to search.
+	 * @return        An array of files in the given path(s).
+	 */
+	(options: string, paths: string[]): ShellArray;
+	(options: string, ...paths: string[]): ShellArray;
+
+	/**
+	 * Returns array of files in the given path, or in current directory if no path provided.
+	 *
+	 * @param paths Paths to search.
+	 * @return      An array of files in the given path(s).
+	 */
+	(paths: string[]): ShellArray;
+	(...paths: string[]): ShellArray;
+}
 
 /**
  * Returns array of files in the given path, or in current directory if no path provided.
- * @param    options  Available options:  -R: recursive -A: all files (include files beginning with ., except for . and ..) -L: follow symlinks -d: list directories themselves, not their contents -l: list objects representing each file, each with fields containing ls -l output fields. See fs.Stats for more info
- * @param  ...paths Paths to search.
- * @return          An array of files in the given path(s).
+ *
+ * @param options Available options:
+ *        - `-R`: recursive
+ *        - `-A`: all files (include files beginning with ., except for . and ..)
+ *        - `-L`: follow symlinks
+ *        - `-d`: list directories themselves, not their contents
+ *        - `-l`: list objects representing each file, each with fields containing
+ *                `ls -l` output fields. See fs.Stats for more info
+ * @param paths   Paths to search.
+ * @return        An array of files in the given path(s).
  */
-export function ls(options: string, ...paths: Array<string | string[]>): ShellArray;
+export const ls: ListFunction;
+
+export interface FindFunction {
+	/**
+	 * Returns array of all files (however deep) in the given paths.
+	 *
+	 * @param path The path(s) to search.
+	 * @return     An array of all files (however deep) in the given path(s).
+	 */
+	(path: string[]): ShellArray;
+	(...path: string[]): ShellArray;
+}
 
 /**
  * Returns array of all files (however deep) in the given paths.
- * @param ...path   The path(s) to search.
- * @return          An array of all files (however deep) in the given path(s).
+ *
+ * @param path The path(s) to search.
+ * @return     An array of all files (however deep) in the given path(s).
  */
-export function find(...path: Array<string | string[]>): ShellArray;
+export const find: FindFunction;
+
+export interface CopyFunction {
+	/**
+	 * Copies files. The wildcard `*` is accepted.
+	 *
+	 * @param options Available options:
+	 *        - `-f`: force (default behavior)
+	 *        - `-n`: no-clobber
+	 *        - `-u`: only copy if source is newer than dest
+	 *        - `-r`, `-R`: recursive
+	 *        - `-L`: follow symlinks
+	 *        - `-P`: don't follow symlinks
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, source: string | string[], dest: string): ShellString;
+
+	/**
+	 * Copies files. The wildcard `*` is accepted.
+	 *
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(source: string | string[], dest: string): ShellString;
+}
 
 /**
- * Copies files. The wildcard * is accepted.
- * @param source  The source.
- * @param   dest  The destination.
- * @return        Object with shell exit code, stderr and stdout.
- */
-export function cp(source: string | string[], dest: string): ShellString;
-
-/**
- * Copies files. The wildcard * is accepted.
- * @param options Available options: -f: force (default behavior) -n: no-clobber -u: only copy if source is newer than dest -r, -R: recursive -L: follow symlinks -P: don't follow symlinks
- * @param source  The source.
- * @param dest    The destination.
- * @return        Object with shell exit code, stderr and stdout.
- */
-export function cp(options: string, source: string | string[], dest: string): ShellString;
-
-/**
- * Removes files. The wildcard * is accepted.
- * @param ...files Files to remove.
- * @return        Object with shell exit code, stderr and stdout.
- */
-export function rm(...files: Array<string | string[]>): ShellString;
-
-/**
- * Removes files. The wildcard * is accepted.
- * @param   options  Available options: -f (force), -r, -R (recursive)
- * @param ...files Files to remove.
- * @return         Object with shell exit code, stderr and stdout.
- */
-export function rm(options: string, ...files: Array<string | string[]>): ShellString;
-
-/**
- * Moves files. The wildcard * is accepted.
+ * Copies files. The wildcard `*` is accepted.
+ *
+ * @param options Available options:
+ *        - `-f`: force (default behavior)
+ *        - `-n`: no-clobber
+ *        - `-u`: only copy if source is newer than dest
+ *        - `-r`, -R: recursive
+ *        - `-L`: follow symlinks
+ *        - `-P`: don't follow symlinks
  * @param source The source.
  * @param dest   The destination.
  * @return       Object with shell exit code, stderr and stdout.
  */
-export function mv(source: string | string[], dest: string): ShellString;
+export const cp: CopyFunction;
+
+export interface RemoveFunction {
+	/**
+	 * Removes files. The wildcard `*` is accepted.
+	 *
+	 * @param options Available options:
+	 *        - `-f`: (force),
+	 *        - `-r`, `-R`: (recursive)
+	 * @param files   Files to remove.
+	 * @return        Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, files: string[]): ShellString;
+	(options: string, ...files: string[]): ShellString;
+
+	/**
+	 * Removes files. The wildcard `*` is accepted.
+	 *
+	 * @param files Files to remove.
+	 * @return      Object with shell exit code, stderr and stdout.
+	 */
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
 
 /**
- * Moves files. The wildcard * is accepted.
- * @param options Available options: -f: force (default behavior) -n: no-clobber
+ * Removes files. The wildcard `*` is accepted.
+ *
+ * @param options Available options:
+ *        - `-f` (force),
+ *        - `-r`, `-R` (recursive)
+ * @param files   Files to remove.
+ * @return        Object with shell exit code, stderr and stdout.
+ */
+export const rm: RemoveFunction;
+
+export interface MoveFunction {
+	/**
+	 * Moves files. The wildcard `*` is accepted.
+	 *
+	 * @param options Available options:
+	 *        - `-f`: force (default behavior)
+	 *        - `-n`: no-clobber
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, source: string | string[], dest: string): ShellString;
+
+	/**
+	 * Moves files. The wildcard `*` is accepted.
+	 *
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(source: string | string[], dest: string): ShellString;
+}
+
+/**
+ * Moves files. The wildcard `*` is accepted.
+ *
+ * @param options Available options:
+ *        - `-f`: force (default behavior)
+ *        - `-n`: no-clobber
  * @param source The source.
  * @param dest   The destination.
  * @return       Object with shell exit code, stderr and stdout.
  */
-export function mv(options: string, source: string | string[], dest: string): ShellString;
+export const mv: MoveFunction;
+
+export interface MkdirFunction {
+	/**
+	 * Creates directories.
+	 *
+	 * @param options Available options:
+	 *        - `-p`: (full paths, will create intermediate dirs if necessary)
+	 * @param dir     The directories to create.
+	 * @return        Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, dir: string[]): ShellString;
+	(options: string, ...dir: string[]): ShellString;
+
+	/**
+	 * Creates directories.
+	 *
+	 * @param dir Directories to create.
+	 * @return    Object with shell exit code, stderr and stdout.
+	 */
+	(dir: string[]): ShellString;
+	(...dir: string[]): ShellString;
+}
 
 /**
  * Creates directories.
- * @param ...dir Directories to create.
- * @return       Object with shell exit code, stderr and stdout.
- */
-export function mkdir(...dir: Array<string | string[]>): ShellString;
-
-/**
- * Creates directories.
- * @param   options Available options: p (full paths, will create intermediate dirs if necessary)
- * @param ...dir  The directories to create.
+ *
+ * @param options Available options:
+ *        - `-p`: (full paths, will create intermediate dirs if necessary)
+ * @param dir     The directories to create.
  * @return        Object with shell exit code, stderr and stdout.
  */
-export function mkdir(options: string, ...dir: Array<string | string[]>): ShellString;
+export const mkdir: MkdirFunction;
 
 /**
  * Evaluates expression using the available primaries and returns corresponding value.
- * @param   option '-b': true if path is a block device; '-c': true if path is a character device; '-d': true if path is a directory; '-e': true if path exists; '-f': true if path is a regular file; '-L': true if path is a symboilc link; '-p': true if path is a pipe (FIFO); '-S': true if path is a socket
- * @param   path   The path.
+ *
+ * @param option Valid options:
+ *        - `-b`: true if path is a block device;
+ *        - `-c`: true if path is a character device;
+ *        - `-d`: true if path is a directory;
+ *        - `-e`: true if path exists;
+ *        - `-f`: true if path is a regular file;
+ *        - `-L`: true if path is a symbolic link;
+ *        - `-p`: true if path is a pipe (FIFO);
+ *        - `-S`: true if path is a socket
+ * @param path    The path.
  * @return        See option parameter.
  */
 export function test(option: TestOptions, path: string): boolean;
 
 export type TestOptions = "-b" | "-c" | "-d" | "-e" | "-f" | "-L" | "-p" | "-S";
 
-/**
- * Returns a string containing the given file, or a concatenated string containing the files if more than one file is given (a new line character is introduced between each file). Wildcard * accepted.
- * @param  ...files Files to use.
- * @return            A string containing the given file, or a concatenated string containing the files if more than one file is given (a new line character is introduced between each file).
- */
-export function cat(...files: Array<string | string[]>): ShellString;
+export interface CatFunction {
+	/**
+	 * Returns a string containing the given file, or a concatenated string
+	 * containing the files if more than one file is given (a new line character
+	 * is introduced between each file).
+	 *
+	 * @param files Files to use. Wildcard `*` accepted.
+	 * @return A string containing the given file, or a concatenated string
+	 *         containing the files if more than one file is given
+	 *         (a new line character is introduced between each file).
+	 */
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
 
 /**
- * Reads an input string from file and performs a JavaScript replace() on the input using the given search regex and replacement string or function. Returns the new string after replacement.
- * @param  searchRegex The regular expression to use for search.
- * @param  replacement The replacement.
- * @param  file        The file to process.
- * @return             The new string after replacement.
+ * Returns a string containing the given file, or a concatenated string
+ * containing the files if more than one file is given (a new line character
+ * is introduced between each file).
+ *
+ * @param files Files to use. Wildcard `*` accepted.
+ * @return A string containing the given file, or a concatenated string
+ *         containing the files if more than one file is given
+ *         (a new line character is introduced between each file).
  */
-export function sed(searchRegex: string | RegExp, replacement: string, file: string): ShellString;
+export const cat: CatFunction;
+
+export interface SedFunction {
+	/**
+	 * Reads an input string from file and performs a JavaScript `replace()`
+	 * on the input using the given search regex and replacement string or function.
+	 *
+	 * @param options Available options:
+	 *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+	 * @param searchRegex The regular expression to use for search.
+	 * @param replacement The replacement.
+	 * @param file        The file to process.
+	 * @return            The new string after replacement.
+	 */
+	(
+		options: string,
+		searchRegex: string | RegExp,
+		replacement: string,
+		file: string
+	): ShellString;
+
+	/**
+	 * Reads an input string from file and performs a JavaScript `replace()`
+	 * on the input using the given search regex and replacement string or function.
+	 *
+	 * @param searchRegex The regular expression to use for search.
+	 * @param replacement The replacement.
+	 * @param file        The file to process.
+	 * @return            The new string after replacement.
+	 */
+	(
+		searchRegex: string | RegExp,
+		replacement: string,
+		file: string
+	): ShellString;
+}
 
 /**
- * Reads an input string from file and performs a JavaScript replace() on the input using the given search regex and replacement string or function. Returns the new string after replacement.
- * @param  options     Available options: -i (Replace contents of 'file' in-place. Note that no backups will be created!)
- * @param  searchRegex The regular expression to use for search.
- * @param  replacement The replacement.
- * @param  file        The file to process.
- * @return             The new string after replacement.
+ * Reads an input string from file and performs a JavaScript `replace()`
+ * on the input using the given search regex and replacement string or function.
+ *
+ * @param options Available options:
+ *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+ * @param searchRegex The regular expression to use for search.
+ * @param replacement The replacement.
+ * @param file        The file to process.
+ * @return            The new string after replacement.
  */
-export function sed(options: string, searchRegex: string | RegExp, replacement: string, file: string): ShellString;
+export const sed: SedFunction;
+
+export interface GrepFunction {
+	/**
+	 * Reads input string from given files and returns a string containing all lines
+	 * of the file that match the given `regex_filter`. Wildcard `*` accepted.
+	 *
+	 * @param options Available options:
+	 *        - `-v`: (Inverse the sense of the regex and print
+	 *                 the lines not matching the criteria.)
+	 *        - `-l`: Print only filenames of matching files
+	 * @param regex_filter The regular expression to use.
+	 * @param files The files to process.
+	 * @return Returns a string containing all lines of the file that match the given regex_filter.
+	 */
+	(
+		options: string,
+		regex_filter: string | RegExp,
+		files: string[]
+	): ShellString;
+	(
+		options: string,
+		regex_filter: string | RegExp,
+		...files: string[]
+	): ShellString;
+
+	/**
+	 * Reads input string from given files and returns a string containing all lines
+	 * of the file that match the given `regex_filter`. Wildcard `*` accepted.
+	 *
+	 * @param regex_filter The regular expression to use.
+	 * @param files        The files to process.
+	 * @return             Returns a string containing all lines of the file that match the given `regex_filter`.
+	 */
+	(regex_filter: string | RegExp, files: string[]): ShellString;
+	(regex_filter: string | RegExp, ...files: string[]): ShellString;
+}
 
 /**
- * Reads input string from given files and returns a string containing all lines of the file that match the given regex_filter. Wildcard * accepted.
- * @param    regex_filter The regular expression to use.
- * @param  ...files     The files to process.
- * @return                Returns a string containing all lines of the file that match the given regex_filter.
+ * Reads input string from given files and returns a string containing all lines
+ * of the file that match the given `regex_filter`. Wildcard `*` accepted.
+ *
+ * @param options Available options:
+ *        - `-v`: (Inverse the sense of the regex and print
+ *                 the lines not matching the criteria.)
+ *        - `-l`: Print only filenames of matching files
+ * @param regex_filter The regular expression to use.
+ * @param files        The files to process.
+ * @return Returns a string containing all lines of the file that match the given `regex_filter`.
  */
-export function grep(regex_filter: string | RegExp, ...files: Array<string | string[]>): ShellString;
-
-/**
- * Reads input string from given files and returns a string containing all lines of the file that match the given regex_filter. Wildcard * accepted.
- * @param    options      Available options: -v (Inverse the sense of the regex and print the lines not matching the criteria.) -l: Print only filenames of matching files
- * @param    regex_filter The regular expression to use.
- * @param  ...files     The files to process.
- * @return                Returns a string containing all lines of the file that match the given regex_filter.
- */
-export function grep(options: string, regex_filter: string | RegExp, ...files: Array<string | string[]>): ShellString;
+export const grep: GrepFunction;
 
 /**
  * Searches for command in the system's PATH. On Windows looks for .exe, .cmd, and .bat extensions.
- * @param  command The command to search for.
- * @return         Returns string containing the absolute path to the command.
+ *
+ * @param command The command to search for.
+ * @return        Returns string containing the absolute path to the command.
  */
 export function which(command: string): ShellString;
 
-/**
- * Prints string to stdout, and returns string with additional utility methods like .to().
- * @param  ...text The text to print.
- * @return           Returns the string that was passed as argument.
- */
-export function echo(...text: string[]): ShellString;
+export interface EchoFunction {
+	/**
+	 * Prints string to stdout, and returns string with additional utility methods like .to().
+	 *
+	 * @param options Available options:
+	 *        - `-e`: interpret backslash escapes (default)
+	 *        - `-n`: remove trailing newline from output
+	 * @param text The text to print.
+	 * @return     Returns the string that was passed as argument.
+	 */
+	(options: string, ...text: string[]): ShellString;
+
+	/**
+	 * Prints string to stdout, and returns string with additional utility methods like .to().
+	 *
+	 * @param text The text to print.
+	 * @return     Returns the string that was passed as argument.
+	 */
+	(...text: string[]): ShellString;
+}
+
+export const echo: EchoFunction;
+
+export interface PushDirFunction {
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when adding directories
+	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     Brings the Nth directory (counting from the left of the list printed by dirs,
+	 *                starting with zero) to the top of the list by rotating the stack.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: "+N"): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when adding directories
+	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     Brings the Nth directory (counting from the right of the list printed by dirs,
+	 *                starting with zero) to the top of the list by rotating the stack.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: "-N"): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when adding directories
+	 *                 to the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     Makes the current working directory be the top of the stack,
+	 *                and then executes the equivalent of `cd dir`.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: string): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param dir Brings the Nth directory (counting from the left of the list printed by dirs,
+	 *            starting with zero) to the top of the list by rotating the stack.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: "+N"): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param dir Brings the Nth directory (counting from the right of the list printed by dirs,
+	 *            starting with zero) to the top of the list by rotating the stack.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: "-N"): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @param dir Makes the current working directory be the top of the stack,
+	 *            and then executes the equivalent of cd dir.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: string): ShellArray;
+
+	/**
+	 * Save the current directory on the top of the directory stack and then cd to dir.
+	 * With no arguments, `pushd` exchanges the top two directories.
+	 *
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(): ShellArray;
+}
 
 /**
- * Prints string to stdout, and returns string with additional utility methods like .to().
- * @param options Available options: -e: interpret backslash escapes (default) -n: remove trailing newline from output
- * @param  ...text The text to print.
- * @return           Returns the string that was passed as argument.
+ * Save the current directory on the top of the directory stack and then cd to dir.
+ * With no arguments, `pushd` exchanges the top two directories.
+ *
+ * @param options Available options:
+ *        - `-n`: (Suppresses the normal change of directory when adding directories
+ *                 to the stack, so that only the stack is manipulated)
+ *        - `-q`: Suppresses output to the console.
+ * @param dir     Makes the current working directory be the top of the stack,
+ *                and then executes the equivalent of `cd dir`.
+ * @return        Returns an array of paths in the stack.
  */
-export function echo(options: string, ...text: string[]): ShellString;
+export const pushd: PushDirFunction;
+
+export interface PopDirFunction {
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when removing directories
+	 *                from the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     Removes the Nth directory (counting from the left of the list printed by dirs), starting with zero.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: "+N"): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when removing directories
+	 *                from the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     Removes the Nth directory (counting from the right of the list printed by dirs), starting with zero.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: "-N"): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @param options Available options:
+	 *        - `-n`: (Suppresses the normal change of directory when removing directories
+	 *                 from the stack, so that only the stack is manipulated)
+	 *        - `-q`: Suppresses output to the console.
+	 * @param dir     You can only use -N and +N.
+	 * @return        Returns an array of paths in the stack.
+	 */
+	(options: string, dir: string): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
+	 *
+	 * @param dir Removes the Nth directory (counting from the left of the list printed by dirs), starting with zero.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: "+N"): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @param dir Removes the Nth directory (counting from the right of the list printed by dirs), starting with zero.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: "-N"): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @param dir You can only use -N and +N.
+	 * @return    Returns an array of paths in the stack.
+	 */
+	(dir: string): ShellArray;
+
+	/**
+	 * When no arguments are given, popd removes the top directory from the stack
+	 * and performs a `cd` to the new top directory.
+	 *
+	 * The elements are numbered from 0 starting at the first directory listed with dirs;
+	 * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+	 *
+	 * @return     Returns an array of paths in the stack.
+	 */
+	(): ShellArray;
+}
 
 /**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param      dir Brings the Nth directory (counting from the left of the list printed by dirs, starting with zero) to the top of the list by rotating the stack.
- * @return     Returns an array of paths in the stack.
+ * When no arguments are given, popd removes the top directory from the stack
+ * and performs a `cd` to the new top directory.
+ *
+ * The elements are numbered from 0 starting at the first directory listed with dirs;
+ * i.e., `popd` is equivalent to `popd +0`. Returns an array of paths in the stack.
+ *
+ * @param options Available options:
+ *        - `-n`: (Suppresses the normal change of directory when removing directories
+ *                 from the stack, so that only the stack is manipulated)
+ *        - `-q`: Suppresses output to the console.
+ * @param dir     You can only use -N and +N.
+ * @return        Returns an array of paths in the stack.
  */
-export function pushd(dir: "+N"): ShellArray;
+export const popd: PopDirFunction;
+
+export interface DirsFunction {
+	/**
+	 * Clears the directory stack by deleting all of the elements.
+	 *
+	 * @param options Clears the directory stack by deleting all of the elements.
+	 * @return        Returns an array of paths in the stack, or a single path if +N or -N was specified.
+	 */
+	(options: "-c"): ShellArray;
+
+	/**
+	 * Display the list of currently remembered directories.
+	 *
+	 * @param options Displays the Nth directory (counting from the left of the list
+	 *                printed by dirs when invoked without options), starting with zero.
+	 * @return        Returns an array of paths in the stack, or a single path if +N or -N was specified.
+	 */
+	(options: "+N"): ShellString;
+
+	/**
+	 * Display the list of currently remembered directories.
+	 *
+	 * @param options Displays the Nth directory (counting from the right of the list
+	 *                printed by dirs when invoked without options), starting with zero.
+	 * @return        Returns an array of paths in the stack, or a single path if +N or -N was specified.
+	 */
+	(options: "-N"): ShellString;
+
+	/**
+	 * Display the list of currently remembered directories.
+	 *
+	 * @param options Available options:
+	 *        - `-c`: Clears the directory stack by deleting all of the elements.
+	 *        - `-N`: Displays the Nth directory (counting from the right of the list
+	 *                printed by dirs when invoked without options), starting with zero.
+	 *        - `+N`: Displays the Nth directory (counting from the left of the list
+	 *                printed by dirs when invoked without options), starting with zero.
+	 * @return        Returns an array of paths in the stack, or a single path if +N or -N was specified.
+	 */
+	(options: string): ShellArray | ShellString;
+}
 
 /**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param      dir Brings the Nth directory (counting from the right of the list printed by dirs, starting with zero) to the top of the list by rotating the stack.
- * @return     Returns an array of paths in the stack.
+ * Display the list of currently remembered directories.
+ *
+ * @param options Available options:
+ *        - `-c`: Clears the directory stack by deleting all of the elements.
+ *        - `-N`: Displays the Nth directory (counting from the right of the list
+ *                printed by dirs when invoked without options), starting with zero.
+ *        - `+N`: Displays the Nth directory (counting from the left of the list
+ *                printed by dirs when invoked without options), starting with zero.
+ * @return        Returns an array of paths in the stack, or a single path if +N or -N was specified.
  */
-export function pushd(dir: "-N"): ShellArray;
+export const dirs: DirsFunction;
+
+export interface LinkFunction {
+	/**
+	 * Links source to dest. Use `-f` to force the link, should dest already exist.
+	 *
+	 * @param options Available options:
+	 *        - `-s`: Create a symbolic link, defaults to a hardlink
+	 *        - `-f`: Force creation
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, source: string, dest: string): ShellString;
+
+	/**
+	 * Links source to dest. Use `-f` to force the link, should dest already exist.
+	 *
+	 * @param source The source.
+	 * @param dest   The destination.
+	 * @return       Object with shell exit code, stderr and stdout.
+	 */
+	(source: string, dest: string): ShellString;
+}
 
 /**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param      dir Makes the current working directory be the top of the stack, and then executes the equivalent of cd dir.
- * @return       Returns an array of paths in the stack.
- */
-export function pushd(dir: string): ShellArray;
-
-/**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when adding directories to the stack, so that only the stack is manipulated) -q: Supresses output to the console.
- * @param      dir Brings the Nth directory (counting from the left of the list printed by dirs, starting with zero) to the top of the list by rotating the stack.
- * @return     Returns an array of paths in the stack.
- */
-export function pushd(options: string, dir: "+N"): ShellArray;
-
-/**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when adding directories to the stack, so that only the stack is manipulated)
- * @param      dir Brings the Nth directory (counting from the right of the list printed by dirs, starting with zero) to the top of the list by rotating the stack.
- * @return     Returns an array of paths in the stack.
- */
-export function pushd(options: string, dir: "-N"): ShellArray;
-
-/**
- * Save the current directory on the top of the directory stack and then cd to dir. With no arguments, pushd exchanges the top two directories. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when adding directories to the stack, so that only the stack is manipulated)
- * @param    dir     Makes the current working directory be the top of the stack, and then executes the equivalent of cd dir.
- * @return         Returns an array of paths in the stack.
- */
-export function pushd(options: string, dir: string): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param      dir Removes the Nth directory (counting from the left of the list printed by dirs), starting with zero.
- * @return     Returns an array of paths in the stack.
- */
-export function popd(dir: "+N"): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @return     Returns an array of paths in the stack.
- */
-export function popd(): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param      dir Removes the Nth directory (counting from the right of the list printed by dirs), starting with zero.
- * @return     Returns an array of paths in the stack.
- */
-export function popd(dir: "-N"): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param      dir You can only use -N and +N.
- * @return       Returns an array of paths in the stack.
- */
-export function popd(dir: string): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when removing directories from the stack, so that only the stack is manipulated) -q: Supresses output to the console.
- * @param      dir     Removes the Nth directory (counting from the left of the list printed by dirs), starting with zero.
- * @return         Returns an array of paths in the stack.
- */
-export function popd(options: string, dir: "+N"): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when removing directories from the stack, so that only the stack is manipulated) -q: Supresses output to the console.
- * @param      dir     Removes the Nth directory (counting from the right of the list printed by dirs), starting with zero.
- * @return         Returns an array of paths in the stack.
- */
-export function popd(options: string, dir: "-N"): ShellArray;
-
-/**
- * When no arguments are given, popd removes the top directory from the stack and performs a cd to the new top directory. The elements are numbered from 0 starting at the first directory listed with dirs; i.e., popd is equivalent to popd +0. Returns an array of paths in the stack.
- * @param    options Available options: -n (Suppresses the normal change of directory when removing directories from the stack, so that only the stack is manipulated) -q: Supresses output to the console.
- * @param    dir     You can only use -N and +N.
- * @return         Returns an array of paths in the stack.
- */
-export function popd(options: string, dir: string): ShellArray;
-
-/**
- * Clears the directory stack by deleting all of the elements.
- * @param      options Clears the directory stack by deleting all of the elements.
- * @return         Returns an array of paths in the stack, or a single path if +N or -N was specified.
- */
-export function dirs(options: "-c"): ShellArray;
-
-/**
- * Display the list of currently remembered directories. Returns an array of paths in the stack, or a single path if +N or -N was specified.
- * @param    options Displays the Nth directory (counting from the left of the list printed by dirs when invoked without options), starting with zero.
- * @return       Returns an array of paths in the stack, or a single path if +N or -N was specified.
- */
-export function dirs(options: "+N"): ShellString;
-
-/**
- * Display the list of currently remembered directories. Returns an array of paths in the stack, or a single path if +N or -N was specified.
- * @param    options Displays the Nth directory (counting from the right of the list printed by dirs when invoked without options), starting with zero.
- * @return       Returns an array of paths in the stack, or a single path if +N or -N was specified.
- */
-export function dirs(options: "-N"): ShellString;
-
-/**
- * Display the list of currently remembered directories. Returns an array of paths in the stack, or a single path if +N or -N was specified.
- * @param  options Available options: -c, -N, +N. You can only use those.
- * @return            Returns an array of paths in the stack, or a single path if +N or -N was specified.
- */
-export function dirs(options: string): any;
-
-/**
- * Links source to dest. Use -f to force the link, should dest already exist.
+ * Links source to dest. Use `-f` to force the link, should dest already exist.
+ *
+ * @param options Available options:
+ *        - `-s`: Create a symbolic link, defaults to a hardlink
+ *        - `-f`: Force creation
  * @param source The source.
  * @param dest   The destination.
  * @return       Object with shell exit code, stderr and stdout.
  */
-export function ln(source: string, dest: string): ShellString;
-
-/**
- * Links source to dest. Use -f to force the link, should dest already exist.
- * @param options Available options: s (symlink), f (force)
- * @param source The source.
- * @param dest   The destination.
- * @return       Object with shell exit code, stderr and stdout.
- */
-export function ln(options: string, source: string, dest: string): ShellString;
+export const ln: LinkFunction;
 
 /**
  * Exits the current process with the given exit code.
+ *
+ * Equivalent to calling `process.exit(code)`.
+ *
  * @param code The exit code.
  */
-export function exit(code: number): void;
+export function exit(code?: number): never;
 
 /**
- * Object containing environment variables (both getter and setter). Shortcut to process.env.
+ * Object containing environment variables (both getter and setter). Shortcut to `process.env`.
  */
-export const env: { [key: string]: string };
+export const env: NodeJS.ProcessEnv;
+
+export interface ExecFunction {
+	/**
+	 * Executes the given command synchronously.
+	 *
+	 * @param command The command to execute.
+	 * @return        Returns an object containing the return code and output as string.
+	 */
+	(command: string): ShellString;
+
+	/**
+	 * Executes the given command synchronously.
+	 *
+	 * @param command The command to execute.
+	 * @param options Silence and synchronous options.
+	 * @return        Returns an object containing the return code and output as string,
+	 *                or if `{async: true}` was passed, a `ChildProcess`.
+	 */
+	(command: string, options: ExecOptions & { async?: false }): ShellString;
+
+	/**
+	 * Executes the given command asynchronously.
+	 *
+	 * @param command The command to execute.
+	 * @param options Silence and synchronous options.
+	 * @return        Returns an object containing the return code and output as string,
+	 *                or if `{async: true}` was passed, a `ChildProcess`.
+	 */
+	(
+		command: string,
+		options: ExecOptions & { async: true }
+	): child.ChildProcess;
+
+	/**
+	 * Executes the given command.
+	 *
+	 * @param command The command to execute.
+	 * @param options Silence and synchronous options.
+	 * @return        Returns an object containing the return code and output as string,
+	 *                or if `{async: true}` was passed, a `ChildProcess`.
+	 */
+	(command: string, options: ExecOptions): ShellString | child.ChildProcess;
+
+	/**
+	 * Executes the given command synchronously.
+	 *
+	 * @param command The command to execute.
+	 * @param options Silence and synchronous options.
+	 * @param callback Receives code and output asynchronously.
+	 */
+	(
+		command: string,
+		options: ExecOptions,
+		callback: ExecCallback
+	): child.ChildProcess;
+
+	/**
+	 * Executes the given command synchronously.
+	 *
+	 * @param command The command to execute.
+	 * @param callback Receives code and output asynchronously.
+	 */
+	(command: string, callback: ExecCallback): child.ChildProcess;
+}
 
 /**
- * Executes the given command synchronously.
- * @param                  command The command to execute.
- * @return          Returns an object containing the return code and output as string.
+ * Executes the given command.
+ *
+ * @param command The command to execute.
+ * @param options Silence and synchronous options.
+ * @param [callback] Receives code and output asynchronously.
+ * @return Returns an object containing the return code and output as string,
+ *         or if `{async: true}` or a `callback` was passed, a `ChildProcess`.
  */
-export function exec(command: string): ExecOutputReturnValue;
-/**
- * Executes the given command synchronously.
- * @param                                      command The command to execute.
- * @param                                 options Silence and synchronous options.
- * @return         Returns an object containing the return code and output as string, or if {async:true} was passed, a ChildProcess.
- */
-export function exec(command: string, options: ExecOptions): ExecOutputReturnValue | child.ChildProcess;
-/**
- * Executes the given command synchronously.
- * @param           command  The command to execute.
- * @param      options  Silence and synchronous options.
- * @param     callback Receives code and output asynchronously.
- */
-export function exec(command: string, options: ExecOptions, callback: ExecCallback): child.ChildProcess;
-/**
- * Executes the given command synchronously.
- * @param           command  The command to execute.
- * @param     callback Receives code and output asynchronously.
- */
-export function exec(command: string, callback: ExecCallback): child.ChildProcess;
+export const exec: ExecFunction;
 
-export type ExecCallback = (code: number, stdout: string, stderr: string) => any;
+export type ExecCallback = (
+	/** The process exit code. */
+	code: number,
+
+	/** The process standard output. */
+	stdout: string,
+
+	/** The process standard error output. */
+	stderr: string
+) => any;
 
 export interface ExecOptions extends child.ExecOptions {
-    /** Do not echo program output to console (default: false). */
-    silent?: boolean;
-    /** Asynchronous execution. If a callback is provided, it will be set to true, regardless of the passed value (default: false). */
-    async?: boolean;
-    /** Character encoding to use. Affects the values returned to stdout and stderr, and what is written to stdout and stderr when not in silent mode (default: 'utf8'). */
-    encoding?: string;
+	/**
+	 * Do not echo program output to console.
+	 *
+	 * @default false
+	 */
+	silent?: boolean;
+
+	/**
+	 * Asynchronous execution.
+	 *
+	 * If a callback is provided, it will be set to `true`, regardless of the passed value.
+	 *
+	 * @default false
+	 */
+	async?: boolean;
+
+	/**
+	 * Character encoding to use.
+	 *
+	 * Affects the values returned by `stdout` and `stderr`,
+	 * and what is written to `stdout` and `stderr` when not in silent mode
+	 *
+	 * @default "utf8"
+	 */
+	encoding?: string;
 }
 
-export interface ExecOutputReturnValue {
-    code: number;
-    stdout: string;
-    stderr: string;
-}
+export interface ShellReturnValue {
+	/** The process exit code. */
+	code: number;
 
-export interface ShellReturnValue extends ExecOutputReturnValue {
-    /**
-     * Analogous to the redirection operator > in Unix, but works with JavaScript strings (such as those returned by cat, grep, etc). Like Unix redirections, to() will overwrite any existing file!
-     * @param file The file to use.
-     */
-    to(file: string): void;
+	/** The process standard output. */
+	stdout: string;
 
-    /**
-     * Analogous to the redirect-and-append operator >> in Unix, but works with JavaScript strings (such as those returned by cat, grep, etc).
-     * @param file The file to append to.
-     */
-    toEnd(file: string): void;
+	/** The process standard error output. */
+	stderr: string;
 
-    cat(...files: string[]): ShellString;
-    exec(callback: ExecCallback): child.ChildProcess;
-    exec(): ExecOutputReturnValue;
-    grep(...files: Array<string | string[]>): ShellString;
-    sed(replacement: string, file: string): ShellString;
+	/**
+	 * Analogous to the redirection operator `>` in Unix, but works with JavaScript strings
+	 * (such as those returned by `cat`, `grep`, etc).
+	 *
+	 * Like Unix redirections, `to()` will overwrite any existing file!
+	 *
+	 * @param file The file to use.
+	 */
+	to(file: string): void;
+
+	/**
+	 * Analogous to the redirect-and-append operator `>>` in Unix, but works with JavaScript strings
+	 * (such as those returned by `cat`, `grep`, etc).
+	 *
+	 * @param file The file to append to.
+	 */
+	toEnd(file: string): void;
+
+	/**
+	 * Returns a string containing the given file, or a concatenated string
+	 * containing the files if more than one file is given (a new line character
+	 * is introduced between each file).
+	 *
+	 * @param files Files to use. Wildcard `*` accepted.
+	 * @return A string containing the given file, or a concatenated string
+	 *         containing the files if more than one file is given
+	 *         (a new line character is introduced between each file).
+	 */
+	cat: CatFunction;
+
+	/**
+	 * Executes the given command.
+	 *
+	 * @param command The command to execute.
+	 * @param options Silence and synchronous options.
+	 * @param [callback] Receives code and output asynchronously.
+	 * @return Returns an object containing the return code and output as string,
+	 *         or if `{async: true}` or a `callback` was passed, a `ChildProcess`.
+	 */
+	exec: ExecFunction;
+
+	/**
+	 * Read the start of a file.
+	 */
+	head: HeadFunction;
+
+	/**
+	 * Reads input string from given files and returns a string containing all lines
+	 * of the file that match the given `regex_filter`. Wildcard `*` accepted.
+	 *
+	 * @param options Available options:
+	 *        - `-v`: (Inverse the sense of the regex and print
+	 *                 the lines not matching the criteria.)
+	 *        - `-l`: Print only filenames of matching files
+	 * @param regex_filter The regular expression to use.
+	 * @param files        The files to process.
+	 * @return Returns a string containing all lines of the file that match the given `regex_filter`.
+	 */
+	grep: GrepFunction;
+
+	/**
+	 * Reads an input string from file and performs a JavaScript `replace()`
+	 * on the input using the given search regex and replacement string or function.
+	 *
+	 * @param options Available options:
+	 *        - `-i`: (Replace contents of 'file' in-place. Note that no backups will be created!)
+	 * @param searchRegex The regular expression to use for search.
+	 * @param replacement The replacement.
+	 * @param file        The file to process.
+	 * @return            The new string after replacement.
+	 */
+	sed: SedFunction;
+
+	/**
+	 * Return the contents of the files, sorted line-by-line.
+	 * Sorting multiple files mixes their content (just as unix sort does).
+	 *
+	 * @param options Available options:
+	 *        - `-r`: Reverse the results
+	 *        - `-n`: Compare according to numerical value
+	 */
+	sort: SortFunction;
+
+	/**
+	 * Read the end of a file.
+	 */
+	tail: TailFunction;
+
+	/**
+	 * Filter adjacent matching lines from input.
+	 *
+	 * @param options Available options:
+	 *        - `-i`: Ignore case while comparing
+	 *        - `-c`: Prefix lines by the number of occurrences
+	 *        - `-d`: Only print duplicate lines, one for each group of identical lines
+	 */
+	uniq: UniqFunction;
 }
 
 export type ShellString = string & ShellReturnValue;
 
 export type ShellArray = string[] & ShellReturnValue;
 
-/**
- * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
- * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
- * - There is no "quiet" option since default behavior is to run silent.
- * @param octalMode The access mode. Octal.
- * @param file      The file to use.
- * @return          Object with shell exit code, stderr and stdout.
- */
-export function chmod(octalMode: number, file: string): ShellString;
+export interface ChmodFunction {
+	/**
+	 * Alters the permissions of a file or directory by either specifying the absolute
+	 * permissions in octal form or expressing the changes in symbols.
+	 *
+	 * This command tries to mimic the POSIX behavior as much as possible.
+	 *
+	 * Notable exceptions:
+	 * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
+	 * - There is no "quiet" option since default behavior is to run silent.
+	 *
+	 * @param options Available options:
+	 *        - `-v`: (output a diagnostic for every file processed),
+	 *        - `-c`: (like -v but report only when a change is made),
+	 *        - `-R`: (change files and directories recursively)
+	 * @param mode    The access mode. Can be an octal string or a symbolic mode string.
+	 * @param file    The file to use.
+	 * @return        Object with shell exit code, stderr and stdout.
+	 */
+	(options: string, mode: string | number, file: string): ShellString;
+
+	/**
+	 * Alters the permissions of a file or directory by either specifying the absolute
+	 * permissions in octal form or expressing the changes in symbols.
+	 *
+	 * This command tries to mimic the POSIX behavior as much as possible.
+	 *
+	 * Notable exceptions:
+	 * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
+	 * - There is no "quiet" option since default behavior is to run silent.
+	 *
+	 * @param mode The access mode. Can be an octal string or a symbolic mode string.
+	 * @param file The file to use.
+	 * @return     Object with shell exit code, stderr and stdout.
+	 */
+	(mode: string | number, file: string): ShellString;
+}
 
 /**
- * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
+ * Alters the permissions of a file or directory by either specifying the absolute
+ * permissions in octal form or expressing the changes in symbols.
+ *
+ * This command tries to mimic the POSIX behavior as much as possible.
+ *
+ * Notable exceptions:
  * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
  * - There is no "quiet" option since default behavior is to run silent.
- * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
- * @param octalMode The access mode. Octal.
- * @param file      The file to use.
- * @return          Object with shell exit code, stderr and stdout.
+ *
+ * @param options Available options:
+ *        - `-v`: (output a diagnostic for every file processed),
+ *        - `-c`: (like -v but report only when a change is made),
+ *        - `-R`: (change files and directories recursively)
+ * @param mode    The access mode. Can be an octal string or a symbolic mode string.
+ * @param file    The file to use.
+ * @return        Object with shell exit code, stderr and stdout.
  */
-export function chmod(options: string, octalMode: number, file: string): ShellString;
-
-/**
- * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
- * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
- * - There is no "quiet" option since default behavior is to run silent.
- * @param mode      The access mode. Can be an octal string or a symbolic mode string.
- * @param file      The file to use.
- * @return          Object with shell exit code, stderr and stdout.
- */
-export function chmod(mode: string, file: string): ShellString;
-
-/**
- * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
- * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
- * - There is no "quiet" option since default behavior is to run silent.
- * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
- * @param mode      The access mode. Can be an octal string or a symbolic mode string.
- * @param file      The file to use.
- * @return          Object with shell exit code, stderr and stdout.
- */
-export function chmod(options: string, mode: string, file: string): ShellString;
+export const chmod: ChmodFunction;
 
 // Non-Unix commands
 
 /**
- * Searches and returns string containing a writeable, platform-dependent temporary directory. Follows Python's tempfile algorithm.
+ * Searches and returns string containing a writeable, platform-dependent temporary directory.
+ * Follows Python's tempfile algorithm.
+ *
  * @return The temp file path.
  */
 export function tempdir(): ShellString;
 
 /**
  * Tests if error occurred in the last command.
+ *
  * @return Returns null if no error occurred, otherwise returns string explaining the error
  */
 export function error(): ShellString;
 
 export type TouchOptionsLiteral = "-a" | "-c" | "-m" | "-d" | "-r";
 
-/**
- * Update the access and modification times of each FILE to the current time. A FILE argument that does not exist is created empty, unless -c is supplied
- */
 export interface TouchOptionsArray {
-    '-d'?: string;
-    '-r'?: string;
+	"-d"?: string;
+	"-r"?: string;
 }
 
-export function touch(...files: string[]): ShellString;
-export function touch(files: string[]): ShellString;
-export function touch(options: TouchOptionsLiteral, ...files: Array<string | string[]>): ShellString;
-export function touch(options: TouchOptionsArray, ...files: Array<string | string[]>): ShellString;
+export interface TouchFunction {
+	(
+		options: TouchOptionsLiteral | TouchOptionsArray,
+		files: string[]
+	): ShellString;
+	(
+		options: TouchOptionsLiteral | TouchOptionsArray,
+		...files: string[]
+	): ShellString;
+
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
+
+/**
+ * Update the access and modification times of each FILE to the current time.
+ * A FILE argument that does not exist is created empty, unless `-c` is supplied
+ */
+export const touch: TouchFunction;
 
 export interface HeadOptions {
-    /** Show the first <num> lines of the files. */
-    '-n': number;
+	/** Show the first <num> lines of the files. */
+	"-n": number;
 }
 
-/** Read the start of a file. */
-export function head(...files: Array<string | string[]>): ShellString;
-/** Read the start of a file. */
-export function head(options: HeadOptions, ...files: Array<string | string[]>): ShellString;
+export interface HeadFunction {
+	/**
+	 * Read the start of a file.
+	 */
+	(options: HeadOptions, files: string[]): ShellString;
+	(options: HeadOptions, ...files: string[]): ShellString;
+
+	/**
+	 * Read the start of a file.
+	 */
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
 
 /**
- * Return the contents of the files, sorted line-by-line. Sorting multiple files mixes their content (just as unix sort does).
+ * Read the start of a file.
  */
-export function sort(...files: Array<string | string[]>): ShellString;
+export const head: HeadFunction;
+
+export interface SortFunction {
+	/**
+	 * Return the contents of the files, sorted line-by-line.
+	 * Sorting multiple files mixes their content (just as unix sort does).
+	 *
+	 * @param options Available options:
+	 *        - `-r`: Reverse the results
+	 *        - `-n`: Compare according to numerical value
+	 */
+	(options: string, files: string[]): ShellString;
+	(options: string, ...files: string[]): ShellString;
+
+	/**
+	 * Return the contents of the files, sorted line-by-line.
+	 * Sorting multiple files mixes their content (just as unix sort does).
+	 */
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
 
 /**
- * Return the contents of the files, sorted line-by-line. Sorting multiple files mixes their content (just as unix sort does).
- * @param options Available options: -r: Reverse the results -n: Compare according to numerical value
+ * Return the contents of the files, sorted line-by-line.
+ * Sorting multiple files mixes their content (just as unix sort does).
+ *
+ * @param options Available options:
+ *        - `-r`: Reverse the results
+ *        - `-n`: Compare according to numerical value
  */
-export function sort(options: string, ...files: Array<string | string[]>): ShellString;
+export const sort: SortFunction;
 
 export interface TailOptions {
-    /** Show the last <num> lines of files. */
-    '-n': number;
+	/** Show the last <num> lines of files. */
+	"-n": number;
 }
 
-/** Read the end of a file. */
-export function tail(...files: Array<string | string[]>): ShellString;
-/** Read the end of a file. */
-export function tail(options: TailOptions, ...files: Array<string | string[]>): ShellString;
+export interface TailFunction {
+	/**
+	 * Read the end of a file.
+	 */
+	(options: TailOptions, files: string[]): ShellString;
+	(options: TailOptions, ...files: string[]): ShellString;
+
+	/**
+	 * Read the end of a file.
+	 */
+	(files: string[]): ShellString;
+	(...files: string[]): ShellString;
+}
+
+/**
+ * Read the end of a file.
+ */
+export const tail: TailFunction;
+
+export interface UniqFunction {
+	/**
+	 * Filter adjacent matching lines from input.
+	 *
+	 * @param options Available options:
+	 *        - `-i`: Ignore case while comparing
+	 *        - `-c`: Prefix lines by the number of occurrences
+	 *        - `-d`: Only print duplicate lines, one for each group of identical lines
+	 */
+	(options: string, input: string, output?: string): ShellString;
+
+	/**
+	 * Filter adjacent matching lines from input.
+	 */
+	(input: string, output?: string): ShellString;
+}
 
 /**
  * Filter adjacent matching lines from input.
+ *
+ * @param options Available options:
+ *        - `-i`: Ignore case while comparing
+ *        - `-c`: Prefix lines by the number of occurrences
+ *        - `-d`: Only print duplicate lines, one for each group of identical lines
  */
-export function uniq(input: string, output?: string): ShellString;
-/**
- * Filter adjacent matching lines from input.
- * @param options Available options: -i: Ignore case while comparing -c: Prefix lines by the number of occurrences -d: Only print duplicate lines, one for each group of identical lines
- */
-export function uniq(options: string, input: string, output?: string): ShellString;
+export const uniq: UniqFunction;
 
 /**
  * Sets global configuration variables
- * @param options Available options: `+/-e`: exit upon error (`config.fatal`), `+/-v`: verbose: show all commands (`config.verbose`), `+/-f`: disable filename expansion (globbing)
+ * @param options Available options:
+ *        - `+/-e`: exit upon error (`config.fatal`),
+ *        - `+/-v`: verbose: show all commands (`config.verbose`),
+ *        - `+/-f`: disable filename expansion (globbing)
  */
 export function set(options: string): void;
 
 // Configuration
 
 export interface ShellConfig {
-    /**
-     * Suppresses all command output if true, except for echo() calls. Default is false.
-     */
-    silent: boolean;
+	/**
+	 * Suppresses all command output if true, except for echo() calls. Default is false.
+	 */
+	silent: boolean;
 
-    /**
-     * If true the script will die on errors. Default is false.
-     */
-    fatal: boolean;
+	/**
+	 * If true the script will die on errors. Default is false.
+	 */
+	fatal: boolean;
 
-    /**
-     * Will print each executed command to the screen. Default is true.
-     */
-    verbose: boolean;
+	/**
+	 * Will print each executed command to the screen. Default is true.
+	 */
+	verbose: boolean;
 
-    /**
-     * Passed to glob.sync() instead of the default options ({}).
-     */
-    globOptions: glob.IOptions;
+	/**
+	 * Passed to glob.sync() instead of the default options ({}).
+	 */
+	globOptions: glob.IOptions;
 
-    /**
-     * Absolute path of the Node binary. Default is null (inferred).
-     */
-    execPath: string | null;
+	/**
+	 * Absolute path of the Node binary. Default is null (inferred).
+	 */
+	execPath: string | null;
 
-    /**
-     * Reset shell.config to the defaults.
-     */
-    reset(): void;
+	/**
+	 * Reset shell.config to the defaults.
+	 */
+	reset(): void;
 }
 
 /**

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -13,8 +13,6 @@
 import child = require("child_process");
 import glob = require("glob");
 
-export as namespace shelljs;
-
 /**
  * Changes the current working directory dir for the duration of the script.
  * Changes to the home directory if no argument is supplied.

--- a/types/shelljs/make.d.ts
+++ b/types/shelljs/make.d.ts
@@ -1,41 +1,42 @@
-import * as shelljs from './';
+import shelljs = require('./index');
 declare global {
-    interface Target {
-        (...args: any[]): void;
-        result?: any;
-        done?: boolean;
-    }
-    const target: {
-        all?: Target;
-        [s: string]: Target;
-    };
-    const cd: typeof shelljs.cd;
-    const pwd: typeof shelljs.pwd;
-    const ls: typeof shelljs.ls;
-    const find: typeof shelljs.find;
-    const cp: typeof shelljs.cp;
-    const rm: typeof shelljs.rm;
-    const mv: typeof shelljs.mv;
-    const mkdir: typeof shelljs.mkdir;
-    const cat: typeof shelljs.cat;
-    const sed: typeof shelljs.sed;
-    const grep: typeof shelljs.grep;
-    const echo: typeof shelljs.echo;
-    const pushd: typeof shelljs.pushd;
-    const popd: typeof shelljs.popd;
-    const dirs: typeof shelljs.dirs;
-    const ln: typeof shelljs.ln;
-    const exit: typeof shelljs.exit;
-    const env: typeof shelljs.env;
-    const exec: typeof shelljs.exec;
-    const chmod: typeof shelljs.chmod;
-    const tempdir: typeof shelljs.tempdir;
-    const error: typeof shelljs.error;
-    const touch: typeof shelljs.touch;
-    const head: typeof shelljs.head;
-    const sort: typeof shelljs.sort;
-    const tail: typeof shelljs.tail;
-    const uniq: typeof shelljs.uniq;
-    const set: typeof shelljs.set;
-    const config: typeof shelljs.config;
+	interface Target {
+		(...args: any[]): void;
+		result?: any;
+		done?: boolean;
+	}
+	const target: {
+		all?: Target;
+		[s: string]: Target;
+	};
+
+	const cat: typeof shelljs.cat;
+	const cd: typeof shelljs.cd;
+	const chmod: typeof shelljs.chmod;
+	const config: typeof shelljs.config;
+	const cp: typeof shelljs.cp;
+	const dirs: typeof shelljs.dirs;
+	const echo: typeof shelljs.echo;
+	const env: typeof shelljs.env;
+	const error: typeof shelljs.error;
+	const exec: typeof shelljs.exec;
+	const exit: typeof shelljs.exit;
+	const find: typeof shelljs.find;
+	const grep: typeof shelljs.grep;
+	const head: typeof shelljs.head;
+	const ln: typeof shelljs.ln;
+	const ls: typeof shelljs.ls;
+	const mkdir: typeof shelljs.mkdir;
+	const mv: typeof shelljs.mv;
+	const popd: typeof shelljs.popd;
+	const pushd: typeof shelljs.pushd;
+	const pwd: typeof shelljs.pwd;
+	const rm: typeof shelljs.rm;
+	const sed: typeof shelljs.sed;
+	const set: typeof shelljs.set;
+	const sort: typeof shelljs.sort;
+	const tail: typeof shelljs.tail;
+	const tempdir: typeof shelljs.tempdir;
+	const touch: typeof shelljs.touch;
+	const uniq: typeof shelljs.uniq;
 }

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -100,9 +100,6 @@ declare let isAsync: boolean;
 
 // $ExpectType ShellString | ChildProcess
 const unknownUntilRuntime = shell.exec("node --version", {async: isAsync});
-if (typeof unknownUntilRuntime.stdout === "string") {
-	const output = unknownUntilRuntime.stdout;
-}
 
 shell.exec("node --version", {silent: true}, (code, stdout, stderr) => {
 	const version = stdout;
@@ -169,6 +166,8 @@ shell.head(["file1", "file2"]); // same as above
 
 shell.sort("foo.txt", "bar.txt");
 shell.sort("-r", "foo.txt");
+shell.sort("-r", ["file.txt"]);
+shell.sort(["file.txt"]);
 
 shell.tail({"-n": 1}, "file*.txt");
 shell.tail("file1", "file2");

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -3,8 +3,8 @@
 import shell = require("shelljs");
 
 if (!shell.which("git")) {
-    shell.echo("Sorry, this script requires git");
-    shell.exit(1);
+	shell.echo("Sorry, this script requires git");
+	shell.exit(1);
 }
 
 // Copy files to release dir
@@ -14,19 +14,24 @@ shell.cp("-R", "stuff/*", "out/Release");
 // Replace macros in each .js file
 shell.cd("lib");
 shell.ls("*.js").forEach(file => {
-    shell.sed("-i", "BUILD_VERSION", "v0.1.2", file);
-    shell.sed("-i", /.*REMOVE_THIS_LINE.*\n/, "", file);
-    shell.sed("-i", /.*REPLACE_LINE_WITH_MACRO.*\n/, shell.cat("macro.js"), file);
+	shell.sed("-i", "BUILD_VERSION", "v0.1.2", file);
+	shell.sed("-i", /.*REMOVE_THIS_LINE.*\n/, "", file);
+	shell.sed(
+		"-i",
+		/.*REPLACE_LINE_WITH_MACRO.*\n/,
+		shell.cat("macro.js"),
+		file
+	);
 });
 
 shell.cd("..");
 
-shell.config.execPath = shell.which('node');
+shell.config.execPath = shell.which("node");
 
 // Run external tool synchronously
 if (shell.exec('git commit -am "Auto-commit"').code !== 0) {
-    shell.echo("Error: Git commit failed");
-    shell.exit(1);
+	shell.echo("Error: Git commit failed");
+	shell.exit(1);
 }
 
 shell.ls("projs/*.js");
@@ -49,8 +54,12 @@ shell.mv(["file1", "file2"], "dir/"); // same as above
 shell.mkdir("-p", "/tmp/a/b/c/d", "/tmp/e/f/g");
 shell.mkdir("-p", ["/tmp/a/b/c/d", "/tmp/e/f/g"]); // same as above
 
-if (shell.test("-d", "/tmp/a/b/c/d")) { /* do something with dir */ }
-if (!shell.test("-f", "/tmp/a/b/c/d")) { /* do something with dir */ }
+if (shell.test("-d", "/tmp/a/b/c/d")) {
+	/* do something with dir */
+}
+if (!shell.test("-f", "/tmp/a/b/c/d")) {
+	/* do something with dir */
+}
 
 let str = shell.cat("file*.txt");
 str = shell.cat("file1", "file2");
@@ -77,41 +86,53 @@ shell.ln("file", "newlink");
 shell.ln("-sf", "file", "existing");
 
 const testPath = shell.env["path"];
-
-import child = require("child_process");
-
 const version = shell.exec("node --version").stdout;
 
-const version2 = shell.exec("node --version", { async: false }) as shell.ExecOutputReturnValue;
+// $ExpectType ShellString
+const version2 = shell.exec("node --version", {async: false});
 const output = version2.stdout;
 
-const asyncVersion3 = shell.exec("node --version", { async: true }) as child.ChildProcess;
+// $ExpectType ChildProcess
+const asyncVersion3 = shell.exec("node --version", {async: true});
 let pid = asyncVersion3.pid;
 
-shell.exec("node --version", { silent: true }, (code, stdout, stderr) => {
-    const version = stdout;
+declare let isAsync: boolean;
+
+// $ExpectType ShellString | ChildProcess
+const unknownUntilRuntime = shell.exec("node --version", {async: isAsync});
+if (typeof unknownUntilRuntime.stdout === "string") {
+	const output = unknownUntilRuntime.stdout;
+}
+
+shell.exec("node --version", {silent: true}, (code, stdout, stderr) => {
+	const version = stdout;
 });
-shell.exec("node --version", { silent: true, async: true, cwd: '/usr/local/bin' }, (code, stdout, stderr) => {
-    const version = stdout;
-});
+shell.exec(
+	"node --version",
+	{silent: true, async: true, cwd: "/usr/local/bin"},
+	(code, stdout, stderr) => {
+		const version = stdout;
+	}
+);
 shell.exec("node --version", (code, stdout, stderr) => {
-    const version = stdout;
+	const version = stdout;
 });
 shell.exec("node --version", (code: number) => {
-    const num: number = code;
+	const num: number = code;
 });
 
+// $ExpectType ChildProcess
 const childProc = shell.exec("node --version", (code: number) => {
-    const num: number = code;
+	const num: number = code;
 });
 pid = childProc.pid;
 
-shell.set('+e');
-shell.set('-e');
-shell.set('+v');
-shell.set('-v');
-shell.set('+f');
-shell.set('-f');
+shell.set("+e");
+shell.set("-e");
+shell.set("+v");
+shell.set("-v");
+shell.set("+f");
+shell.set("-f");
 
 shell.chmod(755, "/Users/brandon");
 shell.chmod("755", "/Users/brandon"); // same as above
@@ -121,34 +142,41 @@ shell.chmod("-Rv", "u+x", "/Users/brandon");
 
 shell.exit(0);
 
-shell.touch('/Users/brandom/test1');
-shell.touch('/Users/brandom/test1', '/Users/brandom/test2');
+shell.touch("/Users/brandom/test1");
+shell.touch("/Users/brandom/test1", "/Users/brandom/test2");
 
-shell.touch(['/Users/brandom/test1']);
-shell.touch(['/Users/brandom/test1', '/Users/brandom/test2']);
+shell.touch(["/Users/brandom/test1"]);
+shell.touch(["/Users/brandom/test1", "/Users/brandom/test2"]);
 
-shell.touch('-c', '/Users/brandom/test1');
-shell.touch('-c', '/Users/brandom/test1', '/Users/brandom/test2');
-shell.touch('-c', ['/Users/brandom/test1', '/Users/brandom/test2']);
+shell.touch("-c", "/Users/brandom/test1");
+shell.touch("-c", "/Users/brandom/test1", "/Users/brandom/test2");
+shell.touch("-c", ["/Users/brandom/test1", "/Users/brandom/test2"]);
 
-shell.touch({ '-r': '/some/file.txt' }, '/Users/brandom/test1');
-shell.touch({ '-r': '/some/file.txt' }, '/Users/brandom/test1', '/Users/brandom/test2');
-shell.touch({ '-r': '/oome/file.txt' }, ['/Users/brandom/test1', '/Users/brandom/test2']);
+shell.touch({"-r": "/some/file.txt"}, "/Users/brandom/test1");
+shell.touch(
+	{"-r": "/some/file.txt"},
+	"/Users/brandom/test1",
+	"/Users/brandom/test2"
+);
+shell.touch({"-r": "/oome/file.txt"}, [
+	"/Users/brandom/test1",
+	"/Users/brandom/test2"
+]);
 
-shell.head({'-n': 1}, 'file*.txt');
-shell.head('file1', 'file2');
-shell.head(['file1', 'file2']); // same as above
+shell.head({"-n": 1}, "file*.txt");
+shell.head("file1", "file2");
+shell.head(["file1", "file2"]); // same as above
 
-shell.sort('foo.txt', 'bar.txt');
-shell.sort('-r', 'foo.txt');
+shell.sort("foo.txt", "bar.txt");
+shell.sort("-r", "foo.txt");
 
-shell.tail({'-n': 1}, 'file*.txt');
-shell.tail('file1', 'file2');
-shell.tail(['file1', 'file2']); // same as above
+shell.tail({"-n": 1}, "file*.txt");
+shell.tail("file1", "file2");
+shell.tail(["file1", "file2"]); // same as above
 
-shell.uniq('foo.txt');
-shell.uniq('-i', 'foo.txt');
-shell.uniq('-cd', 'foo.txt', 'bar.txt');
+shell.uniq("foo.txt");
+shell.uniq("-i", "foo.txt");
+shell.uniq("-cd", "foo.txt", "bar.txt");
 
 const tmp = shell.tempdir(); // "/tmp" for most *nix platforms
 
@@ -159,8 +187,13 @@ shell.config.silent = true;
 shell.config.fatal = true;
 shell.config.verbose = true;
 shell.config.execPath = null;
-shell.config.execPath = '/bin/node';
+shell.config.execPath = "/bin/node";
 shell.config.globOptions = {
-    cwd: './',
-    dot: true
+	cwd: "./",
+	dot: true
 };
+
+shell
+	.ls("dir")
+	.grep(/^stuff/)
+	.head({"-n": 5}).stdout;

--- a/types/shelljs/tsconfig.json
+++ b/types/shelljs/tsconfig.json
@@ -1,24 +1,24 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "make.d.ts",
-        "shelljs-tests.ts"
-    ]
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": false,
+		"strictFunctionTypes": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"make.d.ts",
+		"shelljs-tests.ts"
+	]
 }

--- a/types/shelljs/tslint.json
+++ b/types/shelljs/tslint.json
@@ -1,7 +1,17 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "max-line-length": false,
-        "unified-signatures": false
-    }
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"indent": [
+			true,
+			"tabs"
+		],
+
+		/**
+		 * This package uses TSDoc conditional on the specific
+		 * signature, with an optional parameter at the beginning,
+		 * which `unified-signatures` considers to be mergeable with
+		 * signatures that don't include it.
+		 */
+		"unified-signatures": false
+	}
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://shelljs.org (specifically: http://shelljs.org#execcommand--options--callback, which states that `exec` returns a `ShellString` for synchronous operations)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

I’ve moved longer signatures and signatures with `options` to the top, since TypeScript determines the used overload by going from the top to bottom, returning the moment an overload signature matches, which would result in `...files` absorbing the `options`.

I’ve also split the array version of functions from the varargs version, since the varargs version isn't allowed to have mixed strings and arrays.

I’ve also moved all function definitions into callable interfaces to make reuse in `ShellReturnValue` easier.

---

review?(@sandersn)