### PR TITLE
Fix return type of @storybook/addon-knobs/radios

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -49,7 +49,7 @@ export function color(name: string, value: string, groupId?: string): string;
 
 export function object<T>(name: string, value: T, groupId?: string): T;
 
-export function radios<T>(name: string, options: { [s: string]: T }, value?: T, groupId?: string): string;
+export function radios<T>(name: string, options: { [s: string]: T }, value?: T, groupId?: string): T;
 
 export function select<T>(name: string, options: { [s: string]: T }, value: T, groupId?: string): T;
 export function select<

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -35,7 +35,8 @@ stories.add('with all knobs', () => {
   const selectedColor = color('Color', 'black');
   const favoriteNumber = number('Favorite Number', 42);
   const comfortTemp = number('Comfort Temp', 72, { range: true, min: 60, max: 90, step: 1 });
-  const radioStation = radios('Favorite Radio Station', { 1100: "1100", 2200: "2200", 3300: "3300" });
+  const radioStation: string = radios('Favorite Radio Station', { 1100: "1100", 2200: "2200", 3300: "3300" });
+  const luckyNumber: number = radios('Lucky Number', { 3: 3, 7: 7, 23: 23 });
   const textDecoration = select('Decoration', {
     None: 'none',
     Underline: 'underline',
@@ -77,6 +78,7 @@ stories.add('with all knobs', () => {
       <p>My favorite number is {favoriteNumber}.</p>
       <p>My most comfortable room temperature is {comfortTemp} degrees Fahrenheit.</p>
       <p>My favorite radio station is: {radioStation}</p>
+      <p>My lucky number is {luckyNumber}.</p>
     </div>
   );
 });


### PR DESCRIPTION
`radios` picks value from property values of `options` or default value `value`. So return type should be consistent with them.

This resolves #34389.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
    ~No idea how the testing is done. I don't understand how the stuff in `storybook__addon-knobs-tests.tsx` is testing anything.~
    NVM. I did what I could. Hope it actually tests something.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/@storybook/addon-knobs#radio-buttons
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.