### PR TITLE
aws-lambda: uppercase custom in client context

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -544,7 +544,7 @@ str = cloudwatchLogsDecodedData.logEvents[0].extractedFields!["example"];
 
 /* ClientContext */
 clientContextClient = clientCtx.client;
-anyObj = clientCtx.custom;
+anyObj = clientCtx.Custom;
 clientContextEnv = clientCtx.env;
 
 /* ClientContextEnv */

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -459,7 +459,7 @@ export interface CognitoIdentity {
 
 export interface ClientContext {
     client: ClientContextClient;
-    custom?: any;
+    Custom?: any;
     env: ClientContextEnv;
 }
 


### PR DESCRIPTION
per the aws docs:
https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html
```clientContext – (mobile apps) Client context provided to the Lambda invoker by the client application.

client.installation_id

client.app_title

client.app_version_name

client.app_version_code

client.app_package_name

env.platform_version

env.platform

env.make

env.model

env.locale

Custom – Custom values set by the mobile application.
```

We have been using the upper case value with no problems so i assume the docs are correct here.

