### PR TITLE
Introduces default export to @types/shpjs

### DIFF
--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for shpjs 3.4
 // Project: https://github.com/calvinmetcalf/shapefile-js#readme
 // Definitions by: Hsiao-Ting Yu <https://github.com/littlebtc>
+//                 Kai Volland <https://github.com/kaivolland>  
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.4.3
 
 /// <reference types="node" />
 /// <reference types="geojson" />
@@ -26,4 +27,4 @@ declare namespace shpjs {
 }
 
 declare var shpjs: shpjs.ShpJS;
-export = shpjs;
+export default shpjs;

--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Hsiao-Ting Yu <https://github.com/littlebtc>
 //                 Kai Volland <https://github.com/kaivolland>  
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4.3
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="geojson" />

--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for shpjs 3.4
+// Type definitions for shpjs 3.4.3
 // Project: https://github.com/calvinmetcalf/shapefile-js#readme
 // Definitions by: Hsiao-Ting Yu <https://github.com/littlebtc>
 //                 Kai Volland <https://github.com/kaivolland>  


### PR DESCRIPTION
This introduces the default export to the definitions as it is in the original package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/calvinmetcalf/shapefile-js/blob/gh-pages/lib/index.js#L157
- [x] Increase the version number in the header if appropriate.
  TypeScript Version increased. shpjs version remains the same
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  Change should not break anything but add possibility to import as default.

@littlebtc 