### PR TITLE
fix(sylvester): vector rotate should be able to take matrix as well

### DIFF
--- a/types/sylvester-es6/index.d.ts
+++ b/types/sylvester-es6/index.d.ts
@@ -171,7 +171,7 @@ export class Vector {
      * Rotates the vector about the given object. The object should be a point if the vector is 2D,
      * and a line if it is 3D. Be careful with line directions!
      */
-    rotate(t: number, obj: Vector|Line): Vector;
+    rotate(t: number|Matrix, obj: Vector|Line): Vector;
 
     /**
      * Returns the result of reflecting the point in the given point, line or plane.

--- a/types/sylvester-es6/sylvester-es6-tests.ts
+++ b/types/sylvester-es6/sylvester-es6-tests.ts
@@ -57,6 +57,7 @@ const vectorLiesOn = vector2.liesOn(new Line([1, 0], [0, 1]));
 const vectorLiesIn = vector2.liesIn(new Plane([1, 0], [0, 1]));
 const vectorRotate1 = vector2.rotate(1, vector1);
 const vectorRotate2 = vector2.rotate(1, new Line([1, 0], [0, 1]));
+const vectorRotate3 = vector2.rotate(new Matrix([[1, 0], [0, 1]]), new Line([1, 0], [0, 1]));
 const vectorReflectionIn1 = vector2.reflectionIn(vector1);
 const vectorReflectionIn2 = vector2.reflectionIn(new Line([1, 0], [0, 1]));
 const vectorReflectionIn3 = vector2.reflectionIn(new Plane([1, 0], [0, 1]));

--- a/types/sylvester/index.d.ts
+++ b/types/sylvester/index.d.ts
@@ -291,10 +291,10 @@ interface Vector {
      * Rotates the vector about the given object. The object should be a point if the vector is 2D,
      * and a line if it is 3D. Be careful with line directions!
      *
-     * @param {number} t The angle in radians.
+     * @param {number|Matrix} t The angle in radians or in rotation matrix.
      * @param {Vector|Line} obj The rotation axis.
      */
-    rotate(t: number, obj: Vector|Line): Vector;
+    rotate(t: number|Matrix, obj: Vector|Line): Vector;
 
     /**
      * Returns the result of reflecting the point in the given point, line or plane.

--- a/types/sylvester/sylvester-tests.ts
+++ b/types/sylvester/sylvester-tests.ts
@@ -212,6 +212,7 @@ v = v.reflectionIn(l);
 v = v.reflectionIn(p);
 v = v.rotate(n, v);
 v = v.rotate(n, l);
+v = v.rotate(m, l);
 v = v.round();
 v = v.setElements(v);
 v = v.setElements([n, n]);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`Vector.prototype.rotate takes in Matrix as well`](https://github.com/pithumke/sylvester-es6/blob/master/src/Vector.js#L274)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I realized that when I was using the types for the [ES6 fork of sylvester]((https://github.com/pithumke/sylvester-es6)), apparently [Vector instance takes in Matrix as well](https://github.com/pithumke/sylvester-es6/blob/master/src/Vector.js#L274), not only the angle in radians. This is also the case for the [original library](https://github.com/jcoglan/sylvester/blob/master/src/vector.js#L192). I've fixed both the original and the fork.

Let me know what you think. Thanks.