### PR TITLE
[elliptic] Fixes up type definitions.

### DIFF
--- a/types/elliptic/elliptic-tests.ts
+++ b/types/elliptic/elliptic-tests.ts
@@ -26,7 +26,7 @@ const y = pubPoint.getY();
 // 1) '04' + hex string of x + hex string of y; or
 // 2) object with two hex string properties (x and y); or
 // 3) object with two buffer properties (x and y)
-const pub = pubPoint.encode('hex');                                 // case 1
+const pub = pubPoint.encode('hex', true);                            // case 1
 const aPub = { x: x.toString('hex'), y: y.toString('hex') };         // case 2
 const bPub = { x: x.toBuffer(), y: y.toBuffer() };                   // case 3
 const cPub = { x: x.toArrayLike(Buffer), y: y.toArrayLike(Buffer) }; // case 3

--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -43,8 +43,8 @@ export namespace curve {
 
             constructor(curve: base, type: string);
 
-            encode(enc: string, compact: boolean): string | Buffer;
-            encodeCompressed(enc: string): BN;
+            encode(enc: "hex" | "array", compact: boolean): string | Buffer;
+            encodeCompressed(enc: "hex" | "array"): BN;
             validate(): boolean;
             precompute(power: number): BasePoint;
             dblp(k: number): BasePoint;
@@ -133,8 +133,8 @@ export namespace curve {
         }
 
         class ShortPoint extends base.BasePoint {
-            x: BN;
-            y: BN;
+            x: BN | null;
+            y: BN | null;
             inf: boolean;
 
             toJSON(): BNInput[];
@@ -181,11 +181,11 @@ export class ec {
 
     keyPair(options: ec.KeyPairOptions): ec.KeyPair;
     keyFromPrivate(
-        priv: Buffer | string | ec.KeyPair,
+        priv: Uint8Array | Buffer | string | ec.KeyPair,
         enc?: string
     ): ec.KeyPair;
     keyFromPublic(
-        pub: Buffer | string | { x: string; y: string } | ec.KeyPair,
+        pub: Uint8Array | Buffer | string | { x: string; y: string } | ec.KeyPair,
         enc?: string
     ): ec.KeyPair;
     genKeyPair(options?: ec.GenKeyPairOptions): ec.KeyPair;
@@ -229,7 +229,7 @@ export namespace ec {
     }
 
     interface SignOptions {
-        pers: any;
+        pers?: any;
         persEnc?: string;
         canonical?: boolean;
         k?: BN;
@@ -252,9 +252,11 @@ export namespace ec {
         constructor(ec: ec, options: KeyPairOptions);
 
         validate(): { readonly result: boolean; readonly reason: string };
-        getPublic(compact: boolean, enc?: string): any; // ?
-        getPublic(enc?: string): any; // ?
-        getPrivate(enc?: "hex"): Buffer | BN | string;
+        getPublic(compact: boolean, enc: "hex" | "array"): string | number[];
+        getPublic(enc: "hex" | "array"): string;
+        getPublic(): curve.base.BasePoint;
+        getPrivate(enc: "hex"): string;
+        getPrivate(): BN;
         derive(pub: any): any; // ?
         sign(msg: BNInput, enc: string, options?: SignOptions): Signature;
         sign(msg: BNInput, options?: SignOptions): Signature;
@@ -301,7 +303,7 @@ export class eddsa {
         pub: eddsa.Bytes | eddsa.Point | eddsa.KeyPair
     ): boolean;
     hashInt(): BN;
-    keyFromPublic(pub: eddsa.Bytes): eddsa.KeyPair;
+    keyFromPublic(pub: eddsa.Bytes | eddsa.KeyPair | eddsa.Point): eddsa.KeyPair;
     keyFromSecret(secret: eddsa.Bytes): eddsa.KeyPair;
     makeSignature(sig: eddsa.Signature | Buffer | string): eddsa.Signature;
     encodePoint(point: eddsa.Point): Buffer;


### PR DESCRIPTION
Both `keyFromPrivate` and `keyFromPublic` work with Uint8Array.  `keyFromPublic` accepts anything with a length and an indexer, though I'm not sure how to correctly setup the types for that.  `keyFromPrivate` works with anything that `BN` works with as input, which includes `Uint8Array`s.

The only valid value for `enc` in `getPublic` and `getPrivate` is `hex`, so I narrowed the type on those to only support that instead of `string`.

The `compact` boolean on `getPublic` with an `enc` parameter set to anything other than `hex` will yield `[ this.getY().isEven() ? 0x02 : 0x03 ].concat(x)`.  I chose the string 'array' as an opinion here so at least future readers of code written to use that overload of `getPublic` can have an idea of what they are getting out when they pass something besides `'hex'` in.  (note: if nothing is a falsy value for `enc` is provided when `concat` is truthy, the function will behave the same as if no parameters were passed).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
