### PR TITLE
Remove unused conditions prop from revalidator test, add missing type…

### DIFF
--- a/types/revalidator/index.d.ts
+++ b/types/revalidator/index.d.ts
@@ -36,7 +36,9 @@ declare module Revalidator {
     }
 
     interface JSONSchema<T> {
+        type?: 'object';
         properties?: ISchemas<T>;
+        patternProperties?: ISchemas<T>;
     }
 
     interface ISchemas<T> {

--- a/types/revalidator/revalidator-tests.ts
+++ b/types/revalidator/revalidator-tests.ts
@@ -35,12 +35,7 @@ revalidator.validate(someObject, {
           properties: {
             title: {
               type: 'string',
-              maxLength: 140,
-              conditions: {
-                optional: function () {
-                  return !this.published;
-                }
-              }
+              maxLength: 140
             },
             date: { type: 'string', format: 'date', messages: { format: "must be a valid %{expected} and nothing else" } },
             body: { type: 'string' },


### PR DESCRIPTION
… and patternProperties fields

Found while looking at https://github.com/Microsoft/TypeScript/pull/30853. The missing fields seem to be an oversight, and the `conditions` property used in the test is simply wholly imaginary from what I can tell, as it's not referenced in either the json schema spec or within the library's source.