### PR TITLE
[express-serve-static-core] Correct overload for Response.download()

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -575,10 +575,8 @@ export interface Response extends http.ServerResponse, Express.Response {
      *
      * @api public
      */
-    sendFile(path: string): void;
-    sendFile(path: string, options: any): void;
-    sendFile(path: string, fn: Errback): void;
-    sendFile(path: string, options: any, fn: Errback): void;
+    sendFile(path: string, fn?: Errback): void;
+    sendFile(path: string, options: any, fn?: Errback): void;
 
     /**
      * @deprecated Use sendFile instead.
@@ -610,12 +608,9 @@ export interface Response extends http.ServerResponse, Express.Response {
      *
      * This method uses `res.sendfile()`.
      */
-    download(path: string): void;
-    download(path: string, filename: string): void;
-    download(path: string, fn: Errback): void;
-    download(path: string, filename: string, options: any): void;
-    download(path: string, filename: string, fn: Errback): void;
-    download(path: string, filename: string, options: any, fn: Errback): void;
+    download(path: string, fn?: Errback): void;
+    download(path: string, filename: string, fn?: Errback): void;
+    download(path: string, filename: string, options: any, fn?: Errback): void;
 
     /**
      * Set _Content-Type_ response header with `type` through `mime.lookup()`

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -613,6 +613,7 @@ export interface Response extends http.ServerResponse, Express.Response {
     download(path: string): void;
     download(path: string, filename: string): void;
     download(path: string, fn: Errback): void;
+    download(path: string, filename: string, options: any): void;
     download(path: string, filename: string, fn: Errback): void;
     download(path: string, filename: string, options: any, fn: Errback): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://expressjs.com/en/api.html#res.download](https://expressjs.com/en/api.html#res.download)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I corrected the typings under #34940, but forgot to add an additional overload stating that the final callback for `Response.download()` is optional. After reviewing the *express* source code, the overloads for `Response.download()` should now be complete.