### PR TITLE
Adjust datatables.net-buttons export optiosn to reflect test that shows passing jquery nodes as columns

### DIFF
--- a/types/datatables.net-buttons/index.d.ts
+++ b/types/datatables.net-buttons/index.d.ts
@@ -437,8 +437,9 @@ declare namespace DataTables {
         //#endregion ColVis
     }
 
+    type ButtonSelectorTypes = string | number | JQuery<any>;
     interface ButtonExportOptions {
-        columns?: string | number | string[] | number[];
+        columns?: ButtonSelectorTypes | ButtonSelectorTypes[];
     }
 
     type FunctionButtonCustomizeData = (content: any) => void;


### PR DESCRIPTION
Found while working on https://github.com/Microsoft/TypeScript/pull/30853 - as is, the jquery selectors would cause the assignment to the well-types object to fail and then fall back to the `object` member of the union, losing strict typing. With better excess property checking, we identify the issue.