### PR TITLE
[node] Infer type of value returned by KeyObject.export more accurately

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -135,15 +135,18 @@ declare module "crypto" {
 
     export type KeyObjectType = 'secret' | 'public' | 'private';
 
+    interface KeyExportOptions<T extends KeyFormat> {
+        type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1';
+        format: T;
+        cipher?: string;
+        passphrase?: string | Buffer;
+    }
+
     class KeyObject {
         private constructor();
         asymmetricKeyType?: KeyType;
-        export(options?: {
-            type: 'pkcs1' | 'spki' | 'pkcs8' | 'sec1',
-            format: KeyFormat,
-            cipher?: string,
-            passphrase?: string | Buffer
-        }): string | Buffer;
+        export(options: KeyExportOptions<'pem'>): string | Buffer;
+        export(options?: KeyExportOptions<'der'>): Buffer;
         symmetricSize?: number;
         type: KeyObjectType;
     }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.) (not required in this case)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#crypto_keyobject_export_options
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.