### PR TITLE
React-Big-Calendar: improve typing for Views, specify type for Event,…

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -20,15 +20,21 @@ export type stringOrDate = string | Date;
 export type ViewKey = 'MONTH' | 'WEEK' | 'WORK_WEEK' | 'DAY' | 'AGENDA';
 export type View = 'month' | 'week' | 'work_week' | 'day' | 'agenda';
 export type Views = View[] | {
-    day: boolean | React.SFC | React.Component,
-    agenda: boolean | React.SFC | React.Component,
-    month: boolean | React.SFC | React.Component,
-    week: boolean | React.SFC | React.Component,
-    work_week: boolean | React.SFC | React.Component
+    work_week?: boolean | React.SFC | React.Component,
+    day?: boolean | React.SFC | React.Component,
+    agenda?: boolean | React.SFC | React.Component,
+    month?: boolean | React.SFC | React.Component,
+    week?: boolean | React.SFC | React.Component
 };
 export type Navigate = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 
-export type Event = object;
+export interface Event {
+    allDay?: boolean;
+    title: string;
+    start: Date;
+    end: Date;
+    resource?: any;
+}
 export interface DateRange {
     start: Date;
     end: Date;
@@ -230,8 +236,8 @@ export class DateLocalizer {
     format(value: FormatInput, format: string, culture: Culture): string;
 }
 
-export interface BigCalendarProps<TEvent extends Event = Event, TResource extends object = object> extends React.Props<BigCalendar<TEvent, TResource>> {
-    localizer: DateLocalizer;
+export interface BigCalendarProps<TEvent extends Event = Event, TResource extends object = object> {
+    localizer?: DateLocalizer;
 
     date?: stringOrDate;
     getNow?: () => Date;

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -85,6 +85,24 @@ class CalendarResource {
     ReactDOM.render(<DnD localizer={localizer} />, document.body);
 }
 
+// overriding 'views' props
+{
+    const DaySFC: React.SFC = () => null;
+    // supplying object to 'views' prop with only some of the supported views.
+    // A view can be a boolean or an SFC
+    ReactDOM.render(<BigCalendar
+                        views={{
+                            day: DaySFC,
+                            work_week: true
+                        }}
+    />, document.body);
+}
+
+// options 'views' prop
+{
+    ReactDOM.render(<BigCalendar />, document.body);
+}
+
 {
     class MyCalendar extends BigCalendar<CalendarEvent, CalendarResource> {}
 


### PR DESCRIPTION
1. Views type should have view names be optional
2. Event properties are known, and the Event type now defines them
3. The BigCalendarProps no longer needs to `extend React.Props`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   1. Docs shows `views` prop has not containing all view types: https://intljusticemission.github.io/react-big-calendar/examples/index.html#prop-views
   2. Event type is defined in the docs here: https://intljusticemission.github.io/react-big-calendar/examples/index.html#prop-events
   3. React type definition stating `interface Props` is deprecated: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1185
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
