### PR TITLE
[@types/expo] Fix Segment analytics type definitions

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -20,6 +20,7 @@
 //                 Mattias Sämskar <https://github.com/mattiassamskar>
 //                 Julian Hundeloh <https://github.com/jaulz>
 //                 Matevz Poljanc <https://github.com/matevzpoljanc>
+//                 Romain Faust <https://github.com/romain-faust>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2551,8 +2551,8 @@ export namespace Segment {
 
     function flush(): void;
 
-    function getEnabledAsync(): void;
-    function setEnabledAsync(enabled: boolean): void;
+    function getEnabledAsync(): Promise<boolean>;
+    function setEnabledAsync(enabled: boolean): Promise<void>;
 }
 
 /**

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2535,15 +2535,22 @@ export namespace Segment {
     }
 
     function initialize(options: SegmentOptions): void;
+
     function identify(userId: string): void;
     function identifyWithTraits(userId: string, traits: object): void;
-    function track(event: string): void;
-    function alias(newId: string, options?: { [key: string]: any }): Promise<boolean>;
+    function group(groupId: string): void;
+    function groupWithTraits(groupId: string, traits: object): void;
     function reset(): void;
-    function trackWithProperties(event: string, properties: object): void;
+
+    function alias(newId: string, options?: { [key: string]: any }): Promise<boolean>;
+
     function screen(screenName: string): void;
     function screenWithProperties(screenName: string, properties: object): void;
+    function track(event: string): void;
+    function trackWithProperties(event: string, properties: object): void;
+
     function flush(): void;
+
     function getEnabledAsync(): void;
     function setEnabledAsync(enabled: boolean): void;
 }

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2542,7 +2542,7 @@ export namespace Segment {
     function groupWithTraits(groupId: string, traits: object): void;
     function reset(): void;
 
-    function alias(newId: string, options?: { [key: string]: any }): Promise<boolean>;
+    function alias(newId: string, options?: object): Promise<boolean>;
 
     function screen(screenName: string): void;
     function screenWithProperties(screenName: string, properties: object): void;

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2529,10 +2529,12 @@ export namespace SecureStore {
  * Segment
  */
 export namespace Segment {
-    function initialize(keys: {
-        androidWriteKey: string;
-        iosWriteKey: string;
-    }): void;
+    interface SegmentOptions {
+        androidWriteKey?: string;
+        iosWriteKey?: string;
+    }
+
+    function initialize(options: SegmentOptions): void;
     function identify(userId: string): void;
     function identifyWithTraits(userId: string, traits: object): void;
     function track(event: string): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expo/expo/blob/master/packages/expo-analytics-segment/src/Segment.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.