### PR TITLE
[@types/lodash] _.chain().get() shorthand for empty array default

### DIFF
--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1125,7 +1125,7 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TKey extends keyof T, TDefault>(path: TKey | [TKey], defaultValue: []): T[TKey] extends Array<any> ? ExpChain<Exclude<T[TKey], undefined>> : never;
+        get<TKey extends keyof T>(path: TKey | [TKey], defaultValue: []): T[TKey] extends any[] ? ExpChain<Exclude<T[TKey], undefined>> : ExpChain<Exclude<T[TKey], undefined> | []>;
         /**
          * @see _.get
          */

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1125,7 +1125,7 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TKey extends keyof T>(path: TKey | [TKey], defaultValue: []): T[TKey] extends any[] ? ExpChain<Exclude<T[TKey], undefined>> : ExpChain<Exclude<T[TKey], undefined> | []>;
+        get<TKey extends keyof T>(path: TKey | [TKey], defaultValue: never[]): T[TKey] extends any[] ? ExpChain<Exclude<T[TKey], undefined>> : ExpChain<Exclude<T[TKey], undefined> | []>;
         /**
          * @see _.get
          */

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1125,7 +1125,7 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TKey extends keyof T>(path: TKey | [TKey], defaultValue: never[]): T[TKey] extends any[] ? ExpChain<Exclude<T[TKey], undefined>> : ExpChain<Exclude<T[TKey], undefined> | []>;
+        get<TKey extends keyof T>(path: TKey | [TKey], defaultValue: never[]): T[TKey] extends any[] ? ExpChain<Exclude<T[TKey], undefined>> : ExpChain<Exclude<T[TKey], undefined> | never[]>;
         /**
          * @see _.get
          */

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1125,6 +1125,10 @@ declare module "../index" {
         /**
          * @see _.get
          */
+        get<TKey extends keyof T, TDefault>(path: TKey | [TKey], defaultValue: []): T[TKey] extends Array<any> ? ExpChain<Exclude<T[TKey], undefined>> : never;
+        /**
+         * @see _.get
+         */
         get<TKey extends keyof T, TDefault>(path: TKey | [TKey], defaultValue: TDefault): ExpChain<Exclude<T[TKey], undefined> | TDefault>;
         /**
          * @see _.get

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5201,7 +5201,7 @@ fp.now(); // $ExpectType number
     _.chain({ a: undefined }).get("a"); // $ExpectType never
     _.chain({ a: value }).get("a", defaultValue); // $ExpectType StringChain | PrimitiveChain<false> | PrimitiveChain<true>
     _.chain({ a: undefined }).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
-    _.chain({ a: [1] }).get("a", []); // $ExpectType CollectionChain<number>
+    _.chain({ a: [1] }).get("a", []).map((val) => val.toFixed()); // $ExpectType CollectionChain<string>
 
     fp.get(Symbol.iterator, []); // $ExpectType any
     fp.get(Symbol.iterator)([]); // $ExpectType any

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5201,6 +5201,7 @@ fp.now(); // $ExpectType number
     _.chain({ a: undefined }).get("a"); // $ExpectType never
     _.chain({ a: value }).get("a", defaultValue); // $ExpectType StringChain | PrimitiveChain<false> | PrimitiveChain<true>
     _.chain({ a: undefined }).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
+    _.chain({ a: [1] }).get("a", []); // $ExpectType CollectionChain<number>
 
     fp.get(Symbol.iterator, []); // $ExpectType any
     fp.get(Symbol.iterator)([]); // $ExpectType any


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.11#get
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

## Original issue:

If I use `_.chain(obj).get('prop', []).value()` to grab an array off of an object (while providing an empty array as a fallback), the TypeScript compiler will throw an error when using the current types (v4.14.129).

This issue does not occur if I do _not_ provide a default value, or if I explicitly cast the empty array to the correct type (ie. `.get('prop', [] as number[])`). 

This is a regression from `@types/lodash` v4.14.123

**Note**: My fix is fairly limited in scope (and, TBH, feels kind of messy) -- however, I wasn't able to come up with any similar scenarios.  If I'm missing something, and this is indicative of a larger issue, please feel free to flag it!

---

## Full Example:

### This works
```ts
interface Employee {
  phone?: number
}
interface Employees {
  employees?: Employee[]
}
const all:Employees = { employees: [{ phone: 1 }, {}, {}] };
const phoneUsers = _.chain(all)
    .get('employees')
    .filter((e) => !!e.phone)
    .value();
```

### This does not work
```ts
// same interfaces as above
const phoneUsers = _.chain(all)
    .get('employees', [])
    .filter((e) => !!e.phone) // tsc error
    .value();
```

`.get('employees', [] as Employee[])` _does_ work (but shouldn't be necessary).

This second example worked in `@types/lodash v4.14.123`.  