### PR TITLE
[hast-format] Add types for HAST format 2.3

### DIFF
--- a/types/hast-format/hast-format-tests.ts
+++ b/types/hast-format/hast-format-tests.ts
@@ -1,0 +1,95 @@
+import { Data, Point, Position } from "unist";
+import {
+    Parent,
+    Properties,
+    Literal,
+    Root,
+    Element,
+    DocType,
+    Comment,
+    Text
+} from "hast-format";
+
+const data: Data = {
+    string: "string",
+    number: 1,
+    object: {
+        key: "value"
+    },
+    array: [],
+    boolean: true,
+    null: null
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+    indent: [1]
+};
+
+const literal: Literal = {
+    type: "text",
+    data,
+    point,
+    value: "value"
+};
+
+const comment: Comment = {
+    type: "comment",
+    data,
+    point,
+    value: "value"
+};
+
+const text: Text = {
+    type: "text",
+    data,
+    point,
+    value: "value"
+};
+
+const docType: DocType = {
+    type: "doctype",
+    name: "name",
+    public: "public",
+    system: "system"
+};
+
+const element: Element = getElement();
+
+const parent: Parent = {
+    type: "parent",
+    data,
+    position,
+    children: [getElement(), docType, comment, text]
+};
+
+const root: Root = {
+    type: "root",
+    data,
+    position,
+    children: [getElement(), docType, comment, text]
+};
+
+const properties: Properties = {
+    propertyName1: "propertyValue1",
+    propertyName2: ["propertyValue2", "propertyValue3"],
+    propertyName3: true,
+    propertyName4: 47
+};
+
+function getElement(): Element {
+    return {
+        type: "element",
+        tagName: "tagName",
+        properties,
+        content: root,
+        children: [element, comment, text]
+    };
+}

--- a/types/hast-format/index.d.ts
+++ b/types/hast-format/index.d.ts
@@ -1,0 +1,121 @@
+// Type definitions for non-npm package Hast 2.3
+// Project: https://github.com/syntax-tree/hast
+// Definitions by: lukeggchapman <https://github.com/lukeggchapman>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import {
+    Parent as UnistParent,
+    Literal as UnistLiteral,
+    Node as UnistNode
+} from "unist";
+
+export { UnistNode as Node };
+
+/**
+ * Node in hast containing other nodes.
+ */
+export interface Parent extends UnistParent {
+    /**
+     * List representing the children of a node.
+     */
+    children: Array<Element | DocType | Comment | Text>;
+}
+
+/**
+ * Nodes in hast containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * Root represents a document.
+ * Can be used as the rood of a tree, or as a value of the
+ * content field on a 'template' Element, never as a child.
+ */
+export interface Root extends Parent {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: "root";
+}
+
+/**
+ * Element represents an HTML Element.
+ */
+export interface Element extends Parent {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: "element";
+
+    /**
+     * Represents the element’s local name.
+     */
+    tagName: string;
+
+    /**
+     * Represents information associated with the element.
+     */
+    properties?: Properties;
+
+    /**
+     * If the tagName field is 'template', a content field can be present.
+     */
+    content?: Root;
+
+    /**
+     * List representing the children of a node.
+     */
+    children: Array<Element | Comment | Text>;
+}
+
+/**
+ * Represents information associated with an element.
+ */
+export interface Properties {
+    [PropertyName: string]: any;
+}
+
+/**
+ * Represents an HTML DocumentType.
+ */
+export interface DocType extends UnistNode {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: "doctype";
+
+    name: string;
+
+    /**
+     * Represents the document’s public identifier.
+     */
+    public?: string;
+
+    /**
+     * Represents the document’s system identifier.
+     */
+    system?: string;
+}
+
+/**
+ * Represents an HTML Comment.
+ */
+export interface Comment extends Literal {
+    /**
+     * Represents this variant of a Literal.
+     */
+    type: "comment";
+}
+
+/**
+ * Represents an HTML Text.
+ */
+export interface Text extends Literal {
+    /**
+     * Represents this variant of a Literal.
+     */
+    type: "text";
+}

--- a/types/hast-format/tsconfig.json
+++ b/types/hast-format/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "hast-format-tests.ts"]
+}

--- a/types/hast-format/tslint.json
+++ b/types/hast-format/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

# hast-format

[Hypertext Abstract Syntax Tree (hast) format](https://github.com/syntax-tree/hast) is an implementation of the Universal Syntax Tree ([unist](https://github.com/syntax-tree/unist)). hast-format extends the existing [definitions for unist](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/unist).

These types have the name hast-format because hast is an existing npm package renamed as rehype.
