### PR TITLE
[webpack] fix ToJsonOutput.chunks (should be an array)

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1333,7 +1333,7 @@ declare namespace webpack {
                 rendered: boolean;
                 size: number;
                 siblings: number[];
-            };
+            }[];
             entrypoints?: Record<string, ChunkGroup>;
             errors: string[];
             env?: Record<string, any>;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1307,7 +1307,7 @@ declare namespace webpack {
             assetsByChunkName?: Record<string, Record<string, string[]>>;
             builtAt?: number;
             children?: ToJsonOptions[] & { name?: string };
-            chunks?: {
+            chunks?: Array<{
                 children: number[];
                 childrenByOrder: Record<string, number[]>;
                 entry: boolean;
@@ -1333,7 +1333,7 @@ declare namespace webpack {
                 rendered: boolean;
                 size: number;
                 siblings: number[];
-            }[];
+            }>;
             entrypoints?: Record<string, ChunkGroup>;
             errors: string[];
             env?: Record<string, any>;


### PR DESCRIPTION
**TL;DR**: `stats.toJson().chunks` is an array of objects, not an object.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
