### PR TITLE
[react-native-snap-carousel] Adds missing export getInputRangeFromIndexes

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -419,3 +419,17 @@ export type PaginationProperties = PaginationProps & React.Props<PaginationStati
 export class Pagination extends React.Component<PaginationProperties> { }
 
 export default class Carousel<T> extends React.Component<CarouselProperties<T>> { }
+
+/**
+ * Get scroll interpolator's input range from an array of slide indexes
+ * Indexes are relative to the current active slide (index 0)
+ * For example, using [3, 2, 1, 0, -1] will return:
+ * [
+ *     (index - 3) * sizeRef, // active + 3
+ *     (index - 2) * sizeRef, // active + 2
+ *     (index - 1) * sizeRef, // active + 1
+ *     index * sizeRef, // active
+ *     (index + 1) * sizeRef // active - 1
+ * ]
+ */
+export function getInputRangeFromIndexes(range: number[], index: number, carouselProps: CarouselProps<any>): number[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archriss/react-native-snap-carousel/blob/master/src/index.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
