### PR TITLE
xrm: Set removePreSearch handler to match addPreSearch

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -2905,7 +2905,7 @@ declare namespace Xrm {
              * Removes the handler from the "pre search" event of the Lookup control.
              * @param handler The handler.
              */
-            removePreSearch(handler: () => void): void;
+            removePreSearch(handler: Events.ContextSensitiveHandler): void;
 
             /**
              * Sets the Lookup's default view.


### PR DESCRIPTION
Found I was unable to use removePreSearch since the expected handler type didn't match addPreSearch.