### PR TITLE
feat(chance): add option definitions for common methods

### DIFF
--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -91,8 +91,8 @@ date = chance.date({max});
 const language: string = chance.locale();
 const region: string = chance.locale({region: true});
 
-const languages: string = chance.locales();
-const regions: string = chance.locales({region: true});
+const languages: string[] = chance.locales();
+const regions: string[] = chance.locales({region: true});
 
 let word: string = chance.word();
 word = chance.word({syllables: 10, length: 10});

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -95,9 +95,10 @@ const languages: string[] = chance.locales();
 const regions: string[] = chance.locales({region: true});
 
 let word: string = chance.word();
-word = chance.word({syllables: 10, length: 10});
+word = chance.word({syllables: 10, length: 10, capitalize: true});
 word = chance.word({syllables: 10});
 word = chance.word({length: 10});
+word = chance.word({capitalize: true});
 
 let randomString: string = chance.string();
 randomString = chance.string({pool: 'abcdef', length: 10});

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -4,7 +4,8 @@ const chance = new Chance();
 const createYourOwn = new Chance(Math.random);
 
 // Basic usage
-const randBool: boolean = chance.bool();
+let bool: boolean = chance.bool();
+bool = chance.bool({likelihood: 30});
 
 const birthday: Date = chance.birthday();
 const birthdayStr: Date | string = chance.birthday({ string: true });
@@ -92,3 +93,71 @@ const region: string = chance.locale({region: true});
 
 const languages: string = chance.locales();
 const regions: string = chance.locales({region: true});
