### PR TITLE
node-dir Add promiseFiles and the sync overload of files

### DIFF
--- a/types/node-dir/index.d.ts
+++ b/types/node-dir/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for node-dir
 // Project: https://github.com/fshost/node-dir
 // Definitions by: Panu Horsmalahti <https://github.com/panuhorsmalahti>
+//                 James Lismore <https://github.com/jlismore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node"/>
@@ -66,6 +67,8 @@ export function readFiles(dir: string, options: Options, fileCallback: FileNamed
 export function readFilesStream(dir: string, streamCallback: StreamCallback, finishedCallback?: FinishedCallback): void;
 export function readFilesStream(dir: string, options: Options, streamCallback: StreamCallback, finishedCallback?: FinishedCallback): void;
 export function files(dir: string, callback: (error: any, files: string[]) => void): void;
+export function files(dir: string, syncOption: { sync: true }): string[];
+export function promiseFiles(dir: string): Promise<string[]>;
 export function subdirs(dir: string, callback: (error: any, subdirs: string[]) => void): void;
 export function paths(dir: string, callback: (error: any, paths: PathsResult) => void): void;
 export function paths(dir: string, combine: boolean, callback: (error: any, paths: string[] | PathsResult) => void): void;

--- a/types/node-dir/node-dir-tests.ts
+++ b/types/node-dir/node-dir-tests.ts
@@ -74,6 +74,14 @@ dir.files("./", function(err, files) {
     });
 });
 
+dir.files("./", { sync: true }).map(file => console.log(file.toLowerCase()));
+
+dir.promiseFiles("./")
+    .then(files => {
+        console.log(files);
+    })
+    .catch(e => console.error(e));
+
 dir.subdirs("./", function(err, subdirs) {
     console.log(subdirs);
 });


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/fshost/node-dir#promisefiles-dir-callback->
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
