### PR TITLE
Allow Slate Editor queries to return any type

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1312,7 +1312,7 @@ export class Editor implements Controller {
     undo(): Editor;
     snapshotSelection(): Editor;
     command(name: string, ...args: any[]): Editor;
-    query(query: string, ...args: any[]): Editor;
+    query(query: string, ...args: any[]): any;
     registerCommand(command: string): Editor;
     registerQuery(query: string): Editor;
     applyOperation(operation: Operation): Editor;
@@ -2340,7 +2340,7 @@ export interface Controller {
      */
     snapshotSelection(): Controller;
     command(name: string, ...args: any[]): Controller;
-    query(query: string, ...args: any[]): Controller;
+    query(query: string, ...args: any[]): any;
     /**
      * Add a new command by type to the controller. This will make the command available as a top-level method on the controller
      */

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -119,7 +119,6 @@ editor.setReadOnly(true).setValue(value);
 editor.command("testCommand");
 editor.query("testQuery");
 editor.run("testCommand");
-editor.run("testCommand");
 const result: number = editor.query(pluginQueryName);
 
 // Test all editor commands

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -86,6 +86,7 @@ const schema: SchemaProperties = {
 
 const pluginCommandName = 'plugin_command';
 const pluginQueryName = 'plugin_query';
+const pluginQueryResult = 1000;
 
 const plugin: Plugin = {
     normalizeNode: (node: Node, editor: Editor, next: () => void) => next(),
@@ -96,7 +97,7 @@ const plugin: Plugin = {
     validateNode: (node: Node, editor: Editor, next: () => void) => next(),
 
     commands: { [pluginCommandName]: (editor: Editor, ...args: any[]) => editor },
-    queries: { [pluginQueryName]: (editor: Editor, ...args: any[]) => editor },
+    queries: { [pluginQueryName]: (editor: Editor, ...args: any[]) => pluginQueryResult },
     schema: {...schema},
 };
 
@@ -118,6 +119,8 @@ editor.setReadOnly(true).setValue(value);
 editor.command("testCommand");
 editor.query("testQuery");
 editor.run("testCommand");
+editor.run("testCommand");
+const result: number = editor.query(pluginQueryName);
 
 // Test all editor commands
 editor


### PR DESCRIPTION
[Slate queries](https://docs.slatejs.org/guides/commands-and-queries#running-queries) can return any type (allowing developers to define their own behavior on the `Editor` controller API). This should be reflected on the underlying `query()` method of the `Editor` controller.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.slatejs.org/guides/commands-and-queries#running-queries
https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/controllers/editor.js#L221-L231
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.