### PR TITLE
react-redux: add types for hooks which will be added in version 7.1

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-redux 7.0
+// Type definitions for react-redux 7.1
 // Project: https://github.com/reduxjs/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>,
 //                 Kenzie Togami <https://github.com/kenzierocks>,
@@ -12,6 +12,7 @@
 //                 Anatoli Papirovski <https://github.com/apapirovski>
 //                 Boris Sergeyev <https://github.com/surgeboris>
 //                 Søren Bruus Frank <https://github.com/soerenbf>
+//                 Jonathan Ziller <https://github.com/mrwolfz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -38,6 +39,7 @@ import {
 import {
     Action,
     ActionCreator,
+    ActionCreatorsMapObject,
     AnyAction,
     Dispatch,
     Store
@@ -445,3 +447,240 @@ export const ReactReduxContext: Context<ReactReduxContextValue>;
  * multiple actions dispatched outside of React only result in a single render update.
  */
 export function batch(cb: () => void): void;
+
+// tslint:disable:no-unnecessary-generics
+
+/**
+ * A hook to bind action creators to the redux store's `dispatch` function
+ * similar to how redux's `bindActionCreators` works.
+ *
+ * Supports passing a single action creator, an array/tuple of action
+ * creators, or an object of action creators.
+ *
+ * Any arguments passed to the created callbacks are passed through to
+ * your functions.
+ *
+ * This hook takes a dependencies array as an optional second argument,
+ * which when passed ensures referential stability of the created callbacks.
+ *
+ * @param actions the action creators to bind
+ * @param deps (optional) dependencies array to control referential stability
+ *
+ * @returns callback(s) bound to store's `dispatch` function
+ *
+ * @example
+ *
+ * import React from 'react'
+ * import { useActions } from 'react-redux'
+ *
+ * const increaseCounter = ({ amount }) => ({
+ *   type: 'increase-counter',
+ *   amount,
+ * })
+ *
+ * export const CounterComponent = ({ value }) => {
+ *   // supports passing an object of action creators
+ *   const { increaseCounterByOne, increaseCounterByTwo } = useActions({
+ *     increaseCounterByOne: () => increaseCounter(1),
+ *     increaseCounterByTwo: () => increaseCounter(2),
+ *   }, [])
+ *
+ *   // supports passing an array/tuple of action creators
+ *   const [increaseCounterByThree, increaseCounterByFour] = useActions([
+ *     () => increaseCounter(3),
+ *     () => increaseCounter(4),
+ *   ], [])
+ *
+ *   // supports passing a single action creator
+ *   const increaseCounterBy5 = useActions(() => increaseCounter(5), [])
+ *
+ *   // passes through any arguments to the callback
+ *   const increaseCounterByX = useActions(x => increaseCounter(x), [])
+ *
+ *   return (
+ *     <div>
+ *       <span>{value}</span>
+ *       <button onClick={increaseCounterByOne}>Increase counter by 1</button>
+ *     </div>
+ *   )
+ * }
+ */
+export function useActions<
+    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ReadonlyArray<ActionCreator<A>>, A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ActionCreatorsMapObject<A>, A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ActionCreator<A>, A = ReturnType<T>>(actions: T, deps?: ReadonlyArray<any>): T;
+
+/**
+ * A hook to access the redux `dispatch` function. Note that in most cases where you
+ * might want to use this hook it is recommended to use `useActions` instead to bind
+ * action creators to the `dispatch` function.
+ *
+ * @returns redux store's `dispatch` function
+ *
+ * @example
+ *
+ * import React, { useCallback } from 'react'
+ * import { useReduxDispatch } from 'react-redux'
+ *
+ * export const CounterComponent = ({ value }) => {
+ *   const dispatch = useDispatch()
+ *   const increaseCounter = useCallback(() => dispatch({ type: 'increase-counter' }), [])
+ *   return (
+ *     <div>
+ *       <span>{value}</span>
+ *       <button onClick={increaseCounter}>Increase counter</button>
+ *     </div>
+ *   )
+ * }
+ */
+export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
+
+/**
+ * A hook to access the redux store's state and to bind action creators to
+ * the store's dispatch function. In essence, this hook is a combination of
+ * `useSelector` and `useActions`.
+ *
+ * Note that this hook does currently not allow to pass a dependencies array,
+ * so the passed selector and any created callbacks are not memoized. If you
+ * require memoization, please use `useActions` and `useSelector`.
+ *
+ * @param selector the selector function
+ * @param actions the action creators to bind
+ *
+ * @returns a tuple of the selected state and the bound action creators
+ *
+ * @example
+ *
+ * import React from 'react'
+ * import { useRedux } from 'react-redux'
+ * import { RootState } from './store'
+ *
+ * export const CounterComponent = () => {
+ *   const [counter, { inc1, inc }] = useRedux((state: RootState) => state.counter, {
+ *     inc1: () => ({ type: 'inc1' }),
+ *     inc: amount => ({ type: 'inc', amount }),
+ *   })
+ *
+ *   return (
+ *     <>
+ *       <div>
+ *         {counter}
+ *       </div>
+ *       <button onClick={inc1}>Increment by 1</button>
+ *       <button onClick={() => inc(5)}>Increment by 5</button>
+ *     </>
+ *   )
+ * }
+ */
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction
+    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
+    A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends [ActionCreator<A>, ActionCreator<A>], A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends [ActionCreator<A>], A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<A>>, A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject<A>, A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ActionCreator<A>, A = ReturnType<TActions>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+
+/**
+ * A hook to access the redux store's state. This hook takes a selector function
+ * as an argument. The selector is called with the store state.
+ *
+ * This hook takes a dependencies array as an optional second argument, which
+ * when passed ensures referential stability of the selector (this is primarily
+ * useful if you provide a selector that memoizes values).
+ *
+ * @param selector the selector function
+ * @param deps (optional) dependencies array to control referential stability
+ * of the selector
+ *
+ * @returns the selected state
+ *
+ * @example
+ *
+ * import React from 'react'
+ * import { useSelector } from 'react-redux'
+ * import { RootState } from './store'
+ *
+ * export const CounterComponent = () => {
+ *   const counter = useSelector((state: RootState) => state.counter, [])
+ *   return <div>{counter}</div>
+ * }
+ */
+export function useSelector<TState, TSelected>(selector: (state: TState) => TSelected, deps?: ReadonlyArray<any>): TSelected;
+
+/**
+ * A hook to access the redux store.
+ *
+ * @returns {any} the redux store
+ *
+ * @example
+ *
+ * import React from 'react'
+ * import { useStore } from 'react-redux'
+ *
+ * export const ExampleComponent = () => {
+ *   const store = useStore()
+ *   return <div>{store.getState()}</div>
+ * }
+ */
+export function useStore<S = any, A extends Action = AnyAction>(): Store<S, A>;
+
+// tslint:enable:no-unnecessary-generics

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -504,7 +504,12 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  * A hook to access the redux store's state. This hook takes a selector function
  * as an argument. The selector is called with the store state.
  *
+ * This hook takes an optional equality comparison function as the second parameter
+ * that allows you to customize the way the selected state is compared to determine
+ * whether the component needs to be re-rendered.
+ *
  * @param selector the selector function
+ * @param equalityFn the function that will be used to determine equality
  *
  * @returns the selected state
  *
@@ -519,7 +524,10 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState, TSelected>(selector: (state: TState) => TSelected): TSelected;
+export function useSelector<TState, TSelected>(
+    selector: (state: TState) => TSelected,
+    equalityFn?: (left: TSelected, right: TSelected) => boolean
+): TSelected;
 
 /**
  * A hook to access the redux store.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -467,6 +467,13 @@ export const ReactReduxContext: Context<ReactReduxContextValue>;
  */
 export function batch(cb: () => void): void;
 
+/**
+ * Compares two arbitrary values for shallow equality. Object values are compared based on their keys, i.e. they must
+ * have the same keys and for each key the value must be equal according to the `Object.is()` algorithm. Non-object
+ * values are also compared with the same algorithm as `Object.is()`.
+ */
+export function shallowEqual(left: any, right: any): boolean;
+
 // tslint:disable:no-unnecessary-generics
 
 /**

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -473,12 +473,12 @@ export function batch(cb: () => void): void;
  * import React from 'react'
  * import { useActions } from 'react-redux'
  *
- * const increaseCounter = amount => ({
+ * const increaseCounter = (amount: number) => ({
  *   type: 'increase-counter',
  *   amount,
  * })
  *
- * export const CounterComponent = ({ value }) => {
+ * export const CounterComponent = ({ value }: { value: number }) => {
  *   // supports passing an object of action creators
  *   const { increaseCounterByOne, increaseCounterByTwo } = useActions({
  *     increaseCounterByOne: () => increaseCounter(1),
@@ -574,7 +574,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  * export const CounterComponent = () => {
  *   const [counter, { inc1, inc }] = useRedux((state: RootState) => state.counter, {
  *     inc1: () => ({ type: 'inc1' }),
- *     inc: amount => ({ type: 'inc', amount }),
+ *     inc: (amount: number) => ({ type: 'inc', amount }),
  *   })
  *
  *   return (

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -23,11 +23,6 @@
 // a separate line instead of as a decorator. Discussed in this github issue:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
 
-// NOTE about the wrong react-redux version in the header comment:
-// The actual react-redux version is not 6.0.0, but we had to increase the major version
-// to update this type definitions for redux@4.x from redux@3.x.
-// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321
-
 import {
     Component,
     ComponentClass,

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -515,6 +515,10 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  * that allows you to customize the way the selected state is compared to determine
  * whether the component needs to be re-rendered.
  *
+ * If you do not want to have to specify the root state type for whenever you use
+ * this hook with an inline selector you can use the `TypedUseSelectorHook` interface
+ * to create a version of this hook that is properly typed for your root state.
+ *
  * @param selector the selector function
  * @param equalityFn the function that will be used to determine equality
  *
@@ -535,6 +539,26 @@ export function useSelector<TState, TSelected>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;
+
+/**
+ * This interface allows you to easily create a hook that is properly typed for your
+ * store's root state.
+ *
+ * @example
+ *
+ * interface RootState {
+ *   property: string;
+ * }
+ *
+ * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
+ *
+ */
+export interface TypedUseSelectorHook<TState> {
+    <TSelected>(
+        selector: (state: TState) => TSelected,
+        equalityFn?: (left: TSelected, right: TSelected) => boolean
+    ): TSelected;
+}
 
 /**
  * A hook to access the redux store.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -473,7 +473,7 @@ export function batch(cb: () => void): void;
  * import React from 'react'
  * import { useActions } from 'react-redux'
  *
- * const increaseCounter = ({ amount }) => ({
+ * const increaseCounter = amount => ({
  *   type: 'increase-counter',
  *   amount,
  * })

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -669,7 +669,7 @@ export function useSelector<TState, TSelected>(selector: (state: TState) => TSel
 /**
  * A hook to access the redux store.
  *
- * @returns {any} the redux store
+ * @returns the redux store
  *
  * @example
  *

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -505,17 +505,25 @@ export function batch(cb: () => void): void;
  *   )
  * }
  */
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<
+    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends [ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends [ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends ReadonlyArray<ActionCreator<any>>>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ActionCreatorsMapObject<any>>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ActionCreatorsMapObject>(actions: T, deps?: ReadonlyArray<any>): T;
 export function useActions<T extends ActionCreator<any>>(actions: T, deps?: ReadonlyArray<any>): T;
 
 /**
@@ -583,41 +591,43 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+    TActions
+    extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
-    >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>, ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<any>>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject<any>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<TState, TSelected, TActions extends ActionCreator<any>, A = ReturnType<TActions>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 
 /**

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -470,87 +470,11 @@ export function batch(cb: () => void): void;
 // tslint:disable:no-unnecessary-generics
 
 /**
- * A hook to bind action creators to the redux store's `dispatch` function
- * similar to how redux's `bindActionCreators` works.
+ * A hook to access the redux `dispatch` function.
  *
- * Supports passing a single action creator, an array/tuple of action
- * creators, or an object of action creators.
- *
- * Any arguments passed to the created callbacks are passed through to
- * your functions.
- *
- * This hook takes a dependencies array as an optional second argument,
- * which when passed ensures referential stability of the created callbacks.
- *
- * @param actions the action creators to bind
- * @param deps (optional) dependencies array to control referential stability
- *
- * @returns callback(s) bound to store's `dispatch` function
- *
- * @example
- *
- * import React from 'react'
- * import { useActions } from 'react-redux'
- *
- * const increaseCounter = (amount: number) => ({
- *   type: 'increase-counter',
- *   amount,
- * })
- *
- * export const CounterComponent = ({ value }: { value: number }) => {
- *   // supports passing an object of action creators
- *   const { increaseCounterByOne, increaseCounterByTwo } = useActions({
- *     increaseCounterByOne: () => increaseCounter(1),
- *     increaseCounterByTwo: () => increaseCounter(2),
- *   }, [])
- *
- *   // supports passing an array/tuple of action creators
- *   const [increaseCounterByThree, increaseCounterByFour] = useActions([
- *     () => increaseCounter(3),
- *     () => increaseCounter(4),
- *   ], [])
- *
- *   // supports passing a single action creator
- *   const increaseCounterBy5 = useActions(() => increaseCounter(5), [])
- *
- *   // passes through any arguments to the callback
- *   const increaseCounterByX = useActions(x => increaseCounter(x), [])
- *
- *   return (
- *     <div>
- *       <span>{value}</span>
- *       <button onClick={increaseCounterByOne}>Increase counter by 1</button>
- *     </div>
- *   )
- * }
- */
-export function useActions<
-    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<
-    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<
-    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<
-    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<
-    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends [ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends ReadonlyArray<ActionCreator<any>>>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
-export function useActions<T extends { [key: string]: ActionCreator<any> }>(actions: T, deps?: ReadonlyArray<any>): ResolveThunks<T>;
-export function useActions<T extends ActionCreator<any>>(actions: T, deps?: ReadonlyArray<any>): HandleThunkActionCreator<T>;
-
-/**
- * A hook to access the redux `dispatch` function. Note that in most cases where you
- * might want to use this hook it is recommended to use `useActions` instead to bind
- * action creators to the `dispatch` function.
+ * Note for `redux-thunk` users: the return type of the returned `dispatch` functions for thunks is incorrect.
+ * However, it is possible to get a correctly typed `dispatch` function by creating your own custom hook typed
+ * from the store's dispatch function like this: `const useThunkDispatch = () => useDispatch<typeof store.dispatch>();`
  *
  * @returns redux store's `dispatch` function
  *
@@ -561,28 +485,26 @@ export function useActions<T extends ActionCreator<any>>(actions: T, deps?: Read
  *
  * export const CounterComponent = ({ value }) => {
  *   const dispatch = useDispatch()
- *   const increaseCounter = useCallback(() => dispatch({ type: 'increase-counter' }), [])
  *   return (
  *     <div>
  *       <span>{value}</span>
- *       <button onClick={increaseCounter}>Increase counter</button>
+ *       <button onClick={() => dispatch({ type: 'increase-counter' })}>
+ *         Increase counter
+ *       </button>
  *     </div>
  *   )
  * }
  */
-export function useDispatch<A extends Action = any>(): Dispatch<A>;
+// NOTE: the first overload below and note above can be removed if redux-thunk typings add an overload for
+// the Dispatch function (see also this PR: https://github.com/reduxjs/redux-thunk/pull/247)
+export function useDispatch<TDispatch = Dispatch<any>>(): TDispatch;
+export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
 
 /**
  * A hook to access the redux store's state. This hook takes a selector function
  * as an argument. The selector is called with the store state.
  *
- * This hook takes a dependencies array as an optional second argument, which
- * when passed ensures referential stability of the selector (this is primarily
- * useful if you provide a selector that memoizes values).
- *
  * @param selector the selector function
- * @param deps (optional) dependencies array to control referential stability
- * of the selector
  *
  * @returns the selected state
  *
@@ -593,11 +515,11 @@ export function useDispatch<A extends Action = any>(): Dispatch<A>;
  * import { RootState } from './store'
  *
  * export const CounterComponent = () => {
- *   const counter = useSelector((state: RootState) => state.counter, [])
+ *   const counter = useSelector((state: RootState) => state.counter)
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState, TSelected>(selector: (state: TState) => TSelected, deps?: ReadonlyArray<any>): TSelected;
+export function useSelector<TState, TSelected>(selector: (state: TState) => TSelected): TSelected;
 
 /**
  * A hook to access the redux store.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -14,7 +14,7 @@
 //                 Søren Bruus Frank <https://github.com/soerenbf>
 //                 Jonathan Ziller <https://github.com/mrwolfz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.0
 
 // Known Issue:
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
@@ -133,9 +133,30 @@ export type ResolveThunks<TDispatchProps> =
         }
         : TDispatchProps;
 
-export type ResolveArrayThunks<TDispatchProps> = {
-    [C in keyof TDispatchProps]: HandleThunkActionCreator<TDispatchProps[C]>
-};
+// the conditional type is to support TypeScript 3.0, which does not support mapping over tuples and arrays;
+// once the typings are updated to at least TypeScript 3.1, a simple mapped type can replace this mess
+export type ResolveArrayThunks<TDispatchProps extends ReadonlyArray<any>> =
+    TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5, infer A6, infer A7, infer A8, infer A9]
+    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>,
+        HandleThunkActionCreator<A5>, HandleThunkActionCreator<A6>, HandleThunkActionCreator<A7>, HandleThunkActionCreator<A8>, HandleThunkActionCreator<A9>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5, infer A6, infer A7, infer A8]
+    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>,
+        HandleThunkActionCreator<A5>, HandleThunkActionCreator<A6>, HandleThunkActionCreator<A7>, HandleThunkActionCreator<A8>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5, infer A6, infer A7]
+    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>,
+        HandleThunkActionCreator<A5>, HandleThunkActionCreator<A6>, HandleThunkActionCreator<A7>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5, infer A6]
+    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>, HandleThunkActionCreator<A5>, HandleThunkActionCreator<A6>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5]
+    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>, HandleThunkActionCreator<A5>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4] ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>, HandleThunkActionCreator<A4>]
+    : TDispatchProps extends [infer A1, infer A2, infer A3] ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>, HandleThunkActionCreator<A3>]
+    : TDispatchProps extends [infer A1, infer A2] ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>]
+    : TDispatchProps extends [infer A1] ? [HandleThunkActionCreator<A1>]
+    : TDispatchProps extends Array<infer A> ? Array<HandleThunkActionCreator<A>>
+    : TDispatchProps extends ReadonlyArray<infer A> ? ReadonlyArray<HandleThunkActionCreator<A>>
+    : never
+    ;
 
 /**
  * Connects a React component to a Redux store.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -14,7 +14,7 @@
 //                 Søren Bruus Frank <https://github.com/soerenbf>
 //                 Jonathan Ziller <https://github.com/mrwolfz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 // Known Issue:
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
@@ -39,7 +39,6 @@ import {
 import {
     Action,
     ActionCreator,
-    ActionCreatorsMapObject,
     AnyAction,
     Dispatch,
     Store
@@ -138,6 +137,10 @@ export type ResolveThunks<TDispatchProps> =
             [C in keyof TDispatchProps]: HandleThunkActionCreator<TDispatchProps[C]>
         }
         : TDispatchProps;
+
+export type ResolveArrayThunks<TDispatchProps> = {
+    [C in keyof TDispatchProps]: HandleThunkActionCreator<TDispatchProps[C]>
+};
 
 /**
  * Connects a React component to a Redux store.
@@ -507,24 +510,26 @@ export function batch(cb: () => void): void;
  */
 export function useActions<
     T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): T;
+>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
 export function useActions<
     T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): T;
+>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
 export function useActions<
     T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): T;
+>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
 export function useActions<
     T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ReadonlyArray<ActionCreator<any>>>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ActionCreatorsMapObject>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ActionCreator<any>>(actions: T, deps?: ReadonlyArray<any>): T;
+>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<
+    T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
+>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends [ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends ReadonlyArray<ActionCreator<any>>>(actions: T, deps?: ReadonlyArray<any>): ResolveArrayThunks<T>;
+export function useActions<T extends { [key: string]: ActionCreator<any> }>(actions: T, deps?: ReadonlyArray<any>): ResolveThunks<T>;
+export function useActions<T extends ActionCreator<any>>(actions: T, deps?: ReadonlyArray<any>): HandleThunkActionCreator<T>;
 
 /**
  * A hook to access the redux `dispatch` function. Note that in most cases where you
@@ -549,7 +554,7 @@ export function useActions<T extends ActionCreator<any>>(actions: T, deps?: Read
  *   )
  * }
  */
-export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
+export function useDispatch<A extends Action = any>(): Dispatch<A>;
 
 /**
  * A hook to access the redux store's state and to bind action creators to
@@ -593,42 +598,51 @@ export function useRedux<
     TSelected,
     TActions
     extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
 export function useRedux<
     TState,
     TSelected,
     TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>, ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<any>>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ActionCreator<any>, A = ReturnType<TActions>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends [ActionCreator<any>, ActionCreator<any>]
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
+export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
+export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<any>>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
+export function useRedux<TState, TSelected, TActions extends { [key: string]: ActionCreator<any> }>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveThunks<TActions>];
+export function useRedux<
+    TState,
+    TSelected,
+    TActions extends ActionCreator<any>,
+    A = ReturnType<TActions>
+>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, HandleThunkActionCreator<TActions>];
 
 /**
  * A hook to access the redux store's state. This hook takes a selector function

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -557,7 +557,7 @@ export function useActions<T extends ActionCreator<any>>(actions: T, deps?: Read
  * @example
  *
  * import React, { useCallback } from 'react'
- * import { useReduxDispatch } from 'react-redux'
+ * import { useDispatch } from 'react-redux'
  *
  * export const CounterComponent = ({ value }) => {
  *   const dispatch = useDispatch()
@@ -571,94 +571,6 @@ export function useActions<T extends ActionCreator<any>>(actions: T, deps?: Read
  * }
  */
 export function useDispatch<A extends Action = any>(): Dispatch<A>;
-
-/**
- * A hook to access the redux store's state and to bind action creators to
- * the store's dispatch function. In essence, this hook is a combination of
- * `useSelector` and `useActions`.
- *
- * Note that this hook does currently not allow to pass a dependencies array,
- * so the passed selector and any created callbacks are not memoized. If you
- * require memoization, please use `useActions` and `useSelector`.
- *
- * @param selector the selector function
- * @param actions the action creators to bind
- *
- * @returns a tuple of the selected state and the bound action creators
- *
- * @example
- *
- * import React from 'react'
- * import { useRedux } from 'react-redux'
- * import { RootState } from './store'
- *
- * export const CounterComponent = () => {
- *   const [counter, { inc1, inc }] = useRedux((state: RootState) => state.counter, {
- *     inc1: () => ({ type: 'inc1' }),
- *     inc: (amount: number) => ({ type: 'inc', amount }),
- *   })
- *
- *   return (
- *     <>
- *       <div>
- *         {counter}
- *       </div>
- *       <button onClick={inc1}>Increment by 1</button>
- *       <button onClick={() => inc(5)}>Increment by 5</button>
- *     </>
- *   )
- * }
- */
-export function useRedux<
-    TState,
-    TSelected,
-    TActions
-    extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends [ActionCreator<any>, ActionCreator<any>]
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<any>>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveArrayThunks<TActions>];
-export function useRedux<TState, TSelected, TActions extends { [key: string]: ActionCreator<any> }>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, ResolveThunks<TActions>];
-export function useRedux<
-    TState,
-    TSelected,
-    TActions extends ActionCreator<any>,
-    A = ReturnType<TActions>
->(selector: (state: TState) => TSelected, actions: TActions): [TSelected, HandleThunkActionCreator<TActions>];
 
 /**
  * A hook to access the redux store's state. This hook takes a selector function

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -505,30 +505,18 @@ export function batch(cb: () => void): void;
  *   )
  * }
  */
