### PR TITLE
koa-joi-router: be able to configure routes outside main file

### DIFF
--- a/types/koa-joi-router/index.d.ts
+++ b/types/koa-joi-router/index.d.ts
@@ -29,30 +29,33 @@ declare namespace createRouter {
     interface NestedHandler extends ReadonlyArray<Handler> {}
     type Handler = FullHandler | NestedHandler;
 
-    type Method = (path: string|RegExp, handlerOrConfig: Handler | object, ...handlers: Handler[]) => Router;
+    type Method = (path: string|RegExp, handlerOrConfig: Handler | Config, ...handlers: Handler[]) => Router;
 
     type OutputValidation = { body: Joi.SchemaLike } | { headers: Joi.SchemaLike };
 
-    interface Spec {
+    interface Config {
+      pre?: Handler;
+      validate?: {
+          header?: Joi.SchemaLike;
+          query?: Joi.SchemaLike;
+          params?: Joi.SchemaLike;
+          body?: Joi.SchemaLike;
+          maxBody?: number;
+          failure?: number;
+          type?: 'form'|'json'|'multipart';
+          formOptions?: CoBody.Options;
+          jsonOptions?: CoBody.Options;
+          multipartOptions?: CoBody.Options;
+          output?: {[status: string]: OutputValidation};
+          continueOnError?: boolean;
+      };
+      meta?: any;
+    }
+
+    interface Spec extends Config {
         method: string|string[];
         path: string|RegExp;
         handler: Handler;
-        pre?: Handler;
-        validate?: {
-            header?: Joi.SchemaLike;
-            query?: Joi.SchemaLike;
-            params?: Joi.SchemaLike;
-            body?: Joi.SchemaLike;
-            maxBody?: number;
-            failure?: number;
-            type?: 'form'|'json'|'multipart';
-            formOptions?: CoBody.Options;
-            jsonOptions?: CoBody.Options;
-            multipartOptions?: CoBody.Options;
-            output?: {[status: string]: OutputValidation};
-            continueOnError?: boolean;
-        };
-        meta?: any;
     }
 
     interface Router {

--- a/types/koa-joi-router/koa-joi-router-tests.ts
+++ b/types/koa-joi-router/koa-joi-router-tests.ts
@@ -132,6 +132,34 @@ router().get('/', handler1);
 
 router().get('/', {meta: {desc: 'desc'}}, handler1);
 
+router().get('/user', {
+    validate: {
+        query: {
+          id: Joi.number(),
+          name: Joi.string(),
+        }
+    }
+}, (ctx: koa.Context) => {
+    ctx.status = 201;
+    ctx.body = ctx.request.params;
+});
+
+const spec9: router.Config = {
+    validate: {
+        body: {
+          name: Joi.string(),
+        },
+        type: 'json'
+    }
+};
+
+const spec9Handler = (ctx: koa.Context) => {
+    ctx.status = 201;
+    ctx.body = ctx.request.params;
+};
+
+router().get('/user', spec9, spec9Handler);
+
 const middleware1 = async (ctx: koa.Context, next: () => Promise<any>) => {
   console.log('middleware1');
   await next();


### PR DESCRIPTION
some users of `koa-joi-router` might like to declare their route handlers and configuration outside their main "router" file, splitting `Spec` into 2 interfaces let them do exactly that.

Moreover any `route.get(),post(),put(),delete()` supports introspection when used with the `router.method(path , config, handler [, handler])` signature

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/joi-router#getpostputdelete-etc---http-methods
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**EDIT:**
a minor version bump would be appropriate, but don't know how to do that with definition files
