### PR TITLE
feat: add types for object.pick

### DIFF
--- a/types/object.pick/index.d.ts
+++ b/types/object.pick/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for object.pick 1.3
+// Project: https://github.com/jonschlinkert/object.pick
+// Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/**
+ * Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.
+ *
+ * @param object
+ * @param keys
+ */
+declare function pick<T extends object, U extends keyof T>(object: T, keys: U[]): Pick<T, U>;
+
+export = pick;

--- a/types/object.pick/object.pick-tests.ts
+++ b/types/object.pick/object.pick-tests.ts
@@ -1,0 +1,3 @@
+import pick = require('object.pick');
+
+pick({a: 'a', b: 'b'}, ['a']);

--- a/types/object.pick/tsconfig.json
+++ b/types/object.pick/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "strictFunctionTypes": true,
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object.pick-tests.ts"
+    ]
+}

--- a/types/object.pick/tslint.json
+++ b/types/object.pick/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
