### PR TITLE
Triple-slash reference node in simplecrawler

### DIFF
--- a/types/simplecrawler/crawler.d.ts
+++ b/types/simplecrawler/crawler.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node/v7" />
 import { EventEmitter } from 'events';
 import { Agent as HTTPAgent, IncomingMessage } from 'http';
 import { Agent as HTTPSAgent } from 'https';

--- a/types/simplecrawler/tsconfig.json
+++ b/types/simplecrawler/tsconfig.json
@@ -24,7 +24,6 @@
         "cookies.d.ts",
         "queue.d.ts",
         "cache-backend-fs.d.ts",
-        "crawler.d.ts",
-        "../node/v7/index.d.ts"
+        "crawler.d.ts"
     ]
 }


### PR DESCRIPTION
Previously it was in tsconfig, which breaks the build.
