### PR TITLE
Allow typing of RawDraftEntity's data

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -503,10 +503,10 @@ declare namespace Draft {
             /**
              * A plain object representation of an EntityInstance.
              */
-            interface RawDraftEntity {
+            interface RawDraftEntity<T = { [key: string]: any }> {
                 type: DraftEntityType;
                 mutability: DraftEntityMutability;
-                data: { [key: string]: any };
+                data: T;
             }
 
             /**


### PR DESCRIPTION
It's helpful, when working with `RawDraftEntity`, to have a typed `data` property, whilst it still defaults to `{ [key: string]: any }`

