### PR TITLE
Revert #33437 "aws-lambda Authorizer response context only allows booleans, …

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -27,7 +27,6 @@
 //                 Erik Dalén <https://github.com/dalen>
 //                 Loïk Gaonac'h <https://github.com/loikg>
 //                 Roberto Zen <https://github.com/skyzenr>
-//                 Richard Cornelissen <https://github.com/richardcornelissen>
 //                 Grzegorz Redlicki <https://github.com/redlickigrzegorz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
@@ -565,10 +564,10 @@ export type StatementResource = MaybeStatementPrincipal & ({ Resource: string | 
 export type StatementPrincipal = MaybeStatementResource & ({ Principal: PrincipalValue } | { NotPrincipal: PrincipalValue });
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.
- * https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
+ * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
  */
 export interface AuthResponseContext {
-    [name: string]: boolean | number | string;
+    [name: string]: any;
 }
 
 /**


### PR DESCRIPTION
…numbers and strings"

This reverts #33437 / commit eed96d4372ed55c81eb7e7708c5f3ea02c579ddd, as requested by @penguinbroker and @kossmoboleat (at least)