### PR TITLE
Remove excess proprty and TODO from inert

### DIFF
--- a/types/hapi__inert/hapi__inert-tests.ts
+++ b/types/hapi__inert/hapi__inert-tests.ts
@@ -97,8 +97,7 @@ const provision = async () => {
                         return [''];
                     }
                     return new Error('');
-                },
-                BAD_listing: true,
+                }
             },
         },
         options: { files: { relativeTo: __dirname } }

--- a/types/inert/inert-tests.ts
+++ b/types/inert/inert-tests.ts
@@ -98,7 +98,6 @@ const provision = async () => {
                     }
                     return new Error('');
                 },
-                BAD_listing: true,
             },
         },
         options: { files: { relativeTo: __dirname } }

--- a/types/inert/v4/inert-tests.ts
+++ b/types/inert/v4/inert-tests.ts
@@ -121,8 +121,7 @@ server.route({
                     return [''];
                 }
                 return new Error('');
-            },
-            BAD_listing: true,  // TODO change typings to make this error
+            }
         },
     },
     config: { files: { relativeTo: __dirname } }


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 which _will_ mark these as an error, as desired. (There's no great way to make a version-conditional `$ExpectError`, so i'm just removing the prop so DT stays clean)