### PR TITLE
[aws-iot-device-sdk-jsAdded AWS IOT CustomAuthorizer protocol

### DIFF
--- a/types/aws-iot-device-sdk/index.d.ts
+++ b/types/aws-iot-device-sdk/index.d.ts
@@ -88,14 +88,14 @@ export interface DeviceOptions extends mqtt.IClientOptions {
   minimumConnectionTimeMs?: number;
 
   /**
-   * the connection type, either "mqtts" (default) or "wss" (WebSocket/TLS).
+   * the connection type, either 'mqtts' (default), 'wss' (WebSocket/TLS), or 'wss-custom-auth' (WebSocket/TLS with custom authentication).
    * Note that when set to "wss", values must be provided for the
    * Access Key ID and Secret Key in either the following options or in
    * environment variables as specified in WebSocket Configuration[1].
    *
    * 1. https://github.com/aws/aws-iot-device-sdk-js#websockets
    */
-  protocol?: "mqtts" | "wss";
+  protocol?: "mqtts" | "wss" | "wss-custom-auth";
   /**
    * if protocol is set to "wss", you can use this parameter to pass
    * additional options to the underlying WebSocket object;
@@ -113,6 +113,18 @@ export interface DeviceOptions extends mqtt.IClientOptions {
    * Overrides the environment variable AWS_SECRET_ACCESS_KEY if set.
    */
   secretKey?: string;
+  
+  /**
+  * used to specify your custom authorization headers when protocol is set to 'wss-custom-auth'. 
+  * The fields 'X-Amz-CustomAuthorizer-Name', 'X-Amz-CustomAuthorizer-Signature', 
+  * and the field for your token name are required.
+  */
+  customAuthHeaders?: {
+    'X-Amz-CustomAuthorizer-Name': string,
+    'X-Amz-CustomAuthorizer-Signature': string,
+    'token': string
+  };
+    
   /**
    * (required when authenticating via Cognito, optional otherwise) used
    * to specify the Session Token when protocol is set to "wss". Overrides


### PR DESCRIPTION
As defined in the documentation, it is possible to use AWS custom authorizer for IOT.
This protocol allow developers to use their own authentication mechanism.

https://github.com/aws/aws-iot-device-sdk-js/blob/master/README.md

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
