### PR TITLE
fix path.divideAt return definition as @types/paper

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -3027,20 +3027,20 @@ declare module paper {
          * Clears the path’s handles by setting their coordinates to zero, turning the path into a polygon (or a polyline if it isn’t closed).
          */
         clearHandles(): void;
-
+        
         /**
          * Divides the path on the curve at the given location into two curves, by inserting a new segment at the given location.
          * @param location - the curve location at which to divide the existing curve by inserting a new segment
          * @returns the newly inserted segment if the location is valid, {code null} otherwise
          */
-        divideAt(location: CurveLocation): Segment | null;
+        divideAt(location: CurveLocation): Segment;
 
         /**
          * Divides the path on the curve at the given offset into two curves, by inserting a new segment at the given location.
          * @param offset - the offset at which to divide the existing curve by inserting a new segment
          * @returns the newly inserted segment if the location is valid, {code null} otherwise
          */
-        divideAt(offset: number): Segment | null;
+        divideAt(offset: number): Segment;
 
         /**
          * Splits the path at the given offset. After splitting, the path will be open. If the path was open already, splitting will result in two paths.

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -3027,20 +3027,20 @@ declare module paper {
          * Clears the path’s handles by setting their coordinates to zero, turning the path into a polygon (or a polyline if it isn’t closed).
          */
         clearHandles(): void;
-        
+
         /**
          * Divides the path on the curve at the given location into two curves, by inserting a new segment at the given location.
          * @param location - the curve location at which to divide the existing curve by inserting a new segment
          * @returns the newly inserted segment if the location is valid, {code null} otherwise
          */
-        divideAt(location: CurveLocation): Path;
+        divideAt(location: CurveLocation): Segment | null;
 
         /**
          * Divides the path on the curve at the given offset into two curves, by inserting a new segment at the given location.
          * @param offset - the offset at which to divide the existing curve by inserting a new segment
          * @returns the newly inserted segment if the location is valid, {code null} otherwise
          */
-        divideAt(offset: number): Path;
+        divideAt(offset: number): Segment | null;
 
         /**
          * Splits the path at the given offset. After splitting, the path will be open. If the path was open already, splitting will result in two paths.


### PR DESCRIPTION
The divdeAt funtion shoud return segment, not a Path, even the comment says the return is a Segment.

The problem is addressed here: [https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35151](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35151)

And the official document of **divideAt** function is here.
[http://paperjs.org/reference/path/#divideat-location](http://paperjs.org/reference/path/#divideat-location)