### PR TITLE
elasticsearch: add include_type_name for the relevant Indices APIs

### DIFF
--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1121,6 +1121,7 @@ export interface IndicesCloseParams extends GenericParams {
 }
 
 export interface IndicesCreateParams extends GenericParams {
+    includeTypeName?: boolean;
     waitForActiveShards?: string;
     timeout?: TimeSpan;
     masterTimeout?: TimeSpan;
@@ -1199,6 +1200,7 @@ export interface IndicesForcemergeParams extends GenericParams {
 }
 
 export interface IndicesGetParams extends GenericParams {
+    includeTypeName?: boolean;
     local?: boolean;
     ignoreUnavailable?: boolean;
     allowNoIndices?: boolean;
@@ -1220,6 +1222,7 @@ export interface IndicesGetAliasParams extends GenericParams {
 }
 
 export interface IndicesGetFieldMappingParams extends GenericParams {
+    includeTypeName?: boolean;
     includeDefaults?: boolean;
     ignoreUnavailable?: boolean;
     allowNoIndices?: boolean;
@@ -1231,6 +1234,7 @@ export interface IndicesGetFieldMappingParams extends GenericParams {
 }
 
 export interface IndicesGetMappingParams extends GenericParams {
+    includeTypeName?: boolean;
     ignoreUnavailable?: boolean;
     allowNoIndices?: boolean;
     expandWildcards?: ExpandWildcards;
@@ -1252,6 +1256,7 @@ export interface IndicesGetSettingsParams extends GenericParams {
 }
 
 export interface IndicesGetTemplateParams extends GenericParams {
+    includeTypeName?: boolean;
     flatSettings?: boolean;
     masterTimeout?: TimeSpan;
     local?: boolean;
@@ -1283,6 +1288,7 @@ export interface IndicesPutAliasParams extends GenericParams {
 }
 
 export interface IndicesPutMappingParams extends GenericParams {
+    includeTypeName?: boolean;
     timeout?: TimeSpan;
     masterTimeout?: TimeSpan;
     ignoreUnavailable?: boolean;
@@ -1306,6 +1312,7 @@ export interface IndicesPutSettingsParams extends GenericParams {
 }
 
 export interface IndicesPutTemplateParams extends GenericParams {
+    includeTypeName?: boolean;
     order?: number;
     create?: boolean;
     timeout?: TimeSpan;
@@ -1332,6 +1339,7 @@ export interface IndicesRefreshParams extends GenericParams {
 }
 
 export interface IndicesRolloverParams extends GenericParams {
+    includeTypeName?: boolean;
     timeout?: TimeSpan;
     masterTimeout?: TimeSpan;
     waitForActiveShards?: number | string;


### PR DESCRIPTION
This parameter was introduced around 6.7. It's a requirement for writing cross-version compatible code targeting 6.7.x and 7.x

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.