### PR TITLE
[react-virtualized]fix incompatible onScroll type for ListProps by using OnScrollParams

### DIFF
--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -7,6 +7,7 @@ import {
 } from "./Grid";
 import { Index, IndexRange, Alignment } from "../../index";
 import { CellMeasurerCache, CellPosition } from "./CellMeasurer";
+import { OnScrollParams } from './ScrollSync';
 
 export type ListRowProps = Pick<GridCellProps, Exclude<keyof GridCellProps, 'rowIndex'>> & {
     index: GridCellProps['rowIndex'];
@@ -53,9 +54,7 @@ export type ListProps = GridCoreProps & {
      * This callback can be used to sync scrolling between lists, tables, or grids.
      * ({ clientHeight, scrollHeight, scrollTop }): void
      */
-    onScroll?: (
-        info: { clientHeight: number; scrollHeight: number; scrollTop: number }
-    ) => void;
+    onScroll?: (params: OnScrollParams) => void;
     /** See Grid#overscanIndicesGetter */
     overscanIndicesGetter?: OverscanIndicesGetter;
     /**


### PR DESCRIPTION
fix incompatible onScroll type for ListProps by using OnScrollParams from ScrollSync.d.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34431>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
