### PR TITLE
[googlemaps] Add `LatLngLiteral` support in `LatLng`

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -381,13 +381,13 @@ mvcArrayStr.setAt(0, "z");
 /***** HeatMaps *****/
 
 let heatmap = new google.maps.visualization.HeatmapLayer({
-    data: [new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng(37.782842, -122.443688)],
+    data: [new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng({lat: 37.782842, lng: -122.443688})],
     map: map
 });
 
 // setData Should Accept MVCArray<LatLng>
 heatmap.setData(new google.maps.MVCArray<google.maps.LatLng>(
-    [new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng(37.782842, -122.443688)]
+    [new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng({lat: 37.782842,  lng: -122.443688})]
 ));
 
 // getData Should return MVCArray<LatLng>
@@ -398,7 +398,7 @@ console.log(heatmapDataMvcLL.getAt(0).lat()); // should not throw
 heatmap.setData(new google.maps.MVCArray<google.maps.visualization.WeightedLocation>([
     { weight: 1, location: new google.maps.LatLng(37.782551, -122.445368) },
     { weight: 2, location: new google.maps.LatLng(37.782745, -122.444586) },
-    { weight: 3, location: new google.maps.LatLng(37.782842, -122.443688) }
+    { weight: 3, location: new google.maps.LatLng({lat: 37.782842,  lng: -122.443688}) }
 ]));
 
 // getData Should return MVCArray<LatLng>
@@ -406,12 +406,12 @@ let heatmapDataWL = heatmap.getData<google.maps.visualization.WeightedLocation>(
 console.log(heatmapDataWL.getAt(0).weight); // should not throw
 
 // setData Should Accept LatLng[]
-heatmap.setData([new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng(37.782842, -122.443688)]);
+heatmap.setData([new google.maps.LatLng(37.782551, -122.445368), new google.maps.LatLng(37.782745, -122.444586), new google.maps.LatLng({lat: 37.782842,  lng: -122.443688})]);
 
 // setData Should Accept WeightedLocation[]
 heatmap.setData([
     { weight: 1, location: new google.maps.LatLng(37.782551, -122.445368) },
-    { weight: 2, location: new google.maps.LatLng(37.782745, -122.444586) }
+    { weight: 2, location: new google.maps.LatLng({lat: 37.782745,  lng: -122.444586}) }
 ]);
 
 /***** google.maps.places.PlacesService *****/

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2305,6 +2305,12 @@ declare namespace google.maps {
      * @param noWrap Set noWrap to true to enable values outside of this range.
      */
     constructor(lat: number, lng: number, noWrap?: boolean);
+    /**
+     * Creates a LatLng object representing a geographic point.
+     * @param literal Object literal.
+     * @param noWrap Set noWrap to true to enable values outside of this range.
+     */
+    constructor(literal: LatLngLiteral, noWrap?: boolean);
     /** Comparison function. */
     equals(other: LatLng): boolean;
     /** Returns the latitude in degrees. */


### PR DESCRIPTION
> The constructor also accepts literal objects, and converts them to instances of `LatLng`:
> 
> ```js
>  myLatLng = new google.maps.LatLng({lat: -34, lng: 151});
> ```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [LatLng](https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLng)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
