### PR TITLE
Use secureOptions in request tests, not securityOptions

### DIFF
--- a/types/request-promise-native/request-promise-native-tests.ts
+++ b/types/request-promise-native/request-promise-native-tests.ts
@@ -1,6 +1,7 @@
 import rpn = require('request-promise-native');
 import * as errors from 'request-promise-native/errors';
 import * as path from 'path';
+import constants = require('constants');
 
 rpn('http://www.google.com')
   .then(console.dir)
@@ -336,7 +337,7 @@ options = {
     // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
     // pfx: fs.readFileSync(pfxFilePath),
     passphrase: 'password',
-    securityOptions: 'SSL_OP_NO_SSLv3'
+    secureOptions: constants.SSL_OP_NO_SSLv3
   }
 };
 

--- a/types/request-promise/request-promise-tests.ts
+++ b/types/request-promise/request-promise-tests.ts
@@ -1,6 +1,7 @@
 import rp = require('request-promise');
 import errors = require('request-promise/errors');
 import * as path from "path";
+import constants = require('constants');
 
 rp('http://www.google.com')
     .then(console.dir)
@@ -355,7 +356,7 @@ options = {
         // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
         // pfx: fs.readFileSync(pfxFilePath),
         passphrase: 'password',
-        securityOptions: 'SSL_OP_NO_SSLv3'
+        secureOptions: constants.SSL_OP_NO_SSLv3
     }
 };
 

--- a/types/request/request-tests.ts
+++ b/types/request/request-tests.ts
@@ -6,6 +6,7 @@ import qs = require('querystring');
 import request = require('request');
 import stream = require('stream');
 import urlModule = require('url');
+import constants = require('constants');
 
 let value: any;
 let str: string;
@@ -540,7 +541,7 @@ options = {
         // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
         // pfx: fs.readFileSync(pfxFilePath),
         passphrase: 'password',
-        securityOptions: 'SSL_OP_NO_SSLv3'
+        secureOptions: constants.SSL_OP_NO_SSLv3
     }
 };
 


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853. "securityOptions" is fictional - there's no documentation reference of it anywhere.