### PR TITLE
Added callback to fluxible rehydrate method

### DIFF
--- a/types/fluxible/index.d.ts
+++ b/types/fluxible/index.d.ts
@@ -90,7 +90,7 @@ export class Fluxible {
      * @param callback
      * @async Rehydration may require more asset loading or async IO calls
      */
-    rehydrate(state: any): void;
+    rehydrate(state: any, callback?: Function): void;
 }
 
 /**


### PR DESCRIPTION
It was even in the comments, the parameter exists and it's being used here https://github.com/yahoo/fluxible/blob/master/packages/fluxible/lib/Fluxible.js#L179

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The parameter was missing in the type: https://github.com/yahoo/fluxible/blob/master/packages/fluxible/lib/Fluxible.js#L179