### PR TITLE
[@types/react] New Component types - typing state and props as DeepReadonly

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -509,6 +509,8 @@ declare namespace React {
         defaultProps?: Partial<P>;
         displayName?: string;
     }
+                     
+    type DRFC<T= {}> = FC<DeepReadonly<T>>
 
     interface RefForwardingComponent<T, P = {}> {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
@@ -3007,7 +3009,7 @@ declare global {
     }
                     
     
-    export type DeepReadonly<T> =
+    type DeepReadonly<T> =
     T extends Function ? T :
     T extends ReadonlyArray<infer R> ? IDRArray<R> :
     T extends Map<infer K, infer V> ? IDRMap<K, V> :

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3005,4 +3005,21 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
         }
     }
+                    
+    
+    export type DeepReadonly<T> =
+    T extends Function ? T :
+    T extends ReadonlyArray<infer R> ? IDRArray<R> :
+    T extends Map<infer K, infer V> ? IDRMap<K, V> :
+    T extends object ? DRObject<T> :
+    T
+
+    interface IDRArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+
+    type DRObject<T> = {
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+    }
+
+    interface IDRMap<K, V> extends ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>> {}
+              
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -509,8 +509,8 @@ declare namespace React {
         defaultProps?: Partial<P>;
         displayName?: string;
     }
-                     
-    type DRFC<T= {}> = FC<DeepReadonly<T>>
+
+    type DRFC<T= {}> = FC<DeepReadonly<T>>;
 
     interface RefForwardingComponent<T, P = {}> {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
@@ -3007,9 +3007,12 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
         }
     }
-                    
-    
+
+    //
+    // DeepReadonly
+    // ----------------------------------------------------------------------
     type DeepReadonly<T> =
+    // tslint:disable-next-line: ban-types
     T extends Function ? T :
     T extends ReadonlyArray<infer R> ? DRArray<R> :
     T extends Map<infer K, infer V> ? DRMap<K, V> :

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3005,21 +3005,19 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
         }
     }
-                    
-    
+
     export type DeepReadonly<T> =
     T extends Function ? T :
-    T extends ReadonlyArray<infer R> ? IDRArray<R> :
-    T extends Map<infer K, infer V> ? IDRMap<K, V> :
+    T extends ReadonlyArray<infer R> ? DRArray<R> :
+    T extends Map<infer K, infer V> ? DRMap<K, V> :
     T extends object ? DRObject<T> :
-    T
+    T;
 
-    interface IDRArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+    interface DRArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 
     type DRObject<T> = {
-    readonly [P in keyof T]: DeepReadonly<T[P]>;
-    }
+        readonly [P in keyof T]: DeepReadonly<T[P]>;
+    };
 
-    interface IDRMap<K, V> extends ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>> {}
-              
+    interface DRMap<K, V> extends ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>> {}
 }


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Following [feature suggestion 31914](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31914)

Currently this commit adds: 
1. DeepReadonly generic
2. a new component type DRFC which types props as DeepReadonly. 

It's important to note that typing props as DeepReadonly is a breaking change, since you can't pass a regular array to a function that expects to receive a ReadonlyArray (which lacks methods as push etc.). Therefor it is necessary to offer a new type, and not to replace a current one. 

