### PR TITLE
Clean 20190426

### DIFF
--- a/types/backbone-fetch-cache/index.d.ts
+++ b/types/backbone-fetch-cache/index.d.ts
@@ -175,7 +175,7 @@ declare module "backbone" {
         fetch(options?: ModelFetchWithCacheOptions): JQueryXHR;
     }
 
-    interface CollectionWithCache extends Collection<Model> {
+    interface CollectionWithCache extends Collection {
 
         fetch(options?: CollectionFetchWithCacheOptions): JQueryXHR;
     }

--- a/types/react-instantsearch/index.d.ts
+++ b/types/react-instantsearch/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for react-instantsearch 5.2
-// Project: https://community.algolia.com/react-instantsearch/
+// Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>
 //                 Haroen Viaene <https://github.com/haroenv>


### PR DESCRIPTION
1. Update react-instantsearch URL.
2. backbone-fetch-cache has a type-aware lint rule that was affected by
a change in backbone. It's a dumb rule, but since CI only runs
expectRule for dependents, we didn't catch it on checkin. Now that we're running on
Azure, maybe we should run all lint rules for dependents during CI.
