### PR TITLE
Updated "delaunator" typings to version 3.0

### DIFF
--- a/types/delaunator/delaunator-tests.ts
+++ b/types/delaunator/delaunator-tests.ts
@@ -1,4 +1,4 @@
-import * as Delaunator from 'delaunator';
+import { Delaunator } from 'delaunator';
 
 // Zipped points [x0, y0, x1, y1, ...]
 const zippedPoints = [168, 180, 168, 178, 168, 179, 168, 181, 168, 183, 167, 183, 167, 184];
@@ -22,9 +22,10 @@ Delaunator.from(customPoints, point => point.x, point => point.y);
 Delaunator.from(customPoints, getX, getY);
 
 // To get the coordinates of all triangles, use:
-const triangles = d.triangles;
-const halfedges = d.halfedges;
-const hull = d.hull;
+const triangles = d.triangles; // $ExpectType Uint32Array
+const halfedges = d.halfedges; // $ExpectType Uint32Array
+const hull = d.hull; // $ExpectType Uint32Array
+const coords = d.coords; // $ExpectType ArrayLike<number> | Float64Array
 const coordinates: number[][][] = [];
 for (let i = 0; i < triangles.length; i += 3) {
     coordinates.push([
@@ -33,3 +34,16 @@ for (let i = 0; i < triangles.length; i += 3) {
         defaultPoints[triangles[i + 2]]
     ]);
 }
+
+// Or use Delaunator.coords (but coords is a flat array in the form of [x0, y0, x1, y1, ...])
+const coordinates2: number[][][] = [];
+for (let i = 0; i < triangles.length; i += 3) {
+    coordinates2.push([
+        [coords[triangles[i] * 2], coords[triangles[i] * 2 + 1]],
+        [coords[triangles[i + 1] * 2], coords[triangles[i + 1] * 2 + 1]],
+        [coords[triangles[i + 2] * 2], coords[triangles[i + 2] * 2 + 1]]
+    ]);
+}
+
+// both approaches should give the same result
+JSON.stringify(coordinates) === JSON.stringify(coordinates2);

--- a/types/delaunator/delaunator-tests.ts
+++ b/types/delaunator/delaunator-tests.ts
@@ -1,4 +1,4 @@
-import { Delaunator } from 'delaunator';
+import Delaunator from 'delaunator';
 
 // Zipped points [x0, y0, x1, y1, ...]
 const zippedPoints = [168, 180, 168, 178, 168, 179, 168, 181, 168, 183, 167, 183, 167, 184];

--- a/types/delaunator/delaunator-tests.ts
+++ b/types/delaunator/delaunator-tests.ts
@@ -13,7 +13,7 @@ interface CustomPoint {
     x: number;
     y: number;
 }
-const customPoints = [{x: 168, y: 180}, {x: 168, y: 178}, {x: 168, y: 179}, {x: 168, y: 181}, {x: 168, y: 183}, {x: 167, y: 183}, {x: 167, y: 184}];
+const customPoints = [{ x: 168, y: 180 }, { x: 168, y: 178 }, { x: 168, y: 179 }, { x: 168, y: 181 }, { x: 168, y: 183 }, { x: 167, y: 183 }, { x: 167, y: 184 }];
 
 const getX = (point: CustomPoint) => point.x;
 const getY = (point: CustomPoint) => point.y;
@@ -23,7 +23,7 @@ Delaunator.from(customPoints, getX, getY);
 
 // To get the coordinates of all triangles, use:
 const triangles = d.triangles; // $ExpectType Uint32Array
-const halfedges = d.halfedges; // $ExpectType Uint32Array
+const halfedges = d.halfedges; // $ExpectType Int32Array
 const hull = d.hull; // $ExpectType Uint32Array
 const coords = d.coords; // $ExpectType ArrayLike<number> | Float64Array
 const coordinates: number[][][] = [];

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -5,7 +5,7 @@
 //                 Tobias Kraus <https://github.com/tobiaskraus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export class Delaunator<P> {
+export default class Delaunator<P> {
     /**
      * A Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle).
      * All triangles are directed counterclockwise.
@@ -29,7 +29,7 @@ export class Delaunator<P> {
     /**
      * An array of input coordinates in the form [x0, y0, x1, y1, ....], of the type provided in the constructor (or Float64Array if you used Delaunator.from).
      */
-    coords: ArrayLike<number>|Float64Array;
+    coords: ArrayLike<number> | Float64Array;
 
     /**
      * Constructs a delaunay triangulation object given a typed array of point coordinates of the form: [x0, y0, x1, y1, ...].

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -1,17 +1,19 @@
-// Type definitions for delaunator 2.0
+// Type definitions for delaunator 3.0
 // Project: https://github.com/mapbox/delaunator#readme
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 //                 Bradley Odell <https://github.com/BTOdell>
+//                 Tobias Kraus <https://github.com/tobiaskraus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Delaunator<P> {
+export class Delaunator<P> {
     /**
-     * A flat Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle). All triangles are directed counterclockwise.
+     * A Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle).
+     * All triangles are directed counterclockwise.
      */
     triangles: Uint32Array;
 
     /**
-     * A flat Int32Array array of triangle half-edge indices that allows you to traverse the triangulation.
+     * A Int32Array array of triangle half-edge indices that allows you to traverse the triangulation.
      * i-th half-edge in the array corresponds to vertex triangles[i] the half-edge is coming from.
      * halfedges[i] is the index of a twin half-edge in an adjacent triangle (or -1 for outer half-edges on the convex hull).
      *
@@ -20,36 +22,29 @@ declare class Delaunator<P> {
     halfedges: Int32Array;
 
     /**
-     * A circular doubly-linked list that holds a convex hull of the delaunay triangulation.
+     * A Uint32Array array of indices that reference points on the convex hull of the input data, counter-clockwise.
      */
-    hull: Delaunator.Node;
+    hull: Uint32Array;
+
+    /**
+     * An array of input coordinates in the form [x0, y0, x1, y1, ....], of the type provided in the constructor (or Float64Array if you used Delaunator.from).
+     */
+    coords: ArrayLike<number>|Float64Array;
 
     /**
      * Constructs a delaunay triangulation object given a typed array of point coordinates of the form: [x0, y0, x1, y1, ...].
+     * (use a typed array for best performance).
      */
     constructor(points: ArrayLike<number>);
 
     /**
-     * Constructs a delaunay triangulation object given an array of points (e.g. [x, y]). Duplicate points are skipped.
+     * Constructs a delaunay triangulation object given an array of points ([x, y] by default).
      */
     static from(points: ArrayLike<ArrayLike<number>>): Delaunator<ArrayLike<number>>;
 
     /**
      * Constructs a delaunay triangulation object given an array of custom points. Duplicate points are skipped.
+     * getX and getY are optional functions for custom point formats. Duplicate points are skipped.
      */
     static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator<P>;
 }
-
-declare namespace Delaunator {
-    interface Node {
-        i: number;
-        x: number;
-        y: number;
-        t: number;
-        prev: Node|null;
-        next: Node|null;
-        removed: boolean;
-    }
-}
-
-export = Delaunator;

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -4,8 +4,9 @@
 //                 Bradley Odell <https://github.com/BTOdell>
 //                 Tobias Kraus <https://github.com/tobiaskraus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
 
-export default class Delaunator<P> {
+declare class Delaunator<P> {
     /**
      * A Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle).
      * All triangles are directed counterclockwise.
@@ -48,3 +49,5 @@ export default class Delaunator<P> {
      */
     static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator<P>;
 }
+
+export = Delaunator;

--- a/types/delaunator/tsconfig.json
+++ b/types/delaunator/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/delaunator
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I updated the JSDoc according the updated README from mapbox/delaunator and its datatypes.
I added Delaunator.coords. As there is no  Delaunator.Node anymore (Delaunator.hull changed its datatype), I removed the namespace and exported the class Delaunator directly. So the new import syntax is:

```ts
import { Delaunator } from 'delaunator';
```

(see delaunator-tests.ts) ... which I consider good practice.