### PR TITLE
Add types for react-shadow-dom-retarget-events

### DIFF
--- a/types/react-shadow-dom-retarget-events/index.d.ts
+++ b/types/react-shadow-dom-retarget-events/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for react-shadow-dom-retarget-events 1.0
+// Project: https://github.com/weltn24/react-shadow-dom-retarget-events#readme
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+export = retargetEvents;
+
+/**
+ * Fixes events for react components rendered in a `shadow dom`.
+ *
+ * When you render a react component inside `shadow dom` events will not be dispatched to react. I.e. when a user clicks in your react component nothing happens. This happens (or does not happen)
+ * with any events.
+ *
+ * A bug is filed at [#10422](https://github.com/facebook/react/issues/10422).
+ */
+declare function retargetEvents(shadowRoot: ShadowRoot): void;
+
+declare namespace retargetEvents {}

--- a/types/react-shadow-dom-retarget-events/index.d.ts
+++ b/types/react-shadow-dom-retarget-events/index.d.ts
@@ -15,5 +15,3 @@ export = retargetEvents;
  * A bug is filed at [#10422](https://github.com/facebook/react/issues/10422).
  */
 declare function retargetEvents(shadowRoot: ShadowRoot): void;
-
-declare namespace retargetEvents {}

--- a/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
+++ b/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as retargetEvents from 'react-shadow-dom-retarget-events';
+import retargetEvents from 'react-shadow-dom-retarget-events';
 
 class App extends React.Component {
     render() {

--- a/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
+++ b/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as retargetEvents from 'react-shadow-dom-retarget-events';
+
+class App extends React.Component {
+    render() {
+  	    return <div onClick={() => alert('I have been clicked')}>Click me</div>;
+    }
+}
+
+class MyCustomElement extends HTMLElement {
+    constructor() {
+        super();
+        const mountPoint = document.createElement('span');
+        const shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(mountPoint);
+        ReactDOM.render(<App/>, mountPoint);
+        retargetEvents(shadowRoot);
+    }
+}
+
+customElements.define(name, MyCustomElement);

--- a/types/react-shadow-dom-retarget-events/tsconfig.json
+++ b/types/react-shadow-dom-retarget-events/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "strictFunctionTypes": true,
+        "jsx": "react",
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-shadow-dom-retarget-events-tests.tsx"
+    ]
+}

--- a/types/react-shadow-dom-retarget-events/tsconfig.json
+++ b/types/react-shadow-dom-retarget-events/tsconfig.json
@@ -16,6 +16,7 @@
         "noEmit": true,
         "strictFunctionTypes": true,
         "jsx": "react",
+        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/react-shadow-dom-retarget-events/tslint.json
+++ b/types/react-shadow-dom-retarget-events/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.