### PR TITLE
Avoid extends check for Memo/LazyExoticComponent

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -777,9 +777,9 @@ declare namespace React {
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
     // but can be given its own specific name
-    interface MemoExoticComponent<T extends ComponentType<any>> extends NamedExoticComponent<ComponentPropsWithRef<T>> {
+    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<ComponentPropsWithRef<T>> & {
         readonly type: T;
-    }
+    };
 
     function memo<P extends object>(
         Component: SFC<P>,
@@ -790,9 +790,9 @@ declare namespace React {
         propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
     ): MemoExoticComponent<T>;
 
-    interface LazyExoticComponent<T extends ComponentType<any>> extends ExoticComponent<ComponentPropsWithRef<T>> {
+    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
         readonly _result: T;
-    }
+    };
 
     function lazy<T extends ComponentType<any>>(
         factory: () => Promise<{ default: T }>


### PR DESCRIPTION
A subtype check involving ComponentPropsWithRef<T> is extremely expensive because it is guaranteed to be structural. This PR avoids the subtype check by using intersection instead, which is equivalent in this case.

This PR doesn't address the underlying issue that ComponentProps and PropsWithRef are extremely expensive, but the same technique might be more generally applicable for easy savings in the react ecosystem.