### PR TITLE
Add react-linkify module to DefinitelyTyped

### DIFF
--- a/types/react-linkify/index.d.ts
+++ b/types/react-linkify/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for react-linkify 0.2
+// Project: http://tasti.github.io/react-linkify/
+// Definitions by: Michael James <https://github.com/majames>
+//                 Jacky Wang <https://github.com/jackywang529>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+import * as React from "react";
+
+declare namespace ReactLinkify {
+    /**
+     * Matching information
+     */
+    interface MatchInfo {
+        /**
+         * Link schema, can be empty for fuzzy links, or for protocol-neutral links
+         */
+        schema: string;
+        /**
+         * Offset of matched text
+         */
+        index: number;
+        /**
+         * Index of next char after the end of the matched text
+         */
+        lastIndex: number;
+        /**
+         * Normalized text
+         */
+        text: string;
+        /**
+         * Link, generated from matched text
+         */
+        url: string;
+    }
+
+    interface Props {
+        children: React.ReactNode;
+        /**
+         * Custom anchor tag creator
+         * Default to using exisint <a> tag with the provided href={decoratedHref}, key={key}
+         * and children={decoratedText}, without additional styling
+         */
+        componentDecorator?: (decoratedHref: string, decoratedText: string, key: number) => React.ReactNode;
+        /**
+         * Custom href decorator or mapper on the matched (url) href
+         * Default to no transformation
+         */
+        hrefDecorator?: (urlHref: string) => string;
+        /**
+         * Custom matcher for (url), that returns each match with the matching information
+         * Default to https://github.com/markdown-it/linkify-it's LinkifyIt().tlds(tlds).match
+         */
+        matchDecorator?: (text: string) => MatchInfo[] | null;
+        /**
+         * Custom text decorator or mapper on the matched (url) text
+         * Default to no transformation
+         */
+        textDecorator?: (urlText: string) => string;
+    }
+
+    class ReactLinkify extends React.Component<Props> {}
+}
+
+export default ReactLinkify.ReactLinkify;

--- a/types/react-linkify/react-linkify-tests.tsx
+++ b/types/react-linkify/react-linkify-tests.tsx
@@ -1,0 +1,39 @@
+import LinkifyIt = require("linkify-it");
+import * as React from "react";
+import ReactLinkify from 'react-linkify';
+
+const linkifier = new LinkifyIt();
+
+class ExampleOfUsingReactLinkify extends React.Component {
+	render() {
+		return (
+			<ReactLinkify
+				textDecorator={textDecorator}
+				hrefDecorator={hrefDecorator}
+				componentDecorator={componentDecorator}
+				matchDecorator={matchDecorator}>
+				This is a great website: www.wikipedia.org!
+			</ReactLinkify>
+		);
+	}
+}
+
+function textDecorator(urlText: string): string {
+    return urlText + "is a great url";
+}
+
+function hrefDecorator(urlHref: string): string {
+	return urlHref;
+}
+
+function componentDecorator(decoratedHref: string, decoratedText: string, key: number): React.ReactNode {
+	return (
+		<a href={decoratedHref} key={key}>
+			{decoratedText}
+		</a>
+	);
+}
+
+function matchDecorator(text: string) {
+	return linkifier.match(text);
+}

--- a/types/react-linkify/tsconfig.json
+++ b/types/react-linkify/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-linkify-tests.tsx"
+    ]
+}

--- a/types/react-linkify/tslint.json
+++ b/types/react-linkify/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Add new module, `react-linkify`, to `DefinitelyTyped`.

- [done] Use a meaningful title for the pull request. Include the name of the package modified.
- [done] Test the change in your own code. (Compile and run.)
- [done] Add or edit tests to reflect the change. (Run with `npm test`.)
- [done] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [done] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [done] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [done] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [done] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [done] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [done] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
