### PR TITLE
Add missing message field to DrawErrorOptions

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -453,6 +453,7 @@ declare module 'leaflet' {
 		interface DrawErrorOptions {
 			color?: string;
 			timeout?: number;
+			message?: string;
 		}
 	}
 


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - It seems to be used in [the code](https://github.com/Leaflet/Leaflet.draw/blob/master/src/draw/handler/Draw.Polyline.js#L55) which is linked when you look for the options docs, and is used in the test, so it seems to actually exist and was just missing from the type.