### PR TITLE
Remove excess proprty from hapi tests

### DIFF
--- a/types/hapi__hapi/test/server/server-decorations.ts
+++ b/types/hapi__hapi/test/server/server-decorations.ts
@@ -26,8 +26,7 @@ server.route({
     handler: {
         test: {
             test: 123,
-        },
-        asd: 1,
+        }
     }
 });
 


### PR DESCRIPTION
Found while working on Microsoft/TypeScript#30853 - asd is never augmented into HandlerDecorations in any tests, so it's excess and, with the mentioned PR, an error.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34701 but again for the new location of the types, pretty much.
