### PR TITLE
[lodash] `partition` allow setting tuple type

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1777,6 +1777,10 @@ declare module "../index" {
         * @param callback The function called per iteration.
         * @return Returns the array of grouped elements.
         **/
+        partition<T, U extends T>(
+            collection: List<T> | null | undefined,
+            callback: ValueIteratorTypeGuard<T, U>
+        ): [U[], Array<Exclude<T, U>>];
         partition<T>(
             collection: List<T> | null | undefined,
             callback: ValueIteratee<T>
@@ -1795,6 +1799,10 @@ declare module "../index" {
         /**
          * @see _.partition
          */
+        partition<T, U extends T>(
+            this: LoDashImplicitWrapper<List<T> | null | undefined>,
+            callback: ValueIteratorTypeGuard<T, U>
+        ): LoDashImplicitWrapper<[U[], Array<Exclude<T, U>>]>;
         partition<T>(
             this: LoDashImplicitWrapper<List<T> | null | undefined>,
             callback: ValueIteratee<T>
@@ -1813,6 +1821,10 @@ declare module "../index" {
         /**
          * @see _.partition
          */
+        partition<T, U extends T>(
+            this: LoDashExplicitWrapper<List<T> | null | undefined>,
+            callback: ValueIteratorTypeGuard<T, U>
+        ): LoDashExplicitWrapper<[U[], Array<Exclude<T, U>>]>;
         partition<T>(
             this: LoDashExplicitWrapper<List<T> | null | undefined>,
             callback: ValueIteratee<T>

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -2705,15 +2705,21 @@ declare namespace _ {
     type LodashPartialRight27x1 = (args: ReadonlyArray<any>) => (...args: any[]) => any;
     type LodashPartialRight27x2 = (func: (...args: any[]) => any) => (...args: any[]) => any;
     interface LodashPartition {
-        <T>(callback: lodash.ValueIteratee<T>): LodashPartition1x1<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): LodashPartition1x1<T, U>;
         <T>(callback: lodash.__, collection: lodash.List<T> | null | undefined): LodashPartition1x2<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>, collection: lodash.List<T> | null | undefined): [U[], Array<Exclude<T, U>>];
+        <T>(callback: lodash.ValueIteratee<T>): LodashPartition2x1<T>;
         <T>(callback: lodash.ValueIteratee<T>, collection: lodash.List<T> | null | undefined): [T[], T[]];
-        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition2x2<T>;
+        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition3x2<T>;
         <T extends object>(callback: lodash.ValueIteratee<T[keyof T]>, collection: T | null | undefined): [Array<T[keyof T]>, Array<T[keyof T]>];
     }
-    type LodashPartition1x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
-    type LodashPartition1x2<T> = (callback: lodash.ValueIteratee<T>) => [T[], T[]];
-    type LodashPartition2x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
+    type LodashPartition1x1<T, U> = (collection: lodash.List<T> | null | undefined) => [U[], Array<Exclude<T, U>>];
+    interface LodashPartition1x2<T> {
+        <U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): [U[], Array<Exclude<T, U>>];
+        (callback: lodash.ValueIteratee<T>): [T[], T[]];
+    }
+    type LodashPartition2x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
+    type LodashPartition3x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
     interface LodashPath {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPath1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashPath1x2<TObject>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2794,6 +2794,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 
 // _.partition
 {
+    const mixedArray = [1, 2, '3', '4'];
+
     // $ExpectType [any[], any[]]
     _.partition(anything, (value) => {
         value; // $ExpectType any
@@ -2809,6 +2811,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
         value; // $ExpectType AbcObject
         return true;
     });
+    // $ExpectType [number[], string[]]
+    _.partition(mixedArray, (value): value is number => typeof value === 'number');
 
     // $ExpectType LoDashImplicitWrapper<[any[], any[]]>
     _(anything).partition((value) => {
@@ -2825,6 +2829,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
         value; // $ExpectType AbcObject
         return true;
     });
+    // $ExpectType LoDashImplicitWrapper<[number[], string[]]>
+    _(mixedArray).partition((value): value is number => typeof value === 'number');
 
     // $ExpectType LoDashExplicitWrapper<[any[], any[]]>
     _.chain(anything).partition((value) => {
@@ -2841,6 +2847,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
         value; // $ExpectType AbcObject
         return true;
     });
+    // $ExpectType LoDashExplicitWrapper<[number[], string[]]>
+    _.chain(mixedArray).partition((value): value is number => typeof value === 'number');
 
     // $ExpectType [any[], any[]]
     fp.partition((value) => {
@@ -2859,6 +2867,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
         value; // $ExpectType AbcObject
         return true;
     }, list);
+    // $ExpectType [number[], string[]]
+    fp.partition((value): value is number => typeof value === 'number', mixedArray);
 }
 
 // _.reduce

--- a/types/lodash/readme.md
+++ b/types/lodash/readme.md
@@ -47,9 +47,9 @@
   - In general, no.
 - If the wrapper functions are almost copies of the original functions, shouldn't we auto-generate them like we do for `lodash/fp`?
   - Good idea! If you have time, submit a PR.
-- When I ran `npm run lint lodash`, I got an error that loks like `<--- Last few GCs --->`.
+- When I ran `npm run lint lodash`, I got an error that looks like `<--- Last few GCs --->`.
   - Yeah, this error is really annoying. It means that node.js ran out of memory before it could run all of your tests.
-    - If you see somthing like `Test with 2.6` before that error, it means that there's an error in an older version of typescript.
+    - If you see something like `Test with 2.6` before that error, it means that there's an error in an older version of typescript.
       The hard part is figuring out what the error is.
   - The general procedure for diagnosing these errors is:
     1. Delete half of the tests in `lodash-tests.ts` (either the top half or the bottom half).
@@ -57,6 +57,6 @@
     2. Run `npm run lint lodash`.
     3. If it succeeds, add that half back and delete the other half.
     4. If it fails with a GC error, delete half of the remaining tests.
-      - Note: If both halfs succeed on their own, then the tests are probably just consuming too much memory. Try simplifying them until they pass.
+      - Note: If both halves succeed on their own, then the tests are probably just consuming too much memory. Try simplifying them until they pass.
     5. Repeat steps 1-4 until it gives you the real error message. Usually it's something obscure that only happens in TS 2.3/T.4,
        so commenting/modifying the test is usually the best solution.

--- a/types/lowdb/_lodash.d.ts
+++ b/types/lowdb/_lodash.d.ts
@@ -648,6 +648,10 @@ declare module "./index" {
             iteratees?: _.Many<_.ObjectIteratee<T>>,
             orders?: _.Many<boolean|"asc"|"desc">
         ): LoDashExplicitSyncWrapper<Array<T[keyof T]>>;
+        partition<T, U extends T>(
+            this: LoDashExplicitSyncWrapper<_.List<T> | null | undefined>,
+            callback: _.ValueIteratorTypeGuard<T, U>
+        ): LoDashExplicitSyncWrapper<[U[], Array<Exclude<T, U>>]>;
         partition<T>(
             this: LoDashExplicitSyncWrapper<_.List<T> | null | undefined>,
             callback: _.ValueIteratee<T>
@@ -2244,6 +2248,10 @@ declare module "./index" {
             iteratees?: _.Many<_.ObjectIteratee<T>>,
             orders?: _.Many<boolean|"asc"|"desc">
         ): LoDashExplicitAsyncWrapper<Array<T[keyof T]>>;
+        partition<T, U extends T>(
+            this: LoDashExplicitAsyncWrapper<_.List<T> | null | undefined>,
+            callback: _.ValueIteratorTypeGuard<T, U>
+        ): LoDashExplicitAsyncWrapper<[U[], Array<Exclude<T, U>>]>;
         partition<T>(
             this: LoDashExplicitAsyncWrapper<_.List<T> | null | undefined>,
             callback: _.ValueIteratee<T>


### PR DESCRIPTION
Essentially it allows specifying the tuple type by using type guard when `partition` is used to split array by item types

```
const [numbers, strings] = partition([1, 2, '3', '4'], (value): value is number => typeof value === 'number');
// or
const [numbers, strings] = partition([1, 2, '3', '4'], _.isNumber);
```

I wasn't able to run lint because is TS error

```
declare module "../index"
```

> Cannot augment module '"DefinitelyTyped/types/lodash/index.d.ts"' with value exports because it resolves to a non-module entity.ts(2649)

