### PR TITLE
[async-retry] Change options type to extend retry library types

### DIFF
--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -7,6 +7,7 @@ const o: Options = {
   minTimeout: 3,
   maxTimeout: 4,
   randomize: true,
+  forever: false,
   onRetry: (e: Error) => 42
 };
 

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -1,8 +1,11 @@
-// Type definitions for async-retry 1.3
+// Type definitions for async-retry 1.4
 // Project: https://github.com/zeit/async-retry#readme
 // Definitions by: Albert Wu <https://github.com/albertywu>
 //                 Pablo Rodríguez <https://github.com/MeLlamoPablo>
+//                 Rafał Sawicki <https://github.com/rafsawicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { OperationOptions } from 'retry';
 
 declare function AsyncRetry<A>(
 	fn: AsyncRetry.RetryFunction<A>,
@@ -10,12 +13,7 @@ declare function AsyncRetry<A>(
 ): Promise<A>;
 
 declare namespace AsyncRetry {
-	interface Options {
-		retries?: number;
-		factor?: number;
-		minTimeout?: number;
-		maxTimeout?: number;
-		randomize?: boolean;
+	interface Options extends OperationOptions {
 		onRetry?: (e: Error, attempt: number) => any;
 	}
 

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -4,6 +4,7 @@
 //                 Pablo Rodríguez <https://github.com/MeLlamoPablo>
 //                 Rafał Sawicki <https://github.com/rafsawicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import { OperationOptions } from 'retry';
 


### PR DESCRIPTION
Since async-retry is passing options parameter directly to the underlying retry library, option types can be reused from it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
