### PR TITLE
[@types/react] React.creatContext should receive a optional value

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -336,7 +336,7 @@ declare namespace React {
         displayName?: string;
     }
     function createContext<T>(
-        defaultValue: T,
+        defaultValue?: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -86,6 +86,8 @@ const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
 // React.createContext
 const ContextWithRenderProps = React.createContext('defaultValue');
 
+const ContextWithoutDefaultValue = React.createContext();
+
 // Fragments
 <div>
     <React.Fragment>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

DOC: https://reactjs.org/docs/context.html#reactcreatecontext

> The defaultValue argument is only used when a component does not have a matching Provider above it in the tree. 

And there is an [article](https://medium.com/@thehappybug/using-react-context-in-a-typescript-app-c4ef7504c858) with this issue, use a tricky way to avoid this problem.

![](https://media.giphy.com/media/oFI7FttD0iC8V2Iqmy/giphy.gif)
