### PR TITLE
[@types/auth0-js] remove password from ChangePasswordOptions

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -126,8 +126,7 @@ webAuth.renewAuth({
 }, (err, authResult) => {});
 
 webAuth.changePassword({connection: 'the_connection',
-    email: 'me@example.com',
-    password: '123456'
+    email: 'me@example.com'
 }, (err) => {});
 
 webAuth.passwordlessStart({
@@ -250,7 +249,7 @@ authentication.getSSOData();
 authentication.getSSOData(true, (err, data) => {});
 
 authentication.dbConnection.signup({connection: 'bla', email: 'blabla', password: '123456'}, () => {});
-authentication.dbConnection.changePassword({connection: 'bla', email: 'blabla', password: '123456'}, () => {});
+authentication.dbConnection.changePassword({connection: 'bla', email: 'blabla'}, () => {});
 
 authentication.passwordless.start({ connection: 'bla', send: 'blabla' }, () => {});
 authentication.passwordless.verify({ connection: 'bla', verificationCode: 'asdfasd', email: 'me@example.com' }, () => {});

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -616,7 +616,6 @@ export interface Auth0DelegationToken {
 export interface ChangePasswordOptions {
     connection: string;
     email: string;
-    password?: string;
 }
 
 export interface PasswordlessStartOptions {


### PR DESCRIPTION
## Why

- This option is not used by the Auth0.js 9.10 library
- Changing password through the API is a deprecated workflow
- This is a BREAKING CHANGE since it removes a property, but the property currently provides no functionality

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/auth0.js/issues/926
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.