### PR TITLE
[@types/stream-buffers]: Add false to the return values

### DIFF
--- a/types/stream-buffers/index.d.ts
+++ b/types/stream-buffers/index.d.ts
@@ -15,8 +15,8 @@ export class WritableStreamBuffer extends stream.Writable {
     constructor(options?: WritableStreamBufferOptions);
     size(): number;
     maxSize(): number;
-    getContents(length?: number): Buffer;
-    getContentsAsString(encoding?: string, length?: number): string;
+    getContents(length?: number): Buffer | false;
+    getContentsAsString(encoding?: string, length?: number): string | false;
 }
 
 export interface ReadableStreamBufferOptions extends stream.ReadableOptions {

--- a/types/stream-buffers/stream-buffers-tests.ts
+++ b/types/stream-buffers/stream-buffers-tests.ts
@@ -20,16 +20,16 @@ myWritableStreamBuffer.size();
 myWritableStreamBuffer.maxSize();
 
 // Gets all held data as a Buffer.
-const contents: Buffer = myWritableStreamBuffer.getContents();
+const contents: Buffer = myWritableStreamBuffer.getContents() as Buffer;
 
 // Gets all held data as a utf8 string.
-const stringContents: string = myWritableStreamBuffer.getContentsAsString('utf8');
+const stringContents: string = myWritableStreamBuffer.getContentsAsString('utf8') as string;
 
 // Gets first 5 bytes as a Buffer.
-const contents2: Buffer = myWritableStreamBuffer.getContents(5);
+const contents2: Buffer = myWritableStreamBuffer.getContents(5) as Buffer;
 
 // Gets first 5 bytes as a utf8 string.
-const stringContents2: string = myWritableStreamBuffer.getContentsAsString('utf8', 5);
+const stringContents2: string = myWritableStreamBuffer.getContentsAsString('utf8', 5) as string;
 
 const myReadableStreamBuffer = new streamBuffers.ReadableStreamBuffer({
     frequency: 10,   // in milliseconds.
@@ -46,3 +46,8 @@ myReadableStreamBuffer.on('data', (data) => {
 
 myReadableStreamBuffer.put('the last data this stream will ever see');
 myReadableStreamBuffer.stop();
+
+// Test empty buffer
+const myWritableEmptyStreamBuffer = new streamBuffers.WritableStreamBuffer();
+const emptyContents: boolean = myWritableEmptyStreamBuffer.getContents() as boolean;
+const emptyContentsString: boolean = myWritableEmptyStreamBuffer.getContentsAsString() as boolean;


### PR DESCRIPTION
The source code returns false when the size is zero.

https://github.com/samcday/node-stream-buffer/blob/master/lib/writable_streambuffer.js#L28
https://github.com/samcday/node-stream-buffer/blob/master/lib/writable_streambuffer.js#L42

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
