### PR TITLE
[qrcode-svg] Add type definitions for qrcode-svg module

### DIFF
--- a/types/qrcode-svg/index.d.ts
+++ b/types/qrcode-svg/index.d.ts
@@ -3,27 +3,45 @@
 // Definitions by: Eric Ferreira <https://github.com/ericbf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/**
+ * Generate an svg QR code easily with this class. Just instatiate an instance
+ * with one of the constructors, then either generate the QR code svg as a
+ * string with `.svg(...)` or save it to a file with `.save(...)`.
+ */
 declare class QRCode {
-	constructor(content: string);
-	constructor(options: QRCode.Options);
+    /**
+     * Create a QRCode with the default options and the passed content.
+     * @param content The content to encode in the QRCode.
+     */
+    constructor(content: string);
+    /**
+     * Create a QRCode by specifying its options. Any values not passed in the
+     *   options object will be inferred as the defaults.
+     * @param options The options with which to create the QRCode.
+     */
+    // tslint:disable-next-line:unified-signatures
+    constructor(options: QRCode.Options);
 
+    /** The raw model of this QRCode. */
     qrcode: QRCode.Model;
+
+    /** The options that were used to create this QRCode. */
     options: QRCode.Options;
 
-	/**
-	 * Generates QR Code as SVG image
-	 * @param  opt Set the container. Defaults to `{ container: "svg" }`.
-	 * @return The svg string.
-	 */
-	svg(opt?: {
-		container: "svg" | "g" | "none"
-	}): string;
-	/**
-	 * Writes QR Code image to a file. Requires `fs`.
-	 * @param  file The filename to write to
-	 * @param  callback The callback that will be called, possibly with an error, when done.
-	 */
-	save(file: string, callback: (error?: Error) => void): void;
+    /**
+     * Generates an SVG image of this QRCode
+     * @param  opt Set the container. Defaults to `{ container: "svg" }`.
+     * @return The svg string.
+     */
+    svg(opt?: {
+        container: "svg" | "g" | "none"
+    }): string;
+    /**
+     * Writes this QRCode to a file. Requires `fs`.
+     * @param  file The filename to write to
+     * @param  callback The callback that will be called, possibly with an error, when done.
+     */
+    save(file: string, callback: (error?: Error) => void): void;
 }
 
 declare namespace QRCode {
@@ -42,25 +60,46 @@ declare namespace QRCode {
         padding?: number;
         /** Default is `256`. */
         width?: number;
-        /** Default is `4`. */
-        typeNumber?: number;
     }
 
     interface Model {
+        /**
+         * This QRCode's data matrix. A square, two-dimensional boolean array
+         * of `moduleCount` x `moduleCount` size. True in a given slot means
+         * that spot is filled in in the QRCode visualization.
+         */
         modules: boolean[][];
+        /** The calculated type number for this QRCode. */
         typeNumber: number;
+        /** The numerical error correction level for this QRCode. */
         errorCorrectLevel: number;
+        /** The width/length of this QRCode's modules matrix. */
         moduleCount: number;
+        /** The cache used to store data during the creation of this QRCode. */
         dataCache: number[] | null;
+        /** A list of the data added to this QRCode. */
         dataList: Array<{
             data: string;
             mode: number;
             parsedData: number[];
         }>;
 
+        /**
+         * Queue data up to be added to this QRCode. `make` needs to be called
+         *   to actually generate the QRCode from the data.
+         * @param data The data to queue up in this QRCode.
+         */
         addData(data: string): void;
+        /**
+         * Whether a given coordinate is filled in in this QRCode's matrix.
+         * @param  row The row to check.
+         * @param  col The column to check.
+         * @return True if the coordinate is filled in, false otherwise.
+         */
         isDark(row: number, col: number): boolean;
+        /** Returns the length/width of this QRCode's matrix. */
         getModuleCount(): number;
+        /** Generate this QRCode's matrix from the queued data. */
         make(): void;
     }
 }

--- a/types/qrcode-svg/index.d.ts
+++ b/types/qrcode-svg/index.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for qrcode-svg 1.0
+// Project: https://github.com/papnkukn/qrcode-svg
+// Definitions by: Eric Ferreira <https://github.com/ericbf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class QRCode {
+	constructor(content: string);
+	constructor(options: QRCode.Options);
+
+    qrcode: QRCode.Model;
+    options: QRCode.Options;
+
+	/**
+	 * Generates QR Code as SVG image
+	 * @param  opt Set the container. Defaults to `{ container: "svg" }`.
+	 * @return The svg string.
+	 */
+	svg(opt?: {
+		container: "svg" | "g" | "none"
+	}): string;
+	/**
+	 * Writes QR Code image to a file. Requires `fs`.
+	 * @param  file The filename to write to
+	 * @param  callback The callback that will be called, possibly with an error, when done.
+	 */
+	save(file: string, callback: (error?: Error) => void): void;
+}
+
+declare namespace QRCode {
+    interface Options {
+        /** Default is `"#ffffff"`. */
+        background?: string;
+        /** Default is `"#000000"`. */
+        color?: string;
+        /** The actual content of the QR code */
+        content: string;
+        /** Default is `"M"`. */
+        ecl?: "L" | "M" | "H" | "Q";
+        /** Default is `256`. */
+        height?: number;
+        /** Default is `4`. */
+        padding?: number;
+        /** Default is `256`. */
+        width?: number;
+        /** Default is `4`. */
+        typeNumber?: number;
+    }
+
+    interface Model {
+        modules: boolean[][];
+        typeNumber: number;
+        errorCorrectLevel: number;
+        moduleCount: number;
+        dataCache: number[] | null;
+        dataList: Array<{
+            data: string;
+            mode: number;
+            parsedData: number[];
+        }>;
+
+        addData(data: string): void;
+        isDark(row: number, col: number): boolean;
+        getModuleCount(): number;
+        make(): void;
+    }
+}
+
+export = QRCode;

