### PR TITLE
[react-redux]: Add an explicit dependency on hoist-non-react-statics

### DIFF
--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
+        "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
     }
 }


### PR DESCRIPTION
Will hopefully fix #33690 and fix #34473  by introducing a direct dependency on `hoist-non-react-statics` v3.3.x.

`hoist-non-react-statics` v2.5.x is still commonly-used, and shipped its own `index.d.ts` definitions.  Unfortunately, because this package is widely-used, npm/yarn will often produce a package tree that places `hoist-non-react-statics` above `@types/react-redux`, causing TS to incorrectly resolve the v2.5 definitions instead of the correct v3.3 definitions in `@types`. 

Adding an explicit dependency on the (type-less) v3.3 package appears to force TS to look in `@types` for the correct definition, when it resolves the dependency.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
- **N/A** -- this is a dependency change to deal with a module-resolution quirk. 