### PR TITLE
@types/node Fix groupCollapsed

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -45,7 +45,7 @@ interface Console {
     /**
      * The `console.groupCollapsed()` function is an alias for {@link console.group()}.
      */
-    groupCollapsed(): void;
+    groupCollapsed(...label: any[]): void;
     /**
      * Decreases indentation of subsequent lines by two spaces.
      */


### PR DESCRIPTION
As specified in the MDN docs, [`console.groupCollapsed`](https://developer.mozilla.org/en-US/docs/Web/API/Console/groupCollapsed) accepts arguments 