### PR TITLE
better-sqlite3: add transactions return type, statement bind paramater typing, backup method

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -62,9 +62,21 @@ for (col of stmt.columns()) {
     col.column;
     col.type;
 }
+type BindParameters = [string, number];
+const stmtWithBindTyped = db.prepare<BindParameters>('SELECT * FROM test WHERE name == ? and age = ?');
+stmtWithBindTyped.run('alice', 20);
+// note the following is technically legal according to the docs, but we do not have a way to express both typed args
+// and variable tuples in typescript. If you want to group tuples, you must specify it that way in the prepare function
+// https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#binding-parameters
+// $ExpectError
+stmtWithBindTyped.run(['alice', 20]);
+interface NamedBindParameters { name: string; age: number; }
+const stmtWithNamedBind = db.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age)');
+stmtWithNamedBind.run({ name: 'bob', age: 20 });
 
 const trans: Sqlite.Transaction = db.transaction((param) => stmt.all(param));
 trans('name');
+trans(1);
 trans.default('name');
 trans.deferred('name');
 trans.immediate('name');
@@ -78,3 +90,7 @@ trans.immediate(1);
 trans.exclusive(1);
 // $ExpectError
 transTyped('name');
+
+const transReturn = db.transaction(() => 1);
+// $ExpectType number
+transReturn();

--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -94,3 +94,12 @@ transTyped('name');
 const transReturn = db.transaction(() => 1);
 // $ExpectType number
 transReturn();
+
+db.backup('backup-today.db')
+    .then(({ totalPages, remainingPages }) => {});
+const paused = false;
+db.backup('backup-today.db', {
+    progress({ totalPages: t, remainingPages: r }) {
+        return paused ? 0 : 200;
+    }
+});

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -17,19 +17,19 @@ type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A)
   : never;
 
 declare namespace BetterSqlite3 {
-    interface Statement {
+    interface Statement<BindParameters extends any[]> {
         database: Database;
         source: string;
         reader: boolean;
 
-        run(...params: any[]): Database.RunResult;
-        get(...params: any[]): any;
-        all(...params: any[]): any[];
-        iterate(...params: any[]): IterableIterator<any>;
+        run(...params: BindParameters): Database.RunResult;
+        get(...params: BindParameters): any;
+        all(...params: BindParameters): any[];
+        iterate(...params: BindParameters): IterableIterator<any>;
         pluck(toggleState?: boolean): this;
         expand(toggleState?: boolean): this;
         raw(toggleState?: boolean): this;
-        bind(...params: any[]): this;
+        bind(...params: BindParameters): this;
         columns(): ColumnDefinition[];
         safeIntegers(toggleState?: boolean): this;
     }
@@ -43,11 +43,11 @@ declare namespace BetterSqlite3 {
     }
 
     interface Transaction<F extends VariableArgFunction> {
-        (...params: ArgumentTypes<F>): any;
-        default(...params: ArgumentTypes<F>): any;
-        deferred(...params: ArgumentTypes<F>): any;
-        immediate(...params: ArgumentTypes<F>): any;
-        exclusive(...params: ArgumentTypes<F>): any;
+        (...params: ArgumentTypes<F>): ReturnType<F>;
+        default(...params: ArgumentTypes<F>): ReturnType<F>;
+        deferred(...params: ArgumentTypes<F>): ReturnType<F>;
+        immediate(...params: ArgumentTypes<F>): ReturnType<F>;
+        exclusive(...params: ArgumentTypes<F>): ReturnType<F>;
     }
 
     interface Database {
@@ -57,7 +57,10 @@ declare namespace BetterSqlite3 {
         open: boolean;
         inTransaction: boolean;
 
-        prepare(source: string): Statement;
+        // tslint:disable-next-line no-unnecessary-generics
+        prepare<BindParameters extends any[] | {} = any[]>(source: string): BindParameters extends any[]
+          ? Statement<BindParameters>
+          : Statement<[BindParameters]>;
         transaction<F extends VariableArgFunction>(fn: F): Transaction<F>;
         exec(source: string): this;
         pragma(source: string, options?: Database.PragmaOptions): any;
@@ -120,7 +123,9 @@ declare namespace Database {
 
     type Integer = typeof Integer;
     type SqliteError = typeof SqliteError;
-    type Statement = BetterSqlite3.Statement;
+    type Statement<BindParameters extends any[] | {} = any[]> = BindParameters extends any[]
+      ? BetterSqlite3.Statement<BindParameters>
+      : BetterSqlite3.Statement<[BindParameters]>;
     type ColumnDefinition = BetterSqlite3.ColumnDefinition;
     type Transaction = BetterSqlite3.Transaction<VariableArgFunction>;
     type Database = BetterSqlite3.Database;

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for better-sqlite3 5.2
+// Type definitions for better-sqlite3 5.4
 // Project: http://github.com/JoshuaWise/better-sqlite3
 // Definitions by: Ben Davies <https://github.com/Morfent>
 //                 Mathew Rumsey <https://github.com/matrumz>

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -71,6 +71,7 @@ declare namespace BetterSqlite3 {
         loadExtension(path: string): this;
         close(): this;
         defaultSafeIntegers(toggleState?: boolean): this;
+        backup(destinationFile: string, options?: Database.BackupOptions): Promise<Database.BackupMetadata>;
     }
 
     interface DatabaseConstructor {
@@ -119,6 +120,14 @@ declare namespace Database {
         step: (total: any, next: any) => any;
         inverse?: (total: any, dropped: any) => any;
         result?: (total: any) => any;
+    }
+
+    interface BackupMetadata {
+        totalPages: number;
+        remainingPages: number;
+    }
+    interface BackupOptions {
+        progress: (info: BackupMetadata) => number;
     }
 
     type Integer = typeof Integer;


### PR DESCRIPTION
3 changes to better-sqlite3 in this pr:
- backup method
- transactions now have a return type instead of `any`
- prepared statements can optionally provide a bind parameter type

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [binding-parameters](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#binding-parameters)
  - [transaction return type](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#transactionfunction---function)
    - note: transaction return types are not _strictly_ documented, but they are implicitly documented by the signature `.transaction(function) -> function`
  - [backup method](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#backupdestination-options---promise)
    - note: backup's promise including the BackupMetadata is not strictly documented, but the behavior does exist in the code. I thought it was better to include the info than make it difficult to access in typescript. Lmk which is better though!
  - [v5.4 version bump](https://github.com/JoshuaWise/better-sqlite3/releases/tag/v5.4.0)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.