### PR TITLE
Remove 'co' dependency on 'Generator' type

### DIFF
--- a/types/co/index.d.ts
+++ b/types/co/index.d.ts
@@ -7,10 +7,10 @@
 type ExtractType<T> = T extends IterableIterator<infer R> ? R : never;
 
 interface Co {
-    <F extends (...args: any[]) => Generator>(fn: F, ...args: Parameters<F>): Promise<ExtractType<ReturnType<F>>>;
+    <F extends (...args: any[]) => Iterator<any>>(fn: F, ...args: Parameters<F>): Promise<ExtractType<ReturnType<F>>>;
     default: Co;
     co: Co;
-    wrap: <F extends (...args: any[]) => Generator>(fn: F) => (...args: Parameters<F>) => Promise<ExtractType<ReturnType<F>>>;
+    wrap: <F extends (...args: any[]) => Iterator<any>>(fn: F) => (...args: Parameters<F>) => Promise<ExtractType<ReturnType<F>>>;
 }
 
 declare const co: Co;


### PR DESCRIPTION
This changes the return-type dependency for `co` to use `Iterator<any>` instead of `Generator`. This is due to the fact the definition for `Generator` in the current release of TypeScript is simplify `interface Generator extends Iterator<any> {}`, but once Microsoft/TypeScript#30790 has merged the definition will no longer be quite so trivial.

Also, once Microsoft/TypeScript#30790 has merged we will be able to use `"typesVersions"` to update the definitions to use the new comprehensive `Generator` definition to extract the actual return type of the generator, however that will need to be added in a follow-on PR.