### PR TITLE
[cors] CustomOrigin.requestOrigin can be undefined

### DIFF
--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -40,7 +40,7 @@ app.use(cors({
 app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
-            const allow = requestOrigin.indexOf('.edu') !== -1;
+            const allow = !requestOrigin || requestOrigin.indexOf('.edu') !== -1;
             cb(null, allow);
         } catch (err) {
             cb(err);

--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -39,12 +39,8 @@ app.use(cors({
 }));
 app.use(cors({
     origin: (requestOrigin, cb) => {
-        try {
-            const allow = !requestOrigin || requestOrigin.indexOf('.edu') !== -1;
-            cb(null, allow);
-        } catch (err) {
-            cb(err);
-        }
+        const allow = !requestOrigin || requestOrigin.indexOf('.edu') !== -1;
+        cb(null, allow);
     }
 }));
 app.use(cors((req, cb) => {

--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -39,8 +39,12 @@ app.use(cors({
 }));
 app.use(cors({
     origin: (requestOrigin, cb) => {
-        const allow = !requestOrigin || requestOrigin.indexOf('.edu') !== -1;
-        cb(null, allow);
+        try {
+            const allow = !requestOrigin || requestOrigin.indexOf('.edu') !== -1;
+            cb(null, allow);
+        } catch (err) {
+            cb(err);
+        }
     }
 }));
 app.use(cors((req, cb) => {

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -7,7 +7,7 @@
 import express = require('express');
 
 type CustomOrigin = (
-    requestOrigin: string,
+    requestOrigin: string | undefined,
     callback: (err: Error | null, allow?: boolean) => void
 ) => void;
 

--- a/types/cors/tsconfig.json
+++ b/types/cors/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
In `cors` pacakge, `CustomOrigin.requestOrigin` can be undefined but it's not in type definition.
https://github.com/expressjs/cors#configuring-cors-w-dynamic-origin

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/cors#configuring-cors-w-dynamic-origin
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
