### PR TITLE
remove reference to styled components' css prop

### DIFF
--- a/types/rebass__grid/index.d.ts
+++ b/types/rebass__grid/index.d.ts
@@ -10,7 +10,6 @@
 // TypeScript Version: 2.9
 
 import * as React from "react";
-import { Interpolation } from "styled-components";
 import * as StyledSystem from "styled-system";
 
 export {};
@@ -19,7 +18,6 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export interface BaseProps extends React.Props<any> {
     as?: React.ElementType;
-    css?: Interpolation<any>;
 }
 
 interface BoxKnownProps

--- a/types/rebass__grid/rebass__grid-tests.tsx
+++ b/types/rebass__grid/rebass__grid-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Flex, Box } from "@rebass/grid";
-import { css } from "styled-components";
 import * as Emotion from "@rebass/grid/emotion";
 
 const test = () => (
@@ -118,28 +117,8 @@ const Layout = () => (
     </Flex>
 );
 
-const cssTest = (
-    <Flex css="background: transparent;">
-        <Box
-            css={css`
-                ${{ color: "inherit" }}
-            `}
-        />
-    </Flex>
-);
-
 const EmotionLayout = () => (
     <Emotion.Flex m={4}>
         <Emotion.Box px={3} py={2} />
-    </Emotion.Flex>
-);
-
-const emotionCssTest = (
-    <Emotion.Flex css="background: transparent;">
-        <Emotion.Box
-            css={css`
-                ${{ color: "inherit" }}
-            `}
-        />
     </Emotion.Flex>
 );


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**The Backstory**
- @rebass/grid is compatible with either styled-components or emotion, and exports packages backed by either implementation. The api & typings are exactly the same across implementations.
- The concept of the css prop is supported by both [styled-components](https://www.styled-components.com/docs/api#css-prop) and [emotion](https://emotion.sh/docs/css-prop#___gatsby). The actual implementation of the css prop in these two libraries is similar but not exactly the same. Critically, the two implementations are not API-compatible in all cases. 
- In both libraries, the css prop actually depends on a babel plugin or jsx pragma, and effectively augments the global jsx / dom attributes with an additional property. 
- The emotion team decided to assume that all users would use the babel plugin, and [reflect this in their typings](https://github.com/emotion-js/emotion/blob/2efe235efa5de4b5ca01af3d6ff7047215af43d5/packages/core/types/index.d.ts#L84)
- The styled-components typings assume the opposite, and [do not to reflect this in their typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/styled-components/index.d.ts#L485). Instead they push the decision down to the end-user.
- It looks like @Jessidhia added the css prop to the typings of the grid components in #30467, forwarding the types from styled-components.

**The Solution**
- This change will remove the `css` property from the rebass/grid components, and removes all dependency on the styled-components typings.
- Since each backing implementation provides their own version of the `css` property, it should be the responsibility of those libraries and their typings to reflect this.

**The Risks**
- This is technically a breaking change for anyone who uses styled components with the css prop. Technically, the correct solution is for them to augment their global typings as outlined in the styled components  typings file. But realistically, that is really esoteric and I doubt many people realize that's what they are supposed to do. so.... 🤷‍♂ 