### PR TITLE
Remove excess proprty from hapi tests

### DIFF
--- a/types/hapi/test/server/server-decorations.ts
+++ b/types/hapi/test/server/server-decorations.ts
@@ -26,8 +26,7 @@ server.route({
     handler: {
         test: {
             test: 123,
-        },
-        asd: 1,
+        }
     }
 });
 

--- a/types/hapi/v17/test/server/server-decorations.ts
+++ b/types/hapi/v17/test/server/server-decorations.ts
@@ -26,8 +26,7 @@ server.route({
     handler: {
         test: {
             test: 123,
-        },
-        asd: 1,
+        }
     }
 });
 


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - `asd` is never augmented into `HandlerDecorations` in any tests, so it's excess and, with the mentioned PR, an error.