### PR TITLE
[React] Preserve optionality of props in union types

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2760,6 +2760,7 @@ declare namespace React {
     }
 }
 
+type DistributivePick<T, K extends keyof T> = T extends any ? Pick<T, K> : never;
 // naked 'any' type in a conditional type will short circuit and union both the then/else branches
 // so boolean is only resolved for T = any
 type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false;
@@ -2774,11 +2775,11 @@ type MergePropTypes<P, T> =
         // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
         string extends keyof P ? P :
             // Prefer declared types which are not exactly any
-            & Pick<P, NotExactlyAnyPropertyKeys<P>>
+            & DistributivePick<P, NotExactlyAnyPropertyKeys<P>>
             // For props which are exactly any, use the type inferred from propTypes if present
-            & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
+            & DistributivePick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
             // Keep leftover props not specified in propTypes
-            & Pick<P, Exclude<keyof P, keyof T>>;
+            & DistributivePick<P, Exclude<keyof P, keyof T>>;
 
 // Any prop that has a default prop becomes optional, but its type is unchanged
 // Undeclared default props are augmented into the resulting allowable attributes

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -272,3 +272,5 @@ interface LeaveMeAloneDtslint { foo: string; }
 // const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
 // const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
 // const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };
+
+// const optionalUnionPropTest: JSX.LibraryManagedAttributes<{ propTypes: {} }, { optional?: string } | { optional?: number }> = {};


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Fixes #34589
- [x] ~Increase the version number in the header if appropriate.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

Test results: [test.log](https://github.com/DefinitelyTyped/DefinitelyTyped/files/3087672/test.log)
There are two test failures: one each in `react-bootstrap-table` and `recompose`. I confirmed that they are pre-existing, presumably due to nightly TS changes. Please let me know if these need to be addressed in this PR.

This addresses an issue introduced in #34386 where optional props in union types were reverted to being required.

Thanks for the pointer on `DistributivePick`, @ferdaber; it works great!
This approach does further deepen the definition which does not bode well for #34588. However, I would consider this fix a priority over the deepness issue since the latter issue was resolved in user-land. When I get some more time, I'm going to look into alternate solutions that would help to keep `MergePropTypes` more shallow.
