### PR TITLE
[qunit] Add ES6 import support

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -4,442 +4,455 @@
 //                 Mike North <https://github.com/mike-north>
 //                 Stefan Sechelmann <https://github.com/sechel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
 
-interface Assert {
-    /**
-     * Instruct QUnit to wait for an asynchronous operation.
-     *
-     * The callback returned from `assert.async()` will throw an Error if it is
-     * invoked more than once (or more often than the accepted call count, if
-     * provided).
-     *
-     * This replaces functionality previously provided by `QUnit.stop()` and
-     * `QUnit.start()`.
-     *
-     * @param {number} [acceptCallCount=1] Number of expected callbacks before the test is done.
-     */
-    async(acceptCallCount?: number): () => void;
-
-    /**
-     * A deep recursive comparison, working on primitive types, arrays, objects,
-     * regular expressions, dates and functions.
-     *
-     * The `deepEqual()` assertion can be used just like `equal()` when comparing
-     * the value of objects, such that `{ key: value }` is equal to
-     * `{ key: value }`. For non-scalar values, identity will be disregarded by
-     * deepEqual.
-     *
-     * `notDeepEqual()` can be used to explicitly test deep, strict inequality.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparision value
-     * @param {string} [message] A short description of the assertion
-     */
-    deepEqual<T>(actual: T, expected: T, message?: string): void;
-
-    /**
-     * A non-strict comparison, roughly equivalent to JUnit's assertEquals.
-     *
-     * The `equal` assertion uses the simple comparison operator (`==`) to
-     * compare the actual and expected arguments. When they are equal, the
-     * assertion passes; otherwise, it fails. When it fails, both actual and
-     * expected values are displayed in the test result, in addition to a given
-     * message.
-     *
-     *  `notEqual()` can be used to explicitly test inequality.
-     *
-     * `strictEqual()` can be used to test strict equality.
-     *
-     * @param actual Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    equal(actual: any, expected: any, message?: string): void;
-
-    /**
-     * Specify how many assertions are expected to run within a test.
-     *
-     * To ensure that an explicit number of assertions are run within any test,
-     * use `assert.expect( number )` to register an expected count. If the
-     * number of assertions run does not match the expected count, the test will
-     * fail.
-     *
-     * @param {number} amount Number of assertions in this test.
-     */
-    expect(amount: number): void;
-
-    /**
-     * An inverted deep recursive comparison, working on primitive types,
-     * arrays, objects, regular expressions, dates and functions.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    notDeepEqual(actual: any, expected: any, message?: string): void;
-
-    /**
-     * A non-strict comparison, checking for inequality.
-     *
-     * The `notEqual` assertion uses the simple inverted comparison operator
-     * (`!=`) to compare the actual and expected arguments. When they aren't
-     * equal, the assertion passes; otherwise, it fails. When it fails, both
-     * actual and expected values are displayed in the test result, in addition
-     * to a given message.
-     *
-     * `equal()` can be used to test equality.
-     *
-     * `notStrictEqual()` can be used to test strict inequality.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    notEqual(actual: any, expected: any, message?: string): void;
-
-    /**
-     * A boolean check, inverse of `ok()` and CommonJS's `assert.ok()`, and
-     * equivalent to JUnit's `assertFalse()`. Passes if the first argument is
-     * falsy.
-     *
-     * `notOk()` requires just one argument. If the argument evaluates to false,
-     * the assertion passes; otherwise, it fails. If a second message argument
-     * is provided, it will be displayed in place of the result.
-     *
-     * @param state Expression being tested
-     * @param {string} [message] A short description of the assertion
-     */
-    notOk(state: any, message?: string): void;
-
-    /**
-     * A strict comparison of an object's own properties, checking for inequality.
-     *
-     * The `notPropEqual` assertion uses the strict inverted comparison operator
-     * (`!==`) to compare the actual and expected arguments as Objects regarding
-     * only their properties but not their constructors.
-     *
-     * When they aren't equal, the assertion passes; otherwise, it fails. When
-     * it fails, both actual and expected values are displayed in the test
-     * result, in addition to a given message.
-     *
-     * `equal()` can be used to test equality.
-     *
-     * `propEqual()` can be used to test strict equality of an Object properties.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    notPropEqual(actual: any, expected: any, message?: string): void;
-
-    /**
-     * A strict comparison, checking for inequality.
-     *
-     * The `notStrictEqual` assertion uses the strict inverted comparison
-     * operator (`!==`) to compare the actual and expected arguments. When they
-     * aren't equal, the assertion passes; otherwise, it fails. When it fails,
-     * both actual and expected values are displayed in the test result, in
-     * addition to a given message.
-     *
-     * `equal()` can be used to test equality.
-     *
-     * `strictEqual()` can be used to test strict equality.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    notStrictEqual(actual: any, expected: any, message?: string): void;
-
-    /**
-     * A boolean check, equivalent to CommonJS's assert.ok() and JUnit's
-     * assertTrue(). Passes if the first argument is truthy.
-     *
-     * The most basic assertion in QUnit, ok() requires just one argument. If
-     * the argument evaluates to true, the assertion passes; otherwise, it
-     * fails. If a second message argument is provided, it will be displayed in
-     * place of the result.
-     *
-     * @param state Expression being tested
-     * @param {string} message A short description of the assertion
-     */
-    ok(state: any, message?: string): void;
-
-    /**
-     * A strict type and value comparison of an object's own properties.
-     *
-     * The `propEqual()` assertion provides strictly (`===`) comparison of
-     * Object properties. Unlike `deepEqual()`, this assertion can be used to
-     * compare two objects made with different constructors and prototype.
-     *
-     * `strictEqual()` can be used to test strict equality.
-     *
-     * `notPropEqual()` can be used to explicitly test strict inequality of
-     * Object properties.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    propEqual(actual: any, expected: any, message?: string): void;
-
-    /**
-     * Report the result of a custom assertion
-     *
-     * Some test suites may need to express an expectation that is not defined
-     * by any of QUnit's built-in assertions. This need may be met by
-     * encapsulating the expectation in a JavaScript function which returns a
-     * `Boolean` value representing the result; this value can then be passed
-     * into QUnit's `ok` assertion.
-     *
-     * A more readable solution would involve defining a custom assertion. If
-     * the expectation function invokes `pushResult`, QUnit will be notified of
-     * the result and report it accordingly.
-     *
-     * @param assertionResult The assertion result
-     */
-    pushResult(assertResult: {
-        result: boolean;
-        actual: any;
-        expected: any;
-        message: string;
-    }): void;
-
-    /**
-     * A strict type and value comparison.
-     *
-     * The `strictEqual()` assertion provides the most rigid comparison of type
-     * and value with the strict equality operator (`===`).
-     *
-     * `equal()` can be used to test non-strict equality.
-     *
-     * `notStrictEqual()` can be used to explicitly test strict inequality.
-     *
-     * @param actual Object or Expression being tested
-     * @param expected Known comparison value
-     * @param {string} [message] A short description of the assertion
-     */
-    strictEqual<T>(actual: T, expected: T, message?: string): void;
-
-    /**
-     * Test if a callback throws an exception, and optionally compare the thrown
-     * error.
-     *
-     * When testing code that is expected to throw an exception based on a
-     * specific set of circumstances, use assert.throws() to catch the error
-     * object for testing and comparison.
-     *
-     * In very few environments, like Closure Compiler, throws is considered a
-     * reserved word and will cause an error. For that case, an alias is bundled
-     * called `raises`. It has the same signature and behaviour, just a
-     * different name.
-     */
-    throws(block: () => void, expected?: any, message?: any): void;
-    raises(block: () => void, expected?: any, message?: any): void;
-
-    /**
-     * Test if the provided promise rejects, and optionally compare the
-     * rejection value.
-     *
-     * When testing code that is expected to return a rejected promise based on
-     * a specific set of circumstances, use assert.rejects() for testing and
-     * comparison.
-     *
-     * The expectedMatcher argument can be:
-     *      A function that returns true when the assertion should be considered passing.
-     *      An Error object
-     *      A base constructor to use ala rejectionValue instanceof expectedMatcher
-     *      A RegExp that matches (or partially matches) rejectionValue.toString()
-     *
-     * Note: in order to avoid confusion between the message and the expectedMatcher,
-     * the expectedMatcher can not be a string.
-     *
-     * @param promise promise to test for rejection
-     * @param expectedMatcher Rejection value matcher
-     * @param message A short description of the assertion
-     */
-    rejects(promise: Promise<any>, message?: string): void;
-    rejects(
-        promise: Promise<any>,
-        expectedMatcher?: any,
-        message?: string,
-    ): void;
-
-    /**
-     * A marker for progress in a given test.
-     *
-     * The `step()` assertion registers a passing assertion with a provided message. This makes
-     * it easy to check that specific portions of code are being executed, especially in
-     * asynchronous test cases and when used with `verifySteps()`.
-     *
-     * Together with the `verifySteps()` method, `step()` assertions give you an easy way
-     * to verify both the count and order of code execution.
-     *
-     * @param message Message to display for the step
-     */
-    step(message: string): void;
-
-    /**
-     * A helper assertion to verify the order and number of steps in a test.
-     *
-     * The assert.verifySteps() assertion compares a given array of string values (representing steps)
-     * with the order and values of previous step() calls. This assertion is helpful for verifying
-     * the order and count of portions of code paths, especially asynchronous ones.
-     *
-     * @param steps Array of strings representing steps to verify
-     * @param message A short description of the assertion
-     */
-    verifySteps(steps: string[], message?: string): void;
-
+interface BeginDetails {
+    totalTests: number;
 }
-
-interface Config {
-    altertitle: boolean;
-    autostart: boolean;
-    collapse: boolean;
-    current: any;
-    filter: string | RegExp
-    fixture: string;
-    hidepassed: boolean;
-    maxDepth: number;
+interface DoneDetails {
+    failed: number;
+    passed: number;
+    total: number;
+    runtime: number;
+}
+interface LogDetails {
+    result: boolean;
+    actual: any;
+    expected: any;
+    message: string;
+    source: string;
     module: string;
-    moduleId: string[];
-    notrycatch: boolean;
-    noglobals: boolean;
-    seed: string;
-    reorder: boolean;
-    requireExpects: boolean;
-    testId: string[];
-    testTimeout: number;
-    scrolltop: boolean;
-    urlConfig: {
-        id?: string;
-        label?: string;
-        tooltip?: string;
-        value?: string | string[] | { [key: string]: string }
-    }[];
+    name: string;
+    runtime: number;
+}
+interface ModuleDoneDetails {
+    name: string;
+    failed: number;
+    passed: number;
+    total: number;
+    runtime: number;
+}
+interface ModuleStartDetails {
+    name: string;
+}
+interface TestDoneDetails {
+    name: string;
+    module: string;
+    failed: number;
+    passed: number;
+    total: number;
+    runtime: number;
+}
+interface TestStartDetails {
+    name: string;
+    module: string;
 }
 
-/**
- * An object, ultimately passed to module(),
- * that may have one or more QUnit module hooks
- * 
- * @example
- * 
- * // Passing the hooks to `module()`
- * module('my module', {
- *   beforeEach() {
- *     console.log('test begin ', performance.now())
- *   },
- *   afterEach() {
- *     console.log('test end ', performance.now())
- *   }
- * }, function() {
- *    // tests
- * })
- */
-interface Hooks {
+declare namespace QUnitNS {
+    interface Assert {
+        /**
+         * Instruct QUnit to wait for an asynchronous operation.
+         *
+         * The callback returned from `assert.async()` will throw an Error if it is
+         * invoked more than once (or more often than the accepted call count, if
+         * provided).
+         *
+         * This replaces functionality previously provided by `QUnit.stop()` and
+         * `QUnit.start()`.
+         *
+         * @param {number} [acceptCallCount=1] Number of expected callbacks before the test is done.
+         */
+        async(acceptCallCount?: number): () => void;
 
-    /**
-     * Runs after the last test. If additional tests are defined after the
-     * module's queue has emptied, it will not run this hook again.
-     */
-    after?: (assert: Assert) => void;
+        /**
+         * A deep recursive comparison, working on primitive types, arrays, objects,
+         * regular expressions, dates and functions.
+         *
+         * The `deepEqual()` assertion can be used just like `equal()` when comparing
+         * the value of objects, such that `{ key: value }` is equal to
+         * `{ key: value }`. For non-scalar values, identity will be disregarded by
+         * deepEqual.
+         *
+         * `notDeepEqual()` can be used to explicitly test deep, strict inequality.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparision value
+         * @param {string} [message] A short description of the assertion
+         */
+        deepEqual<T>(actual: T, expected: T, message?: string): void;
 
-    /**
-     * Runs after each test.
-     */
-    afterEach?: (assert: Assert) => void;
+        /**
+         * A non-strict comparison, roughly equivalent to JUnit's assertEquals.
+         *
+         * The `equal` assertion uses the simple comparison operator (`==`) to
+         * compare the actual and expected arguments. When they are equal, the
+         * assertion passes; otherwise, it fails. When it fails, both actual and
+         * expected values are displayed in the test result, in addition to a given
+         * message.
+         *
+         *  `notEqual()` can be used to explicitly test inequality.
+         *
+         * `strictEqual()` can be used to test strict equality.
+         *
+         * @param actual Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        equal(actual: any, expected: any, message?: string): void;
 
-    /**
-     * Runs before the first test.
-     */
-    before?: (assert: Assert) => void;
+        /**
+         * Specify how many assertions are expected to run within a test.
+         *
+         * To ensure that an explicit number of assertions are run within any test,
+         * use `assert.expect( number )` to register an expected count. If the
+         * number of assertions run does not match the expected count, the test will
+         * fail.
+         *
+         * @param {number} amount Number of assertions in this test.
+         */
+        expect(amount: number): void;
 
-    /**
-     * Runs before each test.
-     */
-    beforeEach?: (assert: Assert) => void;
+        /**
+         * An inverted deep recursive comparison, working on primitive types,
+         * arrays, objects, regular expressions, dates and functions.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        notDeepEqual(actual: any, expected: any, message?: string): void;
 
-}
+        /**
+         * A non-strict comparison, checking for inequality.
+         *
+         * The `notEqual` assertion uses the simple inverted comparison operator
+         * (`!=`) to compare the actual and expected arguments. When they aren't
+         * equal, the assertion passes; otherwise, it fails. When it fails, both
+         * actual and expected values are displayed in the test result, in addition
+         * to a given message.
+         *
+         * `equal()` can be used to test equality.
+         *
+         * `notStrictEqual()` can be used to test strict inequality.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        notEqual(actual: any, expected: any, message?: string): void;
 
-/**
- * An object passed to the QUnit "nested" callback,
- * allowing setup of lifecycle hooks
- * 
- * @example
- * 
- * module('my module', function(hooks) {
- *   hooks.beforeEach(function () {
- *     console.log('test begin ', performance.now())
- *   });
- *   hooks.afterEach(function () {
- *     console.log('test end ', performance.now())
- *   });
- * });
- * 
- */
-interface NestedHooks {
-    /**
-     * Runs after the last test. If additional tests are defined after the
-     * module's queue has emptied, it will not run this hook again.
-     */
-    after: (fn: (assert: Assert) => void) => void;
+        /**
+         * A boolean check, inverse of `ok()` and CommonJS's `assert.ok()`, and
+         * equivalent to JUnit's `assertFalse()`. Passes if the first argument is
+         * falsy.
+         *
+         * `notOk()` requires just one argument. If the argument evaluates to false,
+         * the assertion passes; otherwise, it fails. If a second message argument
+         * is provided, it will be displayed in place of the result.
+         *
+         * @param state Expression being tested
+         * @param {string} [message] A short description of the assertion
+         */
+        notOk(state: any, message?: string): void;
 
-    /**
-     * Runs after each test.
-     */
-    afterEach: (fn: (assert: Assert) => void) => void;
+        /**
+         * A strict comparison of an object's own properties, checking for inequality.
+         *
+         * The `notPropEqual` assertion uses the strict inverted comparison operator
+         * (`!==`) to compare the actual and expected arguments as Objects regarding
+         * only their properties but not their constructors.
+         *
+         * When they aren't equal, the assertion passes; otherwise, it fails. When
+         * it fails, both actual and expected values are displayed in the test
+         * result, in addition to a given message.
+         *
+         * `equal()` can be used to test equality.
+         *
+         * `propEqual()` can be used to test strict equality of an Object properties.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        notPropEqual(actual: any, expected: any, message?: string): void;
 
-    /**
-     * Runs before the first test.
-     */
-    before: (fn: (assert: Assert) => void) => void;
+        /**
+         * A strict comparison, checking for inequality.
+         *
+         * The `notStrictEqual` assertion uses the strict inverted comparison
+         * operator (`!==`) to compare the actual and expected arguments. When they
+         * aren't equal, the assertion passes; otherwise, it fails. When it fails,
+         * both actual and expected values are displayed in the test result, in
+         * addition to a given message.
+         *
+         * `equal()` can be used to test equality.
+         *
+         * `strictEqual()` can be used to test strict equality.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        notStrictEqual(actual: any, expected: any, message?: string): void;
 
-    /**
-     * Runs before each test.
-     */
-    beforeEach: (fn: (assert: Assert) => void) => void;
+        /**
+         * A boolean check, equivalent to CommonJS's assert.ok() and JUnit's
+         * assertTrue(). Passes if the first argument is truthy.
+         *
+         * The most basic assertion in QUnit, ok() requires just one argument. If
+         * the argument evaluates to true, the assertion passes; otherwise, it
+         * fails. If a second message argument is provided, it will be displayed in
+         * place of the result.
+         *
+         * @param state Expression being tested
+         * @param {string} message A short description of the assertion
+         */
+        ok(state: any, message?: string): void;
 
-}
+        /**
+         * A strict type and value comparison of an object's own properties.
+         *
+         * The `propEqual()` assertion provides strictly (`===`) comparison of
+         * Object properties. Unlike `deepEqual()`, this assertion can be used to
+         * compare two objects made with different constructors and prototype.
+         *
+         * `strictEqual()` can be used to test strict equality.
+         *
+         * `notPropEqual()` can be used to explicitly test strict inequality of
+         * Object properties.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        propEqual(actual: any, expected: any, message?: string): void;
 
-type moduleFunc1 = (name: string, hooks?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
-type moduleFunc2 = (name: string, nested?: (hooks: NestedHooks) => void) => void;
-type ModuleOnly = { only: moduleFunc1 & moduleFunc2 }
+        /**
+         * Report the result of a custom assertion
+         *
+         * Some test suites may need to express an expectation that is not defined
+         * by any of QUnit's built-in assertions. This need may be met by
+         * encapsulating the expectation in a JavaScript function which returns a
+         * `Boolean` value representing the result; this value can then be passed
+         * into QUnit's `ok` assertion.
+         *
+         * A more readable solution would involve defining a custom assertion. If
+         * the expectation function invokes `pushResult`, QUnit will be notified of
+         * the result and report it accordingly.
+         *
+         * @param assertionResult The assertion result
+         */
+        pushResult(assertResult: {
+            result: boolean;
+            actual: any;
+            expected: any;
+            message: string;
+        }): void;
 
-declare namespace QUnit {
-    interface BeginDetails { totalTests: number }
-    interface DoneDetails { failed: number, passed: number, total: number, runtime: number }
-    interface LogDetails {
-        result: boolean,
-        actual: any;
-        expected: any;
-        message: string;
-        source: string;
+        /**
+         * A strict type and value comparison.
+         *
+         * The `strictEqual()` assertion provides the most rigid comparison of type
+         * and value with the strict equality operator (`===`).
+         *
+         * `equal()` can be used to test non-strict equality.
+         *
+         * `notStrictEqual()` can be used to explicitly test strict inequality.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        strictEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Test if a callback throws an exception, and optionally compare the thrown
+         * error.
+         *
+         * When testing code that is expected to throw an exception based on a
+         * specific set of circumstances, use assert.throws() to catch the error
+         * object for testing and comparison.
+         *
+         * In very few environments, like Closure Compiler, throws is considered a
+         * reserved word and will cause an error. For that case, an alias is bundled
+         * called `raises`. It has the same signature and behaviour, just a
+         * different name.
+         */
+        throws(block: () => void, expected?: any, message?: any): void;
+        raises(block: () => void, expected?: any, message?: any): void;
+
+        /**
+         * Test if the provided promise rejects, and optionally compare the
+         * rejection value.
+         *
+         * When testing code that is expected to return a rejected promise based on
+         * a specific set of circumstances, use assert.rejects() for testing and
+         * comparison.
+         *
+         * The expectedMatcher argument can be:
+         *      A function that returns true when the assertion should be considered passing.
+         *      An Error object
+         *      A base constructor to use ala rejectionValue instanceof expectedMatcher
+         *      A RegExp that matches (or partially matches) rejectionValue.toString()
+         *
+         * Note: in order to avoid confusion between the message and the expectedMatcher,
+         * the expectedMatcher can not be a string.
+         *
+         * @param promise promise to test for rejection
+         * @param expectedMatcher Rejection value matcher
+         * @param message A short description of the assertion
+         */
+        rejects(promise: Promise<any>, message?: string): void;
+        rejects(
+            promise: Promise<any>,
+            expectedMatcher?: any,
+            message?: string
+        ): void;
+
+        /**
+         * A marker for progress in a given test.
+         *
+         * The `step()` assertion registers a passing assertion with a provided message. This makes
+         * it easy to check that specific portions of code are being executed, especially in
+         * asynchronous test cases and when used with `verifySteps()`.
+         *
+         * Together with the `verifySteps()` method, `step()` assertions give you an easy way
+         * to verify both the count and order of code execution.
+         *
+         * @param message Message to display for the step
+         */
+        step(message: string): void;
+
+        /**
+         * A helper assertion to verify the order and number of steps in a test.
+         *
+         * The assert.verifySteps() assertion compares a given array of string values (representing steps)
+         * with the order and values of previous step() calls. This assertion is helpful for verifying
+         * the order and count of portions of code paths, especially asynchronous ones.
+         *
+         * @param steps Array of strings representing steps to verify
+         * @param message A short description of the assertion
+         */
+        verifySteps(steps: string[], message?: string): void;
+    }
+
+    interface Config {
+        altertitle: boolean;
+        autostart: boolean;
+        collapse: boolean;
+        current: any;
+        filter: string | RegExp;
+        fixture: string;
+        hidepassed: boolean;
+        maxDepth: number;
         module: string;
-        name: string;
-        runtime: number;
+        moduleId: string[];
+        notrycatch: boolean;
+        noglobals: boolean;
+        seed: string;
+        reorder: boolean;
+        requireExpects: boolean;
+        testId: string[];
+        testTimeout: number;
+        scrolltop: boolean;
+        urlConfig: {
+            id?: string;
+            label?: string;
+            tooltip?: string;
+            value?: string | string[] | { [key: string]: string };
+        }[];
     }
-    interface ModuleDoneDetails {
-        name: string;
-        failed: number;
-        passed: number;
-        total: number;
-        runtime: number;
-    }
-    interface ModuleStartDetails { name: string }
-    interface TestDoneDetails {
-        name: string;
-        module: string;
-        failed: number;
-        passed: number;
-        total: number;
-        runtime: number;
-    }
-    interface TestStartDetails { name: string; module: string; }
-}
 
-interface QUnit {
+    /**
+     * An object, ultimately passed to module(),
+     * that may have one or more QUnit module hooks
+     *
+     * @example
+     *
+     * // Passing the hooks to `module()`
+     * module('my module', {
+     *   beforeEach() {
+     *     console.log('test begin ', performance.now())
+     *   },
+     *   afterEach() {
+     *     console.log('test end ', performance.now())
+     *   }
+     * }, function() {
+     *    // tests
+     * })
+     */
+    interface Hooks {
+        /**
+         * Runs after the last test. If additional tests are defined after the
+         * module's queue has emptied, it will not run this hook again.
+         */
+        after?: (assert: Assert) => void;
+
+        /**
+         * Runs after each test.
+         */
+        afterEach?: (assert: Assert) => void;
+
+        /**
+         * Runs before the first test.
+         */
+        before?: (assert: Assert) => void;
+
+        /**
+         * Runs before each test.
+         */
+        beforeEach?: (assert: Assert) => void;
+    }
+
+    /**
+     * An object passed to the QUnit "nested" callback,
+     * allowing setup of lifecycle hooks
+     *
+     * @example
+     *
+     * module('my module', function(hooks) {
+     *   hooks.beforeEach(function () {
+     *     console.log('test begin ', performance.now())
+     *   });
+     *   hooks.afterEach(function () {
+     *     console.log('test end ', performance.now())
+     *   });
+     * });
+     *
+     */
+    interface NestedHooks {
+        /**
+         * Runs after the last test. If additional tests are defined after the
+         * module's queue has emptied, it will not run this hook again.
+         */
+        after: (fn: (assert: Assert) => void) => void;
+
+        /**
+         * Runs after each test.
+         */
+        afterEach: (fn: (assert: Assert) => void) => void;
+
+        /**
+         * Runs before the first test.
+         */
+        before: (fn: (assert: Assert) => void) => void;
+
+        /**
+         * Runs before each test.
+         */
+        beforeEach: (fn: (assert: Assert) => void) => void;
+    }
+
+    type moduleFunc1 = (
+        name: string,
+        hooks?: Hooks,
+        nested?: (hooks: NestedHooks) => void
+    ) => void;
+    type moduleFunc2 = (
+        name: string,
+        nested?: (hooks: NestedHooks) => void
+    ) => void;
+    type ModuleOnly = { only: moduleFunc1 & moduleFunc2 };
 
     /**
      * Namespace for QUnit assertions
@@ -450,7 +463,7 @@ interface QUnit {
      *
      * This object has properties for each of QUnit's built-in assertion methods.
      */
-    assert: Assert;
+    const assert: Assert;
 
     /**
      * Register a callback to fire whenever the test suite begins.
@@ -459,7 +472,7 @@ interface QUnit {
      *
      * @callback callback Callback to execute.
      */
-    begin(callback: (details: QUnit.BeginDetails) => void): void;
+    const begin: (callback: (details: BeginDetails) => void) => void;
 
     /**
      * Configuration for QUnit
@@ -467,14 +480,14 @@ interface QUnit {
      * QUnit has a bunch of internal configuration defaults, some of which are
      * useful to override. Check the description for each option for details.
      */
-    config: Config
+    const config: Config;
 
     /**
      * Register a callback to fire whenever the test suite ends.
      *
      * @param callback Callback to execute
      */
-    done(callback: (details: QUnit.DoneDetails) => void): void;
+    const done: (callback: (details: DoneDetails) => void) => void;
 
     /**
      * Advanced and extensible data dumping for JavaScript.
@@ -491,9 +504,9 @@ interface QUnit {
      * Note: This method used to be in QUnit.jsDump, which was changed to
      * QUnit.dump. The old property will be removed in QUnit 3.0.
      */
-    dump: {
+    const dump: {
         maxDepth: number;
-        parse(data: any): string
+        parse(data: any): string;
     };
 
     /**
@@ -507,7 +520,7 @@ interface QUnit {
      * @param target An object whose properties are to be modified
      * @param mixin An object describing which properties should be modified
      */
-    extend(target: any, mixin: any): void;
+    const extend: (target: any, mixin: any) => void;
 
     /**
      * Register a callback to fire whenever an assertion completes.
@@ -518,7 +531,7 @@ interface QUnit {
      *
      * @param callback Callback to execute
      */
-    log(callback: (details: QUnit.LogDetails) => void): void;
+    const log: (callback: (details: LogDetails) => void) => void;
 
     /**
      * Group related tests under a single label.
@@ -558,21 +571,23 @@ interface QUnit {
      * @param hookds Callbacks to run during test execution
      * @param nested A callback with grouped tests and nested modules to run under the current module label
      */
-    module: moduleFunc1 & moduleFunc2 & ModuleOnly;
+    const module: moduleFunc1 & moduleFunc2 & ModuleOnly;
 
     /**
      * Register a callback to fire whenever a module ends.
      *
      * @param callback Callback to execute
      */
-    moduleDone(callback: (details: QUnit.ModuleDoneDetails) => void): void;
+    const moduleDone: (callback: (details: ModuleDoneDetails) => void) => void;
 
     /**
      * Register a callback to fire whenever a module begins.
      *
      * @param callback Callback to execute
      */
-    moduleStart(callback: (details: QUnit.ModuleStartDetails) => void): void;
+    const moduleStart: (
+        callback: (details: ModuleStartDetails) => void
+    ) => void;
 
     /**
      * Adds a test to exclusively run, preventing all other tests from running.
@@ -590,7 +605,7 @@ interface QUnit {
      * @param {string} name Title of unit being tested
      * @param callback Function to close over assertions
      */
-    only(name: string, callback: (assert: Assert) => void): void;
+    const only: (name: string, callback: (assert: Assert) => void) => void;
 
     /**
      * DEPRECATED: Report the result of a custom assertion.
@@ -607,7 +622,12 @@ interface QUnit {
      *
      * @deprecated
      */
-    push(result: boolean, actual: any, expected: any, message: string): void;
+    const push: (
+        result: boolean,
+        actual: any,
+        expected: any,
+        message: string
+    ) => void;
 
     /**
      * Adds a test like object to be skipped.
@@ -621,7 +641,7 @@ interface QUnit {
      *
      * @param {string} Title of unit being tested
      */
-    skip(name: string, callback?: (assert: Assert) => void): void;
+    const skip: (name: string, callback?: (assert: Assert) => void) => void;
 
     /**
      * Returns a single line string representing the stacktrace (call stack).
@@ -638,7 +658,7 @@ interface QUnit {
      *
      * @param {number} offset Set the stacktrace line offset.
      */
-    stack(offset?: number): string;
+    const stack: (offset?: number) => string;
 
     /**
      * `QUnit.start()` must be used to start a test run that has
@@ -650,7 +670,7 @@ interface QUnit {
      * When your async test has multiple exit points, call `QUnit.start()` for the
      * corresponding number of `QUnit.stop()` increments.
      */
-    start(): void;
+    const start: () => void;
 
     /**
      * Add a test to run.
@@ -667,28 +687,30 @@ interface QUnit {
      * @param {string} Title of unit being tested
      * @param callback Function to close over assertions
      */
-    test(name: string, callback: (assert: Assert) => void): void;
+    const test: (name: string, callback: (assert: Assert) => void) => void;
 
     /**
      * Register a callback to fire whenever a test ends.
      *
      * @param callback Callback to execute
      */
-    testDone(callback: (details: {
-        name: string;
-        module: string;
-        failed: number;
-        passed: number;
-        total: number;
-        runtime: number;
-    }) => void): void;
+    const testDone: (
+        callback: (details: {
+            name: string;
+            module: string;
+            failed: number;
+            passed: number;
+            total: number;
+            runtime: number;
+        }) => void
+    ) => void;
 
     /**
      * Register a callback to fire whenever a test begins.
      *
      * @param callback Callback to execute
      */
-    testStart(callback: (details: QUnit.TestStartDetails) => void): void;
+    const testStart: (callback: (details: TestStartDetails) => void) => void;
 
     /**
      * Adds a test which expects at least one failing assertion during its run.
@@ -703,7 +725,7 @@ interface QUnit {
      * @param {string} Title of unit being tested
      * @param callback Function to close over assertions
      */
-    todo(name: string, callback?: (assert: Assert) => void): void;
+    const todo: (name: string, callback?: (assert: Assert) => void) => void;
 
     /**
      * Compares two values. Returns true if they are equivalent.
@@ -711,19 +733,24 @@ interface QUnit {
      * @param a The first value
      * @param b The second value
      */
-    equiv<T>(a: T, b: T): boolean;
+    const equiv: <T>(a: T, b: T) => boolean;
 
     /**
      * Are the test running from the server or not.
      */
-    isLocal: boolean;
+    const isLocal: boolean;
 
     /**
-    * QUnit version
-    */
-    version: string;
-
+     * QUnit version
+     */
+    const version: string;
 }
 
-/* QUnit */
-declare const QUnit: QUnit;
+export const module: typeof QUnitNS.module;
+export const test: typeof QUnitNS.test;
+export const skip: typeof QUnitNS.skip;
+export const only: typeof QUnitNS.only;
+
+declare global {
+    const QUnit: typeof QUnitNS;
+}

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -320,6 +320,24 @@ interface Config {
     }[];
 }
 
+/**
+ * An object, ultimately passed to module(),
+ * that may have one or more QUnit module hooks
+ * 
+ * @example
+ * 
+ * // Passing the hooks to `module()`
+ * module('my module', {
+ *   beforeEach() {
+ *     console.log('test begin ', performance.now())
+ *   },
+ *   afterEach() {
+ *     console.log('test end ', performance.now())
+ *   }
+ * }, function() {
+ *    // tests
+ * })
+ */
 interface Hooks {
 
     /**
@@ -345,6 +363,22 @@ interface Hooks {
 
 }
 
+/**
+ * An object passed to the QUnit "nested" callback,
+ * allowing setup of lifecycle hooks
+ * 
+ * @example
+ * 
+ * module('my module', function(hooks) {
+ *   hooks.beforeEach(function () {
+ *     console.log('test begin ', performance.now())
+ *   });
+ *   hooks.afterEach(function () {
+ *     console.log('test end ', performance.now())
+ *   });
+ * });
+ * 
+ */
 interface NestedHooks {
     /**
      * Runs after the last test. If additional tests are defined after the

--- a/types/qunit/tests/es6-module-tests.ts
+++ b/types/qunit/tests/es6-module-tests.ts
@@ -1,0 +1,40 @@
+import { module, test, skip, only } from 'qunit';
+
+module(
+    'my first test module',
+    {
+        before(assert) {
+            assert.ok('before hook');
+        }
+    },
+    function(cbHooks) {
+        cbHooks.after(function (assert) {
+            assert.ok('after hook');
+        })
+    }
+);
+
+module('my second test module', function(cbHooks) {
+    cbHooks.before(function(assert) {
+        assert.ok('before');
+    });
+    cbHooks.beforeEach(function(assert) {
+        assert.ok('beforeEach');
+    });
+    cbHooks.after(function(assert) {
+        assert.ok('after');
+    });
+    cbHooks.afterEach(function(assert) {
+        assert.ok('afterEach');
+    });
+
+    test('it works', function(assert) {
+        assert.deepEqual([], [], 'Empty arrays are equal!');
+    });
+    only('only test this', function(assert) {
+        assert.deepEqual([], [], 'Empty arrays are equal!');
+    });
+    skip('skip this', function(assert) {
+        assert.deepEqual([], [], 'Empty arrays are equal!');
+    });
+});

--- a/types/qunit/tests/global-tests.ts
+++ b/types/qunit/tests/global-tests.ts
@@ -242,31 +242,31 @@ QUnit.log(function( details ) {
   console.log( output );
 });
 
-QUnit.log(function( details: QUnit.LogDetails ) {
+QUnit.log(function( details ) {
   let x: { actual: number; expected: number; message: string; module: string; name: string; result: boolean; runtime: number; source: string } = details;
   x = details;
 });
 
-QUnit.begin(function( details: QUnit.BeginDetails ) {
+QUnit.begin(function( details ) {
   console.log( "Total tests running: ", details.totalTests);
 });
 
-QUnit.done(function( details: QUnit.DoneDetails ) {
+QUnit.done(function( details ) {
   console.log( "Finished. Failed/total: ", details.failed, details.total, details.passed, details.runtime );
 });
 
-QUnit.moduleDone(function( details: QUnit.ModuleDoneDetails ) {
+QUnit.moduleDone(function( details ) {
   console.log( "Finished running: ", details.name, "Failed/total: ", details.failed, details.total, details.passed, details.runtime );
 });
 
-QUnit.moduleStart(function( details: QUnit.ModuleStartDetails ) {
+QUnit.moduleStart(function( details ) {
   console.log( "Now running: ", details.name );
 });
-QUnit.testDone(function( details: QUnit.TestDoneDetails ) {
+QUnit.testDone(function( details ) {
   console.log( "Finished running: ", details.name, "Failed/total: ", details.failed, details.total, details.passed, details.runtime);
 });
 
-QUnit.testStart(function( details: QUnit.TestStartDetails ) {
+QUnit.testStart(function( details ) {
   console.log( "Now running: ", details.name, ' from module ', details.module );
 });
 

--- a/types/qunit/tsconfig.json
+++ b/types/qunit/tsconfig.json
@@ -19,6 +19,7 @@
     },
     "files": [
         "index.d.ts",
-        "qunit-tests.ts"
+        "tests/global-tests.ts",
+        "tests/es6-module-tests.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

---

This PR makes it possible to explicitly import from QUnit using ES6 module syntax

```ts
import { module, test } from 'qunit';
```

This involved some significant refactoring because the previous state of these types involved no exports (adding the first export broke the implicit availability of a global QUnit namespace)

Additionally, in response to user feedback, I've added some API documentation to the `Hooks` and `NestedHooks` interfaces, in an effort to avoid possible confusion between the two.

cc: @scalvert 