### PR TITLE
[jasmine] Allow calling spyOn for class constructors and add AnyMethods type to jasmine namespace

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -11,6 +11,7 @@
 //                 Yaroslav Admin <https://github.com/devoto13>
 //                 Domas Trijonis <https://github.com/fdim>
 //                 Peter Safranek <https://github.com/pe8ter>
+//                 Moshe Kolodny <https://github.com/kolodny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -150,20 +150,18 @@ interface DoneFn extends Function {
     fail: (message?: Error | string) => void;
 }
 
-type Methods<T> = {
-    [K in {
-        [K in keyof T]: T[K] extends Function ? K : never
-    }[keyof T]]: T[K]
-};
-
 /**
  * Install a spy onto an existing object.
  * @param object The object upon which to install the `Spy`.
  * @param method The name of the method to replace with a `Spy`.
  */
 declare function spyOn<T, K extends keyof T = keyof T>(
-    object: T, method: T[K] extends InferableFunction ? K : never,
-): jasmine.Spy<T[K] extends InferableFunction ? T[K] : never>;
+    object: T, method: T[K] extends Function ? K : never,
+): jasmine.Spy<
+    T[K] extends InferableFunction ? T[K] :
+    T[K] extends {new (...args: infer A): infer V} ? (...args: A) => V :
+    T[K] extends Function ? InferableFunction : never
+>;
 
 /**
  * Install a spy on a property installed with `Object.defineProperty` onto an existing object.
@@ -189,6 +187,12 @@ declare namespace jasmine {
         T extends undefined ?
             (ReadonlyArray<string> | {[methodName: string]: any}) :
             (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends InferableFunction ? T[P] : any>});
+
+    type AnyMethods<T> = {
+        [K in {
+            [K in keyof T]: T[K] extends Function ? K : never
+        }[keyof T]]: InferableFunction
+    };
 
     function clock(): Clock;
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1194,6 +1194,16 @@ describe('better typed spys', () => {
              // $ExpectType string
             spy.calls.first().returnValue;
         });
+        it('works on constructors', () => {
+            class MyClass {
+                constructor(readonly foo: string) {}
+            }
+            const namespace = { MyClass };
+            const spy = spyOn(namespace, 'MyClass');
+            spy.and.returnValue({foo: 'test'});
+            spy.and.returnValue({}); // $ExpectError
+            spy.and.returnValue({foo: 123}); // $ExpectError
+        });
         it('can allows overriding the generic', () => {
             class Base {
                 service() {}
@@ -1217,6 +1227,16 @@ describe('better typed spys', () => {
 
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
+        });
+
+        it('has a way to opt out of inferred function types', () => {
+            interface I {
+                f(): string;
+                f(x: any): number;
+              }
+
+            const spyObject = jasmine.createSpyObj<jasmine.AnyMethods<I>>("spyObject", ["f"]);
+            spyObject.f.and.returnValue("a string - working");
         });
     });
 });


### PR DESCRIPTION
This PR includes a fix to allow calling `spyOn` with a class constructor as well as an `AnyMethods` type which allows opting out of the inferring that's done for `createSpyObj`. This should unblock #34080 for overloaded functions

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- ~Increase the version number in the header if appropriate.~
