### PR TITLE
Add types for rtl-detect

### DIFF
--- a/types/rtl-detect/index.d.ts
+++ b/types/rtl-detect/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for rtl-detect 1.0
+// Project: https://github.com/shadiabuhilal/rtl-detect
+// Definitions by: imprevo <https://github.com/imprevo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function getLangDir(strLocale: string): 'ltr' | 'rtl';
+export function isRtlLang(strLocale: string): boolean | undefined;

--- a/types/rtl-detect/rtl-detect-tests.ts
+++ b/types/rtl-detect/rtl-detect-tests.ts
@@ -1,0 +1,4 @@
+import * as rtlDetect from 'rtl-detect';
+
+rtlDetect.getLangDir('');
+rtlDetect.isRtlLang('');

--- a/types/rtl-detect/tsconfig.json
+++ b/types/rtl-detect/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rtl-detect-tests.ts"
+    ]
+}

--- a/types/rtl-detect/tsconfig.json
+++ b/types/rtl-detect/tsconfig.json
@@ -1,22 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "rtl-detect-tests.ts"
-    ]
+    "files": ["index.d.ts", "rtl-detect-tests.ts"]
 }

--- a/types/rtl-detect/tslint.json
+++ b/types/rtl-detect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
