### PR TITLE
[express-serve-static-core] Add overload to Response.download() [v4.16.0]

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -605,12 +605,16 @@ export interface Response extends http.ServerResponse, Express.Response {
      * when the data transfer is complete, or when an error has
      * ocurred. Be sure to check `res.headerSent` if you plan to respond.
      *
+     * The optional options argument passes through to the underlying
+     * res.sendFile() call, and takes the exact same parameters.
+     *
      * This method uses `res.sendfile()`.
      */
     download(path: string): void;
     download(path: string, filename: string): void;
     download(path: string, fn: Errback): void;
     download(path: string, filename: string, fn: Errback): void;
+    download(path: string, filename: string, options: any, fn: Errback): void;
 
     /**
      * Set _Content-Type_ response header with `type` through `mime.lookup()`


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [Documentation](https://expressjs.com/en/api.html#res.download)
- [Source code](https://github.com/expressjs/express/blob/dc538f6e810bd462c98ee7e6aae24c64d4b1da93/lib/response.js#L530)
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

#### Personal note:
The version number follows the current MINOR release of express, I'm not sure whether the version has to be bumped for npm. Tests are run by `express.d.ts` and `serve-static.d.ts`.