### PR TITLE
[Sequelize]: `scope` should be supported for all association types

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -18,6 +18,7 @@
 //                 Dima Smirnov <https://github.com/smff>
 //                 Duy Truong <https://github.com/truongkhanhduy95>
 //                 Emmanuel Gautier <https://github.com/emmanuelgautier>
+//                 Dan Rumney <https://github.com/dancrumb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1274,6 +1274,7 @@ declare namespace sequelize {
         constraints?: boolean;
         foreignKeyConstraint?: boolean;
 
+        scope?: AssociationScope;
     }
 
     /**

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -136,6 +136,7 @@ User.hasMany( User, {
     foreignKey : 'parent',
     foreignKeyConstraint : true
 } );
+User.hasOne( Task, { foreignKey : 'userId', keyType : Sequelize.STRING, constraints : false } );
 
 User.belongsToMany( Task, { through : 'UserTasks' } );
 User.belongsToMany( User, { through : Task } );

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -136,7 +136,7 @@ User.hasMany( User, {
     foreignKey : 'parent',
     foreignKeyConstraint : true
 } );
-User.hasOne( Task, { foreignKey : 'userId', keyType : Sequelize.STRING, constraints : false } );
+User.hasOne( Task, { foreignKey : 'userId', as : 'activeTasks', scope : { active : true } } );
 
 User.belongsToMany( Task, { through : 'UserTasks' } );
 User.belongsToMany( User, { through : Task } );


### PR DESCRIPTION
Per http://docs.sequelizejs.com/manual/associations.html#scopes (and personal experience), `scope` is supported on all associations.