### PR TITLE
[@storybook/addon-storyshots] Fix missing generic-param error on `renderer` option

### DIFF
--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -70,7 +70,7 @@ export interface InitOptions<Rendered = any> {
     storyNameRegex?: RegExp;
     framework?: string;
     test?: Test;
-    renderer?: (node: React.ReactElement) => Rendered;
+    renderer?: (node: JSX.Element) => Rendered;
     serializer?: (rendered: Rendered) => any;
     integrityOptions?: {};
 }


### PR DESCRIPTION
Prior to #32990, the `React.ReactElement` type did not have an optional first type param. Rather than forcing `@storybook/addon-storyshots` users to upgrade their `@types/react` package (which may require them to also upgrade `react` itself), we can switch to use `JSX.Element` which is and has been a simple alias for `React.ReactElement<any, any>`. This change preserves the `renderer` type while still allowing for compatibility with older versions of `@types/react`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] N/A ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] N/A Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] N/A ~Increase the version number in the header if appropriate.~
- [x] N/A ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~