### PR TITLE
[Slate] Make depth argument optional in editor split commands

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1046,8 +1046,8 @@ export class Editor implements Controller {
     insertText(text: string): Editor;
     setBlocks(properties: BlockProperties | string): Editor;
     setInlines(properties: InlineProperties | string): Editor;
-    splitBlock(depth: number): Editor;
-    splitInline(depth: number): Editor;
+    splitBlock(depth?: number): Editor;
+    splitInline(depth?: number): Editor;
     removeMark(mark: Mark | MarkProperties | string): Editor;
     replaceMark(
         mark: Mark | MarkProperties | string,
@@ -1211,8 +1211,8 @@ export class Editor implements Controller {
     insertTextAtRange(range: Range, text: string): Editor;
     setBlocksAtRange(range: Range, properties: BlockProperties | string): Editor;
     setInlinesAtRange(range: Range, properties: InlineProperties | string): Editor;
-    splitBlockAtRange(range: Range, depth: number): Editor;
-    splitInlineAtRange(range: Range, depth: number): Editor;
+    splitBlockAtRange(range: Range, depth?: number): Editor;
+    splitInlineAtRange(range: Range, depth?: number): Editor;
     removeMarkAtRange(range: Range, mark: Mark | MarkProperties | string): Editor;
     toggleMarkAtRange(range: Range, mark: Mark | MarkProperties | string): Editor;
     unwrapBlockAtRange(range: Range, properties: BlockProperties | string): Editor;


### PR DESCRIPTION
Make depth argument optional in editor.splitBlock & editor.splitInline, as well
as corresponding range commands.


Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.slatejs.org/slate-core/commands#splitblock
https://docs.slatejs.org/slate-core/commands#splitblockatrange
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
