### PR TITLE
fetch raw header values from Email

### DIFF
--- a/types/google-apps-script/google-apps-script.gmail.d.ts
+++ b/types/google-apps-script/google-apps-script.gmail.d.ts
@@ -237,6 +237,7 @@ declare namespace GoogleAppsScript {
       getCc(): string;
       getDate(): Date;
       getFrom(): string;
+      getHeader(header: string): string;  
       getId(): string;
       getPlainBody(): string;
       getRawContent(): string;


### PR DESCRIPTION
A recent update to GmailMessage, support for fetching raw Headers from the Email.

Can be verified in the appscript editor.

```
  var accessToken = e.messageMetadata.accessToken;
  GmailApp.setCurrentMessageAccessToken(accessToken);

  var messageId = e.messageMetadata.messageId;
  var message = GmailApp.getMessageById(messageId);
  var headers = message.getHeader("Message-ID");
  Logger.log('header: '+ headers);
```