### PR TITLE
[y18n] Add typing for y18n

### DIFF
--- a/types/y18n/index.d.ts
+++ b/types/y18n/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for y18n 4.0
+// Project: https://github.com/yargs/y18n
+// Definitions by:  Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+interface Config {
+    /**
+     * The locale directory, default ./locales.
+     */
+    directory: string;
+    /**
+     * Should newly observed strings be updated in file, default true.
+     */
+    updateFiles: boolean;
+    /**
+     * What locale should be used.
+     */
+    locale: string;
+    /**
+     * Should fallback to a language-only file (e.g. en.json) be allowed
+     * if a file matching the locale does not exist (e.g. en_US.json), default true.
+     */
+    fallbackToLanguage: boolean;
+}
+
+declare class Y18N {
+    /**
+     * Create an instance of y18n with the config provided
+     */
+    constructor(config?: Config)
+
+    /**
+     * Print a localized string, %s will be replaced with args.
+     */
+    __(str: string, arg1?: string, arg2?: string, arg3?: string): string;
+
+    /**
+     * Print a localized string with appropriate pluralization.
+     * If %d is provided in the string, the count will replace this placeholder.
+     */
+    __n(singularString: string, pluralString: string, count: number, arg1?: string, arg2?: string, arg3?: string): string;
+
+    /**
+     * Set the current locale being used.
+     */
+    setLocale(str: string): void;
+
+    /**
+     * What locale is currently being used?
+     */
+    getLocale(): string;
+
+    /**
+     * Update the current locale with the key value pairs in obj.
+     */
+    updateLocale(obj: object): void;
+}
+
+export = Y18N;

--- a/types/y18n/tsconfig.json
+++ b/types/y18n/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [
+
+      ],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "y18n-tests.ts"
+    ]
+}

--- a/types/y18n/tslint.json
+++ b/types/y18n/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/y18n/y18n-tests.ts
+++ b/types/y18n/y18n-tests.ts
@@ -1,0 +1,21 @@
+import y18n = require("y18n");
+
+// Testing custom config
+new y18n({
+    directory: '../locales',
+    updateFiles: false,
+    locale: 'en-AU',
+    fallbackToLanguage: false
+});
+
+const Y18N = new y18n();
+
+Y18N.__(`my awesome string: foo`);
+
+Y18N.__n('one fish %s', '%d fishes %s', 2, 'foo');
+
+Y18N.setLocale('en-US');
+
+Y18N.getLocale();
+
+Y18N.updateLocale({});


### PR DESCRIPTION
Adding some TypeScript definitions for `y18n` @bcoe @nexdrew ❤️, let me know if you're cool with this 👍 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.