### PR TITLE
TinyMCE - Spell Checker Pro plugin settings, adding missing functions

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Martin Duparc <https://github.com/martinduparc>
 //                 Poul Poulsen <https://github.com/ipoul>
 //                 Nico Hartto <https://github.com/nicohartto>
+//                 Ashley Workman <https://github.com/CymruKakashi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -320,6 +320,20 @@ export interface Settings {
   imagetools_toolbar?: string;
 
   imagetools_api_key?: string;
+
+  spellchecker_rpc_url?: string;
+
+  spellchecker_language?: string;
+
+  spellchecker_languages?: string;
+
+  spellchecker_dialog?: boolean;
+
+  spellchecker_whitelist?: string[];
+
+  spellchecker_on_load?: boolean;
+
+  spellchecker_active?: boolean;
 }
 
 export namespace settings {

--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -55,6 +55,12 @@ export function walk(o: {}, f: () => void, n?: string, s?: string): void;
 
 export function init(settings: Settings): void;
 
+export function triggerSave(): void;
+
+export function get(id: string): Editor
+
+export function get(id: number): Editor
+
 export interface Settings {
   table_toolbar?: string;
 

--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -57,9 +57,7 @@ export function init(settings: Settings): void;
 
 export function triggerSave(): void;
 
-export function get(id: string): Editor
-
-export function get(id: number): Editor
+export function get(id: string | number): Editor;
 
 export interface Settings {
   table_toolbar?: string;

--- a/types/tinymce/tinymce-tests.ts
+++ b/types/tinymce/tinymce-tests.ts
@@ -48,6 +48,13 @@ const settings: tinymce.Settings = {
   table_advtab: false,
   table_cell_advtab: false,
   table_row_advtab: false,
+  spellchecker_rpc_url: 'https://mydomain.com',
+  spellchecker_language: 'en',
+  spellchecker_languages: 'US English=en,UK English=en_gb,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Norwegian=nb,Brazilian Portuguese=pt_BR,Iberian Portuguese=pt_PT,Spanish=es,Swedish=sv',
+  spellchecker_dialog: true,
+  spellchecker_whitelist: ['itemOne','itemTwo'],
+  spellchecker_on_load: true,
+  spellchecker_active: true,
 };
 
 tinymce.init(settings);

--- a/types/tinymce/tinymce-tests.ts
+++ b/types/tinymce/tinymce-tests.ts
@@ -50,9 +50,12 @@ const settings: tinymce.Settings = {
   table_row_advtab: false,
   spellchecker_rpc_url: 'https://mydomain.com',
   spellchecker_language: 'en',
-  spellchecker_languages: 'US English=en,UK English=en_gb,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Norwegian=nb,Brazilian Portuguese=pt_BR,Iberian Portuguese=pt_PT,Spanish=es,Swedish=sv',
+  spellchecker_languages: 'US English=en,UK English=en_gb',
   spellchecker_dialog: true,
-  spellchecker_whitelist: ['itemOne','itemTwo'],
+  spellchecker_whitelist: [
+      'itemOne',
+      'itemTwo'
+  ],
   spellchecker_on_load: true,
   spellchecker_active: true,
 };


### PR DESCRIPTION
Currently the TinyMCE types do not contain any type information for many of the available plugins, these plugins mainly rely on properties from on the tinymce.Settings object so I have added the Spellchecker PRO specific settings.

Additionally I've added in some missing tinymce methods.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.tiny.cloud/docs/plugins/tinymcespellchecker/
https://www.tiny.cloud/docs/api/tinymce/root_tinymce/#get
https://www.tiny.cloud/docs/api/tinymce/root_tinymce/#triggersave

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
