### PR TITLE
[electron-window-state] Electron should not be a dependency 

### DIFF
--- a/types/electron-window-state/package.json
+++ b/types/electron-window-state/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "dependencies": {
+    "devDependencies": {
         "electron": "*"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

With electron as a full dependency of `@types/electron-window-state`, the latest version of electron is downloaded into the dependency tree, even if you're not using this version.

If changing an existing definition:
- [ ] Increase the version number in the header if appropriate.
