### PR TITLE
[@loadable/server] Missing publicPath in ChunkExtractorOptions

### DIFF
--- a/types/loadable__server/index.d.ts
+++ b/types/loadable__server/index.d.ts
@@ -16,19 +16,23 @@ export type ChunkExtractorOptions = {
 	 * Optional output path (only for `requireEntrypoint`)
 	 */
 	outputPath?: string;
-  /**
-   * Optional namespace in case of multiple apps on same page
-   */
-  namespace?: string;
+	/**
+	 * Optional public path to override stats.publicPath at runtime
+	 */
+	publicPath?: string;
+	/**
+	 * Optional namespace in case of multiple apps on same page
+	 */
+	namespace?: string;
 } & ({
 	/**
 	 * Stats file path generated using `@loadable/webpack-plugin`
 	 */
 	statsFile: string;
  } | {
-	 /**
-	  * Stats generated using `@loadable/webpack-plugin`.
-	  */
+	/**
+	 * Stats generated using `@loadable/webpack-plugin`.
+	 */
 	stats: object;
  });
 


### PR DESCRIPTION
Add missing `publicPath` parameter in `ChunkExtractorOptions` as documented [here](https://github.com/smooth-code/loadable-components/blob/9731e9c5f450f0c732c46d4dfdbbc6057a0f4d6a/website/src/pages/docs/server-side-rendering.mdx#override-statspublicpath-at-runtime) and from [here in the code](https://github.com/smooth-code/loadable-components/blob/f2a6bbd6d7e96780eed8422011942f2f2785c96f/packages/server/src/ChunkExtractor.js#L164).
