### PR TITLE
[@types/victory] Add y0 data accessor to datable components

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1087,6 +1087,13 @@ declare module "victory" {
      * @default "y"
      */
     y?: DataGetterPropType;
+    /**
+     * Use y0 data accessor prop to determine how the component defines the baseline y0 data.
+     * This prop is useful for defining custom baselines for components like VictoryBar or VictoryArea.
+     * This prop may be given in a variety of formats.
+     * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
+     */
+    y0?: DataGetterPropType;
   }
 
   // Common labable interface

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -487,6 +487,7 @@ test = (
         { y: 6, x: 'B' },
         { y: 7, x: 'C' },
       ]}
+      y0={(d) => d.y - 1}
     />
   </VictoryChart>
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://formidable.com/open-source/victory/docs/common-props/#y0
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.