### PR TITLE
[styled-components] Revert union distribution

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -47,9 +47,9 @@ export type StyledProps<P> = ThemedStyledProps<P, AnyIfEmpty<DefaultTheme>>;
 // Wrap in an outer-level conditional type to allow distribution over props that are unions
 type Defaultize<P, D> = P extends any
     ? string extends keyof P ? P :
-        & PickU<P, Exclude<keyof P, keyof D>>
-        & Partial<PickU<P, Extract<keyof P, keyof D>>>
-        & Partial<PickU<D, Exclude<keyof D, keyof P>>>
+        & Pick<P, Exclude<keyof P, keyof D>>
+        & Partial<Pick<P, Extract<keyof P, keyof D>>>
+        & Partial<Pick<D, Exclude<keyof D, keyof P>>>
     : never;
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D; }
@@ -66,13 +66,13 @@ export type StyledComponentProps<
     // The props that are made optional by .attrs
     A extends keyof any
 > = WithOptionalTheme<
-    OmitU<
+    Omit<
         ReactDefaultizedProps<
             C,
             React.ComponentPropsWithRef<C>
         > & O,
         A
-    > & Partial<PickU<React.ComponentPropsWithRef<C> & O, A>>,
+    > & Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
     T
 > & WithChildrenIfReactComponentClass<C>;
 
@@ -347,10 +347,8 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 >;
 
 // Helper type operators
-// Pick that distributes over union types
-export type PickU<T, K extends keyof T> = T extends any ? {[P in K]: T[P]} : never;
-export type OmitU<T, K extends keyof T> = T extends any ? PickU<T, Exclude<keyof T, K>> : never;
-type WithOptionalTheme<P extends { theme?: T }, T> = OmitU<P, "theme"> & {
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1056,6 +1056,7 @@ function unionTest() {
         font-size: ${props => props.kind === 'book' ? 16 : 14}
     `;
 
-    <StyledReadable kind="book" author="Hejlsberg" />;
+    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
+    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }


### PR DESCRIPTION
Closes #34391 
Reverts #33061

Related Microsoft/TypeScript#30663

It seems like union support is not that desired anyway since there weren't any reports before this change (I suppose). Users can still get that behavior either by using a local type fork (and stick with ~3.3) or use `@types/styled-components@4.1.10`. But for folks using the default setup (e.g. install latest versions; default ide setup with typescript, just type hints) this can be a major blocker.

I would hope that this revert won't stop the TypeScript team from investigating the perf regression. There are other packages that use this approach. Since no perf regression was reported for those I want to wait until someone can verify that this caused a perf regression there as well.

/cc @weswigham