### PR TITLE
Dialogflow types update

### DIFF
--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -570,7 +570,7 @@ export interface BatchUpdateEntitiesRequest {
     entities: Entity[];
     languageCode?: string;
     /** @link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto */
-    updateMask?: any; 
+    updateMask?: any;
 }
 
 export interface BatchDeleteEntitiesRequest {

--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -138,12 +138,26 @@ export namespace v2 {
             options?: gax.CallOptions
         ): Promise<void>;
 
-        // TODO: add batch style calls
-        // batchUpdateEntityTypes
-        // batchDeleteEntityTypes
-        // batchCreateEntities
-        // batchUpdateEntities
-        // batchDeleteEntities
+        batchUpdateEntityTypes(
+            request: BatchUpdateEntityTypesRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
+        batchDeleteEntityTypes(
+            request: BatchDeleteEntityTypesRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
+        batchCreateEntities(
+            request: BatchCreateEntitiesRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
+        batchUpdateEntities(
+            request: BatchUpdateEntitiesRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
+        batchDeleteEntities(
+            request: BatchDeleteEntitiesRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
 
         projectAgentPath(project: string): string;
         entityTypePath(project: string, entityType: string): string;
@@ -183,9 +197,14 @@ export namespace v2 {
             options?: gax.CallOptions
         ): Promise<void>;
 
-        // TODO: add batch style calls
-        // batchUpdateIntents(request: BatchUpdateIntentsRequest): void;
-        // batchDeleteIntents(request: BatchDeleteIntentsRequest): void;
+        batchUpdateIntents(
+            request: BatchUpdateIntentsRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
+        batchDeleteIntents(
+            request: BatchDeleteIntentsRequest,
+            options?: gax.CallOptions
+        ): Promise<[gax.Operation]>;
 
         projectAgentPath(project: string): string;
         intentPath(project: string, intent: string): string;
@@ -520,6 +539,46 @@ export interface DeleteEntityTypeRequest {
     name: string;
 }
 
+export interface BatchDeleteEntityTypesRequest {
+    parent: string;
+    entityTypeNames: string[];
+}
+
+export interface EntityTypeBatch {
+    entityTypes: EntityType[];
+}
+
+export interface BatchUpdateEntityTypesRequest {
+    parent: string;
+    // Union field entity_type_batch can be only one of the following:
+    entityTypeBatchUri?: string;
+    entityTypeBatchInline?: EntityTypeBatch;
+    // End of list of possible types for union field entity_type_batch.
+    languageCode?: string;
+    /** @link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto */
+    updateMask?: any;
+}
+
+export interface BatchCreateEntitiesRequest {
+    parent: string;
+    entities: Entity[];
+    languageCode?: string;
+}
+
+export interface BatchUpdateEntitiesRequest {
+    parent: string;
+    entities: Entity[];
+    languageCode?: string;
+    /** @link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto */
+    updateMask?: any; 
+}
+
+export interface BatchDeleteEntitiesRequest {
+    parent: string;
+    entityValues: string[];
+    languageCode?: string;
+}
+
 export interface ListSessionEntityTypesRequest {
     parent: string;
     pageSize?: number;
@@ -573,6 +632,26 @@ export interface UpdateIntentRequest {
 
 export interface DeleteIntentRequest {
     name: string;
+}
+
+export interface IntentBatch {
+    intents: Intent[];
+}
+
+export interface BatchUpdateIntentsRequest {
+    parent: string;
+    // Union field intent_batch can be only one of the following:
+    intentBatchUri?: string;
+    intentBatchInline?: IntentBatch;
+    // End of list of possible types for union field intent_batch.
+    languageCode?: string;
+    updateMask?: any;
+    intentView?: IntentView;
+}
+
+export interface BatchDeleteIntentsRequest {
+    parent: string;
+    intents: Intent[];
 }
 
 export interface DetectIntentRequest {

--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -927,7 +927,7 @@ export enum IntentView {
 export interface Intent {
     name: string;
     displayName: string;
-    webhookState: string;
+    webhookState?: string;
     priority?: number;
     isFallback?: boolean;
     mlEnabled?: boolean;
@@ -940,8 +940,8 @@ export interface Intent {
     parameters?: Parameter[];
     messages?: Message[];
     defaultResponsePlatforms?: string[];
-    rootFollowupIntentName: string;
-    parentFollowupIntentName: string;
+    rootFollowupIntentName?: string;
+    parentFollowupIntentName?: string;
     followupIntentInfo?: FollowupIntentInfo[];
 }
 

--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -658,13 +658,17 @@ export interface DetectIntentRequest {
     session: string;
     queryInput: QueryInput;
     queryParams?: QueryParams;
-    inputAudio?: any;
+    inputAudio?: string;
+    outputAudioConfig?: OutputAudioConfig;
 }
 
 export interface DetectIntentResponse {
     responseId: string;
     queryResult: QueryResult;
+    alternativeQueryResults: QueryResult[];
     webhookStatus: Status;
+    outputAudio: string;
+    outputAudioConfig: OutputAudioConfig;
 }
 
 export interface QueryResult {
@@ -688,6 +692,7 @@ export interface QueryResult {
         };
     };
     diagnosticInfo: any;
+    knowledgeAnswers: any;
 }
 
 export interface Status {
@@ -1004,7 +1009,43 @@ export interface TextInput {
     languageCode: string;
 }
 
+// TODO export enum AudioEncoding
+
+export interface InputAudioConfig {
+    // required by the documentation https://cloud.google.com/dialogflow-enterprise/docs/reference/rest/v2beta1/QueryInput
+    // but resolved by autodetection
+    audioEncoding?: any;
+    sampleRateHertz?: number;
+    languageCode: string;
+    phraseHints?: string[];
+    model?: string;
+}
+
+// TODO export enum OutputAudioEncoding
+
+export interface OutputAudioConfig {
+    audioEncoding: any;
+    sampleRateHertz?: number;
+    synthesizeSpeechConfig?: SynthesizeSpeechConfig;
+}
+
+export interface SynthesizeSpeechConfig {
+    speakingRate?: number;
+    pitch?: number;
+    volumeGainDb?: number;
+    effectsProfileId?: string[];
+    voice?: VoiceSelectionParams;
+}
+
+// TODO export enum SsmlVoiceGender
+
+export interface VoiceSelectionParams {
+    name?: string;
+    ssmlGender?: any;
+}
+
 export interface QueryInput {
+    audioConfig?: InputAudioConfig;
     text?: TextInput;
     event?: EventInput;
 }
@@ -1016,7 +1057,11 @@ export interface QueryParams {
     resetContexts?: boolean;
     sessionEntityTypes?: SessionEntityType[];
     payload?: any;
+    knowledgeBaseNames?: string[];
+    sentimentAnalysisRequestConfig?: any;
 }
+
+// TODO export interface SentimentAnalysisRequestConfig
 
 export interface LatLong {
     latitude: number;


### PR DESCRIPTION
Types definition for dialogflow module did not implement batch functions and some interfaces were outdated.

- batch functions of IntentsClient and EntityTypesClient implemented
- a few new interfaces added to support batch functions
- interfaces like `Intent`, `QueryInput`, `QueryParams` or `QueryResult` updated according to the documentation: https://cloud.google.com/dialogflow-enterprise/docs/reference/rest/v2beta1-overview

- `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

- the version number was not increased yet.

