### PR TITLE
[stripe] Add API version 2019-02-19 account props

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -218,6 +218,83 @@ declare namespace Stripe {
             business_primary_color?: string;
 
             /**
+             * Optional information related to the business.
+             */
+            business_profile?: {
+                /**
+                 * The merchant category code for the account. MCCs are used to classify businesses
+                 * based on the goods or services they provide.
+                 */
+                mcc?: string;
+
+                /**
+                 * The customer-facing business name.
+                 */
+                name?: string;
+
+                /**
+                 * Internal-only description of the product sold or service provided by the
+                 * business. It’s used by Stripe for risk and underwriting purposes.
+                 */
+                product_description?: string;
+
+                /**
+                 * A publicly available mailing address for sending support issues to.
+                 */
+                support_address?: {
+                    /**
+                     * Address line 1 (Street address/PO Box/Company name)
+                     */
+                    line1?: string;
+
+                    /**
+                     * Address line 2 (Apartment/Suite/Unit/Building)
+                     */
+                    line2?: string;
+
+                    /**
+                     * City/Suburb/Town/Village
+                     */
+                    city?: string;
+
+                    /**
+                     * State/Province/County
+                     */
+                    state?: string;
+
+                    /**
+                     * Zip/Postal Code
+                     */
+                    postal_code?: string;
+
+                    /**
+                     * 2-letter country code
+                     */
+                    country?: string;
+                };
+
+                /**
+                 * A publicly available email address for sending support issues to.
+                 */
+                support_email?: string;
+
+                /**
+                 * A publicly available phone number to call with support issues.
+                 */
+                support_phone?: string;
+
+                /**
+                 * A publicly available website for handling support issues.
+                 */
+                support_url?: string;
+
+                /**
+                 * The business’s publicly available website.
+                 */
+                url?: string;
+            };
+
+            /**
              * The URL that best shows the service or product provided for this account
              */
             business_url?: string;
@@ -283,6 +360,149 @@ declare namespace Stripe {
              * purposes.
              */
             product_description?: string;
+
+            /**
+             * Account options for customizing how the account functions within Stripe.
+             */
+            settings?: {
+                /**
+                 * Settings used to apply the account’s branding to email receipts, invoices,
+                 * Checkout, and other products.
+                 */
+                branding?: {
+                    /**
+                     * (ID of a file upload) An icon for the account. Must be square and at
+                     * least 128px x 128px.
+                     */
+                    icon?: string;
+
+                    /**
+                     * (ID of a file upload) A logo for the account that will be used in
+                     * Checkout instead of the icon and without the account’s name next to it
+                     * if provided. Must be at least 128px x 128px. This can be unset by
+                     * updating the value to null and then saving.
+                     */
+                    logo?: string;
+
+                    /**
+                     * A CSS hex color value representing the primary branding color for this account.
+                     */
+                    primary_color?: string;
+                };
+
+                /**
+                 * Settings specific to card charging on the account.
+                 */
+                card_payments?: {
+                    /**
+                     * Automatically declines certain charge types regardless of whether the card
+                     * issuer accepted or declined the charge.
+                     */
+                    decline_on?: {
+                        /**
+                         * Whether Stripe automatically declines charges with an incorrect ZIP or
+                         * postal code. This setting only applies when a ZIP or postal code is
+                         * provided and they fail bank verification.
+                         */
+                        avs_failure?: boolean;
+
+                        /**
+                         * Whether Stripe automatically declines charges with an incorrect CVC.
+                         * This setting only applies when a CVC is provided and it fails bank
+                         * verification.
+                         */
+                        cvc_failure?: boolean;
+                    };
+
+                    /**
+                     * The default text that appears on credit card statements when a charge is
+                     * made. This field prefixes any dynamic statement_descriptor specified on the
+                     * charge. statement_descriptor_prefix is useful for maximizing descriptor space
+                     * for the dynamic portion.
+                     */
+                    statement_descriptor_prefix?: string;
+                };
+
+                /**
+                 * Settings used to configure the account within the Stripe dashboard.
+                 */
+                dashboard?: {
+                    /**
+                     * The display name for this account. This is used on the Stripe Dashboard to
+                     * differentiate between accounts.
+                     */
+                    display_name?: string;
+
+                    /**
+                     * The timezone used in the Stripe Dashboard for this account. A list of
+                     * possible time zone values is maintained at the IANA Time Zone Database.
+                     */
+                    timezone?: string;
+                };
+
+                /**
+                 * Settings that apply across payment methods for charging on the account.
+                 */
+                payments?: {
+                    /**
+                     * The default text that appears on credit card statements when a charge is
+                     * made. This field prefixes any dynamic statement_descriptor specified on the
+                     * charge.
+                     */
+                    statement_descriptor?: string;
+                };
+
+                /**
+                 * Settings specific to the account’s payouts.
+                 */
+                payouts?: {
+                    /**
+                     * A Boolean indicating if Stripe should try to reclaim negative balances from
+                     * an attached bank account. See our Understanding Connect Account Balances
+                     * documentation for details. Default value is true for Express accounts and
+                     * false for Custom accounts.
+                     */
+                    debit_negative_balances?: boolean;
+
+                    /**
+                     * Details on when funds from charges are available, and when they are paid out
+                     * to an external account. See our Setting Bank and Debit Card Payouts
+                     * documentation for details.
+                     */
+                    schedule?: {
+                        /**
+                         * The number of days charges for the account will be held before being paid out.
+                         * May also be the string “minimum” for the lowest available value (based on
+                         * country). Default is “minimum”. Does not apply when interval is “manual”.
+                         */
+                        delay_days?: number | string;
+
+                        /**
+                         * How frequently funds will be paid out. One of "manual" (for only triggered
+                         * via API call), "daily", "weekly", or "monthly". Default is "daily".
+                         */
+                        interval?: "manual" | "daily" | "weekly" | "monthly";
+
+                        /**
+                         * The day of the month funds will be paid out. Required and available only if
+                         * interval is "monthly".
+                         */
+                        monthly_anchor?: number;
+
+                        /**
+                         * The day of the week funds will be paid out, of the style ‘monday’,
+                         * ‘tuesday’, etc. Required and available only if interval is weekly.
+                         */
+                        weekly_anchor?: "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday";
+                    };
+
+                    /**
+                     * The text that appears on the bank account statement for payouts. If not set,
+                     * this defaults to the platform’s bank descriptor as set in the Dashboard.
+                     */
+                    statement_descriptor?: string;
+                };
+            };
 
             /**
              * The text that will appear on credit card statements by default if a charge is

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -698,6 +698,118 @@ stripe.accounts.update("acct_17wV8KBoqMA9o2xk",
     }
 );
 
+stripe.accounts.update("acct_17wV8KBoqMA9o2xk",
+    {
+        business_profile: {
+            mcc: '1234',
+            name: 'My Amazing Company',
+            product_description: 'My Amazing Product',
+            support_address: {
+                line1: '42 Wallaby Way',
+                line2: 'Apt 1',
+                city: 'Sydney',
+                state: 'NSW',
+                postal_code: '1000',
+                country: 'Australia'
+            },
+            support_email: 'support@example.org',
+            support_phone: '+15555551212',
+            support_url: 'https://example.org',
+            url: 'https://example.org'
+        },
+        settings: {
+            branding: {
+                icon: 'https://example.org/icon.png',
+                logo: 'https://example.org/logo.png',
+                primary_color: '#a346b7'
+            },
+            card_payments: {
+                decline_on: {
+                    avs_failure: false,
+                    cvc_failure: false
+                },
+                statement_descriptor_prefix: 'foo'
+            },
+            dashboard: {
+                display_name: 'My Amazing Company',
+                timezone: 'America/Montreal'
+            },
+            payments: {
+                statement_descriptor: 'example.org'
+            },
+            payouts: {
+                debit_negative_balances: true,
+                schedule: {
+                    delay_days: 7,
+                    interval: 'daily',
+                    monthly_anchor: 1,
+                    weekly_anchor: 'monday'
+                },
+                statement_descriptor: 'foo'
+            }
+        }
+    }).then(
+    (account) => {
+        // asynchronously called
+    }
+);
+
+stripe.accounts.update("acct_17wV8KBoqMA9o2xk",
+    {
+        business_profile: {
+            mcc: null,
+            name: null,
+            product_description: null,
+            support_address: {
+                line1: null,
+                line2: null,
+                city: null,
+                state: null,
+                postal_code: null,
+                country: null,
+            },
+            support_email: null,
+            support_phone: null,
+            support_url: null,
+            url: null
+        },
+        settings: {
+            branding: {
+                icon: null,
+                logo: null,
+                primary_color: null
+            },
+            card_payments: {
+                decline_on: {
+                    avs_failure: null,
+                    cvc_failure: null
+                },
+                statement_descriptor_prefix: null
+            },
+            dashboard: {
+                display_name: null,
+                timezone: null
+            },
+            payments: {
+                statement_descriptor: null
+            },
+            payouts: {
+                debit_negative_balances: null,
+                schedule: {
+                    delay_days: null,
+                    interval: null,
+                    monthly_anchor: null,
+                    weekly_anchor: null
+                },
+                statement_descriptor: null
+            }
+        }
+    }).then(
+    (account) => {
+        // asynchronously called
+    }
+);
+
 stripe.accounts.del("acct_17wV8KBoqMA9o2xk", (err, confirmation) => { });
 stripe.accounts.del("acct_17wV8KBoqMA9o2xk").then((confirmation) => { });
 


### PR DESCRIPTION
#34447 recreated, with unit tests requested by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34447#pullrequestreview-226171968

I've added type definitions for the new account.business_profile and
account.settings fields introduced in API version 2019-02-19. There are
still some other account props that remain undefined.

For reference: https://stripe.com/docs/upgrades#2019-02-19

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/upgrades#2019-02-19
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.