### PR TITLE
[@types/koa-bodyparser] Make body parameter on koa module definition optional

### DIFF
--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jerry Chin <https://github.com/hellopao>
 //                 Anup Kishore <https://github.com/anup-2s>
 //                 Hiroshi Ioka <https://github.com/hirochachacha>
+//                 Alexi Maschas <https://github.com/amaschas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -20,7 +21,7 @@ import * as Koa from "koa";
 
 declare module "koa" {
     interface Request {
-        body: any;
+        body?: any;
         rawBody: string;
     }
 }

--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-bodyparser 4.2
+// Type definitions for koa-bodyparser 4.3
 // Project: https://github.com/koajs/body-parser
 // Definitions by: Jerry Chin <https://github.com/hellopao>
 //                 Anup Kishore <https://github.com/anup-2s>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa-joi-router/index.d.ts
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm using `koa-bodyparser` in my current project, and ran into an issue when I started using `koa-joi-router` alongside it. The issue is that the type definitions for `koa-joi-router` define the body parameter of the koa object as optional, while `koa-bodyparser` defines it as required. I've tested this change in my code, and everything seems to work fine if the body parameter is optional, hence this change. This would be an issue with any Koa middleware that needs to be aware of the body param on the Koa module, so this should enhance future compatibility with other middlewares as well.