### PR TITLE
[draft-js] Add role prop on draft editor interface

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -121,6 +121,8 @@ declare namespace Draft {
                 ariaLabel?: string;
                 ariaMultiline?: boolean;
 
+                role?: string;
+
                 webDriverTestID?: string;
 
                 /**


### PR DESCRIPTION
although the flow interface definition in the draft-js repo doesn't include this prop, the actual component [uses this prop](https://github.com/facebook/draft-js/blob/master/src/component/base/DraftEditor.react.js#L340) and [pass it down](https://github.com/facebook/draft-js/blob/master/src/component/base/DraftEditor.react.js#L413) to the `div`.