### PR TITLE
@types/google-map-react - Style property definition

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -143,6 +143,7 @@ export interface Props {
   onGoogleApiLoaded?(maps: { map: any, maps: any }): void;
   onTilesLoaded?(): void;
   yesIWantToUseGoogleMapApiInternals?: boolean;
+  style?: HTMLProps<HTMLDivElement>;
 }
 
 export default class GoogleMapReact extends React.Component<Props> {}

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -143,7 +143,7 @@ export interface Props {
   onGoogleApiLoaded?(maps: { map: any, maps: any }): void;
   onTilesLoaded?(): void;
   yesIWantToUseGoogleMapApiInternals?: boolean;
-  style?: HTMLProps<HTMLDivElement>;
+  style?: React.HTMLProps<HTMLDivElement>;
 }
 
 export default class GoogleMapReact extends React.Component<Props> {}


### PR DESCRIPTION
Allows setting style properties to the container of the component.