### PR TITLE
[scrypt-js] change types of password and salt to accept array and Uint8Array

### DIFF
--- a/types/scrypt-js/index.d.ts
+++ b/types/scrypt-js/index.d.ts
@@ -1,13 +1,14 @@
 // Type definitions for scrypt-js 2.0
 // Project: https://github.com/ricmoo/scrypt-js
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+//                 Romain Delamare <https://github.com/alightgoesout>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types= "node" />
 
 declare function scrypt(
-    password: Buffer,
-    salt: Buffer,
+    password: Buffer | ReadonlyArray<number> | Uint8Array,
+    salt: Buffer | ReadonlyArray<number> | Uint8Array,
     N: number,
     r: number,
     p: number,

--- a/types/scrypt-js/scrypt-js-tests.ts
+++ b/types/scrypt-js/scrypt-js-tests.ts
@@ -1,7 +1,10 @@
 import scrypt = require('scrypt-js');
 
 const testBuffer = Buffer.from('test');
+const testArray = [74, 65, 73, 74];
+const testUint8Array = Uint8Array.from(testArray);
 const testCB = (err: Error | undefined | null, progress: number, key?: ReadonlyArray<number>) => {};
 
-// $ExpectType void
-scrypt(testBuffer, testBuffer, 1, 1, 1, 1, testCB);
+scrypt(testBuffer, testBuffer, 1, 1, 1, 1, testCB); // $ExpectType void
+scrypt(testArray, testArray, 1, 1, 1, 1, testCB); // $ExpectType void
+scrypt(testUint8Array, testUint8Array, 1, 1, 1, 1, testCB); // $ExpectType void


### PR DESCRIPTION
The scrypt-js library accepts any array-like object for `password` or `salt`. See [release notes for 2.0.0](https://github.com/ricmoo/scrypt-js/releases/tag/v2.0.0).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ricmoo/scrypt-js/releases/tag/v2.0.0
