### PR TITLE
Allow XRegExp build subs parameter to accept objects

### DIFF
--- a/types/xregexp/index.d.ts
+++ b/types/xregexp/index.d.ts
@@ -49,7 +49,7 @@ declare namespace OuterXRegExp {
     // begin API definitions
     function addToken(regex: RegExp, handler: (matchArr: RegExpExecArray, scope: string) => string, options?: TokenOpts): void;
 
-    function build(pattern: string, subs: string[], flags?: string): RegExp;
+    function build(pattern: string, subs: string[] | {[name: string]: RegExp}, flags?: string): RegExp;
     function cache(pattern: string, flags?: string): RegExp;
     function escape(str: string): string;
     function exec(str: string, regex: RegExp, pos?: number, sticky?: boolean): RegExpExecArray;
@@ -92,7 +92,7 @@ declare namespace OuterXRegExp {
         // begin API definitions
         function addToken(regex: RegExp, handler: (matchArr: RegExpExecArray, scope: string) => string, options?: TokenOpts): void;
 
-        function build(pattern: string, subs: string[], flags?: string): RegExp;
+        function build(pattern: string, subs: string[] | {[name: string]: RegExp}, flags?: string): RegExp;
         function cache(pattern: string, flags?: string): RegExp;
         function escape(str: string): string;
         function exec(str: string, regex: RegExp, pos?: number, sticky?: boolean): RegExpExecArray;

--- a/types/xregexp/xregexp-tests.ts
+++ b/types/xregexp/xregexp-tests.ts
@@ -22,6 +22,7 @@ var bool: boolean;
 var strArr: string[];
 var strArrArr: string[][];
 var pattern: string;
+var subs: { [name: string]: RegExp };
 var flags: string;
 var right: string;
 var left: string;
@@ -68,6 +69,8 @@ XRegExp.addToken(regex, (arr, scope) => {
 
 regex = XRegExp.build(pattern, strArr, flags);
 regex = XRegExp.build(pattern, strArr);
+regex = XRegExp.build(pattern, subs, flags);
+regex = XRegExp.build(pattern, subs);
 regex = XRegExp.cache(pattern);
 regex = XRegExp.cache(pattern, flags);
 


### PR DESCRIPTION
`XRegExp.build()` should accept an object with named substitutions as its second parameter.

http://xregexp.com/api/#build

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://xregexp.com/api/#build
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.