### PR TITLE
[react-click-outside-hook] add type def for useClickOutside function

### DIFF
--- a/types/react-click-outside-hook/index.d.ts
+++ b/types/react-click-outside-hook/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Bryan Deloeste <https://github.com/bdeloeste>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
-import { MutableRefObject } from "react";
 
-export function useClickOutside<T>(): [MutableRefObject<T>, boolean];
+type HookReturnTuple = [((node?: Element | null) => void), boolean];
+
+export function useClickOutside(): HookReturnTuple;

--- a/types/react-click-outside-hook/index.d.ts
+++ b/types/react-click-outside-hook/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bdeloeste/react-click-outside-hook#readme
 // Definitions by: Bryan Deloeste <https://github.com/bdeloeste>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.8
 import { MutableRefObject } from "react";
 
 export function useClickOutside<T>(): [MutableRefObject<T>, boolean];

--- a/types/react-click-outside-hook/index.d.ts
+++ b/types/react-click-outside-hook/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-type HookReturnTuple = [((node?: Element | null) => void), boolean];
+export type HookReturnTuple = [((node?: Element | null) => void), boolean];
 
 export function useClickOutside(): HookReturnTuple;

--- a/types/react-click-outside-hook/index.d.ts
+++ b/types/react-click-outside-hook/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for react-click-outside-hook 1.0
+// Project: https://github.com/bdeloeste/react-click-outside-hook#readme
+// Definitions by: Bryan Deloeste <https://github.com/bdeloeste>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { MutableRefObject } from "react";
+
+export function useClickOutside<T>(): [MutableRefObject<T>, boolean];

--- a/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
+++ b/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { render } from "react-dom";
+
+import { useClickOutside } from "react-click-outside-hook";
+
+function Component() {
+    const [ref, hasClickedOutside] = useClickOutside<HTMLDivElement>();
+    return <div ref={ref}>{hasClickedOutside.toString()}</div>;
+}
+
+render(<Component />, document.getElementById("test"));

--- a/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
+++ b/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
@@ -4,7 +4,7 @@ import { render } from "react-dom";
 import { useClickOutside } from "react-click-outside-hook";
 
 function Component() {
-    const [ref, hasClickedOutside] = useClickOutside<HTMLDivElement>();
+    const [ref, hasClickedOutside] = useClickOutside();
     return <div ref={ref}>{hasClickedOutside.toString()}</div>;
 }
 

--- a/types/react-click-outside-hook/tsconfig.json
+++ b/types/react-click-outside-hook/tsconfig.json
@@ -10,7 +10,8 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
     },
     "files": ["index.d.ts", "react-click-outside-hook-tests.tsx"]
 }

--- a/types/react-click-outside-hook/tsconfig.json
+++ b/types/react-click-outside-hook/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "jsx": "react",
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-click-outside-hook-tests.tsx"]
+}

--- a/types/react-click-outside-hook/tslint.json
+++ b/types/react-click-outside-hook/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

`npm` run lint react-tag-autocomplete was already giving error, commented in this issue: [Cannot find module 'csstype'](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24788)

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
