### PR TITLE
Mongodb: Fix typos: Cursor#max and Cursor#min

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1726,7 +1726,7 @@ export class Cursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#map */
     map<U>(transform: (document: T) => U): Cursor<U>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#max */
-    max(max: number): Cursor<T>;
+    max(max: object): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#maxAwaitTimeMS */
     maxAwaitTimeMS(value: number): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#maxScan */
@@ -1734,7 +1734,7 @@ export class Cursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#maxTimeMS */
     maxTimeMS(value: number): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#min */
-    min(min: number): Cursor<T>;
+    min(min: object): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#next */
     next(): Promise<T | null>;
     next(callback: MongoCallback<T | null>): void;

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -105,8 +105,8 @@ mongodb.MongoClient.connect(connectionString, options, (err: mongodb.MongoError,
         cursor = cursor.hint('age_1');
         cursor = cursor.limit(1);
         cursor = cursor.map((result) => {});
-        cursor = cursor.max(1);
-        cursor = cursor.min(1);
+        cursor = cursor.max({ age: 130 });
+        cursor = cursor.min({ age: 18 });
         cursor = cursor.maxAwaitTimeMS(1);
         cursor = cursor.maxScan({});
         cursor = cursor.maxTimeMS(1);


### PR DESCRIPTION
Referring to the official documentation I updated two types. See [Cursor#min](http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#min) and [Cursor#max](http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#max).

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
