### PR TITLE
[spotify-web-playback-sdk] Declare Spotify namespace as window global

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -9,6 +9,7 @@
 
 interface Window {
     onSpotifyWebPlaybackSDKReady(): void;
+    Spotify: typeof Spotify;
 }
 
 declare namespace Spotify {

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -3,7 +3,7 @@
  * © 2017 Spotify AB
  */
 
-const player = new Spotify.Player({
+const player = new window.Spotify.Player({
     name: "Carly Rae Jepsen Player",
     getOAuthToken: (callback: (t: string) => void) => {
         // Run code to get a fresh access token


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *No functional change*
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
