### PR TITLE
[@types/pdfmake] extended background definition for other content types

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -181,7 +181,7 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        background?: () => string | string;
+        background?: ((currentPage: number, pageSize: PageSize) => string | Content | null) | string;
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -181,7 +181,7 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentDefinitions {
-        background?: ((currentPage: number, pageSize: PageSize) => string | Content | null) | string;
+        background?: string | ((currentPage: number, pageSize: PageSize) => string | Content | null);
         compress?: boolean;
         content: string | Content;
         defaultStyle?: Style;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pdfmake.github.io/docs/document-definition-object/background-layer/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As mentioned in the linked documentation, the background prop can return any content, not just strings. Addition of null also required to allow for dynamic page backgrounds.