### PR TITLE
Enable strict null checks on reflux

### DIFF
--- a/types/reflux/reflux-tests.tsx
+++ b/types/reflux/reflux-tests.tsx
@@ -48,7 +48,7 @@ Reflux.createAction({
 let action = Reflux.createAction();
 action = Reflux.createAction({ children: ['delayComplete'] });
 action = Reflux.createAction({ actionName: 'load' });
-action = Reflux.createAction({ preEmit: (id: number) => { console.log(id); }, shouldEmit: (id: number) => { console.log(id); return id > 0; } });
+action = Reflux.createAction({ preEmit: (id: number) => { console.log(id); return undefined; }, shouldEmit: (id: number) => { console.log(id); return id > 0; } });
 
 let actions = Reflux.createActions([{ actionName: 'fireBall' }, { actionName: 'magicMissile', sync: false }]);
 actions = Reflux.createActions({ fireBall: { sync: false } });

--- a/types/reflux/tsconfig.json
+++ b/types/reflux/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "jsx": "react",


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - the `preEmit` as written wasn't actually assignable to the `ActionDefinition` interface (`void` isn't assignable to `any[]`) and was falling back to the `object` check.

Plus - turning on strict function types for a library is good.