### PR TITLE
fix(js-yaml): predicate is a function and not a string

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -15,7 +15,7 @@ export class Type {
 	resolve(data: any): boolean;
 	construct(data: any): any;
 	instanceOf: object | null;
-	predicate: (data:object) => boolean | null;
+	predicate: ((data: object) => boolean) | null;
 	represent: ((data: object) => any) | { [x: string]: (data: object) => any; } | null;
 	defaultStyle: string | null;
 	styleAliases: { [x: string]: any; };
@@ -82,7 +82,7 @@ export interface TypeConstructorOptions {
 	resolve?: (data: any) => boolean;
 	construct?: (data: any) => any;
 	instanceOf?: object;
-	predicate?: (data:object) => boolean;
+	predicate?: (data: object) => boolean;
 	represent?: ((data: object) => any) | { [x: string]: (data: object) => any };
 	defaultStyle?: string;
 	styleAliases?: { [x: string]: any; };

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -15,7 +15,7 @@ export class Type {
 	resolve(data: any): boolean;
 	construct(data: any): any;
 	instanceOf: object | null;
-	predicate: string | null;
+	predicate: (data:object) => boolean | null;
 	represent: ((data: object) => any) | { [x: string]: (data: object) => any; } | null;
 	defaultStyle: string | null;
 	styleAliases: { [x: string]: any; };
@@ -82,7 +82,7 @@ export interface TypeConstructorOptions {
 	resolve?: (data: any) => boolean;
 	construct?: (data: any) => any;
 	instanceOf?: object;
-	predicate?: string;
+	predicate?: (data:object) => boolean;
 	represent?: ((data: object) => any) | { [x: string]: (data: object) => any };
 	defaultStyle?: string;
 	styleAliases?: { [x: string]: any; };

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -104,7 +104,7 @@ type.resolve;
 type.construct;
 // $ExpectType object | null
 type.instanceOf;
-// $ExpectType (data:object) => boolean | null
+// $ExpectType ((data: object) => boolean) | null
 type.predicate;
 // $ExpectType ((data: object) => any) | { [x: string]: (data: object) => any; } | null
 type.represent;

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -23,7 +23,7 @@ const typeConstructorOptions: TypeConstructorOptions = {
 	resolve: fn,
 	construct: fn,
 	instanceOf: obj,
-	predicate: (obj) => true,
+	predicate: (obj) => false,
 	represent: fn,
 	defaultStyle: str,
 	styleAliases: map

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -23,7 +23,7 @@ const typeConstructorOptions: TypeConstructorOptions = {
 	resolve: fn,
 	construct: fn,
 	instanceOf: obj,
-	predicate: str,
+	predicate: (obj) => true,
 	represent: fn,
 	defaultStyle: str,
 	styleAliases: map
@@ -104,7 +104,7 @@ type.resolve;
 type.construct;
 // $ExpectType object | null
 type.instanceOf;
-// $ExpectType string | null
+// $ExpectType (data:object) => boolean | null
 type.predicate;
 // $ExpectType ((data: object) => any) | { [x: string]: (data: object) => any; } | null
 type.represent;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/bool.js#L28
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/js/undefined.js#L26
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/null.js#L26
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/js/regexp.js#L58
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/float.js#L113
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/js/function.js#L90
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/binary.js#L136
https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/type/int.js#L158
https://github.com/nodeca/js-yaml/blob/9d4ce5e2895365c943d2bdf7e7c8ac1be3ec51a3/dist/js-yaml.js#L767
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
