### PR TITLE
@types/react-router: Adds support for typing the state on <Redirect />

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -23,7 +23,7 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Nicholas Hehr <https://github.com/HipsterBrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from 'react';
 import * as H from 'history';

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -54,15 +54,15 @@ export interface PromptProps {
 }
 export class Prompt extends React.Component<PromptProps, any> { }
 
-export interface RedirectProps {
-  to: H.LocationDescriptor;
+export interface RedirectProps<LocationState = any> {
+  to: H.LocationDescriptor<LocationState>;
   push?: boolean;
   from?: string;
   path?: string;
   exact?: boolean;
   strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps, any> { }
+export class Redirect<LocationState = any> extends React.Component<RedirectProps<LocationState>, any> { }
 
 export interface StaticContext {
   statusCode?: number;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -53,7 +53,7 @@ export interface PromptProps {
   when?: boolean;
 }
 export class Prompt extends React.Component<PromptProps, any> { }
-export interface RedirectProps<S> {
+export interface RedirectProps<S = any> {
   to: H.LocationDescriptor<S>;
   push?: boolean;
   from?: string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -53,15 +53,15 @@ export interface PromptProps {
   when?: boolean;
 }
 export class Prompt extends React.Component<PromptProps, any> { }
-export interface RedirectProps<LocationState> {
-  to: H.LocationDescriptor<LocationState>;
+export interface RedirectProps<S> {
+  to: H.LocationDescriptor<S>;
   push?: boolean;
   from?: string;
   path?: string;
   exact?: boolean;
   strict?: boolean;
 }
-export class Redirect<LocationState = any> extends React.Component<RedirectProps<LocationState>, any> { }
+export class Redirect<S = any> extends React.Component<RedirectProps<S>, any> { }
 
 export interface StaticContext {
   statusCode?: number;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -53,8 +53,7 @@ export interface PromptProps {
   when?: boolean;
 }
 export class Prompt extends React.Component<PromptProps, any> { }
-
-export interface RedirectProps<LocationState = any> {
+export interface RedirectProps<LocationState> {
   to: H.LocationDescriptor<LocationState>;
   push?: boolean;
   from?: string;

--- a/types/react-router/test/Redirect.tsx
+++ b/types/react-router/test/Redirect.tsx
@@ -35,13 +35,12 @@ const RedirectWithValidTypedState = () => {
 
 const RedirectWithInvalidTypedState = () => {
     return (
-        // $ExpectError
         <Redirect<State>
-            // $ExpectError
             to={{
                 pathname: "/somewhere",
                 state: {
                     foo: true,
+                    // $ExpectError
                     bar: "this should fail"
                 }
             }}

--- a/types/react-router/test/Redirect.tsx
+++ b/types/react-router/test/Redirect.tsx
@@ -20,7 +20,7 @@ const RedirectWithoutTypedState = () => {
     );
 };
 
-const RedirectWithTypedState = () => {
+const RedirectWithValidTypedState = () => {
     return (
         <Redirect<State>
             to={{
@@ -33,4 +33,24 @@ const RedirectWithTypedState = () => {
     );
 };
 
-export { RedirectWithoutTypedState, RedirectWithTypedState };
+const RedirectWithInvalidTypedState = () => {
+    return (
+        //$ExpectError
+        <Redirect<State>
+            //$ExpectError
+            to={{
+                pathname: "/somewhere",
+                state: {
+                    foo: true,
+                    bar: "this should fail"
+                }
+            }}
+        />
+    );
+};
+
+export {
+    RedirectWithoutTypedState,
+    RedirectWithValidTypedState,
+    RedirectWithInvalidTypedState
+};

--- a/types/react-router/test/Redirect.tsx
+++ b/types/react-router/test/Redirect.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Redirect } from "react-router";
+
+interface State {
+    foo: boolean;
+}
+
+const RedirectWithoutTypedState = () => {
+    return (
+        <Redirect
+            to={{
+                pathname: "/somewhere",
+                state: {
+                    foo: "bar"
+                }
+            }}
+        />
+    );
+};
+
+const RedirectWithTypedState = () => {
+    return (
+        <Redirect<State>
+            to={{
+                pathname: "/somewhere",
+                state: {
+                    foo: true
+                }
+            }}
+        />
+    );
+};
+
+export { RedirectWithoutTypedState, RedirectWithTypedState };

--- a/types/react-router/test/Redirect.tsx
+++ b/types/react-router/test/Redirect.tsx
@@ -1,3 +1,5 @@
+// TypeScript Version: 2.9
+
 import * as React from "react";
 import { Redirect } from "react-router";
 

--- a/types/react-router/test/Redirect.tsx
+++ b/types/react-router/test/Redirect.tsx
@@ -35,9 +35,9 @@ const RedirectWithValidTypedState = () => {
 
 const RedirectWithInvalidTypedState = () => {
     return (
-        //$ExpectError
+        // $ExpectError
         <Redirect<State>
-            //$ExpectError
+            // $ExpectError
             to={{
                 pathname: "/somewhere",
                 state: {

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -1,15 +1,10 @@
 {
     "compilerOptions": {
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
+        "lib": ["es6", "dom"],
         "jsx": "react",
         "strictNullChecks": true,
         "strictFunctionTypes": false,
@@ -40,6 +35,7 @@
         "test/Switch.tsx",
         "test/InheritingRoute.tsx",
         "test/WithRouter.tsx",
-        "test/RouterContext.tsx"
+        "test/RouterContext.tsx",
+        "test/Redirect.tsx"
     ]
 }


### PR DESCRIPTION
The current implementation of `<Redirect />` doesn't support any generic to type its state, so there's no way to validate it.

Imagine the following route:

```
interface MyAwesomeRouteState {
 foo: boolean;
}

<Redirect to={{
   pathname: "/my-awesome-route",
   state: {
      foo: true,
      bar: "this should fail, but it won't :'("
   }
}} />
````

With these changes, validating the state becomes possible:

```
interface MyAwesomeRouteState {
 foo: boolean;
}

<Redirect<MyAwesomeRouteState> to={{
   pathname: "/my-awesome-route",
   state: {
      foo: true,
      bar: "this will now fail :)"
   }
}} />
````
🎉