### PR TITLE
Add BackgorundFetch namespace and fix function name in Location namespace

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -19,6 +19,7 @@
 //                 Vinit Sood <https://github.com/vinitsood>
 //                 Mattias Sämskar <https://github.com/mattiassamskar>
 //                 Julian Hundeloh <https://github.com/jaulz>
+//                 Matevz Poljanc <https://github.com/matevzpoljanc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -717,6 +718,24 @@ export class PlaybackObject {
      * Returns a `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once it is unloaded, or rejects if unloading failed. See below for details on `PlaybackStatus`.
      */
     unloadAsync(): Promise<PlaybackStatus>;
+}
+// #endregion
+
+// #region BackgroundFetch
+/**
+ * BackgroundFetch
+ */
+export namespace BackgroundFetch {
+    function getStatusAsync(): Promise<Status>;
+    function registerTaskAsync(taskName: string): Promise<void>;
+    function unregisterTaskAsync(taskName: string): Promise<void>;
+    function setMinimumIntervalAsync(minimumInterval: number): Promise<void>;
+
+    enum Status {
+        Restricted = 1,
+        Denied = 2,
+        Available = 3
+    }
 }
 // #endregion
 
@@ -2244,7 +2263,7 @@ export namespace Location {
     function reverseGeocodeAsync(location: LocationProps): Promise<GeocodeData[]>;
     function requestPermissionsAsync(): Promise<void>;
     function hasServicesEnabledAsync(): Promise<boolean>;
-    function startgeocodUpdatesAsync(taskName: string, options: LocationTaskOptions): Promise<void>;
+    function startLocationUpdatesAsync(taskName: string, options: LocationTaskOptions): Promise<void>;
     function stopLocationUpdatesAsync(taskName: string): Promise<void>;
     function hasStartedLocationUpdatesAsync(taskName: string): Promise<boolean>;
     function startGeofencingAsync(taskName: string, regions: Region[]): Promise<void>;


### PR DESCRIPTION
Added definitions for BackgroundFetch functionality and bug fix for Location.startLocationUpdatesAsync functionality.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/v32.0.0/sdk/background-fetch/
https://docs.expo.io/versions/v32.0.0/sdk/location/#locationstartlocationupdatesasynctaskname-options
- [ x ] Increase the version number in the header if appropriate.
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
