### PR TITLE
[paper] Fix hitTest types, add constructors to PaperScope

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1236,6 +1236,37 @@ declare module paper {
          */
         static get(id: string): PaperScope;
 
+        /**
+         * All the classes for paper can be constructed via the PaperScope instance, so
+         * that they are associated with that scope
+         */
+        Matrix: typeof Matrix;
+        Point: typeof Point;
+        Rectangle: typeof Rectangle;
+        Size: typeof Size;
+        PaperScope: typeof PaperScope;
+        Item: typeof Item;
+        Group: typeof Group;
+        Layer: typeof Layer;
+        Shape: typeof Shape;
+        Raster: typeof Raster;
+        PlacedSymbol: typeof PlacedSymbol;
+        PathItem: typeof PathItem;
+        Path: typeof Path;
+        CompoundPath: typeof CompoundPath;
+        Segment: typeof Segment;
+        Curve: typeof Curve;
+        CurveLocation: typeof CurveLocation;
+        Project: typeof Project;
+        Symbol: typeof Symbol;
+        Style: typeof Style;
+        Color: typeof Color;
+        Gradient: typeof Gradient;
+        GradientStop: typeof GradientStop;
+        View: typeof View;
+        Tool: typeof Tool;
+        TextItem: typeof TextItem;
+        PointText: typeof PointText;
     }
     export interface IHitTestOptions{
 

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1276,9 +1276,9 @@ declare module paper {
         tolerance?: number;
 
         /**
-         * only hit-test again a certain item class and its sub-classes: Group, Layer, Path, CompoundPath, Shape, Raster, PlacedSymbol, PointText, etc.
+         * only hit-test against a certain item class and its sub-classes: Group, Layer, Path, CompoundPath, Shape, Raster, PlacedSymbol, PointText, etc.
          */
-        class?: Function;
+        class?: { new(...args: any[]): Item; };
 
         /**
          * a match function to be called for each found hit result: Return true to return the result, false to keep searching

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1715,7 +1715,7 @@ declare module paper {
          * @param options.guides - hit-test items that have Item#guide set to true.
          * @param options.selected - only hit selected items.
          */
-        hitTest(point: Point, options?: IHitTestOptions): HitResult;
+        hitTest(point: Point, options?: IHitTestOptions): HitResult | null;
 
         /**
          * Performs a hit-test on the item and its children (if it is a Group or Layer) at the location of the specified point, returning all found hits.
@@ -4171,7 +4171,7 @@ declare module paper {
          * @param options.guides - hit-test items that have Item#guide set to true.
          * @param options.selected - only hit selected items.
          */
-        hitTest(point: Point, options?: IHitTestOptions): HitResult;
+        hitTest(point: Point, options?: IHitTestOptions): HitResult | null;
 
         /**
          * Performs a hit-test on the item and its children (if it is a Group or Layer) at the location of the specified point, returning all found hits.

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1278,7 +1278,7 @@ declare module paper {
         /**
          * only hit-test again a certain item class and its sub-classes: Group, Layer, Path, CompoundPath, Shape, Raster, PlacedSymbol, PointText, etc.
          */
-        class?: string;
+        class?: Function;
 
         /**
          * a match function to be called for each found hit result: Return true to return the result, false to keep searching

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1278,7 +1278,7 @@ declare module paper {
         /**
          * only hit-test against a certain item class and its sub-classes: Group, Layer, Path, CompoundPath, Shape, Raster, PlacedSymbol, PointText, etc.
          */
-        class?: { new(...args: any[]): Item; };
+        class?: new(...args: any[]) => Item;
 
         /**
          * a match function to be called for each found hit result: Return true to return the result, false to keep searching

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -46,7 +46,7 @@ let hitOptionsInterfacePartial:paper.IHitTestOptions = {match: (hit: paper.HitRe
 let hitOptionsInterfaceFull:paper.IHitTestOptions = {tolerance: 0, class: 'Path', match: (hit: paper.HitResult)=>{return true;}, fill: true, stroke: false, segments: true, curves: false, handles: true, ends: true, position: false, center: true, bounds: true, guides: false, selected: true};
 let compoundPath: paper.CompoundPath = new paper.CompoundPath(dottedLinePath);
 let hitTestPoint = dottedLinePath.segments[0].point;
-let hitTestResult: paper.HitResult;
+let hitTestResult: paper.HitResult | null;
 let hitTestResults: paper.HitResult[];
 // These are Item hit tests
 hitTestResult = compoundPath.hitTest(hitTestPoint);

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -85,6 +85,21 @@ paper.settings.insertItems = true
 const paperScope = new paper.PaperScope();
 paperScope.settings.insertItems = false;
 
+// When multiple paper scopes may be in play you have to use the classes from inside
+// the right scope to create new objects rather than the global classes from the
+// module's default export,
+const scopedRectangle: paper.Rectangle = new paperScope.Rectangle(2,2,7,7);
+const scopedPoint: paper.Point = new paperScope.Point(25, 25);
+const scopedPath: paper.Path = new paperScope.Path.Line(new paperScope.Point(0,0), scopedPoint);
+const scopedTool: paper.Tool = new paperScope.Tool();
+const scopedMatrix: paper.Matrix = new paperScope.Matrix(1,2,3,4,5,6);
+const scopedLayer: paper.Layer = new paperScope.Layer([]);
+const scopedShape: paper.Shape = paperScope.Shape.Circle(new paperScope.Point(20,20),5);
+const scopedRaster: paper.Raster = new paperScope.Raster('http://github.com/favicon.png');
+const scopedProject: paper.Project = new paperScope.Project('id');
+const scopedColor: paper.Color = new paperScope.Color(255, 255, 255);
+const scopedPointText: paper.PointText = new paperScope.PointText(new paperScope.Point(1,1));
+
 function Examples() {
     function BooleanOperations(){
         let text = new paper.PointText({

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -39,11 +39,11 @@ dottedLineTool.onMouseUp = function(event: any) {
 // These objects are to make sure older code which didn't have the IHitTestOptions available still work.
 let hitOptionsEmpty = {};
 let hitOptionsPartial = {tolerance: 0, extra: true};
-let hitOptionsFull = {tolerance: 0, class: 'Path', match: (hit: paper.HitResult)=>{return true;}, fill: true, stroke: false, segments: true, curves: false, handles: true, ends: true, position: false, center: true, bounds: true, guides: false, selected: true};
+let hitOptionsFull: paper.IHitTestOptions = {tolerance: 0, class: paper.Path, match: (hit: paper.HitResult)=>{return true;}, fill: true, stroke: false, segments: true, curves: false, handles: true, ends: true, position: false, center: true, bounds: true, guides: false, selected: true};
 // These objects are to make sure new code which uses the IHitTestOptions work.
 let hitOptionsInterfaceEmpty:paper.IHitTestOptions = {};
 let hitOptionsInterfacePartial:paper.IHitTestOptions = {match: (hit: paper.HitResult)=>{return true;}};
-let hitOptionsInterfaceFull:paper.IHitTestOptions = {tolerance: 0, class: 'Path', match: (hit: paper.HitResult)=>{return true;}, fill: true, stroke: false, segments: true, curves: false, handles: true, ends: true, position: false, center: true, bounds: true, guides: false, selected: true};
+let hitOptionsInterfaceFull:paper.IHitTestOptions = {tolerance: 0, class: paper.Path, match: (hit: paper.HitResult)=>{return true;}, fill: true, stroke: false, segments: true, curves: false, handles: true, ends: true, position: false, center: true, bounds: true, guides: false, selected: true};
 let compoundPath: paper.CompoundPath = new paper.CompoundPath(dottedLinePath);
 let hitTestPoint = dottedLinePath.segments[0].point;
 let hitTestResult: paper.HitResult | null;


### PR DESCRIPTION
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 

* http://paperjs.org/reference/item/#hittest-point

> options.class: Function — only hit-test against a specific item class, or any of its sub-classes, by providing the constructor function against which an instanceof check is performed: Group, Layer, Path, CompoundPath, Shape, Raster, SymbolItem, PointText, …
>
> ...
>
> Returns: HitResult — a hit result object describing what exactly was hit or null if nothing was hit

* http://paperjs.org/reference/paperscope/

> When working with normal JavaScript code, PaperScope objects need to be manually created and handled.
> 
> Paper classes can only be accessed through PaperScope objects. Thus in PaperScript they are global, while in JavaScript, they are available on the global paper object. For JavaScript you can use paperScope.install(scope) to install the Paper classes and objects on the global scope. Note that when working with more than one scope, this still works for classes, but not for objects like paperScope.project, since they are not updated in the injected scope if scopes are switched.
> 
> The global paper object is simply a reference to the currently active PaperScope.
