### PR TITLE
[react-motion] Fix missing generic-param error on children

### DIFF
--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -65,7 +65,7 @@ interface MotionProps {
      * Callback with your interpolated styles. Must return one react element to render
      * @param interpolatedStyle
      */
-    children?: (interpolatedStyle: PlainStyle) => ReactElement;
+    children?: (interpolatedStyle: PlainStyle) => JSX.Element;
     /**
      * The callback that fires when the animation comes to a rest.
      */
@@ -113,7 +113,7 @@ interface TransitionProps {
      * <StaggeredMotion/>
      */
     styles: Array<TransitionStyle> | InterpolateFunction;
-    children?: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement;
+    children?: (interpolatedStyles: Array<TransitionPlainStyle>) => JSX.Element;
     /**
      * Triggers when a new element will appear
      * @param styleThatEntered


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chenglou/react-motion/blob/master/src/Types.js#L65
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.