### PR TITLE
[node] Make definitions of generateKeyPair(Sync) less restrictive

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -424,46 +424,10 @@ declare module "crypto" {
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
         cipher?: string;
-        passphrase?: string;
+        passphrase?: string | Buffer;
     }
 
-    interface KeyPairKeyObjectResult {
-        publicKey: KeyObject;
-        privateKey: KeyObject;
-    }
-
-    interface ECKeyPairKeyObjectOptions {
-        /**
-         * Name of the curve to use.
-         */
-        namedCurve: string;
-    }
-
-    interface RSAKeyPairKeyObjectOptions {
-        /**
-         * Key size in bits
-         */
-        modulusLength: number;
-
-        /**
-         * @default 0x10001
-         */
-        publicExponent?: number;
-    }
-
-    interface DSAKeyPairKeyObjectOptions {
-        /**
-         * Key size in bits
-         */
-        modulusLength: number;
-
-        /**
-         * Size of q in bits
-         */
-        divisorLength: number;
-    }
-
-    interface RSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
+    interface RSAKeyPairOptions {
         /**
          * Key size in bits
          */
@@ -472,17 +436,25 @@ declare module "crypto" {
          * @default 0x10001
          */
         publicExponent?: number;
+    }
 
+    interface RSAKeyPairOptionsEncodingPublicKey<PubF extends KeyFormat> extends RSAKeyPairOptions {
         publicKeyEncoding: {
             type: 'pkcs1' | 'spki';
             format: PubF;
         };
+    }
+
+    interface RSAKeyPairOptionsEncodingPrivateKey<PrivF extends KeyFormat> extends RSAKeyPairOptions {
         privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
             type: 'pkcs1' | 'pkcs8';
         };
     }
 
-    interface DSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
+    type RSAEncodingKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> =
+        RSAKeyPairOptionsEncodingPublicKey<PubF> & RSAKeyPairOptionsEncodingPrivateKey<PrivF>;
+
+    interface DSAKeyPairOptions {
         /**
          * Key size in bits
          */
@@ -491,90 +463,142 @@ declare module "crypto" {
          * Size of q in bits
          */
         divisorLength: number;
+    }
 
+    interface DSAKeyPairOptionsEncodingPublicKey<PubF extends KeyFormat> extends DSAKeyPairOptions {
         publicKeyEncoding: {
             type: 'spki';
             format: PubF;
         };
+    }
+
+    interface DSAKeyPairOptionsEncodingPrivateKey<PrivF extends KeyFormat> extends DSAKeyPairOptions {
         privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
             type: 'pkcs8';
         };
     }
 
-    interface ECKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
+    type DSAEncodingKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> =
+        DSAKeyPairOptionsEncodingPublicKey<PubF> & DSAKeyPairOptionsEncodingPrivateKey<PrivF>;
+
+    interface ECKeyPairOptions {
         /**
          * Name of the curve to use.
          */
         namedCurve: string;
+    }
 
+    interface ECKeyPairOptionsEncodingPublicKey<PubF extends KeyFormat> extends ECKeyPairOptions {
         publicKeyEncoding: {
             type: 'pkcs1' | 'spki';
             format: PubF;
         };
+    }
+
+    interface ECKeyPairOptionsEncodingPrivateKey<PrivF extends KeyFormat> extends ECKeyPairOptions {
         privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
             type: 'sec1' | 'pkcs8';
         };
     }
 
