### PR TITLE
[hls.js] Restore Hls.media property and fix annotation.

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -33,7 +33,11 @@ if (Hls.isSupported()) {
 
     const version: string = Hls.version;
     hls.loadSource('http://www.streambox.fr/playlists/test_001/stream.m3u8');
-    hls.attachMedia(video);
+    if (hls.media === undefined || hls.media === null) {
+        hls.attachMedia(video);
+    } else {
+        console.log('src: ', hls.media.src);
+    }
 
     hls.once(Hls.Events.MANIFEST_PARSED, (event: "hlsManifestParsed", data: Hls.manifestParsedData) => {
         video.play();

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1667,12 +1667,6 @@ declare class Hls {
      */
     startLevel: number;
     /**
-     * (default: true)
-     * if set to true, start level playlist and first fragments will be loaded automatically, after triggering of Hls.Events.MANIFEST_PARSED event
-     * if set to false, an explicit API call (hls.startLoad(startPosition=-1)) will be needed to start quality level/fragment loading.
-     */
-    autoStartLoad: boolean;
-    /**
      * get: Return the bound videoElement from the hls instance
      */
     readonly media?: HTMLVideoElement | null;

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1667,6 +1667,16 @@ declare class Hls {
      */
     startLevel: number;
     /**
+     * (default: true)
+     * if set to true, start level playlist and first fragments will be loaded automatically, after triggering of Hls.Events.MANIFEST_PARSED event
+     * if set to false, an explicit API call (hls.startLoad(startPosition=-1)) will be needed to start quality level/fragment loading.
+     */
+    autoStartLoad: boolean;
+    /**
+     * get: Return the bound videoElement from the hls instance
+     */
+    readonly media?: HTMLVideoElement | null;
+    /**
      *  hls.js config
      */
     config: Hls.Config;


### PR DESCRIPTION
(cc: @ArtDesire)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ArtDesire notes my mistake](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/61521a9795ec6dcfcfd665a369e4b4da9e9d1811#r33046870), [the property is found in the docs implying it to be readonly](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlsmedia), [code confirms it’s likely meant only to be altered with `attachMedia(media)`/`detachMedia()`](https://github.com/video-dev/hls.js/blob/v0.12.4/src/hls.js#L246-L259).
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I made a mistake in my last PR and erroneously removed the property `Hls.media` that _does_ exist, but is managed differently from the majority (if not all) of the other publicly facing properties. While not managed behind accessors it _is_ noted in the docs and implied therein to be readonly. This PR corrects my error and adds some additional code to the tests that should catch this same error in the future.

Note that I’ve also found `Hls.url` to exist with close to the same pattern of behavior: implied to be readonly and set/unset with `loadSource(url)`/`destroy()`. But while it appears in the [autogenerated docs](https://hls-js.netlify.com/api-docs/class/src/hls.js~hls#instance-member-url) it does not appear to exist in the [human generated ones](https://github.com/video-dev/hls.js/blob/master/docs/API.md). Given this it’s unclear to me whether it’s meant to be part of the public API as well.

(Additionally `npm test` is currently failing due to an error concerning `hoist-non-react-statics`, but deleting those types entirely shows `hls.js` to complete tests successfully.)