### PR TITLE
[duplexer2] Support regular stream.Duplex options

### DIFF
--- a/types/duplexer2/duplexer2-tests.ts
+++ b/types/duplexer2/duplexer2-tests.ts
@@ -31,3 +31,25 @@ duplex.write("oh, hi there", () => {
 duplex.end("", () => {
   console.log("finished ending");
 });
+
+const duplexWithOptions = duplexer2({ readableObjectMode: true, writableObjectMode: true }, writable, readable);
+
+duplexWithOptions.on("data", (e: any) => {
+  console.log("got data", JSON.stringify(e));
+});
+
+duplexWithOptions.on("finish", () => {
+  console.log("got finish event");
+});
+
+duplexWithOptions.on("end", () => {
+  console.log("got end event");
+});
+
+duplexWithOptions.write("oh, hi there", () => {
+  console.log("finished writing");
+});
+
+duplexWithOptions.end("", () => {
+  console.log("finished ending");
+});

--- a/types/duplexer2/index.d.ts
+++ b/types/duplexer2/index.d.ts
@@ -1,13 +1,20 @@
 // Type definitions for duplexer2 0.1
 // Project: https://github.com/deoxxa/duplexer2
 // Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42>
+//                 Simon Oulevay <https://github.com/AlphaHydrae>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Definition file started by dts-gen
 
 /// <reference types="node" />
 
-declare function duplexer2(options: {bubbleErrors: boolean}, writable: NodeJS.WritableStream, readable: NodeJS.ReadableStream): NodeJS.ReadWriteStream;
+import { DuplexOptions } from 'stream';
+
+interface Duplexer2Options extends DuplexOptions {
+  bubbleErrors?: boolean;
+}
+
+declare function duplexer2(options: Duplexer2Options, writable: NodeJS.WritableStream, readable: NodeJS.ReadableStream): NodeJS.ReadWriteStream;
 declare function duplexer2(writable: NodeJS.WritableStream, readable: NodeJS.ReadableStream): NodeJS.ReadWriteStream;
 
 export = duplexer2;


### PR DESCRIPTION
As documented in https://www.npmjs.com/package/duplexer2#duplexer2-1,
options should not only be the duplexer2-specific `bubbleErrors` option,
but also regular stream.Duplex options.