### PR TITLE
Knockout.mapping jsdocs, tests and typing overhall

### DIFF
--- a/types/knockout.mapping/index.d.ts
+++ b/types/knockout.mapping/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/SteveSanderson/knockout.mapping
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, 
 //                 Mathias Lorenzen <https://github.com/ffMathy>
+//                 Leonardo Lombardi <https://github.com/ltlombardi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,11 +13,36 @@ export as namespace mapping;
 declare var self: KnockoutMapping;
 export = self;
 
+
 declare global {
-    type KnockoutObservableType<T> = {	
-        [P in keyof T]: KnockoutObservable<KnockoutObservableType<T[P]>>|T[P];	
+    // the idea behind this is good, but doesn't work as intended. This will make object properties T | Observable<T>, 
+    //and you will have to put the correct Type in each property to use them, what defeats the purpose. Besides, this gives  
+    //RangeError: Maximum call stack size exceeded in TSC when used in all the mapping signatures. Maybe this can be used with TS 2.8 and conditional typing
+    type KnockoutObservableType<T> = {
+        [P in keyof T]: KnockoutObservable<KnockoutObservableType<T[P]>> | T[P];
     };
-    
+
+    type KnockoutMappingOptions<T> = KnockoutMappingSpecificOptions<T> | KnockoutMappingStandardOptions
+
+    interface KnockoutMappingStandardOptions {
+        ignore?: string[];
+        include?: string[];
+        copy?: string[];
+        observe?: string[];
+        mappedProperties?: string[]; // Undocumented
+        deferEvaluation?: boolean; // Undocumented
+    }
+
+    type KnockoutMappingSpecificOptions<T> = {
+        [P in keyof T]?: KnockoutPropertyMappingCallBack
+    }
+
+    interface KnockoutPropertyMappingCallBack {
+        create?: (options: KnockoutMappingCreateOptions) => void;
+        update?: (options: KnockoutMappingUpdateOptions) => void;
+        key?: (data: any) => any;
+    }
+
     interface KnockoutMappingCreateOptions {
         data: any;
         parent: any;
@@ -29,35 +55,130 @@ declare global {
         observable?: KnockoutObservable<any>;
     }
 
-    interface KnockoutMappingOptions {
-        ignore?: string[];
-        include?: string[];
-        copy?: string[];
-        mappedProperties?: string[];
-        deferEvaluation?: boolean;
-        create?: (options: KnockoutMappingCreateOptions) => void;
-        update?: (options: KnockoutMappingUpdateOptions) => void;
-        key?: (data: any) => any;
-    }
-
     interface KnockoutMapping {
+        /**
+         * Checks if an object was created using KnockoutMapping
+         * @param viewModel View model object to be checked.
+         */
         isMapped(viewModel: any): boolean;
-        fromJS<T>(jsObject: T[]): KnockoutObservableArray<KnockoutObservableType<T>>;
-        fromJS<T>(jsObject: T[], targetOrOptions: any): KnockoutObservableArray<KnockoutObservableType<T>>;
-        fromJS<T>(jsObject: T[], inputOptions: any, target: any): KnockoutObservableArray<KnockoutObservableType<T>>;
-        fromJS<T>(jsObject: T): KnockoutObservableType<T>;
-        fromJS<T>(jsObject: T, targetOrOptions: any): KnockoutObservableType<T>;
-        fromJS<T>(jsObject: T, inputOptions: any, target: any): KnockoutObservableType<T>;
-        fromJSON(jsonString: string): any;
-        fromJSON(jsonString: string, targetOrOptions: any): any;
-        fromJSON(jsonString: string, inputOptions: any, target: any): any;
-        toJS<T>(viewModel: KnockoutObservableArray<T>|KnockoutObservableType<T>[]|KnockoutObservableArray<KnockoutObservableType<T>>|T[], options?: KnockoutMappingOptions): T[];
-        toJS<T>(viewModel: KnockoutObservable<T>|KnockoutObservableType<T>|KnockoutObservable<KnockoutObservableType<T>>, options?: KnockoutMappingOptions): T;
-        toJS<T>(viewModel: T, options?: KnockoutMappingOptions): T;
-        toJSON(rootObject: any, options?: KnockoutMappingOptions): string;
-        defaultOptions(): KnockoutMappingOptions;
+
+        //fromJS could be reduced the number of declarations, but KnockoutObservableType<T> would have to use Conditional Types available only on TS v2.8
+
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source Plain JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: string, options?: KnockoutMappingOptions<string>, target?: KnockoutObservable<string>): KnockoutObservable<string>;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source Plain JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: string, target: KnockoutObservable<string>): KnockoutObservable<string>;
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source Plain JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: number, options?: KnockoutMappingOptions<number>, target?: KnockoutObservable<number>): KnockoutObservable<number>;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source Plain JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: number, target: KnockoutObservable<number>): KnockoutObservable<number>;
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source Plain JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: boolean, options?: KnockoutMappingOptions<boolean>, target?: KnockoutObservable<boolean>): KnockoutObservable<boolean>;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source Plain JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS(source: boolean, target: KnockoutObservable<boolean>): KnockoutObservable<boolean>;
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source Plain JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS<T>(source: T[], options?: KnockoutMappingOptions<T[]>, target?: KnockoutObservableArray<any>): KnockoutObservableArray<any>;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source Plain JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS<T>(source: T[], target: KnockoutObservableArray<any>): KnockoutObservableArray<any>;
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source Plain JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS<T>(source: T, options?: KnockoutMappingOptions<T>, target?: any): any;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source Plain JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJS<T>(source: T, target: any): any;
+        /**
+         * Creates a view model object with observable properties for each of the properties on the source. 
+         * If 'target' is supplied, instead, target's observable properties are updated.
+         * @param source JSON of a JavaScript object to be mapped.
+         * @param options Options on mapping behavior.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJSON(source: string, options?: KnockoutMappingOptions<any>, target?: any): any;
+        /**
+         * Updates target's observable properties with those of the sources.
+         * @param source JSON of a JavaScript object to be mapped.
+         * @param target View model object previosly mapped to be updated.
+         */
+        fromJSON(source: string, target: any): any;
+        /**
+         * Creates an unmapped object containing only the properties of the mapped object that were part of your original JS object. 
+         * @param viewModel View model object previosly mapped.
+         * @param options Options on mapping behavior.
+         */
+        toJS<T>(viewModel: KnockoutObservable<T>, options?: KnockoutMappingOptions<T>): T;
+        toJS<T>(viewModel: KnockoutObservableArray<T>, options?: KnockoutMappingOptions<T>): T[];
+        toJS<T>(viewModel: KnockoutObservableType<T>, options?: KnockoutMappingOptions<T>): T;
+        toJS(viewModel: any, options?: KnockoutMappingOptions<any>): any;
+        /**
+         * Creates an unmapped object containing only the properties of the mapped object that were part of your original JS object. Stringify the result.
+         * @param viewModel Object with observables to be converted.
+         * @param options Options on mapping behavior.
+         */
+        toJSON<T>(viewModel: T, options?: KnockoutMappingOptions<T>): string;
+        /**
+         * Get the default mapping options
+         */
+        defaultOptions(): KnockoutMappingStandardOptions;
+        /**
+         * Undocumented. Reset Mapping default options.
+         */
         resetDefaultOptions(): void;
