### PR TITLE
@types/xml2js change the type of the Error object

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -6,14 +6,15 @@
 //                 Edward Hinkle <https://github.com/edwardhinkle>
 //                 Behind The Math <https://github.com/BehindTheMath>
 //                 Claas Ahlrichs <https://github.com/claasahl>
+//                 Grzegorz Redlicki <https://github.com/redlickigrzegorz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
 import { EventEmitter } from 'events';
 import * as processors from './lib/processors';
 
-export function parseString(xml: convertableToString, callback: (err: any, result: any) => void): void;
-export function parseString(xml: convertableToString, options: OptionsV2, callback: (err: any, result: any) => void): void;
+export function parseString(xml: convertableToString, callback: (err: Error, result: any) => void): void;
+export function parseString(xml: convertableToString, options: OptionsV2, callback: (err: Error, result: any) => void): void;
 
 export const defaults: {
     '0.1': Options;

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -2,9 +2,9 @@ import xml2js = require('xml2js');
 import * as processors from 'xml2js/lib/processors';
 import fs = require('fs');
 
-xml2js.parseString('<root>Hello xml2js!</root>', (err: any, result: any) => { });
+xml2js.parseString('<root>Hello xml2js!</root>', (err: Error, result: any) => { });
 
-xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: any, result: any) => { });
+xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: Error, result: any) => { });
 
 xml2js.parseString('<root>Hello xml2js!</root>', {
     attrkey: '$',
@@ -30,14 +30,14 @@ xml2js.parseString('<root>Hello xml2js!</root>', {
     attrValueProcessors: undefined,
     tagNameProcessors: undefined,
     valueProcessors: undefined
-}, (err: any, result: any) => { });
+}, (err: Error, result: any) => { });
 
 xml2js.parseString('<root>Hello xml2js!</root>', {
     attrNameProcessors: [processors.firstCharLowerCase, xml2js.processors.normalize],
     attrValueProcessors: [processors.normalize],
     tagNameProcessors: [processors.stripPrefix],
     valueProcessors: [processors.parseBooleans, processors.parseNumbers]
-}, (err: any, result: any) => { });
+}, (err: Error, result: any) => { });
 
 let builder = new xml2js.Builder({
     renderOpts: {
@@ -81,7 +81,7 @@ v2Defaults.async = false;
 v2Defaults.chunkSize = 20000;
 
 fs.readFile(__dirname + '/foo.xml', (err, data) => {
-    parser.parseString(data, (err: any, result: any) => {
+    parser.parseString(data, (err: Error, result: any) => {
         console.dir(result);
         console.log('Done');
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I didn't create an issue for this problem but in this pull request, I changed the type for the `err` parameter which was treated as `any` but it should be always the `Error` object instead.

I found this problem during using the [util.promisify](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original). I got the error about missing third argument: `TS2554: Expected 3 arguments, but got 2.`

The types provided for `util` module treated this method as the method with 3 arguments instead of 2 arguments and the callback.

With this change, everything is working correctly.