### PR TITLE
pageRows should be a DerrivedDataObject, not a number

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -5,6 +5,7 @@
 //                 Krzysztof Porębski <https://github.com/Havret>,
 //                 Andy S <https://github.com/andys8>,
 //                 Grzegorz Rozdzialik <https://github.com/Gelio>
+//                 Cam Pepin <https://github.com/cpepin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as React from 'react';
@@ -712,7 +713,6 @@ export interface FinalState<D = any> extends TableProps<D> {
     frozen: boolean;
     startRow: number;
     endRow: number;
-    pageRows: number;
     padRows: number;
     hasColumnFooter: boolean;
     hasHeaderGroups: boolean;
@@ -722,6 +722,7 @@ export interface FinalState<D = any> extends TableProps<D> {
 
     allVisibleColumns: Array<Column<D>>;
     allDecoratedColumns: Array<Column<D>>;
+    pageRows: DerivedDataObject[];
     resolvedData: DerivedDataObject[];
     sortedData: DerivedDataObject[];
     headerGroups: any[];


### PR DESCRIPTION
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/tannerlinsley/react-table/blob/v6/src/index.js>

As you can see from source, pageRows is actually just a subset of the resolved data.  I came across this when writing a custom table, leveraging the table state for paginated results.
