### PR TITLE
[nock] Fix Interceptor.reply.

### DIFF
--- a/types/nock/nock-tests.ts
+++ b/types/nock/nock-tests.ts
@@ -2,16 +2,16 @@ import nock = require('nock');
 import * as fs from 'fs';
 import { URL } from 'url';
 
-let scope: nock.Scope;
+let scope: nock.Scope = nock("http://example.com");
 let inst: nock.Interceptor;
-let str: string;
+let str = "foo";
 let strings: string[];
-let bool: boolean;
+let bool = true;
 let defs: nock.NockDefinition[];
-let options: nock.Options;
+let options: nock.Options = {};
 
 const num = 42;
-const obj: {[k: string]: any} = {};
+const obj: { [k: string]: any } = {};
 const regex = /test/;
 
 inst = scope.head(str);
@@ -244,6 +244,11 @@ nock('http://example.com')
   .query(true)
   .reply(200, {results: [{id: 'pgte'}]});
 
+nock('http://example.com', { encodedQueryParams: true })
+  .get('/users')
+  .query('foo%5Bbar%5D%3Dhello%20world%21')
+  .reply(200, { results: [{ id: 'pgte' }] });
+
 // Specifying replies
 scope = nock('http://myapp.iriscouch.com')
                 .get('/users/1')
@@ -310,6 +315,7 @@ scope = nock('http://www.google.com')
 scope = nock('http://www.google.com')
    .get('/cat-poems')
    .reply(function(uri, requestBody) {
+     str = this.req.path;
      console.log('path:', this.req.path);
      console.log('headers:', this.req.headers);
      // ...

--- a/types/nock/tsconfig.json
+++ b/types/nock/tsconfig.json
@@ -5,8 +5,8 @@
             "es6"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/nock/tslint.json
+++ b/types/nock/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-any-union": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I was working on removing the `no-any-union` lint override and realized
that `any` was being used in several places where a plain objected was
intended. It was also covering up that reply bodies can be Buffers or
Streams.

[Docs for specifying replies](https://github.com/nock/nock#specifying-replies)

Note: There was a bug in place. Previously, the types allowed for `reply`
to take two args, a callback and an object of headers. However, this
form is not documented and turns out to not be functional when
inspecting [the source](https://github.com/nock/nock/blob/cb56669e0bee13dfa9c668ecb3d0efb714f6240c/lib/interceptor.js#L68-L72).

I’ve confirmed with the lib maintainers that the bug was in `@types`.
https://github.com/nock/nock/issues/1513

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.