### PR TITLE
node-red: Fix RED.nodes.getNode return type

### DIFF
--- a/types/node-red/index.d.ts
+++ b/types/node-red/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for node-red 0.17
+// Type definitions for node-red 0.20
 // Project: http://nodered.org
 // Definitions by: Anders E. Andersen <https://github.com/andersea>
 //                 Thomas B. Mørch <https://github.com/tbowmo>
+//                 Bernardo Belchior <https://github.com/bernardobelchior>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.4
 
 /// <reference types="node" />
 

--- a/types/node-red/index.d.ts
+++ b/types/node-red/index.d.ts
@@ -173,9 +173,9 @@ export interface Nodes {
      * node, this call is used to get access to the running
      * instance.
      * @param id - the id of the node.
-     * @return - the node matching the given id.
+     * @return - the node matching the given id, or null if it does not exist.
      */
-    getNode(id: NodeId): Node;
+    getNode(id: NodeId): Node | null;
     /**
      * Cycle through all node definition objects.
      *


### PR DESCRIPTION
Update getNode return type, since the 'id' may not map to a valid node. In this case, node-red will return null.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-red/node-red/blob/0.20.5/packages/node_modules/%40node-red/runtime/lib/nodes/flows/index.js#L208
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.