### PR TITLE
[react-bootstrap-typeahead] Fix HighlighterProps to reflect how they're used

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -334,7 +334,7 @@ export class TypeaheadInputMulti<T extends TypeaheadModel> extends React.Compone
 --------------------------------------------------------------------------- */
 export interface HighligherProps {
     children: React.ReactNode;
-    search: string;
+    search?: string;
 }
 
 export class Highlighter extends React.PureComponent<HighligherProps> { }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Explanation

In the source for the `Highlighter` component, there's an explicit check to see if the `search` prop is falsey. This contradicts the existing types, which requires that the `search` prop is provided. This would also produce type errors with [the given sample code](https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/API.md#search-string-required):

```jsx
<Typeahead
  ...
  renderMenuItemChildren={(option, props, idx) => (
    <Highlighter search={props.text}>
      {option[props.labelKey]}
    </Highlighter>
  )}
/>
```

In this case, `props.text` is typed as `string | undefined`, which causes a type error. So an alternative fix would be to change the typings for `MenuProps.text`, but for me it was easier to verify that `Highligher` handles null/undefined well than it was to reason about when `MenuProps.text` might or might not be undefined.
