### PR TITLE
[autoprefixer] Specify Stats object and stricter types

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -1,17 +1,19 @@
-import autoprefixer = require("autoprefixer");
+import autoprefixer = require('autoprefixer');
 import { Transformer } from 'postcss';
 
+// No options
 const ap1: Transformer = autoprefixer();
 
+// Default options
 const ap2: Transformer = autoprefixer({
-  browsers: [],
-  env: "test",
-  cascade: false,
-  add: false,
-  remove: false,
-  supports: false,
-  flexbox: false,
-  grid: false,
-  stats: {},
-  ignoreUnknownVersions: false,
+    browsers: [],
+    env: 'test',
+    cascade: true,
+    add: true,
+    remove: true,
+    supports: true,
+    flexbox: true,
+    grid: false,
+    stats: {},
+    ignoreUnknownVersions: false
 });

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by:  Armando Meziat <https://github.com/odnamrataizem>, murt <https://github.com/murt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.7
 
 import { Plugin } from 'postcss';
 import { Stats } from 'browserslist';

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -4,19 +4,20 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import { Plugin } from "postcss";
+import { Plugin } from 'postcss';
+import { Stats } from 'browserslist';
 
 declare namespace autoprefixer {
     interface Options {
-        browsers?: string[] | string;
         env?: string;
         cascade?: boolean;
         add?: boolean;
         remove?: boolean;
         supports?: boolean;
         flexbox?: boolean | 'no-2009';
-        grid?: boolean | 'autoplace' | 'no-autoplace';
-        stats?: any;
+        grid?: false | 'autoplace' | 'no-autoplace';
+        stats?: Stats;
+        browsers?: string[] | string;
         ignoreUnknownVersions?: boolean;
     }
 

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for autoprefixer 9.4
+// Type definitions for autoprefixer 9.5
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by:  Armando Meziat <https://github.com/odnamrataizem>, murt <https://github.com/murt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "7.x.x"
+        "postcss": "7.x.x",
+        "browserslist": "4.x.x"
     }
 }

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "7.x.x",
-        "browserslist": "4.x.x"
+        "postcss": "7.x.x"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/autoprefixer#options
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

__

When running the tests, I get the following error:
```
ERROR: 1:1  npm-naming  d.ts file must have a matching npm package.
To resolve this error, either:
1. Change the name to match an npm package.
2. Add a Definitely Typed header with the first line


    // Type definitions for non-npm package autoprefixer-browser

Add -browser to the end of your name to make sure it doesn't conflict with existing npm packages.

- OR -

3. Explicitly provide dts-critic with a source file. This is not allowed for submission to Definitely Typed.
 See: https://github.com/Microsoft/dtslint/blob/master/docs/npm-naming.md
```

EDIT: The error does not occur with CI.