### PR TITLE
Terminal-kit: argument width in GridMenuOptions is optional

### DIFF
--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -488,7 +488,7 @@ declare namespace Terminal {
   interface GridMenuOptions {
     y?: number;
     x?: number;
-    width: number;
+    width?: number;
     style?: CTerminal;
     selectedStyle?: CTerminal;
     leftPadding?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cronvel/terminal-kit/blob/master/doc/high-level.md#gridmenu-menuitems--options--callback-
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
