### PR TITLE
Update types for argon2-browser 1.5.

### DIFF
--- a/types/argon2-browser/argon2-browser-tests.ts
+++ b/types/argon2-browser/argon2-browser-tests.ts
@@ -24,11 +24,11 @@ const verifyMandatoryOptions: argon2.VerifyOptions = {
   (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2i })).encoded; // $ExpectType string
   (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2id })).encoded; // $ExpectType string
 
-  await argon2.verify(verifyMandatoryOptions);
-  await argon2.verify({...verifyMandatoryOptions, encoded: new Uint8Array([0, 1, 2, 3])});
+  await argon2.verify(verifyMandatoryOptions); // $ExpectType void
+  await argon2.verify({...verifyMandatoryOptions, encoded: new Uint8Array([0, 1, 2, 3])}); // $ExpectType void
 
-  await argon2.verify({ ...verifyMandatoryOptions, distPath: 'path' });
-  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2d });
-  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2i });
-  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2id });
+  await argon2.verify({ ...verifyMandatoryOptions, distPath: 'path' }); // $ExpectType void
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2d }); // $ExpectType void
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2i }); // $ExpectType void
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2id }); // $ExpectType void
 })();

--- a/types/argon2-browser/argon2-browser-tests.ts
+++ b/types/argon2-browser/argon2-browser-tests.ts
@@ -11,18 +11,18 @@ const verifyMandatoryOptions: argon2.VerifyOptions = {
 };
 
 (async () => {
-  (await argon2.hash(hashMandatoryOptions)).encoded; // string
-  (await argon2.hash(hashMandatoryOptions)).hash; // Uint8Array
-  (await argon2.hash(hashMandatoryOptions)).hashHex; // string
+  (await argon2.hash(hashMandatoryOptions)).encoded; // $ExpectType string
+  (await argon2.hash(hashMandatoryOptions)).hash; // $ExpectType Uint8Array
+  (await argon2.hash(hashMandatoryOptions)).hashHex; // $ExpectType string
 
-  (await argon2.hash({ ...hashMandatoryOptions, distPath: 'path' })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, hashLen: 24 })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, mem: 1024 })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, parallelism: 1 })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, time: 1 })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2d })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2i })).encoded; // string
-  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2id })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, distPath: 'path' })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, hashLen: 24 })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, mem: 1024 })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, parallelism: 1 })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, time: 1 })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2d })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2i })).encoded; // $ExpectType string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2id })).encoded; // $ExpectType string
 
   await argon2.verify(verifyMandatoryOptions);
   await argon2.verify({...verifyMandatoryOptions, encoded: new Uint8Array([0, 1, 2, 3])});

--- a/types/argon2-browser/argon2-browser-tests.ts
+++ b/types/argon2-browser/argon2-browser-tests.ts
@@ -1,20 +1,34 @@
-import { argon2 } from 'argon2-browser';
+import 'argon2-browser';
 
-const mandatoryOptions = {
+const hashMandatoryOptions: argon2.HashOptions = {
   pass: 'Qwerty12?',
-  salt: 'Salty'
+  salt: 'Salty',
+};
+
+const verifyMandatoryOptions: argon2.VerifyOptions = {
+  encoded: '$argon2d$v=19$m=1024,t=1,p=1$U2FsdHlTYWx0eQ$1jpGIXoUTdOQSUFaAP8qCnsr8yTGbF2srlkfrUM+hIo',
+  pass: 'Qwerty12?',
 };
 
 (async () => {
-  (await argon2.hash(mandatoryOptions)).encoded; // string
-  (await argon2.hash(mandatoryOptions)).hash; // Uint8Array
-  (await argon2.hash(mandatoryOptions)).hashHex; // string
+  (await argon2.hash(hashMandatoryOptions)).encoded; // string
+  (await argon2.hash(hashMandatoryOptions)).hash; // Uint8Array
+  (await argon2.hash(hashMandatoryOptions)).hashHex; // string
 
-  (await argon2.hash({ ...mandatoryOptions, distPath: 'path' })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, hashLen: 24 })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, mem: 1024 })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, parallelism: 1 })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, time: 1 })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, type: argon2.ArgonType.Argon2d })).encoded; // string
-  (await argon2.hash({ ...mandatoryOptions, type: argon2.ArgonType.Argon2i })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, distPath: 'path' })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, hashLen: 24 })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, mem: 1024 })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, parallelism: 1 })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, time: 1 })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2d })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2i })).encoded; // string
+  (await argon2.hash({ ...hashMandatoryOptions, type: argon2.ArgonType.Argon2id })).encoded; // string
+
+  await argon2.verify(verifyMandatoryOptions);
+  await argon2.verify({...verifyMandatoryOptions, encoded: new Uint8Array([0, 1, 2, 3])});
+
+  await argon2.verify({ ...verifyMandatoryOptions, distPath: 'path' });
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2d });
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2i });
+  await argon2.verify({ ...verifyMandatoryOptions, type: argon2.ArgonType.Argon2id });
 })();

--- a/types/argon2-browser/index.d.ts
+++ b/types/argon2-browser/index.d.ts
@@ -1,13 +1,14 @@
-// Type definitions for argon2-browser 1.1
+// Type definitions for argon2-browser 1.5
 // Project: https://github.com/antelle/argon2-browser#readme
 // Definitions by: Ivan Gabriele <https://github.com/ivangabriele>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export namespace argon2 {
-    function hash(options: Argon2BrowserHashOptions): Promise<Argon2BrowserHashResult>;
+declare namespace argon2 {
+    function hash(options: HashOptions): Promise<HashResult>;
+    function verify(options: VerifyOptions): Promise<void>;
 
-    interface Argon2BrowserHashOptions {
+    interface HashOptions {
         distPath?: string;
         hashLen?: number;
         mem?: number;
@@ -18,14 +19,22 @@ export namespace argon2 {
         type?: ArgonType;
     }
 
-    interface Argon2BrowserHashResult {
+    interface HashResult {
         encoded: string;
         hash: Uint8Array;
         hashHex: string;
     }
 
+    interface VerifyOptions {
+        distPath?: string;
+        encoded: string | Uint8Array;
+        pass: string;
+        type?: ArgonType;
+    }
+
     enum ArgonType {
         Argon2d = 0,
-        Argon2i = 1
+        Argon2i = 1,
+        Argon2id = 2,
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/antelle/argon2-browser
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note that I did some BC because either the types have never worked or the library itself has done some BC without increasing the major version number. So I think it's OK. Let me know what you think.
