### PR TITLE
Webpack v3 test and docs use options as a string, yet don't declare it in the types

### DIFF
--- a/types/webpack/v3/index.d.ts
+++ b/types/webpack/v3/index.d.ts
@@ -389,7 +389,7 @@ declare namespace webpack {
     }
     interface NewLoader {
         loader: string;
-        options?: { [name: string]: any };
+        options?: { [name: string]: any } | string;
     }
     type Loader = string | OldLoader | NewLoader;
 
@@ -455,7 +455,7 @@ declare namespace webpack {
         query?: { [name: string]: any };
     }
     interface NewLoaderRule extends BaseSingleLoaderRule {
-        options?: { [name: string]: any };
+        options?: { [name: string]: any } | string;
     }
     type LoaderRule = OldLoaderRule | NewLoaderRule;
     interface OldUseRule extends BaseDirectRule {


### PR DESCRIPTION
Confirmed in the [v3 docs](https://github.com/webpack/webpack.js.org/blob/v3.11.0/src/content/configuration/module.md#useentry).

Found while working on https://github.com/Microsoft/TypeScript/pull/30853.