### PR TITLE
fix(ssri): Return `Promise` type by default

### DIFF
--- a/types/ssri/.editorconfig
+++ b/types/ssri/.editorconfig
@@ -1,0 +1,3 @@
+# This package uses tabs
+[*]
+indent_style = tab

--- a/types/ssri/index.d.ts
+++ b/types/ssri/index.d.ts
@@ -8,141 +8,174 @@ import { Utf8AsciiLatin1Encoding, Hash as CryptoHash } from "crypto";
 import { Readable, Transform } from "stream";
 
 export interface HashLike {
-    algorithm: string;
-    digest: string;
-    options?: string[];
+	algorithm: string;
+	digest: string;
+	options?: string[];
 }
 
 export interface IntegrityLike {
-    [algorithm: string]: HashLike[];
+	[algorithm: string]: HashLike[];
 }
 
 export type IntegrityMap = Integrity & IntegrityLike;
 
 export class Hash implements HashLike {
-    constructor(hash: string, opts?: { strict?: boolean });
+	constructor(hash: string, opts?: { strict?: boolean });
 
-    source: string;
-    algorithm: string;
-    digest: string;
-    options?: string[];
-    isHash: boolean;
+	source: string;
+	algorithm: string;
+	digest: string;
+	options?: string[];
+	isHash: boolean;
 
-    hexDigest(): string;
+	hexDigest(): string;
 
-    toJSON(): string;
+	toJSON(): string;
 
-    toString(opts?: { strict?: boolean }): string;
+	toString(opts?: { strict?: boolean }): string;
 }
 
 export class Integrity {
-    isIntegrity: boolean;
+	isIntegrity: boolean;
 
-    toJSON(): string;
+	toJSON(): string;
 
-    toString(opts?: { strict?: boolean, sep?: string }): string;
+	toString(opts?: { strict?: boolean, sep?: string }): string;
 
-    concat(
-        integrity: string | IntegrityLike | HashLike,
-        opts?: { strict?: boolean }
-    ): IntegrityMap;
+	concat(
+		integrity: string | IntegrityLike | HashLike,
+		opts?: { strict?: boolean },
+	): IntegrityMap;
 
-    hexDigest(): string;
+	hexDigest(): string;
 
-    match(
-        integrity: string | IntegrityLike | HashLike,
-        opts?: { strict?: boolean, pickAlgorithm?: (algo1: string, algo2: string) => string }
-    ): Hash | false;
+	match(
+		integrity: string | IntegrityLike | HashLike,
+		opts?: {
+			strict?: boolean,
+			pickAlgorithm?: (algo1: string, algo2: string) => string,
+		},
+	): Hash | false;
 
-    pickAlgorithm(opts?: { pickAlgorithm?: (algo1: string, algo2: string) => string }): string;
+	pickAlgorithm(opts?: {
+		pickAlgorithm?: (algo1: string, algo2: string) => string,
+	}): string;
 }
 
 export function parse(
-    sri: string | IntegrityLike | HashLike,
-    opts?: { single?: false, strict?: boolean }
+	sri: string | IntegrityLike | HashLike,
+	opts?: { single?: false, strict?: boolean, },
 ): IntegrityMap;
 export function parse(
-    sri: string | IntegrityLike | HashLike,
-    opts?: { single: true, strict?: boolean }
+	sri: string | IntegrityLike | HashLike,
+	opts?: { single: true, strict?: boolean, },
 ): Hash;
 export function parse(
-    sri: string | IntegrityLike | HashLike,
-    opts?: { single?: boolean, strict?: boolean }
+	sri: string | IntegrityLike | HashLike,
+	opts?: { single?: boolean, strict?: boolean, },
 ): IntegrityMap | Hash;
 
 export function stringify(
-    obj: string | IntegrityLike | HashLike,
-    opts?: { strict?: boolean, sep?: string }
+	obj: string | IntegrityLike | HashLike,
+	opts?: { strict?: boolean, sep?: string, },
 ): string;
 
 export function fromHex(
-    hexDigest: string,
-    algorithm: string,
-    opts?: { single?: false, strict?: boolean, options?: ReadonlyArray<string> }
+	hexDigest: string,
+	algorithm: string,
+	opts?: {
+		single?: false,
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+	},
 ): IntegrityMap;
 export function fromHex(
-    hexDigest: string,
-    algorithm: string,
-    opts?: { single: true, strict?: boolean, options?: ReadonlyArray<string> }
+	hexDigest: string,
+	algorithm: string,
+	opts?: { single: true, strict?: boolean, options?: ReadonlyArray<string> },
 ): Hash;
 export function fromHex(
-    hexDigest: string,
-    algorithm: string,
-    opts?: { single?: boolean, strict?: boolean, options?: ReadonlyArray<string> }
+	hexDigest: string,
+	algorithm: string,
+	opts?: {
+		single?: boolean,
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+	},
 ): IntegrityMap | Hash;
 
 export function fromData(
-    data: string | Buffer | NodeJS.TypedArray | DataView,
-    opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string> }
+	data: string | Buffer | NodeJS.TypedArray | DataView,
+	opts?: {
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+		algorithms?: ReadonlyArray<string>,
+	},
 ): IntegrityMap;
 
 export function fromStream(
-    stream: Readable,
-    opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string> }
+	stream: Readable,
+	opts?: {
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+		algorithms?: ReadonlyArray<string>,
+	},
 ): Promise<IntegrityMap>;
 export function fromStream(
-    stream: Readable,
-    opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string>, Promise?: PromiseConstructorLike }
+	stream: Readable,
+	opts?: {
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+		algorithms?: ReadonlyArray<string>,
+		Promise?: PromiseConstructorLike,
+	},
 ): PromiseLike<IntegrityMap>;
 
 export function checkData(
-    data: string | Buffer | NodeJS.TypedArray,
-    sri: string | IntegrityLike | HashLike,
-    opts?: { strict?: boolean, error?: boolean, size?: number, pickAlgorithm?: (algo1: string, algo2: string) => string }
+	data: string | Buffer | NodeJS.TypedArray,
+	sri: string | IntegrityLike | HashLike,
+	opts?: {
+		strict?: boolean,
+		error?: boolean,
+		size?: number,
+		pickAlgorithm?: (algo1: string, algo2: string) => string,
+	},
 ): Hash | false;
 
 export function checkStream(
-    stream: Readable,
-    sri: string | IntegrityLike | HashLike,
-    opts?: {
-        strict?: boolean,
-        options?: ReadonlyArray<string>,
-        size?: number,
-        pickAlgorithm?: (algo1: string, algo2: string) => string,
-    }
+	stream: Readable,
+	sri: string | IntegrityLike | HashLike,
+	opts?: {
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+		size?: number,
+		pickAlgorithm?: (algo1: string, algo2: string) => string,
+	},
 ): Promise<Hash>;
 export function checkStream(
-    stream: Readable,
-    sri: string | IntegrityLike | HashLike,
-    opts?: {
-        strict?: boolean,
-        options?: ReadonlyArray<string>,
-        size?: number,
-        pickAlgorithm?: (algo1: string, algo2: string) => string,
-        Promise?: PromiseConstructorLike
-    }
+	stream: Readable,
+	sri: string | IntegrityLike | HashLike,
+	opts?: {
+		strict?: boolean,
+		options?: ReadonlyArray<string>,
+		size?: number,
+		pickAlgorithm?: (algo1: string, algo2: string) => string,
+		Promise?: PromiseConstructorLike,
+	},
 ): PromiseLike<Hash>;
 
