### PR TITLE
Allow SeamlessImmutable/ImmutableArray.concat to accept an array argument

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Seamless-immutable 7.1
+// Type definitions for Seamless-immutable 7.2
 // Project: https://github.com/rtfeldman/seamless-immutable
 // Definitions by: alex3165 <https://github.com/alex3165>
 //                 Stepan Burguchev <https://github.com/xsburg>
@@ -57,7 +57,7 @@ declare namespace SeamlessImmutable {
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M]>(propertyPath: [ K, L, M, N ]): Immutable<T[K][L][M][N]>;
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M]>(propertyPath: [ K, L, M, N ], defaultValue: T[K][L][M][N]): Immutable<T[K][L][M][N]>;
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
-            propertyPath: [ K, L, M, N, O ]): Immutable<T[K][L][M][N][O]>;
+            propertyPath: [ K, L, M, N, O ]): Immutable<T[K][L][M][N][O]>
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
             propertyPath: [ K, L, M, N, O ], defaultValue: T[K][L][M][N][O]): Immutable<T[K][L][M][N][O]>;
         getIn(propertyPath: string[]): Immutable<any>;
@@ -105,7 +105,7 @@ declare namespace SeamlessImmutable {
             map<TTarget>(mapFuction: (item: T) => TTarget): Immutable<TTarget[]>;
             filter(filterFunction: (item: T) => boolean): Immutable<T[]>;
             slice(start?: number, end?: number): Immutable<T[]>;
-            concat(...arr: T[]): Immutable<T[]>;
+            concat(...arr: Array<T|T[]>): Immutable<T[]>;
             reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): Immutable<T>;
             reduce<TTarget>(callbackfn: (previousValue: TTarget, currentValue: T, currentIndex: number, array: T[]) => TTarget, initialValue?: TTarget): Immutable<TTarget>;
             reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): Immutable<T>;

--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -57,7 +57,7 @@ declare namespace SeamlessImmutable {
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M]>(propertyPath: [ K, L, M, N ]): Immutable<T[K][L][M][N]>;
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M]>(propertyPath: [ K, L, M, N ], defaultValue: T[K][L][M][N]): Immutable<T[K][L][M][N]>;
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
-            propertyPath: [ K, L, M, N, O ]): Immutable<T[K][L][M][N][O]>
+            propertyPath: [ K, L, M, N, O ]): Immutable<T[K][L][M][N][O]>;
         getIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
             propertyPath: [ K, L, M, N, O ], defaultValue: T[K][L][M][N][O]): Immutable<T[K][L][M][N][O]>;
         getIn(propertyPath: string[]): Immutable<any>;

--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Seamless-immutable 7.2
+// Type definitions for Seamless-immutable 7.1
 // Project: https://github.com/rtfeldman/seamless-immutable
 // Definitions by: alex3165 <https://github.com/alex3165>
 //                 Stepan Burguchev <https://github.com/xsburg>

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -120,7 +120,14 @@ interface ExtendedUser extends User {
 
     // concat. Call the mutable array's 'concat' with the same args to ensure compatability. Make sure the output array is immutable.
     array.asMutable().concat({ firstName: 'Happy', lastName: 'Cat' });
-    const concat: Immutable.Immutable<User[]> = array.concat({ firstName: 'Happy', lastName: 'Cat' });
+    const concat: Immutable.Immutable<User[]> = array
+        .concat({ firstName: 'Happy', lastName: 'Cat' }, { firstName: 'Silly', lastName: 'Cat' })
+        .concat([{firstName: 'saucy', lastName: 'Cat'}], {firstName: 'Fussy', lastName: 'Cat'})
+        .concat([
+            {firstName: 'Fancy', lastName: 'Cat'},
+            {firstName: 'Sassy', lastName: 'Cat'}],
+            [{firstName: 'Bossy', lastName: 'Cat'}
+        ]);
     concat.asMutable();
 
     // reduce. Call the mutable array's 'reduce' with the same function to ensure compatability. Make sure the output array is immutable.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
```javascript
const a0 = SeamlessImmutable([1,2,3,4])
const a1 = SeamlessImmutable([6,7,8,9])
a0.concat(5).concat(a1)
// [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
```
- [x] Increase the version number in the header if appropriate.
- [N/A ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
