### PR TITLE
Add definition of non-npm package amap-js-api-autocomplete

### DIFF
--- a/types/amap-js-api-autocomplete/amap-js-api-autocomplete-tests.ts
+++ b/types/amap-js-api-autocomplete/amap-js-api-autocomplete-tests.ts
@@ -1,0 +1,108 @@
+declare const div: HTMLDivElement;
+
+const input = document.createElement('input');
+// $ExpectType Autocomplete
+const autoComplete = new AMap.Autocomplete();
+// $ExpectType Autocomplete
+new AMap.Autocomplete({});
+// $ExpectType Autocomplete
+new AMap.Autocomplete({
+    type: 'type',
+    city: 'city',
+    datatype: 'all',
+    citylimit: true,
+    input: 'input',
+    output: 'output',
+    outPutDirAuto: true
+});
+// $ExpectType Autocomplete
+new AMap.Autocomplete({
+    type: 'type',
+    city: 'city',
+    datatype: 'all',
+    citylimit: true,
+    input,
+    output: div,
+    outPutDirAuto: true
+});
+
+autoComplete.search('keyword', (status, result) => {
+    const temp: 'error' | 'complete' | 'no_data' = status;
+    if (typeof result !== 'string') {
+        // $ExpectType number
+        result.count;
+        // $ExpectType string
+        result.info;
+        // $ExpectType Tip[]
+        result.tips;
+        {
+            const tip = result.tips[0];
+            // $ExpectType string
+            tip.adcode;
+            // $ExpectType string
+            tip.address;
+            // $ExpectType any[]
+            tip.city;
+            // $ExpectType string
+            tip.district;
+            // $ExpectType string
+            tip.id;
+            // $ExpectType LngLat
+            tip.location;
+            // $ExpectType string
+            tip.name;
+            // $ExpectType string
+            tip.typecode;
+        }
+    } else {
+        // $ExpectType string
+        result;
+    }
+});
+
+// $ExpectType void
+autoComplete.setType();
+// $ExpectType void
+autoComplete.setType('type');
+
+// $ExpectType void
+autoComplete.setCity();
+// $ExpectType void
+autoComplete.setCity('city');
+
+// $ExpectType void
+autoComplete.setCityLimit(false);
+
+autoComplete.on('complete', (event: AMap.Autocomplete.EventMap['complete']) => {
+    // $ExpectType "complete"
+    event.type;
+    // $ExpectType string
+    event.info;
+    if ('tips' in event) {
+        // $ExpectType number
+        event.count;
+        // $ExpectType Tip[]
+        event.tips;
+    }
+});
+
+autoComplete.on('error', (event: AMap.Autocomplete.EventMap['error']) => {
+    // $ExpectType "error"
+    event.type;
+    // $ExpectType string
+    event.info;
+});
+
+autoComplete.on('select', (event: AMap.Autocomplete.EventMap['select']) => {
+    // $ExpectType "select"
+    event.type;
+    // $ExpectType Tip
+    event.tip;
+});
+
+autoComplete.on('choose', (event: AMap.Autocomplete.EventMap['choose']) => {
+    // $ExpectType "choose"
+    event.type;
+    // $ExpectType Tip
+    event.tip;
+});

--- a/types/amap-js-api-autocomplete/index.d.ts
+++ b/types/amap-js-api-autocomplete/index.d.ts
@@ -1,0 +1,144 @@
+// Type definitions for non-npm package amap-js-api-autocomplete 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/search#m_AMap.Autocomplete
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace Autocomplete {
+        interface EventMap {
+            complete: Event<'complete', SearchResult | { info: string }>;
+            error: Event<'error', { info: string }>;
+            select: Event<'select', { tip: Tip }>;
+            choose: Event<'choose', { tip: Tip }>;
+        }
+        type DataType = 'all' | 'bus' | 'poi' | 'busline';
+        interface Options {
+            /**
+             * 输入提示时限定POI类型，多个类型用“|”分隔
+             */
+            type?: string;
+            /**
+             * 输入提示时限定城市
+             */
+            city?: string;
+            /**
+             * 返回的数据类型
+             */
+            datatype?: DataType;
+            /**
+             * 是否强制限制在设置的城市内搜索
+             */
+            citylimit?: boolean;
+            /**
+             * 指定输入框
+             */
+            input?: string | HTMLInputElement;
+            /**
+             * 指定输出面板
+             */
+            output?: string | HTMLDivElement;
+            /**
+             * 是否在input位于页面较下方的时候自动将输入面板显示在input上方以避免被遮挡
+             */
+            outPutDirAuto?: boolean;
+
+            // internal
+            closeResultOnScroll?: boolean;
+            lang?: Lang;
+        }
+        interface Tip {
+            /**
+             * 名称
+             */
+            name: string;
+            /**
+             * 所属区域
+             */
+            district: string;
+            /**
+             * 区域编码
+             */
+            adcode: string;
+            /**
+             * 地址
+             */
+            address: string;
+            /**
+             * 城市
+             */
+            city: any[];
+            /**
+             * ID
+             */
+            id: string;
+            /**
+             * 坐标经纬度
+             */
+            location: LngLat;
+            /**
+             * 类型编码
+             */
+            typecode: string;
+        }
+        interface SearchResult {
+            /**
+             * 查询状态说明
+             */
+            info: string;
+            /**
+             * 输入提示条数
+             */
+            count: number;
+            /**
+             * 输入提示列表
+             */
+            tips: Tip[];
+        }
+        type SearchStatus = 'complete' | 'error' | 'no_data';
+    }
+    class Autocomplete extends EventEmitter {
+        /**
+         * 输入提示，根据输入关键字提示匹配信息
+         * @param options 选项
+         */
+        constructor(options?: Autocomplete.Options);
+        /**
+         * 根据输入关键字提示匹配信息
+         * @param keyword 关键字
+         * @param callback 回调
+         */
+        search(
+            keyword: string,
+            callback: (status: Autocomplete.SearchStatus, result: Autocomplete.SearchResult | string) => void
+        ): void;
+        /**
+         * 设置提示Poi类型，多个类型用“|”分隔
+         * @param type Poi类型
+         */
+        setType(type?: string): void;
+        /**
+         * 设置城市
+         * @param city 城市
+         */
+        setCity(city?: string): void;
+        /**
+         * 设置是否强制限制城市
+         * @param cityLimit 是否强制限制城市
+         */
+        setCityLimit(cityLimit: boolean): void;
+
+        // internal
+        /**
+         * 设置查询语言
+         * @param lang 语言
+         */
+        setLang(lang?: Lang): void;
+        /**
+         * 返回查询语言
+         */
+        getLang(): Lang | undefined;
+    }
+}

--- a/types/amap-js-api-autocomplete/tsconfig.json
+++ b/types/amap-js-api-autocomplete/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-autocomplete-tests.ts"
+    ]
+}

--- a/types/amap-js-api-autocomplete/tslint.json
+++ b/types/amap-js-api-autocomplete/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