-export function useActions<
-    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
-    >(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<
-    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
-    >(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<
-    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
-    >(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<
-    T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
-    >(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<A>, ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends [ActionCreator<A>], A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ReadonlyArray<ActionCreator<A>>, A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ActionCreatorsMapObject<A>, A = AnyAction>(actions: T, deps?: ReadonlyArray<any>): T;
-export function useActions<T extends ActionCreator<A>, A = ReturnType<T>>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>, ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends [ActionCreator<any>]>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ReadonlyArray<ActionCreator<any>>>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ActionCreatorsMapObject<any>>(actions: T, deps?: ReadonlyArray<any>): T;
+export function useActions<T extends ActionCreator<any>>(actions: T, deps?: ReadonlyArray<any>): T;
 
 /**
  * A hook to access the redux `dispatch` function. Note that in most cases where you
@@ -595,49 +583,42 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]
     >(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 export function useRedux<
     TState,
     TSelected,
-    TActions extends [ActionCreator<A>, ActionCreator<A>, ActionCreator<A>],
-    A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends [ActionCreator<A>, ActionCreator<A>], A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends [ActionCreator<A>], A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<A>>, A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject<A>, A = AnyAction>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
-export function useRedux<TState, TSelected, TActions extends ActionCreator<A>, A = ReturnType<TActions>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+    TActions extends [ActionCreator<any>, ActionCreator<any>, ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>, ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends [ActionCreator<any>]>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ReadonlyArray<ActionCreator<any>>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ActionCreatorsMapObject<any>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
+export function useRedux<TState, TSelected, TActions extends ActionCreator<any>, A = ReturnType<TActions>>(selector: (state: TState) => TSelected, actions: TActions): [TSelected, TActions];
 
 /**
  * A hook to access the redux store's state. This hook takes a selector function

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -23,7 +23,6 @@ import {
     MapDispatchToProps,
     useActions,
     useDispatch,
-    useRedux,
     useSelector,
     useStore,
 } from 'react-redux';
@@ -1423,98 +1422,6 @@ function testUseSelector() {
 
     const { extraneous } = useSelector(selector); // $ExpectError
     useSelector(selector, [counter]);
-}
-
-function testUseRedux() {
-    interface State {
-        counter: number;
-    }
-    const actionCreator1 = (selected: boolean) => ({
-        type: "ACTION_CREATOR_1",
-        payload: selected,
-    });
-    const actionCreator2 = ({ items }: { items: string[] }) => ({
-        type: "ACTION_CREATOR_2",
-        payload: {
-            items
-        }
-    });
-    const thunkActionCreator = () => {
-        return (dispatch: Dispatch) => {
-            return dispatch({
-                type: "THUNK_ACTION_CREATOR",
-                payload: [],
-            });
-        };
-    };
-    const selector = (state: State) => {
-        return {
-            counter: state.counter,
-        };
-    };
-    function testUseReduxSingle() {
-        const [selected, boundAction1] = useRedux(selector, actionCreator1);
-        selected.counter === 1;
-        selected.counter === "321"; // $ExpectError
-        boundAction1(); // $ExpectError
-        boundAction1(true);
-    }
-    function testUseReduxThunk() {
-        const [selected, boundThunk] = useRedux(selector, thunkActionCreator);
-        const result = boundThunk();
-        result.payload[0];
-        result.payload.data; // $ExpectError
-    }
-    function testUseReduxArray() {
-        const [
-            selected,
-            [
-                boundAction1,
-                boundAction2,
-                boundThunk,
-            ]
-        ] = useRedux(selector, [actionCreator1, actionCreator2, thunkActionCreator]);
-        boundAction1(); // $ExpectError
-        boundAction2(true); // $ExpectError
-        boundAction1(true);
-        boundAction2({ items: ["a"] });
-        const result = boundThunk();
-        result.payload[0];
-        result.payload.data; // $ExpectError
-    }
-    function testUseReduxArrayExtraneous() {
-        const [
-            selected,
-            boundAction1,
-            nonexistentAction, // $ExpectError
-        ] = useRedux(selector, [actionCreator1]);
-    }
-
-    function testUseReduxObject() {
-        const [
-            selected,
-            {
-                actionCreator1: boundAction1,
-                actionCreator2: boundAction2,
-                thunkActionCreator: boundThunk,
-            },
-        ] = useRedux(selector, { actionCreator1, actionCreator2, thunkActionCreator });
-        boundAction1(); // $ExpectError
-        boundAction2(true); // $ExpectError
-        boundAction1(true);
-        boundAction2({ items: ["a"] });
-        const result = boundThunk();
-        result.payload[0];
-        result.payload.data; // $ExpectError
-    }
-
-    function testUseReduxObjectExtraneous() {
-        const [
-            state,
-            { actionCreator1: boundAction1 },
-            nonexistentThing, // $ExpectError
-        ] = useRedux(selector, { actionCreator1 });
-    }
 }
 
 function testUseStore() {

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -25,6 +25,7 @@ import {
     useDispatch,
     useSelector,
     useStore,
+    TypedUseSelectorHook,
 } from 'react-redux';
 import objectAssign = require('object-assign');
 
@@ -1366,6 +1367,19 @@ function testUseSelector() {
     useSelector(() => 1, compare);
     const compare2 = (_l: number, _r: string) => true;
     useSelector(() => 1, compare2); // $ExpectError
+
+    interface RootState {
+        property: string;
+    }
+
+    const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+     // $ExpectType string
+    const r = useTypedSelector(state => {
+        // $ExpectType RootState
+        state;
+        return state.property;
+    });
 }
 
 function testUseStore() {

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -20,6 +20,7 @@ import {
     ReactReduxContext,
     ReactReduxContextValue,
     Selector,
+    shallowEqual,
     MapDispatchToProps,
     useDispatch,
     useSelector,
@@ -1298,6 +1299,15 @@ function TestSelector() {
     notSimpleSelect(state); // $ExpectError
 }
 
+function testShallowEqual() {
+    shallowEqual(); // $ExpectError
+    shallowEqual('a'); // $ExpectError
+    shallowEqual('a', 'a');
+    shallowEqual({ test: 'test' }, { test: 'test' });
+    shallowEqual({ test: 'test' }, 'a');
+    const x: boolean = shallowEqual('a', 'a');
+}
+
 function testUseDispatch() {
     const actionCreator = (selected: boolean) => ({
         type: "ACTION_CREATOR",
@@ -1342,6 +1352,20 @@ function testUseSelector() {
 
     const { extraneous } = useSelector(selector); // $ExpectError
     useSelector(selector);
+
+    useSelector(selector, 'a'); // $ExpectError
+    useSelector(selector, (l, r) => l === r);
+    useSelector(selector, (l, r) => {
+        // $ExpectType { counter: number; active: string; }
+        l;
+        return l === r;
+    });
+
+    useSelector(selector, shallowEqual);
+    const compare = (_l: number, _r: number) => true;
+    useSelector(() => 1, compare);
+    const compare2 = (_l: number, _r: string) => true;
+    useSelector(() => 1, compare2); // $ExpectError
 }
 
 function testUseStore() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reduxjs/react-redux/tree/v7-hooks-alpha/src/hooks
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I am the author of the react-redux alpha hooks implementation (which I prototyped in TypeScript). These type definitions are mostly taken from my own source code.
