### PR TITLE
Remove myself from definition contributors list for Underscore

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov>,
 //                 Josh Baldwin <https://github.com/jbaldwin>,
 //                 Christopher Currens <https://github.com/ccurrens>,
-//                 Cassey Lottman <https://github.com/clottman>,
 //                 Ard Timmerman <https://github.com/confususs>,
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>,
 //                 Florian Keller <https://github.com/ffflorian>


### PR DESCRIPTION
No code changes, just removing myself from contributors. I don't use typescript or underscore much anymore, so don't want to keep getting notified on definition change requests. 