### PR TITLE
[react-router-dom] Allow ref objects in Link.innerRef

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -4,6 +4,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Philip Jackson <https://github.com/p-jackson>
 //                 John Reilly <https://github.com/johnnyreilly>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -47,7 +48,7 @@ export class HashRouter extends React.Component<HashRouterProps, any> {}
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to: H.LocationDescriptor;
     replace?: boolean;
-    innerRef?: (node: HTMLAnchorElement | null) => void;
+    innerRef?: React.Ref<HTMLAnchorElement>;
 }
 export class Link extends React.Component<LinkProps, any> {}
 

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -39,5 +39,7 @@ const Component: React.SFC<OtherProps> = props => {
 
 <Link to="/url" />;
 
-const acceptRef = (node: HTMLAnchorElement | null) => {};
-<Link to="/url" replace={true} innerRef={acceptRef} />;
+const refCallback: React.Ref<HTMLAnchorElement> = node => {};
+<Link to="/url" replace={true} innerRef={refCallback} />;
+const ref = React.createRef<HTMLAnchorElement>();
+<Link to="/url" replace={true} innerRef={ref} />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - `innerRef` is forwarded to the `ref` of an `a` host component which accepts `React.Ref<HTMLAnchorElement>`: https://github.com/ReactTraining/react-router/blob/10d78bbaaae70657f00154481e717b3c8c65b3a2/packages/react-router-dom/modules/Link.js#L51
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
