### PR TITLE
Correct documentation link in types/youtube

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -11,7 +11,7 @@
 
 /**
  * @see https://developers.google.com/youtube/iframe_api_reference
- * @see https://developers.google.com/YouTube/player_parameters
+ * @see https://developers.google.com/youtube/player_parameters
  */
 declare namespace YT
 {


### PR DESCRIPTION
Make "youtube" lowercase in reference link. Camelcase "YouTube" goes to a 404 page.