### PR TITLE
Add missing topOffset and leftOffset props to scroll-into-view Alignment

### DIFF
--- a/types/scroll-into-view/index.d.ts
+++ b/types/scroll-into-view/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for scroll-into-view 1.6.0
 // Project: https://github.com/KoryNunn/scroll-into-view
 // Definitions by: zivni <https://github.com/zivni>
+//                 Thibaut <https://github.com/Thibaut-Fatus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module __ScrollIntoView {
@@ -17,6 +18,10 @@ declare module __ScrollIntoView {
         top?: number
         /** 0 to 1, default 0.5 (center) */
         left?: number
+        /** pixels to offset top alignment */
+        topOffset?: number
+        /** pixels to offset left alignment */
+        leftOffset?: number
     }
 
     /** type will be 'complete' if the scroll completed or 'canceled' if the current scroll was canceled by a new scroll */

--- a/types/scroll-into-view/scroll-into-view-tests.ts
+++ b/types/scroll-into-view/scroll-into-view-tests.ts
@@ -13,7 +13,9 @@ scrollIntoView(someElement, {
     },
     align: {
         top: 0,
-        left: 1
+        left: 1,
+        topOffset: 20,
+        leftOffset: 20
     }
 });
 


### PR DESCRIPTION
Add 2 missing props to [scroll-into-view](https://github.com/KoryNunn/scroll-into-view) `Alignment` interface:
- `topOffset?: number` pixels to offset top alignment
- `leftOffset?: number` pixels to offset left alignment

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [scroll-into-view](https://github.com/KoryNunn/scroll-into-view)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
