### PR TITLE
[hapi]: fix custom events and (partly) nested server methods

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -4034,7 +4034,7 @@ export namespace Lifecycle {
 
 export namespace Util {
     interface Dictionary<T> {
-        [key: string]: T;
+        [key: string]: T | Dictionary<T>;
     }
 
     type HTTP_METHODS_PARTIAL_LOWERCASE = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2375,7 +2375,7 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    on<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
@@ -2399,7 +2399,7 @@ export interface ServerEvents extends Podium {
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    once<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2375,6 +2375,8 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
+    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
      * @param criteria - the subscription criteria which must be one of:
@@ -2396,6 +2398,8 @@ export interface ServerEvents extends Podium {
     once(criteria: 'start' | ServerEventCriteria<'start'>, listener: StartEventHandler): void;
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
+
+    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi/v17/index.d.ts
+++ b/types/hapi/v17/index.d.ts
@@ -2364,6 +2364,8 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
+    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
      * @param criteria - the subscription criteria which must be one of:
@@ -2385,6 +2387,8 @@ export interface ServerEvents extends Podium {
     once(criteria: 'start' | ServerEventCriteria<'start'>, listener: StartEventHandler): void;
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
+
+    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi/v17/index.d.ts
+++ b/types/hapi/v17/index.d.ts
@@ -3993,7 +3993,7 @@ export namespace Lifecycle {
 
 export namespace Util {
     interface Dictionary<T> {
-        [key: string]: T;
+        [key: string]: T | Dictionary<T>;
     }
 
     type HTTP_METHODS_PARTIAL_LOWERCASE = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';

--- a/types/hapi/v17/index.d.ts
+++ b/types/hapi/v17/index.d.ts
@@ -2364,7 +2364,7 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    on<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
@@ -2388,7 +2388,7 @@ export interface ServerEvents extends Podium {
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    once<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -4035,7 +4035,7 @@ export namespace Lifecycle {
 
 export namespace Util {
     interface Dictionary<T> {
-        [key: string]: T;
+        [key: string]: T | Dictionary<T>;
     }
 
     type HTTP_METHODS_PARTIAL_LOWERCASE = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -2376,6 +2376,8 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
+    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
      * @param criteria - the subscription criteria which must be one of:
@@ -2397,6 +2399,8 @@ export interface ServerEvents extends Podium {
     once(criteria: 'start' | ServerEventCriteria<'start'>, listener: StartEventHandler): void;
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
+
+    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -2376,7 +2376,7 @@ export interface ServerEvents extends Podium {
 
     on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    on<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    on<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
@@ -2400,7 +2400,7 @@ export interface ServerEvents extends Podium {
 
     once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
-    once<T extends string, U extends Podium.Listener>(criteria: T | ServerEventCriteria<T>, listener: U): void;
+    once<T extends string>(criteria: T | ServerEventCriteria<T>, listener: Podium.Listener): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapijs.com/api#-servermethodname-method-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

While working with the types for Hapi, I discovered two flaws, which are IMO incorrect typed and not representing the documented functionality.

## 1. Custom events

The hapi method `server.event(eventName)` allows to register a custom event type. But when I try to use this in an event handler, typescript throws an error, as it only expects the default events in the ServerEvents interface. To fix this, I added an generic handler for `on` and `once` to handle the custom events.

Docu: 
## 2. Nested server methods.

As in the documentation for [server.methods](https://hapijs.com/api#-servermethodname-method-options):

> Method names can be nested (e.g. utils.users.get) which will automatically create the full path under server.methods (e.g. accessed via server.methods.utils.users.get). 

The current type of 

```typescript
  interface Dictionary<T> {
        [key: string]: T;
    }
```

does not allow this nesting. 

Unfortunately does my change no pass the tests and so I would left this PR for discussion, how to solve the issue.

 @rafaelsouzaf, @jhsimms, @SimonSchick, @saboya