### PR TITLE
[jszip] Add `decodeFileName` option for JSZipLoadOptions interface

### DIFF
--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -132,6 +132,7 @@ declare namespace JSZip {
         checkCRC32?: boolean;
         optimizedBinaryString?: boolean;
         createFolders?: boolean;
+        decodeFileName?(filenameBytes: Uint8Array): string;
     }
 }
 

--- a/types/jszip/jszip-tests.ts
+++ b/types/jszip/jszip-tests.ts
@@ -44,7 +44,13 @@ function testJSZip() {
 	const zip = createTestZip();
 	zip.generateAsync({compression: "DEFLATE", type: "base64"}).then((serializedZip) => {
 		const newJszip = new JSZip();
-		return newJszip.loadAsync(serializedZip, {base64: true/*, checkCRC32: true*/});
+		return newJszip.loadAsync(serializedZip, {
+			base64: true,
+			checkCRC32: true,
+			optimizedBinaryString: true,
+			createFolders: true,
+			decodeFileName: filenameBytes => filenameBytes.toString()
+		});
 	}).then((newJszip: JSZip) => {
 		newJszip.file("test.txt").async('text').then((text: string) => {
 			if (text === "test string") {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://stuk.github.io/jszip/documentation/api_jszip/load_async.html#decodefilename-option
- [x] Increase the version number in the header if appropriate.
    - Do not need, because this option is implemented since v2.6.0.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
    - N/A