### PR TITLE
Update inputRef type: handling createRef

### DIFF
--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -49,7 +49,7 @@ declare module "react-textarea-autosize" {
         /**
          * Allows an owner to retrieve the DOM node.
          */
-        inputRef?: ((node: HTMLTextAreaElement) => void) | RefObject<HTMLTextAreaElement>;
+        inputRef?: ((node: HTMLTextAreaElement) => void) | React.RefObject<HTMLTextAreaElement>;
     }
 
     /**

--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -49,7 +49,7 @@ declare module "react-textarea-autosize" {
         /**
          * Allows an owner to retrieve the DOM node.
          */
-        inputRef?: (node: HTMLTextAreaElement) => void;
+        inputRef?: ((node: HTMLTextAreaElement) => void) | RefObject<HTMLTextAreaElement>;
     }
 
     /**

--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for react-textarea-autosize 4.3.0
 // Project: https://github.com/andreypopp/react-textarea-autosize
-// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Jerry Zou <https://github.com/zry656565>
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>,
+//                 Jerry Zou <https://github.com/zry656565>
+//                 Rahul Sagore <https://github.com/Rahul-Sagore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/andreypopp/react-textarea-autosize/issues/214>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Context:** `Textarea` in `react-textarea-autosize` accepts `inputRef`, a prop which accepts both types of ref creation:
1) `inputRef={ (ref) => this.inputRef = ref }` and
2) `inputRef = React.createRef()` as well.

But in `@types/react-textarea-autosize`, only 1st is handle, hence it throws the error:
```
Type error: Type 'RefObject<HTMLTextAreaElement>' is not assignable to type '(node: HTMLTextAreaElement) => void'.
```

Handled this issue in this PR.