### PR TITLE
jsonpack: add type definitions

### DIFF
--- a/types/jsonpack/index.d.ts
+++ b/types/jsonpack/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for jsonpack 1.1
+// Project: https://github.com/sapienlab/jsonpack
+// Definitions by: Vlad Jerca <https://github.com/vladjerca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+export interface PackOptions {
+    verbose?: boolean;
+}
+
+export interface PackDebugOptions extends PackOptions {
+    debug?: boolean;
+}
+
+export interface DebugObject {
+    dictionary: {
+        strings: string[],
+        integers: number[],
+        floats: number[],
+    };
+    ast: Array<{
+        type: string;
+        index: number;
+    }>;
+    packed: string;
+}
+
+export function pack(json: string | object, options?: PackOptions): string;
+export function pack(json: string | object, options?: PackDebugOptions): DebugObject;
+// tslint:disable-next-line no-unnecessary-generics
+export function unpack<T = {}>(packed: string, options?: PackOptions): T;

--- a/types/jsonpack/jsonpack-tests.ts
+++ b/types/jsonpack/jsonpack-tests.ts
@@ -1,0 +1,13 @@
+import * as jsonpack from 'jsonpack';
+
+const obj = { myString: 'myStringValue' };
+
+jsonpack.pack(obj); // $ExpectType string
+jsonpack.pack(obj, { verbose: true }); // $ExpectType string
+jsonpack.pack(JSON.stringify(obj)); // $ExpectType string
+jsonpack.pack(JSON.stringify(obj), { debug: true }); // $ExpectType DebugObject
+
+const packed = 'packed-string-here';
+
+jsonpack.unpack(packed); // $ExpectType {}
+jsonpack.unpack<string>(packed, { verbose: true }); // $ExpectType string

--- a/types/jsonpack/tsconfig.json
+++ b/types/jsonpack/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsonpack-tests.ts"
+    ]
+}

--- a/types/jsonpack/tslint.json
+++ b/types/jsonpack/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add type definitions for `jsonpack`:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
