### PR TITLE
util.promisify: compatible with the latest @types/node

### DIFF
--- a/types/util.promisify/auto.d.ts
+++ b/types/util.promisify/auto.d.ts
@@ -1,0 +1,3 @@
+import shim = require("./shim");
+
+export {};

--- a/types/util.promisify/index.d.ts
+++ b/types/util.promisify/index.d.ts
@@ -1,36 +1,41 @@
 // Type definitions for util.promisify 1.0
 // Project: https://github.com/ljharb/util.promisify#readme
 // Definitions by: Adam Voss <https://github.com/adamvoss>
+//                 Piotr Roszatycki <https://github.com/dex4er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ Note that ES6 modules cannot directly export callable functions.
- *~ This file should be imported using the CommonJS-style:
- *~   import x = require('util.promisify');
- *~
- *~ Refer to the documentation to understand common
- *~ workarounds for this limitation of ES6 modules.
- */
-export = promisify;
+/// <reference types="node" />
 
-declare function promisify(f: (...args: any[]) => void): (...args: any[]) => Promise<any>;
+// tslint:disable:ban-types
+interface CustomPromisify<TCustom extends Function> extends Function {
+    __promisify__: TCustom;
+}
+
+declare function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
+declare function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
+declare function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
+declare function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
+declare function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
+declare function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+declare function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
+declare function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+declare function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+declare function promisify<T1, T2, T3, T4, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void,
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
+declare function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+declare function promisify<T1, T2, T3, T4, T5, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void,
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+declare function promisify<T1, T2, T3, T4, T5>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void,
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
+declare function promisify(fn: Function): Function;
 
 declare namespace promisify {
-    interface implementation {
-        (fn: (...args: any[]) => void): (...args: any[]) => Promise<any>;
-        custom: symbol;
-        customPromisifyArgs: symbol | undefined;
-    }
-
-    const custom: symbol;
-    const customPromisifyArgs: symbol;
-    function getPolyfill(): implementation;
-    const implementation: implementation;
-    function shim(): implementation;
+    function getPolyfill(): typeof promisify;
+    const implementation: typeof promisify;
+    function shim(): typeof promisify;
 }
 
-declare module "util" {
-    let promisify: {
-        (fn: (...args: any[]) => void): (...args: any[]) => Promise<any>;
-        custom: symbol;
-    };
-}
+export = promisify;

--- a/types/util.promisify/polyfill.d.ts
+++ b/types/util.promisify/polyfill.d.ts
@@ -1,0 +1,29 @@
+/// <reference types="node" />
+
+// tslint:disable:ban-types max-line-length
+interface CustomPromisify<TCustom extends Function> extends Function {
+    __promisify__: TCustom;
+}
+
+declare function getPolyfill<TCustom extends Function>(): (fn: CustomPromisify<TCustom>) => TCustom;
+declare function getPolyfill<TResult>(): (fn: (callback: (err: Error | null, result: TResult) => void) => void) => () => Promise<TResult>;
+declare function getPolyfill(): (fn: (callback: (err?: Error | null) => void) => void) => () => Promise<void>;
+declare function getPolyfill<T1, TResult>(): (fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void) => (arg1: T1) => Promise<TResult>;
+declare function getPolyfill<T1>(): (fn: (arg1: T1, callback: (err?: Error | null) => void) => void) => (arg1: T1) => Promise<void>;
+declare function getPolyfill<T1, T2, TResult>(): (fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void) => (arg1: T1, arg2: T2) => Promise<TResult>;
+declare function getPolyfill<T1, T2>(): (fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void) => (arg1: T1, arg2: T2) => Promise<void>;
+declare function getPolyfill<T1, T2, T3, TResult>(): (fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void) => (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+declare function getPolyfill<T1, T2, T3>(): (fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void) => (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+declare function getPolyfill<T1, T2, T3, T4, TResult>(): (
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void,
+) => (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
+declare function getPolyfill<T1, T2, T3, T4>(): (fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void) => (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+declare function getPolyfill<T1, T2, T3, T4, T5, TResult>(): (
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void,
+) => (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+declare function getPolyfill<T1, T2, T3, T4, T5>(): (
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void,
+) => (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
+declare function getPolyfill(): (fn: Function) => Function;
+
+export = getPolyfill;

--- a/types/util.promisify/shim.d.ts
+++ b/types/util.promisify/shim.d.ts
@@ -1,0 +1,3 @@
+import getPolyfill = require("./polyfill");
+
+export = getPolyfill;

--- a/types/util.promisify/tsconfig.json
+++ b/types/util.promisify/tsconfig.json
@@ -17,7 +17,10 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "auto.d.ts",
         "index.d.ts",
+        "polyfill.d.ts",
+        "shim.d.ts",
         "util.promisify-tests.ts"
     ]
 }

--- a/types/util.promisify/util.promisify-tests.ts
+++ b/types/util.promisify/util.promisify-tests.ts
@@ -1,11 +1,15 @@
-/// <reference types="node/v0" />
-
 import * as util from 'util';
-import * as fs from "fs";
+import * as fs from 'fs';
 import promisify = require('util.promisify');
 
-// tslint:disable-next-line ban-types
-let readFile: Function = promisify(fs.readFile);
+import 'util.promisify/auto';
 
-promisify.shim();
+let readFile = promisify(fs.readFile);
 readFile = util.promisify(fs.readFile);
+
+let implementation = promisify.getPolyfill();
+implementation = promisify.shim();
+implementation = promisify.implementation;
+
+import promisifyShim = require('util.promisify/shim');
+promisifyShim();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/util.html#util_util_promisify_original
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The typings are copy-pasted from the latest `@types/node` so it is possible to use `util` and `util.promisify` modules in the same source file (currently it is not possible).

Additionally separate typings for extra modules has been added.
