### PR TITLE
Grunt - Updated file copy option process

### DIFF
--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -139,3 +139,16 @@ let myTest = function (grunt: IGrunt) {
         cwd: '.'
     }, '*.ts');
 }
+// test to check process function assignment.
+let mytest = function(grunt: IGrunt) {
+    const opt:grunt.file.IFileWriteStringOption = {
+        encoding: grunt.file.defaultEncoding,
+        process: (contents: string, srcPath: string, destPath: string): string | boolean => {
+            grunt.log.writeln('"file source path"' + srcPath);
+            grunt.log.writeln('"file destination path"' + destPath);
+            // return false so no actual copying takes place
+            return false;
+        }
+    }
+    grunt.file.copy('./test.file',"./testcopy.file", opt);
+}

--- a/types/grunt/index.d.ts
+++ b/types/grunt/index.d.ts
@@ -320,7 +320,7 @@ declare namespace grunt {
          * @see IFileWriteBufferOption
          * @see IFileWriteStringOption
          */
-        interface IFileWriteOptions {
+        interface IFileWriteOptions extends grunt.file.IFileEncodedOption {
             /**
              * These optional globbing patterns will be matched against the filepath
              * (not the filename) using grunt.file.isMatch. If any specified globbing
@@ -349,11 +349,24 @@ declare namespace grunt {
          */
         interface IFileWriteStringOption extends grunt.file.IFileWriteOptions {
             /**
-             * The source file contents and file path are passed into this function,
-             * whose return value will be used as the destination file's contents. If
-             * this function returns `false`, the file copy will be aborted.
-             */
-            process?: (file: string) => boolean;
+            * The source file contents, source file path, and destination file path
+            * are passed into this function, whose return value will be used as the
+            * destination file's contents.  
+            * If this function returns 'false', the file copy will be aborted.
+            * @example
+            ```ts
+const copyOptions: grunt.file.IFileWriteStringOption = {
+  encoding: options.encoding,
+  process: (contents: string, srcpath: string, destpath: string): string | boolean => {
+      // some other code
+      // return the content to be written or return false to cancel
+      return contents;
+  },
+  noProcess: options.noProcess,
+};
+            ```
+            */
+            process?: (contents: string, srcpath: string, destpath: string) => (string | boolean);
         }
 
         /**


### PR DESCRIPTION
FileWriteStringOption.process now supports:
```
(contents: string, srcpath: string, destpath: string) => (string | boolean);
```
This is in alignment with the documentation.
see: [grunt.file](https://gruntjs.com/api/grunt.file#grunt.file.copy)
See grunt [lib/grunt/file.js](https://github.com/gruntjs/grunt/blob/master/lib/grunt/file.js)
```
file._copy = function(srcpath, destpath, options)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
