### PR TITLE
sqs-producer: Added missing attributes in Options interface

### DIFF
--- a/types/sqs-producer/index.d.ts
+++ b/types/sqs-producer/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for sqs-producer 1.5
 // Project: https://github.com/BBC/sqs-producer
 // Definitions by: Daniel Chao <http://dchao.co/>
+//                 John Hamelink <https://johnhamelink.com/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/sqs-producer/index.d.ts
+++ b/types/sqs-producer/index.d.ts
@@ -7,9 +7,11 @@
 import { SQS } from "aws-sdk";
 
 export interface Options {
+  accessKeyId?: string;
+  batchSize?: number;
   queueUrl: string;
   region?: string;
-  batchSize?: number;
+  secretAccessKey?: string;
   sqs?: SQS;
 }
 

--- a/types/sqs-producer/sqs-producer-tests.ts
+++ b/types/sqs-producer/sqs-producer-tests.ts
@@ -7,6 +7,13 @@ const producer = Producer.create({
   region: 'eu-west-1'
 });
 
+const producer2 = Producer.create({
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  queueUrl: 'https://sqs.eu-west-1.amazonaws.com/account-id/queue-name',
+  region: 'eu-west-1',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+});
+
 // send messages to the queue
 producer.send(['msg1', 'msg2'], err => {
   if (err) console.log(err);


### PR DESCRIPTION
Added accessKeyId and secretAccessKey (taken from the README on the
project) to the Options interface. Added an (unused) producer to the
test with the extra Options set.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bbc/sqs-producer/tree/2aeb4c0ec6f9eed23f4d37b417fcd6090dbdb70e#usage
- [x] Increase the version number in the header if appropriate.
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~