### PR TITLE
[react-native-tab-view] change labelStyle to TextStyle

### DIFF
--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -4,6 +4,7 @@
 //                 Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 //                 Gerardo Pacheco <https://github.com/geriux>
+//                 Kazuyuki Takahashi <https://github.com/kazyk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { PureComponent, ReactNode, ComponentType } from 'react'
@@ -11,6 +12,7 @@ import {
   Animated,
   StyleProp,
   ViewStyle,
+  TextStyle,
   EasingFunction
 } from 'react-native'
 
@@ -221,7 +223,7 @@ export type TabBarProps<T extends RouteBase = RouteBase> = SceneRendererProps<
   useNativeDriver?: boolean;
   tabStyle?: StyleProp<ViewStyle>
   indicatorStyle?: StyleProp<ViewStyle>
-  labelStyle?: StyleProp<ViewStyle>
+  labelStyle?: StyleProp<TextStyle>
   style?: StyleProp<ViewStyle>
 }
 


### PR DESCRIPTION
Changed type of `labelStyle` to `StyleProp<TextStyle>`.
Passing `labelStyle={{color: 'red'}}` actually works but currently produces an error.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: doc:https://github.com/react-native-community/react-native-tab-view#labelstyle, flowtype:https://github.com/react-native-community/react-native-tab-view/blob/0da558e950e6522662072e82789706c405d3778d/src/TabBar.js#L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

