### PR TITLE
Add type parameter for airbnb-prop-types ref objects

### DIFF
--- a/types/airbnb-prop-types/index.d.ts
+++ b/types/airbnb-prop-types/index.d.ts
@@ -162,7 +162,7 @@ export function range<T extends number>(min?: number, max?: number): PropTypes.R
 
 export function range(min?: number, max?: number): PropTypes.Requireable<number>;
 
-export function ref(): PropTypes.Requireable<ReactLegacyRefLike<HTMLElement>>;
+export function ref<T = HTMLElement>(): PropTypes.Requireable<ReactLegacyRefLike<T>>;
 
 export function requiredBy<P>(
     requiredByPropName: string,


### PR DESCRIPTION
Added a type param to the `ref` type for airbnb-prop-types. Previously it was always assuming that the ref would be to an HTMLElement, but that's not the case. Some elements (such as HTMLButtonElement) have more methods than others, and we need to be specific in some cases.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/prop-types/pull/57
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.