### PR TITLE
[@types/react-select] Make SingleValue children prop accept children of type ReactNode

### DIFF
--- a/types/react-select/lib/components/SingleValue.d.ts
+++ b/types/react-select/lib/components/SingleValue.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { colors, spacing } from '../theme';
 import { CommonProps } from '../types';
 
@@ -8,7 +8,7 @@ interface State {
 }
 interface ValueProps<OptionType> {
   /** The children to be rendered. */
-  children: string;
+  children: ReactNode;
   /* The data of the selected option rendered in the Single Value componentn */
   data: OptionType;
   /** Props passed to the wrapping element for the group. */


### PR DESCRIPTION
I think it makes sense for SingleValue component to accept children of type `ReactNode`, in consistency with other custom components accepting children of type `ReactNode`, not just string.
I wonder if such a change deserves a version bump, if it does - I'll be happy to do so.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[Control.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7c33a958277e53aa335dcddec28ebfe6502638ca/types/react-select/lib/components/Control.d.ts#L17) [Option.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7c33a958277e53aa335dcddec28ebfe6502638ca/types/react-select/lib/components/Option.d.ts#L25)>