### PR TITLE
[prompts] Fix `type` and `validate` function definitions

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prompts 2.04
+// Type definitions for prompts 2.0
 // Project: https://github.com/terkelg/prompts
 // Definitions by: Berkay GURSOY <https://github.com/Berkays>
 //                 Daniel Perez Alvarez <https://github.com/danielpa9708>
@@ -60,7 +60,7 @@ declare namespace prompts {
     }
 
     interface PromptObject<T extends string = string> {
-        type: ValueOrFunc<PromptType> | Falsy;
+        type: PromptType | Falsy | PrevCaller<T, PromptType | Falsy>;
         name: ValueOrFunc<T>;
         message?: ValueOrFunc<string>;
         initial?: string | number | boolean | Date;

--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -66,7 +66,7 @@ declare namespace prompts {
         initial?: string | number | boolean | Date;
         style?: string;
         format?: PrevCaller<T, void>;
-        validate?: PrevCaller<T, void>;
+        validate?: PrevCaller<T, boolean | string>;
         onState?: PrevCaller<T, void>;
         min?: number;
         max?: number;

--- a/types/prompts/prompts-tests.ts
+++ b/types/prompts/prompts-tests.ts
@@ -12,3 +12,23 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
     const HasPropValue: HasProperty<typeof response, "value"> = true;
     const DoesntHavePropAsdf: HasProperty<typeof response, "asdf"> = false;
 })();
+
+(async () => {
+    await prompts([
+        {
+            type: 'text',
+            name: 'language',
+            message: "What langauge is the next greatest thing since sliced bread?",
+        },
+        {
+            type: (prev, values) => {
+                const HasPromptName: HasProperty<typeof values, "language"> = true;
+                const DoesntHavePromptTypes: HasProperty<typeof values, "text"> = false;
+
+                return prev === 'javascript' ? 'confirm' : null;
+            },
+            name: 'confirmation',
+            message: "Have you tried TypeScript?"
+        }
+    ]);
+})();


### PR DESCRIPTION
1. Allows `type` to return `Falsy` values:

As defined in the documentation here: https://github.com/terkelg/prompts#type

The `type` field can be a function which returns a `Falsy` value to disable the prompt, which is currently not allowed by these type definitions:

> If `type` is a falsy value the prompter will skip that question.

2. Fixes the type of `values` in `PrevCaller`:

The definition for `PrevCaller` for `type` is also fixed in this PR, in that the current behavior sets `values: Answers<T>` with `T = PromptType`, instead of using `T` from `PromptObject` (so `values` contained keys like `"select"` instead of keys that corresponded to the `name`'s).

3. Updates `validate` to allow returning `boolean | string` instead of `void`

See: https://github.com/terkelg/prompts#textmessage-initial-style

> Receive user input. Should return true if the value is valid, and an error message String otherwise. If false is returned, a default error message is shown

----

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.