### PR TITLE
Add string tuple possibility for .. and !..

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3179,9 +3179,9 @@ declare namespace sequelize {
         $notLike: string | WherePGStatement;
         $notILike: string | WherePGStatement;
         $between: [number, number] | [Date, Date];
-        "..": [number, number];
+        "..": [number, number] | [string, string];
         $notBetween: [number, number];
-        "!..": [number, number];
+        "!..": [number, number] | [string, string];
         $overlap: [number, number] | [string, string];
         "&&": [number, number];
         $contains: any;


### PR DESCRIPTION
While working on https://github.com/Microsoft/TypeScript/pull/30853, I saw that in the tests, there's a `".."` selector used with date-stamp strings (which is not (yet) caught as an error); it looks like those types are missing from the `WhereLogic` partial.