### PR TITLE
[victory] Added missing color prop in VictoryGroupProps

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1771,11 +1771,11 @@ declare module "victory" {
      * @example ["dogs", "cats", "mice"]
      */
     categories?: CategoryPropType;
-     /**
+    /**
      * The color prop is an optional prop that defines a single color to be applied to the
      * children of VictoryGroup. The color prop will override colors specified via colorScale.
      */
-    color?: string
+    color?: string;
     /**
      * The colorScale prop is an optional prop that defines the color scale the chart's bars
      * will be created on. This prop should be given as an array of CSS colors, or as a string

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -8,6 +8,7 @@
 //                 Stack Builders <https://github.com/stackbuilders>
 //                 Esteban Ibarra <https://github.com/ibarrae>
 //                 Dominic Lee <https://github.com/dominictwlee>
+//                 Dave Vedder <https://github.com/veddermatic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -1770,6 +1771,11 @@ declare module "victory" {
      * @example ["dogs", "cats", "mice"]
      */
     categories?: CategoryPropType;
+     /**
+     * The color prop is an optional prop that defines a single color to be applied to the
+     * children of VictoryGroup. The color prop will override colors specified via colorScale.
+     */
+    color?: string
     /**
      * The colorScale prop is an optional prop that defines the color scale the chart's bars
      * will be created on. This prop should be given as an array of CSS colors, or as a string

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -494,7 +494,7 @@ test = (
 
 // VictoryGroup test
 test = (
-  <VictoryGroup offset={40}>
+  <VictoryGroup color="#46c85e" offset={40}>
     <VictoryBar
       data={[{ x: "a", y: 2 }, { x: "b", y: 3 }, { x: "c", y: 5 }]}
     />


### PR DESCRIPTION
If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://formidable.com/open-source/victory/docs/victory-group#color
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
