### PR TITLE
Fixed error on 'filter' method when is used with the 'pipe' method. @types/ramda.

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for google-map-react 0.23
 // Project: https://github.com/google-map-react/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
-// Definitions by: Andres Rosero <https://github.com/drebits>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for google-map-react 0.23
 // Project: https://github.com/google-map-react/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
+// Definitions by: Andres Rosero <https://github.com/drebits>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -601,9 +601,9 @@ declare namespace R {
     }
 
     interface Filter {
-        <T>(fn: (value: T) => boolean): FilterOnceApplied<T>;
         <T, Kind extends 'array'>(fn: (value: T) => boolean): (list: ReadonlyArray<T>) => T[];
         <T, Kind extends 'object'>(fn: (value: T) => boolean): (list: Dictionary<T>) => Dictionary<T>;
+        <T>(fn: (value: T) => boolean): FilterOnceApplied<T>;
         <T>(fn: (value: T) => boolean, list: ReadonlyArray<T>): T[];
         <T>(fn: (value: T) => boolean, obj: Dictionary<T>): Dictionary<T>;
     }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -819,6 +819,10 @@ R.times(i, 5);
     const d: number[] = R.pipe(
         R.reject<number, 'array'>(isEven),
     )([0, 1]); // => [1]
+
+    const e: any[] = R.pipe(
+        R.filter(R.has('a')),
+    )([{ a: 0, b: 1 }, { a: 0, b: 1 }, { a: 0, b: 1 }]);
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### Issue

I only changed the order from this:

```javascript
<T>(fn: (value: T) => boolean): FilterOnceApplied<T>;
<T, Kind extends 'array'>(fn: (value: T) => boolean): (list: ReadonlyArray<T>) => T[];
<T, Kind extends 'object'>(fn: (value: T) => boolean): (list: Dictionary<T>) => Dictionary<T>;
<T>(fn: (value: T) => boolean, list: ReadonlyArray<T>): T[];
<T>(fn: (value: T) => boolean, obj: Dictionary<T>): Dictionary<T>;
```

to this:

```javascript
<T, Kind extends 'array'>(fn: (value: T) => boolean): (list: ReadonlyArray<T>) => T[];
<T, Kind extends 'object'>(fn: (value: T) => boolean): (list: Dictionary<T>) => Dictionary<T>;
<T>(fn: (value: T) => boolean): FilterOnceApplied<T>;
<T>(fn: (value: T) => boolean, list: ReadonlyArray<T>): T[];
<T>(fn: (value: T) => boolean, obj: Dictionary<T>): Dictionary<T>;
```

Because it was causing troubles like [this](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21217) or [this](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25581) when **R.filter** is used inside **R.pipe**.
Another example:

```javascript
const dataArr = [{ a: 0, b: 1 }, { b: 2 }, { a: 3, b: 4 }, { a: 5, b: 6 }, { x: 7, b: 8 }]

const onlyWithPropA: any[] = R.pipe(
    R.filter(R.has('a')),
    // more code
)(dataArr);
```

Due to, the data array that is passed to the function, isn't considered an array. Because *"it doesn't have properties like length, concat, join, slice, etc"*.