### PR TITLE
fix(treeify): types

### DIFF
--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for treeify 1.1.0
+// Type definitions for treeify 1.1
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
 //                 Xiao Liang <https://github.com/yxliang01>

--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for treeify 1.1
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
-// Definitions by: Xiao Liang <https://github.com/yxliang01>
+//                 Xiao Liang <https://github.com/yxliang01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,27 +1,29 @@
-// Type definitions for treeify 1.0
+// Type definitions for treeify 1.1.0
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
+// Definitions by: Xiao Liang <https://github.com/yxliang01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
 export interface TreeObject {
-    [k: string]: TreeValue;
+    readonly [k: string]: TreeValue;
 }
-export type TreeValue = string | TreeObject;
+export type TreeValue = string | PrintObject;
+export type PrintObject = TreeObject | ReadonlyArray<any>;
 
 export function asTree(
-    treeObj: TreeObject,
+    printObj: PrintObject,
     showValues: boolean,
-    hideFunctions: boolean
+    hideFunctions?: boolean
 ): string;
 
 export function asLines(
-    treeObj: TreeObject,
+    printObj: PrintObject,
     showValues: boolean,
     lineCallback: (line: string) => void
 ): string;
 export function asLines(
-    treeObj: TreeObject,
+    printObj: PrintObject,
     showValues: boolean,
     hideFunctions: boolean,
     lineCallback: (line: string) => void

--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for treeify 1.1.0
+// Type definitions for treeify 1.1
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
 // Definitions by: Xiao Liang <https://github.com/yxliang01>

--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for treeify 1.1
+// Type definitions for treeify 1.1.0
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
 //                 Xiao Liang <https://github.com/yxliang01>

--- a/types/treeify/treeify-tests.ts
+++ b/types/treeify/treeify-tests.ts
@@ -11,6 +11,25 @@ treeify.asTree(
     true
 );
 
+// Ignore the `hideFunctions` argument
+treeify.asTree(
+    {
+        apples: 'gala', //      ├─ apples: gala
+        oranges: 'mandarin' //  └─ oranges: mandarin
+    },
+    true,
+);
+
+// Test printing arrays
+treeify.asTree(
+    [{
+        apples: 'gala', //      ├─ apples: gala
+        oranges: 'mandarin' //  └─ oranges: mandarin
+    }],
+    true,
+    true
+);
+
 treeify.asLines(
     {
         apples: 'gala', //                       ├─ apples: gala


### PR DESCRIPTION
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/notatestuser/treeify . Note: the documentation didn't specify that the `hideFunctions` argument for method `asTree` is optional, it is however optional. The documentation doesn't also explicitly state that it supports `Array` object, it instead just use placeholder `obj` which can be an `Array`.
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
- [X] Tested locally

Changes:
- Fixed previously only `object` can be supplied as argument for printing
- Made `TreeObject` attributes `readonly`
- Fixed `asTree` `hideFunctions` argument that it should be optional