### PR TITLE
allow null on attrs for NodeType.create methods

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1035,7 +1035,7 @@ export class NodeType<S extends Schema = any> {
    * set of marks.
    */
   create(
-    attrs?: { [key: string]: any },
+    attrs?: { [key: string]: any } | null,
     content?: Fragment<S> | ProsemirrorNode<S> | Array<ProsemirrorNode<S>>,
     marks?: Array<Mark<S>>
   ): ProsemirrorNode<S>;
@@ -1045,7 +1045,7 @@ export class NodeType<S extends Schema = any> {
    * if it doesn't match.
    */
   createChecked(
-    attrs?: { [key: string]: any },
+    attrs?: { [key: string]: any } | null,
     content?: Fragment<S> | ProsemirrorNode<S> | Array<ProsemirrorNode<S>>,
     marks?: Array<Mark<S>>
   ): ProsemirrorNode<S>;
@@ -1058,7 +1058,7 @@ export class NodeType<S extends Schema = any> {
    * `Fragment.empty` as content.
    */
   createAndFill(
-    attrs?: { [key: string]: any },
+    attrs?: { [key: string]: any } | null,
     content?: Fragment<S> | ProsemirrorNode<S> | Array<ProsemirrorNode<S>>,
     marks?: Array<Mark<S>>
   ): ProsemirrorNode<S> | null | undefined;


### PR DESCRIPTION
The ProseMirror docs [recommend passing null](https://prosemirror.net/docs/ref/#model.NodeType.create) to the NodeType.create, NodeType.createChecked, and NodeType.createAndFill methods to use the default attrs of the NodeType.

This pull request makes the typings allow nulls for these methods.

@bradleyayers @davidka @timjb @neknalb @patsimm