### PR TITLE
fix lodash's Collection.groupBy return type

### DIFF
--- a/types/lodash/ts3.1/common/collection.d.ts
+++ b/types/lodash/ts3.1/common/collection.d.ts
@@ -956,7 +956,7 @@ declare module "../index" {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): Object<Dictionary<string>>;
+        groupBy(iteratee?: ValueIteratee<string>): Object<Dictionary<string[]>>;
     }
     interface Collection<T> {
         /**
@@ -974,7 +974,7 @@ declare module "../index" {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string>>;
+        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string[]>>;
     }
     interface StringNullableChain {
         /**

--- a/types/lodash/ts3.1/common/collection.d.ts
+++ b/types/lodash/ts3.1/common/collection.d.ts
@@ -962,7 +962,7 @@ declare module "../index" {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T>): Object<Dictionary<T>>;
+        groupBy(iteratee?: ValueIteratee<T>): Object<Dictionary<T[]>>;
     }
     interface Object<T> {
         /**
@@ -986,7 +986,7 @@ declare module "../index" {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T>): ObjectChain<Dictionary<T>>;
+        groupBy(iteratee?: ValueIteratee<T>): ObjectChain<Dictionary<T[]>>;
     }
     interface ObjectChain<T> {
         /**

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -2480,23 +2480,23 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.groupBy(dictionary, ""); // $ExpectType Dictionary<AbcObject[]>
     _.groupBy(dictionary, { a: 42 }); // $ExpectType Dictionary<AbcObject[]>
 
-    _("").groupBy(); // $ExpectType Object<Dictionary<string>>
-    _("").groupBy(stringIterator); // $ExpectType Object<Dictionary<string>>
-    _(list).groupBy(); // $ExpectType Object<Dictionary<AbcObject>>
-    _(list).groupBy(valueIterator); // $ExpectType Object<Dictionary<AbcObject>>
-    _(list).groupBy(""); // $ExpectType Object<Dictionary<AbcObject>>
-    _(list).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<AbcObject>>
+    _("").groupBy(); // $ExpectType Object<Dictionary<string[]>>
+    _("").groupBy(stringIterator); // $ExpectType Object<Dictionary<string[]>>
+    _(list).groupBy(); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy(valueIterator); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy(""); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<AbcObject[]>>
     _(dictionary).groupBy(); // $ExpectType Object<Dictionary<AbcObject[]>>
     _(dictionary).groupBy(valueIterator); // $ExpectType Object<Dictionary<AbcObject[]>>
     _(dictionary).groupBy(""); // $ExpectType Object<Dictionary<AbcObject[]>>
     _(dictionary).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<AbcObject[]>>
 
-    _.chain("").groupBy(); // $ExpectType ObjectChain<Dictionary<string>>
-    _.chain("").groupBy(stringIterator); // $ExpectType ObjectChain<Dictionary<string>>
-    _.chain(list).groupBy(); // $ExpectType ObjectChain<Dictionary<AbcObject>>
-    _.chain(list).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject>>
-    _.chain(list).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject>>
-    _.chain(list).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<AbcObject>>
+    _.chain("").groupBy(); // $ExpectType ObjectChain<Dictionary<string[]>>
+    _.chain("").groupBy(stringIterator); // $ExpectType ObjectChain<Dictionary<string[]>>
+    _.chain(list).groupBy(); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
     _.chain(dictionary).groupBy(); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
     _.chain(dictionary).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
     _.chain(dictionary).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>


### PR DESCRIPTION
should be

```ts
Object<Dictionary<T[]>>
// not
Object<Dictionary<T>>
```

Edit: Looks like String should also return `Object<Dictionary<string[]>>`, even though each string is guaranteed to be 1 character long.

Fixes #35337