### PR TITLE
Remove h2o2 todo

### DIFF
--- a/types/h2o2/h2o2-tests.ts
+++ b/types/h2o2/h2o2-tests.ts
@@ -133,8 +133,7 @@ const badProtocolDemo: hapi.ServerRoute = {
     handler: {
         proxy: {
             host: '10.33.33.1',
-            port: '443',
-            BAD_protocol: 'https'  // TODO change typings to fix this / submit bug report
+            port: '443'
             // port: null // detected as incompatible
         }
     }


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - which _does_ make this into an error, just like the TODO wants. (Without conditional $ExpectError's there's no good way to test it, though)