### PR TITLE
[aws-lambda] Keys should be optional inside CloudFrontHeaders

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -1019,6 +1019,11 @@ const cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWS
 
 const cloudFrontResponseHandler: AWSLambda.CloudFrontResponseHandler = (event: AWSLambda.CloudFrontResponseEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontResponseCallback) => { };
 
+const cloudFrontHeaders: AWSLambda.CloudFrontHeaders = {
+    'content-type': [{ value: 'text/plain' }],
+    'x-foo-bar': [{ key: 'X-Foo-Bar', value: 'example' }]
+};
+
 const customAuthorizerHandler: AWSLambda.CustomAuthorizerHandler = (event: AWSLambda.CustomAuthorizerEvent, context: AWSLambda.Context, cb: AWSLambda.CustomAuthorizerCallback) => { };
 
 interface CustomEvent { eventString: string; eventBool: boolean; }

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -965,9 +965,7 @@ const cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWS
 
     let s3Origin: AWSLambda.CloudFrontS3Origin = {
         authMethod: 'none',
-        customHeaders: {
-          'content-type': [{ value: 'text/plain' }]
-        },
+        customHeaders: {},
         domainName: 'example.com',
         path: '/',
         region: 'us-east-1'

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -965,7 +965,9 @@ const cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWS
 
     let s3Origin: AWSLambda.CloudFrontS3Origin = {
         authMethod: 'none',
-        customHeaders: {},
+        customHeaders: {
+          'content-type': [{ value: 'text/plain' }]
+        },
         domainName: 'example.com',
         path: '/',
         region: 'us-east-1'

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -734,7 +734,7 @@ export type CodePipelineCloudWatchEvent =
  */
 export interface CloudFrontHeaders {
     [name: string]: Array<{
-        key: string;
+        key?: string;
         value: string;
     }>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _see below_
- ~Increase the version number in the header if appropriate.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

----

According to the AWS documentation, it is optional to specify a `key` for each header value, but the type declaration is currently requiring this to be specified unnecessarily.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#lambda-event-structure-response

> - `key` (optional) is the case-sensitive name of the header as it appears in an HTTP request; for example, `accept` or `host`.
> - If you do not include the header key portion of the key-value pair, Lambda@Edge will automatically insert a header key using the header name that you provide. Regardless of how you've formatted the header name, the header key that is inserted automatically will be formatted with initial capitalization for each part, separated by hyphens (-).
>
>   For example, you can add a header like the following, without a header key: `'content-type': [{ value: 'text/html;charset=UTF-8' }]`. In this example, Lambda@Edge creates the following header key: `Content-Type`.

By making this property optional, one is able to write:

```ts
import { CloudFrontHeaders } from 'aws-lambda';

const headers: CloudFrontHeaders = {
  'content-type': [{ value: 'text/plain '}],
};
```

... instead of having to repeat the header name like:

```ts
import { CloudFrontHeaders } from 'aws-lambda';

const headers: CloudFrontHeaders = {
  'content-type': [{ key: 'content-type', value: 'text/plain '}],
};
```