### PR TITLE
[react-aria-menubutton] Extend React.HTMLProps

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -13,7 +13,7 @@ export interface WrapperState {
 }
 
 export interface WrapperProps<T extends HTMLElement>
-	extends React.HTMLAttributes<T> {
+	extends React.HTMLProps<T> {
 	/**
 	 * A callback to run when the user makes a selection
 	 * (i.e. clicks or presses Enter or Space on a `MenuItem`).
@@ -58,7 +58,7 @@ export interface WrapperProps<T extends HTMLElement>
 export class Wrapper extends React.Component<WrapperProps<HTMLElement>> {}
 
 export interface ButtonProps<T extends HTMLElement>
-	extends React.HTMLAttributes<T> {
+	extends React.HTMLProps<T> {
 	/**
 	 * If true, the element is disabled
 	 * (aria-disabled='true', not in tab order, clicking has no effect).
@@ -82,7 +82,7 @@ export interface ButtonProps<T extends HTMLElement>
 export class Button extends React.Component<ButtonProps<HTMLElement>> {}
 
 export interface MenuProps<T extends HTMLElement>
-	extends React.HTMLAttributes<T> {
+	extends React.HTMLProps<T> {
 	/**
 	 * The HTML tag for this element. Default: 'span'.
 	 */
@@ -95,7 +95,7 @@ export interface MenuProps<T extends HTMLElement>
 export class Menu extends React.Component<MenuProps<HTMLElement>> {}
 
 export interface MenuItemProps<T extends HTMLElement>
-	extends React.HTMLAttributes<T> {
+	extends React.HTMLProps<T> {
 	/**
 	 * If value has a value, it will be passed to the onSelection handler
 	 * when the `MenuItem` is selected


### PR DESCRIPTION
This PR each component's interface to extend `React.HTMLProps` instead of `React.HTMLAttributes` so `ref` can be passed down.