### PR TITLE
[hoist-non-react-statics] Fix #33690 once and for all

### DIFF
--- a/types/hoist-non-react-statics/package.json
+++ b/types/hoist-non-react-statics/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "hoist-non-react-statics": "^3.3.0"
+  }
+}

--- a/types/hoist-non-react-statics/package.json
+++ b/types/hoist-non-react-statics/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "hoist-non-react-statics": "^3.3.0"
   }


### PR DESCRIPTION
Introduce an explicit dependency on `hoist-non-react-statics`, since older versions of that package included their own types, which would take precedence over the corresponding `@types` pacakge

Quote from https://github.com/Microsoft/types-publisher/pull/595:
> From version 2.2.0 to 3.0.0, the hoist-non-react-statics package defined its own typings. In 3.0.0, they were removed.

Fixes #33690 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