-export function integrityStream(
-    opts?: {
-        single?: boolean,
-        strict?: boolean,
-        options?: ReadonlyArray<string>,
-        algorithms?: ReadonlyArray<string>,
-        integrity?: string | IntegrityLike | HashLike,
-        size?: number,
-        pickAlgorithm?: (algo1: string, algo2: string) => string,
-    }
-): Transform;
+export function integrityStream(opts?: {
+	single?: boolean,
+	strict?: boolean,
+	options?: ReadonlyArray<string>,
+	algorithms?: ReadonlyArray<string>,
+	integrity?: string | IntegrityLike | HashLike,
+	size?: number,
+	pickAlgorithm?: (algo1: string, algo2: string) => string,
+}): Transform;
 
-export function create(opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string> }): CryptoHash;
+export function create(opts?: {
+	strict?: boolean,
+	options?: ReadonlyArray<string>,
+	algorithms?: ReadonlyArray<string>,
+}): CryptoHash;

--- a/types/ssri/index.d.ts
+++ b/types/ssri/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ssri 6.0
 // Project: https://github.com/zkat/ssri
 // Definitions by: Jeow Li Huan <https://github.com/huan086>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Utf8AsciiLatin1Encoding, Hash as CryptoHash } from "crypto";
@@ -58,13 +59,16 @@ export class Integrity {
 
 export function parse(
     sri: string | IntegrityLike | HashLike,
-    opts?: { strict?: boolean }
+    opts?: { single?: false, strict?: boolean }
 ): IntegrityMap;
-
 export function parse(
     sri: string | IntegrityLike | HashLike,
     opts?: { single: true, strict?: boolean }
 ): Hash;
+export function parse(
+    sri: string | IntegrityLike | HashLike,
+    opts?: { single?: boolean, strict?: boolean }
+): IntegrityMap | Hash;
 
 export function stringify(
     obj: string | IntegrityLike | HashLike,
@@ -74,20 +78,28 @@ export function stringify(
 export function fromHex(
     hexDigest: string,
     algorithm: string,
-    opts?: { strict?: boolean, options?: ReadonlyArray<string> }
+    opts?: { single?: false, strict?: boolean, options?: ReadonlyArray<string> }
 ): IntegrityMap;
-
 export function fromHex(
     hexDigest: string,
     algorithm: string,
     opts?: { single: true, strict?: boolean, options?: ReadonlyArray<string> }
 ): Hash;
+export function fromHex(
+    hexDigest: string,
+    algorithm: string,
+    opts?: { single?: boolean, strict?: boolean, options?: ReadonlyArray<string> }
+): IntegrityMap | Hash;
 
 export function fromData(
     data: string | Buffer | NodeJS.TypedArray | DataView,
     opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string> }
 ): IntegrityMap;
 
+export function fromStream(
+    stream: Readable,
+    opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string> }
+): Promise<IntegrityMap>;
 export function fromStream(
     stream: Readable,
     opts?: { strict?: boolean, options?: ReadonlyArray<string>, algorithms?: ReadonlyArray<string>, Promise?: PromiseConstructorLike }
@@ -99,6 +111,16 @@ export function checkData(
     opts?: { strict?: boolean, error?: boolean, size?: number, pickAlgorithm?: (algo1: string, algo2: string) => string }
 ): Hash | false;
 
+export function checkStream(
+    stream: Readable,
+    sri: string | IntegrityLike | HashLike,
+    opts?: {
+        strict?: boolean,
+        options?: ReadonlyArray<string>,
+        size?: number,
+        pickAlgorithm?: (algo1: string, algo2: string) => string,
+    }
+): Promise<Hash>;
 export function checkStream(
     stream: Readable,
     sri: string | IntegrityLike | HashLike,

--- a/types/ssri/ssri-tests.ts
+++ b/types/ssri/ssri-tests.ts
@@ -1,135 +1,182 @@
 /// <reference types="node" />
 
-import ssri = require('ssri');
-import { Hash as CryptoHash } from "crypto";
-import { createReadStream } from 'fs';
-import { Transform } from 'stream';
+import ssri = require("ssri");
+import { createReadStream } from "fs";
 
-const integrityString = 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo';
-const hash = { algorithm: 'sha512', digest: 'c0ffee', options: [] };
+const integrityString =
+	"sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo";
+const hash = { algorithm: "sha512", digest: "c0ffee", options: [] };
 
 const integrity = {
-    sha1: [{ algorithm: 'sha1', digest: 'deadbeef', options: [] }],
-    sha512: [
-        { algorithm: 'sha512', digest: 'c0ffee', options: [] },
-        { algorithm: 'sha512', digest: 'bad1dea', options: ['foo'] }
-    ],
+	sha1: [{ algorithm: "sha1", digest: "deadbeef", options: [] }],
+	sha512: [
+		{ algorithm: "sha512", digest: "c0ffee", options: [] },
+		{ algorithm: "sha512", digest: "bad1dea", options: ["foo"] },
+	],
 };
+const single: boolean | undefined = (() => {
+	const i = Math.random();
+	if (i < 0.5) return undefined;
+	if (i < 0.75) return false;
+	return true;
+})();
 
-const parseString1: ssri.IntegrityMap = ssri.parse(integrityString);
-const parseHash: ssri.IntegrityMap = ssri.parse(hash);
-const parseIntegrity: ssri.IntegrityMap = ssri.parse(integrity);
-const parseStringSingle: ssri.Hash = ssri.parse(integrityString, { single: true, strict: true });
-const parseStringWithOptions: ssri.IntegrityMap = ssri.parse(integrityString, { strict: true });
+// $ExpectType IntegrityMap
+ssri.parse(integrityString);
+// $ExpectType IntegrityMap
+ssri.parse(hash);
+// $ExpectType IntegrityMap
+ssri.parse(integrity);
+// $ExpectType Hash
+ssri.parse(integrityString, { single: true, strict: true });
+// $ExpectType IntegrityMap
+ssri.parse(integrityString, { strict: true });
+// $ExpectType IntegrityMap | Hash
+ssri.parse(integrityString, { single, strict: true });
 
-const stringifyString: string = ssri.stringify('\n\rsha512-foo\n\t\tsha384-bar');
-const stringifyHash: string = ssri.stringify(hash);
-const stringifyIntegrity: string = ssri.stringify(integrity);
-const stringifyStringWithOptions: string = ssri.stringify(
-    '\n\rsha512-foo\n\t\tsha384-bar',
-    { strict: false, sep: ',' }
-);
+// $ExpectType string
+ssri.stringify("\n\rsha512-foo\n\t\tsha384-bar");
+// $ExpectType string
+ssri.stringify(hash);
+// $ExpectType string
+ssri.stringify(integrity);
+// $ExpectType string
+ssri.stringify("\n\rsha512-foo\n\t\tsha384-bar", { strict: false, sep: "," });
 
-const integrityConcatString: ssri.IntegrityMap = new ssri.Integrity().concat(integrityString);
-const integrityConcatHash: ssri.IntegrityMap = new ssri.Integrity().concat(hash);
-const integrityConcatIntegrity: ssri.IntegrityMap = new ssri.Integrity().concat(integrity);
-const integrityConcatStringWithOptions: ssri.IntegrityMap = new ssri.Integrity().concat(
-    integrityString,
-    { strict: true }
-);
+// $ExpectType IntegrityMap
+new ssri.Integrity().concat(integrityString);
+// $ExpectType IntegrityMap
+new ssri.Integrity().concat(hash);
+// $ExpectType IntegrityMap
+new ssri.Integrity().concat(integrity);
+// $ExpectType IntegrityMap
+new ssri.Integrity().concat(integrityString, { strict: true });
 
-const integrityToString: string = new ssri.Integrity().toString();
-const integrityToStringWithOptions: string = new ssri.Integrity().toString({ strict: false, sep: ',' });
+// $ExpectType string
+new ssri.Integrity().toString();
+// $ExpectType string
+new ssri.Integrity().toString({ strict: false, sep: "," });
 
-const integrityToJson: string = new ssri.Integrity().toJSON();
+// $ExpectType string
+new ssri.Integrity().toJSON();
 
-const integrityMatchString: ssri.Hash | false = new ssri.Integrity().match(integrityString);
-const integrityMatchHash: ssri.Hash | false = new ssri.Integrity().match(hash);
-const integrityMatchIntegrity: ssri.Hash | false = new ssri.Integrity().match(integrity);
-const integrityMatchStringWithOptions: ssri.Hash | false = new ssri.Integrity().match(
-    integrityString,
-    { strict: true, pickAlgorithm: (a, b) => a }
-);
-
-const integrityPickAlgorithm: string = new ssri.Integrity().pickAlgorithm();
-const integrityPickAlgorithmWithOptions: string = new ssri.Integrity().pickAlgorithm({ pickAlgorithm: (a, b) => a });
-
-const integrityHexDigest: string = new ssri.Integrity().hexDigest();
-
-const fromHex: ssri.IntegrityMap = ssri.fromHex('75e69d6de79f', 'sha1');
-const fromHexSingle: ssri.Hash = ssri.fromHex(
-    '75e69d6de79f',
-    'sha1',
-    { single: true, strict: false, options: ['sriOpt'] }
-);
-const fromHexWithOptions: ssri.IntegrityMap = ssri.fromHex(
-    '75e69d6de79f',
-    'sha1',
-    { strict: false, options: ['sriOpt'] }
-);
-
-const fromDataString: ssri.IntegrityMap = ssri.fromData('foobarbaz');
-const fromDataBuffer: ssri.IntegrityMap = ssri.fromData(Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]));
-const fromDataStringWithOptions: ssri.IntegrityMap = ssri.fromData(
-    'foobarbaz', {
-        algorithms: ['sha256', 'sha384', 'sha512'],
-        strict: true,
-        options: ['sriOpt']
-    }
-);
-
-const fromStream: PromiseLike<ssri.IntegrityMap> = ssri.fromStream(createReadStream('index.js'));
-const fromStreamWithOptions: PromiseLike<ssri.IntegrityMap> = ssri.fromStream(
-    createReadStream('index.js'), {
-        algorithms: ['sha1', 'sha512'],
-        strict: true,
-        options: ['sriOpt'],
-        Promise
-    }
-);
-
-const create: CryptoHash = ssri.create();
-const createWithOptions: CryptoHash = ssri.create({
-    algorithms: ['sha1', 'sha512'],
-    strict: true,
-    options: ['sriOpt']
+// $ExpectType false | Hash
+new ssri.Integrity().match(integrityString);
+// $ExpectType false | Hash
+new ssri.Integrity().match(hash);
+// $ExpectType false | Hash
+new ssri.Integrity().match(integrity);
+// $ExpectType false | Hash
+new ssri.Integrity().match(integrityString, {
+	strict: true,
+	pickAlgorithm: (a, b) => a,
 });
 
-const checkDataString: ssri.Hash | false = ssri.checkData('data', integrityString);
-const checkDataBuffer: ssri.Hash | false = ssri.checkData(
-    Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]),
-    integrityString
-);
-const checkDataHash: ssri.Hash | false = ssri.checkData('data', hash);
-const checkDataIntegrity: ssri.Hash | false = ssri.checkData('data', integrity);
-const checkDataStringWithOptions: ssri.Hash | false = ssri.checkData(
-    'data',
-    integrityString,
-    { strict: true, pickAlgorithm: (a, b) => a, error: true, size: 1 }
-);
+// $ExpectType string
+new ssri.Integrity().pickAlgorithm();
+// $ExpectType string
+new ssri.Integrity().pickAlgorithm({ pickAlgorithm: (a, b) => a });
 
-const checkStreamString: PromiseLike<ssri.Hash> = ssri.checkStream(createReadStream('index.js'), integrityString);
-const checkStreamHash: PromiseLike<ssri.Hash> = ssri.checkStream(createReadStream('index.js'), hash);
-const checkStreamIntegrity: PromiseLike<ssri.Hash> = ssri.checkStream(createReadStream('index.js'), integrity);
-const checkStreamWithOptions: PromiseLike<ssri.Hash> = ssri.checkStream(
-    createReadStream('index.js'),
-    integrityString,
-    {
-        strict: true,
-        options: ['sriOpt'],
-        pickAlgorithm: (a, b) => a,
-        size: 1,
-        Promise
-    }
-);
+// $ExpectType string
+new ssri.Integrity().hexDigest();
 
-const integrityStream: Transform = ssri.integrityStream();
-const integrityStreamWithOptions: Transform = ssri.integrityStream({
-    single: true,
-    strict: true,
-    options: ['sriOpt'],
-    pickAlgorithm: (a, b) => a,
-    size: 1,
-    integrity,
-    algorithms: ['sha1', 'sha256']
+// $ExpectType IntegrityMap
+ssri.fromHex("75e69d6de79f", "sha1");
+// $ExpectType Hash
+ssri.fromHex("75e69d6de79f", "sha1", {
+	single: true,
+	strict: false,
+	options: ["sriOpt"],
+});
+// $ExpectType IntegrityMap
+ssri.fromHex("75e69d6de79f", "sha1", { strict: false, options: ["sriOpt"] });
+// $ExpectType IntegrityMap | Hash
+ssri.fromHex("75e69d6de79f", "sha1", {
+	single,
+	strict: false,
+	options: ["sriOpt"],
+});
+
+// $ExpectType IntegrityMap
+ssri.fromData("foobarbaz");
+// $ExpectType IntegrityMap
+ssri.fromData(Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]));
+// $ExpectType IntegrityMap
+ssri.fromData("foobarbaz", {
+	algorithms: ["sha256", "sha384", "sha512"],
+	strict: true,
+	options: ["sriOpt"],
+});
+
+// $ExpectType Promise<IntegrityMap>
+ssri.fromStream(createReadStream("index.js"));
+// $ExpectType PromiseLike<IntegrityMap>
+ssri.fromStream(createReadStream("index.js"), {
+	algorithms: ["sha1", "sha512"],
+	strict: true,
+	options: ["sriOpt"],
+	Promise,
+});
+
+// $ExpectType Hash
+ssri.create();
+// $ExpectType Hash
+ssri.create({
+	algorithms: ["sha1", "sha512"],
+	strict: true,
+	options: ["sriOpt"],
+});
+
+// $ExpectType false | Hash
+ssri.checkData("data", integrityString);
+// $ExpectType false | Hash
+ssri.checkData(
+	Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]),
+	integrityString,
+);
+// $ExpectType false | Hash
+ssri.checkData("data", hash);
+// $ExpectType false | Hash
+ssri.checkData("data", integrity);
+// $ExpectType false | Hash
+ssri.checkData("data", integrityString, {
+	strict: true,
+	pickAlgorithm: (a, b) => a,
+	error: true,
+	size: 1,
+});
+
+// $ExpectType Promise<Hash>
+ssri.checkStream(createReadStream("index.js"), integrityString);
+// $ExpectType Promise<Hash>
+ssri.checkStream(createReadStream("index.js"), hash);
+// $ExpectType Promise<Hash>
+ssri.checkStream(createReadStream("index.js"), integrity);
+// $ExpectType Promise<Hash>
+ssri.checkStream(createReadStream("index.js"), integrityString, {
+	strict: true,
+	options: ["sriOpt"],
+	pickAlgorithm: (a, b) => a,
+	size: 1,
+});
+// $ExpectType PromiseLike<Hash>
+ssri.checkStream(createReadStream("index.js"), integrityString, {
+	strict: true,
+	options: ["sriOpt"],
+	pickAlgorithm: (a, b) => a,
+	size: 1,
+	Promise,
+});
+
+// $ExpectType Transform
+ssri.integrityStream();
+// $ExpectType Transform
+ssri.integrityStream({
+	single: true,
+	strict: true,
+	options: ["sriOpt"],
+	pickAlgorithm: (a, b) => a,
+	size: 1,
+	integrity,
+	algorithms: ["sha1", "sha256"],
 });

--- a/types/ssri/tsconfig.json
+++ b/types/ssri/tsconfig.json
@@ -1,23 +1,23 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "ssri-tests.ts"
-    ]
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"ssri-tests.ts"
+	]
 }

--- a/types/ssri/tslint.json
+++ b/types/ssri/tslint.json
@@ -1,1 +1,9 @@
-{ "extends": "dtslint/dt.json" }
+{
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"indent": [
+			true,
+			"tabs"
+		]
+	}
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/zkat/ssri/blob/v6.0.1/README.md#api>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Since I’ve completely rewritten the tests to use `$ExpectType`, I’ve ended up reformatting them to use tabs.

I’ve also added union returning overloads for `parse(…)` and `fromHex(…)` until Microsoft/TypeScript#14107 is resolved.