### PR TITLE
Added date prompts type

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for prompts 1.2
+// Type definitions for prompts 2.04
 // Project: https://github.com/terkelg/prompts
 // Definitions by: Berkay GURSOY <https://github.com/Berkays>
 //                 Daniel Perez Alvarez <https://github.com/danielpa9708>
 //                 Kamontat Chantrachirathumrong <https://github.com/kamontat>
+//                 theweirdone <https://github.com/theweirdone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 export = prompts;
 
@@ -27,6 +28,8 @@ declare namespace prompts {
         function autocomplete(args: PromptObject): any;
 
         function confirm(args: PromptObject): void;
+
+        function date(args: PromptObject): any;
 
         function invisible(args: PromptObject): any;
 
@@ -60,7 +63,7 @@ declare namespace prompts {
         type: ValueOrFunc<PromptType> | Falsy;
         name: ValueOrFunc<T>;
         message?: ValueOrFunc<string>;
-        initial?: string | number | boolean;
+        initial?: string | number | boolean | Date;
         style?: string;
         format?: PrevCaller<T, void>;
         validate?: PrevCaller<T, void>;
@@ -77,6 +80,7 @@ declare namespace prompts {
         hint?: string;
         suggest?: ((prev: any, values: any, prompt: PromptObject) => void);
         limit?: number;
+        mask?: string;
     }
 
     type Answers<T extends string> = { [id in T]: any };
@@ -89,7 +93,7 @@ declare namespace prompts {
 
     type Falsy = false | null | undefined;
 
-    type PromptType = "text" | "password" | "invisible" | "number" | "confirm" | "list" | "toggle" | "select" | "multiselect" | "autocomplete";
+    type PromptType = "text" | "password" | "invisible" | "number" | "confirm" | "list" | "toggle" | "select" | "multiselect" | "autocomplete" | "date";
 
     type ValueOrFunc<T extends string> = T | PrevCaller<T>;
 }


### PR DESCRIPTION
The current definition does not allow for the "date" type of prompt. My PR fixes this.

If changing an existing definition:
Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/prompts/v/2.0.4#datemessage-initial-warn
