### PR TITLE
Remove definitions for deprecated MapView

### DIFF
--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -89,10 +89,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.ListView,
     T
   >;
-  MapView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.MapView,
-    T
-  >;
   Modal: ReactNativeThemedStyledFunction<
     typeof ReactNative.Modal,
     T


### PR DESCRIPTION
Related to:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35239

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)

This is related to a conflict with the now-separate module "MapView" / `react-native-maps`, which is also a deprecated and unsupported module from `react-native` (these are two separate modules, `react-native-maps` is now community supported and maintained). The existence of these types conflicts with that modules index.d.ts.

I have a PR to get them to remove that if we can also move all types into an @types/react-native-maps module for better maintenance and consistency.

I cannot fix the conflict in my original PR on @types/react-native without this change.