### PR TITLE
[react-mentions] Add props from textarea 

### DIFF
--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -6,6 +6,9 @@
 // TypeScript Version: 2.8
 import * as React from "react";
 
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+export {};
+
 /**
  * MentionsInput is the main component rendering the textarea control. It takes one or multiple Mention components as its children.
  */
@@ -19,7 +22,7 @@ export const Mention: React.SFC<MentionProps>;
 /**
  * The properties for the @see MentionsInput component.
  */
-export interface MentionsInputProps {
+export interface MentionsInputProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange' | 'onBlur' | 'onKeyDown' | 'onSelect'> {
     /**
      * If set to `true` a regular text input element will be rendered
      * instead of a textarea


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Not documented in the README (will open PR for that too), but it is supported in code https://github.com/signavio/react-mentions/blob/d88ba0402ebcf53a7aac88d6f8bfac71757159b1/src/MentionsInput.js#L146 The only issue is that it should technically be the union of `textarea` and `input` props, but trying to do that causes a lot of issue, so this is the best I can do since textarea is the default 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
