### PR TITLE
[coinbase-commerce-node] Correct placement of Webhook namespace.

### DIFF
--- a/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
+++ b/types/coinbase-commerce-node/coinbase-commerce-node-tests.ts
@@ -6,13 +6,13 @@ import {
     Client,
     EventResource,
     CreateCharge,
+    Webhook,
     resources as Resource
 } from 'coinbase-commerce-node';
 
 const Checkout = Resource.Checkout;
 const Charge = Resource.Charge;
 const Event = Resource.Event;
-const Webhook = Resource.Webhook;
 
 /**
  * Initialize client.

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -575,29 +575,29 @@ export namespace resources {
         static all(paginationOptions: PaginationRequest, callback?: Callback<Event[]>): Promise<Event[]>;
     }
 
-    /**
-     * Webhook class.
-     *
-     * @link https://github.com/coinbase/coinbase-commerce-node#webhooks
-     */
-    namespace Webhook {
-        /**
-         * Verify a signature header.
-         *
-         * @link https://github.com/coinbase/coinbase-commerce-node#verify-signature-header
-         */
-        function verifySigHeader(rawBody: string, signature: string, sharedSecret: string): void;
-    }
-
     export {
-        Webhook,
         Event,
         Charge,
         Checkout,
     };
 }
 
+/**
+ * Webhook class.
+ *
+ * @link https://github.com/coinbase/coinbase-commerce-node#webhooks
+ */
+declare module Webhook {
+    /**
+     * Verify a signature header.
+     *
+     * @link https://github.com/coinbase/coinbase-commerce-node#verify-signature-header
+     */
+    export function verifySigHeader(rawBody: string, signature: string, sharedSecret: string): void;
+}
+
 export {
+    Webhook,
     Pagination,
     ChargeResource,
     CheckoutResource,

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -593,7 +593,7 @@ declare namespace Webhook {
      *
      * @link https://github.com/coinbase/coinbase-commerce-node#verify-signature-header
      */
-    export function verifySigHeader(rawBody: string, signature: string, sharedSecret: string): void;
+    function verifySigHeader(rawBody: string, signature: string, sharedSecret: string): void;
 }
 
 export {

--- a/types/coinbase-commerce-node/index.d.ts
+++ b/types/coinbase-commerce-node/index.d.ts
@@ -587,7 +587,7 @@ export namespace resources {
  *
  * @link https://github.com/coinbase/coinbase-commerce-node#webhooks
  */
-declare module Webhook {
+declare namespace Webhook {
     /**
      * Verify a signature header.
      *


### PR DESCRIPTION
Corrected the placement of the `Webhook` namespace for [coinbase-commerce-node](https://github.com/coinbase/coinbase-commerce-node).

The `Webhook` module is a top-level export, but its namespace was nested under the [`resources`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cf02bffc101de9896e6f3734b10ad94454c50043/types/coinbase-commerce-node/index.d.ts#L442) module.

- [x] Test the change in your own code.
- [x] Adjust tests according to changes.

## Source references
##### `resources` definition
https://github.com/coinbase/coinbase-commerce-node/blob/master/index.js#L1
##### `Webhooks` export
https://github.com/coinbase/coinbase-commerce-node/blob/master/index.js#L24
##### `resources` export
https://github.com/coinbase/coinbase-commerce-node/blob/master/index.js#L25