### PR TITLE
Lazy.js (v0.5.1) - missing parameter on .uniq method

### DIFF
--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for Lazy.js 0.3.4
+// Type definitions for Lazy.js 0.5.1
 // Project: https://github.com/dtao/lazy.js/
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mike Doughty <https://github.com/miso440>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 Mike Doughty <https://github.com/miso440>
+//                 Gabriel Lorquet <https://github.com/gablorquet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace LazyJS {

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -168,7 +168,7 @@ declare namespace LazyJS {
       toArray(): T[];
       toObject(): any;
       union(var_args: T[]): Sequence<T>;
-      uniq(): Sequence<T>;
+      uniq(key: keyof T): Sequence<T>;
       where(properties: any): Sequence<T>;
       without(...var_args: T[]): Sequence<T>;
       without(var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,10 +1,10 @@
-// TypeScript Version: 2.1
 // Type definitions for Lazy.js 0.5.1
 // Project: https://github.com/dtao/lazy.js/
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Mike Doughty <https://github.com/miso440>
 //                 Gabriel Lorquet <https://github.com/gablorquet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare namespace LazyJS {
     interface LazyStatic {

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -171,7 +171,7 @@ declare namespace LazyJS {
       toArray(): T[];
       toObject(): any;
       union(var_args: T[]): Sequence<T>;
-      uniq(key: keyof T): Sequence<T>;
+      uniq(key?: keyof T): Sequence<T>;
       where(properties: any): Sequence<T>;
       without(...var_args: T[]): Sequence<T>;
       without(var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,3 +1,4 @@
+// TypeScript Version: 2.1
 // Type definitions for Lazy.js 0.5.1
 // Project: https://github.com/dtao/lazy.js/
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>


### PR DESCRIPTION
As per the official docs unit (http://danieltao.com/lazy.js/docs/#Sequence-uniq) should be able to accept the key of the unit that will be used to determine unicity 

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
