### PR TITLE
[react-transition-group] Support optional `classNames` prop on `<CSSTransition/>`

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -33,7 +33,7 @@ declare namespace CSSTransition {
      * ```
      */
     interface CSSTransitionProps extends TransitionProps {
-        classNames: string | CSSTransitionClassNames;
+        classNames?: string | CSSTransitionClassNames;
     }
 }
 

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-transition-group 2.0
+// Type definitions for react-transition-group 2.8
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 //                 Epskampie <https://github.com/Epskampie>

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -120,6 +120,10 @@ const Test: React.StatelessComponent = () => {
             >
                 <div>{ "test" }</div>
             </CSSTransition>
+
+            <CSSTransition timeout={ 100 }>
+                <div>{ "test" }</div>
+            </CSSTransition>
         </TransitionGroup>
     );
 };


### PR DESCRIPTION
Since v2.8.0, classNames prop has been optional.

See also:
- https://github.com/reactjs/react-transition-group/blob/v2.8.0/CHANGELOG.md
- https://github.com/reactjs/react-transition-group/pull/481

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-transition-group/blob/v2.8.0/CHANGELOG.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
