### PR TITLE
[@styled-system] Add missing props to Margin and Padding

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -127,7 +127,7 @@ export interface SpaceProps<TLength = TLengthStyledSystem> {
 
 export const space: styleFn;
 
-export interface MarginProps extends Pick<SpaceProps, 'm' | 'margin' | 'mt' | 'marginTop' | 'mb' | 'marginBottom' | 'ml' | 'marginLeft' | 'mr' | 'marginRight'> {}
+export interface MarginProps extends Pick<SpaceProps, 'm' | 'margin' | 'mt' | 'marginTop' | 'mb' | 'marginBottom' | 'ml' | 'marginLeft' | 'mr' | 'marginRight' | 'my' | 'mx'> {}
 export interface MarginTopProps extends Pick<SpaceProps, 'mt' | 'marginTop'> {}
 export interface MarginBottomProps extends Pick<SpaceProps, 'mb' | 'marginBottom'> {}
 export interface MarginLeftProps extends Pick<SpaceProps, 'ml' | 'marginLeft'> {}
@@ -139,7 +139,7 @@ export const marginBottom: styleFn;
 export const marginLeft: styleFn;
 export const marginRight: styleFn;
 
-export interface PaddingProps extends Pick<SpaceProps, 'p' | 'padding' | 'pt' | 'paddingTop' | 'pb' | 'paddingBottom' | 'pl' | 'paddingLeft' | 'pr' | 'paddingRight'> {}
+export interface PaddingProps extends Pick<SpaceProps, 'p' | 'padding' | 'pt' | 'paddingTop' | 'pb' | 'paddingBottom' | 'pl' | 'paddingLeft' | 'pr' | 'paddingRight' | 'py' | 'px'> {}
 export interface PaddingTopProps extends Pick<SpaceProps, 'pt' | 'paddingTop'> {}
 export interface PaddingBottomProps extends Pick<SpaceProps, 'pb' | 'paddingBottom'> {}
 export interface PaddingLeftProps extends Pick<SpaceProps, 'pl' | 'paddingLeft'> {}

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -73,8 +73,8 @@ import {
     GridRowGapProps,
     GridRowProps,
     gridTemplateColumns,
-    gridTemplateRows,
     GridTemplateColumnsProps,
+    gridTemplateRows,
     GridTemplateRowsProps,
     height,
     HeightProps,
@@ -90,6 +90,8 @@ import {
     LetterSpacingProps,
     lineHeight,
     LineHeightProps,
+    margin,
+    MarginProps,
     maxHeight,
     MaxHeightProps,
     maxWidth,
@@ -98,6 +100,8 @@ import {
     MinHeightProps,
     minWidth,
     MinWidthProps,
+    padding,
+    PaddingProps,
     position,
     PositionProps,
     right,
@@ -288,6 +292,15 @@ const TestButton: React.ComponentType<ButtonProps> = styled`
     ${buttonStyle}
     ${space}
     ${styles.textColor}
+`;
+
+interface SpacerProps
+    extends MarginProps,
+        PaddingProps {}
+
+const Spacer: React.ComponentType<SpacerProps> = styled`
+    ${margin};
+    ${padding};
 `;
 
 const test = () => (
@@ -546,6 +559,19 @@ const test = () => (
         <Box borderLeft={["1px solid red", "2px solid red"]} />
 
         <TestButton variant="primary" m={2} color="tomato" />
+
+        <Spacer m={[1, 2, 3]} p={[1, 2, 3]} />
+        <Spacer ml={[1, 2, 3]} pl={[1, 2, 3]} />
+        <Spacer mr={[1, 2, 3]} pr={[1, 2, 3]} />
+        <Spacer mt={[1, 2, 3]} pt={[1, 2, 3]} />
+        <Spacer mb={[1, 2, 3]} pb={[1, 2, 3]} />
+        <Spacer mx={[1, 2, 3]} px={[1, 2, 3]} />
+        <Spacer my={[1, 2, 3]} py={[1, 2, 3]} />
+        <Spacer margin={[1, 2, 3]} padding={[1, 2, 3]} />
+        <Spacer marginLeft={[1, 2, 3]} paddingLeft={[1, 2, 3]} />
+        <Spacer marginRight={[1, 2, 3]} paddingRight={[1, 2, 3]} />
+        <Spacer marginTop={[1, 2, 3]} paddingTop={[1, 2, 3]} />
+        <Spacer marginBottom={[1, 2, 3]} paddingBottom={[1, 2, 3]} />
     </div>
 );
 
@@ -678,10 +704,12 @@ export const justifySelfPropTypes = justifySelf.propTypes;
 export const leftPropTypes = left.propTypes;
 export const letterSpacingPropTypes = letterSpacing.propTypes;
 export const lineHeightPropTypes = lineHeight.propTypes;
+export const marginPropTypes = margin.propTypes;
 export const maxHeightPropTypes = maxHeight.propTypes;
 export const maxWidthPropTypes = maxWidth.propTypes;
 export const minHeightPropTypes = minHeight.propTypes;
 export const minWidthPropTypes = minWidth.propTypes;
+export const paddingPropTypes = padding.propTypes;
 export const positionPropTypes = position.propTypes;
 export const rightPropTypes = right.propTypes;
 export const sizePropTypes = size.propTypes;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/styled-system/styled-system/blob/master/src/index.js>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This PR contains the following improvements:
- Update `marginProps` to include `my` and `mx`
- Update `paddingProps` to include `py` and `px` 
- Update tests