+
+let word: string = chance.word();
+word = chance.word({syllables: 10, length: 10});
+word = chance.word({syllables: 10});
+word = chance.word({length: 10});
+
+let randomString: string = chance.string();
+randomString = chance.string({pool: 'abcdef', length: 10});
+randomString = chance.string({pool: 'abcdef'});
+randomString = chance.string({length: 10});
+
+let url: string = chance.url();
+url = chance.url({protocol: 'http'});
+url = chance.url({domain: 'www.socialradar.com'});
+url = chance.url({domain_prefix: 'dev'});
+url = chance.url({path: 'images'});
+url = chance.url({extensions: ['gif', 'jpg', 'png']});
+url = chance.url({protocol: 'http', domain: 'www.socialradar.com', domain_prefix: 'dev', path: 'images', extensions: ['gif', 'jpg', 'png']});
+
+let integer: number = chance.integer();
+integer = chance.integer({min: 1});
+integer = chance.integer({max: 10});
+integer = chance.integer({min: 1, max: 10});
+
+let first: string = chance.first();
+first = chance.first({gender: 'male'});
+first = chance.first({nationality: 'en'});
+first = chance.first({gender: 'male', nationality: 'en'});
+
+let last: string = chance.last();
+last = chance.last({nationality: 'en'});
+last = chance.last({nationality: 'jp'});
+last = chance.last({nationality: '*'});
+
+let prefix: string = chance.prefix();
+prefix = chance.prefix({gender: 'male'});
+prefix = chance.prefix({gender: 'female'});
+prefix = chance.prefix({gender: 'all'});
+prefix = chance.prefix({full: true});
+prefix = chance.prefix({gender: 'male', full: true});
+
+let suffix: string = chance.suffix();
+suffix = chance.suffix({full: true});
+
+let name: string  = chance.name();
+name = chance.name({middle: true});
+name = chance.name({middle_initial: true});
+name = chance.name({prefix: true});
+name = chance.name({suffix: true});
+name = chance.name({nationality: 'it'});
+name = chance.name({gender: 'male'});
+name = chance.name({full: true});
+name = chance.name({middle: true, middle_initial: true, prefix: true, suffix: true, nationality: 'en', gender: 'male', full: true});
+
+let email: string = chance.email();
+email = chance.email({domain: 'chance.com'});
+email = chance.email({length: 10});
+email = chance.email({domain: 'chance.com', length: 10});
+
+let sentence: string = chance.sentence();
+sentence = chance.sentence({words: 10});
+sentence = chance.sentence({punctuation: false});
+sentence = chance.sentence({punctuation: '.'});
+sentence = chance.sentence({punctuation: '?'});
+sentence = chance.sentence({punctuation: ';'});
+sentence = chance.sentence({punctuation: '!'});
+sentence = chance.sentence({punctuation: ':'});
+sentence = chance.sentence({words: 10, punctuation: '?'});

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -194,6 +194,7 @@ declare namespace Chance {
     interface WordOptions {
         length: number;
         syllables: number;
+        capitalize: boolean;
     }
 
     interface StringOptions {

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -5,6 +5,11 @@
 //                 Carlos Sanchez <https://github.com/cafesanu>
 //                 Colby M. White <https://github.com/colbywhite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+// a bit of cleverness from jcalz at https://stackoverflow.com/a/48244432
+// this will ensure that empty objects are not allowed for objects with optional parameters
+type AtLeastOneKey<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
 
 declare namespace Chance {
     type Seed = number | string;
@@ -25,19 +30,19 @@ declare namespace Chance {
 
     interface Chance extends Seeded {
         // Basics
-        bool(opts?: Options): boolean;
+        bool(opts?: {likelihood: number}): boolean;
         character(opts?: Options): string;
         floating(opts?: Options): number;
-        integer(opts?: Options): number;
+        integer(opts?: AtLeastOneKey<IntegerOptions>): number;
         letter(opts?: Options): string;
         natural(opts?: Options): number;
-        string(opts?: Options): string;
+        string(opts?: AtLeastOneKey<StringOptions>): string;
 
         // Text
         paragraph(opts?: Options): string;
-        sentence(opts?: Options): string;
+        sentence(opts?: AtLeastOneKey<SentenceOptions>): string;
         syllable(opts?: Options): string;
-        word(opts?: Options): string;
+        word(opts?: AtLeastOneKey<WordOptions>): string;
 
         // Person
         age(opts?: Options): number;
@@ -46,14 +51,14 @@ declare namespace Chance {
         birthday(opts?: Options): Date | string;
         cf(opts?: Options): string;
         cpf(): string;
-        first(opts?: Options): string;
-        last(opts?: Options): string;
-        name(opts?: Options): string;
-        name_prefix(opts?: Options): string;
-        name_suffix(opts?: Options): string;
-        prefix(opts?: Options): string;
+        first(opts?: AtLeastOneKey<FirstNameOptions>): string;
+        last(opts?: LastNameOptions): string;
+        name(opts?: AtLeastOneKey<NameOptions>): string;
+        name_prefix(opts?: AtLeastOneKey<PrefixOptions>): string;
+        name_suffix(opts?: SuffixOptions): string;
+        prefix(opts?: AtLeastOneKey<PrefixOptions>): string;
         ssn(opts?: Options): string;
-        suffix(opts?: Options): string;
+        suffix(opts?: SuffixOptions): string;
 
         // Mobile
         animal(opts?: Options): string;
@@ -70,7 +75,7 @@ declare namespace Chance {
         color(opts?: Options): string;
         company(): string;
         domain(opts?: Options): string;
-        email(opts?: Options): string;
+        email(opts?: AtLeastOneKey<EmailOptions>): string;
         fbid(): string;
         google_analytics(): string;
         hashtag(): string;
@@ -80,7 +85,7 @@ declare namespace Chance {
         profession(opts?: Options): string;
         tld(): string;
         twitter(): string;
-        url(opts?: Options): string;
+        url(opts?: AtLeastOneKey<UrlOptions>): string;
 
         // Location
         address(opts?: Options): string;
@@ -184,6 +189,66 @@ declare namespace Chance {
     // the correct options interfaces for each method
     interface Options {
         [id: string]: any;
+    }
+
+    interface WordOptions {
+        length: number;
+        syllables: number;
+    }
+
+    interface StringOptions {
+        length: number;
+        pool: string;
+    }
+
+    interface UrlOptions {
+        protocol: string;
+        domain: string;
+        domain_prefix: string;
+        path: string;
+        extensions: string[];
+    }
+
+    interface IntegerOptions {
+        min: number;
+        max: number;
+    }
+
+    type FirstNameNationalities = 'en' | 'it';
+    type LastNameNationalities = FirstNameNationalities | 'nl' | 'uk' | 'de' | 'jp' | 'es' | 'fr' | '*';
+
+    interface FullNameOptions {
+        middle: boolean;
+        middle_initial: boolean;
+        prefix: boolean;
+        suffix: boolean;
+    }
+
+    interface FirstNameOptions {
+        gender: 'male' | 'female';
+        nationality: FirstNameNationalities;
+    }
+
+    interface LastNameOptions {
+        nationality: LastNameNationalities;
+    }
+
+    interface SuffixOptions {
+        full: boolean;
+    }
+
+    type PrefixOptions = { gender: 'male' | 'female' | 'all' } & SuffixOptions;
+
+    type NameOptions = FullNameOptions & FirstNameOptions & LastNameOptions & PrefixOptions;
+
+    interface EmailOptions {
+        length: number;
+        domain: string;
+    }
+
+    interface SentenceOptions {
+        words: number;
+        punctuation: '.' | '?' | ';' | '!' | ':' | boolean;
     }
 
     interface DateOptions {

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -97,8 +97,8 @@ declare namespace Chance {
         depth(opts?: Options): number;
         geohash(opts?: Options): string;
         latitude(opts?: Options): number;
-        locale(opts?: LocaleOptions): string;
-        locales(opts?: LocaleOptions): string;
+        locale(opts?: {region: true}): string;
+        locales(opts?: {region: true}): string[];
         longitude(opts?: Options): number;
         phone(opts?: Options): string;
         postal(): string;
@@ -259,10 +259,6 @@ declare namespace Chance {
         day?: number;
         min?: Date;
         max?: Date;
-    }
-
-    interface LocaleOptions {
-        region: boolean;
     }
 
     interface Month {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - the documentation is not thorough on all the parameters that are possible. so source code was looked at
  - [chance.bool](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L130)
  - [chance.word](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L711)
  - [chance.string](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L386)
  - [chance.url](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L1460)
  - [chance.integer](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L267)
  - [chance.first](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L839)
  - [chance.last](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L862)
    - note that the [`lastNames` data map](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L2598) supports more nationalities than the one for `firstNames`
  - [chance.prefix/chance.name_prefix](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L1019)
  - [chance.suffix/chance.name_suffix](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L1097)
  - [chance.name](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L966)
    - note that the options for this one are passed into several others as is. this ends up making things a bit more complicated, but what is valid to `name` is the smallest subset of all the methods it passes the options to. the typing reflects that. i.e `last` takes in more nationalities than `first`, but `name` should only allow the nationalities that support `first`.
  - [chance.email](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L1377)
  - [chance.sentence](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L652)
- [x] Increase the version number in the header if appropriate.
  - no major/minor version bump needed
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - not needed

This is a different attempt at #34855 from @Hakier. It does more methods while also using source code to inform the types since the documentation has holes in it. It also uses a [clever solution](https://stackoverflow.com/a/48244432) (i.e the `AtLeastOneKey` generic type) from @jcalz in order to prevent an empty object from being passed in as a parameter. while this is technically allowed by chancejs, it is a sign that the user is doing something incorrect and thus it is ideal for the typings to prevent that.

This also fixes an error I introduced in ##34523. The return types of `chance.locales` should've been a `string[]`, not a `string`.