### PR TITLE
Fix incorrect argument type on TSTypeReference

### DIFF
--- a/types/babel-types/babel-types-tests.ts
+++ b/types/babel-types/babel-types-tests.ts
@@ -115,7 +115,7 @@ t.TSTypeParameterDeclaration([param]);
 t.TSTypeParameterInstantiation([any]);
 t.TSTypePredicate(id, t.TSTypeAnnotation(any));
 t.TSTypeQuery(id);
-t.TSTypeReference(id);
+t.TSTypeReference(id, t.TSTypeParameterInstantiation([any]));
 t.TSUndefinedKeyword();
 t.TSUnionType([any]);
 t.TSVoidKeyword();

--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -1509,7 +1509,7 @@ export function TSTypeParameterDeclaration(params: TSTypeParameter[]): TSTypePar
 export function TSTypeParameterInstantiation(params: TSType[]): TSTypeParameterInstantiation;
 export function TSTypePredicate(parameterName: Identifier | TSThisType, typeAnnotation: TSTypeAnnotation): TSTypePredicate;
 export function TSTypeQuery(exprName: TSEntityName): TSTypeQuery;
-export function TSTypeReference(typeName: TSEntityName, typeParameters?: TypeParameterInstantiation): TSTypeReference;
+export function TSTypeReference(typeName: TSEntityName, typeParameters?: TSTypeParameterInstantiation): TSTypeReference;
 export function TSUndefinedKeyword(): TSUndefinedKeyword;
 export function TSUnionType(types: TSType[]): TSUnionType;
 export function TSVoidKeyword(): TSVoidKeyword;


### PR DESCRIPTION
[docs](https://babeljs.io/docs/en/babel-types#tstypereference), [source](https://github.com/babel/babel/blob/8ca99b9f0938daa6a7d91df81e612a1a24b09d98/packages/babel-types/src/definitions/typescript.js#L166)
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - [docs](https://babeljs.io/docs/en/babel-types#tstypereference)
    - [source](https://github.com/babel/babel/blob/8ca99b9f0938daa6a7d91df81e612a1a24b09d98/packages/babel-types/src/definitions/typescript.js#L166)
