### PR TITLE
redux-mock-store Add method option for mocking getState method rather than giving static state

### DIFF
--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -13,7 +13,9 @@ export interface MockStore<S = any, A extends Redux.Action = Redux.AnyAction> ex
 
 export type MockStoreEnhanced<S = {}, DispatchExts = {}> = MockStore<S> & {dispatch: DispatchExts};
 
-export type MockStoreCreator<S = {}, DispatchExts = {}> = (state?: S) => MockStoreEnhanced<S, DispatchExts>;
+export type MockStoreCreator<S = {}, DispatchExts = {}> = (state?: S | MockGetState<S>) => MockStoreEnhanced<S, DispatchExts>;
+
+export type MockGetState<S = {}> = (actions: Redux.AnyAction[]) => S;
 
 /**
  * Create Mock Store returns a function that will create a mock store from a state


### PR DESCRIPTION
As in the docs to the main JS library you can either supply state to the MockStoreCreator or you can pass a method in which is given the list of currently dispatched actions

Please fill in this template.
- [no tests ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dmitry-zaets/redux-mock-store#api
- [ ] Increase the version number in the header if appropriate.

