### PR TITLE
Add type definitions for cryptex

### DIFF
--- a/types/cryptex/cryptex-tests.ts
+++ b/types/cryptex/cryptex-tests.ts
@@ -12,3 +12,5 @@ cryptex.update({
 });
 
 const value: Promise<string> = cryptex.getSecret("foo", true);
+const decryptedValue: Promise<string> = cryptex.decrypt("foo");
+const encryptedValue: Promise<string> = cryptex.encrypt("bar");

--- a/types/cryptex/cryptex-tests.ts
+++ b/types/cryptex/cryptex-tests.ts
@@ -1,6 +1,14 @@
 import * as cryptex from "cryptex";
 
-cryptex.decrypt("") // $ExpectType Promise<string>
-cryptex.encrypt("") // $ExpectType Promise<string>
-cryptex.getSecret("") // $ExpectType Promise<string>
-cryptex.getSecrets([""]) // $ExpectType Promise<Array<string>>
+cryptex.update({
+    config: {
+        keySource: "none",
+        algorithm: "plaintext",
+        secretEncoding: "binary",
+        secrets: {
+            "foo": "bar"
+        }
+    }
+});
+
+const value: Promise<string> = cryptex.getSecret("foo");

--- a/types/cryptex/cryptex-tests.ts
+++ b/types/cryptex/cryptex-tests.ts
@@ -6,9 +6,9 @@ cryptex.update({
         algorithm: "plaintext",
         secretEncoding: "binary",
         secrets: {
-            "foo": "bar"
+            foo: "bar"
         }
     }
 });
 
-const value: Promise<string> = cryptex.getSecret("foo");
+const value: Promise<string> = cryptex.getSecret("foo", true);

--- a/types/cryptex/cryptex-tests.ts
+++ b/types/cryptex/cryptex-tests.ts
@@ -1,0 +1,6 @@
+import * as cryptex from "cryptex";
+
+cryptex.decrypt("") // $ExpectType Promise<string>
+cryptex.encrypt("") // $ExpectType Promise<string>
+cryptex.getSecret("") // $ExpectType Promise<string>
+cryptex.getSecrets([""]) // $ExpectType Promise<Array<string>>

--- a/types/cryptex/index.d.ts
+++ b/types/cryptex/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for cryptex 1.0
+// Project: https://github.com/technologyadvice/cryptex
+// Definitions by: Robert Brownstein <https://github.com/brownstein>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+// this is the config structure for a given env
+// typically, you find these in cryptex.json
+export interface CryptexConfig {
+    keySource: string;
+    keySourceOpts: {
+        dataKey?: string;
+        region?: string;
+    };
+    secrets: object;
+}
+// constructor and update params
+export interface CryptexOpts {
+    file?: string;
+    env?: string;
+    cacheKey?: boolean;
+    cacheKeyTimeout?: number;
+    config?: CryptexConfig;
+}
+// cryptex exports a module-level instance by default
+export function decrypt(data: string, encoding?: string): Promise<string>;
+export function encrypt(data: string, encoding?: string): Promise<string>;
+export function getSecret(secret: string, optional?: boolean): Promise<string>;
+export function getSecrets(secrets: string[], optional?: boolean): Promise<string[]>;
+export function update(opts: CryptexOpts): void;
+
+// but you can still create individual instances
+export class Cryptex {
+    constructor(opts: CryptexOpts)
+    decrypt(data: string, encoding?: string): string;
+    encrypt(data: string, encoding?: string): string;
+    getSecret(secret: string, optional?: boolean): Promise<string>;
+    getSecrets(secrets: string[], optional?: boolean): Promise<string[]>;
+    update(opts: CryptexOpts): void;
+}

--- a/types/cryptex/index.d.ts
+++ b/types/cryptex/index.d.ts
@@ -8,10 +8,12 @@
 // typically, you find these in cryptex.json
 export interface CryptexConfig {
     keySource: string;
-    keySourceOpts: {
+    keySourceOpts?: {
         dataKey?: string;
         region?: string;
     };
+    algorithm?: string;
+    secretEncoding?: string;
     secrets: object;
 }
 // constructor and update params

--- a/types/cryptex/tsconfig.json
+++ b/types/cryptex/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/cryptex/tsconfig.json
+++ b/types/cryptex/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "cryptex-tests.ts"
     ]
 }

--- a/types/cryptex/tslint.json
+++ b/types/cryptex/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds type definitions for `cryptex`, a secret storage module that leverages KMS.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

