### PR TITLE
Fix compile error w/ passport-facebook, latest passport typings, typescript 3.4

### DIFF
--- a/types/passport-facebook/index.d.ts
+++ b/types/passport-facebook/index.d.ts
@@ -47,7 +47,7 @@ export type VerifyFunction =
 export type VerifyFunctionWithRequest =
     (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
 
-export class Strategy extends passport.Strategy {
+export class Strategy implements passport.Strategy {
     constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
     constructor(options: StrategyOption, verify: VerifyFunction);
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- x] Add or edit tests to reflect the change. (Run with `npm test`.)
- x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---------

None of the above apply; this is a simple syntax error, possibly caused by a change in a dependency, unsure. When I compile with the latest typescript it fails with an error that it can't extend passport.Strategy and suggests "implements" instead -- this change works and fixes the problem.