### PR TITLE
pump: pump should return a single stream instead of an array.

### DIFF
--- a/types/pump/index.d.ts
+++ b/types/pump/index.d.ts
@@ -5,10 +5,10 @@
 
 /// <reference types="node" />
 
-declare function pump(streams: pump.Stream[], callback?: pump.Callback): pump.Stream[];
+declare function pump(streams: pump.Stream[], callback?: pump.Callback): pump.Stream;
 
 // callback have to be passed as last argument
-declare function pump(...streams: Array<pump.Stream | pump.Callback>): pump.Stream[];
+declare function pump(...streams: Array<pump.Stream | pump.Callback>): pump.Stream;
 
 declare namespace pump {
     type Callback = (err: Error) => any;

--- a/types/pump/index.d.ts
+++ b/types/pump/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for pump 1.0
+// Type definitions for pump 1.1
 // Project: https://github.com/mafintosh/pump
-// Definitions by: Tomek Łaziuk <https://github.com/tlaziuk>
+// Definitions by: Tomek Łaziuk <https://github.com/tlaziuk>, Jason Cordial <https://github.com/jcordial>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/pump/pump-tests.ts
+++ b/types/pump/pump-tests.ts
@@ -47,6 +47,8 @@ setTimeout(() => {
     throw new Error('timeout');
 }, 5000);
 
+// $ExpectType Stream
 pump(createReadStream('/dev/random'), toHex(), createWriteStream('/dev/null'));
 
+// $ExpectType Stream
 pump([createReadStream('/dev/random'), toHex(), createWriteStream('/dev/null')]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mafintosh/pump#usage>>
> Similarly to stream.pipe(), pump() returns the last stream passed in, so you can do:
> ```javscript 
> return pump(s1, s2) // returns s2
> ```
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---
I double checked the source to be sure, but pump only returns the last stream passed in, not an array of streams.

https://github.com/mafintosh/pump/blob/fee3d11cbf4c9029e1ece7a524de6ea83812b5a6/index.js#L79

https://github.com/mafintosh/pump/blob/fee3d11cbf4c9029e1ece7a524de6ea83812b5a6/index.js#L55