### PR TITLE
[@babel/core] add missing default extensions type

### DIFF
--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -26,6 +26,7 @@ export {
 export type Node = t.Node;
 export type ParseResult = t.File | t.Program;
 export const version: string;
+export const DEFAULT_EXTENSIONS: ['.js', '.jsx', '.es6', '.es', '.mjs'];
 
 export interface TransformOptions {
     /**


### PR DESCRIPTION
This PR adds type definition for `DEFAULT_EXTENSIONS` which is defined in @babel/core [here](https://github.com/babel/babel/blob/master/packages/babel-core/src/index.js#L39-L45). Is explicitly listing the string values the best way to define that type since they cant change? Or should it be `export const DEFAULT_EXTENSIONS: string[];`?

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/master/packages/babel-core/src/index.js#L39-L45
- [ ] Increase the version number in the header if appropriate: The version number in the header is old but I think bumping it might be out of scope for this PR. 
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.