### PR TITLE
[react-native] Correct types for NetInfo event listeners

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -20,6 +20,7 @@
 //                 Saransh Kataria <https://github.com/saranshkataria>
 //                 Francesco Moro <https://github.com/franzmoro>
 //                 Wojciech Tyczynski <https://github.com/tykus160>
+//                 Jake Bloom <https://github.com/jakebloom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -7707,6 +7708,10 @@ export interface ConnectionInfo {
     effectiveType: EffectiveConnectionType;
 }
 
+interface NetInfoEventListener {
+    remove: () => void;
+}
+
 export interface NetInfoStatic {
     /**
      * This function is deprecated. Use `getConnectionInfo` instead. Returns a promise that
@@ -7725,7 +7730,7 @@ export interface NetInfoStatic {
      *   the network status changes. The argument to the event handler is one of the deprecated
      *   connectivity types listed above.
      */
-    addEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => void;
+    addEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => NetInfoEventListener;
 
     /**
      * Removes the listener for network status changes.
@@ -7751,7 +7756,7 @@ export interface NetInfoStatic {
         /**
          * eventName is expected to be `change`(deprecated) or `connectionChange`
          */
-        addEventListener: (eventName: string, listener: (result: boolean) => void) => void;
+        addEventListener: (eventName: string, listener: (result: boolean) => void) => NetInfoEventListener;
 
         /**
          * eventName is expected to be `change`(deprecated) or `connectionChange`

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -87,6 +87,7 @@ import {
     ViewPropTypes,
     requireNativeComponent,
     Keyboard,
+    NetInfo,
 } from "react-native";
 
 declare module "react-native" {
@@ -869,4 +870,9 @@ const ShareTest = () => {
 const KeyboardTest = () => {
     const subscriber = Keyboard.addListener("keyboardDidHide", (event) => {event});
     subscriber.remove();
+}
+
+const NetInfoTest = () => {
+    const subscription = NetInfo.addEventListener('connectionChange', (result) => console.log(result));
+    subscription.remove();
 }


### PR DESCRIPTION
The types were inaccurate - the net info event listener returns an object that can have `remove` called on it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Network/NetInfo.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
