### PR TITLE
[@types/ramda] fix trailing commas

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -27,6 +27,7 @@
 //                 Nitesh Phadatare <https://github.com/minitesh>
 //                 Krantisinh Deshmukh <https://github.com/krantisinh>
 //                 Pierre-Antoine Mills <https://github.com/pirix-gh>
+//                 Brekk Bockrath <https://github.com/brekk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
@@ -646,40 +647,32 @@ declare namespace R {
     }
 
     type PipeWithFns<V0, T> = [
-        (x0: V0) => T,
+        (x0: V0) => T
     ] | [
         (x0: V0) => any,
-        (x: any) => T,
-    ] | [
-        (x0: V0) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
@@ -687,8 +680,7 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
@@ -697,8 +689,7 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: any) => T,
+        (x: any) => T
     ] | [
         (x0: V0) => any,
         (x: any) => any,
@@ -708,45 +699,47 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
+        (x: any) => T
+    ] | [
+        (x0: V0) => any,
         (x: any) => any,
-        (x: any) => T,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => T
     ];
 
     type ComposeWithFns<V0, T> = [
-        (x0: V0) => T,
+        (x0: V0) => T
     ] | [
         (x: any) => T,
-        (x: V0) => any,
-    ] | [
-        (x: any) => T,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
@@ -754,8 +747,7 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
@@ -764,8 +756,7 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
-        (x: any) => any,
-        (x: V0) => any,
+        (x: V0) => any
     ] | [
         (x: any) => T,
         (x: any) => any,
@@ -775,8 +766,18 @@ declare namespace R {
         (x: any) => any,
         (x: any) => any,
         (x: any) => any,
+        (x: V0) => any
+    ] | [
+        (x: any) => T,
         (x: any) => any,
-        (x: V0) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: any) => any,
+        (x: V0) => any
     ];
 
     type Merge<Primary, Secondary> = { [K in keyof Primary]: Primary[K] } & { [K in Exclude<keyof Secondary, CommonKeys<Primary, Secondary>>]: Secondary[K] };


### PR DESCRIPTION
This is simply a PR which removes trailing commas in ramda/index.d.ts and addresses https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34565

Please let me know if there's more that is needed here.
--

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34565
- [ ] Increase the version number in the header if appropriate. -- *I wasn't sure if this was needed here.*
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
