### PR TITLE
[react-tracking] Export additional interfaces

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -17,7 +17,7 @@ export interface TrackingProp {
 
 type Falsy = false | null | undefined | "";
 
-interface Options<T> {
+export interface Options<T> {
     /**
      * By default, data tracking objects are pushed to `window.dataLayer[]`. This is a good default if you use Google
      * Tag Manager. You can override this by passing in a dispatch function as a second parameter to the tracking
@@ -56,7 +56,7 @@ export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any]) =>
 // through a JSX component that be used without casting.
 type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction;
 type MethodDecorator = <T>(target: object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
-type Decorator = ClassDecorator & MethodDecorator;
+export type Decorator = ClassDecorator & MethodDecorator;
 
 /**
  * This is the type of the `track` function. It’s declared as an interface so that consumers can extend the typing and

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Track, track as _track, TrackingProp } from 'react-tracking';
+import { Track, track as _track, TrackingProp, Options, Decorator } from 'react-tracking';
 
 function customEventReporter(data: { page?: string }) {}
 


### PR DESCRIPTION
This PR exports a few additional interfaces for use in [our wrapper implementation](https://github.com/artsy/reaction/blob/master/src/Artsy/Analytics/track.ts#L3) of `react-tracking`, which were lost when we moved the types over to DefinitivelyTyped. 
