### PR TITLE
added static type for unsafeCurrentUser() method

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -690,6 +690,7 @@ subscription.on('close', () => {});
         static requestPasswordReset(email: string, options?: SuccessFailureOptions): Promise<User>;
         static extend(protoProps?: any, classProps?: any): any;
         static hydrate(userJSON: any): Promise<User>;
+        static enableUnsafeCurrentUser(): void;
 
         signUp(attrs?: any, options?: SignUpOptions): Promise<this>;
         logIn(options?: SuccessFailureOptions): Promise<this>;


### PR DESCRIPTION
Parse.User has a static method called `unsafeCurrentUser`, but it was missing from this ts file.

Docs on unsafeCurrentUser method:
https://parseplatform.org/Parse-SDK-JS/api/v1.11.1/Parse.User.html#.enableUnsafeCurrentUser

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
