### PR TITLE
Add type for new "ref" proptype in airbnb-prop-type

### DIFF
--- a/types/airbnb-prop-types/airbnb-prop-types-tests.ts
+++ b/types/airbnb-prop-types/airbnb-prop-types-tests.ts
@@ -152,6 +152,9 @@ AirbnbPropTypes.range(0, 10);
 // $ExpectType Requireable<5>
 AirbnbPropTypes.range<5>(0, 10);
 
+// $ExpectType Requireable<LegacyRef<HTMLElement>>
+AirbnbPropTypes.ref();
+
 // $ExpectType Requireable<string | null>
 AirbnbPropTypes.requiredBy('foo', PropTypes.string);
 // $ExpectType Validator<number>

--- a/types/airbnb-prop-types/airbnb-prop-types-tests.ts
+++ b/types/airbnb-prop-types/airbnb-prop-types-tests.ts
@@ -152,7 +152,7 @@ AirbnbPropTypes.range(0, 10);
 // $ExpectType Requireable<5>
 AirbnbPropTypes.range<5>(0, 10);
 
-// $ExpectType Requireable<LegacyRef<HTMLElement>>
+// $ExpectType Requireable<ReactLegacyRefLike<HTMLElement>>
 AirbnbPropTypes.ref();
 
 // $ExpectType Requireable<string | null>

--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -5,7 +5,6 @@
 // TypeScript Version: 3.0
 
 import * as PropTypes from 'prop-types';
-import * as React from 'react';
 
 export interface ReactComponentLike {
     setState(...args: any[]): any;
@@ -24,6 +23,12 @@ export interface ReactClassComponentLike {
 export type ReactFunctionComponentLike = (...args: any[]) => PropTypes.ReactNodeLike;
 
 export type ReactTypeLike = string | ReactClassComponentLike | ReactFunctionComponentLike;
+
+export interface ReactRefLike<T> {
+    readonly current: T | null;
+}
+
+export type ReactLegacyRefLike<T> = (instance: T | null) => void | ReactRefLike<T> | null;
 
 export interface Specifier<T = any> {
     max?: number;
@@ -157,7 +162,7 @@ export function range<T extends number>(min?: number, max?: number): PropTypes.R
 
 export function range(min?: number, max?: number): PropTypes.Requireable<number>;
 
-export function ref(): PropTypes.Requireable<React.LegacyRef<HTMLElement>>;
+export function ref(): PropTypes.Requireable<ReactLegacyRefLike<HTMLElement>>;
 
 export function requiredBy<P>(
     requiredByPropName: string,

--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 3.0
 
 import * as PropTypes from 'prop-types';
+import * as React from 'react';
 
 export interface ReactComponentLike {
     setState(...args: any[]): any;
@@ -155,6 +156,8 @@ export function or<T = any>(
 export function range<T extends number>(min?: number, max?: number): PropTypes.Requireable<T>;
 
 export function range(min?: number, max?: number): PropTypes.Requireable<number>;
+
+export function ref(): PropTypes.Requireable<React.LegacyRef<HTMLElement>>;
 
 export function requiredBy<P>(
     requiredByPropName: string,

--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for airbnb-prop-types 2.11
+// Type definitions for airbnb-prop-types 2.13
 // Project: https://github.com/airbnb/prop-types
 // Definitions by: Miles Johnson <https://github.com/milesj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -28,7 +28,7 @@ export interface ReactRefLike<T> {
     readonly current: T | null;
 }
 
-export type ReactLegacyRefLike<T> = (instance: T | null) => void | ReactRefLike<T>;
+export type ReactLegacyRefLike<T> = ((instance: T | null) => void) | ReactRefLike<T>;
 
 export interface Specifier<T = any> {
     max?: number;

--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -28,7 +28,7 @@ export interface ReactRefLike<T> {
     readonly current: T | null;
 }
 
-export type ReactLegacyRefLike<T> = (instance: T | null) => void | ReactRefLike<T> | null;
+export type ReactLegacyRefLike<T> = (instance: T | null) => void | ReactRefLike<T>;
 
 export interface Specifier<T = any> {
     max?: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/prop-types/pull/54
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
