### PR TITLE
react-native: Updates the comment for the keyboardShouldPersistTaps prop

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4104,10 +4104,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     columnWrapperStyle?: StyleProp<ViewStyle>;
 
     /**
-     * When false tapping outside of the focused text input when the keyboard
-     * is up dismisses the keyboard. When true the scroll view will not catch
-     * taps and the keyboard will not dismiss automatically. The default value
-     * is false.
+     * Determines when the keyboard should stay visible after a tap.
+     * - 'never' (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
+     * - 'always', the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
+     * - 'handled', the keyboard will not dismiss automatically when the tap was handled by a children, (or captured by an ancestor).
+     * - false, deprecated, use 'never' instead
+     * - true, deprecated, use 'always' instead
      */
     keyboardShouldPersistTaps?: boolean | "always" | "never" | "handled";
 
@@ -6584,10 +6586,12 @@ export interface ScrollViewProps extends ViewProps, ScrollViewPropsIOS, ScrollVi
     keyboardDismissMode?: "none" | "interactive" | "on-drag";
 
     /**
-     * When false tapping outside of the focused text input when the keyboard
-     * is up dismisses the keyboard. When true the scroll view will not catch
-     * taps and the keyboard will not dismiss automatically. The default value
-     * is false.
+     * Determines when the keyboard should stay visible after a tap.
+     * - 'never' (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
+     * - 'always', the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
+     * - 'handled', the keyboard will not dismiss automatically when the tap was handled by a children, (or captured by an ancestor).
+     * - false, deprecated, use 'never' instead
+     * - true, deprecated, use 'always' instead
      */
     keyboardShouldPersistTaps?: boolean | "always" | "never" | "handled";
 


### PR DESCRIPTION
This PR updates the comment for the `keyboardShouldPersistTaps` prop in the `react-native` type definitions. I did not change the actual type definitions themselves. Rather, it seems like the comment was still referring to an order version of this prop's type. This caused me confusion when my IDE would popup incorrect documentation for this prop.

Here's a link to the live documentation for the prop in question: https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps

I hope this helps.