### PR TITLE
Run lint instead of test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Please fill in this template.
 
 - [ ] Use a meaningful title for the pull request. Include the name of the package modified.
 - [ ] Test the change in your own code. (Compile and run.)
-- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
+- [ ] Add or edit tests to reflect the change. (Run with `npm run lint`.)
 - [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
 - [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
 - [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Please fill in this template.
 
 - [ ] Use a meaningful title for the pull request. Include the name of the package modified.
 - [ ] Test the change in your own code. (Compile and run.)
-- [ ] Add or edit tests to reflect the change. (Run with `npm run lint`.)
+- [ ] Add or edit tests to reflect the change. (Run with `npm run lint <package-name>`.)
 - [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
 - [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
 - [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


### PR DESCRIPTION
According to [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34277#issuecomment-479279885) I suspect we aren't supposed to actually run `npm test`, which makes sense given how difficult it is to get working locally.

