### PR TITLE
Update requestPermissions typing

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -31,8 +31,8 @@ export interface PushNotificationOptions {
     requestPermissions?: boolean;
 }
 
-export type PriorityType = 'max' | 'high' | 'low' | 'min' | 'default';
-export type RepeatType = 'week' | 'day' | 'hour' | 'minute' | 'time';
+export type PriorityType = "max" | "high" | "low" | "min" | "default";
+export type RepeatType = "week" | "day" | "hour" | "minute" | "time";
 
 export class PushNotificationObject {
     /* Android only properties */
@@ -75,16 +75,22 @@ export interface PushNotification {
     unregister(): void;
     localNotification(details: PushNotificationObject): void;
     localNotificationSchedule(details: PushNotificationScheduleObject): void;
-    requestPermissions(): void;
+    requestPermissions(
+        permissions?: Array<"alert" | "badge" | "sound">
+    ): Promise<PushNotificationPermissions>;
     presentLocalNotification(details: PushNotificationObject): void;
     scheduleLocalNotification(details: PushNotificationScheduleObject): void;
     cancelLocalNotifications(details: object): void;
     cancelAllLocalNotifications(): void;
     setApplicationIconBadgeNumber(badgeCount: number): void;
     getApplicationIconBadgeNumber(callback: (badgeCount: number) => void): void;
-    popInitialNotification(callback: (notification: PushNotification | null) => void): void;
+    popInitialNotification(
+        callback: (notification: PushNotification | null) => void
+    ): void;
     abandonPermissions(): void;
-    checkPermissions(callback: (permissions: PushNotificationPermissions) => void): void;
+    checkPermissions(
+        callback: (permissions: PushNotificationPermissions) => void
+    ): void;
     registerNotificationActions(actions: string[]): void;
     clearAllNotifications(): void;
 }


### PR DESCRIPTION
I've updated the `requestPermissions` type signature to match its actual behavior which also mirrors the  official docs: https://facebook.github.io/react-native/docs/pushnotificationios#requestpermissions

Pretty sure the formatting changes were applied by DT's formatting rules. I can undo those if they're unwelcome. 