### PR TITLE
[route-parser] Improve type-safety by making the Route class generic

### DIFF
--- a/types/route-parser/index.d.ts
+++ b/types/route-parser/index.d.ts
@@ -2,8 +2,9 @@
 // Project: http://github.com/rcs/route-parser
 // Definitions by: Ian Ker-Seymer <https://github.com/ianks>, Bob Buehler <https://github.com/bobbuehler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-declare class Route {
+declare class Route<TParams extends {} = { [i: string]: any }> {
     /**
      * Represents a route
      * @example
@@ -23,7 +24,7 @@ declare class Route {
      * var route = new Route('/:one/:two')
      * route.match('/foo/bar/') // -> {one: 'foo', two: 'bar'}
      */
-    match(pathname: string): { [i: string]: string } | false;
+    match(pathname: string): {[k in keyof TParams]: string} | false;
 
     /**
      * Reverse a route specification to a path, returning false if it can't be
@@ -32,7 +33,7 @@ declare class Route {
      * var route = new Route('/:one/:two')
      * route.reverse({one: 'foo', two: 'bar'}) -> '/foo/bar'
      */
-    reverse(params: { [i: string]: any }): string | false;
+    reverse(params: TParams): string | false;
 }
 
 declare namespace Route {}

--- a/types/route-parser/route-parser-tests.ts
+++ b/types/route-parser/route-parser-tests.ts
@@ -1,5 +1,18 @@
 import Route = require('route-parser');
 
 const route = new Route('/users/:id');
+
+// $ExpectType false | { [x: string]: string; }
 const matched = route.match('/users/42'); // => { id: '42' }
+// $ExpectType string | false
 const reversed = route.reverse({ id: 42 });
+// $ExpectType Route<{ id: number; }>
+const route0 = new Route<{id: number}>('/users/:id');
+// $ExpectType string | false
+route0.reverse({id: 1});
+// $ExpectType false | { id: string; }
+route0.match('/users/:id');
+// $ExpectType Route<{ slug: string; }>
+const route1 = new Route<{slug: string}>('/posts/:slug');
+// $ExpectType string | false
+route1.reverse({slug: "hello"});


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rcs/route-parser>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