--- a/types/qrcode-svg/qrcode-svg-tests.ts
+++ b/types/qrcode-svg/qrcode-svg-tests.ts
@@ -1,19 +1,18 @@
-import * as QRCode from "qrcode-svg";
+import QRCode = require("qrcode-svg");
 
 const qrCode = new QRCode(`sample-data`);
 
 const assert = (result: boolean, messagePrefix: string, successMessage: string, errorMessage: string) => {
     if (result) {
-        console.log(`${messagePrefix} ${successMessage}`);
+        console.log(`[qrcode-svg] ${messagePrefix} ${successMessage}`);
     } else {
-        console.error(`${messagePrefix} ${errorMessage}`);
+        console.error(`[qrcode-svg] ${messagePrefix} ${errorMessage}`);
     }
 };
 
 assert(qrCode.options.padding === 4, "Default value for padding", "matches expected.", "does not match expected.");
 assert(qrCode.options.width === 256, "Default value for width", "matches expected.", "does not match expected.");
 assert(qrCode.options.height === 256, "Default value for height", "matches expected.", "does not match expected.");
-assert(qrCode.options.typeNumber === 4, "Default value for typeNumber", "matches expected.", "does not match expected.");
 assert(qrCode.options.background === "#ffffff", "Default value for background", "matches expected.", "does not match expected.");
 assert(qrCode.options.color === "#000000", "Default value for color", "matches expected.", "does not match expected.");
 
@@ -21,4 +20,4 @@ assert(Array.isArray(qrCode.qrcode.modules) &&
     qrCode.qrcode.modules.length === 0 ||
         Array.isArray(qrCode.qrcode.modules[0]), "Modules in qrcode is", "a two-dimensional array", "not a two-dimensional array");
 
-assert(typeof qrCode.svg() === "string", "QRCode", "generated an svg string", "did not generate an svg string");
+assert(typeof qrCode.svg() === "string", "QRCode object", "generated an svg string", "did not generate an svg string");

--- a/types/qrcode-svg/qrcode-svg-tests.ts
+++ b/types/qrcode-svg/qrcode-svg-tests.ts
@@ -1,0 +1,24 @@
+import * as QRCode from "qrcode-svg";
+
+const qrCode = new QRCode(`sample-data`);
+
+const assert = (result: boolean, messagePrefix: string, successMessage: string, errorMessage: string) => {
+    if (result) {
+        console.log(`${messagePrefix} ${successMessage}`);
+    } else {
+        console.error(`${messagePrefix} ${errorMessage}`);
+    }
+};
+
+assert(qrCode.options.padding === 4, "Default value for padding", "matches expected.", "does not match expected.");
+assert(qrCode.options.width === 256, "Default value for width", "matches expected.", "does not match expected.");
+assert(qrCode.options.height === 256, "Default value for height", "matches expected.", "does not match expected.");
+assert(qrCode.options.typeNumber === 4, "Default value for typeNumber", "matches expected.", "does not match expected.");
+assert(qrCode.options.background === "#ffffff", "Default value for background", "matches expected.", "does not match expected.");
+assert(qrCode.options.color === "#000000", "Default value for color", "matches expected.", "does not match expected.");
+
+assert(Array.isArray(qrCode.qrcode.modules) &&
+    qrCode.qrcode.modules.length === 0 ||
+        Array.isArray(qrCode.qrcode.modules[0]), "Modules in qrcode is", "a two-dimensional array", "not a two-dimensional array");
+
+assert(typeof qrCode.svg() === "string", "QRCode", "generated an svg string", "did not generate an svg string");

--- a/types/qrcode-svg/tsconfig.json
+++ b/types/qrcode-svg/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "qrcode-svg-tests.ts"
+    ]
+}

--- a/types/qrcode-svg/tslint.json
+++ b/types/qrcode-svg/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "unified-signatures": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/qrcode-svg/tslint.json
+++ b/types/qrcode-svg/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
This commit adds the QRCode class, along with the associated types in a namespace of the same name. It also adds a couple tests to validate the main parts are as expected.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.