### PR TITLE
[google.visualization] Added type support for Controls and Dashboards

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1172,7 +1172,7 @@ declare namespace google {
         // https://developers.google.com/chart/interactive/docs/gallery/controls#dashboard
         export class Dashboard {
             constructor(containerRef: HTMLElement);
-            bind(controls: any, charts: ChartWrapper): google.visualization.Dashboard;
+            bind(controls: ControlWrapper | ControlWrapper[], charts: ChartWrapper | ChartWrapper[]): google.visualization.Dashboard;
             draw(dataTable: DataTable): void;
             getSelection(): Object[];
         }

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1174,11 +1174,12 @@ declare namespace google {
             constructor(containerRef: HTMLElement);
             bind(controls: any, charts: ChartWrapper): google.visualization.Dashboard;
             draw(dataTable: DataTable): void;
-            getSelection(): object[];
+            getSelection(): Object[];
         }
 
         //#endregion
         //#region ControlWrapper
+        
         // https://developers.google.com/chart/interactive/docs/gallery/controls#controlwrapperobject
         export class ControlWrapper {
             constructor(opt_spec?: ControlWrapperOptions)

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1202,7 +1202,7 @@ declare namespace google {
         }
 
         export interface ControlWrapperOptions {        
-            controlType?: string;
+            controlType: string;
             containerId: string;
             options?: Object;
             state?: Object;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1192,17 +1192,17 @@ declare namespace google {
             getOption(key: string, opt_default_val?: any): any;
             getOptions(): Object;
             getState(): Object;
-            setControlType(type): void;
+            setControlType(type: string): void;
             setControlName(name: string): void;
-            setContainerId(id): void;
-            setOption(key, value): void;
-            setOptions(options_obj): void;
-            setState(state_obj): void;
+            setContainerId(id: number): void;
+            setOption(key: string, value: string): void;
+            setOptions(options_obj: Object): void;
+            setState(state_obj: Object): void;
         }
 
         export interface ControlWrapperOptions {        
-            controlType?: String;
-            containerId?: String;
+            controlType?: string;
+            containerId?: string;
             options?: Object;
             state?: Object;
         }

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1167,6 +1167,47 @@ declare namespace google {
         }
 
         //#endregion
+        //#region Dashboard
+
+        // https://developers.google.com/chart/interactive/docs/gallery/controls#dashboard
+        export class Dashboard {
+            constructor(containerRef: HTMLElement);
+            bind(controls: any, charts: ChartWrapper): google.visualization.Dashboard;
+            draw(dataTable: DataTable): void;
+            getSelection(): object[];
+        }
+
+        //#endregion
+        //#region ControlWrapper
+        // https://developers.google.com/chart/interactive/docs/gallery/controls#controlwrapperobject
+        export class ControlWrapper {
+            constructor(opt_spec?: ControlWrapperOptions)
+            draw(): void;
+            toJSON(): string;
+            clone(): ControlWrapper;
+            getControlType(): string;
+            getControlName(): string;
+            getControl(): ControlWrapper;
+            getContainerId(): string;
+            getOption(key: string, opt_default_val?: any): any;
+            getOptions(): Object;
+            getState(): Object;
+            setControlType(type): void;
+            setControlName(name: string): void;
+            setContainerId(id): void;
+            setOption(key, value): void;
+            setOptions(options_obj): void;
+            setState(state_obj): void;
+        }
+
+        export interface ControlWrapperOptions {        
+            controlType?: String;
+            containerId?: String;
+            options?: Object;
+            state?: Object;
+        }
+
+        //#endregion
         //#region Events
 
         namespace events {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1203,7 +1203,7 @@ declare namespace google {
 
         export interface ControlWrapperOptions {        
             controlType?: string;
-            containerId?: string;
+            containerId: string;
             options?: Object;
             state?: Object;
         }


### PR DESCRIPTION
https://developers.google.com/chart/interactive/docs/gallery/controls

Currently @types/google.visualization doesn't support the Controls and Dashboards feature of the google.visualization framework. I have added the class and interface definitions provided by the google documentation (the link provided above).
