### PR TITLE
[react-select] Fix the default exported component by using the StateManager

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -8,8 +8,7 @@
 import SelectBase from './lib/Select';
 import { StateManager } from './lib/stateManager';
 
-export default SelectBase;
-// export default StateManager;
+export default StateManager;
 
 export { SelectBase };
 export { default as Async } from './lib/Async';

--- a/types/react-select/lib/Select.d.ts
+++ b/types/react-select/lib/Select.d.ts
@@ -316,7 +316,7 @@ export default class Select<OptionType> extends React.Component<Props<OptionType
     selectProps: Readonly<{
         children?: React.ReactNode;
     }> & Readonly<Props<OptionType>>;
-};
+  };
 
   getNextFocusedValue(nextSelectValue: OptionsType<OptionType>): OptionType;
 

--- a/types/react-select/lib/stateManager.d.ts
+++ b/types/react-select/lib/stateManager.d.ts
@@ -4,10 +4,31 @@ import SelectBase, { Props as SelectProps } from './Select';
 import { ActionMeta, InputActionMeta, ValueType } from './types';
 
 export interface DefaultProps<OptionType> {
+  defaultInputValue: string;
+  defaultMenuIsOpen: boolean;
+  defaultValue: ValueType<OptionType>;
+}
+
+export interface Props<OptionType> {
   defaultInputValue?: string;
   defaultMenuIsOpen?: boolean;
   defaultValue?: ValueType<OptionType>;
+  inputValue?: string;
+  menuIsOpen?: boolean;
+  value?: ValueType<OptionType>;
+  onChange?: (value: ValueType<OptionType>, actionMeta: ActionMeta) => void;
 }
