### PR TITLE
[@types/copy-webpack-plugin] Update to v5.0 of copy-webpack-plugin

### DIFF
--- a/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
+++ b/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
@@ -63,21 +63,22 @@ const c: Configuration = {
 			// Copy glob results (without dot files) to {output}/to/directory/
 			{
 				from: '**/*.png',
-				fromArgs: { dot: false },
 				to: 'to/directory'
 			},
 
-			// Copy all files in the images directory with the '-copy' suffix
-			// Test captures the filename and directory path excluding the suffix in 
-			// capture group [1]. To recreates the exact directory structure and file names
-			// without '-copy' suffix.
+			// Turns 1st and 2nd level directory names into file name seperated by a dash for png files
 			{
-				from: 'assets/images/**/*-copy.*',
-				to: 'img/[1].[ext]',
-				test: /.*images[/\\](.+)-copy\..*$/i,
-				toType: 'template',
+				from: '*/*',
+				to: '[1]-[2].[hash].[ext]',
+				test: /([^/]+)\/(.+)\.png$/,
 			},
 		], {
+			// Log only errors
+			logLevel: 'error',
+			
+			// All 'from' paths will be intepreted from this context
+			context: 'app/',
+
 			ignore: [
 				// Doesn't copy any files with a txt extension
 				'*.txt',

--- a/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
+++ b/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
@@ -66,6 +66,17 @@ const c: Configuration = {
 				fromArgs: { dot: false },
 				to: 'to/directory'
 			},
+
+			// Copy all files in the images directory with the '-copy' suffix
+			// Test captures the filename and directory path excluding the suffix in 
+			// capture group [1]. To recreates the exact directory structure and file names
+			// without '-copy' suffix.
+			{
+				from: 'assets/images/**/*-copy.*',
+				to: 'img/[1].[ext]',
+				test: /.*images[/\\](.+)-copy\..*$/i,
+				toType: 'template',
+			},
 		], {
 			ignore: [
 				// Doesn't copy any files with a txt extension

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for copy-webpack-plugin v5.0
+// Type definitions for copy-webpack-plugin 5.0
 // Project: https://github.com/webpack-contrib/copy-webpack-plugin
 // Definitions by: 	flying-sheep <https://github.com/flying-sheep>
 // 					avin-kavish  <https://github.com/avin-kavish>

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,12 +1,13 @@
-// Type definitions for copy-webpack-plugin 4.4
+// Type definitions for copy-webpack-plugin v5.0.2
 // Project: https://github.com/webpack-contrib/copy-webpack-plugin
-// Definitions by: flying-sheep <https://github.com/flying-sheep>
+// Definitions by: 	flying-sheep <https://github.com/flying-sheep>
+// 					avin-kavish  <https://github.com/avin-kavish>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 /// <reference types="node"/>
 
-import { Plugin } from 'webpack'
+import { Plugin, compiler } from 'webpack'
 import { IOptions } from 'minimatch'
 
 interface MiniMatchGlob extends IOptions {
@@ -20,55 +21,69 @@ interface MiniMatchOptions extends IOptions {
 interface CopyPattern {
 	/** File source path or glob */
 	from: string | MiniMatchGlob
-	/** See the `node-glob` options in addition to the ones below. (default: `{ cwd: context }`) */
-	fromArgs?: MiniMatchOptions
 	/**
 	 * Path or webpack file-loader patterns. defaults:
 	 * output root if `from` is file or dir.
 	 * resolved glob path if `from` is glob.
 	 */
 	to?: string
-	/**
-	 * How to interpret `to`. defaults:
-	 * 'file' if to has extension or from is file.
-	 * 'dir' if from is directory, to has no extension or ends in '/'.
-	 * 'template' if to contains a template pattern.
-	 */
-	toType?: 'file' | 'dir' | 'template'
-	/** A path that determines how to interpret the `from` path. (default: `compiler.options.context`) */
+	/** A path that determines how to interpret the `from` path. 
+	 * 
+	 * (default: `options.context | compiler.options.context`) 
+	 * */
 	context?: string
 	/**
-	 * Removes all directory references and only copies file names.
-	 *
-	 * If files have the same name, the result is non-deterministic. (default: `false`)
+	 * How to interpret `to`. default: undefined
+	 * 
+	 * `file` - if 'to' has extension or 'from' is file.
+	 * `dir` - if 'from' is directory, 'to' has no extension or ends in '/'.
+	 * `template` - if 'to' contains a template pattern.
 	 */
-	flatten?: boolean
-	/** Additional globs to ignore for this pattern. (default: `[]`) */
-	ignore?: Array<string | MiniMatchGlob>
-	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
-	transform?: (content: Buffer, path: string) => string | Buffer
-	/** Enable transform caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. (default: `false`) */
-	cache?: boolean | { key: string }
-	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
-	force?: boolean
+	toType?: 'file' | 'dir' | 'template'
 	/** 
 	 * Pattern for extracting elements to be used in `to` templates. 
 	 * 
 	 * Defines a `RegExp` to match some parts of the file path. These capture groups can be reused in the name property using [N] 
 	 * placeholder. Note that [0] will be replaced by the entire path of the file, whereas [1] will contain the first capturing 
-	 * parenthesis of your {RegExp} and so on...
+	 * parenthesis of your RegExp and so on...
 	 * 
 	 * */
 	test?: RegExp
+	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
+	force?: boolean
+	/** Additional globs to ignore for this pattern. (default: `[]`) */
+	ignore?: Array<string | MiniMatchGlob>
+	/**
+	 * Removes all directory references and only copies file names. (default: `false`)
+	 *
+	 * If files have the same name, the result is non-deterministic. 
+	 */
+	flatten?: boolean
+	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
+	transform?: (content: Buffer, path: string) => string | Buffer | Promise<string | Buffer>
+	/** 
+	 * Enable transform caching.  (default: `false`)
+	 * 
+	 * You can use `{ key: 'my-cache-key' }` to invalidate the cache.  
+	 * */
+	cache?: boolean | { key: string }
+	/** 
+	 * Allows to modify the writing path.
+	 * 
+	 *  Returns the new path or a promise that resolves into the new path
+	 */
+	transformPath?: (targetPath: string, absolutePath: string) => string | Promise<string>
 }
 
 interface CopyWebpackPluginConfiguration {
-	/** Array of globs to ignore. (applied to from; default: `[]`) */
+	/** Level of messages that the module will log. (default: `'warn'`) */
+	logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
+	/** Array of globs to ignore. (applied to `from`; default: `[]`) */
 	ignore?: Array<string | MiniMatchGlob>
+	/** A path that determines how to interpret the from path, shared for all patterns. default: `'compiler.options.context'` */
+	context?: string
 	/** Copies files, regardless of modification when using `watch` or `webpack-dev-server`. All files are copied on first build, regardless of this option. (default: `false`) */
 	copyUnmodified?: boolean
-	/** Debug level. warning: only warnings, info/true: file location and read info, debug: very detailed debugging info. (default: `'warning'`) */
-	debug?: 'warning' | 'info'|true | 'debug'
 }
 
 interface CopyWebpackPlugin {

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for copy-webpack-plugin v5.0.2
+// Type definitions for copy-webpack-plugin v5.0
 // Project: https://github.com/webpack-contrib/copy-webpack-plugin
 // Definitions by: 	flying-sheep <https://github.com/flying-sheep>
 // 					avin-kavish  <https://github.com/avin-kavish>

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -51,6 +51,15 @@ interface CopyPattern {
 	cache?: boolean | { key: string }
 	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
 	force?: boolean
+	/** 
+	 * Pattern for extracting elements to be used in `to` templates. 
+	 * 
+	 * Defines a `RegExp` to match some parts of the file path. These capture groups can be reused in the name property using [N] 
+	 * placeholder. Note that [0] will be replaced by the entire path of the file, whereas [1] will contain the first capturing 
+	 * parenthesis of your {RegExp} and so on...
+	 * 
+	 * */
+	test?: RegExp
 }
 
 interface CopyWebpackPluginConfiguration {


### PR DESCRIPTION
Update to v5.0 of copy-webpack-plugin

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/copy-webpack-plugin
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

summoning @flying-sheep 


