### PR TITLE
Added type definition for `string-pixel-width`

### DIFF
--- a/types/string-pixel-width/index.d.ts
+++ b/types/string-pixel-width/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for string-pixel-width 1.7
+// Project: https://github.com/adambisek/string-pixel-width#readme
+// Definitions by: Graham Dyson <https://github.com/grahamdyson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = getWidth;
+
+declare function getWidth(
+	string: string,
+	settings?: Settings,
+): number;
+
+interface Settings {
+	bold?: boolean;
+	font?: "andale mono"|"arial"|"avenir next"|"avenir"|"comic sans ms"|"courier new"|"georgia"|"impact"|"open sans"|"tahoma"|"times new roman"|"trebuchet ms"|"verdana"|"webdings";
+	italic?: boolean;
+	size?: number;
+}

--- a/types/string-pixel-width/string-pixel-width-tests.ts
+++ b/types/string-pixel-width/string-pixel-width-tests.ts
@@ -1,0 +1,14 @@
+import stringPixelWidth = require('string-pixel-width');
+
+// $ExpectType number
+stringPixelWidth("test");
+// $ExpectType number
+stringPixelWidth("test", {});
+// $ExpectType number
+stringPixelWidth("test", { bold: true });
+// $ExpectType number
+stringPixelWidth("test", { font: "arial" });
+// $ExpectType number
+stringPixelWidth("test", { italic: true });
+// $ExpectType number
+stringPixelWidth("test", { size: 10 });

--- a/types/string-pixel-width/tsconfig.json
+++ b/types/string-pixel-width/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string-pixel-width-tests.ts"
+    ]
+}

--- a/types/string-pixel-width/tslint.json
+++ b/types/string-pixel-width/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.