### PR TITLE
[@types/auth0-js] add missing error_description field

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for Auth0.js 8.11
+// Type definitions for Auth0.js 9.10
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 //                 Bartosz Kotrys <https://github.com/bkotrys>
+//                 Mark Nelissen <https://github.com/marknelissen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -569,7 +569,9 @@ export type SpecErrorCodes =
 
 export interface Auth0Error {
     error: LibErrorCodes | SpecErrorCodes | string;
-    errorDescription: string;
+    errorDescription?: string;
+    // Auth0 is not consistent in the naming of the error description field
+    error_description?: string;
     // Need to include non-intuitive error fields that Auth0 uses
     code?: string;
     description?: string;


### PR DESCRIPTION
Auth0-js is not consistent in the use of errorDescription within error objects returned to the callback method, not even within the same method (eg. WebAuth.checkSession). Depending on the error (and thus the place where it is constructed) the description in contained in either errorDescription or error_description.

On top of this, the official documentation snippets make use of error_description. It is unclear which is the "official" one, but technically, both are possible. So the typing should reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
