### PR TITLE
Adding [Symbol.toStringTag] to Bluebird

### DIFF
--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -42,7 +42,7 @@ type IterateFunction<T, R> = (item: T, index: number, arrayLength: number) => Re
 
 declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   [Symbol.toStringTag]: "Promise";
-  
+
   /**
    * Create a new promise. The passed in function will receive functions
    * `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -41,6 +41,8 @@ type Resolvable<R> = R | PromiseLike<R>;
 type IterateFunction<T, R> = (item: T, index: number, arrayLength: number) => Resolvable<R>;
 
 declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
+  [Symbol.toStringTag]: "Promise";
+  
   /**
    * Create a new promise. The passed in function will receive functions
    * `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.


### PR DESCRIPTION
This is a rehash of #10831, which was closed because Bluebird did not have this Symbol available back then.

Please fill in this template.

If changing an existing definition:
- Follows on from https://github.com/petkaantonov/bluebird/issues/1277
