### PR TITLE
Mark parameters in knockout test as optional

### DIFF
--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -650,7 +650,7 @@ function test_Components() {
         ko.components.register("name", { template: "string-template", viewModel: { instance: null } });
 
         // viewModel from createViewModel factory method
-        ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: KnockoutComponentTypes.ComponentInfo) { return null; } } });
+        ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params?: any, componentInfo?: KnockoutComponentTypes.ComponentInfo) { return null; } } });
 
         // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - the cb as written required `ComponentInfo` to be present, but the signature it's being assigned to has it as optional. Prior to the linked PR, the union with `KnockoutComponentTypes.EmptyConfig` hid this bug, as pretty much anything is assignable to the empty config.