### PR TITLE
[vis] Added widthConstraint options to NodeOptions

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -777,8 +777,10 @@ export class Timeline {
   );
 
   /**
-   * Add new vertical bar representing a custom time that can be dragged by the user. Parameter time can be a Date, Number, or String, and is new Date() by default.
-   * Parameter id can be Number or String and is undefined by default. The id is added as CSS class name of the custom time bar, allowing to style multiple time bars differently.
+   * Add new vertical bar representing a custom time that can be dragged by the user.
+   * Parameter time can be a Date, Number, or String, and is new Date() by default.
+   * Parameter id can be Number or String and is undefined by default.
+   * The id is added as CSS class name of the custom time bar, allowing to style multiple time bars differently.
    * The method returns id of the created bar.
    */
   addCustomTime(time: DateType, id?: IdType): IdType;
@@ -859,7 +861,8 @@ export class Timeline {
   removeCustomTime(id: IdType): void;
 
   /**
-   * Set a current time. This can be used for example to ensure that a client's time is synchronized with a shared server time. Only applicable when option showCurrentTime is true.
+   * Set a current time. This can be used for example to ensure that a client's time is synchronized with a shared server time.
+   * Only applicable when option showCurrentTime is true.
    */
   setCurrentTime(time: DateType): void;
 
@@ -895,12 +898,14 @@ export class Timeline {
   setItems(items: DataItemCollectionType): void;
 
   /**
-   * Set or update options. It is possible to change any option of the timeline at any time. You can for example switch orientation on the fly.
+   * Set or update options. It is possible to change any option of the timeline at any time.
+   * You can for example switch orientation on the fly.
    */
   setOptions(options: TimelineOptions): void;
 
   /**
-   * Select one or multiple items by their id. The currently selected items will be unselected. To unselect all selected items, call `setSelection([])`.
+   * Select one or multiple items by their id. The currently selected items will be unselected.
+   * To unselect all selected items, call `setSelection([])`.
    */
   setSelection(ids: IdType | IdType[], options?: { focus: boolean, animation: TimelineAnimationOptions }): void;
 
@@ -1862,7 +1867,9 @@ export interface NodeOptions {
 
   value?: number;
 
-  /** If false, no widthConstraint is applied. If a number is specified, the minimum and maximum widths of the node are set to the value. The node's label's lines will be broken on spaces to stay below the maximum and the node's width will be set to the minimum if less than the value. */
+  /** If false, no widthConstraint is applied. If a number is specified, the minimum and maximum widths of the node are set to the value.
+   * The node's label's lines will be broken on spaces to stay below the maximum and the node's width
+   * will be set to the minimum if less than the value. */
   widthConstraint?: number | boolean | { minimum?: number, maximum?: number }
 
   x?: number;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1861,6 +1861,9 @@ export interface NodeOptions {
 
   value?: number;
 
+  /** If false, no widthConstraint is applied. If a number is specified, the minimum and maximum widths of the node are set to the value. The node's label's lines will be broken on spaces to stay below the maximum and the node's width will be set to the minimum if less than the value. */
+  widthConstraint?: number | boolean | { minimum?: number, maximum?: number }
+
   x?: number;
 
   y?: number;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1867,10 +1867,12 @@ export interface NodeOptions {
 
   value?: number;
 
-  /** If false, no widthConstraint is applied. If a number is specified, the minimum and maximum widths of the node are set to the value.
+  /**
+   * If false, no widthConstraint is applied. If a number is specified, the minimum and maximum widths of the node are set to the value.
    * The node's label's lines will be broken on spaces to stay below the maximum and the node's width
-   * will be set to the minimum if less than the value. */
-  widthConstraint?: number | boolean | { minimum?: number, maximum?: number }
+   * will be set to the minimum if less than the value.
+   */
+  widthConstraint?: number | boolean | { minimum?: number, maximum?: number };
 
   x?: number;
 

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -13,6 +13,7 @@
 //                 Avraham Essoudry <https://github.com/avrahamcool>
 //                 Dmitriy Trifonov <https://github.com/divideby>
 //                 Sam Welek <https://github.com/tiberiushunter>
+//                 Slaven Tomac <https://github.com/slavede>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { MomentInput, MomentFormatSpecification, Moment } from 'moment';

--- a/types/vis/vis-tests.ts
+++ b/types/vis/vis-tests.ts
@@ -1,4 +1,6 @@
-import { NodeOptions } from './index';
+import { NodeOptions } from 'vis';
+import vis from 'vis';
+
 // Test DataSet constructor
 new vis.DataSet();
 new vis.DataSet({});

--- a/types/vis/vis-tests.ts
+++ b/types/vis/vis-tests.ts
@@ -1,3 +1,4 @@
+import { NodeOptions } from './index';
 // Test DataSet constructor
 new vis.DataSet();
 new vis.DataSet({});
@@ -217,3 +218,29 @@ options = {
 };
 
 network.setOptions(options);
+
+//
+// should accept different formats of widthConstraint for NodeOptions
+//
+let nodeWidthConstraintOptions: NodeOptions = {
+    widthConstraint: {
+        maximum: 100
+    }
+}
+nodeWidthConstraintOptions = {
+    widthConstraint: false
+}
+nodeWidthConstraintOptions = {
+    widthConstraint: {
+        minimum: 1,
+        maximum: 5
+    }
+}
+nodeWidthConstraintOptions = {
+    widthConstraint: {
+        minimum: 1
+    }
+}
+nodeWidthConstraintOptions = {
+    widthConstraint: 150
+}

--- a/types/vis/vis-tests.ts
+++ b/types/vis/vis-tests.ts
@@ -1,5 +1,5 @@
 import { NodeOptions } from 'vis';
-import vis from 'vis';
+import vis = require('vis');
 
 // Test DataSet constructor
 new vis.DataSet();
@@ -37,7 +37,7 @@ data.add([
 ]);
 
 // subscribe to any change in the DataSet
-data.on('*', (event, properties, senderId) => {
+data.on('*', (event: any, properties: any, senderId: any) => {
   console.log('event', event, properties);
 });
 
@@ -57,7 +57,7 @@ console.log('item1', item1);
 
 // retrieve a filtered subset of the data
 let items = data.get({
-  filter: (item) => {
+  filter: (item: any) => {
     return item.group === 1;
   }
 });
@@ -80,7 +80,7 @@ console.log('formatted items', items);
 data = new vis.DataSet<TestData>();
 
 // subscribe to any change in the DataSet
-data.on('*', (event, properties, senderId) => {
+data.on('*', (event: any, properties: any, senderId: any) => {
   console.log('event:', event, 'properties:', properties, 'senderId:', senderId);
 });
 
@@ -135,14 +135,14 @@ const dataset = new vis.DataSet<TestData>();
 
 // retrieve all items having a property group with value 2
 const group2 = dataset.get({
-  filter: (item) => {
+  filter: (item: any) => {
     return (item.group === 2);
   }
 });
 
 // retrieve all items having a property balance with a value above zero
 const positiveBalance = dataset.get({
-  filter: (item) => {
+  filter: (item: any) => {
     return item.balance !== undefined && item.balance > 0;
   }
 });
@@ -228,21 +228,21 @@ let nodeWidthConstraintOptions: NodeOptions = {
     widthConstraint: {
         maximum: 100
     }
-}
+};
 nodeWidthConstraintOptions = {
     widthConstraint: false
-}
+};
 nodeWidthConstraintOptions = {
     widthConstraint: {
         minimum: 1,
         maximum: 5
     }
-}
+};
 nodeWidthConstraintOptions = {
     widthConstraint: {
         minimum: 1
     }
-}
+};
 nodeWidthConstraintOptions = {
     widthConstraint: 150
-}
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). 

Also fixed previous lint issues

http://visjs.org/docs/network/nodes.html
NodeOptions should have widthConstraint option.
