### PR TITLE
[@types/react] Improve ComponentProps handling of class components

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -765,7 +765,7 @@ declare namespace React {
      */
     type ComponentProps<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =
         T extends JSXElementConstructor<infer P>
-            ? P
+            ? ReactManagedAttributes<T, P>
             : T extends keyof JSX.IntrinsicElements
                 ? JSX.IntrinsicElements[T]
                 : {};

--- a/types/react/test/ComponentProps.tsx
+++ b/types/react/test/ComponentProps.tsx
@@ -1,0 +1,43 @@
+import React = require("react");
+
+// Function/class components
+// ---------------------------------------
+interface FunctionComponentProps {
+    foo?: number;
+    bar: number;
+}
+const FunctionComponent: React.FC<FunctionComponentProps> = ({
+    foo = 123,
+    bar
+}) => {
+    return <div>{foo + bar}</div>;
+};
+
+interface ClassComponentProps {
+    foo: number;
+    bar: number;
+}
+class ClassComponent extends React.Component<ClassComponentProps> {
+    static defaultProps = {
+        foo: 123,
+    };
+
+    render() {
+        return <div>{this.props.foo + this.props.bar}</div>;
+    }
+}
+
+const fcProps: React.ComponentProps<typeof FunctionComponent> = { bar: 123 };
+const ccProps: React.ComponentProps<typeof ClassComponent> = { bar: 123 };
+
+// Intrinsic elements
+// ---------------------------------------
+type ImgProps = React.ComponentProps<'img'>;
+// $ExpectType "async" | "auto" | "sync" | undefined
+type ImgPropsDecoding = ImgProps['decoding'];
+type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
+type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
+// $ExpectType false
+type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -356,16 +356,6 @@ const Profiler = React.unstable_Profiler;
   <div />
 </Profiler>;
 
-type ImgProps = React.ComponentProps<'img'>;
-// $ExpectType "async" | "auto" | "sync" | undefined
-type ImgPropsDecoding = ImgProps['decoding'];
-type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
-type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
-type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
-// $ExpectType false
-type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
-
 const HasClassName: React.ReactType<{ className?: string }> = 'a';
 const HasFoo: React.ReactType<{ foo: boolean }> = 'a'; // $ExpectError
 const HasFoo2: React.ReactType<{ foo: boolean }> = (props: { foo: boolean }) => null;

--- a/types/react/tsconfig.json
+++ b/types/react/tsconfig.json
@@ -4,6 +4,7 @@
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx",
+        "test/ComponentProps.tsx",
         "test/managedAttributes.tsx",
         "test/hooks.tsx"
     ],


### PR DESCRIPTION
Wrapping `P` in `ReactManagedAttributes` generates a type where `defaultProps` of a class component are taken into consideration.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

The code that made me discover this problem is closed source.
But in addition to the included test, I can share this piece of dummy code that does not work with the current types:
```ts
type Props = {
  foo: () => number;
  bar: number
};
class MyComponent extends React.Component<Props> {
  static defaultProps = {
    foo: () => 123,
  };

  render() {
    return <div>{this.props.foo() + this.props.bar}</div>;
  }
}

type MyComponentProps = React.ComponentProps<typeof MyComponent>;
// TS2741: Property 'foo' is missing in type '{ bar: number; }' but required in type 'Props'.
const props: MyComponentProps = { bar: 123 };
```
