### PR TITLE
Update project urls

### DIFF
--- a/types/fsevents/index.d.ts
+++ b/types/fsevents/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for fsevents 1.1
-// Project: https://github.com/fsevents/fsevents
+// Project: https://github.com/fsevents/fsevents, https://github.com/strongloop/fsevents
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for serialport 7.0
-// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport
+// Project: https://github.com/node-serialport/node-serialport
 // Definitions by: Jeremy Foster <https://github.com/codefoster>
 //                 Andrew Pearson <https://github.com/apearson>
 //                 Cameron Tacklind <https://github.com/cinderblock>

--- a/types/stompjs/stompjs-tests.ts
+++ b/types/stompjs/stompjs-tests.ts
@@ -81,8 +81,8 @@ let message: Stomp.Message = {
     headers: {},
     body: 'body',
 
-    ack({}) { },
-    nack({}) { }
+    ack(header) { },
+    nack(header) { }
 }
 
 message.ack();


### PR DESCRIPTION
stompjs is also broken on CI but doesn't repro on my laptop. I'll investigate when I get to my desk this morning.

Edit: stompjs repros on my desktop. The improved contextual typing of Microsoft/Typescript#30568 gives a new, correct error on the empty-object destructuring in an object literal method. The parameter could also be undefined, so it's not safe to destructure it.