### PR TITLE
[react-tracking] Add new Context API types

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tracking 5.0
+// Type definitions for react-tracking 6.0
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -57,6 +57,12 @@ export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any]) =>
 type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction;
 type MethodDecorator = <T>(target: object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
 export type Decorator = ClassDecorator & MethodDecorator;
+
+export type TrackingContext<T = any> = React.Context<{
+    tracking: Options<T> & { data?: {} }
+}>;
+
+export const ReactTrackingContext: TrackingContext;
 
 /**
  * This is the type of the `track` function. It’s declared as an interface so that consumers can extend the typing and

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Track, track as _track, TrackingProp, Options, Decorator } from 'react-tracking';
+import { Track, track as _track, TrackingProp, Options, Decorator, TrackingContext, ReactTrackingContext } from 'react-tracking';
 
 function customEventReporter(data: { page?: string }) {}
 
@@ -70,3 +70,18 @@ class Test extends React.Component<any, null> {
         );
     }
 }
+
+const TestContext = () => {
+    const trackingContext = {
+        tracking: {
+            data: { foo: 'bar' },
+            dispatch: (data: {}) => data,
+            process: (x: string) => x
+        }
+    };
+    return (
+        <ReactTrackingContext.Provider value={trackingContext}>
+            <div>hello how are you</div>
+        </ReactTrackingContext.Provider>
+    );
+};


### PR DESCRIPTION
This PR updates types to match `react-tracking@6.0.0`'s new React 16.3+ Context API. 

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/nytimes/react-tracking/pull/118>
- [x] Increase the version number in the header if appropriate.
