### PR TITLE
Allow HtmlTemplate to have arbitrary properties for passing variables to templates

### DIFF
--- a/types/google-apps-script/google-apps-script.html.d.ts
+++ b/types/google-apps-script/google-apps-script.html.d.ts
@@ -86,6 +86,7 @@ declare namespace GoogleAppsScript {
       getCode(): string;
       getCodeWithComments(): string;
       getRawContent(): string;
+      [propName: string]: any;
     }
 
     /**


### PR DESCRIPTION
To pass in data to an HtmlTemplate, you need to create a new property containing the variable that you will then access in your html file (see documentation linked below). This was giving me compiler errors, which I was able to fix by allowing HtmlTemplate to have additional properties of arbitrary names and types. Not sure if this is the correct solution since this is my first time contribution to a typescript definition file, so someone ought to check this out before merging.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/apps-script/guides/html/templates#pushing_variables_to_templates>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.