### PR TITLE
[@types/got] Support retries of "POST" method

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -306,7 +306,7 @@ got('http://todomvc.com', { retry: 2 });
 got('http://todomvc.com', {
     retry: {
         retries: 2,
-        methods: ['GET'],
+        methods: ['GET', 'POST'],
         statusCodes: [408, 504],
         maxRetryAfter: 1,
         errorCodes: ['ETIMEDOUT']

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -252,7 +252,7 @@ declare namespace got {
 
     interface RetryOptions {
         retries?: number | RetryFunction;
-        methods?: Array<'GET' | 'POST' | 'PUT' | 'POST' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+        methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
         statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
         maxRetryAfter?: number;
         /**

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -252,7 +252,7 @@ declare namespace got {
 
     interface RetryOptions {
         retries?: number | RetryFunction;
-        methods?: Array<'GET' | 'PUT' | 'POST' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+        methods?: Array<'GET' | 'POST' | 'PUT' | 'POST' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
         statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
         maxRetryAfter?: number;
         /**

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -251,7 +251,7 @@ declare namespace got {
 
     interface RetryOptions {
         retries?: number | RetryFunction;
-        methods?: Array<'GET' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+        methods?: Array<'GET' | 'PUT' | 'POST' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
         statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
         maxRetryAfter?: number;
         /**

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -5,6 +5,7 @@
 //                 Konstantin Ikonnikov <https://github.com/ikokostya>
 //                 Stijn Van Nieuwenhuyse <https://github.com/stijnvn>
 //                 Matthew Bull <https://github.com/wingsbob>
+//                 Ryan Wilson-Perkin <https://github.com/ryanwilsonperkin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
The current list of supported methods for RetryOptions omits the "POST" method. I believe this is because the list was taken from https://www.npmjs.com/package/got#retry however this is only the _default_ methods that are supported. [This issue](https://github.com/sindresorhus/got/issues/757) from the `got` GitHub repo indicates that it _is_ possible to specifically state that you would like to retry on POST as well.

I have a use-case where I'd like to automatically retry failed POSTs but can't right now without overriding the typing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got/issues/757
- ~[ ] Increase the version number in the header if appropriate.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
