### PR TITLE
@types/koa-compose: Add more typed compose cases

### DIFF
--- a/types/koa-compose/index.d.ts
+++ b/types/koa-compose/index.d.ts
@@ -6,9 +6,45 @@
 
 import * as Koa from "koa";
 
-declare function compose<T, U, V, W>(
-    middleware: [Koa.Middleware<T, U>, Koa.Middleware<V, W>]
-): Koa.Middleware<T & V, U & W>;
+declare function compose<T1, U1, T2, U2>(
+    middleware: [Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>]
+): Koa.Middleware<T1 & T2, U1 & U2>;
+
+declare function compose<T1, U1, T2, U2, T3, U3>(
+    middleware: [Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>]
+): Koa.Middleware<T1 & T2 & T3, U1 & U2 & U3>;
+
+declare function compose<T1, U1, T2, U2, T3, U3, T4, U4>(
+    middleware: [Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>, Koa.Middleware<T4, U4>]
+): Koa.Middleware<T1 & T2 & T3 & T4, U1 & U2 & U3 & U4>;
+
+declare function compose<T1, U1, T2, U2, T3, U3, T4, U4, T5, U5>(
+    middleware: [
+        Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>, Koa.Middleware<T4, U4>,
+        Koa.Middleware<T5, U5>
+    ]
+): Koa.Middleware<T1 & T2 & T3 & T4 & T5, U1 & U2 & U3 & U4 & U5>;
+
+declare function compose<T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6>(
+    middleware: [
+        Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>, Koa.Middleware<T4, U4>,
+        Koa.Middleware<T5, U5>, Koa.Middleware<T6, U6>
+    ]
+): Koa.Middleware<T1 & T2 & T3 & T4 & T5 & T6, U1 & U2 & U3 & U4 & U5 & U6>;
+
+declare function compose<T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7>(
+    middleware: [
+        Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>, Koa.Middleware<T4, U4>,
+        Koa.Middleware<T5, U5>, Koa.Middleware<T6, U6>, Koa.Middleware<T7, U7>
+    ]
+): Koa.Middleware<T1 & T2 & T3 & T4 & T5 & T6 & T7, U1 & U2 & U3 & U4 & U5 & U6 & U7>;
+
+declare function compose<T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7, T8, U8>(
+    middleware: [
+        Koa.Middleware<T1, U1>, Koa.Middleware<T2, U2>, Koa.Middleware<T3, U3>, Koa.Middleware<T4, U4>,
+        Koa.Middleware<T5, U5>, Koa.Middleware<T6, U6>, Koa.Middleware<T7, U7>, Koa.Middleware<T8, U8>
+    ]
+): Koa.Middleware<T1 & T2 & T3 & T4 & T5 & T6 & T7 & T8, U1 & U2 & U3 & U4 & U5 & U6 & U7 & U8>;
 
 declare function compose<T>(middleware: Array<compose.Middleware<T>>): compose.ComposedMiddleware<T>;
 

--- a/types/koa-compose/index.d.ts
+++ b/types/koa-compose/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for koa-compose 3.2
 // Project: https://github.com/koajs/compose
 // Definitions by: jKey Lu <https://github.com/jkeylu>
+//                 Anton Astashov <https://github.com/astashov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/koa-compose/koa-compose-tests.ts
+++ b/types/koa-compose/koa-compose-tests.ts
@@ -49,3 +49,13 @@ new Koa<{}, {}>()
         ctx.body = "Something";
         await next();
     });
+
+new Koa<{}, {}>()
+    .use(compose([fooMiddleware, barMiddleware, wooMiddleware]))
+    .use(async (ctx, next) => {
+        ctx.state.foo;
+        ctx.state.bar;
+        ctx.state.woo;
+        ctx.body = "Something";
+        await next();
+    });


### PR DESCRIPTION
Right now if you want typesafe compose, you have to compose composes by
2-element arrays. I.e. if you have 4 middlewares you want to compose
together, and you want to do that in a typesafe way, without losing type
information, you have to do it like this:

```ts
import compose from "koa-compose"

const myMiddleware = compose([
  firstMiddleware,
  compose([
    secondMiddleware,
    compose([
      thirdMiddleware,
      fourthMiddleware
    ])
  ])
]);
```

It works, but looks clunky and complicated. Would be cool to still have
type-safe way of composing, but with less clunkiness. Like:

```ts
import compose from "koa-compose"

const myMiddleware = compose([
  firstMiddleware,
  secondMiddleware,
  thirdMiddleware,
  fourthMiddleware
]);
```

It's hard to solve that issue for general case, but we could just add
typesafe compose overrides for up to e.g. 8-element arrays. If it's more
than 8 - you still can compose composes. But in general IMHO it will
reduce clunkiness of it.