### PR TITLE
@types/cookie - Add 'none' as a valid value for sameSite of the CookieSerializeOptions

### DIFF
--- a/types/cookie/cookie-tests.ts
+++ b/types/cookie/cookie-tests.ts
@@ -5,6 +5,8 @@ function test_serialize(): void {
 
     retVal = cookie.serialize('foo', 'bar');
     retVal = cookie.serialize('foo', 'bar', { httpOnly: true });
+    retVal = cookie.serialize('foo', 'bar', { sameSite: 'none' });
+    retVal = cookie.serialize('foo', 'bar', { sameSite: 'lax' });
 }
 
 function test_parse(): void {
@@ -22,7 +24,8 @@ function test_options(): void {
         maxAge: 200,
         domain: 'example.com',
         secure: false,
-        httpOnly: false
+        httpOnly: false,
+        sameSite: 'strict'
     };
 
     const parseOptios: cookie.CookieParseOptions = {

--- a/types/cookie/index.d.ts
+++ b/types/cookie/index.d.ts
@@ -71,6 +71,8 @@ export interface CookieSerializeOptions {
      * enforcement.
      * - `'strict'` will set the `SameSite` attribute to Strict for strict same
      * site enforcement.
+     *  - `'none'` will set the SameSite attribute to None for an explicit
+     *  cross-site cookie.
      */
     sameSite?: boolean | 'lax' | 'strict' | 'none';
     /**

--- a/types/cookie/index.d.ts
+++ b/types/cookie/index.d.ts
@@ -72,7 +72,7 @@ export interface CookieSerializeOptions {
      * - `'strict'` will set the `SameSite` attribute to Strict for strict same
      * site enforcement.
      */
-    sameSite?: boolean | 'lax' | 'strict';
+    sameSite?: boolean | 'lax' | 'strict' | 'none';
     /**
      * Specifies the boolean value for the `Secure` `Set-Cookie` attribute. When
      * truthy, the `Secure` attribute is set, otherwise it is not. By default,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* `None` is a valid option for `sameSite` in `cookie.serialise`: https://github.com/jshttp/cookie#samesite
* `None` added to possible options for `SameSite`: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00
* Chrome 76 will be changing behaviour to assume `Lax` if `None` is not provided: https://web.dev/samesite-cookies-explained/ (therefore, we must be able to add `None` as a value)
* Chrome following this proposal: https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
