### PR TITLE
[react-select] Fix the type of the options prop which can be a readonly array.

### DIFF
--- a/types/react-select/lib/types.d.ts
+++ b/types/react-select/lib/types.d.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
-export type OptionsType<OptionType> = OptionType[];
+export type OptionsType<OptionType> = ReadonlyArray<OptionType>;
 
 export interface GroupType<OptionType> {
   options: OptionsType<OptionType>;
   [key: string]: any;
 }
 
-export type GroupedOptionsType<UnionOptionType> = Array<GroupType<UnionOptionType>>;
+export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>>;
 
 export type ValueType<OptionType> = OptionType | OptionsType<OptionType> | null | undefined;
 

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -7,7 +7,7 @@ export interface ColourOption {
     disabled?: boolean;
 }
 
-export const colourOptions: ColourOption[] = [
+export const colourOptions: ReadonlyArray<ColourOption> = [
   { value: 'ocean', label: 'Ocean', color: '#00B8D9' },
   { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },


### PR DESCRIPTION
The fix is actually a recommendation of the common mistakes.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.