### PR TITLE
[node-gravatar] add string enums and profile_url()

### DIFF
--- a/types/gravatar/gravatar-tests.ts
+++ b/types/gravatar/gravatar-tests.ts
@@ -3,12 +3,12 @@
 import gravatar = require('gravatar');
 
 gravatar.url("email@example.com");
-gravatar.url("email@example.com", { s: 200, r: "pg", d: "404" });
-gravatar.url("email@example.com", { size: 200, r: "pg", d: "404" });
-gravatar.url("email@example.com", { s: 200 });
+gravatar.url("email@example.com", { s: "200", r: "pg", d: "404" });
+gravatar.url("email@example.com", { size: "200", r: "pg", d: "404" });
+gravatar.url("email@example.com", { s: "200" });
 gravatar.url("email@example.com", { default: "404" });
-gravatar.url("email@example.com", { s: 200, rating: "pg", d: "404" }, true);
-gravatar.url("email@example.com", { s: 200, r: "pg", default: "404" }, false);
+gravatar.url("email@example.com", { s: "200", rating: "pg", d: "404" }, true);
+gravatar.url("email@example.com", { s: "200", r: "pg", default: "404" }, false);
 gravatar.url("email@example.com", { d: "404" }, false);
 gravatar.url("email@example.com", { forcedefault: "y" }, false);
 gravatar.url("email@example.com", { f: "y" });

--- a/types/gravatar/gravatar-tests.ts
+++ b/types/gravatar/gravatar-tests.ts
@@ -3,14 +3,14 @@
 import gravatar = require('gravatar');
 
 gravatar.url("email@example.com");
-gravatar.url("email@example.com", { s: "200", r: "pg", d: "404" });
-gravatar.url("email@example.com", { size: "200", r: "pg", d: "404" });
-gravatar.url("email@example.com", { s: "200" });
+gravatar.url("email@example.com", { s: 200, r: "pg", d: "404" });
+gravatar.url("email@example.com", { size: 200, r: "pg", d: "404" });
+gravatar.url("email@example.com", { s: 200 });
 gravatar.url("email@example.com", { default: "404" });
-gravatar.url("email@example.com", { s: "200", rating: "pg", d: "404" }, true);
-gravatar.url("email@example.com", { s: "200", r: "pg", default: "404" }, false);
+gravatar.url("email@example.com", { s: 200, rating: "pg", d: "404" }, true);
+gravatar.url("email@example.com", { s: 200, r: "pg", default: "404" }, false);
 gravatar.url("email@example.com", { d: "404" }, false);
 gravatar.url("email@example.com", { forcedefault: "y" }, false);
 gravatar.url("email@example.com", { f: "y" });
 gravatar.url("email@example.com", { protocol: "https" });
-gravatar.url("email@example.com", { format: "xml" });
+gravatar.profile_url("email@example.com", { format: "xml" });

--- a/types/gravatar/index.d.ts
+++ b/types/gravatar/index.d.ts
@@ -1,23 +1,35 @@
 // Type definitions for gravatar v1.8.0
 // Project: https://github.com/emerleite/node-gravatar
 // Definitions by: Denis Sokolov <https://github.com/denis-sokolov>
+//                 April Arcus <https://github.com/aprilarcus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace GravatarModule {
-  type Options = {
-    d?: string
-    default?: string
-    f?: string
-    forcedefault?: string
-    format?: string
-    protocol?: string
-    r?: string
-    rating?: string
-    s?: string
-    size?: string
+declare module 'gravatar' {
+
+  type URL = string
+
+  type Default = URL | '404' | 'mp' | 'identicon' | 'monsterid' | 'wavatar' | 'retro' | 'robohash' | 'blank'
+
+  type Rating = 'g' | 'pg' | 'r' | 'x'
+
+  interface Options {
+    size?: number,
+    s?: number,
+    default?: Default,
+    d?: Default,
+    rating?: Rating,
+    r?: Rating,
+    forcedefault?: 'y',
+    f?: 'y',
+    protocol?: boolean | 'http' | 'https',
+    cdn?: string
   }
 
-  function url(email: string, options?: Options, forceProtocol?: boolean): string;
-}
+  interface ProfileOptions extends Options {
+    format?: 'json' | 'xml' | 'php' | 'vcf' | 'qr'
+  }
 
-export = GravatarModule;
+  export function url (email: string, options?: Options, https?: boolean): string
+  export function profile_url (email: string, options?: ProfileOptions, https?: boolean): string
+
+}

--- a/types/gravatar/index.d.ts
+++ b/types/gravatar/index.d.ts
@@ -12,9 +12,11 @@ declare module 'gravatar' {
 
   type Rating = 'g' | 'pg' | 'r' | 'x'
 
+  type Size = string | number
+
   interface Options {
-    size?: number,
-    s?: number,
+    size?: Size,
+    s?: Size,
     default?: Default,
     d?: Default,
     rating?: Rating,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
> I am documenting the following additional features:
> - `size` should be of type `number`. Interpolating a non-integer value here will cause gravatar's API to silently replace the `size` parameter with a default value.
> - various options are redefined from strings to unions of string literals
> - the `format` option is only meaningful on the `profile_url()` function. This function is added to the definition and the type of its options bag is updated accordingly.
- [x] Increase the version number in the header if appropriate.
> no version number changes
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`