### PR TITLE
Add defition of non npm package amap-js-api-city-search

### DIFF
--- a/types/amap-js-api-city-search/amap-js-api-city-search-tests.ts
+++ b/types/amap-js-api-city-search/amap-js-api-city-search-tests.ts
@@ -1,0 +1,63 @@
+// $ExpectType CitySearch
+const citySearch = new AMap.CitySearch();
+
+citySearch.getLocalCity((status, result) => {
+    const statusTemp: 'error' | 'complete' | 'no_data' = status;
+    if (typeof result !== 'string') {
+        // $ExpectType SearchResult
+        result;
+        // $ExpectType string
+        result.adcode;
+        // $ExpectType Bounds
+        result.bounds;
+        // $ExpectType string
+        result.city;
+        // $ExpectType string
+        result.info;
+        // $ExpectType string
+        result.infocode;
+        // $ExpectType string
+        result.province;
+        // $ExpectType string
+        result.rectangle;
+        // $ExpectType string
+        result.status;
+    } else {
+        // $ExpectType string
+        result;
+    }
+});
+
+// $ExpectType void
+citySearch.getCityByIp('ip', (status, result) => {
+    const statusTemp: 'error' | 'complete' | 'no_data' = status;
+    const resultTemp: AMap.CitySearch.SearchResult | string = result;
+});
+
+citySearch.on('complete', (event: AMap.CitySearch.EventMap['complete']) => {
+    // $ExpectType "complete"
+    event.type;
+    // $ExpectType string
+    event.adcode;
+    // $ExpectType Bounds
+    event.bounds;
+    // $ExpectType string
+    event.city;
+    // $ExpectType string
+    event.info;
+    // $ExpectType string
+    event.infocode;
+    // $ExpectType string
+    event.province;
+    // $ExpectType string
+    event.rectangle;
+    // $ExpectType string
+    event.status;
+});
+
+citySearch.on('error', (event: AMap.CitySearch.EventMap['error']) => {
+    // $ExpectType string
+    event.info;
+    // $ExpectType "error"
+    event.type;
+});

--- a/types/amap-js-api-city-search/index.d.ts
+++ b/types/amap-js-api-city-search/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for non-npm package amap-js-api-city-search 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/location#m_AMap.CitySearch
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace CitySearch {
+        interface EventMap {
+            complete: Event<'complete', SearchResult>;
+            error: Event<'error', { info: string }>;
+        }
+        interface SearchResult {
+            /**
+             * 城市名称
+             */
+            city: string;
+            rectangle: string;
+            /**
+             * 城市范围
+             */
+            bounds: Bounds;
+            /**
+             * 成功信息
+             */
+            info: string;
+            /**
+             * 地区编号
+             */
+            adcode: string;
+            /**
+             * 查询信息码
+             */
+            infocode: string;
+            /**
+             * 省份
+             */
+            province: string;
+            /**
+             * 查询状态
+             */
+            status: string;
+        }
+        type SearchStatus = 'error' | 'complete' | 'no_data';
+    }
+    /**
+     * 根据IP返回对应城市信息
+     */
+    class CitySearch extends EventEmitter {
+        /**
+         * 自动获取用户IP，回调返回当前用户所在城市
+         * @param callback 查询回调
+         */
+        getLocalCity(callback: (status: CitySearch.SearchStatus, result: CitySearch.SearchResult | string) => void): void;
+        /**
+         * 根据输入IP地址返回对应城市信息
+         * @param ip IP
+         * @param callback 查询回调
+         */
+        getCityByIp(
+            ip: string,
+            callback: (status: CitySearch.SearchStatus, result: CitySearch.SearchResult | string) => void
+        ): void;
+    }
+}

--- a/types/amap-js-api-city-search/tsconfig.json
+++ b/types/amap-js-api-city-search/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-city-search-tests.ts"
+    ]
+}

--- a/types/amap-js-api-city-search/tslint.json
+++ b/types/amap-js-api-city-search/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
