### PR TITLE
[@types/promise-retry] Export a namespace

### DIFF
--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -24,4 +24,6 @@ type RetryableFn<ResolutionType> = ((retry: (error: any) => never, attempt: numb
  */
 declare function promiseRetry<ResolutionType>(retryableFn: RetryableFn<ResolutionType>, options?: OperationOptions): Promise<ResolutionType>;
 declare function promiseRetry<ResolutionType>(options: OperationOptions, retryableFn: RetryableFn<ResolutionType>): Promise<ResolutionType>;
+// Exporting a namespace too
+namespace promiseRetry {}
 export = promiseRetry;

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -25,5 +25,5 @@ type RetryableFn<ResolutionType> = ((retry: (error: any) => never, attempt: numb
 declare function promiseRetry<ResolutionType>(retryableFn: RetryableFn<ResolutionType>, options?: OperationOptions): Promise<ResolutionType>;
 declare function promiseRetry<ResolutionType>(options: OperationOptions, retryableFn: RetryableFn<ResolutionType>): Promise<ResolutionType>;
 // Exporting a namespace too
-namespace promiseRetry {}
+declare namespace promiseRetry {}
 export = promiseRetry;


### PR DESCRIPTION
When exporting a function using `export = promiseRetry` the module should have a namespace of the same name.

See https://github.com/Microsoft/TypeScript/issues/5073

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/5073
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
