### PR TITLE
Fix vuelidate missing $model definition, and helpers.req() returns boolean

### DIFF
--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -22,7 +22,7 @@ export type CustomRule = (value: any, parentVm?: any) => boolean
 
 export interface Helpers {
     withParams(params: Params, rule: CustomRule | ValidationRule): ValidationRule
-    req(value: any): ValidationRule
+    req(value: any): boolean
     ref(reference: string | ((vm: any, parentVm?: Vue) => any), vm: any, parentVm?: Vue): any
     len(value: any): number
     regex(type: string, expr: RegExp): ValidationRule

--- a/types/vuelidate/vuelidate.d.ts
+++ b/types/vuelidate/vuelidate.d.ts
@@ -16,6 +16,7 @@ export interface Validation extends Vue {
     readonly $error: boolean
     readonly $pending: boolean
     readonly $params: { [attr: string]: any }
+    $model: any
 
     // const validationMethods
     $touch(): never


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - `$model` is used throughout the documentation and `vuelidate` testing, it just returns the underlying model value. We use this all over the place in our app. Example: https://vuelidate.netlify.com/#sub-basic-form
    - `helpers.req` explicitly returns a boolean, not a `ValidationRule`: https://github.com/vuelidate/vuelidate/blob/master/src/validators/common.js#L5. This fixes #32876
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

--- 

@janesser these are a couple small fixes for @types/vuelidate - thanks again for all of your tons of hard work on it.