### PR TITLE
allow arbitrary attrs on DecorationAttrs

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -128,6 +128,11 @@ export interface DecorationAttrs {
    * this type (and the other attributes are applied to this element).
    */
   nodeName?: string | null;
+  /**
+   * Specify additional attrs that will be mapped directly to the
+   * target node's DOM attributes.
+   */
+  [key: string]: string | null | undefined;
 }
 /**
  * A collection of [decorations](#view.Decoration), organized in


### PR DESCRIPTION
This pull request modifies the DecorationAttrs interface to allow arbitrary strings which ProseMirror maps as-is to the target node's attributes.

This should resolve #35369.

@bradleyayers @davidka @timjb @patsimm