### PR TITLE
@types/stripe: Added name to customer options, as described in API docs

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1742,6 +1742,12 @@ declare namespace Stripe {
              */
             invoice_prefix?: string;
 
+            /**
+             * Customer's full name.  It's displayed alongside the customer in your dashboard.  This can be unset by updating
+             * the value to null and then saving.
+             */
+            name?: string;
+
             shipping?: IShippingInformation;
 
             /**

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1663,6 +1663,12 @@ declare namespace Stripe {
             email?: string;
 
             /**
+             * Customer's full name.  It's displayed alongside the customer in your dashboard.  This can be unset by updating
+             * the value to null and then saving.
+             */
+            name?: string;
+
+            /**
              * The identifier of the plan to subscribe the customer to. If provided, the returned customer object will have a list of subscriptions
              * that the customer is currently subscribed to. If you subscribe a customer to a plan without a free trial, the customer must have a
              * valid card as well.


### PR DESCRIPTION
This is a pretty small PR, just adding a key to the Stripe Customer create/update methods as supported by the following documentation links:
- https://stripe.com/docs/api/customers/create#create_customer-name
- https://stripe.com/docs/api/customers/update#update_customer-name

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).