### PR TITLE
[atom] Revert TextEditor.getLastCursor type

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -17,7 +17,6 @@ declare const mouseEvent: MouseEvent;
 
 declare let buffer: Atom.TextBuffer;
 declare const color: Atom.Color;
-declare let maybeCursor: Atom.Cursor | undefined;
 declare let cursor: Atom.Cursor;
 declare let cursors: Atom.Cursor[];
 declare let decoration: Atom.Decoration;
@@ -2790,7 +2789,7 @@ function testTextEditor() {
     editor.moveToBeginningOfPreviousParagraph();
     editor.selectLargerSyntaxNode();
     editor.selectSmallerSyntaxNode();
-    maybeCursor = editor.getLastCursor();
+    cursor = editor.getLastCursor();
 
     str = editor.getWordUnderCursor();
     str = editor.getWordUnderCursor({});

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1939,7 +1939,7 @@ export class TextEditor {
     moveToBeginningOfPreviousParagraph(): void;
 
     /** Returns the most recently added Cursor. */
-    getLastCursor(): Cursor | undefined;
+    getLastCursor(): Cursor;
 
     /** Returns the word surrounding the most recently added cursor. */
     getWordUnderCursor(options?: {


### PR DESCRIPTION
This PR amends a questionable part of #34821, which I was a bit too late to amend yesterday. Sorry.

Apparently, `getLastCursor` returning `undefined` was unintended and evidently was at some point silently fixed, at least for most cases.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
Tracing the call chain for `createLastSelectionIfNeeded` shows that a cursor should be created at (0,0) if needed on each call to `getLastCursor`; consider:
https://github.com/atom/atom/blob/v1.36.0/src/text-editor.js#L2823
https://github.com/atom/atom/blob/v1.36.0/src/text-editor.js#L3485
https://github.com/atom/atom/blob/v1.36.0/src/text-editor.js#L3032
https://github.com/atom/atom/blob/v1.36.0/src/text-editor.js#L617
https://github.com/atom/atom/blob/v1.36.0/src/text-editor.js#L3434
Additionally, commit https://github.com/atom/atom/commit/4bbc1d806e02c89ac3d2a2996f70087ed4b6a017 shows that `getLastCursor` isn't intended to return `undefined`
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
