### PR TITLE
Set defaults for the type parameters of generic types in backbone

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -196,6 +196,8 @@ class Library extends Backbone.Collection<Book> {
 
 class Books extends Backbone.Collection<Book> { }
 
+class ArbitraryCollection extends Backbone.Collection { }
+
 function test_collection() {
 
     var books = new Books();
@@ -481,5 +483,29 @@ namespace v1Changes {
         // Test for Backbone.sync override.
         Backbone.sync('create', new Employee());
         Backbone.sync('read', new EmployeeCollection());
+    }
+}
+
+interface BookViewOptions extends Backbone.ViewOptions<Book> {
+    featured: boolean;
+}
+
+class BookView extends Backbone.View<Book> {
+    featured: boolean;
+    constructor(options: BookViewOptions) {
+        super(options);
+        this.featured = !!options.featured;
+    }
+}
+
+interface ModellessViewOptions extends Backbone.ViewOptions {
+    color?: string;
+}
+
+class ModellessView extends Backbone.View {
+    color: string;
+    constructor(options: ModellessViewOptions) {
+        super(options);
+        this.color = options.color;
     }
 }

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -547,7 +547,7 @@ declare namespace Backbone {
     }
 
     // SYNC
-    function sync(method: string, model: Model | Collection<Model>, options?: JQueryAjaxSettings): any;
+    function sync(method: string, model: Model | Collection, options?: JQueryAjaxSettings): any;
     function ajax(options?: JQueryAjaxSettings): JQueryXHR;
     var emulateHTTP: boolean;
     var emulateJSON: boolean;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -300,7 +300,7 @@ declare namespace Backbone {
         matches(attrs: any): boolean;
     }
 
-    class Collection<TModel extends Model> extends ModelBase implements Events {
+    class Collection<TModel extends Model = Model> extends ModelBase implements Events {
 
         /**
         * Do not use, prefer TypeScript's extend functionality.
@@ -492,7 +492,7 @@ declare namespace Backbone {
         private _updateHash(location: Location, fragment: string, replace: boolean): void;
     }
 
-   interface ViewOptions<TModel extends Model> {
+   interface ViewOptions<TModel extends Model = Model> {
       model?: TModel;
        // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
       collection?: Backbone.Collection<any>; //was: Collection<TModel>;
@@ -504,7 +504,7 @@ declare namespace Backbone {
       attributes?: {[id: string]: any};
     }
 
-    class View<TModel extends Model> extends EventsMixin implements Events {
+    class View<TModel extends Model = Model> extends EventsMixin implements Events {
 
         /**
         * Do not use, prefer TypeScript's extend functionality.

--- a/types/backbone/tslint.json
+++ b/types/backbone/tslint.json
@@ -8,7 +8,6 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
-        "npm-naming": false,
         "export-just-namespace": false,
         "interface-name": false,
         "jsdoc-format": false,


### PR DESCRIPTION
The Collection and View classes in backbone take a Backbone.Model subclass as type parameter. Often, just the base class is fine, you don't care about the subclass interface, or sometimes in the case of View, you're not using a Model at all. It is cumbersome to have to specify that the model type is just `Backbone.Model` every time. So I set it as the default. This is inherently a non-breaking change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add ~or edit~ tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://backbonejs.org *Backbone's Model and Collection base classes can be used directly without subclassing and are often fine as-is.*
- [x] Increase the version number in the header if appropriate. *Not appropriate.*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. *Already present.*