### PR TITLE
[shelljs] Added construct and function signatures for shelljs/ShellString

### DIFF
--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -966,7 +966,6 @@ export type ShellString = string & ShellReturnValue;
 
 export type ShellArray = string[] & ShellReturnValue;
 
-
 export interface ShellStringConstructor {
 	/**
 	 * Wraps a string (or array) value. This has all the string (or array) methods,

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -965,6 +965,51 @@ export type ShellString = string & ShellReturnValue;
 
 export type ShellArray = string[] & ShellReturnValue;
 
+export const ShellString: ShellStringFunction;
+
+export interface ShellStringFunction {
+	/**
+	 * Wraps a string (or array) value. This has all the string (or array) methods,
+	 * but also exposes extra methods: `.to()`, `.toEnd()`, and all the pipe-able
+	 * methods (ex. `.cat()`, `.grep()`, etc.).
+	 *
+	 * This can be easily converted into a string by calling `.toString()`.
+	 *
+	 * This type also exposes the corresponding command's stdout, stderr, and return status
+	 * code via the `.stdout` (string), `.stderr` (string), and `.code` (number) properties
+	 * respectively.
+	 *
+	 * Construct signature allows for:
+	 *
+	 * var foo = new ShellString('hello world');
+	 *
+	 * as per example in shelljs docs:
+	 * https://github.com/shelljs/shelljs#shellstringstr
+	 *
+	 * @param value 	The string value to wrap.
+	 * @return				A string-like object with special methods.
+	 */
+	new(value: string): ShellString;
+	new(value: string[]): ShellArray;
+
+	/**
+	 * Wraps a string (or array) value. This has all the string (or array) methods,
+	 * but also exposes extra methods: `.to()`, `.toEnd()`, and all the pipe-able
+	 * methods (ex. `.cat()`, `.grep()`, etc.).
+	 *
+	 * This can be easily converted into a string by calling `.toString()`.
+	 *
+	 * This type also exposes the corresponding command's stdout, stderr, and return status
+	 * code via the `.stdout` (string), `.stderr` (string), and `.code` (number) properties
+	 * respectively.
+	 *
+	 * @param value 	The string value to wrap.
+	 * @return				A string-like object with special methods.
+	 */
+	(value: string): ShellString;
+	(value: string[]): ShellArray;
+}
+
 export interface ChmodFunction {
 	/**
 	 * Alters the permissions of a file or directory by either specifying the absolute

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -966,9 +966,8 @@ export type ShellString = string & ShellReturnValue;
 
 export type ShellArray = string[] & ShellReturnValue;
 
-export const ShellString: ShellStringFunction;
 
-export interface ShellStringFunction {
+export interface ShellStringConstructor {
 	/**
 	 * Wraps a string (or array) value. This has all the string (or array) methods,
 	 * but also exposes extra methods: `.to()`, `.toEnd()`, and all the pipe-able
@@ -1010,6 +1009,8 @@ export interface ShellStringFunction {
 	(value: string): ShellString;
 	(value: string[]): ShellArray;
 }
+
+export const ShellString: ShellStringConstructor;
 
 export interface ChmodFunction {
 	/**

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -6,6 +6,7 @@
 //                 Paul Huynh <https://github.com/pheromonez>
 //                 Alexander Futász <https://github.com/aldafu>
 //                 ExE Boss <https://github.com/ExE-Boss>
+//                 Mirco Sanguineti <https://github.com/msanguineti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>

--- a/types/shelljs/make.d.ts
+++ b/types/shelljs/make.d.ts
@@ -39,4 +39,5 @@ declare global {
 	const tempdir: typeof shelljs.tempdir;
 	const touch: typeof shelljs.touch;
 	const uniq: typeof shelljs.uniq;
+	const ShellString: typeof shelljs.ShellString;
 }

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -89,24 +89,24 @@ const testPath = shell.env["path"];
 const version = shell.exec("node --version").stdout;
 
 // $ExpectType ShellString
-const version2 = shell.exec("node --version", {async: false});
+const version2 = shell.exec("node --version", { async: false });
 const output = version2.stdout;
 
 // $ExpectType ChildProcess
-const asyncVersion3 = shell.exec("node --version", {async: true});
+const asyncVersion3 = shell.exec("node --version", { async: true });
 let pid = asyncVersion3.pid;
 
 declare let isAsync: boolean;
 
 // $ExpectType ShellString | ChildProcess
-const unknownUntilRuntime = shell.exec("node --version", {async: isAsync});
+const unknownUntilRuntime = shell.exec("node --version", { async: isAsync });
 
-shell.exec("node --version", {silent: true}, (code, stdout, stderr) => {
+shell.exec("node --version", { silent: true }, (code, stdout, stderr) => {
 	const version = stdout;
 });
 shell.exec(
 	"node --version",
-	{silent: true, async: true, cwd: "/usr/local/bin"},
+	{ silent: true, async: true, cwd: "/usr/local/bin" },
 	(code, stdout, stderr) => {
 		const version = stdout;
 	}
@@ -149,18 +149,18 @@ shell.touch("-c", "/Users/brandom/test1");
 shell.touch("-c", "/Users/brandom/test1", "/Users/brandom/test2");
 shell.touch("-c", ["/Users/brandom/test1", "/Users/brandom/test2"]);
 
-shell.touch({"-r": "/some/file.txt"}, "/Users/brandom/test1");
+shell.touch({ "-r": "/some/file.txt" }, "/Users/brandom/test1");
 shell.touch(
-	{"-r": "/some/file.txt"},
+	{ "-r": "/some/file.txt" },
 	"/Users/brandom/test1",
 	"/Users/brandom/test2"
 );
-shell.touch({"-r": "/oome/file.txt"}, [
+shell.touch({ "-r": "/oome/file.txt" }, [
 	"/Users/brandom/test1",
 	"/Users/brandom/test2"
 ]);
 
-shell.head({"-n": 1}, "file*.txt");
+shell.head({ "-n": 1 }, "file*.txt");
 shell.head("file1", "file2");
 shell.head(["file1", "file2"]); // same as above
 
@@ -169,7 +169,7 @@ shell.sort("-r", "foo.txt");
 shell.sort("-r", ["file.txt"]);
 shell.sort(["file.txt"]);
 
-shell.tail({"-n": 1}, "file*.txt");
+shell.tail({ "-n": 1 }, "file*.txt");
 shell.tail("file1", "file2");
 shell.tail(["file1", "file2"]); // same as above
 
@@ -195,4 +195,10 @@ shell.config.globOptions = {
 shell
 	.ls("dir")
 	.grep(/^stuff/)
-	.head({"-n": 5}).stdout;
+	.head({ "-n": 5 }).stdout;
+
+const foo = new shell.ShellString('hello world');
+const farr = new shell.ShellString(['hello', 'world']);
+
+const bar = shell.ShellString('hello world');
+const barr = shell.ShellString(['hello', 'world']);

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -89,24 +89,24 @@ const testPath = shell.env["path"];
 const version = shell.exec("node --version").stdout;
 
 // $ExpectType ShellString
-const version2 = shell.exec("node --version", { async: false });
+const version2 = shell.exec("node --version", {async: false});
 const output = version2.stdout;
 
 // $ExpectType ChildProcess
-const asyncVersion3 = shell.exec("node --version", { async: true });
+const asyncVersion3 = shell.exec("node --version", {async: true});
 let pid = asyncVersion3.pid;
 
 declare let isAsync: boolean;
 
 // $ExpectType ShellString | ChildProcess
-const unknownUntilRuntime = shell.exec("node --version", { async: isAsync });
+const unknownUntilRuntime = shell.exec("node --version", {async: isAsync});
 
-shell.exec("node --version", { silent: true }, (code, stdout, stderr) => {
+shell.exec("node --version", {silent: true}, (code, stdout, stderr) => {
 	const version = stdout;
 });
 shell.exec(
 	"node --version",
-	{ silent: true, async: true, cwd: "/usr/local/bin" },
+	{silent: true, async: true, cwd: "/usr/local/bin"},
 	(code, stdout, stderr) => {
 		const version = stdout;
 	}
@@ -149,18 +149,18 @@ shell.touch("-c", "/Users/brandom/test1");
 shell.touch("-c", "/Users/brandom/test1", "/Users/brandom/test2");
 shell.touch("-c", ["/Users/brandom/test1", "/Users/brandom/test2"]);
 
-shell.touch({ "-r": "/some/file.txt" }, "/Users/brandom/test1");
+shell.touch({"-r": "/some/file.txt"}, "/Users/brandom/test1");
 shell.touch(
-	{ "-r": "/some/file.txt" },
+	{"-r": "/some/file.txt"},
 	"/Users/brandom/test1",
 	"/Users/brandom/test2"
 );
-shell.touch({ "-r": "/oome/file.txt" }, [
+shell.touch({"-r": "/oome/file.txt"}, [
 	"/Users/brandom/test1",
 	"/Users/brandom/test2"
 ]);
 
-shell.head({ "-n": 1 }, "file*.txt");
+shell.head({"-n": 1}, "file*.txt");
 shell.head("file1", "file2");
 shell.head(["file1", "file2"]); // same as above
 
@@ -169,7 +169,7 @@ shell.sort("-r", "foo.txt");
 shell.sort("-r", ["file.txt"]);
 shell.sort(["file.txt"]);
 
-shell.tail({ "-n": 1 }, "file*.txt");
+shell.tail({"-n": 1}, "file*.txt");
 shell.tail("file1", "file2");
 shell.tail(["file1", "file2"]); // same as above
 
@@ -195,10 +195,10 @@ shell.config.globOptions = {
 shell
 	.ls("dir")
 	.grep(/^stuff/)
-	.head({ "-n": 5 }).stdout;
+	.head({"-n": 5}).stdout;
 
 const foo = new shell.ShellString('hello world');
 const farr = new shell.ShellString(['hello', 'world']);
 
-const bar = shell.ShellString('hello world');
+const boo = shell.ShellString('hello world');
 const barr = shell.ShellString(['hello', 'world']);


### PR DESCRIPTION
Please refer to #34614

I had to re-submit the code since I've botched it by rebasing my branch... Note to self: walk away from computing machinery when half asleep.

The signatures are both function and construct. They take only 1 parameter (either a `string` or a `string[]`) to comply with the docs and not to mess with the private API.

@gkalpak  sorry again for the mishap.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/shelljs/shelljs#shellstringstr
