### PR TITLE
[cytoscape] Add StylesheetHelper type definitions and fix typo

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -6,7 +6,7 @@
 //                  Jan-Niclas Struewer <https://github.com/janniclas>
 //                  Cerberuser <https://github.com/cerberuser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-//
+///
 // Translation from Objects in help to Typescript interface.
 // http://js.cytoscape.org/#notation/functions
 // TypeScript Version: 2.3
@@ -81,7 +81,7 @@ declare namespace cytoscape {
         /**
          * Scratchpad data (usually temp or nonserialisable data)
          */
-        scatch?: Scratchpad;
+        scratch?: Scratchpad;
         /**
          * The model position of the node (optional on init, mandatory after)
          */
@@ -4874,4 +4874,26 @@ declare namespace cytoscape {
      * http://js.cytoscape.org/#extensions
      */
     function use(module: Ext): void;
+
+    /**
+    * Helper function that provides a functional syntax for adding styles.
+    * Note: Review the docs and source if you experience issues with this module.
+    * Docs: http://js.cytoscape.org/#style/format
+    * Original JS Source: https://github.com/cytoscape/cytoscape.js/blob/unstable/src/stylesheet.js
+    */
+    interface StylesheetHelper {
+        instanceString(): string
+        selector(s: string): StylesheetHelper
+        css(value: {}): StylesheetHelper
+        css(name: string, value: {}): StylesheetHelper
+        style(value: {}): StylesheetHelper
+        style(name: string, value: {}): StylesheetHelper
+        generateStyle(cy: Stylesheet): Stylesheet
+        appendToStyle(style: Stylesheet): Stylesheet
+    }
+    /**
+    * Creates and returns a new StylesheetHelper that provides a functional syntax for adding styles.
+    * http://js.cytoscape.org/#style/format
+    */
+    function stylesheet(): StylesheetHelper;
 }


### PR DESCRIPTION
The comments that I added should describe this in more detail. I noticed this missing while developing and wanted to add it.

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cytoscape/cytoscape.js/blob/unstable/src/stylesheet.js

