### PR TITLE
[mssql] Add Request.query tagged template overloads

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -8,6 +8,7 @@
 //                 Peter Keuter <https://github.com/pkeuter>
 //                 David Gasperoni <https://github.com/mcdado>
 //                 Jeff Wooden <https://github.com/woodenconsulting>
+//                 Cahil Foley <https://github.com/cahilfoley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -273,7 +274,9 @@ export declare class Request extends events.EventEmitter {
     public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
     public pipe(stream: NodeJS.WritableStream): NodeJS.WritableStream;
     public query(command: string): Promise<IResult<any>>;
+    public query(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
     public query<Entity>(command: string): Promise<IResult<Entity>>;
+    public query<Entity>(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
     public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
     public batch(batch: string): Promise<IResult<any>>;
     public batch<Entity>(batch: string): Promise<IResult<Entity>>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -43,7 +43,7 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
             else if (result.recordset.length > 0) {
             }
         });
-        
+
         requestQuery.query`SELECT * FROM TABLE`.then(res => { });
 
         getArticlesQuery = "SELECT 1 as value FROM TABLE";
@@ -57,8 +57,6 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
             else if (result.recordset.length > 0 && result.recordset[0].value) {
             }
         });
-        
-        requestQuery.query<Entity>`SELECT * FROM TABLE`.then(res => { });
 
         var requestStoredProcedure = new sql.Request(connection);
         var testId: number = 0;
@@ -178,7 +176,6 @@ function test_promise_returns() {
     request.query('SELECT 1').then((recordset) => { });
     request.query`SELECT ${1} as value`.then(res => { });
     request.query<Entity>('SELECT 1 as value').then(res => { });
-    request.query<Entity>`SELECT ${1} as value`.then(res => { });
     request.execute('procedure_name').then((recordset) => { });
 }
 

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -43,6 +43,8 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
             else if (result.recordset.length > 0) {
             }
         });
+        
+        requestQuery.query`SELECT * FROM TABLE`.then(res => { });
 
         getArticlesQuery = "SELECT 1 as value FROM TABLE";
 
@@ -55,6 +57,8 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
             else if (result.recordset.length > 0 && result.recordset[0].value) {
             }
         });
+        
+        requestQuery.query<Entity>`SELECT * FROM TABLE`.then(res => { });
 
         var requestStoredProcedure = new sql.Request(connection);
         var testId: number = 0;
@@ -172,7 +176,9 @@ function test_promise_returns() {
     request.batch<Entity>('create procedure #temporary as select * from table;select 1 as value').then((recordset) => { });
     request.bulk(new sql.Table("table_name")).then(() => { });
     request.query('SELECT 1').then((recordset) => { });
+    request.query`SELECT ${1} as value`.then(res => { });
     request.query<Entity>('SELECT 1 as value').then(res => { });
+    request.query<Entity>`SELECT ${1} as value`.then(res => { });
     request.execute('procedure_name').then((recordset) => { });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The documentation for using ES6 tagged template literals is [here](https://github.com/tediousjs/node-mssql#es6-tagged-template-literals). The documentation does not provide an example of using template literals on the `Request` interface but they use the same mechanism internally ([implementation](https://github.com/tediousjs/node-mssql/blob/master/lib/base.js#L408)).
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.