### PR TITLE
fix(node): add `undefined` return to `url` in `inspector`

### DIFF
--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -3251,7 +3251,7 @@ declare module "inspector" {
     function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    function url(): string;
+    function url(): string | undefined;
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1078,7 +1078,7 @@ import * as constants from 'constants';
         inspector.open(0, 'localhost');
         inspector.open(0, 'localhost', true);
         inspector.close();
-        const inspectorUrl: string = inspector.url();
+        const inspectorUrl: string | undefined = inspector.url();
 
         const session = new inspector.Session();
         session.connect();

--- a/types/node/scripts/generate-inspector/inspector.d.ts.template
+++ b/types/node/scripts/generate-inspector/inspector.d.ts.template
@@ -73,7 +73,7 @@ declare module "inspector" {
     function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    function url(): string;
+    function url(): string | undefined;
 }

--- a/types/node/v10/inspector.d.ts
+++ b/types/node/v10/inspector.d.ts
@@ -3156,7 +3156,7 @@ declare module "inspector" {
     function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    function url(): string;
+    function url(): string | undefined;
 }

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -4810,7 +4810,7 @@ import * as constants from 'constants';
         inspector.open(0, 'localhost');
         inspector.open(0, 'localhost', true);
         inspector.close();
-        const inspectorUrl: string = inspector.url();
+        const inspectorUrl: string | undefined = inspector.url();
 
         const session = new inspector.Session();
         session.connect();

--- a/types/node/v11/inspector.d.ts
+++ b/types/node/v11/inspector.d.ts
@@ -3251,7 +3251,7 @@ declare module "inspector" {
     function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    function url(): string;
+    function url(): string | undefined;
 }

--- a/types/node/v11/node-tests.ts
+++ b/types/node/v11/node-tests.ts
@@ -1078,7 +1078,7 @@ import * as constants from 'constants';
         inspector.open(0, 'localhost');
         inspector.open(0, 'localhost', true);
         inspector.close();
-        const inspectorUrl: string = inspector.url();
+        const inspectorUrl: string | undefined = inspector.url();
 
         const session = new inspector.Session();
         session.connect();

--- a/types/node/v8/inspector.d.ts
+++ b/types/node/v8/inspector.d.ts
@@ -2506,7 +2506,7 @@ declare module "inspector" {
     export function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    export function url(): string;
+    export function url(): string | undefined;
 }

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -4041,7 +4041,7 @@ namespace inspector_tests {
         inspector.open(0, 'localhost');
         inspector.open(0, 'localhost', true);
         inspector.close();
-        const inspectorUrl: string = inspector.url();
+        const inspectorUrl: string | undefined = inspector.url();
 
         const session = new inspector.Session();
         session.connect();

--- a/types/node/v9/inspector.d.ts
+++ b/types/node/v9/inspector.d.ts
@@ -2524,7 +2524,7 @@ declare module "inspector" {
     export function close(): void;
 
     /**
-     * Return the URL of the active inspector, or undefined if there is none.
+     * Return the URL of the active inspector, or `undefined` if there is none.
      */
-    export function url(): string;
+    export function url(): string | undefined;
 }

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -4106,7 +4106,7 @@ namespace inspector_tests {
         inspector.open(0, 'localhost');
         inspector.open(0, 'localhost', true);
         inspector.close();
-        const inspectorUrl: string = inspector.url();
+        const inspectorUrl: string | undefined = inspector.url();
 
         const session = new inspector.Session();
         session.connect();


### PR DESCRIPTION
This commit fixes the return type of the `url` function from the `inspector` Node module. The value `undefined` is returned when there is no active inspector.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/inspector.html#inspector_inspector_url>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
