### PR TITLE
cookie-session: Adds Keygrip to allowed types for the cookie-session keys property

### DIFF
--- a/types/cookie-session/cookie-session-tests.ts
+++ b/types/cookie-session/cookie-session-tests.ts
@@ -2,6 +2,7 @@
 
 import express = require('express');
 import cookieSession = require('cookie-session');
+import Keygrip = require('keygrip');
 
 var app = express()
 
@@ -37,3 +38,14 @@ app2.use(cookieSession({
 app2.use(function (req, res, next) {
   req.sessionOptions.maxAge = req.session['maxAge'] || req.sessionOptions.maxAge
 });
+
+
+var app3 = express()
+
+app3.set('trust proxy', 1) // trust first proxy
+
+// a Keygrip object may be used instead of an array of keys.
+app3.use(cookieSession({
+  name: 'session',
+  keys: Keygrip(['key1', 'key2'])
+}));

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -5,115 +5,116 @@
 // TypeScript Version: 2.2
 
 /// <reference types="express" />
+/// <reference types="keygrip" />
 
 declare namespace Express {
-    interface Request extends CookieSessionInterfaces.CookieSessionRequest {}
+  interface Request extends CookieSessionInterfaces.CookieSessionRequest { }
 }
 
 declare namespace CookieSessionInterfaces {
-    interface CookieSessionOptions {
-        /**
-         * The name of the cookie to set, defaults to session.
-         */
-        name?: string;
+  interface CookieSessionOptions {
+    /**
+     * The name of the cookie to set, defaults to session.
+     */
+    name?: string;
 
-        /**
-         * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
-         */
-        keys?: Array<string>;
+    /**
+     * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
+     */
+    keys?: Array<string> | import('keygrip');
 
-        /**
-         * A string which will be used as single key if keys is not provided.
-         */
-        secret?: string;
+    /**
+     * A string which will be used as single key if keys is not provided.
+     */
+    secret?: string;
 
-        /**
-         * a number representing the milliseconds from Date.now() for expiry.
-         */
-        maxAge?: number;
+    /**
+     * a number representing the milliseconds from Date.now() for expiry.
+     */
+    maxAge?: number;
 
-        /**
-         * a Date object indicating the cookie's expiration date (expires at the end of session by default).
-         */
-        expires?: Date;
+    /**
+     * a Date object indicating the cookie's expiration date (expires at the end of session by default).
+     */
+    expires?: Date;
 
-        /**
-         * a string indicating the path of the cookie (/ by default).
-         */
-        path?: string;
+    /**
+     * a string indicating the path of the cookie (/ by default).
+     */
+    path?: string;
 
-        /**
-         * a string indicating the domain of the cookie (no default).
-         */
-        domain?: string;
+    /**
+     * a string indicating the domain of the cookie (no default).
+     */
+    domain?: string;
 
-        /**
-         * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', or true (which maps to 'strict').
-         */
-        sameSite?: "strict" | "lax" | boolean;
+    /**
+     * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', or true (which maps to 'strict').
+     */
+    sameSite?: "strict" | "lax" | boolean;
 
-        /**
-         * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).
-         */
-        secure?: boolean;
+    /**
+     * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).
+     */
+    secure?: boolean;
 
-        /**
-         * a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
-         */
-        secureProxy?: boolean;
+    /**
+     * a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
+     */
+    secureProxy?: boolean;
 
-        /**
-         * a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (true by default).
-         */
-        httpOnly?: boolean;
+    /**
+     * a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (true by default).
+     */
+    httpOnly?: boolean;
 
-        /**
-         * a boolean indicating whether the cookie is to be signed (true by default). If this is true, another cookie of the same name with the .sig suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of cookie-name=cookie-value against the
-         * first Keygrip key. This signature key is used to detect tampering the next time a cookie is received.
-         */
-        signed?: boolean;
+    /**
+     * a boolean indicating whether the cookie is to be signed (true by default). If this is true, another cookie of the same name with the .sig suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of cookie-name=cookie-value against the
+     * first Keygrip key. This signature key is used to detect tampering the next time a cookie is received.
+     */
+    signed?: boolean;
 
-        /**
-         * a boolean indicating whether to overwrite previously set cookies of the same name (true by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
-         */
-        overwrite?: boolean;
-    }
+    /**
+     * a boolean indicating whether to overwrite previously set cookies of the same name (true by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
+     */
+    overwrite?: boolean;
+  }
 
-    interface CookieSessionObject {
-        /**
-         * Is true if the session has been changed during the request.
-         */
-        isChanged?: boolean;
+  interface CookieSessionObject {
+    /**
+     * Is true if the session has been changed during the request.
+     */
+    isChanged?: boolean;
 
-        /**
-         * Is true if the session is new.
-         */
-        isNew?: boolean;
+    /**
+     * Is true if the session is new.
+     */
+    isNew?: boolean;
 
-        /**
-         * Determine if the session has been populated with data or is empty.
-         */
-        isPopulated?: boolean;
+    /**
+     * Determine if the session has been populated with data or is empty.
+     */
+    isPopulated?: boolean;
 
-        [propertyName: string]: any;
-    }
+    [propertyName: string]: any;
+  }
 
-    interface CookieSessionRequest {
-        /**
-         * Represents the session for the given request.
-         */
-        session?: CookieSessionObject;
+  interface CookieSessionRequest {
+    /**
+     * Represents the session for the given request.
+     */
+    session?: CookieSessionObject;
 
-        /**
-         * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.
-         */
-        sessionOptions: CookieSessionOptions;
-    }
+    /**
+     * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.
+     */
+    sessionOptions: CookieSessionOptions;
+  }
 }
 
 declare module "cookie-session" {
-    import express = require('express');
+  import express = require('express');
 
-    function cookieSession(options?: CookieSessionInterfaces.CookieSessionOptions): express.RequestHandler;
-    export = cookieSession;
+  function cookieSession(options?: CookieSessionInterfaces.CookieSessionOptions): express.RequestHandler;
+  export = cookieSession;
 }

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/cookie-session
 // Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>, Jason Cordial <https://github.com/btomw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.9
 
 /// <reference types="express" />
 /// <reference types="keygrip" />

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -1,120 +1,120 @@
 // Type definitions for cookie-session 2.0
 // Project: https://github.com/expressjs/cookie-session
-// Definitions by:  Borislav Zhivkov <https://github.com/borislavjivkov>, Jason Cordial <https://github.com/jcordial>
+// Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.2
 
 /// <reference types="express" />
 /// <reference types="keygrip" />
 
 declare namespace Express {
-  interface Request extends CookieSessionInterfaces.CookieSessionRequest { }
+    interface Request extends CookieSessionInterfaces.CookieSessionRequest {}
 }
 
 declare namespace CookieSessionInterfaces {
-  interface CookieSessionOptions {
-    /**
-     * The name of the cookie to set, defaults to session.
-     */
-    name?: string;
+    interface CookieSessionOptions {
+        /**
+         * The name of the cookie to set, defaults to session.
+         */
+        name?: string;
 
-    /**
-     * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
-     */
-    keys?: Array<string> | import('keygrip');
+        /**
+         * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
+         */
+        keys?: Array<string> | import('keygrip');
 
-    /**
-     * A string which will be used as single key if keys is not provided.
-     */
-    secret?: string;
+        /**
+         * A string which will be used as single key if keys is not provided.
+         */
+        secret?: string;
 
-    /**
-     * a number representing the milliseconds from Date.now() for expiry.
-     */
-    maxAge?: number;
+        /**
+         * a number representing the milliseconds from Date.now() for expiry.
+         */
+        maxAge?: number;
 
-    /**
-     * a Date object indicating the cookie's expiration date (expires at the end of session by default).
-     */
-    expires?: Date;
+        /**
+         * a Date object indicating the cookie's expiration date (expires at the end of session by default).
+         */
+        expires?: Date;
 
-    /**
-     * a string indicating the path of the cookie (/ by default).
-     */
-    path?: string;
+        /**
+         * a string indicating the path of the cookie (/ by default).
+         */
+        path?: string;
 
-    /**
-     * a string indicating the domain of the cookie (no default).
-     */
-    domain?: string;
+        /**
+         * a string indicating the domain of the cookie (no default).
+         */
+        domain?: string;
 
-    /**
-     * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', or true (which maps to 'strict').
-     */
-    sameSite?: "strict" | "lax" | boolean;
+        /**
+         * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', or true (which maps to 'strict').
+         */
+        sameSite?: "strict" | "lax" | boolean;
 
-    /**
-     * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).
-     */
-    secure?: boolean;
+        /**
+         * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).
+         */
+        secure?: boolean;
 
-    /**
-     * a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
-     */
-    secureProxy?: boolean;
+        /**
+         * a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
+         */
+        secureProxy?: boolean;
 
-    /**
-     * a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (true by default).
-     */
-    httpOnly?: boolean;
+        /**
+         * a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (true by default).
+         */
+        httpOnly?: boolean;
 
-    /**
-     * a boolean indicating whether the cookie is to be signed (true by default). If this is true, another cookie of the same name with the .sig suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of cookie-name=cookie-value against the
-     * first Keygrip key. This signature key is used to detect tampering the next time a cookie is received.
-     */
-    signed?: boolean;
+        /**
+         * a boolean indicating whether the cookie is to be signed (true by default). If this is true, another cookie of the same name with the .sig suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of cookie-name=cookie-value against the
+         * first Keygrip key. This signature key is used to detect tampering the next time a cookie is received.
+         */
+        signed?: boolean;
 
-    /**
-     * a boolean indicating whether to overwrite previously set cookies of the same name (true by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
-     */
-    overwrite?: boolean;
-  }
+        /**
+         * a boolean indicating whether to overwrite previously set cookies of the same name (true by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
+         */
+        overwrite?: boolean;
+    }
 
-  interface CookieSessionObject {
-    /**
-     * Is true if the session has been changed during the request.
-     */
-    isChanged?: boolean;
+    interface CookieSessionObject {
+        /**
+         * Is true if the session has been changed during the request.
+         */
+        isChanged?: boolean;
 
-    /**
-     * Is true if the session is new.
-     */
-    isNew?: boolean;
+        /**
+         * Is true if the session is new.
+         */
+        isNew?: boolean;
 
-    /**
-     * Determine if the session has been populated with data or is empty.
-     */
-    isPopulated?: boolean;
+        /**
+         * Determine if the session has been populated with data or is empty.
+         */
+        isPopulated?: boolean;
 
-    [propertyName: string]: any;
-  }
+        [propertyName: string]: any;
+    }
 
-  interface CookieSessionRequest {
-    /**
-     * Represents the session for the given request.
-     */
-    session?: CookieSessionObject;
+    interface CookieSessionRequest {
+        /**
+         * Represents the session for the given request.
+         */
+        session?: CookieSessionObject;
 
-    /**
-     * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.
-     */
-    sessionOptions: CookieSessionOptions;
-  }
+        /**
+         * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.
+         */
+        sessionOptions: CookieSessionOptions;
+    }
 }
 
 declare module "cookie-session" {
-  import express = require('express');
+    import express = require('express');
 
-  function cookieSession(options?: CookieSessionInterfaces.CookieSessionOptions): express.RequestHandler;
-  export = cookieSession;
+    function cookieSession(options?: CookieSessionInterfaces.CookieSessionOptions): express.RequestHandler;
+    export = cookieSession;
 }

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -1,8 +1,8 @@
 // Type definitions for cookie-session 2.0
 // Project: https://github.com/expressjs/cookie-session
-// Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
+// Definitions by:  Borislav Zhivkov <https://github.com/borislavjivkov>, Jason Cordial <https://github.com/jcordial>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.9
 
 /// <reference types="express" />
 /// <reference types="keygrip" />

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for cookie-session 2.0
 // Project: https://github.com/expressjs/cookie-session
-// Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
+// Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>, Jason Cordial <https://github.com/btomw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/expressjs/cookie-session#keys>>
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---
The types don't show Keygrip as an option for the `keys` property. I linked to the documentation for the master branch of `cookie-session`, but index.d.ts header implies these types are for the 2.0 branch.

I checked the code for that version of cookie-session, and it's still true that a Keygrip can be used, so I think this should be ok to add.