### PR TITLE
[react-aria-menubutton] Fix typo for closeOptions

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -158,6 +158,6 @@ export function closeMenu(
 		 * If `true`, the widget's button will receive focus when the
 		 * menu closes. Default: `false`.
 		 */
-		focusMenu: boolean;
+		focusButton: boolean;
 	}
 ): void;

--- a/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
+++ b/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
@@ -117,7 +117,7 @@ class DemoOne extends React.Component<{}, DemoOneState> {
 ReactDOM.render(<DemoOne />, document.getElementById("demo-one"));
 
 closeMenu("");
-closeMenu("", { focusMenu: true });
+closeMenu("", { focusButton: true });
 
 openMenu("");
 openMenu("", { focusMenu: true });


### PR DESCRIPTION
`closeOptions` should actually contain a `focusButton`, not `focusMenu`.

Reference: https://github.com/davidtheclark/react-aria-menubutton/blob/master/src/createManager.js#L99
