### PR TITLE
Update index.d.ts

### DIFF
--- a/types/string-hash/index.d.ts
+++ b/types/string-hash/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Ethan Rubio <https://github.com/ethanrubio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare namespace stringHash {};
+    
 declare function stringHash(str: string): number;
 
 export = stringHash;


### PR DESCRIPTION
This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.