### PR TITLE
[@types/redis] ++ add missing type Buffer

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -439,8 +439,8 @@ export interface Commands<R> {
     /**
      * Get the value of a key.
      */
-    get(key: string, cb?: Callback<string>): R;
-    GET(key: string, cb?: Callback<string>): R;
+    get(key: string, cb?: Callback<string | Buffer>): R;
+    GET(key: string, cb?: Callback<string | Buffer>): R;
 
     /**
      * Returns the bit value at offset in the string value stored at key.

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -6,11 +6,12 @@ const num = 0;
 const str = 'any string';
 const err: Error = new Error();
 const args: any[] = [];
-const resCallback: (err: Error | null, res: any) => void = () => {};
-const numCallback: (err: Error | null, res: number) => void = () => {};
-const strCallback: (err: Error | null, res: string) => void = () => {};
-const okCallback: (err: Error | null, res: 'OK') => void = () => {};
-const messageHandler: (channel: string, message: any) => void = () => {};
+const resCallback: (err: Error | null, res: any) => void = () => { };
+const numCallback: (err: Error | null, res: number) => void = () => { };
+const strCallback: (err: Error | null, res: string | Buffer) => void = () => { };
+const bufferCallback: (err: Error | null, res: string | Buffer) => void = () => { };
+const okCallback: (err: Error | null, res: 'OK') => void = () => { };
+const messageHandler: (channel: string, message: any) => void = () => { };
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
@@ -20,30 +21,37 @@ redis.print(err, value);
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 const options: redis.ClientOpts = {
-  host: 'localhost',
-  port: 6379,
+    host: 'localhost',
+    port: 6379,
 };
+const optionsWithBuffer: redis.ClientOpts = {
+    host: 'localhost',
+    port: 6379,
+    return_buffers: true,
+};
+
 let client: redis.RedisClient = redis.createClient(num, str, options);
+const clientWithBuffer: redis.RedisClient = redis.createClient(num, str, optionsWithBuffer);
 
 // Test the `retry_strategy` property
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
-  // Ensure that the properties of RetryStrategyOptions are resilient to breaking change.
-  // If the properties of the interface changes, the variables below will also need to be adapted.
-  const error: Error = options.error;
-  const total_retry_time: number = options.total_retry_time;
-  const times_connected: number = options.times_connected;
-  const attempt: number = options.attempt;
-  return 5000;
+    // Ensure that the properties of RetryStrategyOptions are resilient to breaking change.
+    // If the properties of the interface changes, the variables below will also need to be adapted.
+    const error: Error = options.error;
+    const total_retry_time: number = options.total_retry_time;
+    const times_connected: number = options.times_connected;
+    const attempt: number = options.attempt;
+    return 5000;
 }
 function retryStrategyError(options: redis.RetryStrategyOptions): Error {
-  return new Error('Foo');
+    return new Error('Foo');
 }
 client = redis.createClient({
-  retry_strategy: retryStrategyNumber
+    retry_strategy: retryStrategyNumber
 });
 client = redis.createClient({
-  retry_strategy: retryStrategyError
+    retry_strategy: retryStrategyError
 });
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
@@ -70,6 +78,9 @@ client.bitcount(str, num, num, numCallback);
 client.set(str, str, okCallback);
 client.get(str, strCallback);
 client.exists(str, numCallback);
+
+// Buffer
+clientWithBuffer.get(str, bufferCallback);
 
 // Event handlers
 client.on(str, messageHandler);
@@ -99,11 +110,11 @@ client.subscribe(str);
 
 // Multi
 client.multi()
-  .scard(str)
-  .smembers(str)
-  .keys('*', resCallback)
-  .dbsize()
-  .exec(resCallback);
+    .scard(str)
+    .smembers(str)
+    .keys('*', resCallback)
+    .dbsize()
+    .exec(resCallback);
 
 client.multi([['get', 'test']]).exec();
 

--- a/types/redis/ts3.1/index.d.ts
+++ b/types/redis/ts3.1/index.d.ts
@@ -423,8 +423,8 @@ export interface Commands<R> {
     /**
      * Get the value of a key.
      */
-    get(key: string, cb?: Callback<string>): R;
-    GET(key: string, cb?: Callback<string>): R;
+    get(key: string, cb?: Callback<string | Buffer>): R;
+    GET(key: string, cb?: Callback<string | Buffer>): R;
 
     /**
      * Returns the bit value at offset in the string value stored at key.


### PR DESCRIPTION
When ClientOpts.return_buffers is set to **true** => Commands.**get** and Commands.**GET** can be **string** or **Buffer**.

This PR fixing the bug that it can only be **string** right now.