### PR TITLE
Types for the 'mixed.notType' property from the Yup library.

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -369,6 +369,7 @@ export class Ref {
 // tslint:disable-next-line:no-empty-interface
 export interface Lazy extends Schema<any> {}
 
+// tslint:disable-next-line:strict-export-declare-modifiers
 interface FormatErrorParams {
   path: string;
   type: string;
@@ -376,6 +377,7 @@ interface FormatErrorParams {
   originalValue?: any;
 }
 
+// tslint:disable-next-line:strict-export-declare-modifiers
 type LocaleValue =
     | string
     | ((params: FormatErrorParams) => string);

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -374,7 +374,6 @@ interface FormatErrorParams {
   type: string;
   value?: any;
   originalValue?: any;
-  label?: string;
 }
 
 type LocaleValue =

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -50,10 +50,6 @@ export type TestOptionsMessage =
     | string
     | ((params: object & Partial<TestMessageParams>) => string);
 
-export type NotTypeOptionsMessage =
-    | ((_ref: NotTypeRef) => string)
-    | string;
-
 export interface Schema<T> {
     clone(): this;
     label(label: string): this;
@@ -80,7 +76,6 @@ export interface Schema<T> {
     typeError(message?: TestOptionsMessage): this;
     oneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
     notOneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
-    notType(message: NotTypeOptionsMessage): this;
     when(keys: string | any[], builder: WhenOptions<this>): this;
     test(
         name: string,
@@ -237,13 +232,6 @@ export interface TestContext {
     createError: (params?: { path?: string; message?: string }) => ValidationError;
 }
 
-export interface NotTypeRef {
-    path: string;
-    type: string;
-    value: string | null;
-    originalValue: string | null;
-}
-
 export interface ValidateOptions {
     /**
      * Only validate the input, and skip and coercion or transformation. Default - false
@@ -381,8 +369,20 @@ export class Ref {
 // tslint:disable-next-line:no-empty-interface
 export interface Lazy extends Schema<any> {}
 
+interface FormatErrorParams {
+  path: string;
+  type: string;
+  value?: any;
+  originalValue?: any;
+  label?: string;
+}
+
+type LocaleValue =
+    | string
+    | ((params: FormatErrorParams) => string);
+
 export interface LocaleObject {
-    mixed?: { [key in keyof MixedSchema]?: string };
+    mixed?: { [key in keyof MixedSchema]?: string; } & { notType?: LocaleValue };
     string?: { [key in keyof StringSchema]?: string };
     number?: { [key in keyof NumberSchema]?: string };
     boolean?: { [key in keyof BooleanSchema]?: string };

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -369,16 +369,14 @@ export class Ref {
 // tslint:disable-next-line:no-empty-interface
 export interface Lazy extends Schema<any> {}
 
-// tslint:disable-next-line:strict-export-declare-modifiers
-interface FormatErrorParams {
+export interface FormatErrorParams {
   path: string;
   type: string;
   value?: any;
   originalValue?: any;
 }
 
-// tslint:disable-next-line:strict-export-declare-modifiers
-type LocaleValue =
+export type LocaleValue =
     | string
     | ((params: FormatErrorParams) => string);
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -50,6 +50,10 @@ export type TestOptionsMessage =
     | string
     | ((params: object & Partial<TestMessageParams>) => string);
 
+export type NotTypeOptionsMessage =
+    | ((_ref: NotTypeRef) => string)
+    | string;
+
 export interface Schema<T> {
     clone(): this;
     label(label: string): this;
@@ -76,6 +80,7 @@ export interface Schema<T> {
     typeError(message?: TestOptionsMessage): this;
     oneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
     notOneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
+    notType(message: NotTypeOptionsMessage): this;
     when(keys: string | any[], builder: WhenOptions<this>): this;
     test(
         name: string,
@@ -230,6 +235,13 @@ export interface TestContext {
     schema: Schema<any>;
     resolve: (value: any) => any;
     createError: (params?: { path?: string; message?: string }) => ValidationError;
+}
+
+export interface NotTypeRef {
+    path: string;
+    type: string;
+    value: string | null;
+    originalValue: string | null;
 }
 
 export interface ValidateOptions {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -13,7 +13,8 @@ import {
     TestOptions,
     ValidateOptions,
     NumberSchema,
-    TestContext
+    TestContext,
+    LocaleObject
 } from "yup";
 
 // reach function
@@ -159,17 +160,6 @@ mixed.oneOf(["hello", "world"], "message");
 mixed.oneOf(["hello", "world"], () => "message");
 mixed.notOneOf(["hello", "world"], "message");
 mixed.notOneOf(["hello", "world"], () => "message");
-mixed.notType("message");
-mixed.notType(() => "message");
-mixed.notType((_ref) => {
-    const isCast: boolean = _ref.originalValue != null && _ref.originalValue !== _ref.value;
-    const finalPartOfTheMessage = isCast
-        ? ` (cast from the value '${_ref.originalValue}').`
-        : '.';
-
-    return `${_ref.path} must be a '${_ref.type}'` +
-        ` but the final value was: '${_ref.value}'${finalPartOfTheMessage}`;
-});
 mixed.when("isBig", {
     is: value => true,
     then: yup.number().min(5),
@@ -460,6 +450,30 @@ const validateOptions: ValidateOptions = {
     recursive: true,
     context: {
         key: "value"
+    }
+};
+
+const localeNotType1: LocaleObject = {
+    mixed: {
+        notType: "message"
+    }
+};
+const localeNotType2: LocaleObject = {
+    mixed: {
+        notType: () => "message"
+    }
+};
+const localeNotType3: LocaleObject = {
+    mixed: {
+        notType: (_ref) => {
+            const isCast: boolean = _ref.originalValue != null && _ref.originalValue !== _ref.value;
+            const finalPartOfTheMessage = isCast
+                ? ` (cast from the value '${_ref.originalValue}').`
+                : '.';
+
+            return `${_ref.path} must be a '${_ref.type}'` +
+                ` but the final value was: '${_ref.value}'${finalPartOfTheMessage}`;
+        }
     }
 };
 

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -159,6 +159,17 @@ mixed.oneOf(["hello", "world"], "message");
 mixed.oneOf(["hello", "world"], () => "message");
 mixed.notOneOf(["hello", "world"], "message");
 mixed.notOneOf(["hello", "world"], () => "message");
+mixed.notType("message");
+mixed.notType(() => "message");
+mixed.notType((_ref) => {
+    const isCast: boolean = _ref.originalValue != null && _ref.originalValue !== _ref.value;
+    const finalPartOfTheMessage = isCast
+        ? ` (cast from the value '${_ref.originalValue}').`
+        : '.';
+
+    return `${_ref.path} must be a '${_ref.type}'` +
+        ` but the final value was: '${_ref.value}'${finalPartOfTheMessage}`;
+});
 mixed.when("isBig", {
     is: value => true,
     then: yup.number().min(5),

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -455,16 +455,19 @@ const validateOptions: ValidateOptions = {
 
 const localeNotType1: LocaleObject = {
     mixed: {
+        required: "message",
         notType: "message"
     }
 };
 const localeNotType2: LocaleObject = {
     mixed: {
+        required: "message",
         notType: () => "message"
     }
 };
 const localeNotType3: LocaleObject = {
     mixed: {
+        required: "message",
         notType: (_ref) => {
             const isCast: boolean = _ref.originalValue != null && _ref.originalValue !== _ref.value;
             const finalPartOfTheMessage = isCast


### PR DESCRIPTION
Hi, i'm implementing the types for the 'mixed.notType' property from the yup library, which is not typed right now.
The [Yup library code](https://github.com/jquense/yup/blob/a8935b789aed67a00867b536e6684ad9c493fc53/src/locale.js#L8) and [the issue](https://github.com/jquense/yup/issues/249) that is happening.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [yup library code](https://github.com/jquense/yup/blob/a8935b789aed67a00867b536e6684ad9c493fc53/src/locale.js#L8) and [the issue](https://github.com/jquense/yup/issues/249).
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
