### PR TITLE
add missing properties to @types/pdfMake

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -155,7 +155,7 @@ declare module "pdfmake/build/pdfmake" {
 
     interface Table {
         body: Content[][] | TableCell[][];
-        dontBreakRows?: boolean;
+        // dontBreakRows?: boolean;
         headerRows?: number;
         heights?: Array<string | number> | TableRowFunction;
         layout?: string | TableLayoutFunctions;
@@ -163,7 +163,7 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface Content {
-        style?: string | string[];
+        style?: "string"; //string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
@@ -181,15 +181,15 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        background?: any;
+        // background?: any;
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;
         footer?: TDocumentHeaderFooterFunction;
         header?: TDocumentHeaderFooterFunction;
-        images?: any;
+        // images?: any;
         info?: TDocumentInformation;
-        pageBreakBefore?: any;
+        // pageBreakBefore?: any;
         pageMargins?: Margins;
         pageOrientation?: PageOrientation;
         pageSize?: PageSize;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -190,7 +190,7 @@ declare module "pdfmake/build/pdfmake" {
         images?: { [key: string]: string };
         info?: TDocumentInformation;
         pageBreakBefore?: (
-            currentNode?: any,
+            currentNode?: CurrentNode,
             followingNodesOnPage?: any,
             nodesOnNextPage?: any,
             previousNodesOnPage?: any

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -155,7 +155,7 @@ declare module "pdfmake/build/pdfmake" {
 
     interface Table {
         body: Content[][] | TableCell[][];
-        dontBreakRows?: () => boolean;
+        dontBreakRows?: boolean;
         headerRows?: number;
         heights?: Array<string | number> | TableRowFunction;
         layout?: string | TableLayoutFunctions;
@@ -181,15 +181,20 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        background?: () => any;
+        background?: (currentPage?: any, pageSize?: any) => any;
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;
         footer?: TDocumentHeaderFooterFunction;
         header?: TDocumentHeaderFooterFunction;
-        images?: any;
+        images?: Record<string, string>;
         info?: TDocumentInformation;
-        pageBreakBefore?: () => boolean;
+        pageBreakBefore?: (
+            currentNode?: any,
+            followingNodesOnPage?: any,
+            nodesOnNextPage?: any,
+            previousNodesOnPage?: any
+        ) => boolean;
         pageMargins?: Margins;
         pageOrientation?: PageOrientation;
         pageSize?: PageSize;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -181,13 +181,13 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        background?: (currentPage?: any, pageSize?: any) => any;
+        background?: () => string | string;
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;
         footer?: TDocumentHeaderFooterFunction;
         header?: TDocumentHeaderFooterFunction;
-        images?: Record<string, string>;
+        images?: { [key: string]: string };
         info?: TDocumentInformation;
         pageBreakBefore?: (
             currentNode?: any,
@@ -199,6 +199,32 @@ declare module "pdfmake/build/pdfmake" {
         pageOrientation?: PageOrientation;
         pageSize?: PageSize;
         styles?: Style;
+    }
+
+    interface CurrentNode {
+        id: string;
+        headlineLevel: string;
+        text: string | string[] | Content[];
+        ul: Content[];
+        ol: Content[];
+        table: Table;
+        image: string;
+        qr: string;
+        canvas: string;
+        columns: Content[];
+        style: string | string[];
+        pageOrientation: PageOrientation;
+        pageNumbers: number[];
+        pages: number;
+        stack: boolean;
+        startPosition: {
+            pageNumber: number;
+            pageOrientation: PageOrientation;
+            left: number;
+            right: number;
+            verticalRatio: number;
+            horizontalRatio: number;
+        };
     }
 
     interface Pagesize {

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -101,9 +101,9 @@ declare module "pdfmake/build/pdfmake" {
 
     type TDocumentHeaderFooterFunction = (
         currentPage: number,
-        pageCount: number
-    ) => // pageSize?: any
-    any;
+        pageCount: number,
+        pageSize?: { width: number; height: number }
+    ) => any;
 
     type Margins = number | [number, number] | [number, number, number, number];
 
@@ -155,7 +155,7 @@ declare module "pdfmake/build/pdfmake" {
 
     interface Table {
         body: Content[][] | TableCell[][];
-        // dontBreakRows?: boolean;
+        dontBreakRows?: () => boolean;
         headerRows?: number;
         heights?: Array<string | number> | TableRowFunction;
         layout?: string | TableLayoutFunctions;
@@ -163,7 +163,7 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface Content {
-        style?: "string"; //string | string[];
+        style?: string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
@@ -181,15 +181,15 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        // background?: any;
+        background?: () => any;
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;
         footer?: TDocumentHeaderFooterFunction;
         header?: TDocumentHeaderFooterFunction;
-        // images?: any;
+        images?: any;
         info?: TDocumentInformation;
-        // pageBreakBefore?: any;
+        pageBreakBefore?: () => boolean;
         pageMargins?: Margins;
         pageOrientation?: PageOrientation;
         pageSize?: PageSize;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -101,9 +101,9 @@ declare module "pdfmake/build/pdfmake" {
 
     type TDocumentHeaderFooterFunction = (
         currentPage: number,
-        pageCount: number,
-        pageSize?: any
-    ) => any;
+        pageCount: number
+    ) => // pageSize?: any
+    any;
 
     type Margins = number | [number, number] | [number, number, number, number];
 

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -6,72 +6,77 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-declare module 'pdfmake/build/vfs_fonts' {
+declare module "pdfmake/build/vfs_fonts" {
     let pdfMake: {
         vfs: any;
         [name: string]: any;
     };
 }
 
-declare module 'pdfmake/build/pdfmake' {
+declare module "pdfmake/build/pdfmake" {
     let vfs: TFontFamily;
     let fonts: { [name: string]: TFontFamilyTypes };
-    function createPdf(documentDefinitions: TDocumentDefinitions, tableLayouts?: any, fonts?: any, vfs?: any): TCreatedPdf;
+    function createPdf(
+        documentDefinitions: TDocumentDefinitions,
+        tableLayouts?: any,
+        fonts?: any,
+        vfs?: any
+    ): TCreatedPdf;
 
     enum PageSize {
-        A0_x_4 = '4A0',
-        A0_x_2 = '2A0',
-        AO = 'A0',
-        A1 = 'A1',
-        A2 = 'A2',
-        A3 = 'A3',
-        A4 = 'A4',
-        A5 = 'A5',
-        A6 = 'A6',
-        A7 = 'A7',
-        A8 = 'A8',
-        A9 = 'A9',
-        A1O = 'A10',
-        BO = 'B0',
-        B1 = 'B1',
-        B2 = 'B2',
-        B3 = 'B3',
-        B4 = 'B4',
-        B5 = 'B5',
-        B6 = 'B6',
-        B7 = 'B7',
-        B8 = 'B8',
-        B9 = 'B9',
-        B1O = 'B10',
-        CO = 'C0',
-        C1 = 'C1',
-        C2 = 'C2',
-        C3 = 'C3',
-        C4 = 'C4',
-        C5 = 'C5',
-        C6 = 'C6',
-        C7 = 'C7',
-        C8 = 'C8',
-        C9 = 'C9',
-        C1O = 'C10',
-        RA1 = 'RA1',
-        RA2 = 'RA2',
-        RA3 = 'RA3',
-        RA4 = 'RA4',
-        SRA1 = 'SRA1',
-        SRA2 = 'SRA2',
-        SRA3 = 'SRA3',
-        SRA4 = 'SRA4',
-        EXECUTIVE = 'EXECUTIVE',
-        FOLIO = 'FOLIO',
-        LEGAL = 'LEGAL',
-        LETTER = 'LETTER',
-        TABLOID = 'TABLOID'
+        A0_x_4 = "4A0",
+        A0_x_2 = "2A0",
+        AO = "A0",
+        A1 = "A1",
+        A2 = "A2",
+        A3 = "A3",
+        A4 = "A4",
+        A5 = "A5",
+        A6 = "A6",
+        A7 = "A7",
+        A8 = "A8",
+        A9 = "A9",
+        A1O = "A10",
+        BO = "B0",
+        B1 = "B1",
+        B2 = "B2",
+        B3 = "B3",
+        B4 = "B4",
+        B5 = "B5",
+        B6 = "B6",
+        B7 = "B7",
+        B8 = "B8",
+        B9 = "B9",
+        B1O = "B10",
+        CO = "C0",
+        C1 = "C1",
+        C2 = "C2",
+        C3 = "C3",
+        C4 = "C4",
+        C5 = "C5",
+        C6 = "C6",
+        C7 = "C7",
+        C8 = "C8",
+        C9 = "C9",
+        C1O = "C10",
+        RA1 = "RA1",
+        RA2 = "RA2",
+        RA3 = "RA3",
+        RA4 = "RA4",
+        SRA1 = "SRA1",
+        SRA2 = "SRA2",
+        SRA3 = "SRA3",
+        SRA4 = "SRA4",
+        EXECUTIVE = "EXECUTIVE",
+        FOLIO = "FOLIO",
+        LEGAL = "LEGAL",
+        LETTER = "LETTER",
+        TABLOID = "TABLOID"
     }
 
     enum PageOrientation {
-        PORTRAIT = 'PORTRAIT',
-        LANDSCAPE = 'LANDSCAPE'
+        PORTRAIT = "PORTRAIT",
+        LANDSCAPE = "LANDSCAPE"
     }
 
     let pdfMake: pdfMakeStatic;
@@ -94,30 +99,34 @@ declare module 'pdfmake/build/pdfmake' {
         keywords?: string;
     }
 
-    type TDocumentHeaderFooterFunction = (currentPage: number, pageCount: number) => any;
+    type TDocumentHeaderFooterFunction = (
+        currentPage: number,
+        pageCount: number,
+        pageSize?: any
+    ) => any;
 
     type Margins = number | [number, number] | [number, number, number, number];
 
-    type Alignment = 'left' | 'right' | 'justify' | 'center' | string;
+    type Alignment = "left" | "right" | "justify" | "center" | string;
 
     interface Style {
         font?: any;
-		fontSize?: number;
-		fontFeatures?: any;
-		bold?: boolean;
-		italics?: boolean;
-		alignment?: Alignment;
-		color?: string;
-		columnGap?: any;
-		fillColor?: string;
-		decoration?: any;
-		decorationany?: any;
-		decorationColor?: string;
-		background?: any;
-		lineHeight?: number;
-		characterSpacing?: number;
-		noWrap?: boolean;
-		markerColor?: string;
+        fontSize?: number;
+        fontFeatures?: any;
+        bold?: boolean;
+        italics?: boolean;
+        alignment?: Alignment;
+        color?: string;
+        columnGap?: any;
+        fillColor?: string;
+        decoration?: any;
+        decorationany?: any;
+        decorationColor?: string;
+        background?: any;
+        lineHeight?: number;
+        characterSpacing?: number;
+        noWrap?: boolean;
+        markerColor?: string;
         leadingIndent?: any;
         [additionalProperty: string]: any;
     }
@@ -145,15 +154,16 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface Table {
-        widths?: Array<(string | number)>;
-        heights?: Array<(string | number)> | TableRowFunction;
-        headerRows?: number;
         body: Content[][] | TableCell[][];
+        dontBreakRows?: boolean;
+        headerRows?: number;
+        heights?: Array<string | number> | TableRowFunction;
         layout?: string | TableLayoutFunctions;
+        widths?: Array<string | number>;
     }
 
     interface Content {
-        style?: 'string';
+        style?: string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
@@ -162,7 +172,7 @@ declare module 'pdfmake/build/pdfmake' {
         width?: string | number;
         height?: string | number;
         fit?: [number, number];
-        pageBreak?: 'before' | 'after';
+        pageBreak?: "before" | "after";
         alignment?: Alignment;
         table?: Table;
         ul?: Content[];
@@ -171,16 +181,19 @@ declare module 'pdfmake/build/pdfmake' {
     }
 
     interface TDocumentDefinitions {
-        info?: TDocumentInformation;
+        background?: any;
         compress?: boolean;
-        header?: TDocumentHeaderFooterFunction;
-        footer?: TDocumentHeaderFooterFunction;
         content: string | Content;
-        styles?: Style;
-        pageSize?: PageSize;
-        pageOrientation?: PageOrientation;
-        pageMargins?: Margins;
         defaultStyle?: Style;
+        footer?: TDocumentHeaderFooterFunction;
+        header?: TDocumentHeaderFooterFunction;
+        images?: any;
+        info?: TDocumentInformation;
+        pageBreakBefore?: any;
+        pageMargins?: Margins;
+        pageOrientation?: PageOrientation;
+        pageSize?: PageSize;
+        styles?: Style;
     }
 
     interface Pagesize {
@@ -201,17 +214,17 @@ declare module 'pdfmake/build/pdfmake' {
     type CreatedPdfDownloadParams = (
         defaultFileName?: string,
         cb?: () => void,
-        options?: BufferOptions,
+        options?: BufferOptions
     ) => void;
 
     type CreatedPdfOpenPrintParams = (
         options?: BufferOptions,
-        win?: Window | null,
+        win?: Window | null
     ) => void;
 
     type CreatedPdfBufferParams = (
         cb: (result: any, pages: Page[]) => void,
-        options?: BufferOptions,
+        options?: BufferOptions
     ) => void;
 
     interface TCreatedPdf {


### PR DESCRIPTION
- modification to TDocumentDefinitions based on https://pdfmake.github.io/docs/document-definition-object/images/  and https://pdfmake.github.io/docs/document-definition-object/page/
- modification to Table based on http://pdfmake.org/playground.html example on Tables
- modification to TDocumentHeaderFooterFunction based on https://pdfmake.github.io/docs/document-definition-object/headers-footers/
- modification to Content based on https://pdfmake.github.io/docs/document-definition-object/styling/