### PR TITLE
[puppeteer] Fix misspelled paper format "Tabloid"

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -553,7 +553,7 @@ export type LayoutDimension = string | number;
 export type PDFFormat =
   | "Letter"
   | "Legal"
-  | "Tabload"
+  | "Tabloid"
   | "Ledger"
   | "A0"
   | "A1"


### PR DESCRIPTION
This was incorrectly spelled `"Tabload"`, which is not a paper format.
Screenshot of Chrome print menu:
![Tabloid, not Tabload](https://monosnap.com/image/TKXCinVWcrZrc5laSPXUvC6Hmw1WDz.png)

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

