### PR TITLE
[@types/prop-types] Add support of `as const` to oneOf

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -65,7 +65,7 @@ export const element: Requireable<ReactElementLike>;
 export const symbol: Requireable<symbol>;
 export const elementType: Requireable<ReactComponentLike>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
-export function oneOf<T>(types: T[]): Requireable<T>;
+export function oneOf<T>(types: ReadonlyArray<T>): Requireable<T>;
 export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
 export function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
 export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T; }>;

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -79,8 +79,8 @@ export function exact<P extends ValidationMap<any>>(type: P): Requireable<Requir
  * @param typeSpecs Map of name to a ReactPropType
  * @param values Runtime values that need to be type-checked
  * @param location e.g. "prop", "context", "child context"
- * @param componentName Name of the component for error messages.
- * @param getStack Returns the component stack.
+ * @param componentName Name of the component for error messages
+ * @param getStack Returns the component stack
  */
 export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;
 


### PR DESCRIPTION
### Common way before https://github.com/Microsoft/TypeScript/pull/29510 was to use `tuple` trick

```ts
export const tuple = <T extends string[]>(...args: T) => args;
const sizes = tuple('default', 'large');
export type SizeType = typeof sizes[number];

export const Button = (props: { size: SizeType }) => <div></div>;

Button.propTypes = {
  size: PropTypes.oneOf(sizes),
};
```

### After https://github.com/Microsoft/TypeScript/pull/29510 has landed we could use `as const`
```ts
const sizes = ['default', 'large'] as const;
export type SizeType = typeof sizes[number];

export const Button = (props: { size: SizeType }) => <div></div>;

Button.propTypes = {
  size: PropTypes.oneOf(sizes),   // Error: Type 'readonly ["default", "large"]' is missing the following properties from type '{}[]': pop, push, reverse, shift and 6 more. [2345]
};
```

### Some evidence
`tuple` is pretty common approach, for example, it is used in [ant.design](https://github.com/ant-design/ant-design/blob/eba49beecd9d0617b34195137ce36b5f56679a00/components/button/button.tsx#L43)

### Change
Change is to replace type `T[]` of `oneOf` parameter with `ReadonlyArray<T>`.
This change relaxes requirement for an Array.

> Also I tried `readonly T[]` and it works fine too. But this is [pretty new feature](https://github.com/Microsoft/TypeScript/pull/29435)

### Tested
This change was tested on my project and I used `as const` in part of code location, while keeping old way for another part of code locations. Both old and new ways work fine.
