### PR TITLE
[react-input-autosize] Only accept callback style refs for inputRef 

### DIFF
--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -9,7 +9,7 @@ import * as React from 'react';
 
 export interface AutosizeInputProps extends React.InputHTMLAttributes<HTMLInputElement>, React.ClassAttributes<HTMLInputElement> {
     inputClassName?: string;
-    inputRef?: React.Ref<HTMLInputElement>;
+    inputRef?: (instance: HTMLInputElement | null) => void;
     inputStyle?: React.CSSProperties;
     minWidth?: string | number;
     onAutosize?: (inputWidth: string | number) => void;

--- a/types/react-input-autosize/react-input-autosize-tests.tsx
+++ b/types/react-input-autosize/react-input-autosize-tests.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import AutosizeInput, { AutosizeInputProps } from 'react-input-autosize';
 
 class Test extends React.Component<AutosizeInputProps> {
-    input: HTMLInputElement;
+    input: HTMLInputElement | null = null;
     auto: AutosizeInput;
 
-    inputRef = (ref: HTMLInputElement) => {
+    inputRef = (ref: HTMLInputElement | null) => {
         this.input = ref;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Not documented, but clearly from the code and proptype - this component only accepts old style callback refs https://github.com/JedWatson/react-input-autosize/blob/master/src/AutosizeInput.js#L77
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
