### PR TITLE
Fix colornames default export type definition

### DIFF
--- a/types/colornames/colornames-tests.ts
+++ b/types/colornames/colornames-tests.ts
@@ -1,13 +1,9 @@
 import colorNames = require("colornames");
 
 // $ExpectType string | undefined
-const color = colorNames("red");
+colorNames("red");
 // $ExpectType string | undefined
-color;
-// $ExpectType string | undefined
-const undefinedColor = colorNames("donkey");
-// $ExpectType string | undefined
-undefinedColor;
+colorNames("donkey");
 // $ExpectType Color
 const blue = colorNames.get("blue");
 // $ExpectType boolean | undefined

--- a/types/colornames/colornames-tests.ts
+++ b/types/colornames/colornames-tests.ts
@@ -1,19 +1,21 @@
 import colorNames = require("colornames");
 
-// $ExpectType Color
+// $ExpectType string | undefined
 const color = colorNames("red");
-
 // $ExpectType string
-color.value;
-// $ExpectType boolean | undefined
-color.css;
-// $ExpectType boolean | undefined
-color.vga;
+color;
+// $ExpectType undefined
+const undefinedColor = colorNames("donkey");
+// $ExpectType undefined
+undefinedColor;
 // $ExpectType string
-color.name;
-
-// $ExpectType Color
-colorNames.get("blue");
+const blue = colorNames.get("blue");
+// $ExpectType boolean | undefined
+blue.css;
+// $ExpectType boolean | undefined
+blue.vga;
+// $ExpectType string
+blue.name;
 // $ExpectType Color[]
 colorNames.get.all();
 // $ExpectType Color[]

--- a/types/colornames/colornames-tests.ts
+++ b/types/colornames/colornames-tests.ts
@@ -2,13 +2,13 @@ import colorNames = require("colornames");
 
 // $ExpectType string | undefined
 const color = colorNames("red");
-// $ExpectType string
+// $ExpectType string | undefined
 color;
-// $ExpectType undefined
+// $ExpectType string | undefined
 const undefinedColor = colorNames("donkey");
-// $ExpectType undefined
+// $ExpectType string | undefined
 undefinedColor;
-// $ExpectType string
+// $ExpectType Color
 const blue = colorNames.get("blue");
 // $ExpectType boolean | undefined
 blue.css;

--- a/types/colornames/index.d.ts
+++ b/types/colornames/index.d.ts
@@ -53,7 +53,7 @@ interface GlobalResolver {
     /**
      * Gets the color with the specified name.
      */
-    (name: string): Color;
+    (name: string): string | undefined;
 
     /**
      * Provides the functionality to query colors.

--- a/types/colornames/index.d.ts
+++ b/types/colornames/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for colornames 1.1
 // Project: https://github.com/timoxley/colornames#readme
 // Definitions by: Manuel Thalmann <https://github.com/manuth>
+//                 Benjamin Turner <https://github.com/blturner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/timoxley/colornames/blob/1.1.1/index.js#L24
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The exported default function does not return a `Color` object, it returns the hexadecimal string value of the resolved color name. The type definition assumes it is a `Color` object.

I encountered this error when attempting to use the library in an existing typescript project using `import`.

In testing this change to the type definition, I did notice that using `require` did not cause any typescript errors:
```
const getHex = require("colornames");
```

But importing the library this way did:
```
import * as getHex from "colornames";
```

The changes to the type definition in this PR work with both of the above examples.
