### PR TITLE
[expo] re-export types from RN SVG

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -595,7 +595,7 @@ const allSecureStoreKeychainAccessibleValues: number[] = [
         </Svg.Defs>
         <Svg.G transform="translate(0, 0)" y={20}>
             <Svg.Text fill="blue" transform={{ translateX: 0, translateY: 0 }}>
-                <Svg.TextPath href="#path" startOffset="-10%">
+                <Svg.TextPath href="#path" startOffset="-10%" midLine="smooth">
                     We go up and down,
                     <Svg.TSpan fill="red" dy="5,5,5">then up again</Svg.TSpan>
                 </Svg.TextPath>
@@ -609,7 +609,7 @@ const allSecureStoreKeychainAccessibleValues: number[] = [
         </Svg.G>
         <Svg.Use href="#shape" transform="translate(0, 0)" x="20" y="0" />
         <Svg.Use href="#shape" transform={{ translateX: 0, translateY: 0 }} x="20" y="0" width="20" height="20"/>
-        <Svg.Symbol id="symbol" viewBox="0 0 150 110" width="100" height="50">
+        <Svg.Symbol id="symbol" viewBox="0 0 150 110">
             <Svg.Circle cx="50" cy="50" r="40" strokeWidth="8" stroke="red" fill="red"/>
             <Svg.Circle cx="90" cy="60" r="40" strokeWidth="8" stroke="green" fill="white"/>
         </Svg.Symbol>

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2610,146 +2610,30 @@ export namespace SQLite {
 /**
  * Svg
  */
-export interface SvgCommonProps {
-    fill?: string;
-    fillOpacity?: number | string;
-    fillRule?: 'nonzero' | 'evenodd';
-    opacity?: number | string;
-    stroke?: string;
-    strokeWidth?: number | string;
-    strokeOpacity?: number | string;
-    strokeLinecap?: string;
-    strokeLinejoin?: string;
-    strokeDasharray?: any[];
-    strokeDashoffset?: any;
-    transform?: string | object;
-    x?: number | string;
-    y?: number | string;
-    rotate?: number | string;
-    rotation?: number | string;
-    scale?: number | string;
-    origin?: number | string;
-    originX?: number | string;
-    originY?: number | string;
-    id?: string;
-    disabled?: boolean;
-    onPress?: () => any;
-    onPressIn?: () => any;
-    onPressOut?: () => any;
-    onLongPress?: () => any;
-    delayPressIn?: number;
-    delayPressOut?: number;
-    delayLongPress?: number;
-}
+import * as RNSvg from 'react-native-svg';
 
-export interface SvgRectProps extends SvgCommonProps {
-    width: number | string;
-    height: number | string;
-    rx?: number | string;
-    ry?: number | string;
-}
-
-export interface SvgCircleProps extends SvgCommonProps {
-    cx: number | string;
-    cy: number | string;
-    r: number | string;
-}
-
-export interface SvgEllipseProps extends SvgCommonProps {
-    cx: number | string;
-    cy: number | string;
-    rx: number | string;
-    ry: number | string;
-}
-
-export interface SvgLineProps extends SvgCommonProps {
-    x1: number | string;
-    y1: number | string;
-    x2: number | string;
-    y2: number | string;
-}
-
-export interface SvgPolyProps extends SvgCommonProps {
-    points: string;
-}
-
-export interface SvgPathProps extends SvgCommonProps {
-    d: string;
-}
-
-export interface SvgTextProps extends SvgCommonProps {
-    textAnchor?: string;
-    fontSize?: number | string;
-    fontWeight?: string;
-}
-
-export interface SvgTSpanProps extends SvgTextProps {
-    dx?: string;
-    dy?: string;
-}
-
-export interface SvgTextPathProps extends SvgCommonProps {
-    href?: string;
-    startOffset?: string;
-}
-
-export interface SvgUseProps extends SvgCommonProps {
-    href: string;
-    x: number | string;
-    y: number | string;
-    width?: number | string;
-    height?: number | string;
-}
-
-export interface SvgSymbolProps extends SvgCommonProps {
-    viewBox: string;
-    preserveAspectRatio?: string;
-    width: number | string;
-    height: number | string;
-}
-
-export interface SvgLinearGradientProps extends SvgCommonProps {
-    x1: number | string;
-    x2: number | string;
-    y1: number | string;
-    y2: number | string;
-}
-
-export interface SvgRadialGradientProps extends SvgCommonProps {
-    cx: number | string;
-    cy: number | string;
-    rx: number | string;
-    ry: number | string;
-    fx: number | string;
-    fy: number | string;
-    gradientUnits?: string;
-}
-
-export interface SvgStopProps extends SvgCommonProps {
-    offset?: string;
-    stopColor?: string;
-    stopOpacity?: string;
-}
-
-export class Svg extends Component<{ width: number, height: number, viewBox?: string, preserveAspectRatio?: string }> {
-    static Circle: ComponentClass<SvgCircleProps>;
-    static ClipPath: ComponentClass<SvgCommonProps>;
-    static Defs: ComponentClass;
-    static Ellipse: ComponentClass<SvgEllipseProps>;
-    static G: ComponentClass<SvgCommonProps>;
-    static Line: ComponentClass<SvgLineProps>;
-    static LinearGradient: ComponentClass<SvgLinearGradientProps>;
-    static Path: ComponentClass<SvgPathProps>;
-    static Polygon: ComponentClass<SvgPolyProps>;
-    static Polyline: ComponentClass<SvgPolyProps>;
-    static RadialGradient: ComponentClass<SvgRadialGradientProps>;
-    static Rect: ComponentClass<SvgRectProps>;
-    static Stop: ComponentClass<SvgStopProps>;
-    static Symbol: ComponentClass<SvgSymbolProps>;
-    static Text: ComponentClass<SvgTextProps>;
-    static TextPath: ComponentClass<SvgTextPathProps>;
-    static TSpan: ComponentClass<SvgTSpanProps>;
-    static Use: ComponentClass<SvgUseProps>;
+export class Svg extends RNSvg.Svg {
+    static Circle: typeof RNSvg.Circle;
+    static ClipPath: typeof RNSvg.ClipPath;
+    static Defs: typeof RNSvg.Defs;
+    static Ellipse: typeof RNSvg.Ellipse;
+    static G: typeof RNSvg.G;
+    static Image: typeof RNSvg.Image;
+    static Line: typeof RNSvg.Line;
+    static LinearGradient: typeof RNSvg.LinearGradient;
+    static Mask: typeof RNSvg.Mask;
+    static Path: typeof RNSvg.Path;
+    static Pattern: typeof RNSvg.Pattern;
+    static Polygon: typeof RNSvg.Polygon;
+    static Polyline: typeof RNSvg.Polyline;
+    static RadialGradient: typeof RNSvg.RadialGradient;
+    static Rect: typeof RNSvg.Rect;
+    static Stop: typeof RNSvg.Stop;
+    static Symbol: typeof RNSvg.Symbol;
+    static Text: typeof RNSvg.Text;
+    static TextPath: typeof RNSvg.TextPath;
+    static TSpan: typeof RNSvg.TSpan;
+    static Use: typeof RNSvg.Use;
 }
 // #endregion
 

--- a/types/expo/package.json
+++ b/types/expo/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "react-native-maps": "*"
+    "react-native-maps": "*",
+    "react-native-svg": "*"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-svg/blob/3e4505caa484188eb4dcc94e57011be9bdd0ce94/index.d.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`react-native-svg` comes with its own extensive typings, and the one currently in DT has a bunch of holes (I've sent 2 PRs recently, and my project still has a bunch of other errors). Re-using their typings seems ideal (and fixes all of the type errors in the SVGs in my project).

I'm not sure if the lost props exports are wanted?