### PR TITLE
[react-select] Add missing optional flag for valueContainer

### DIFF
--- a/types/react-select/lib/styles.d.ts
+++ b/types/react-select/lib/styles.d.ts
@@ -62,7 +62,7 @@ export interface Styles {
   option?: styleFn;
   placeholder?: styleFn;
   singleValue?: styleFn;
-  valueContainer: styleFn;
+  valueContainer?: styleFn;
 }
 export type StylesConfig = Partial<Styles>;
 export type GetStyles = (a: string, b: Props) => CSSProperties;


### PR DESCRIPTION
All parts of the styles object are optional - it appears that one `?` was missing, unlike all the other keys in the `styles` object. AFAIK there's no reason why `valueContainer` should be mandatory - [the documentation doesn't single it out from any other `styles` prop](https://react-select.com/styles).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-select.com/styles
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
