### PR TITLE
[coinbase-commerce-node] Add missing event type and make EventResource generic.

### DIFF
--- a/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
+++ b/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
@@ -292,8 +292,6 @@ const eventChargeResponseExample: EventResource<ChargeResource> = {
     data: chargeResponseExample,
 };
 
-
-
 /**
  * Retrieve an event by ID.
  */

--- a/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
+++ b/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
@@ -269,6 +269,32 @@ const eventResponseExample: EventResource = {
 };
 
 /**
+ * Event resource with Checkout data.
+ */
+const eventCheckoutResponseExample: EventResource<CheckoutResource> = {
+    id: '24934862-d980-46cb-9402-43c81b0cdba6',
+    resource: 'event',
+    type: 'charge:created',
+    api_version: '2018-03-22',
+    created_at: '2017-01-31T20:49:02Z',
+    data: checkoutResponseExample,
+};
+
+/**
+ * Event resource with Charge data.
+ */
+const eventChargeResponseExample: EventResource<ChargeResource> = {
+    id: '24934862-d980-46cb-9402-43c81b0cdba6',
+    resource: 'event',
+    type: 'charge:created',
+    api_version: '2018-03-22',
+    created_at: '2017-01-31T20:49:02Z',
+    data: chargeResponseExample,
+};
+
+
+
+/**
  * Retrieve an event by ID.
  */
 Event.retrieve(eventResponseExample.id).then((event) => {

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -424,7 +424,7 @@ interface EventResource {
      * Event Payload.
      * Resource of the associated object at the time of the event.
      */
-    data: ChargeResource | CheckoutResource;
+    data: ChargeResource & CheckoutResource;
 }
 
 /**

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -408,7 +408,7 @@ interface EventResource {
     /**
      * Event type.
      */
-    type: 'charge:created' | 'charge:confirmed' | 'charge:failed' | 'charge:delayed' | 'charge:pending';
+    type: 'charge:created' | 'charge:confirmed' | 'charge:failed' | 'charge:delayed' | 'charge:pending' | 'charge:resolved';
 
     /**
      * Event creation time.

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -394,7 +394,7 @@ interface CheckoutResource extends BaseCheckout {
  *
  * @link
  */
-interface EventResource {
+interface EventResource<T = ChargeResource | CheckoutResource> {
     /**
      * Event UUID.
      */
@@ -424,7 +424,7 @@ interface EventResource {
      * Event Payload.
      * Resource of the associated object at the time of the event.
      */
-    data: ChargeResource & CheckoutResource;
+    data: T;
 }
 
 /**


### PR DESCRIPTION
Adjusted `EventResource` interface to include a left-out event type. ([`charge:resolved`](https://commerce.coinbase.com/docs/api/#types-of-events)) Also made the EventResource interface a generic to allow for non-payment-related event handling.

- [x] Test the change in your own code. (Compile and run.)
- [x] Add tests for changes.

## Reference links
##### Types of events
https://commerce.coinbase.com/docs/api/#types-of-events
##### The event resource
https://commerce.coinbase.com/docs/api/#event-resource