### PR TITLE
[braintree] Fix some types (transaction.status, clientToken.generate(...))

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -62,7 +62,7 @@ declare namespace braintree {
         settlementBatchSumary: T extends SettlementBatchSummary ? SettlementBatchSummary : never;
         subscription: T extends Subscription ? Subscription : never;
         transaction: T extends Transaction ? Transaction : never;
-        clientToken: T extends ClientToken ? ClientToken : never;
+        clientToken: T extends ClientToken ? string : never;
     }
 
     /**
@@ -81,7 +81,7 @@ declare namespace braintree {
     }
 
     interface ClientTokenGateway {
-        generate(request: ClientTokenRequest): Promise<ClientToken>;
+        generate(request: ClientTokenRequest): Promise<ValidatedResponse<ClientToken>>;
     }
 
     interface CreditCardGateway {

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -62,6 +62,7 @@ declare namespace braintree {
         settlementBatchSumary: T extends SettlementBatchSummary ? SettlementBatchSummary : never;
         subscription: T extends Subscription ? Subscription : never;
         transaction: T extends Transaction ? Transaction : never;
+        clientToken: T extends ClientToken ? ClientToken : never;
     }
 
     /**
@@ -80,7 +81,7 @@ declare namespace braintree {
     }
 
     interface ClientTokenGateway {
-        generate(request: ClientTokenRequest): Promise<string>;
+        generate(request: ClientTokenRequest): Promise<ClientToken>;
     }
 
     interface CreditCardGateway {
@@ -473,6 +474,7 @@ declare namespace braintree {
         email?: string;
         fax?: string;
         firstName?: string;
+        id?: string;
         lastName?: string;
         paymentMethodNonce?: string;
         phone?: string;
@@ -1145,6 +1147,10 @@ declare namespace braintree {
         voiceReferralNumber?: string;
     }
 
+    interface ClientToken {
+      clientToken: string;
+    }
+
     export interface TransactionRequest {
         amount: string;
         billing?: {
@@ -1314,8 +1320,8 @@ declare namespace braintree {
         id: string;
     }
 
-    export type TransactionStatus = 'AuthorizationExpired' | 'Authorized' | 'Authorizing' | 'SettlementPending' | 'SettlemnetDeclined' |
-        'Failed' | 'GatewayRejected' | 'ProcessorDeclined' | 'Settled' | 'Settling' | 'SubmittedForSettlement' | 'Voided';
+    export type TransactionStatus = 'authorization_expired' | 'authorized' | 'authorizing' | 'settlement_pending' | 'settlement_declined' |
+        'failed' | 'gateway_rejected' | 'processor_declined' | 'settled' | 'settling' | 'submitted_for_settlement' | 'voided';
 
     export interface TransactionStatusHistory {
         amount: string;


### PR DESCRIPTION
- Transaction statuses are `snake_case` (lowercase with underscore)
- `clientToken.generate(...)` response is `{clientToken: string, success: true}` instead of `string`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

.clientToken property on response object:
 - https://github.com/braintree/braintree_node/blob/master/lib/braintree/client_token_gateway.js#L58

.id is a valid parameter in create customer request:
https://developers.braintreepayments.com/reference/request/customer/create/node#id

The statuses being returned from the API are lowercase, even though the documentation says otherwise.