### PR TITLE
[meteor-astronomy] typing improved.

### DIFF
--- a/types/meteor-astronomy/index.d.ts
+++ b/types/meteor-astronomy/index.d.ts
@@ -7,6 +7,7 @@
 /// <reference types="meteor" />
 
 declare namespace MeteorAstronomy {
+    type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
     type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]; // tslint:disable-line:ban-types
     type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
     type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]; // tslint:disable-line:ban-types
@@ -54,7 +55,7 @@ declare namespace MeteorAstronomy {
     interface ClassModel<T> {
         name: string;
         collection?: Mongo.Collection<T>;
-        fields: Fields<T>;
+        fields: Fields<Omit<T, '_id'>>;
         behaviors?: object;
         secured?: {
             insert: boolean,
@@ -76,19 +77,19 @@ declare namespace MeteorAstronomy {
         set(fields: Partial<T>, options?: {cast?: boolean; clone?: boolean; merge?: boolean}): void;
         set(field: string, value: any): void;
         get(field: string): any;
-        get(fields: string[]): any[];
+        get(fields: string[]): Partial<T>;
         isModified(field?: string): boolean;
         getModified(): any;
         getModifiedValues(options?: {old?: boolean, raw?: boolean}): Partial<T>;
         getModifier(): any;
         raw(): T;
         raw(field: string): any;
-        raw(fields: string[]): any[];
+        raw(fields: string[]): Array<Partial<T>>;
         save(options?: SaveAndValidateOptions<keyof T>, callback?: SaveAndValidateCallback): void;
-        save(callback?: SaveAndValidateCallback): void;
-        copy(save: boolean): any;
+        save(options: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
+        copy(save?: boolean): Model<T>;
         validate(options?: SaveAndValidateOptions<keyof T>, callback?: SaveAndValidateCallback): void;
-        validate(callback?: SaveAndValidateCallback): void;
+        validate(options: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
         remove(callback?: RemoveCallback): void;
     };
 

--- a/types/meteor-astronomy/index.d.ts
+++ b/types/meteor-astronomy/index.d.ts
@@ -84,12 +84,12 @@ declare namespace MeteorAstronomy {
         getModifier(): any;
         raw(): T;
         raw(field: string): any;
-        raw(fields: string[]): Array<Partial<T>>;
-        save(options?: SaveAndValidateOptions<keyof T>, callback?: SaveAndValidateCallback): void;
-        save(options: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
+        raw(fields: string[]): Partial<T>;
+        save(options: SaveAndValidateOptions<keyof T>, callback: SaveAndValidateCallback): void;
+        save(optionsOrCallback?: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
         copy(save?: boolean): Model<T>;
-        validate(options?: SaveAndValidateOptions<keyof T>, callback?: SaveAndValidateCallback): void;
-        validate(options: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
+        validate(options: SaveAndValidateOptions<keyof T>, callback: SaveAndValidateCallback): void;
+        validate(optionsOrCallback?: SaveAndValidateOptions<keyof T> | SaveAndValidateCallback): void;
         remove(callback?: RemoveCallback): void;
     };
 


### PR DESCRIPTION
Impoved typing for meteor-astronomy (ant replaced with correct types), some bugs fixed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://jagi.github.io/meteor-astronomy/#setting-and-getting-values
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
