### PR TITLE
webpack: add child context properties

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -950,6 +950,10 @@ declare namespace webpack {
                 webassembly: ModuleTemplate;
             };
 
+            isChild(): boolean;
+            context: string;
+            outputPath: string;
+
             entries: any[];
             _preparedEntrypoints: any[];
             entrypoints: Map<any, any>;


### PR DESCRIPTION
Adds missing properties to a "Compiler" instance as seen in following lines of code:

https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L183 
https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L565 
https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L122

