### PR TITLE
Stripe: Add incomplete and incomplete expired subscription status

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5161,7 +5161,7 @@ declare namespace Stripe {
     }
 
     namespace subscriptions {
-        type SubscriptionStatus = "trialing" | "active" | "past_due" | "canceled" | "unpaid";
+        type SubscriptionStatus = "incomplete" | "incomplete_expired" | "trialing" | "active" | "past_due" | "canceled" | "unpaid";
         type SubscriptionBilling = "charge_automatically" | "send_invoice";
         /**
          * Subscriptions allow you to charge a customer's card on a recurring basis. A subscription ties a customer to
@@ -5243,13 +5243,29 @@ declare namespace Stripe {
             start: number;
 
             /**
-             * Possible values are "trialing", "active", "past_due", "canceled", or "unpaid". A subscription still in its trial period is trialing
-             * and moves to active when the trial period is over. When payment to renew the subscription fails, the subscription becomes
-             * past_due. After Stripe has exhausted all payment retry attempts, the subscription ends up with a status of either canceled
-             * or unpaid depending on your retry settings. Note that when a subscription has a status of unpaid, no subsequent invoices
-             * will be attempted (invoices will be created, but then immediately automatically closed. Additionally, updating customer
-             * card details will not lead to Stripe retrying the latest invoice.). After receiving updated card details from a customer,
-             * you may choose to reopen and pay their closed invoices.
+             * Possible values are `incomplete`, `incomplete_expired`, `trialing`, `active`,
+             * `past_due`, `canceled`, or `unpaid`.
+             *
+             * For `billing=charge_automatically` a subscription moves into `incomplete` if the
+             * initial payment attempt fails. A subscription in this state can only have metadata
+             * and default_source updated. Once the first invoice is paid, the subscription moves
+             * into an `active` state. If the first invoice is not paid within 23 hours, the
+             * subscription transitions to `incomplete_expired`. This is a terminal state, the open
+             * invoice will be voided and no further invoices will be generated.
+             *
+             * A subscription that is currently in a trial period is `trialing` and moves to
+             * `active` when the trial period is over.
+             *
+             * If subscription `billing=charge_automatically` it becomes `past_due` when payment to
+             * renew it fails and `canceled` or `unpaid` (depending on your subscriptions settings)
+             * when Stripe has exhausted all payment retry attempts.
+             *
+             * If subscription `billing=send_invoice` it becomes `past_due` when its invoice is not
+             * paid by the due date, and `canceled` or `unpaid` if it is still not paid by an
+             * additional deadline after that. Note that when a subscription has a status of
+             * `unpaid`, no subsequent invoices will be attempted (invoices will be created, but
+             * then immediately automatically closed). After receiving updated payment information
+             * from a customer, you may choose to reopen and pay their closed invoices.
              */
             status: SubscriptionStatus;
 


### PR DESCRIPTION
[Version 2019-03-14](https://stripe.com/docs/upgrades#2019-03-14) of the Stripe API added two new values to the subscription status.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/upgrades#2019-03-14
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
