### PR TITLE
Async: update async.retry to have errorFilter

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -197,7 +197,8 @@ export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback
 export function retry<T, E = Error>(
     opts: number | {
         times: number,
-        interval: number | ((retryCount: number) => number)
+        interval: number | ((retryCount: number) => number),
+        errorFilter?: (error: Error) => boolean
     },
     task: (callback: AsyncResultCallback<T, E>, results: any) => void,
     callback: AsyncResultCallback<any, E>

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -300,6 +300,7 @@ async.auto<A>({
 async.retry(3, (callback, results) => { }, (err, result) => { });
 async.retry({ times: 3, interval: 200 }, (callback, results) => { }, (err, result) => { });
 async.retry({ times: 3, interval: (retryCount) => 200 * retryCount }, (callback, results) => { }, (err, result) => { });
+async.retry({ times: 3, interval: 200, errorFilter: (err) => true }, (callback, results) => { }, (err, result) => { });
 
 async.parallel([
         (callback: (err: Error, val: string) => void) => { },


### PR DESCRIPTION
Async's retry function also takes an errorFilter as you can see [here](https://github.com/caolan/async/blob/4330d536c106592139fa82062494c9dba0da1fdb/lib/retry.js#L29) but it doesn't exist in the type definitions. This commit just adds that.

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: (Source)[https://github.com/caolan/async/blob/4330d536c106592139fa82062494c9dba0da1fdb/lib/retry.js#L29]
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