-    interface KeyPairSyncResult<T1 extends string | Buffer, T2 extends string | Buffer> {
+    type ECEncodingKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> =
+    ECKeyPairOptionsEncodingPublicKey<PubF> & ECKeyPairOptionsEncodingPrivateKey<PrivF>;
+
+    interface KeyPairSyncResult<T1 extends string | Buffer | KeyObject, T2 extends string | Buffer | KeyObject> {
         publicKey: T1;
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
+    function generateKeyPairSync(type: 'rsa', options: RSAEncodingKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(type: 'rsa', options: RSAEncodingKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(type: 'rsa', options: RSAEncodingKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(type: 'rsa', options: RSAEncodingKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptionsEncodingPublicKey<'pem'>): KeyPairSyncResult<string, KeyObject>;
+    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptionsEncodingPublicKey<'der'>): KeyPairSyncResult<Buffer, KeyObject>;
+    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptionsEncodingPrivateKey<'pem'>): KeyPairSyncResult<KeyObject, string>;
+    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptionsEncodingPrivateKey<'der'>): KeyPairSyncResult<KeyObject, Buffer>;
+    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions): KeyPairSyncResult<KeyObject, KeyObject>;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
+    function generateKeyPairSync(type: 'dsa', options: DSAEncodingKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(type: 'dsa', options: DSAEncodingKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(type: 'dsa', options: DSAEncodingKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(type: 'dsa', options: DSAEncodingKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptionsEncodingPublicKey<'pem'>): KeyPairSyncResult<string, KeyObject>;
+    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptionsEncodingPublicKey<'der'>): KeyPairSyncResult<Buffer, KeyObject>;
+    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptionsEncodingPrivateKey<'pem'>): KeyPairSyncResult<KeyObject, string>;
+    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptionsEncodingPrivateKey<'der'>): KeyPairSyncResult<KeyObject, Buffer>;
+    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions): KeyPairSyncResult<KeyObject, KeyObject>;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
+    function generateKeyPairSync(type: 'ec', options: ECEncodingKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(type: 'ec', options: ECEncodingKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(type: 'ec', options: ECEncodingKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(type: 'ec', options: ECEncodingKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptionsEncodingPublicKey<'pem'>): KeyPairSyncResult<string, KeyObject>;
+    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptionsEncodingPublicKey<'der'>): KeyPairSyncResult<Buffer, KeyObject>;
+    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptionsEncodingPrivateKey<'pem'>): KeyPairSyncResult<KeyObject, string>;
+    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptionsEncodingPrivateKey<'der'>): KeyPairSyncResult<KeyObject, Buffer>;
+    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions): KeyPairSyncResult<KeyObject, KeyObject>;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAEncodingKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAEncodingKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAEncodingKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAEncodingKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptionsEncodingPublicKey<'pem'>, callback: (err: Error | null, publicKey: string, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptionsEncodingPublicKey<'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptionsEncodingPrivateKey<'pem'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: string) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptionsEncodingPrivateKey<'der'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAEncodingKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAEncodingKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAEncodingKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAEncodingKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptionsEncodingPublicKey<'pem'>, callback: (err: Error | null, publicKey: string, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptionsEncodingPublicKey<'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptionsEncodingPrivateKey<'pem'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: string) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptionsEncodingPrivateKey<'der'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'ec', options: ECEncodingKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
+    function generateKeyPair(type: 'ec', options: ECEncodingKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'ec', options: ECEncodingKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
+    function generateKeyPair(type: 'ec', options: ECEncodingKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'ec', options: ECKeyPairOptionsEncodingPublicKey<'pem'>, callback: (err: Error | null, publicKey: string, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'ec', options: ECKeyPairOptionsEncodingPublicKey<'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: KeyObject) => void): void;
+    function generateKeyPair(type: 'ec', options: ECKeyPairOptionsEncodingPrivateKey<'pem'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: string) => void): void;
+    function generateKeyPair(type: 'ec', options: ECKeyPairOptionsEncodingPrivateKey<'der'>, callback: (err: Error | null, publicKey: KeyObject, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'ec', options: ECKeyPairOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(type: "rsa", options: RSAEncodingKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
+        function __promisify__(type: "rsa", options: RSAEncodingKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
+        function __promisify__(type: "rsa", options: RSAEncodingKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
+        function __promisify__(type: "rsa", options: RSAEncodingKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(type: "rsa", options: RSAKeyPairOptionsEncodingPublicKey<'pem'>): Promise<{ publicKey: string, privateKey: KeyObject }>;
+        function __promisify__(type: "rsa", options: RSAKeyPairOptionsEncodingPublicKey<'der'>): Promise<{ publicKey: Buffer, privateKey: KeyObject }>;
+        function __promisify__(type: "rsa", options: RSAKeyPairOptionsEncodingPrivateKey<'pem'>): Promise<{ publicKey: KeyObject, privateKey: string }>;
+        function __promisify__(type: "rsa", options: RSAKeyPairOptionsEncodingPrivateKey<'der'>): Promise<{ publicKey: KeyObject, privateKey: Buffer }>;
+        function __promisify__(type: "rsa", options: RSAKeyPairOptions): Promise<{ publicKey: KeyObject, privateKey: KeyObject }>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(type: "dsa", options: DSAEncodingKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
+        function __promisify__(type: "dsa", options: DSAEncodingKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
+        function __promisify__(type: "dsa", options: DSAEncodingKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
+        function __promisify__(type: "dsa", options: DSAEncodingKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(type: "dsa", options: DSAKeyPairOptionsEncodingPublicKey<'pem'>): Promise<{ publicKey: string, privateKey: KeyObject }>;
+        function __promisify__(type: "dsa", options: DSAKeyPairOptionsEncodingPublicKey<'der'>): Promise<{ publicKey: Buffer, privateKey: KeyObject }>;
+        function __promisify__(type: "dsa", options: DSAKeyPairOptionsEncodingPrivateKey<'pem'>): Promise<{ publicKey: KeyObject, privateKey: string }>;
+        function __promisify__(type: "dsa", options: DSAKeyPairOptionsEncodingPrivateKey<'der'>): Promise<{ publicKey: KeyObject, privateKey: Buffer }>;
+        function __promisify__(type: "dsa", options: DSAKeyPairOptions): Promise<{ publicKey: KeyObject, privateKey: KeyObject }>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(type: "ec", options: ECEncodingKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
+        function __promisify__(type: "ec", options: ECEncodingKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
+        function __promisify__(type: "ec", options: ECEncodingKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
+        function __promisify__(type: "ec", options: ECEncodingKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(type: "ec", options: ECKeyPairOptionsEncodingPublicKey<'pem'>): Promise<{ publicKey: string, privateKey: KeyObject }>;
+        function __promisify__(type: "ec", options: ECKeyPairOptionsEncodingPublicKey<'der'>): Promise<{ publicKey: Buffer, privateKey: KeyObject }>;
+        function __promisify__(type: "ec", options: ECKeyPairOptionsEncodingPrivateKey<'pem'>): Promise<{ publicKey: KeyObject, privateKey: string }>;
+        function __promisify__(type: "ec", options: ECKeyPairOptionsEncodingPrivateKey<'der'>): Promise<{ publicKey: KeyObject, privateKey: Buffer }>;
+        function __promisify__(type: "ec", options: ECKeyPairOptions): Promise<{ publicKey: KeyObject, privateKey: KeyObject }>;
     }
 
     /**

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -417,6 +417,117 @@ import { promisify } from 'util';
             type: 'pkcs8',
         },
     });
+
+    const pemPem: {
+        publicKey: string;
+        privateKey: string;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
+
+    const pemDer: {
+        publicKey: string;
+        privateKey: Buffer;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    });
+
+    const derPem: {
+        publicKey: Buffer;
+        privateKey: string;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
+
+    const derDer: {
+        publicKey: Buffer;
+        privateKey: Buffer;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    });
+
+    const pemObject: {
+        publicKey: string;
+        privateKey: crypto.KeyObject;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        }
+    });
+
+    const derObject: {
+        publicKey: Buffer;
+        privateKey: crypto.KeyObject;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        }
+    });
+
+    const objectPem: {
+        publicKey: crypto.KeyObject;
+        privateKey: string;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        }
+    });
+
+    const objectDer: {
+        publicKey: crypto.KeyObject;
+        privateKey: Buffer;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1'
+        }
+    });
+
+    const objectObject: {
+        publicKey: crypto.KeyObject;
+        privateKey: crypto.KeyObject;
+    } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 123
+    });
 }
 
 {
@@ -462,6 +573,86 @@ import { promisify } from 'util';
             type: 'pkcs8',
         },
     }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: Buffer) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: crypto.KeyObject) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: crypto.KeyObject) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: crypto.KeyObject, privateKey: string) => {});
+
+    crypto.generateKeyPair('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: crypto.KeyObject, privateKey: Buffer) => {});
 }
 
 {
@@ -517,6 +708,117 @@ import { promisify } from 'util';
             passphrase: 'secret',
             type: 'pkcs8',
         },
+    });
+
+    const pemPem: Promise<{
+        publicKey: string;
+        privateKey: string;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
+
+    const pemDer: Promise<{
+        publicKey: string;
+        privateKey: Buffer;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    });
+
+    const derPem: Promise<{
+        publicKey: Buffer;
+        privateKey: string;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
+
+    const derDer: Promise<{
+        publicKey: Buffer;
+        privateKey: Buffer;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        },
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs8',
+        },
+    });
+
+    const pemObject: Promise<{
+        publicKey: string;
+        privateKey: crypto.KeyObject;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        }
+    });
+
+    const derObject: Promise<{
+        publicKey: Buffer;
+        privateKey: crypto.KeyObject;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        publicKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1',
+        }
+    });
+
+    const objectPem: Promise<{
+        publicKey: crypto.KeyObject;
+        privateKey: string;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs1',
+        }
+    });
+
+    const objectDer: Promise<{
+        publicKey: crypto.KeyObject;
+        privateKey: Buffer;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123,
+        privateKeyEncoding: {
+            format: 'der',
+            type: 'pkcs1'
+        }
+    });
+
+    const objectObject: Promise<{
+        publicKey: crypto.KeyObject;
+        privateKey: crypto.KeyObject;
+    }> = generateKeyPairPromisified('rsa', {
+        modulusLength: 123
     });
 }
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.) (not required in this case)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#crypto_crypto_generatekeypair_type_options_callback
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.