### PR TITLE
fix incorrect return values for aws-serverless-express proxy

### DIFF
--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -37,14 +37,7 @@ export function proxy(
     server: http.Server,
     event: any,
     context: lambda.Context,
-    resolutionMode: 'CONTEXT_SUCCEED',
-): ProxyResult;
-
-export function proxy(
-    server: http.Server,
-    event: any,
-    context: lambda.Context,
-    resolutionMode: 'PROMISE'
+    resolutionMode: 'CONTEXT_SUCCEED' | 'PROMISE',
 ): ProxyResult;
 
 export function proxy(

--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -38,7 +38,7 @@ export function proxy(
     event: any,
     context: lambda.Context,
     resolutionMode: 'CONTEXT_SUCCEED',
-): void;
+): ProxyResult;
 
 export function proxy(
     server: http.Server,
@@ -53,4 +53,4 @@ export function proxy(
     context: lambda.Context,
     resolutionMode: 'CALLBACK',
     callback?: (error: any, response: Response) => void
-): void;
+): ProxyResult;


### PR DESCRIPTION
proxy() returns a ProxyResult as long as resolutionMode is provided.
https://github.com/awslabs/aws-serverless-express/blob/master/src/index.js#L210

As it is now, the types are misleading and prevent you from awaiting the promise, which is required for it all to work.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
  * not appropriate. It looks like these types have been wrong ever since ProxyResult was added
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
