### PR TITLE
Fix errors from Microsoft/TypeScript#30769

### DIFF
--- a/types/activex-libreoffice/activex-libreoffice-tests.ts
+++ b/types/activex-libreoffice/activex-libreoffice-tests.ts
@@ -129,7 +129,7 @@
 
     function createStruct<K extends keyof LibreOffice.StructNameMap>(strTypeName: K): LibreOffice.StructNameMap[K] {
         const classSize = coreReflection.forName(strTypeName);
-        const aStruct: [LibreOffice.StructNameMap[K]] = [] as any;
+        const aStruct: [LibreOffice.InstantiableNameMap[K]] = [] as any;
         classSize.createObject(aStruct);
         return aStruct[0];
     }

--- a/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -779,7 +779,7 @@ class MyCustomBody extends React.Component<MyCustomBodyProps> implements ModalBo
   getFieldValue() {
     const newRow: Partial<Product> = {};
     this.props.columns.forEach((column, i) => {
-      newRow[column.field] = (this.refs[column.field] as HTMLInputElement).value;
+      newRow[column.field] = (this.refs[column.field] as HTMLInputElement).value as number & string;
     }, this);
     return newRow as Product;
   }


### PR DESCRIPTION
Microsoft/TypeScript#30769 is now in `typescript@next` and finds a couple of bugs in tests.

active-libreoffice's test code was wrong, and easy to fix because it was just using the wrong type. 

react-bootstrip-table's test code is harder to fix, since the ref's value is known to be a string, but all of `newRow`'s properties are numbers except one, so the code is guaranteed to be wrong for all but one property. 

For now I just put a cast in, but production code should probably also add a type check beforehand: `if (typeof newRow[column.field] === 'string')`. TS doesn't narrow on computed element access so the cast is still necessary.