### PR TITLE
Move global declarations into a namespace for 'amap-js-api'.

### DIFF
--- a/types/amap-js-api/type-util.d.ts
+++ b/types/amap-js-api/type-util.d.ts
@@ -1,12 +1,12 @@
-type Omit<T, E extends keyof T> = {
-    [K in Exclude<keyof T, E>]: T[K]
-};
+declare namespace AMap {
+    type Omit<T, E extends keyof T> = {
+        [K in Exclude<keyof T, E>]: T[K]
+    };
 
-type OptionalKey<T> = { [K in keyof T]-?: undefined extends T[K] ? K : never }[keyof T];
-// type OmitUndefined<M> = Omit<M, { [K in keyof M]: M[K] extends undefined ? K : never }[keyof M]>;
-// type PickUndefined<M> = Omit<M, keyof OmitUndefined<M>>;
+    type OptionalKey<T> = { [K in keyof T]-?: undefined extends T[K] ? K : never }[keyof T];
 
-type Merge<O, T> =
-    { [K in Exclude<keyof O, keyof T | OptionalKey<O>>]-?: O[K]; } &
-    { [K in Extract<Exclude<keyof O, keyof T>, OptionalKey<O>>]?: O[K]; } &
-    T;
+    type Merge<O, T> =
+        { [K in Exclude<keyof O, keyof T | OptionalKey<O>>]-?: O[K]; } &
+        { [K in Extract<Exclude<keyof O, keyof T>, OptionalKey<O>>]?: O[K]; } &
+        T;
+}


### PR DESCRIPTION
These types pollute the global namespace, and conflict with the upcoming `Omit` type helper coming to TypeScript 3.5.

Related to https://github.com/Microsoft/TypeScript/pull/30552