### PR TITLE
[@types/jpeg-autorotate] Update for 5.0

### DIFF
--- a/types/jpeg-autorotate/index.d.ts
+++ b/types/jpeg-autorotate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jpeg-autorotate 4.0
+// Type definitions for jpeg-autorotate 5.0
 // Project: https://github.com/johansatge/jpeg-autorotate#readme
 // Definitions by: Slessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -19,13 +19,33 @@ export interface CustomError extends Error {
     code: errors;
 }
 
+export interface RotateOptions {
+    quality?: number;
+}
+
+export interface RotateDimensions {
+    height: number;
+    width: number;
+}
+
 export function rotate(
     path_or_buffer: string | Buffer,
-    options?: { quality?: number },
+    options?: RotateOptions,
+): Promise<{
+    buffer: Buffer;
+    orientation: number;
+    dimensions: RotateDimensions;
+    quality: number;
+}>;
+
+export function rotate(
+    path_or_buffer: string | Buffer,
+    options?: RotateOptions,
     module_callback?: (
         error: CustomError | null,
-        buffer: Buffer | null,
+        buffer: Buffer,
         orientation: number | null,
-        dimensions: { height: number; width: number } | null,
+        dimensions: RotateDimensions | null,
+        quality: number | null,
     ) => void,
 ): void;

--- a/types/jpeg-autorotate/index.d.ts
+++ b/types/jpeg-autorotate/index.d.ts
@@ -30,7 +30,7 @@ export interface RotateDimensions {
 
 export function rotate(
     path_or_buffer: string | Buffer,
-    options?: RotateOptions,
+    options: RotateOptions,
 ): Promise<{
     buffer: Buffer;
     orientation: number;
@@ -40,7 +40,7 @@ export function rotate(
 
 export function rotate(
     path_or_buffer: string | Buffer,
-    options?: RotateOptions,
+    options: RotateOptions,
     module_callback?: (
         error: CustomError | null,
         buffer: Buffer,

--- a/types/jpeg-autorotate/jpeg-autorotate-tests.ts
+++ b/types/jpeg-autorotate/jpeg-autorotate-tests.ts
@@ -1,7 +1,7 @@
 import * as jo from "jpeg-autorotate";
 
-jo.rotate("img.jpg");
-jo.rotate(new Buffer(""));
+jo.rotate("img.jpg", {});
+jo.rotate(new Buffer(""), {});
 jo.rotate(new Buffer(""), { quality: 50 });
 jo.rotate("img.jpg", { quality: 100 }, (error, buffer, orientation, dimensions, quality) => {
     if (error && error.code === jo.errors.correct_orientation) {

--- a/types/jpeg-autorotate/jpeg-autorotate-tests.ts
+++ b/types/jpeg-autorotate/jpeg-autorotate-tests.ts
@@ -3,21 +3,36 @@ import * as jo from "jpeg-autorotate";
 jo.rotate("img.jpg");
 jo.rotate(new Buffer(""));
 jo.rotate(new Buffer(""), { quality: 50 });
-jo.rotate("img.jpg", { quality: 100 }, (error, buffer, orientation, dimensions) => {
+jo.rotate("img.jpg", { quality: 100 }, (error, buffer, orientation, dimensions, quality) => {
     if (error && error.code === jo.errors.correct_orientation) {
         console.log("The orientation of this image is already correct!");
     }
 
     if (orientation) {
-        console.log("Orientation was: " + orientation);
+        console.log(`Orientation was: ${orientation}`);
     }
 
     if (dimensions) {
-        console.log("Height after rotation: " + dimensions.height);
-        console.log("Width after rotation: " + dimensions.width);
+        console.log(`Dimensions after rotation: ${dimensions.width}x${dimensions.height}`);
     }
 
-    if (buffer) {
-        buffer.readInt8(0);
+    if (quality) {
+        console.log(`Quality: ${quality}`);
     }
+
+    buffer.readInt8(0);
 });
+
+jo.rotate("img.jpg", { quality: 100 })
+    .then(({ buffer, orientation, dimensions, quality }) => {
+        console.log(`Orientation was: ${orientation}`);
+        console.log(`Dimensions after rotation: ${dimensions.width}x${dimensions.height}`);
+        console.log(`Quality: ${quality}`);
+
+        buffer.readInt8(0);
+    })
+    .catch((error: jo.CustomError) => {
+        if (error && error.code === jo.errors.correct_orientation) {
+            console.log("The orientation of this image is already correct!");
+        }
+    });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/johansatge/jpeg-autorotate#changelog
> tl;dr rotate() will now return a promise if no callback is specified
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
