### PR TITLE
Add missing params to customer creation options

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1438,6 +1438,16 @@ declare namespace Stripe {
              * This can be unset by updating the value to null and then saving.
              */
             email?: string;
+            
+            /**
+             * The customer's full name or business name.
+             */
+            name?: string;
+            
+            /**
+             * The customer’s phone number.
+             */
+            phone?: string;
 
             /**
              * The identifier of the plan to subscribe the customer to. If provided, the returned customer object will have a list of subscriptions


### PR DESCRIPTION
These params are allowed when creating customer, per stripe docs: https://stripe.com/docs/api/customers/create

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/customers/create
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
