### PR TITLE
[copy-webpack-plugin] fix transform parameter

### DIFF
--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+/// <reference types="node"/>
+
 import { Plugin } from 'webpack'
 import { IOptions } from 'minimatch'
 
@@ -44,7 +46,7 @@ interface CopyPattern {
 	/** Additional globs to ignore for this pattern. (default: `[]`) */
 	ignore?: Array<string | MiniMatchGlob>
 	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
-	transform?: (content: string, path: string) => string
+	transform?: (content: Buffer, path: string) => string
 	/** Enable transform caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. (default: `false`) */
 	cache?: boolean | { key: string }
 	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -46,7 +46,7 @@ interface CopyPattern {
 	/** Additional globs to ignore for this pattern. (default: `[]`) */
 	ignore?: Array<string | MiniMatchGlob>
 	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
-	transform?: (content: Buffer, path: string) => string
+	transform?: (content: Buffer, path: string) => string | Buffer
 	/** Enable transform caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. (default: `false`) */
 	cache?: boolean | { key: string }
 	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */


### PR DESCRIPTION
the `content` parameter of `transform` is a `Buffer`, not a `string`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This isn't documented explicitly, but it is a buffer. I'm 100% positive of this.