### PR TITLE
Add types for @ungap/url-search-params

### DIFF
--- a/types/ungap__url-search-params/index.d.ts
+++ b/types/ungap__url-search-params/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for @ungap/url-search-params 0.1
+// Project: https://github.com/ungap/url-search-params
+// Definitions by: Nick <https://github.com/nick121212>
+//                 Neha <https://github.com/nrathi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/**
+ * Based on definitions of lib.dom and  lib.dom.iteralbe
+ */
+declare class URLSearchParams {
+    constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);
+
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    sort(): void;
+    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
+
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+}
+
+export = URLSearchParams;

--- a/types/ungap__url-search-params/tsconfig.json
+++ b/types/ungap__url-search-params/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es5",
+            "es6"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ungap__url-search-params-tests.ts"
+    ]
+}

--- a/types/ungap__url-search-params/tslint.json
+++ b/types/ungap__url-search-params/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/ungap__url-search-params/ungap__url-search-params-tests.ts
+++ b/types/ungap__url-search-params/ungap__url-search-params-tests.ts
@@ -1,0 +1,33 @@
+import URLSearchParams = require("url-search-params");
+
+new URLSearchParams([["1", "2"]]);
+new URLSearchParams({ x: "y" });
+new URLSearchParams();
+new URLSearchParams(new URLSearchParams());
+
+const params = new URLSearchParams("a=1&b=2");
+
+params.append("b", "3");
+params.delete("a");
+params.delete("c");
+params.get("b");
+params.get("d");
+params.getAll("b");
+params.has("b");
+params.keys();
+params.set("b", "4");
+params.set("c", "5");
+params.toString();
+params.values();
+
+params.forEach((value, key, params) => {
+    const test: [string, string, URLSearchParams] = [value, key, params];
+});
+
+for (const [key, value] of params) {
+    const test: [string, string] = [key, value];
+}
+
+for (const [key, value] of params.entries()) {
+    const test: [string, string] = [key, value];
+}


### PR DESCRIPTION
This is mostly a copy of the `url-search-params` types.  That package has been moved into the @ungap scope on NPM.  I have been using these types in my projects with no issues.

Changes:

* Updated name, repo URL, and version
* Removed unneeded rule in tslint config

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
