### PR TITLE
[Rebass] Update rebass base props to facilitate use of string or css function

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -18,7 +18,10 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export interface BaseProps extends React.Props<any> {
     as?: React.ReactType;
-    css?: StyledComponents.CSSObject;
+    css?:
+        | StyledComponents.CSSObject
+        | StyledComponents.BaseThemedCssFunction<any>
+        | string;
 }
 
 interface BoxKnownProps

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -20,7 +20,7 @@ export interface BaseProps extends React.Props<any> {
     as?: React.ReactType;
     css?:
         | StyledComponents.CSSObject
-        | StyledComponents.BaseThemedCssFunction<any>
+        | StyledComponents.FlattenSimpleInterpolation
         | string;
 }
 

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Box, Flex, Text, Heading, Button, Link, Image, Card } from "rebass";
 import "styled-components/macro";
 
@@ -14,6 +14,13 @@ const ExtendedBox = styled(Box)`
 ExtendedBox.defaultProps = {
     p: 3
 };
+
+const boxCss = css`
+    background: purple;
+    color: white;
+`;
+
+const CssBox = () => <Box css={boxCss} />;
 
 export default () => (
     <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em">
@@ -57,6 +64,8 @@ export default () => (
             >
                 String css prop
             </Box>
+
+            <CssBox />
         </Flex>
     </Box>
 );

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Box, Flex, Text, Heading, Button, Link, Image, Card } from "rebass";
+import "styled-components/macro";
 
 const CustomComponent: React.FunctionComponent = ({ children }) => {
     return <div>{children}</div>;
@@ -14,7 +15,7 @@ ExtendedBox.defaultProps = {
     p: 3
 };
 
-() => (
+export default () => (
     <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em">
         <Flex width={1} alignItems="center" justifyContent="center">
             <Heading fontSize={5} fontWeight="bold">
@@ -49,6 +50,13 @@ ExtendedBox.defaultProps = {
                 CustomComponent
             </Box>
             <ExtendedBox m={2}>ExtendedBox</ExtendedBox>
+            <Box
+                css={`
+                    color: red;
+                `}
+            >
+                String css prop
+            </Box>
         </Flex>
     </Box>
 );


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.styled-components.com/docs/api#css-prop>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hello! I noticed rebass complained whenever a string is used inside its css prop, however as the [styled-components docs show](https://www.styled-components.com/docs/api#css-prop) you can use a string/template literal.
