### PR TITLE
[expo] add `strokeMiterlimit` to svg props

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2622,6 +2622,7 @@ export interface SvgCommonProps {
     strokeLinejoin?: string;
     strokeDasharray?: any[];
     strokeDashoffset?: any;
+    strokeMiterlimit?: number;
     transform?: string | object;
     x?: number | string;
     y?: number | string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-svg/blob/6bd27dfeba3422482b43b15bef287b72d1bf7d54/lib/extract/extractStroke.js#L48-L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.