### PR TITLE
fix(sharp): add missing modulate type

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -434,6 +434,13 @@ declare namespace sharp {
          */
         recomb(inputMatrix: Matrix3x3): Sharp;
 
+        /**
+         * Transforms the image using brightness, saturation and hue rotation.
+         * @param options describes the modulation
+         * @returns A sharp instance that can be used to chain operations
+         */
+        modulate(options?: { brightness?: number, saturation?: number, hue?: number }): Sharp;
+
         //#endregion
 
         //#region Output functions

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -244,4 +244,8 @@ sharp('input.gif')
         [0.2990, 0.5870, 0.1140],
         [0.2392, 0.4696, 0.0912],
     ])
+
+    .modulate({ brightness: 2 })
+    .modulate({ hue: 180 })
+    .modulate({ brightness: 0.5, saturation: 0.5, hue: 90 })
 ;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

* 0.22.1 with support of `modulate` was [released](https://github.com/lovell/sharp/blob/master/docs/changelog.md#v0221---25th-april-2019)
* [`modulate` api docs](https://github.com/lovell/sharp/blob/b494b2e8724df3bb0a80ee15ff51582d6c65fd2a/docs/api-operation.md#modulate)