### PR TITLE
[@ember/array] Fix incorrect typing of Enumerable.sortBy

### DIFF
--- a/types/ember__array/-private/enumerable.d.ts
+++ b/types/ember__array/-private/enumerable.d.ts
@@ -151,7 +151,7 @@ interface Enumerable<T> {
      * Converts the enumerable into an array and sorts by the keys
      * specified in the argument.
      */
-    sortBy(property: string): NativeArray<T>;
+    sortBy(...property: string[]): NativeArray<T>;
     /**
      * Returns a new enumerable that contains only items containing a unique property value.
      * The default implementation returns an array regardless of the receiver type.


### PR DESCRIPTION
`sortBy` allows you to pass multiple properties to sort on. This is documented here: https://api.emberjs.com/ember/3.9/classes/EmberArray/methods/sortBy?anchor=sortBy
