### PR TITLE
Altered types for widget used in GridStack

### DIFF
--- a/types/gridstack/gridstack-tests.ts
+++ b/types/gridstack/gridstack-tests.ts
@@ -1,12 +1,5 @@
 /// <reference types="jquery"/>
 
-
-
-// Type definitions for Gridstack
-// Project: http://troolee.github.io/gridstack.js/
-// Definitions by: Pascal Senn <https://github.com/PascalSenn/>, Ricky Blankenaufulland <https://github.com/ZoolWay/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 var options: IGridstackOptions = {
     float: true
 };

--- a/types/gridstack/index.d.ts
+++ b/types/gridstack/index.d.ts
@@ -16,16 +16,16 @@ interface GridStack {
      *   Widget will be always placed even if result height is more than actual grid height. You need to use willItFit method before calling addWidget for additional check.
      *
      * @param {string | HTMLElement | JQuery} el widget to add
-     * @param {number} x widget position x
-     * @param {number} y widget position y
-     * @param {number} width  widget dimension width
-     * @param {number} height widget dimension height
-     * @param {boolean} autoPosition if true then x, y parameters will be ignored and widget will be places on the first available position
-     * @param {number} minWidth minimum width allowed during resize/creation
-     * @param {number} maxWidth maximum width allowed during resize/creation
-     * @param {number} minHeight minimum height allowed during resize/creation
-     * @param {number} maxHeight maximum height allowed during resize/creation
-     * @param {number | string} id value for data-gs-id
+     * @param {number} x widget position x (optional)
+     * @param {number} y widget position y (optional)
+     * @param {number} width  widget dimension width (optional)
+     * @param {number} height widget dimension height (optional)
+     * @param {boolean} autoPosition if true then x, y parameters will be ignored and widget will be places on the first available position (optional)
+     * @param {number} minWidth minimum width allowed during resize/creation (optional)
+     * @param {number} maxWidth maximum width allowed during resize/creation (optional)
+     * @param {number} minHeight minimum height allowed during resize/creation (optional)
+     * @param {number} maxHeight maximum height allowed during resize/creation (optional)
+     * @param {number | string} id value for data-gs-id (optional)
      */
     addWidget(el: string | HTMLElement | JQuery, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number | string): JQuery
     /**

--- a/types/gridstack/index.d.ts
+++ b/types/gridstack/index.d.ts
@@ -12,6 +12,8 @@ interface JQuery {
     data(key: "gridstack"): GridStack;
 }
 
+type GridStackWidgetType = string | HTMLElement | JQuery;
+
 interface GridStack {
     /**
      * Creates new widget and returns it.
@@ -30,7 +32,7 @@ interface GridStack {
      * @param {number} maxHeight maximum height allowed during resize/creation (optional)
      * @param {number | string} id value for data-gs-id (optional)
      */
-    addWidget(el: string | HTMLElement | JQuery, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number | string): JQuery
+    addWidget(el: GridStackWidgetType, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number | string): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */
@@ -95,10 +97,10 @@ interface GridStack {
     isAreaEmpty(x: number, y: number, width: number, height: number): void
     /**
     * Locks/unlocks widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {string | HTMLElement | JQuery} el widget to modify.
     * @param {boolean} val if true widget will be locked.
     */
-    locked(el: HTMLElement, val: boolean): void
+    locked(el: GridStackWidgetType, val: boolean): void
     /**
      * If you add elements to your gridstack container by hand, you have to tell gridstack afterwards to make them widgets.
      *
@@ -106,51 +108,51 @@ interface GridStack {
      *
      * @param {string | HTMLElement | JQuery} el widget to add
      */
-    makeWidget(el: string | HTMLElement | JQuery): JQuery
+    makeWidget(el: GridStackWidgetType): JQuery
     /**
      * Set the maxWidth for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {string | HTMLElement | JQuery} el widget to modify.
     * @param {number} val A numeric value of the number of columns
      */
-    maxWidth(el: HTMLElement, val: number): void
+    maxWidth(el: GridStackWidgetType, val: number): void
     /**
     * Set the minWidth for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {string | HTMLElement | JQuery} el widget to modify.
     * @param {number} val A numeric value of the number of columns
     */
-    minWidth(el: HTMLElement, val: number): void
+    minWidth(el: GridStackWidgetType, val: number): void
     /**
     * Set the maxHeight for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {string | HTMLElement | JQuery} el widget to modify.
     * @param {number} val A numeric value of the number of rows
     */
-    maxHeight(el: HTMLElement, val: number): void
+    maxHeight(el: GridStackWidgetType, val: number): void
     /**
     * Set the minHeight for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {string | HTMLElement | JQuery} el widget to modify.
     * @param {number} val A numeric value of the number of rows
     */
-    minHeight(el: HTMLElement, val: number): void
+    minHeight(el: GridStackWidgetType, val: number): void
     /**
    * Enables/Disables moving.
-   * @param {HTMLElement} el widget to modify.
+   * @param {string | HTMLElement | JQuery} el widget to modify.
    * @param {number} val if true widget will be draggable.
    */
-    movable(el: HTMLElement, val: boolean): void
+    movable(el: GridStackWidgetType, val: boolean): void
     /**
     * Changes widget position
-    * @param {HTMLElement} el  widget to modify
+    * @param {string | HTMLElement | JQuery} el  widget to modify
     * @param {number} x new position x. If value is null or undefined it will be ignored.
     * @param {number} y new position y. If value is null or undefined it will be ignored.
     *
     */
-    move(el: HTMLElement, x: number, y: number): void
+    move(el: GridStackWidgetType, x: number, y: number): void
     /**
     * Removes widget from the grid.
-    * @param {HTMLElement} el  widget to modify
+    * @param {string | HTMLElement | JQuery} el  widget to modify
     * @param {boolean} detachNode if false DOM node won't be removed from the tree (Optional. Default true).
     */
-    removeWidget(el: HTMLElement, detachNode?: boolean): void
+    removeWidget(el: GridStackWidgetType, detachNode?: boolean): void
     /**
     * Removes all widgets from the grid.
     * @param {boolean} detachNode if false DOM node won't be removed from the tree (Optional. Default true).
@@ -158,17 +160,17 @@ interface GridStack {
     removeAll(detachNode?: boolean): void
     /**
     * Changes widget size
-    * @param {HTMLElement} el  widget to modify
+    * @param {string | HTMLElement | JQuery} el  widget to modify
     * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
     * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
     */
-    resize(el: HTMLElement, width: number, height: number): void
+    resize(el: GridStackWidgetType, width: number, height: number): void
     /**
     * Enables/Disables resizing.
-    * @param {HTMLElement} el  widget to modify
+    * @param {string | HTMLElement | JQuery} el  widget to modify
     * @param {boolean} val  if true widget will be resizable.
     */
-    resizable(el: HTMLElement, val: boolean): void
+    resizable(el: GridStackWidgetType, val: boolean): void
     /**
      * Toggle the grid animation state. Toggles the grid-stack-animate class.
      * @param {boolean} doAnimate if true the grid will animate.
@@ -189,13 +191,13 @@ interface GridStack {
     setStatic(staticValue: boolean): void
     /**
     * Updates widget position/size.
-    * @param {HTMLElement} el  widget to modify
+    * @param {string | HTMLElement | JQuery} el  widget to modify
     * @param {number} x new position x. If value is null or undefined it will be ignored.
     * @param {number} y new position y. If value is null or undefined it will be ignored.
     * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
     * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
     */
-    update(el: HTMLElement, x: number, y: number, width: number, height: number): void
+    update(el: GridStackWidgetType, x: number, y: number, width: number, height: number): void
     /**
      * Sets the vertial margin
      * @param {number} value new vertical margin value.
@@ -211,9 +213,6 @@ interface GridStack {
     * @param {boolean} autoPosition  if true then x, y parameters will be ignored and widget will be places on the first available position
     */
     willItFit(x: number, y: number, width: number, height: number, autoPosition: boolean): boolean
-
-
-
 }
 /**
 * Defines the coordiantes of a object

--- a/types/gridstack/index.d.ts
+++ b/types/gridstack/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for Gridstack
+// Type definitions for Gridstack 0.4
 // Project: http://troolee.github.io/gridstack.js/
-// Definitions by: Pascal Senn <https://github.com/PascalSenn>, Ricky Blankenaufulland <https://github.com/ZoolWay>, Sl1MBoy <https://github.com/Sl1MBoy>, John Archer <https://github.com/JohnArcher>
+// Definitions by: Pascal Senn <https://github.com/PascalSenn>
+//                 Ricky Blankenaufulland <https://github.com/ZoolWay>
+//                 Sl1MBoy <https://github.com/Sl1MBoy>
+//                 John Archer <https://github.com/JohnArcher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/gridstack/index.d.ts
+++ b/types/gridstack/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Gridstack
 // Project: http://troolee.github.io/gridstack.js/
-// Definitions by: Pascal Senn <https://github.com/PascalSenn>, Ricky Blankenaufulland <https://github.com/ZoolWay>, Sl1MBoy <https://github.com/Sl1MBoy>
+// Definitions by: Pascal Senn <https://github.com/PascalSenn>, Ricky Blankenaufulland <https://github.com/ZoolWay>, Sl1MBoy <https://github.com/Sl1MBoy>, John Archer <https://github.com/JohnArcher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -21,8 +21,13 @@ interface GridStack {
      * @param {number} width  widget dimension width
      * @param {number} height widget dimension height
      * @param {boolean} autoPosition if true then x, y parameters will be ignored and widget will be places on the first available position
+     * @param {number} minWidth minimum width allowed during resize/creation
+     * @param {number} maxWidth maximum width allowed during resize/creation
+     * @param {number} minHeight minimum height allowed during resize/creation
+     * @param {number} maxHeight maximum height allowed during resize/creation
+     * @param {number | string} id value for data-gs-id
      */
-    addWidget(el: string | HTMLElement | JQuery, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number): JQuery
+    addWidget(el: string | HTMLElement | JQuery, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number | string): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */
@@ -61,17 +66,17 @@ interface GridStack {
     * Enables/disables widget moving.
     * This is a shortcut for:
     * grid.movable(this.container.children('.' + this.opts.itemClass), doEnable);
-    * @param {boolean} doEnable 
+    * @param {boolean} doEnable
     * @param {boolean} includeNewWidgets will force new widgets to be draggable
     */
     enableMove(doEnable: boolean, includeNewWidgets: boolean): void
     /**
      * Enables/disables widget resizing.
-     * @param {boolean} doEnable 
+     * @param {boolean} doEnable
      * @param {boolean} includeNewWidgets will force new widgets to be resizable
      */
     enableResize(doEnable: boolean, includeNewWidgets: boolean): void
-    /** 
+    /**
     * Get the position of the cell under a pixel on screen.
     * @param  {MousePosition}  position the position of the pixel to resolve in absolute coordinates, as an object with top and leftproperties
     * @param  {boolean}  useOffset if true, value will be based on offset vs position (Optional. Default false). Useful when grid is within position: relative element.
@@ -92,7 +97,7 @@ interface GridStack {
     */
     locked(el: HTMLElement, val: boolean): void
     /**
-     * If you add elements to your gridstack container by hand, you have to tell gridstack afterwards to make them widgets. 
+     * If you add elements to your gridstack container by hand, you have to tell gridstack afterwards to make them widgets.
      *
      *   If you want gridstack to add the elements for you, use addWidget instead. Makes the given element a widget and returns it.
      *
@@ -123,7 +128,7 @@ interface GridStack {
     * @param {number} val A numeric value of the number of rows
     */
     minHeight(el: HTMLElement, val: number): void
-    /** 
+    /**
    * Enables/Disables moving.
    * @param {HTMLElement} el widget to modify.
    * @param {number} val if true widget will be draggable.
@@ -167,8 +172,8 @@ interface GridStack {
      */
     setAnimation(doAnimate: boolean): void
     /**
-     * (Experimental) Modify number of columns in the grid. 
-     * Will attempt to update existing widgets to conform to new number of columns. 
+     * (Experimental) Modify number of columns in the grid.
+     * Will attempt to update existing widgets to conform to new number of columns.
      * Requires gridstack-extra.css or gridstack-extra.min.css.
      * @param {number} gridWidth Integer between 1 and 12.
      * @param {boolean} doNotPropagate if true existing widgets will not be updated.
@@ -204,7 +209,7 @@ interface GridStack {
     */
     willItFit(x: number, y: number, width: number, height: number, autoPosition: boolean): boolean
 
-    
+
 
 }
 /**
@@ -258,7 +263,7 @@ interface IGridstackOptions {
      */
     cellHeight?: number;
     /**
-     * class that implement drag'n'drop functionallity for gridstack. 
+     * class that implement drag'n'drop functionallity for gridstack.
      * If false grid will be static. (default: null - first available plugin will be used)
      */
     ddPlugin?: any;
@@ -319,7 +324,7 @@ interface IGridstackOptions {
     */
     resizable?: {};
     /**
-     * if true widgets could be removed by dragging outside of the grid. It could also be a jQuery selector string, 
+     * if true widgets could be removed by dragging outside of the grid. It could also be a jQuery selector string,
      */
     removable?: boolean | string;
     /**

--- a/types/gridstack/tslint.json
+++ b/types/gridstack/tslint.json
@@ -7,7 +7,6 @@
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,
-        "dt-header": false,
         "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,


### PR DESCRIPTION
The type of the widget element for all proper function was extended to "string | HTMLElement | JQuery" as this was inconsitent before.
For the function signature an alias type called "GridStackWidgetType" was introduced, but the jsdoc comments where altered to take the real types, so intellisense shows the real types.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gridstack/gridstack.js/tree/develop/doc#api
