### PR TITLE
[natural] updated classifiers classification definition

### DIFF
--- a/types/natural/index.d.ts
+++ b/types/natural/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Natural v0.6.3
+// Type definitions for Natural 0.6
 // Project: https://github.com/NaturalNode/natural
 // Definitions by: Dylan R. E. Moonfire <https://github.com/dmoonfire>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/natural/index.d.ts
+++ b/types/natural/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Natural 0.2.2
+// Type definitions for Natural v0.6.3
 // Project: https://github.com/NaturalNode/natural
 // Definitions by: Dylan R. E. Moonfire <https://github.com/dmoonfire>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -67,6 +67,7 @@ declare var LancasterStemmer: {
     stem(token: string): string;
 }
 
+interface BayesClassifierClassification { label: string, value: number }
 interface BayesClassifierCallback { (err: any, classifier: any): void }
 declare class BayesClassifier {
     events: events.EventEmitter;
@@ -74,12 +75,13 @@ declare class BayesClassifier {
     addDocument(text: string[], stem: string): void;
     train(): void;
     classify(observation: string): string;
-    getClassifications(observation: string): string[];
+    getClassifications(observation: string): BayesClassifierClassification[];
     save(filename: string, callback: BayesClassifierCallback): void;
     static load(filename: string, stemmer: Stemmer, callback: BayesClassifierCallback): void;
     static restore(classifier: any, stemmer?: Stemmer): BayesClassifier;
 }
 
+interface LogisticRegressionClassifierClassification { label: string, value: number }
 interface LogisticRegressionClassifierCallback { (err: any, classifier: any): void }
 declare class LogisticRegressionClassifier {
     events: events.EventEmitter;
@@ -87,7 +89,7 @@ declare class LogisticRegressionClassifier {
     addDocument(text: string[], stem: string): void;
     train(): void;
     classify(observation: string): string;
-    getClassifications(observation: string): string[];
+    getClassifications(observation: string): LogisticRegressionClassifierClassification[];
     save(filename: string, callback: LogisticRegressionClassifierCallback): void;
     static load(filename: string, stemmer: Stemmer, callback: LogisticRegressionClassifierCallback): void;
     static restore(classifier: any, stemmer?: Stemmer): LogisticRegressionClassifier;

--- a/types/natural/natural-tests.ts
+++ b/types/natural/natural-tests.ts
@@ -59,7 +59,12 @@ classifier.addDocument('sell gold', 'sell');
 classifier.train();
 console.log(classifier.classify('i am short silver'));
 console.log(classifier.classify('i am long copper'));
-console.log(classifier.getClassifications('i am long copper'));
+var classifications = classifier.getClassifications('i am long copper');
+classifications.forEach(function(classification) {
+    var label = classification.label
+    var value = classification.value
+    console.log('label: ' + label + ', value: ' + value)
+})
 classifier.addDocument(['sell', 'gold'], 'sell');
 classifier.events.on('trainedWithDocument', function (obj: any) {
    console.log(obj);

--- a/types/natural/natural-tests.ts
+++ b/types/natural/natural-tests.ts
@@ -1,9 +1,3 @@
-// Type definitions for Natural 0.2.1
-// Project: https://github.com/NaturalNode/natural
-// Definitions by: Dylan R. E. Moonfire <https://github.com/dmoonfire/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 import natural = require('natural');
 
 // Tokenizers


### PR DESCRIPTION
This PR adds a more accurate definition for the Bayesian and logistic regression classifiers' classification entry, it's currently defined as `string[]` but it's actually an array of a specific object type `{ label: string, value: number }`.

Side note: this is my first time contributing to DT so I hope that I updated the tests in a satisfying manner.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

 If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NaturalNode/natural#bayesian-and-logistic-regression
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }.
