### PR TITLE
stripe: Update missing fields and add a deprecated field for backward…

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -886,6 +886,13 @@ declare namespace Stripe {
             receipt_number: string | null;
 
             /**
+             * This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the
+             * latest state of the charge, including any refunds. If the charge is for an Invoice, the
+             * receipt will be stylized as an Invoice receipt.
+             */
+            receipt_url: string;
+
+            /**
              * Whether or not the charge has been fully refunded. If the charge is only partially refunded,
              * this attribute will still be false.
              */
@@ -1501,6 +1508,11 @@ declare namespace Stripe {
              */
             email?: string;
 
+            /**
+             * The prefix for the customer used to generate unique invoice numbers.
+             */
+            invoice_prefix?: string;
+
             shipping?: IShippingInformation;
 
             /**
@@ -2112,6 +2124,11 @@ declare namespace Stripe {
             statement_descriptor: string;
 
             /**
+             * The status of the invoice, one of draft, open, paid, uncollectible, or void.
+             */
+            status: string;
+
+            /**
              * The subscription that this invoice was prepared for, if any.
              */
             subscription: string | subscriptions.ISubscription;
@@ -2214,6 +2231,11 @@ declare namespace Stripe {
              * type is already subscription, as it'd be redundant with id.
              */
             subscription: string;
+
+            /**
+             * The subscription item that generated this invoice item. Left empty if the line item is not an explicit result of a subscription.
+             */
+            subscription_item: string;
 
             /**
              * A string identifying the type of the source of this line item, either an invoiceitem or a subscription
@@ -2411,6 +2433,11 @@ declare namespace Stripe {
              * or it can be a dictionary with the following options:
              */
             created?: IDateFilter;
+
+            /**
+             * @deprecated Use created property instead as of api version 2019-03-14.
+             */
+            date?: IDateFilter;
 
             /**
              * The identifier of the customer whose invoices to return. If none is provided, all invoices will be returned.


### PR DESCRIPTION
…s compatibility

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
Include the receipt url on charges:
https://stripe.com/docs/api/charges/object#charge_object-receipt_url

Include invoice status on invoice:
https://stripe.com/docs/api/invoices/object

Add back deprecated option for those still on older api versions:
https://stripe.com/docs/upgrades#2019-03-14

Include invoice_prefix for customer object in ICustomerUpdateOptions:
https://stripe.com/docs/api/customers/object#customer_object-invoice_prefix and is updatable: https://stripe.com/docs/api/customers/update

Include subscription_item on invoice line item:
https://stripe.com/docs/api/invoices/line_item
