### PR TITLE
Remove animation property reference from semantic-ui-sidebar tests

### DIFF
--- a/types/semantic-ui-sidebar/semantic-ui-sidebar-tests.ts
+++ b/types/semantic-ui-sidebar/semantic-ui-sidebar-tests.ts
@@ -105,7 +105,6 @@ function test_sidebar() {
             method: 'method',
             pusher: 'pusher',
             movedSidebar: 'movedSidebar',
-            animation: 'animation',
             overlay: 'overlay',
             notFound: 'notFound'
         }


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853

The test seems wrong, since the library doesn't seem to use it - https://github.com/Semantic-Org/UI-Sidebar/blob/master/index.js#L1023