### PR TITLE
[forge-viewer] Repair definitions in BubbleNode and Viewer3D

### DIFF
--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -344,11 +344,12 @@ declare namespace Autodesk {
           isGeomLeaf(): boolean;
           isMetadata(): boolean;
           isViewable(): boolean;
+          isViewPreset(): boolean;
           name(): string;
           search(propsToMatch: BubbleNodeSearchProps): BubbleNode[];
           searchByTag(tagsToMatch: object): BubbleNode[];
           setTag(tag: string, value: any): void;
-          traverse(cb: () => void): boolean;
+          traverse(cb: (bubble: BubbleNode) => boolean): boolean;
           urn(searchParent: boolean): string;
           useAsDefault(): boolean;
         }
@@ -732,6 +733,7 @@ declare namespace Autodesk {
             setUp(config?: any): void;
             setUseLeftHandedInput(value: boolean): void;
             setUsePivotAlways(value: boolean): void;
+            setView(viewNode: BubbleNode, options: any): void;
             setViewCube(face: string): void;
             setViewFromArray(params: any[]): void;
             setViewFromFile(): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://forge.autodesk.com/en/docs/viewer/v6/reference/Viewing/BubbleNode/ https://forge.autodesk.com/en/docs/viewer/v6/reference/Viewing/Viewer3D/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The changes have not been made public via the documentation, but using them against the current iteration of the forge viewer has confirmed that these are accurate. 