### PR TITLE
Ember: fix type for `Route#controllerFor`.

### DIFF
--- a/types/ember/test/inject.ts
+++ b/types/ember/test/inject.ts
@@ -33,7 +33,8 @@ class LoginRoute extends Ember.Route {
     }
 
     anyOldMethod() {
-        this.controllerFor('application').set('string', 'must be a string');
+        this.get('application').set('string', 'must be a string');
+        this.controllerFor('application'); // $ExpectType Controller
     }
 }
 

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -46,10 +46,10 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
     /**
      * Returns the controller of the current route, or a parent (or any
      * ancestor) route in a route hierarchy.
-     * 
+     *
      * The controller instance must already have been created, either through
      * entering the associated route or using `generateController`.
-     * 
+     *
      * @param name the name of the route or controller
      */
     controllerFor(name: string): Controller;

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -44,11 +44,15 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
     beforeModel(transition: Transition): any;
 
     /**
-     * Returns the controller for a particular route or name.
-     * The controller instance must already have been created, either through entering the
-     * associated route or using `generateController`.
+     * Returns the controller of the current route, or a parent (or any
+     * ancestor) route in a route hierarchy.
+     * 
+     * The controller instance must already have been created, either through
+     * entering the associated route or using `generateController`.
+     * 
+     * @param name the name of the route or controller
      */
-    controllerFor<K extends keyof ControllerRegistry>(name: K): ControllerRegistry[K];
+    controllerFor(name: string): Controller;
 
     /**
      * Disconnects a view that has been rendered into an outlet.

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -3,7 +3,6 @@ import Array from '@ember/array';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
 import Transition from '@ember/routing/-private/transition';
-import { assertType } from './lib/assert';
 
 class Post extends EmberObject {}
 

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -3,6 +3,7 @@ import Array from '@ember/array';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
 import Transition from '@ember/routing/-private/transition';
+import { assertType } from './lib/assert';
 
 class Post extends EmberObject {}
 
@@ -109,6 +110,9 @@ Route.extend({
         this.controllerFor('application').set('model', model);
     },
 });
+
+const route = Route.create();
+route.controllerFor('whatever'); // $ExpectType Controller
 
 class RouteUsingClass extends Route.extend({
     randomProperty: 'the .extend + extends bit type-checks properly',


### PR DESCRIPTION
Previously, `Route#controllerFor` was defined as taking a name from the controller registry, but it should accept the name of a route matching either the current route or one of its parents in the route hierarchy. We cannot (currently) constrain it to match the route hierarchy, so simply using `string` is the best option we have and users can then narrow it to a specific `Controller` subclass.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember/3.8/classes/Route/methods/controllerFor?anchor=controllerFor>
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~