### PR TITLE
Fix typo in mangopay tests

### DIFF
--- a/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
+++ b/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
@@ -277,7 +277,7 @@ api.Wallets.create({
 });
 
 const wallet = new api.models.Wallet({
-  Currency: "GB",
+  Currency: "GBP",
   Description: "A description",
   Owners: ["user-id"]
 });


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - the weaker `UpdateWallet` type previously meant this this was assignable to the constructor type, even though it had a `Currency` field with the incorrect type.