### PR TITLE
@types/mongodb - Add MongoNetworkError & MongoParseError classes

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -225,6 +225,14 @@ export class MongoError extends Error {
      * https://github.com/mongodb/node-mongodb-native/blob/a12aa15ac3eaae3ad5c4166ea1423aec4560f155/test/functional/find_tests.js#L1111
      */
     errmsg?: string;
+    name: string;
+}
+
+
+/** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoNetworkError.html */
+export class MongoNetworkError extends MongoError {
+    constructor(message: string);
+    errorLabels: string[];
 }
 
 

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -236,6 +236,12 @@ export class MongoNetworkError extends MongoError {
 }
 
 
+/** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoParseError.html */
+export class MongoParseError extends MongoError {
+    constructor(message: string);
+}
+
+
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#.connect */
 export interface MongoClientOptions extends
     DbCreateOptions,

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -344,3 +344,7 @@ mongodb.connect(connectionString).then((client) => {
         testCollectionReduceFunction
     );
 });
+
+// Test other error classes
+new mongodb.MongoNetworkError('network error');
+new mongodb.MongoParseError('parse error');


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/3.1/api/node_modules_mongodb-core_lib_error.js.html#line58
- [ ] Increase the version number in the header if appropriate. **Where do I do this?**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds two classes which were missing from the type definitions:
- MongoNetworkError
- MongoParseError

It also adds the `name` property to the `MongoError` class as this is something which exists in the source code implementation but is not covered by the types.
