### PR TITLE
fetch-mock: response header values are always strings

### DIFF
--- a/types/fetch-mock/index.d.ts
+++ b/types/fetch-mock/index.d.ts
@@ -82,7 +82,7 @@ declare namespace fetchMock {
         /**
          * Set the response headers.
          */
-        headers?: { [key: string]: string | number };
+        headers?: { [key: string]: string };
 
         /**
          * If this property is present then a Promise rejected with the value


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (tested locally by editing `node_modules/\@types/fetch-mock/index.d.ts` directly)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35462#issuecomment-492757844
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

ping @merrywhether 🙏 