### PR TITLE
Cleanup for DOM update in typescript@next

### DIFF
--- a/types/awesomplete/index.d.ts
+++ b/types/awesomplete/index.d.ts
@@ -9,10 +9,10 @@
 declare class Awesomplete {
     constructor(input: Element | HTMLElement | string, o?: Awesomplete.Options);
     static all: any[];
-    static $$(expr: string | NodeSelector, con?: any): NodeList;
+    static $$(expr: string | ParentNode, con?: any): NodeList;
     static ITEM: (text: string, input: string) => HTMLElement;
     static $: {
-        (expr: string|Element, con?: NodeSelector): string | Element;
+        (expr: string|Element, con?: ParentNode): string | Element;
         regExpEscape(s: { replace(arg0: RegExp, arg1: string): void }): any;
         create(tag: string, o: any): HTMLElement;
         fire(target: EventTarget, type: string, properties: any): any;

--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -8,7 +8,7 @@ function ModuleTest(): void {
     Module.preinitializedWebGLContext = new WebGLRenderingContext();
 
     let package: ArrayBuffer = Module.getPreloadedPackage("package-name", 100);
-    let exports: WebAssembly.Exports = Module.instantiateWasm(
+    let exports: Module.WebAssemblyExports = Module.instantiateWasm(
         [{name: "func-name", kind: "function"}],
         (module: WebAssembly.Module) => {}
     );

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -3,7 +3,12 @@
 // Definitions by: Kensuke Matsuzaki <https://github.com/zakki>
 //                 Periklis Tsirakidis <https://github.com/periklis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 2.2
+
+/** Other WebAssembly declarations, for compatibility with older versions of Typescript */
+declare namespace WebAssembly {
+    interface Module { }
+}
 
 declare namespace Emscripten {
     interface FileSystemType {

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -3,9 +3,7 @@
 // Definitions by: Kensuke Matsuzaki <https://github.com/zakki>
 //                 Periklis Tsirakidis <https://github.com/periklis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
-
-/// <reference types="webassembly-js-api" />
+// TypeScript Version: 3.5
 
 declare namespace Emscripten {
     interface FileSystemType {
@@ -14,6 +12,17 @@ declare namespace Emscripten {
 
 declare namespace Module {
     type EnvironmentType = "WEB" | "NODE" | "SHELL" | "WORKER";
+
+    type WebAssemblyImports =  Array<{
+        name: string;
+        kind: string;
+    }>;
+
+    type WebAssemblyExports = Array<{
+        module: string;
+        name: string;
+        kind: string;
+    }>;
 
     function print(str: string): void;
     function printErr(str: string): void;
@@ -32,9 +41,9 @@ declare namespace Module {
     function destroy(object: object): void;
     function getPreloadedPackage(remotePackageName: string, remotePackageSize: number): ArrayBuffer;
     function instantiateWasm(
-        imports: WebAssembly.Imports,
+        imports: WebAssemblyImports,
         successCallback: (module: WebAssembly.Module) => void
-    ): WebAssembly.Exports;
+    ): WebAssemblyExports;
     function locateFile(url: string): string;
     function onCustomMessage(event: MessageEvent): void;
 

--- a/types/webassembly-web-api/index.d.ts
+++ b/types/webassembly-web-api/index.d.ts
@@ -2,9 +2,7 @@
 // Project: https://webassembly.org/
 // Definitions by: Johannes Henninger <https://github.com/jhenninger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
-
-/// <reference types="webassembly-js-api" />
+// TypeScript Version: 3.5
 
 /**
  *  The WebAssembly Web API defines extensions to the JavaScript API made
@@ -12,6 +10,11 @@
  *  API](https://www.w3.org/TR/wasm-web-api-1/) for more information.
  */
 declare namespace WebAssembly {
+    interface ResultObject {
+        module: Module;
+        instance: Instance;
+    }
+
     function compileStreaming(source: Response | Promise<Response>): Promise<Module>;
     function instantiateStreaming(source: Response | Promise<Response>, importObject?: object): Promise<ResultObject>;
 }

--- a/types/webassembly-web-api/index.d.ts
+++ b/types/webassembly-web-api/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://webassembly.org/
 // Definitions by: Johannes Henninger <https://github.com/jhenninger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 2.2
 
 /**
  *  The WebAssembly Web API defines extensions to the JavaScript API made
@@ -10,6 +10,11 @@
  *  API](https://www.w3.org/TR/wasm-web-api-1/) for more information.
  */
 declare namespace WebAssembly {
+    /// Other WebAssembly declarations, for compatibility with older versions of Typescript
+    // tslint:disable-next-line no-empty-interface
+    interface Module { }
+    // tslint:disable-next-line no-empty-interface
+    interface Instance { }
     interface ResultObject {
         module: Module;
         instance: Instance;


### PR DESCRIPTION
1. awesomeplete: Switch off of now-removed type name.
2. emscripten: Remove dependency on webassembly-js-api now that 3.5 has
it in the DOM.
3. webassembly-web-api: Same

I'll remove webassembly-js-api in a separate PR since it's no longer needed, along with some other now-included packages.

Note that (2) and (3) now include a couple of ambient declarations for WebAssembly for compatibility with older versions. People using older versions of Typescript with webassembly-web-api or emscripten will now need to install webassembly-js-api alongside them.