### PR TITLE
[request-promise] add export RequestPromiseAPI

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -22,11 +22,12 @@ declare namespace requestPromise {
         resolveWithFullResponse?: boolean;
     }
 
+    type RequestPromiseAPI = request.RequestAPI<RequestPromise, RequestPromiseOptions, request.RequiredUriUrl>;
     type FullResponse = request.Response;
     type OptionsWithUri = request.UriOptions & RequestPromiseOptions;
     type OptionsWithUrl = request.UrlOptions & RequestPromiseOptions;
     type Options = OptionsWithUri | OptionsWithUrl;
 }
 
-declare const requestPromise: request.RequestAPI<requestPromise.RequestPromise, requestPromise.RequestPromiseOptions, request.RequiredUriUrl>;
+declare const requestPromise: requestPromise.RequestPromiseAPI;
 export = requestPromise;

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -28,10 +28,11 @@ declare namespace requestPromise {
         resolveWithFullResponse?: boolean;
     }
 
+    type RequestPromiseAPI = request.RequestAPI<RequestPromise, RequestPromiseOptions, request.RequiredUriUrl>;
     type OptionsWithUri = request.UriOptions & RequestPromiseOptions;
     type OptionsWithUrl = request.UrlOptions & RequestPromiseOptions;
     type Options = OptionsWithUri | OptionsWithUrl;
 }
 
-declare var requestPromise: request.RequestAPI<requestPromise.RequestPromise, requestPromise.RequestPromiseOptions, request.RequiredUriUrl>;
+declare const requestPromise: requestPromise.RequestPromiseAPI;
 export = requestPromise;


### PR DESCRIPTION
[request.defaults();](https://github.com/request/request#requestdefaultsoptions) return type
![image](https://user-images.githubusercontent.com/1300172/56180703-6f6dfd80-6045-11e9-8276-908d629cd4f8.png)

Exports to be used for external type declarations.

**Using**
```ts
import * as request from 'request-promise';

class Test {
  public request: request.RequestPromiseAPI;

  constructor() {
    this.request = request.defaults({});
    this.request.get({ url: '' });
  }
}
```
