### PR TITLE
[node-telegram-bot-api]  Mark several properties on the WebHookOptions interface as optional

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-telegram-bot-api 0.30
+// Type definitions for node-telegram-bot-api 0.31
 // Project: https://github.com/yagop/node-telegram-bot-api
 // Definitions by: Alex Muench <https://github.com/ammuench>
 //                 Agadar <https://github.com/agadar>
@@ -78,9 +78,9 @@ declare namespace TelegramBot {
     interface WebHookOptions {
         host?: string;
         port?: number;
-        key: string;
-        cert: string;
-        pfx: string;
+        key?: string;
+        cert?: string;
+        pfx?: string;
         autoOpen?: boolean;
         https?: ServerOptions;
         healthEndpoint?: string;

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -1,6 +1,6 @@
 import TelegramBot = require('node-telegram-bot-api');
 
-const MyTelegramBot = new TelegramBot('token');
+const MyTelegramBot = new TelegramBot('token', { webHook: { host: 'myhost'}})
 
 MyTelegramBot.startPolling({restart: true});
 MyTelegramBot.stopPolling();

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -1,6 +1,6 @@
 import TelegramBot = require('node-telegram-bot-api');
 
-const MyTelegramBot = new TelegramBot('token', { webHook: { host: 'myhost'}})
+const MyTelegramBot = new TelegramBot('token', { webHook: { host: 'myhost'}});
 
 MyTelegramBot.startPolling({restart: true});
 MyTelegramBot.stopPolling();


### PR DESCRIPTION
Marks the `key`, `cert` and `pfx` properties of the `WebHookOptions` interface as optional, in response to the information provided in issue #35206 

Updates the tests file to test the changes accordingly

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35206
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
