### PR TITLE
[react-albus] Define WithWizard render prop component

### DIFF
--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -41,15 +41,19 @@ export interface WizardProps {
 
 export const Wizard: React.ComponentType<WizardProps>;
 
+export type WizardContextRenderProps =
+    | { render?: (wizard: WizardContext) => React.ReactNode }
+    | { children: (wizard: WizardContext) => React.ReactNode };
+
+export const WithWizard: React.ComponentType<WizardContextRenderProps>;
+
 export interface StepsProps {
     step?: StepObject;
 }
 
 export const Steps: React.ComponentType<StepsProps>;
 
-export type StepProps = StepObject & (
-    | { render?: (wizard: WizardContext) => React.ReactNode }
-    | { children: (wizard: WizardContext) => React.ReactNode });
+export type StepProps = StepObject & WizardContextRenderProps;
 
 /**
  * In addition to id, any additional props added to <Step> will be available on each step object.


### PR DESCRIPTION
Fixes Error: `Module '"node_modules/@types/react-albus"' has no exported member 'WithWizard'. Did you mean 'withWizard'?"`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/americanexpress/react-albus/blob/master/src/index.js#L18
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

