### PR TITLE
[redux-actions] Make action type generic along with createAction for string literal inference (2.7)

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -87,9 +87,9 @@ export type ActionFunction4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4
 export type ActionFunctionAny<R> = (...args: any[]) => R;
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/createAction.js#L6
-export function createAction<T extends ActionType = ActionType>(
+export function createAction<Payload = any, T extends ActionType = ActionType>(
     actionType: T,
-): ActionFunctionAny<Action<any>>;
+): ActionFunctionAny<Action<Payload, T>>;
 
 export function createAction<Payload, T extends ActionType = ActionType>(
     actionType: T,

--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -11,18 +11,20 @@
 
 export as namespace ReduxActions;
 
+export type ActionType = string;
+
 // FSA-compliant action.
 // See: https://github.com/acdlite/flux-standard-action
-export interface BaseAction<T extends string> {
+export interface BaseAction<T extends ActionType> {
     type: T;
 }
 
-export interface Action<Payload, T extends string> extends BaseAction<T> {
+export interface Action<Payload, T extends ActionType = ActionType> extends BaseAction<T> {
     payload: Payload;
     error?: boolean;
 }
 
-export interface ActionMeta<Payload, Meta, T extends string> extends Action<Payload, T> {
+export interface ActionMeta<Payload, Meta, T extends ActionType = ActionType> extends Action<Payload, T> {
     meta: Meta;
 }
 
@@ -31,29 +33,29 @@ export interface CombinedActionType {
     _dummy: undefined;
 }
 
-export type ReducerMapValue<State, Payload, T extends string> =
-    Reducer<State, Payload, T>
-    | ReducerNextThrow<State, Payload, T>
-    | ReducerMap<State, Payload, T>;
+export type ReducerMapValue<State, Payload> =
+    Reducer<State, Payload>
+    | ReducerNextThrow<State, Payload>
+    | ReducerMap<State, Payload>;
 
-export interface ReducerMap<State, Payload, T extends string> {
-    [actionType: string]: ReducerMapValue<State, Payload, T>;
+export interface ReducerMap<State, Payload> {
+    [actionType: string]: ReducerMapValue<State, Payload>;
 }
 
-export interface ReducerMapMeta<State, Payload, Meta, T extends string> {
-    [actionType: string]: ReducerMeta<State, Payload, Meta, T> | ReducerNextThrowMeta<State, Payload, Meta, T> | ReducerMapMeta<State, Payload, Meta, T>;
+export interface ReducerMapMeta<State, Payload, Meta> {
+    [actionType: string]: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta> | ReducerMapMeta<State, Payload, Meta>;
 }
 
-export interface ReducerNextThrow<State, Payload, T extends string> {
-    next?(state: State, action: Action<Payload, T>): State;
+export interface ReducerNextThrow<State, Payload> {
+    next?(state: State, action: Action<Payload>): State;
 
-    throw?(state: State, action: Action<Payload, T>): State;
+    throw?(state: State, action: Action<Payload>): State;
 }
 
-export interface ReducerNextThrowMeta<State, Payload, Meta, T extends string> {
-    next?(state: State, action: ActionMeta<Payload, Meta, T>): State;
+export interface ReducerNextThrowMeta<State, Payload, Meta> {
+    next?(state: State, action: ActionMeta<Payload, Meta>): State;
 
-    throw?(state: State, action: ActionMeta<Payload, Meta, T>): State;
+    throw?(state: State, action: ActionMeta<Payload, Meta>): State;
 }
 
 export type BaseActionFunctions<TAction> =
@@ -64,17 +66,17 @@ export type BaseActionFunctions<TAction> =
     ActionFunction4<any, any, any, any, TAction> |
     ActionFunctionAny<TAction>;
 
-export type ActionFunctions<Payload, T extends string> = BaseActionFunctions<Action<Payload, T>>;
+export type ActionFunctions<Payload> = BaseActionFunctions<Action<Payload>>;
 
-export type ActionWithMetaFunctions<Payload, Meta, T extends string> = BaseActionFunctions<ActionMeta<Payload, Meta, T>>;
+export type ActionWithMetaFunctions<Payload, Meta> = BaseActionFunctions<ActionMeta<Payload, Meta>>;
 
-export type Reducer<State, Payload, T extends string> = (state: State, action: Action<Payload, T>) => State;
+export type Reducer<State, Payload> = (state: State, action: Action<Payload>) => State;
 
-export type ReducerMeta<State, Payload, Meta, T extends string> = (state: State, action: ActionMeta<Payload, Meta, T>) => State;
+export type ReducerMeta<State, Payload, Meta> = (state: State, action: ActionMeta<Payload, Meta>) => State;
 
-export type ReduxCompatibleReducer<State, Payload, T extends string> = (state: State | undefined, action: Action<Payload, T>) => State;
+export type ReduxCompatibleReducer<State, Payload> = (state: State | undefined, action: Action<Payload>) => State;
 
-export type ReduxCompatibleReducerMeta<State, Payload, Meta, T extends string> = (state: State | undefined, action: ActionMeta<Payload, Meta, T>) => State;
+export type ReduxCompatibleReducerMeta<State, Payload, Meta> = (state: State | undefined, action: ActionMeta<Payload, Meta>) => State;
 
 /** argument inferring borrowed from lodash definitions */
 export type ActionFunction0<R> = () => R;
@@ -85,112 +87,112 @@ export type ActionFunction4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4
 export type ActionFunctionAny<R> = (...args: any[]) => R;
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/createAction.js#L6
-export function createAction<T extends string>(
+export function createAction<T extends ActionType = ActionType>(
     actionType: T,
-): ActionFunctionAny<Action<any, T>>;
+): ActionFunctionAny<Action<any>>;
 
-export function createAction<Payload, T extends string>(
+export function createAction<Payload, T extends ActionType = ActionType>(
     actionType: T,
     payloadCreator: ActionFunction0<Payload>,
 ): ActionFunction0<Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, T extends string>(
+export function createAction<Payload, Arg1, T extends ActionType = ActionType>(
     actionType: T,
     payloadCreator: ActionFunction1<Arg1, Payload>,
 ): ActionFunction1<Arg1, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2, T extends string>(
+export function createAction<Payload, Arg1, Arg2, T extends ActionType = ActionType>(
     actionType: T,
     payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
 ): ActionFunction2<Arg1, Arg2, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2, Arg3, T extends string>(
+export function createAction<Payload, Arg1, Arg2, Arg3, T extends ActionType = ActionType>(
     actionType: T,
     payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
 ): ActionFunction3<Arg1, Arg2, Arg3, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2, Arg3, Arg4, T extends string>(
+export function createAction<Payload, Arg1, Arg2, Arg3, Arg4, T extends ActionType = ActionType>(
     actionType: T,
     payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
 ): ActionFunction4<Arg1, Arg2, Arg3, Arg4, Action<Payload, T>>;
 
-export function createAction<Payload, T extends string>(
+export function createAction<Payload, T extends ActionType = ActionType>(
     actionType: T,
 ): ActionFunction1<Payload, Action<Payload, T>>;
 
-export function createAction<Meta, T extends string>(
-    actionType: string,
+export function createAction<Meta, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: null | undefined,
     metaCreator: ActionFunctionAny<Meta>,
 ): ActionFunctionAny<ActionMeta<any, Meta, T>>;
 
-export function createAction<Payload, Meta, T extends string>(
-    actionType: string,
+export function createAction<Payload, Meta, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: ActionFunctionAny<Payload>,
     metaCreator: ActionFunctionAny<Meta>,
 ): ActionFunctionAny<ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, T extends string>(
-    actionType: string,
+export function createAction<Payload, Meta, Arg1, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: ActionFunction1<Arg1, Payload>,
     metaCreator: ActionFunction1<Arg1, Meta>,
 ): ActionFunction1<Arg1, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2, T extends string>(
-    actionType: string,
+export function createAction<Payload, Meta, Arg1, Arg2, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
     metaCreator: ActionFunction2<Arg1, Arg2, Meta>,
 ): ActionFunction2<Arg1, Arg2, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2, Arg3, T extends string>(
-    actionType: string,
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
     metaCreator: ActionFunction3<Arg1, Arg2, Arg3, Meta>,
 ): ActionFunction3<Arg1, Arg2, Arg3, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4, T extends string>(
-    actionType: string,
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4, T extends ActionType = ActionType>(
+    actionType: T,
     payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
     metaCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Meta>,
 ): ActionFunction4<Arg1, Arg2, Arg3, Arg4, ActionMeta<Payload, Meta, T>>;
 
-export function handleAction<State, Payload, T extends string>(
-    actionType: string | ActionFunctions<Payload, T> | CombinedActionType,
-    reducer: Reducer<State, Payload, T> | ReducerNextThrow<State, Payload, T>,
-    initialState: State,
-): ReduxCompatibleReducer<State, Payload, T>;
+export function handleAction<State, Payload>(
+    actionType: string | ActionFunctions<Payload> | CombinedActionType,
+    reducer: Reducer<State, Payload> | ReducerNextThrow<State, Payload>,
+    initialState: State
+): ReduxCompatibleReducer<State, Payload>;
 
-export function handleAction<State, Payload, Meta, T extends string>(
-    actionType: string | ActionWithMetaFunctions<Payload, Meta, T> | CombinedActionType,
-    reducer: ReducerMeta<State, Payload, Meta, T> | ReducerNextThrowMeta<State, Payload, Meta, T>,
-    initialState: State,
-): ReduxCompatibleReducerMeta<State, Payload, Meta, T>;
+export function handleAction<State, Payload, Meta>(
+    actionType: string | ActionWithMetaFunctions<Payload, Meta> | CombinedActionType,
+    reducer: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta>,
+    initialState: State
+): ReduxCompatibleReducerMeta<State, Payload, Meta>;
 
 export interface Options {
     prefix?: string;
     namespace?: string;
 }
 
-export function handleActions<StateAndPayload, T extends string>(
-    reducerMap: ReducerMap<StateAndPayload, StateAndPayload, T>,
+export function handleActions<StateAndPayload>(
+    reducerMap: ReducerMap<StateAndPayload, StateAndPayload>,
     initialState: StateAndPayload,
-    options?: Options,
-): ReduxCompatibleReducer<StateAndPayload, StateAndPayload, T>;
+    options?: Options
+): ReduxCompatibleReducer<StateAndPayload, StateAndPayload>;
 
-export function handleActions<State, Payload, T extends string>(
-    reducerMap: ReducerMap<State, Payload, T>,
+export function handleActions<State, Payload>(
+    reducerMap: ReducerMap<State, Payload>,
     initialState: State,
-    options?: Options,
-): ReduxCompatibleReducer<State, Payload, T>;
+    options?: Options
+): ReduxCompatibleReducer<State, Payload>;
 
-export function handleActions<State, Payload, Meta, T extends string>(
-    reducerMap: ReducerMapMeta<State, Payload, Meta, T>,
+export function handleActions<State, Payload, Meta>(
+    reducerMap: ReducerMapMeta<State, Payload, Meta>,
     initialState: State,
-    options?: Options,
-): ReduxCompatibleReducerMeta<State, Payload, Meta, T>;
+    options?: Options
+): ReduxCompatibleReducerMeta<State, Payload, Meta>;
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/combineActions.js#L21
-export function combineActions(...actionTypes: Array<ActionFunctions<any, any> | string | symbol>): CombinedActionType;
+export function combineActions(...actionTypes: Array<ActionFunctions<any> | string | symbol>): CombinedActionType;
 
 export interface ActionMap<Payload, Meta> {
     [actionType: string]:
@@ -200,16 +202,16 @@ export interface ActionMap<Payload, Meta> {
         undefined;
 }
 
-export function createActions<Payload, T extends string>(
+export function createActions<Payload>(
     actionMapOrIdentityAction: ActionMap<Payload, any> | string,
     ...identityActions: Array<string | Options>
 ): {
-    [actionName: string]: ActionFunctionAny<Action<Payload, T>>
+    [actionName: string]: ActionFunctionAny<Action<Payload>>
 };
 
-export function createActions<T extends string>(
+export function createActions(
     actionMapOrIdentityAction: ActionMap<any, any> | string,
     ...identityActions: Array<string | Options>
 ): {
-    [actionName: string]: ActionFunctionAny<Action<any, T>>
+    [actionName: string]: ActionFunctionAny<Action<any>>
 };

--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-actions 2.6
+// Type definitions for redux-actions 2.7
 // Project: https://github.com/redux-utilities/redux-actions
 // Definitions by: Jack Hsu <https://github.com/jaysoo>,
 //                 Alex Gorbatchev <https://github.com/alexgorbatchev>,

--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -13,16 +13,16 @@ export as namespace ReduxActions;
 
 // FSA-compliant action.
 // See: https://github.com/acdlite/flux-standard-action
-export interface BaseAction {
-    type: string;
+export interface BaseAction<T extends string> {
+    type: T;
 }
 
-export interface Action<Payload> extends BaseAction {
+export interface Action<Payload, T extends string> extends BaseAction<T> {
     payload: Payload;
     error?: boolean;
 }
 
-export interface ActionMeta<Payload, Meta> extends Action<Payload> {
+export interface ActionMeta<Payload, Meta, T extends string> extends Action<Payload, T> {
     meta: Meta;
 }
 
@@ -31,24 +31,29 @@ export interface CombinedActionType {
     _dummy: undefined;
 }
 
-export type ReducerMapValue<State, Payload> = Reducer<State, Payload> | ReducerNextThrow<State, Payload> | ReducerMap<State, Payload>;
+export type ReducerMapValue<State, Payload, T extends string> =
+    Reducer<State, Payload, T>
+    | ReducerNextThrow<State, Payload, T>
+    | ReducerMap<State, Payload, T>;
 
-export interface ReducerMap<State, Payload> {
-    [actionType: string]: ReducerMapValue<State, Payload>;
+export interface ReducerMap<State, Payload, T extends string> {
+    [actionType: string]: ReducerMapValue<State, Payload, T>;
 }
 
-export interface ReducerMapMeta<State, Payload, Meta> {
-    [actionType: string]: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta> | ReducerMapMeta<State, Payload, Meta>;
+export interface ReducerMapMeta<State, Payload, Meta, T extends string> {
+    [actionType: string]: ReducerMeta<State, Payload, Meta, T> | ReducerNextThrowMeta<State, Payload, Meta, T> | ReducerMapMeta<State, Payload, Meta, T>;
 }
 
-export interface ReducerNextThrow<State, Payload> {
-    next?(state: State, action: Action<Payload>): State;
-    throw?(state: State, action: Action<Payload>): State;
+export interface ReducerNextThrow<State, Payload, T extends string> {
+    next?(state: State, action: Action<Payload, T>): State;
+
+    throw?(state: State, action: Action<Payload, T>): State;
 }
 
-export interface ReducerNextThrowMeta<State, Payload, Meta> {
-    next?(state: State, action: ActionMeta<Payload, Meta>): State;
-    throw?(state: State, action: ActionMeta<Payload, Meta>): State;
+export interface ReducerNextThrowMeta<State, Payload, Meta, T extends string> {
+    next?(state: State, action: ActionMeta<Payload, Meta, T>): State;
+
+    throw?(state: State, action: ActionMeta<Payload, Meta, T>): State;
 }
 
 export type BaseActionFunctions<TAction> =
@@ -59,17 +64,17 @@ export type BaseActionFunctions<TAction> =
     ActionFunction4<any, any, any, any, TAction> |
     ActionFunctionAny<TAction>;
 
-export type ActionFunctions<Payload> = BaseActionFunctions<Action<Payload>>;
+export type ActionFunctions<Payload, T extends string> = BaseActionFunctions<Action<Payload, T>>;
 
-export type ActionWithMetaFunctions<Payload, Meta> = BaseActionFunctions<ActionMeta<Payload, Meta>>;
+export type ActionWithMetaFunctions<Payload, Meta, T extends string> = BaseActionFunctions<ActionMeta<Payload, Meta, T>>;
 
-export type Reducer<State, Payload> = (state: State, action: Action<Payload>) => State;
+export type Reducer<State, Payload, T extends string> = (state: State, action: Action<Payload, T>) => State;
 
-export type ReducerMeta<State, Payload, Meta> = (state: State, action: ActionMeta<Payload, Meta>) => State;
+export type ReducerMeta<State, Payload, Meta, T extends string> = (state: State, action: ActionMeta<Payload, Meta, T>) => State;
 
-export type ReduxCompatibleReducer<State, Payload> = (state: State | undefined, action: Action<Payload>) => State;
+export type ReduxCompatibleReducer<State, Payload, T extends string> = (state: State | undefined, action: Action<Payload, T>) => State;
 
-export type ReduxCompatibleReducerMeta<State, Payload, Meta> = (state: State | undefined, action: ActionMeta<Payload, Meta>) => State;
+export type ReduxCompatibleReducerMeta<State, Payload, Meta, T extends string> = (state: State | undefined, action: ActionMeta<Payload, Meta, T>) => State;
 
 /** argument inferring borrowed from lodash definitions */
 export type ActionFunction0<R> = () => R;
@@ -80,131 +85,131 @@ export type ActionFunction4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4
 export type ActionFunctionAny<R> = (...args: any[]) => R;
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/createAction.js#L6
-export function createAction(
-    actionType: string
-): ActionFunctionAny<Action<any>>;
+export function createAction<T extends string>(
+    actionType: T,
+): ActionFunctionAny<Action<any, T>>;
 
-export function createAction<Payload>(
-    actionType: string,
-    payloadCreator: ActionFunction0<Payload>
-): ActionFunction0<Action<Payload>>;
+export function createAction<Payload, T extends string>(
+    actionType: T,
+    payloadCreator: ActionFunction0<Payload>,
+): ActionFunction0<Action<Payload, T>>;
 
-export function createAction<Payload, Arg1>(
-    actionType: string,
-    payloadCreator: ActionFunction1<Arg1, Payload>
-): ActionFunction1<Arg1, Action<Payload>>;
+export function createAction<Payload, Arg1, T extends string>(
+    actionType: T,
+    payloadCreator: ActionFunction1<Arg1, Payload>,
+): ActionFunction1<Arg1, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2>(
-    actionType: string,
-    payloadCreator: ActionFunction2<Arg1, Arg2, Payload>
-): ActionFunction2<Arg1, Arg2, Action<Payload>>;
+export function createAction<Payload, Arg1, Arg2, T extends string>(
+    actionType: T,
+    payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
+): ActionFunction2<Arg1, Arg2, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2, Arg3>(
-    actionType: string,
-    payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>
-): ActionFunction3<Arg1, Arg2, Arg3, Action<Payload>>;
+export function createAction<Payload, Arg1, Arg2, Arg3, T extends string>(
+    actionType: T,
+    payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
+): ActionFunction3<Arg1, Arg2, Arg3, Action<Payload, T>>;
 
-export function createAction<Payload, Arg1, Arg2, Arg3, Arg4>(
-    actionType: string,
-    payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>
-): ActionFunction4<Arg1, Arg2, Arg3, Arg4, Action<Payload>>;
+export function createAction<Payload, Arg1, Arg2, Arg3, Arg4, T extends string>(
+    actionType: T,
+    payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
+): ActionFunction4<Arg1, Arg2, Arg3, Arg4, Action<Payload, T>>;
 
-export function createAction<Payload>(
-    actionType: string
-): ActionFunction1<Payload, Action<Payload>>;
+export function createAction<Payload, T extends string>(
+    actionType: T,
+): ActionFunction1<Payload, Action<Payload, T>>;
 
-export function createAction<Meta>(
+export function createAction<Meta, T extends string>(
     actionType: string,
     payloadCreator: null | undefined,
-    metaCreator: ActionFunctionAny<Meta>
-): ActionFunctionAny<ActionMeta<any, Meta>>;
+    metaCreator: ActionFunctionAny<Meta>,
+): ActionFunctionAny<ActionMeta<any, Meta, T>>;
 
-export function createAction<Payload, Meta>(
+export function createAction<Payload, Meta, T extends string>(
     actionType: string,
     payloadCreator: ActionFunctionAny<Payload>,
-    metaCreator: ActionFunctionAny<Meta>
-): ActionFunctionAny<ActionMeta<Payload, Meta>>;
+    metaCreator: ActionFunctionAny<Meta>,
+): ActionFunctionAny<ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1>(
+export function createAction<Payload, Meta, Arg1, T extends string>(
     actionType: string,
     payloadCreator: ActionFunction1<Arg1, Payload>,
-    metaCreator: ActionFunction1<Arg1, Meta>
-): ActionFunction1<Arg1, ActionMeta<Payload, Meta>>;
+    metaCreator: ActionFunction1<Arg1, Meta>,
+): ActionFunction1<Arg1, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2>(
+export function createAction<Payload, Meta, Arg1, Arg2, T extends string>(
     actionType: string,
     payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
-    metaCreator: ActionFunction2<Arg1, Arg2, Meta>
-): ActionFunction2<Arg1, Arg2, ActionMeta<Payload, Meta>>;
+    metaCreator: ActionFunction2<Arg1, Arg2, Meta>,
+): ActionFunction2<Arg1, Arg2, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2, Arg3>(
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3, T extends string>(
     actionType: string,
     payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
-    metaCreator: ActionFunction3<Arg1, Arg2, Arg3, Meta>
-): ActionFunction3<Arg1, Arg2, Arg3, ActionMeta<Payload, Meta>>;
+    metaCreator: ActionFunction3<Arg1, Arg2, Arg3, Meta>,
+): ActionFunction3<Arg1, Arg2, Arg3, ActionMeta<Payload, Meta, T>>;
 
-export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4>(
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4, T extends string>(
     actionType: string,
     payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
-    metaCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Meta>
-): ActionFunction4<Arg1, Arg2, Arg3, Arg4, ActionMeta<Payload, Meta>>;
+    metaCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Meta>,
+): ActionFunction4<Arg1, Arg2, Arg3, Arg4, ActionMeta<Payload, Meta, T>>;
 
-export function handleAction<State, Payload>(
-    actionType: string | ActionFunctions<Payload> | CombinedActionType,
-    reducer: Reducer<State, Payload> | ReducerNextThrow<State, Payload>,
-    initialState: State
-): ReduxCompatibleReducer<State, Payload>;
+export function handleAction<State, Payload, T extends string>(
+    actionType: string | ActionFunctions<Payload, T> | CombinedActionType,
+    reducer: Reducer<State, Payload, T> | ReducerNextThrow<State, Payload, T>,
+    initialState: State,
+): ReduxCompatibleReducer<State, Payload, T>;
 
-export function handleAction<State, Payload, Meta>(
-    actionType: string | ActionWithMetaFunctions<Payload, Meta> | CombinedActionType,
-    reducer: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta>,
-    initialState: State
-): ReduxCompatibleReducerMeta<State, Payload, Meta>;
+export function handleAction<State, Payload, Meta, T extends string>(
+    actionType: string | ActionWithMetaFunctions<Payload, Meta, T> | CombinedActionType,
+    reducer: ReducerMeta<State, Payload, Meta, T> | ReducerNextThrowMeta<State, Payload, Meta, T>,
+    initialState: State,
+): ReduxCompatibleReducerMeta<State, Payload, Meta, T>;
 
 export interface Options {
     prefix?: string;
     namespace?: string;
 }
 
-export function handleActions<StateAndPayload>(
-    reducerMap: ReducerMap<StateAndPayload, StateAndPayload>,
+export function handleActions<StateAndPayload, T extends string>(
+    reducerMap: ReducerMap<StateAndPayload, StateAndPayload, T>,
     initialState: StateAndPayload,
-    options?: Options
-): ReduxCompatibleReducer<StateAndPayload, StateAndPayload>;
+    options?: Options,
+): ReduxCompatibleReducer<StateAndPayload, StateAndPayload, T>;
 
-export function handleActions<State, Payload>(
-    reducerMap: ReducerMap<State, Payload>,
+export function handleActions<State, Payload, T extends string>(
+    reducerMap: ReducerMap<State, Payload, T>,
     initialState: State,
-    options?: Options
-): ReduxCompatibleReducer<State, Payload>;
+    options?: Options,
+): ReduxCompatibleReducer<State, Payload, T>;
 
-export function handleActions<State, Payload, Meta>(
-    reducerMap: ReducerMapMeta<State, Payload, Meta>,
+export function handleActions<State, Payload, Meta, T extends string>(
+    reducerMap: ReducerMapMeta<State, Payload, Meta, T>,
     initialState: State,
-    options?: Options
-): ReduxCompatibleReducerMeta<State, Payload, Meta>;
+    options?: Options,
+): ReduxCompatibleReducerMeta<State, Payload, Meta, T>;
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/combineActions.js#L21
-export function combineActions(...actionTypes: Array<ActionFunctions<any> | string | symbol>): CombinedActionType;
+export function combineActions(...actionTypes: Array<ActionFunctions<any, any> | string | symbol>): CombinedActionType;
 
 export interface ActionMap<Payload, Meta> {
     [actionType: string]:
-    ActionMap<Payload, Meta> |
-    ActionFunctionAny<Payload> |
-    [ActionFunctionAny<Payload>, ActionFunctionAny<Meta>] |
-    undefined;
+        ActionMap<Payload, Meta> |
+        ActionFunctionAny<Payload> |
+        [ActionFunctionAny<Payload>, ActionFunctionAny<Meta>] |
+        undefined;
 }
 
-export function createActions<Payload>(
+export function createActions<Payload, T extends string>(
     actionMapOrIdentityAction: ActionMap<Payload, any> | string,
     ...identityActions: Array<string | Options>
 ): {
-    [actionName: string]: ActionFunctionAny<Action<Payload>>
+    [actionName: string]: ActionFunctionAny<Action<Payload, T>>
 };
 
-export function createActions(
+export function createActions<T extends string>(
     actionMapOrIdentityAction: ActionMap<any, any> | string,
     ...identityActions: Array<string | Options>
 ): {
-    [actionName: string]: ActionFunctionAny<Action<any>>
+    [actionName: string]: ActionFunctionAny<Action<any, T>>
 };

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -218,6 +218,7 @@ actionMetaFrom2Args.meta.remote;
 typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFrom2Args);
 
 const act0 = ReduxActions.createAction('ACTION0');
+act0().type; // $ExpectType 'ACTION0'
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/__tests__/createAction-test.js#L111
 act0().payload; // $ExpectType any
 act0().payload === undefined;
@@ -226,37 +227,46 @@ act0({ foo: 'bar' }).payload.foo === 'bar';
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/__tests__/createAction-test.js#L122
 const act0_meta = ReduxActions.createAction('ACTION0_META', null, () => ({ foo: 'bar' }));
+act0_meta().type; // $ExpectType 'ACTION0_META'
 act0_meta().payload; // $ExpectType any
 act0_meta().meta.foo === 'bar';
 
 const act1 = ReduxActions.createAction<string>('ACTION1');
+act1().type; // $ExpectType string
 act1('hello').payload; // $ExpectType string
 act1('hello').payload === 'hello';
 
 const act1_meta = ReduxActions.createAction('ACTION1_META', null, (foo: string) => ({ foo }));
+act1_meta().type; // $ExpectType 'ACTION1_META'
 act1_meta('hello').payload; // $ExpectType any
 act1_meta('hello').payload === 'hello';
 act1_meta('hello').meta.foo === 'hello';
 
 const act1_type_meta = ReduxActions.createAction('ACTION1_TYPE_META', (x: number) => x, () => ({ foo: 'bar' }));
+act1_type_meta().type; // $ExpectType 'ACTION1_TYPE_META'
 act1_type_meta(42).payload; // $ExpectType number
 act1_type_meta(42).meta.foo === 'bar';
 
 const act1_identity = ReduxActions.createAction('ACTION1_IDENTITY', (x: string) => x);
+act1_identity('hello').type; // $ExpectType 'ACTION1_IDENTITY'
 act1_identity('hello').payload; // $ExpectType string
 act1_identity('hello').payload === 'hello';
 
 const act2 = ReduxActions.createAction('ACTION2', (s: {load: boolean}) => s);
+act2({load: true}).type; // $ExpectType 'ACTION2'
 act2({load: true}).payload.load; // $ExpectType boolean
 
 const act3 = ReduxActions.createAction('ACTION3', (s: string) => ({s}));
+act3('hello').type; // $ExpectType 'ACTION3'
 act3('hello').payload.s === 'hello';
 
 const act4 = ReduxActions.createAction('ACTION4', null, (x1: string, x2: number) => ({}));
+act4('hello', 42).type; // $ExpectType 'ACTION4'
 act4('hello', 42).payload; // $ExpectType any
 Object.getOwnPropertyNames(act4('hello', 42).payload).length === 2;
 
 const act5 = ReduxActions.createAction('ACTION5', null, (...args: any[]) => ({}));
+act5('hello', 42).type; // $ExpectType 'ACTION5'
 act5('hello', 42).payload; // $ExpectType any
 Object.getOwnPropertyNames(act5('hello', 42).payload).length === 2;
 
@@ -275,11 +285,11 @@ actions0_actionTwo('value', 2).payload[1] === 2;
 interface Actions1Payload {
     [key: string]: number;
 }
-const { actions1_actionOne } = ReduxActions.createActions({
+const { ACTION_ONE } = ReduxActions.createActions({
     ACTION_ONE: (key: string, value: number): Actions1Payload => ({ [key]: value })
 });
-actions1_actionOne('value', 1).payload; // $ExpectType Actions1Payload
-actions1_actionOne('value', 1).payload.value === 1;
+ACTION_ONE('value', 1).payload; // $ExpectType Actions1Payload
+ACTION_ONE('value', 1).payload.value === 1;
 
 const options: ReduxActions.Options = {
     prefix: 'TEST'
@@ -300,7 +310,7 @@ ReduxActions.handleAction(act3, (state, action) => {
     return { hello: action.payload.s };
 }, {hello: 'greetings'});
 
-ReduxActions.handleAction(ReduxActions.combineActions(act1, act3, act2), (state, action) => state + 1, 0);
+ReduxActions.handleAction(ReduxActions.combineActions(act3, act2), (state, action) => state + 1, 0);
 
 ReduxActions.handleActions({
     [`${ReduxActions.combineActions(act1, act3, act2)}`](state, action) {

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -218,7 +218,7 @@ actionMetaFrom2Args.meta.remote;
 typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFrom2Args);
 
 const act0 = ReduxActions.createAction('ACTION0');
-act0().type; // $ExpectType 'ACTION0'
+act0().type; // $ExpectType "ACTION0"
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/__tests__/createAction-test.js#L111
 act0().payload; // $ExpectType any
 act0().payload === undefined;
@@ -227,7 +227,7 @@ act0({ foo: 'bar' }).payload.foo === 'bar';
 
 // https://github.com/redux-utilities/redux-actions/blob/v2.3.0/src/__tests__/createAction-test.js#L122
 const act0_meta = ReduxActions.createAction('ACTION0_META', null, () => ({ foo: 'bar' }));
-act0_meta().type; // $ExpectType 'ACTION0_META'
+act0_meta().type; // $ExpectType "ACTION0_META"
 act0_meta().payload; // $ExpectType any
 act0_meta().meta.foo === 'bar';
 
@@ -237,36 +237,36 @@ act1('hello').payload; // $ExpectType string
 act1('hello').payload === 'hello';
 
 const act1_meta = ReduxActions.createAction('ACTION1_META', null, (foo: string) => ({ foo }));
-act1_meta().type; // $ExpectType 'ACTION1_META'
+act1_meta().type; // $ExpectType "ACTION1_META"
 act1_meta('hello').payload; // $ExpectType any
 act1_meta('hello').payload === 'hello';
 act1_meta('hello').meta.foo === 'hello';
 
 const act1_type_meta = ReduxActions.createAction('ACTION1_TYPE_META', (x: number) => x, () => ({ foo: 'bar' }));
-act1_type_meta().type; // $ExpectType 'ACTION1_TYPE_META'
+act1_type_meta().type; // $ExpectType "ACTION1_TYPE_META"
 act1_type_meta(42).payload; // $ExpectType number
 act1_type_meta(42).meta.foo === 'bar';
 
 const act1_identity = ReduxActions.createAction('ACTION1_IDENTITY', (x: string) => x);
-act1_identity('hello').type; // $ExpectType 'ACTION1_IDENTITY'
+act1_identity('hello').type; // $ExpectType "ACTION1_IDENTITY"
 act1_identity('hello').payload; // $ExpectType string
 act1_identity('hello').payload === 'hello';
 
 const act2 = ReduxActions.createAction('ACTION2', (s: {load: boolean}) => s);
-act2({load: true}).type; // $ExpectType 'ACTION2'
+act2({load: true}).type; // $ExpectType "ACTION2"
 act2({load: true}).payload.load; // $ExpectType boolean
 
 const act3 = ReduxActions.createAction('ACTION3', (s: string) => ({s}));
-act3('hello').type; // $ExpectType 'ACTION3'
+act3('hello').type; // $ExpectType "ACTION3"
 act3('hello').payload.s === 'hello';
 
 const act4 = ReduxActions.createAction('ACTION4', null, (x1: string, x2: number) => ({}));
-act4('hello', 42).type; // $ExpectType 'ACTION4'
+act4('hello', 42).type; // $ExpectType "ACTION4"
 act4('hello', 42).payload; // $ExpectType any
 Object.getOwnPropertyNames(act4('hello', 42).payload).length === 2;
 
 const act5 = ReduxActions.createAction('ACTION5', null, (...args: any[]) => ({}));
-act5('hello', 42).type; // $ExpectType 'ACTION5'
+act5('hello', 42).type; // $ExpectType "ACTION5"
 act5('hello', 42).payload; // $ExpectType any
 Object.getOwnPropertyNames(act5('hello', 42).payload).length === 2;
 
@@ -285,11 +285,11 @@ actions0_actionTwo('value', 2).payload[1] === 2;
 interface Actions1Payload {
     [key: string]: number;
 }
-const { ACTION_ONE } = ReduxActions.createActions({
+const { actions1_actionOne } = ReduxActions.createActions({
     ACTION_ONE: (key: string, value: number): Actions1Payload => ({ [key]: value })
 });
-ACTION_ONE('value', 1).payload; // $ExpectType Actions1Payload
-ACTION_ONE('value', 1).payload.value === 1;
+actions1_actionOne('value', 1).payload; // $ExpectType Actions1Payload
+actions1_actionOne('value', 1).payload.value === 1;
 
 const options: ReduxActions.Options = {
     prefix: 'TEST'
@@ -310,7 +310,7 @@ ReduxActions.handleAction(act3, (state, action) => {
     return { hello: action.payload.s };
 }, {hello: 'greetings'});
 
-ReduxActions.handleAction(ReduxActions.combineActions(act3, act2), (state, action) => state + 1, 0);
+ReduxActions.handleAction(ReduxActions.combineActions(act1, act3, act2), (state, action) => state + 1, 0);
 
 ReduxActions.handleActions({
     [`${ReduxActions.combineActions(act1, act3, act2)}`](state, action) {


### PR DESCRIPTION
This is still in progress but I'm hoping someone can help out too.

This PR changes the action type from string to a generic constrained to string. This prevents TS from widening a string literal to a string type. This shouldn't be disruptive with the default type set. 

Note that this PR only updates the various `Action` types and the `createAction` functions. Updates to `createActions` are next to impossible IMO until we get something like https://github.com/microsoft/TypeScript/issues/12754 or change the API to be a little stricter.

Thoughts?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
![action-type-generic](https://user-images.githubusercontent.com/73474/57903355-4a7ecd00-7833-11e9-8c19-cbf9accff176.gif)