+        /**
+         * Undocumented. Custom implementation of JavaScript's typeof.
+         * @param x object to check type
+         */
         getType(x: any): any;
+        /**
+         * Undocumented.
+         */
         visitModel(rootObject: any, callback: Function, options?: { visitedObjects?: any; parentName?: string; ignore?: string[]; copy?: string[]; include?: string[]; }): any;
     }
 
@@ -75,7 +196,7 @@ declare global {
         mappedDestroyAll(): void;
     }
 
-    interface KnockoutStatic {
+    interface KnockoutStatic { // this is a declaration merging with knockout's interface
         mapping: KnockoutMapping;
     }
 }

--- a/types/knockout.mapping/knockout.mapping-tests.ts
+++ b/types/knockout.mapping/knockout.mapping-tests.ts
@@ -30,6 +30,10 @@ let userMappingOptions: KnockoutMappingOptions<User> = {
     deferEvaluation: false,
     firstName: { create: function (options: KnockoutMappingCreateOptions) { } },
 };
+let badMapping = {
+    ignof3efere: ['age'],
+    inclfefeude: ['name'],
+}
 
 // fromJS function with JS object
 
@@ -38,7 +42,6 @@ mapping.fromJS(userInputJS, {}); // $ExpectType any
 mapping.fromJS(userInputJS, {}, mappedUserViewModel); // $ExpectType any
 mapping.fromJS(userInputJS, mappedUserViewModel); // $ExpectType any
 mapping.fromJS(userInputJS, userMappingOptions, mappedUserViewModel); // $ExpectType any
