### PR TITLE
[Slate] fix type of SchemaProperties.document.text

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -49,7 +49,7 @@ export interface Rules {
     }>;
     normalize?: (editor: Editor, error: SlateError) => void;
     parent?: ObjectAndType | ObjectAndType[];
-    text?: RegExp;
+    text?: RegExp | ((text: string) => boolean);
 }
 
 export interface SchemaProperties {

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -74,7 +74,8 @@ const schema: SchemaProperties = {
                 }
             }
         },
-        marks: [{ type: 'bold' }, { type: t => ['bold', 'underline'].indexOf(t) !== -1 }]
+        marks: [{ type: 'bold' }, { type: t => ['bold', 'underline'].indexOf(t) !== -1 }],
+        text: /^Test$/
     },
     blocks: {
         image: {
@@ -82,6 +83,14 @@ const schema: SchemaProperties = {
             marks: [{ type: 'bold' }, { type: t => ['bold', 'underline'].indexOf(t) !== -1 }]
         },
     },
+};
+
+const schema2: SchemaProperties = {
+    document: {
+        text(text) {
+            return true;
+        }
+    }
 };
 
 const pluginCommandName = 'plugin_command';


### PR DESCRIPTION
according to docs at https://docs.slatejs.org/slate-core/schema#text
can be either a RegExp or a function taking a string
and returning a boolean

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.slatejs.org/slate-core/schema#text