+
+type StateProps<T extends SelectProps<any>> = Pick<T, Exclude<keyof T,
+  | 'inputValue'
+  | 'value'
+  | 'menuIsOpen'
+  | 'onChange'
+  | 'onInputChange'
+  | 'onMenuClose'
+  | 'onMenuOpen'
+>>;
+
 interface State<OptionType> {
   inputValue: string;
   menuIsOpen: boolean;
@@ -19,7 +40,7 @@ type GetOptionType<T> = T extends SelectBase<infer OT> ? OT : never;
 export class StateManager<
   OptionType = { label: string; value: string },
   T extends SelectBase<OptionType> = SelectBase<OptionType>
-> extends Component<SelectProps<OptionType> & DefaultProps<OptionType>, State<OptionType>> {
+> extends Component<StateProps<SelectProps<OptionType>> & Props<OptionType> & SelectProps<OptionType>, State<OptionType>> {
   static defaultProps: DefaultProps<any>;
 
   select: T;
@@ -28,8 +49,8 @@ export class StateManager<
   blur(): void;
   getProp(key: string): any;
   callProp(name: string, ...args: any[]): any;
-  onChange: (value: any, actionMeta: ActionMeta) => void;
-  onInputChange: (value: any, actionMeta: InputActionMeta) => void;
+  onChange: (value: ValueType<OptionType>, actionMeta: ActionMeta) => void;
+  onInputChange: (value: ValueType<OptionType>, actionMeta: InputActionMeta) => void;
   onMenuOpen: () => void;
   onMenuClose: () => void;
 }

--- a/types/react-select/lib/stateManager.d.ts
+++ b/types/react-select/lib/stateManager.d.ts
@@ -1,14 +1,12 @@
 import { Component, ComponentType, Ref as ElementRef } from 'react';
 
+import SelectBase, { Props as SelectProps } from './Select';
 import { ActionMeta, InputActionMeta, ValueType } from './types';
 
-export interface Props<OptionType> {
+export interface DefaultProps<OptionType> {
   defaultInputValue?: string;
   defaultMenuIsOpen?: boolean;
   defaultValue?: ValueType<OptionType>;
-  inputValue?: string;
-  menuIsOpen?: boolean;
-  value?: ValueType<OptionType>;
 }
 interface State<OptionType> {
   inputValue: string;
@@ -16,10 +14,15 @@ interface State<OptionType> {
   value: ValueType<OptionType>;
 }
 
-export class StateManager<OptionType> extends Component<Props<OptionType>, State<OptionType>> {
-  static defaultProps: Props<any>;
+type GetOptionType<T> = T extends SelectBase<infer OT> ? OT : never;
 
-  select: ElementRef<any>;
+export class StateManager<
+  OptionType = { label: string; value: string },
+  T extends SelectBase<OptionType> = SelectBase<OptionType>
+> extends Component<SelectProps<OptionType> & DefaultProps<OptionType>, State<OptionType>> {
+  static defaultProps: DefaultProps<any>;
+
+  select: T;
 
   focus(): void;
   blur(): void;
@@ -31,6 +34,8 @@ export class StateManager<OptionType> extends Component<Props<OptionType>, State
   onMenuClose: () => void;
 }
 
-export function manageState(SelectComponent: ComponentType<any>): StateManager<any>;
+export function manageState<T extends SelectBase<any>>(
+  SelectComponent: T
+): StateManager<GetOptionType<T>, T>;
 
 export default manageState;

--- a/types/react-select/test/examples/OnMenuOpen.tsx
+++ b/types/react-select/test/examples/OnMenuOpen.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import Select from 'react-select';
+import { ColourOption, colourOptions } from '../data';
+import { Note } from '../styled-components';
+
+const Checkbox = (props: any) => <input type="checkbox" {...props} />;
+
+interface State {
+  defaultMenuScroll?: number;
+}
+
+export default class SelectScrolledMenu extends React.Component<{}, State> {
+  wrappedSelect: React.RefObject<Select<ColourOption>>;
+
+  handleChangeMenuScrollDefault = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.setState({defaultMenuScroll: parseInt(event.target.value, 10)});
+  }
+
+  handleMenuOpen = (): void => {
+    const {defaultMenuScroll} = this.state;
+    if (!defaultMenuScroll || !this.wrappedSelect.current) {
+      return;
+    }
+    const select = this.wrappedSelect.current.select;
+    setTimeout((): void => {
+      select.setState(
+        {focusedOption: colourOptions[defaultMenuScroll - 1]},
+        (): void => {
+          select.focusOption('pagedown');
+        },
+      );
+    });
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Select<ColourOption>
+          className="basic-single"
+          classNamePrefix="select"
+          defaultValue={colourOptions[0]}
+          name="color"
+          options={colourOptions}
+          ref={this.wrappedSelect}
+        />
+        <Note Tag="label">
+          Default focused option index:
+          <input
+            value={this.state.defaultMenuScroll}
+            onChange={this.handleChangeMenuScrollDefault}
+            type="numeric"
+          />
+          Clearable
+        </Note>
+      </React.Fragment>
+    );
+  }
+}

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -96,6 +96,7 @@
         "test/examples/CustomValueContainer.tsx",
         "test/examples/Experimental.tsx",
         "test/examples/MenuPortal.tsx",
+        "test/examples/OnMenuOpen.tsx",
         "test/examples/OnSelectResetsInput.tsx",
         "test/examples/Popout.tsx",
         "test/examples/StyledMulti.tsx",


### PR DESCRIPTION
The exported component of the ReactSelect library is actually a wrapper around the Select component, using a StateManager. See the wrapping call [here](https://github.com/JedWatson/react-select/blob/master/src/index.js#L7). The updated component accepts the same props but it now handles properly having a `select` field on which one can call methods like `focusOption`.

I think the previous version was in place to quickly get a type running but does not match the values returned by the library.

Checklist:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/JedWatson/react-select/blob/master/src/index.js#L7>
- [ ] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm not sure about increasing the version number: it's still related to the same major/minor version of the React Select library. However it's a breaking change compare to the (broken) existing state of the types.