-mapping.fromJS(userInputJS, userInputJS, mappedUserViewModel); // $ExpectError
 
 let untypedObject: any = { age: 22 };
 let untypedArrayObject: Array<any> = [2, 3];
@@ -90,7 +93,7 @@ mapping.toJS(ko.observableArray(untypedArrayObject)); // $ExpectType any[]
 // toJSON function
 mapping.toJSON(nameObjectInput); // $ExpectType string
 mapping.toJSON(nameObjectInput, {}); // $ExpectType string
-mapping.toJSON(mappedUserViewModel, userMappingOptions); // $ExpectType string
+mapping.toJSON<MappedUser>(mappedUserViewModel, userMappingOptions); // $ExpectType string
 
 // visitModel function
 mapping.visitModel(nameObjectInput, function (x: any) { return x; }, {});

--- a/types/knockout.mapping/knockout.mapping-tests.ts
+++ b/types/knockout.mapping/knockout.mapping-tests.ts
@@ -1,77 +1,102 @@
-var inputJSON = '{ name: "foo" }';
-var inputData = { name: 'foo' };
-var inputModel = { name: 'bar' };
-var inputParent = { name: 'parent' };
-var options = {};
+//variable tests and definitions
 
-var createOptions = {
-    data: inputData,
-    parent: parent
+let userInputJS: User = { firstName: 'foo', lastName: 'bar', age: 12 };
+interface User {
+    firstName: string;
+    lastName: string;
+    age: number;
 }
 
-var updateOptions = {
-    data: inputData,
-    parent: parent,
-    target: inputModel,
-    observable: ko.observable(7)
+interface MappedUser {
+    firstName: KnockoutObservable<string>;
+    lastName: KnockoutObservable<string>;
+    age: KnockoutObservable<number>;
 }
 
-var targetOptions = {};
-var inputOptions = {};
-
-var mappingOptions = {
+let badUserMappingOptions: KnockoutMappingOptions<User> = {
     ignore: ['age'],
     include: ['name'],
     copy: ['height'],
     mappedProperties: ['age', 'name'],
     deferEvaluation: false,
-    create: function (options: KnockoutMappingCreateOptions) { },
-    update: function (options: KnockoutMappingUpdateOptions) { },
-    key: function (data: any) { return data; }
-}
+    create: function (options: KnockoutMappingCreateOptions) { }, // $ExpectError
+};
 
+let userMappingOptions: KnockoutMappingOptions<User> = {
+    ignore: ['age'],
+    include: ['name'],
+    copy: ['height'],
+    mappedProperties: ['age', 'name'],
+    deferEvaluation: false,
+    firstName: { create: function (options: KnockoutMappingCreateOptions) { } },
+};
 
-// Utility functions
-mapping.isMapped(inputModel);
-mapping.defaultOptions();
-mapping.resetDefaultOptions();
-mapping.getType(inputModel);
+// fromJS function with JS object
 
-// fromJS function
-mapping.fromJS(inputData);
-mapping.fromJS(inputData, targetOptions);
-mapping.fromJS(inputData, inputOptions, inputModel);
+let mappedUserViewModel: MappedUser = mapping.fromJS(userInputJS); // $ExpectType any
+mapping.fromJS(userInputJS, {}); // $ExpectType any
+mapping.fromJS(userInputJS, {}, mappedUserViewModel); // $ExpectType any
+mapping.fromJS(userInputJS, mappedUserViewModel); // $ExpectType any
+mapping.fromJS(userInputJS, userMappingOptions, mappedUserViewModel); // $ExpectType any
+mapping.fromJS(userInputJS, userInputJS, mappedUserViewModel); // $ExpectError
+
+let untypedObject: any = { age: 22 };
+let untypedArrayObject: Array<any> = [2, 3];
+mapping.fromJS(untypedObject); // $ExpectType any
+mapping.fromJS(untypedArrayObject); // $ExpectType KnockoutObservableArray<any>
+
+// fromJS function with JS array and primitives
+let inputNumber = 3;
+let inputString = "foo"
+let inputBoolean = true;
+let inputNumberArray = [3, 4, 67];
+
+mapping.fromJS(inputNumber); // $ExpectType KnockoutObservable<number>
+mapping.fromJS(inputString);  // $ExpectType KnockoutObservable<string>
+mapping.fromJS(inputBoolean);  // $ExpectType KnockoutObservable<boolean>
+let numberArrayViewModel = mapping.fromJS(inputNumberArray);  // $ExpectType KnockoutObservableArray<any>
 
 // fromJSON function
-mapping.fromJSON(inputJSON);
-mapping.fromJSON(inputJSON, targetOptions);
-mapping.fromJSON(inputJSON, inputOptions, inputModel);
+interface nameObject {
+    name: string
+}
 
-mapping.fromJS(inputJSON, {
-    fieldNeedingCustomOptions: {
-        key: (data: any) => data.id,
-        create: (options: KnockoutMappingCreateOptions) => {
-            return mapping.fromJS(options.data);
-        },
-        update: (options: KnockoutMappingUpdateOptions) => {
-            return mapping.fromJS(options.data, options.target);
-        }
-    }
-});
+let nameObjectInput: nameObject = { name: 'bar' };
+let nameObjectInputJSON = '{ name: "foo" }';
+
+mapping.fromJSON(nameObjectInputJSON); // $ExpectType any
+mapping.fromJSON(nameObjectInputJSON, {}); // $ExpectType any
+mapping.fromJSON(nameObjectInputJSON, nameObjectInput); // $ExpectType any
+mapping.fromJSON(nameObjectInputJSON, {}, nameObjectInput); // $ExpectType any
+
+let userInputJSON = "{ firstName: 'foo', lastName: 'bar', age: 12 }";
+mapping.fromJSON(userInputJSON, userMappingOptions, mappedUserViewModel); // $ExpectType any
 
 // toJS function
-mapping.toJS(inputModel);
-mapping.toJS(inputModel, mappingOptions);
+let nameObject: nameObject = mapping.toJS(nameObjectInput);
+mapping.toJS(nameObjectInput, {});
+
+mapping.toJS<User>(mappedUserViewModel); // $ExpectType User
+mapping.toJS<User>(mappedUserViewModel, {}); // $ExpectType User
+
+mapping.toJS<number>(mappedUserViewModel); // $ExpectError
+mapping.toJS<User>(inputString); // $ExpectError
+mapping.toJS(ko.observable(2)); // $ExpectType number
+mapping.toJS(numberArrayViewModel); // $ExpectType any[]
+
+mapping.toJS(untypedObject); // $ExpectType any
+mapping.toJS(ko.observableArray(untypedArrayObject)); // $ExpectType any[]
 
 // toJSON function
-mapping.toJSON(inputModel);
-mapping.toJSON(inputModel, mappingOptions);
+mapping.toJSON(nameObjectInput); // $ExpectType string
+mapping.toJSON(nameObjectInput, {}); // $ExpectType string
+mapping.toJSON(mappedUserViewModel, userMappingOptions); // $ExpectType string
 
 // visitModel function
-mapping.visitModel(inputModel, function (x: any) { return x; }, {});
-mapping.visitModel(inputModel, function (x: any) { return x; }, { visitedObjects: null });
-mapping.visitModel(inputModel, function (x: any) { return x; }, { parentName: 'parent' });
-mapping.visitModel(inputModel, function (x: any) { return x; }, { ignore: ['age'] });
-mapping.visitModel(inputModel, function (x: any) { return x; }, { copy: ['height'] });
-mapping.visitModel(inputModel, function (x: any) { return x; }, { include: ['name'] });
-mapping.visitModel(inputModel, function (x: any) { return x; }, { visitedObjects: null, parentName: 'parent', ignore: ['age'], copy: ['height'], include: ['name'] });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, {});
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { visitedObjects: null });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { parentName: 'parent' });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { ignore: ['age'] });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { copy: ['height'] });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { include: ['name'] });
+mapping.visitModel(nameObjectInput, function (x: any) { return x; }, { visitedObjects: null, parentName: 'parent', ignore: ['age'], copy: ['height'], include: ['name'] });

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -13,7 +13,7 @@
 
 interface KnockoutSubscribableFunctions<T> {
     /**
-     * Notify subscribers of knockout "change" event. This doesn't acctually change the observable value.
+     * Notify subscribers of knockout "change" event. This doesn't actually change the observable value.
      * @param eventValue A value to be sent with the event.
      * @param event The knockout event.
      */
@@ -73,7 +73,7 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutReadonlyObservable
      */
     pop(): T;
     /**
-     * Adds a new item to the end of array.
+     * Adds new item or items to the end of array.
      * @param items Items  to be added.
      */
     push(...items: T[]): void;
@@ -82,7 +82,7 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutReadonlyObservable
      */
     shift(): T;
     /**
-     * Inserts a new item at the beginning of the array.
+     * Inserts new item or items at the beginning of the array.
      * @param items Items to be added.
      */
     unshift(...items: T[]): number;


### PR DESCRIPTION
This took a lot of time. Knockout Mapping has a API with too much overload. It's methods accept all kind of inputs..
Changes:
- small fixes in knockout
- fix type for the mapping options.
- reduce number of method overload, better mapping all the method calling options with optional parameters.
- complete overhaul of typings
- add JSDoc to most of the methods.
- add Undocumented when method doesn't have documentation.

Reasoning:
The idea behind `type KnockoutObservableType<T>` is good, but doesn't work as intended. This will make object properties `T | KnockoutObservable<T>`, and you will have to put the correct type in each property to use them, what defeats the purpose of this typing. 
For example: 
```
let userInputJS: User = { firstName: 'foo', lastName: 'bar', age: 12 };
interface User {
    firstName: string;
    lastName: string;
    age: number;
}
let mappedUser : KnockoutObservableType<User> = mapping.fromJS(userInputJS); 
mappedUser.age(43); // gives error, because can be Number, not just KnockoutObservable<number>
(mappedUser.age as KnockoutObservable<number>)(43); // have to do something like this...
```

Besides, this gives `RangeError: Maximum call stack size exceeded` in TSC in the examples I used in the tests file, when used in  `fromJS<T>()`. It's seems to me it's a recursive type that doesn't have a end clause... Maybe this can be used with TS 2.8 and conditional typing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://knockoutjs.com/documentation/plugins-mapping.html>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
