### PR TITLE
[secure-password] Add definition

### DIFF
--- a/types/secure-password/index.d.ts
+++ b/types/secure-password/index.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for secure-password 3.1
+// Project: https://github.com/emilbayes/secure-password#readme
+// Definitions by: Jarom Loveridge <https://github.com/jloveridge>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+/// <reference types="node" />
+
+declare class SecurePassword {
+    constructor(opts?: { memlimit?: number; opslimit?: number; });
+
+    memlimit: number;
+
+    opslimit: number;
+
+    /**
+     * Create a hash of the password.
+     * @param passwordBuf
+     */
+    hash(passwordBuf: Buffer): Promise<Buffer>;
+    hash(passwordBuf: Buffer, cb: (err: any, hash?: Buffer) => void): void;
+
+    /**
+     * Create a hash of the password buffer.
+     * @param buff
+     */
+    hashSync(buff: Buffer): Buffer;
+
+    /**
+     * Verify password and hash match.
+     * @param passwordBuf
+     * @param hashBuf
+     */
+    verify(passwordBuf: Buffer, hashBuf: Buffer): Promise<symbol>;
+    verify(passwordBuf: Buffer, hashBuf: Buffer, cb: (err: any, result?: symbol) => void): void;
+
+    /**
+     * Verify password and hash match.
+     * @param passwordBuf
+     * @param hashBuf
+     */
+    verifySync(passwordBuf: Buffer, hashBuf: Buffer): symbol;
+
+    static HASH_BYTES: number;
+
+    static INVALID: symbol;
+
+    static INVALID_UNRECOGNIZED_HASH: symbol;
+
+    static MEMLIMIT_DEFAULT: number;
+
+    static MEMLIMIT_MAX: number;
+
+    static MEMLIMIT_MIN: number;
+
+    static OPSLIMIT_DEFAULT: number;
+
+    static OPSLIMIT_MAX: number;
+
+    static OPSLIMIT_MIN: number;
+
+    static PASSWORD_BYTES_MAX: number;
+
+    static PASSWORD_BYTES_MIN: number;
+
+    static VALID: symbol;
+
+    static VALID_NEEDS_REHASH: symbol;
+}
+
+export = SecurePassword;

--- a/types/secure-password/secure-password-tests.ts
+++ b/types/secure-password/secure-password-tests.ts
@@ -1,0 +1,14 @@
+import SecurePassword = require('secure-password');
+
+const sp = new SecurePassword();
+const spWithOpts = new SecurePassword({memlimit: 10, opslimit: 10});
+
+const clearTextBuf = Buffer.from('testing');
+
+const hashPromise = sp.hash(clearTextBuf).then((hash) => hash);
+sp.hash(clearTextBuf, (err, hash) => {});
+const hashBuf = sp.hashSync(clearTextBuf);
+
+const verifyPromise = sp.verify(clearTextBuf, hashBuf).then((symb) => symb);
+sp.verify(clearTextBuf, hashBuf, (err, result) => {});
+const verifyResult = sp.verifySync(clearTextBuf, hashBuf);

--- a/types/secure-password/tsconfig.json
+++ b/types/secure-password/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "secure-password-tests.ts"
+    ]
+}

--- a/types/secure-password/tslint.json
+++ b/types/secure-password/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.

Attempting to run `dtslint secure-password` always resulted in:
`Duplicate identifier 'prototype'.`

I was unable to resolve it so resorted to an older style module definition format that seems to work just fine.

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
