### PR TITLE
Adding StripeOption "betas" which allows use of Stripe's Checkout Beta

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -31,6 +31,7 @@ declare namespace stripe {
 
     interface StripeOptions {
       stripeAccount?: string;
+      betas?: string[];
     }
 
     interface TokenOptions {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -6,6 +6,7 @@ declare function it(desc: string, fn: () => void): void;
 describe("Stripe", () => {
     it("should excercise all Stripe API", () => {
         const stripe = Stripe('public-key');
+        const stripeWithBetaOption = Stripe('public-key', { betas: ['beta-feature'] });
         const elements = stripe.elements();
         const style = {
             base: {


### PR DESCRIPTION
Stripe has made a new checkout api that can be used if you include  betas: ['checkout_beta_4']  in StripeOptions.
 https://stripe.com/docs/payments/checkout