### PR TITLE
[@feathersjs/feathers] Add hook normalization & finally hook

### DIFF
--- a/types/feathersjs__feathers/feathersjs__feathers-tests.ts
+++ b/types/feathersjs__feathers/feathersjs__feathers-tests.ts
@@ -21,5 +21,15 @@ app.service('users').hooks({
             context.statusCode = 200;
             context.dispatch = { test: 'true' };
         }
+    },
+    after: [
+        (context: HookContext) => {
+            context.statusCode = 200;
+            context.dispatch = { test: 'true' };
+        }
+    ],
+    finally: (context: HookContext) => {
+        context.statusCode = 200;
+        context.dispatch = { test: 'true' };
     }
 });

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -137,9 +137,10 @@ declare namespace feathers {
     }
 
     interface HooksObject {
-        before: Partial<HookMap>;
-        after: Partial<HookMap>;
-        error: Partial<HookMap>;
+        before: Partial<HookMap> | Hook | Hook[];
+        after: Partial<HookMap> | Hook | Hook[];
+        error: Partial<HookMap> | Hook | Hook[];
+        finally: Partial<HookMap> | Hook | Hook[];
     }
 
     // todo: figure out what to do: These methods don't actually need to be implemented, so they can be undefined at runtime. Yet making them optional gets cumbersome in strict mode.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
**Docs**
https://docs.feathersjs.com/api/hooks.html#registering-hooks (doesn't list `finally`, see comments at end of PR)
**Source**
Links are to `master`, but all are also on current `buzzard` branch.
The first part is hook normalization to allow `Hook | Hook[]`:
https://github.com/feathersjs/feathers/blob/656bae7875e03c45497fb3dd340f04e89cab0a20/packages/commons/src/hooks.ts#L69-L85
The second part is adding `finally`:
https://github.com/feathersjs/feathers/blob/656bae7875e03c45497fb3dd340f04e89cab0a20/packages/feathers/lib/hooks/index.js#L73
https://github.com/feathersjs/feathers/blob/656bae7875e03c45497fb3dd340f04e89cab0a20/packages/feathers/lib/hooks/index.js#L156-L159
https://github.com/feathersjs/feathers/blob/656bae7875e03c45497fb3dd340f04e89cab0a20/packages/feathers/lib/hooks/index.js#L177
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`finally` is not listed in the [documentation](https://docs.feathersjs.com/api/hooks.html#registering-hooks). Is this on purpose? It seems it does the same as `after`, so if it's deprecated, should we add the definition and include `@deprecated` JSDoc? Otherwise I'd be happy to PR to the docs.