### PR TITLE
fix(hapi__nes): add callback parameters to onDisconnect

### DIFF
--- a/types/hapi__nes/client.d.ts
+++ b/types/hapi__nes/client.d.ts
@@ -10,8 +10,8 @@ declare class Client {
     constructor(url: string, options?: Client.ClientOptions);
     onError: (err: any) => void;
     onConnect: () => void;
-    onDisconnect: () => void;
     onDisconnect: (willReconnect: boolean, log: { code: number, explanation: string, reason: string, wasClean: boolean }) => void;
+    onUpdate: (message: any) => void;
     connect(options: Client.ClientConnectOptions): Promise<any>;
     connect(): Promise<any>;
     disconnect(): Promise<any>;

--- a/types/hapi__nes/client.d.ts
+++ b/types/hapi__nes/client.d.ts
@@ -11,7 +11,7 @@ declare class Client {
     onError: (err: any) => void;
     onConnect: () => void;
     onDisconnect: () => void;
-    onUpdate: (message: any) => void;
+    onDisconnect: (willReconnect: boolean, log: { code: number, explanation: string, reason: string, wasClean: boolean }) => void;
     connect(options: Client.ClientConnectOptions): Promise<any>;
     connect(): Promise<any>;
     disconnect(): Promise<any>;

--- a/types/hapi__nes/test/client-require.ts
+++ b/types/hapi__nes/test/client-require.ts
@@ -10,3 +10,4 @@ const options: Client.ClientConnectOptions = {
 }
 
 const client: Client = new Client('ws://localhost', options);
+client.onDisconnect = (willReconnect) => {}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/nes/blob/master/API.md#new-clienturl-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.