### PR TITLE
Added type definition for `object-fit-images`

### DIFF
--- a/types/object-fit-images/index.d.ts
+++ b/types/object-fit-images/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for object-fit-images 3.2
+// Project: https://github.com/bfred-it/object-fit-images#readme
+// Definitions by: Christopher Parsons <https://github.com/cwparsons>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export interface ObjectFitImagesOptions {
+    watchMQ?: boolean;
+}
+
+export default function objectFitImages(
+    images?:
+        | Element
+        | Element[]
+        | HTMLCollectionOf<HTMLElement>
+        | NodeList
+        | string
+        | null,
+    options?: ObjectFitImagesOptions
+): void;

--- a/types/object-fit-images/object-fit-images-tests.ts
+++ b/types/object-fit-images/object-fit-images-tests.ts
@@ -1,0 +1,35 @@
+import objectFitImages from "object-fit-images";
+
+objectFitImages(); // $ExpectType void
+
+const imageByQuerySelector = document.querySelector("img");
+
+if (imageByQuerySelector) {
+    objectFitImages(imageByQuerySelector); // $ExpectType void
+}
+
+const imagesByTagName = document.getElementsByTagName("img");
+
+if (imagesByTagName) {
+    objectFitImages(imagesByTagName); // $ExpectType void
+}
+
+const imagesByQuerySelector = document.querySelectorAll("img");
+
+if (imagesByQuerySelector) {
+    objectFitImages(imagesByQuerySelector); // $ExpectType void
+}
+
+objectFitImages(null); // $ExpectType void
+
+objectFitImages("img"); // $ExpectType void
+
+objectFitImages(true); // $ExpectError
+
+objectFitImages(undefined, {}); // $ExpectType void
+
+objectFitImages(undefined, { watchMQ: true }); // $ExpectType void
+
+objectFitImages(undefined, { foo: false }); // $ExpectError
+
+objectFitImages(undefined, undefined, undefined); // $ExpectError

--- a/types/object-fit-images/tsconfig.json
+++ b/types/object-fit-images/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-fit-images-tests.ts"
+    ]
+}

--- a/types/object-fit-images/tslint.json
+++ b/types/object-fit-images/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
