### PR TITLE
[googlemaps] Enable `strict-export-declare-modifiers` rule

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -43,7 +43,7 @@ THE SOFTWARE.
 
 declare namespace google.maps {
   /***** Map *****/
-  export class Map extends MVCObject {
+  class Map extends MVCObject {
     constructor(mapDiv: Element|null, opts?: MapOptions);
     fitBounds(
         bounds: LatLngBounds|LatLngBoundsLiteral,
@@ -76,14 +76,14 @@ declare namespace google.maps {
     setClickableIcons(clickable: boolean): void;
   }
 
-  export interface Padding {
+  interface Padding {
     bottom: number;
     left: number;
     right: number;
     top: number;
   }
 
-  export interface MapOptions {
+  interface MapOptions {
     /**
      * Color used for the background of the Map div. This color will be visible
      * when tiles have not yet loaded as the user pans. This option can only be
@@ -269,7 +269,7 @@ declare namespace google.maps {
    * constant's name. For example, 'satellite' or
    * google.maps.MapTypeId.SATELLITE.
    */
-  export enum MapTypeId {
+  enum MapTypeId {
     /**
        This map type displays a transparent layer of major streets on satellite
        images.
@@ -288,7 +288,7 @@ declare namespace google.maps {
 
   /***** Controls *****/
   /** Options for the rendering of the map type control. */
-  export interface MapTypeControlOptions {
+  interface MapTypeControlOptions {
     /** IDs of map types to show in the control. */
     mapTypeIds?: (MapTypeId|string)[];
     /**
@@ -300,16 +300,16 @@ declare namespace google.maps {
     style?: MapTypeControlStyle;
   }
 
-  export enum MapTypeControlStyle {DEFAULT, DROPDOWN_MENU, HORIZONTAL_BAR}
+  enum MapTypeControlStyle {DEFAULT, DROPDOWN_MENU, HORIZONTAL_BAR}
 
-  export interface OverviewMapControlOptions {
+  interface OverviewMapControlOptions {
     opened?: boolean;
   }
 
-  export type GestureHandlingOptions = 'cooperative'|'greedy'|'none'|'auto';
+  type GestureHandlingOptions = 'cooperative'|'greedy'|'none'|'auto';
 
   /** Options for the rendering of the pan control. */
-  export interface PanControlOptions {
+  interface PanControlOptions {
     /**
      * Position id. Used to specify the position of the control on the map.
      * The default position is TOP_LEFT.
@@ -318,7 +318,7 @@ declare namespace google.maps {
   }
 
   /** Options for the rendering of the rotate control. */
-  export interface RotateControlOptions {
+  interface RotateControlOptions {
     /**
      * Position id. Used to specify the position of the control on the map.
      * The default position is TOP_LEFT.
@@ -327,15 +327,15 @@ declare namespace google.maps {
   }
 
   /** Options for the rendering of the scale control. */
-  export interface ScaleControlOptions {
+  interface ScaleControlOptions {
     /** Style id. Used to select what style of scale control to display. */
     style?: ScaleControlStyle;
   }
 
-  export enum ScaleControlStyle {DEFAULT}
+  enum ScaleControlStyle {DEFAULT}
 
   /** Options for the rendering of the Street View pegman control on the map. */
-  export interface StreetViewControlOptions {
+  interface StreetViewControlOptions {
     /**
      * Position id. Used to specify the position of the control on the map. The
      * default position is embedded within the navigation (zoom and pan)
@@ -348,7 +348,7 @@ declare namespace google.maps {
   }
 
   /** Options for the rendering of the zoom control. */
-  export interface ZoomControlOptions {
+  interface ZoomControlOptions {
     /**
      * Position id. Used to specify the position of the control on the map.
      * The default position is TOP_LEFT.
@@ -357,14 +357,14 @@ declare namespace google.maps {
     style?: ZoomControlStyle;
   }
 
-  export enum ZoomControlStyle {DEFAULT, LARGE, SMALL}
+  enum ZoomControlStyle {DEFAULT, LARGE, SMALL}
 
   /**
    * Identifiers used to specify the placement of controls on the map. Controls
    * are positioned relative to other controls in the same layout position.
    * Controls that are added first are positioned closer to the edge of the map.
    */
-  export enum ControlPosition {
+  enum ControlPosition {
     /** Elements are positioned in the center of the bottom row. */
     BOTTOM_CENTER,
     /**
@@ -412,7 +412,7 @@ declare namespace google.maps {
   type DrawingMode = 'Point'|'LineString'|'Polygon';
 
   /***** Data *****/
-  export class Data extends MVCObject {
+  class Data extends MVCObject {
     constructor(options?: Data.DataOptions);
     add(feature: Data.Feature|Data.FeatureOptions): Data.Feature;
     addGeoJson(geoJson: Object, options?: Data.GeoJsonOptions): Data.Feature[];
@@ -438,8 +438,8 @@ declare namespace google.maps {
     toGeoJson(callback: (feature: Object) => void): void;
   }
 
-  export module Data {
-    export interface DataOptions {
+  module Data {
+    interface DataOptions {
       controlPosition?: ControlPosition;
       controls?: DrawingMode[]|null;
       drawingMode?: DrawingMode|null;
@@ -448,11 +448,11 @@ declare namespace google.maps {
       style?: Data.StylingFunction|Data.StyleOptions;
     }
 
-    export interface GeoJsonOptions {
+    interface GeoJsonOptions {
       idPropertyName?: string;
     }
 
-    export interface StyleOptions {
+    interface StyleOptions {
       clickable?: boolean;
       cursor?: string;
       draggable?: boolean;
@@ -469,9 +469,9 @@ declare namespace google.maps {
       zIndex?: number;
     }
 
-    export type StylingFunction = (feature: Data.Feature) => Data.StyleOptions;
+    type StylingFunction = (feature: Data.Feature) => Data.StyleOptions;
 
-    export class Feature {
+    class Feature {
       constructor(options?: Data.FeatureOptions);
       forEachProperty(callback: (value: any, name: string) => void): void;
       getGeometry(): Data.Geometry;
@@ -483,58 +483,58 @@ declare namespace google.maps {
       toGeoJson(callback: (feature: Object) => void): void;
     }
 
-    export interface FeatureOptions {
+    interface FeatureOptions {
       geometry?: Data.Geometry|LatLng|LatLngLiteral;
       id?: number|string;
       properties?: Object;
     }
 
-    export class Geometry {
+    class Geometry {
       getType(): string;
       forEachLatLng(callback: (latLng: LatLng) => void): void;
     }
 
-    export class Point extends Data.Geometry {
+    class Point extends Data.Geometry {
       constructor(latLng: LatLng|LatLngLiteral);
       get(): LatLng;
     }
 
-    export class MultiPoint extends Data.Geometry {
+    class MultiPoint extends Data.Geometry {
       constructor(elements: (LatLng|LatLngLiteral)[]);
       getArray(): LatLng[];
       getAt(n: number): LatLng;
       getLength(): number;
     }
 
-    export class LineString extends Data.Geometry {
+    class LineString extends Data.Geometry {
       constructor(elements: (LatLng|LatLngLiteral)[]);
       getArray(): LatLng[];
       getAt(n: number): LatLng;
       getLength(): number;
     }
 
-    export class MultiLineString extends Data.Geometry {
+    class MultiLineString extends Data.Geometry {
       constructor(elements: (Data.LineString|(LatLng|LatLngLiteral)[])[]);
       getArray(): Data.LineString[];
       getAt(n: number): Data.LineString;
       getLength(): number;
     }
 
-    export class LinearRing extends Data.Geometry {
+    class LinearRing extends Data.Geometry {
       constructor(elements: (LatLng|LatLngLiteral)[]);
       getArray(): LatLng[];
       getAt(n: number): LatLng;
       getLength(): number;
     }
 
-    export class Polygon extends Data.Geometry {
+    class Polygon extends Data.Geometry {
       constructor(elements: (Data.LinearRing|(LatLng|LatLngLiteral)[])[]);
       getArray(): Data.LinearRing[];
       getAt(n: number): Data.LinearRing;
       getLength(): number;
     }
 
-    export class MultiPolygon extends Data.Geometry {
+    class MultiPolygon extends Data.Geometry {
       constructor(elements: (Data.Polygon|
                              (LinearRing|(LatLng|LatLngLiteral)[])[])[]);
       getArray(): Data.Polygon[];
@@ -542,39 +542,39 @@ declare namespace google.maps {
       getLength(): number;
     }
 
-    export class GeometryCollection extends Data.Geometry {
+    class GeometryCollection extends Data.Geometry {
       constructor(elements: (Data.Geometry[]|LatLng[]|LatLngLiteral)[]);
       getArray(): Data.Geometry[];
       getAt(n: number): Data.Geometry;
       getLength(): number;
     }
 
-    export interface MouseEvent extends google.maps.MouseEvent {
+    interface MouseEvent extends google.maps.MouseEvent {
       feature: Data.Feature;
     }
 
-    export interface AddFeatureEvent {
+    interface AddFeatureEvent {
       feature: Data.Feature;
     }
 
-    export interface RemoveFeatureEvent {
+    interface RemoveFeatureEvent {
       feature: Data.Feature;
     }
 
-    export interface SetGeometryEvent {
+    interface SetGeometryEvent {
       feature: Data.Feature;
       newGeometry: Data.Geometry;
       oldGeometry: Data.Geometry;
     }
 
-    export interface SetPropertyEvent {
+    interface SetPropertyEvent {
       feature: Data.Feature;
       name: string;
       newValue: any;
       oldValue: any;
     }
 
-    export interface RemovePropertyEvent {
+    interface RemovePropertyEvent {
       feature: Data.Feature;
       name: string;
       oldValue: any;
@@ -583,7 +583,7 @@ declare namespace google.maps {
 
   /***** Overlays *****/
 
-  export type MarkerChangeOptionEventNames =
+  type MarkerChangeOptionEventNames =
     "animation_changed" |
     "clickable_changed" |
     "cursor_changed" |
@@ -596,7 +596,7 @@ declare namespace google.maps {
     "visible_changed" |
     "zindex_changed";
 
-  export type MarkerMouseEventNames =
+  type MarkerMouseEventNames =
     "click" |
     "dblclick" |
     "drag" |
@@ -611,7 +611,7 @@ declare namespace google.maps {
   /**
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#Marker Maps JavaScript API}
    */
-  export class Marker extends MVCObject {
+  class Marker extends MVCObject {
     /**
      * The maximum default `z-index` that the API will assign to a marker. You
      * may set a higher `z-index` to bring a marker to the front.
@@ -711,7 +711,7 @@ declare namespace google.maps {
    * {@link Marker}.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerOptions Maps JavaScript API}
    */
-  export interface MarkerOptions {
+  interface MarkerOptions {
     /**
      * The offset from the marker's position to the tip of an InfoWindow that
      * has been opened with the marker as anchor.
@@ -814,7 +814,7 @@ declare namespace google.maps {
   }
 
   /** @see {@link MarkerOptions} */
-  export interface ReadonlyMarkerOptions {
+  interface ReadonlyMarkerOptions {
     /** @see {@link MarkerOptions#anchorPoint} */
     readonly anchorPoint?: Point;
     /** @see {@link MarkerOptions#animation} */
@@ -855,7 +855,7 @@ declare namespace google.maps {
    * A structure representing a Marker icon image.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#Icon Maps JavaScript API}
    */
-  export interface Icon {
+  interface Icon {
     /**
      * The position at which to anchor an image in correspondence to the
      * location of the marker on the map. By default, the anchor is located
@@ -897,7 +897,7 @@ declare namespace google.maps {
   }
 
   /** @see {@link Icon} */
-  export interface ReadonlyIcon {
+  interface ReadonlyIcon {
     /** @see {@link Icon#anchor} */
     readonly anchor?: Point;
     /** @see {@link Icon#labelOrigin} */
@@ -919,7 +919,7 @@ declare namespace google.maps {
    * {@link Icon#labelOrigin labelOrigin} property in the {@link Icon} class.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerLabel Maps JavaScript API}
    */
-  export interface MarkerLabel {
+  interface MarkerLabel {
     /**
      * The color of the label text.
      * @default 'black'
@@ -954,7 +954,7 @@ declare namespace google.maps {
   }
 
   /** @see {@link MarkerLabel} */
-  export interface ReadonlyMarkerLabel {
+  interface ReadonlyMarkerLabel {
     /** @see {@link MarkerLabel#color} */
     color?: string;
     /** @see {@link MarkerLabel#fontFamily} */
@@ -974,7 +974,7 @@ declare namespace google.maps {
     3: number;
   }
 
-  export interface MarkerShapeCircle {
+  interface MarkerShapeCircle {
     type: 'circle';
     /**
      * Coords is **[x1,y1,r]** where x1,y2 are the coordinates of the center of
@@ -983,7 +983,7 @@ declare namespace google.maps {
     coords: [number, number, number];
   }
 
-  export interface MarkerShapeRect {
+  interface MarkerShapeRect {
     type: 'rect';
     /**
      * Coords is **[x1,y1,x2,y2]** where x1,y1 are the coordinates of the
@@ -993,7 +993,7 @@ declare namespace google.maps {
     coords: [number, number, number, number];
   }
 
-  export interface MarkerShapePoly {
+  interface MarkerShapePoly {
     type: 'poly';
     /**
      * Coords is **[x1,y1,x2,y2...xn,yn]** where each x,y pair contains the
@@ -1008,14 +1008,14 @@ declare namespace google.maps {
    * non-transparent region of an image.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerShape Maps JavaScript API}
    */
-  export type MarkerShape = MarkerShapeCircle | MarkerShapeRect | MarkerShapePoly;
+  type MarkerShape = MarkerShapeCircle | MarkerShapeRect | MarkerShapePoly;
 
   /**
    * Describes a symbol, which consists of a vector path with styling. A symbol
    * can be used as the icon of a marker, or placed on a polyline.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#Symbol Maps JavaScript API}
    */
-  export interface Symbol {
+  interface Symbol {
     /**
      * The position of the symbol relative to the marker or polyline. The
      * coordinates of the symbol's path are translated left and up by the
@@ -1095,7 +1095,7 @@ declare namespace google.maps {
   }
 
   /** @see {@link Symbol} */
-  export interface ReadonlySymbol {
+  interface ReadonlySymbol {
     /** @see {@link Symbol#anchor} */
     readonly anchor?: Point;
     /** @see {@link Symbol#fillColor} */
@@ -1122,7 +1122,7 @@ declare namespace google.maps {
    * Built-in symbol paths.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#SymbolPath Maps JavaScript API}
    */
-  export enum SymbolPath {
+  enum SymbolPath {
     /**
      * A backward-pointing closed arrow.
      * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#SymbolPath.BACKWARD_CLOSED_ARROW Maps JavaScript API}
@@ -1156,7 +1156,7 @@ declare namespace google.maps {
    * {@link MarkerOptions#animation animation} option to play an animation.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#Animation Maps JavaScript API}
    */
-  export enum Animation {
+  enum Animation {
     /**
      * Marker bounces until animation is stopped.
      * @see {@link https://developers.google.com/maps/documentation/javascript/reference/marker#Animation.BOUNCE Maps JavaScript API}
@@ -1173,7 +1173,7 @@ declare namespace google.maps {
    * An overlay that looks like a bubble and is often connected to a marker.
    * This class extends MVCObject.
    */
-  export class InfoWindow extends MVCObject {
+  class InfoWindow extends MVCObject {
     /**
      * Creates an info window with the given options. An InfoWindow can be
      * placed on a map at a particular position or above a marker,
@@ -1205,7 +1205,7 @@ declare namespace google.maps {
     setZIndex(zIndex: number): void;
   }
 
-  export interface InfoWindowOptions {
+  interface InfoWindowOptions {
     /**
      * Content to display in the InfoWindow. This can be an HTML element, a
      * plain-text string, or a string containing HTML. The InfoWindow will be
@@ -1248,7 +1248,7 @@ declare namespace google.maps {
     zIndex?: number;
   }
 
-  export class Polyline extends MVCObject {
+  class Polyline extends MVCObject {
     constructor(opts?: PolylineOptions);
     getDraggable(): boolean;
     getEditable(): boolean;
@@ -1263,7 +1263,7 @@ declare namespace google.maps {
     setVisible(visible: boolean): void;
   }
 
-  export interface PolylineOptions {
+  interface PolylineOptions {
     /**
      * Indicates whether this Polyline handles mouse events. Defaults to true.
      */
@@ -1313,14 +1313,14 @@ declare namespace google.maps {
     zIndex?: number;
   }
 
-  export interface IconSequence {
+  interface IconSequence {
     fixedRotation?: boolean;
     icon?: Symbol;
     offset?: string;
     repeat?: string;
   }
 
-  export class Polygon extends MVCObject {
+  class Polygon extends MVCObject {
     constructor(opts?: PolygonOptions);
     getDraggable(): boolean;
     getEditable(): boolean;
@@ -1340,7 +1340,7 @@ declare namespace google.maps {
     setVisible(visible: boolean): void;
   }
 
-  export interface PolygonOptions {
+  interface PolygonOptions {
     /**
      * Indicates whether this Polygon handles mouse events. Defaults to true.
      */
@@ -1405,13 +1405,13 @@ declare namespace google.maps {
     zIndex?: number;
   }
 
-  export interface PolyMouseEvent extends MouseEvent {
+  interface PolyMouseEvent extends MouseEvent {
     edge?: number;
     path?: number;
     vertex?: number;
   }
 
-  export class Rectangle extends MVCObject {
+  class Rectangle extends MVCObject {
     constructor(opts?: RectangleOptions);
     getBounds(): LatLngBounds;
     getDraggable(): boolean;
@@ -1426,7 +1426,7 @@ declare namespace google.maps {
     setVisible(visible: boolean): void;
   }
 
-  export interface RectangleOptions {
+  interface RectangleOptions {
     bounds?: LatLngBounds|LatLngBoundsLiteral;
     clickable?: boolean;
     draggable?: boolean;
@@ -1443,7 +1443,7 @@ declare namespace google.maps {
   }
 
   /** A circle on the Earth's surface; also known as a "spherical cap". */
-  export class Circle extends MVCObject {
+  class Circle extends MVCObject {
     /**
      * Create a circle using the passed CircleOptions, which specify the
      * center, radius, and style.
@@ -1484,7 +1484,7 @@ declare namespace google.maps {
     setVisible(visible: boolean): void;
   }
 
-  export interface CircleOptions {
+  interface CircleOptions {
     /** The center */
     center?: LatLng|LatLngLiteral;
     /** Indicates whether this Circle handles mouse events. Defaults to true. */
@@ -1531,7 +1531,7 @@ declare namespace google.maps {
     zIndex?: number;
   }
 
-  export interface CircleLiteral extends CircleOptions {
+  interface CircleLiteral extends CircleOptions {
     /** The center of the Circle. */
     center?: LatLng|LatLngLiteral;
     /** The radius in meters on the Earth's surface. */
@@ -1541,7 +1541,7 @@ declare namespace google.maps {
   /**
    * The possible positions of the stroke on a polygon.
    */
-  export enum StrokePosition {
+  enum StrokePosition {
     /**
      * The stroke is centered on the polygon's path, with half the stroke inside
      * the polygon and half the stroke outside the polygon.
@@ -1553,7 +1553,7 @@ declare namespace google.maps {
     OUTSIDE
   }
 
-  export class GroundOverlay extends MVCObject {
+  class GroundOverlay extends MVCObject {
     constructor(
         url: string, bounds: LatLngBounds|LatLngBoundsLiteral,
         opts?: GroundOverlayOptions);
@@ -1565,13 +1565,13 @@ declare namespace google.maps {
     setOpacity(opacity: number): void;
   }
 
-  export interface GroundOverlayOptions {
+  interface GroundOverlayOptions {
     clickable?: boolean;
     map?: Map;
     opacity?: number;
   }
 
-  export class OverlayView extends MVCObject {
+  class OverlayView extends MVCObject {
     draw(): void;
     getMap(): Map|StreetViewPanorama;
     getPanes(): MapPanes;
@@ -1581,7 +1581,7 @@ declare namespace google.maps {
     setMap(map: Map|StreetViewPanorama|null): void;
   }
 
-  export interface MapPanes {
+  interface MapPanes {
     floatPane: Element;
     floatShadow: Element;
     mapPane: Element;
@@ -1592,7 +1592,7 @@ declare namespace google.maps {
     overlayShadow: Element;
   }
 
-  export class MapCanvasProjection extends MVCObject {
+  class MapCanvasProjection extends MVCObject {
     fromContainerPixelToLatLng(pixel: Point, nowrap?: boolean): LatLng;
     fromDivPixelToLatLng(pixel: Point, nowrap?: boolean): LatLng;
     fromLatLngToContainerPixel(latLng: LatLng): Point;
@@ -1601,14 +1601,14 @@ declare namespace google.maps {
   }
 
   /***** Services *****/
-  export class Geocoder {
+  class Geocoder {
     geocode(
         request: GeocoderRequest,
         callback: (results: GeocoderResult[], status: GeocoderStatus) => void):
         void;
   }
 
-  export interface GeocoderRequest {
+  interface GeocoderRequest {
     address?: string;
     bounds?: LatLngBounds|LatLngBoundsLiteral;
     componentRestrictions?: GeocoderComponentRestrictions;
@@ -1617,7 +1617,7 @@ declare namespace google.maps {
     region?: string;
   }
 
-  export interface GeocoderComponentRestrictions {
+  interface GeocoderComponentRestrictions {
     administrativeArea?: string;
     country?: string|string[];
     locality?: string;
@@ -1625,7 +1625,7 @@ declare namespace google.maps {
     route?: string;
   }
 
-  export enum GeocoderStatus {
+  enum GeocoderStatus {
     ERROR,
     INVALID_REQUEST,
     OK,
@@ -1635,7 +1635,7 @@ declare namespace google.maps {
     ZERO_RESULTS
   }
 
-  export interface GeocoderResult {
+  interface GeocoderResult {
     address_components: GeocoderAddressComponent[];
     formatted_address: string;
     geometry: GeocoderGeometry;
@@ -1645,27 +1645,27 @@ declare namespace google.maps {
     types: string[];
   }
 
-  export interface GeocoderAddressComponent {
+  interface GeocoderAddressComponent {
     long_name: string;
     short_name: string;
     types: string[];
   }
 
-  export interface GeocoderGeometry {
+  interface GeocoderGeometry {
     bounds: LatLngBounds;
     location: LatLng;
     location_type: GeocoderLocationType;
     viewport: LatLngBounds;
   }
 
-  export enum GeocoderLocationType {
+  enum GeocoderLocationType {
     APPROXIMATE,
     GEOMETRIC_CENTER,
     RANGE_INTERPOLATED,
     ROOFTOP
   }
 
-  export class DirectionsRenderer extends MVCObject {
+  class DirectionsRenderer extends MVCObject {
     constructor(opts?: DirectionsRendererOptions);
     getDirections(): DirectionsResult;
     getMap(): Map;
@@ -1678,7 +1678,7 @@ declare namespace google.maps {
     setRouteIndex(routeIndex: number): void;
   }
 
-  export interface DirectionsRendererOptions {
+  interface DirectionsRendererOptions {
     directions?: DirectionsResult;
     draggable?: boolean;
     hideRouteList?: boolean;
@@ -1695,7 +1695,7 @@ declare namespace google.maps {
     suppressPolylines?: boolean;
   }
 
-  export class DirectionsService {
+  class DirectionsService {
     route(
         request: DirectionsRequest,
         callback: (result: DirectionsResult, status: DirectionsStatus) => void):
@@ -1703,7 +1703,7 @@ declare namespace google.maps {
   }
 
   /** A directions query to be sent to the DirectionsService. */
-  export interface DirectionsRequest {
+  interface DirectionsRequest {
     /**
      * If true, instructs the Directions service to avoid ferries where
      * possible. Optional.
@@ -1770,35 +1770,35 @@ declare namespace google.maps {
     waypoints?: DirectionsWaypoint[];
   }
 
-  export enum TravelMode {BICYCLING, DRIVING, TRANSIT, WALKING}
+  enum TravelMode {BICYCLING, DRIVING, TRANSIT, WALKING}
 
-  export enum UnitSystem {IMPERIAL, METRIC}
+  enum UnitSystem {IMPERIAL, METRIC}
 
-  export interface TransitOptions {
+  interface TransitOptions {
     arrivalTime?: Date;
     departureTime?: Date;
     modes?: TransitMode[];
     routingPreference?: TransitRoutePreference;
   }
 
-  export enum TransitMode {BUS, RAIL, SUBWAY, TRAIN, TRAM}
+  enum TransitMode {BUS, RAIL, SUBWAY, TRAIN, TRAM}
 
-  export enum TransitRoutePreference {FEWER_TRANSFERS, LESS_WALKING}
+  enum TransitRoutePreference {FEWER_TRANSFERS, LESS_WALKING}
 
-  export interface TransitFare {}
+  interface TransitFare {}
 
-  export interface DrivingOptions {
+  interface DrivingOptions {
     departureTime: Date;
     trafficModel?: TrafficModel
   }
 
-  export enum TrafficModel {BEST_GUESS, OPTIMISTIC, PESSIMISTIC}
+  enum TrafficModel {BEST_GUESS, OPTIMISTIC, PESSIMISTIC}
 
   /**
    * A DirectionsWaypoint represents a location between origin and destination
    * through which the trip should be routed.
    */
-  export interface DirectionsWaypoint {
+  interface DirectionsWaypoint {
     /**
      * Waypoint location. Can be an address string, a LatLng, or a Place.
      * Optional.
@@ -1815,7 +1815,7 @@ declare namespace google.maps {
     stopover: boolean;
   }
 
-  export enum DirectionsStatus {
+  enum DirectionsStatus {
     INVALID_REQUEST,
     MAX_WAYPOINTS_EXCEEDED,
     NOT_FOUND,
@@ -1826,7 +1826,7 @@ declare namespace google.maps {
     ZERO_RESULTS
   }
 
-  export interface DirectionsResult {
+  interface DirectionsResult {
     geocoded_waypoints: DirectionsGeocodedWaypoint[];
     routes: DirectionsRoute[];
   }
@@ -1834,7 +1834,7 @@ declare namespace google.maps {
   /**
    * A single geocoded waypoint.
    */
-  export interface DirectionsGeocodedWaypoint {
+  interface DirectionsGeocodedWaypoint {
     partial_match: boolean;
     place_id: string;
     types: string[];
@@ -1845,7 +1845,7 @@ declare namespace google.maps {
    * Note that though this object is "JSON-like," it is not strictly JSON,
    * as it directly and indirectly includes LatLng objects.
    */
-  export interface DirectionsRoute {
+  interface DirectionsRoute {
     /** The bounds for this route. */
     bounds: LatLngBounds;
     /** Copyrights text to be displayed for this route. */
@@ -1891,7 +1891,7 @@ declare namespace google.maps {
     waypoint_order: number[];
   }
 
-  export interface DirectionsLeg {
+  interface DirectionsLeg {
     arrival_time: Time;
     departure_time: Time;
     distance: Distance;
@@ -1905,7 +1905,7 @@ declare namespace google.maps {
     via_waypoints: LatLng[];
   }
 
-  export interface DirectionsStep {
+  interface DirectionsStep {
     distance: Distance;
     duration: Duration;
     end_location: LatLng;
@@ -1917,23 +1917,23 @@ declare namespace google.maps {
     travel_mode: TravelMode;
   }
 
-  export interface Distance {
+  interface Distance {
     text: string;
     value: number;
   }
 
-  export interface Duration {
+  interface Duration {
     text: string;
     value: number;
   }
 
-  export interface Time {
+  interface Time {
     text: string;
     time_zone: string;
     value: Date;
   }
 
-  export interface TransitDetails {
+  interface TransitDetails {
     arrival_stop: TransitStop;
     arrival_time: Time;
     departure_stop: TransitStop;
@@ -1944,12 +1944,12 @@ declare namespace google.maps {
     num_stops: number;
   }
 
-  export interface TransitStop {
+  interface TransitStop {
     location: LatLng;
     name: string;
   }
 
-  export interface TransitLine {
+  interface TransitLine {
     agencies: TransitAgency[];
     color: string;
     icon: string;
@@ -1960,20 +1960,20 @@ declare namespace google.maps {
     vehicle: TransitVehicle;
   }
 
-  export interface TransitAgency {
+  interface TransitAgency {
     name: string;
     phone: string;
     url: string;
   }
 
-  export interface TransitVehicle {
+  interface TransitVehicle {
     icon: string;
     local_icon: string;
     name: string;
     type: VehicleType;
   }
 
-  export enum VehicleType {
+  enum VehicleType {
     BUS,
     CABLE_CAR,
     COMMUTER_TRAIN,
@@ -1993,7 +1993,7 @@ declare namespace google.maps {
     TROLLEYBUS
   }
 
-  export class ElevationService {
+  class ElevationService {
     getElevationAlongPath(
         request: PathElevationRequest,
         callback:
@@ -2006,22 +2006,22 @@ declare namespace google.maps {
         void;
   }
 
-  export interface LocationElevationRequest {
+  interface LocationElevationRequest {
     locations: LatLng[];
   }
 
-  export interface PathElevationRequest {
+  interface PathElevationRequest {
     path?: LatLng[];
     samples?: number;
   }
 
-  export interface ElevationResult {
+  interface ElevationResult {
     elevation: number;
     location: LatLng;
     resolution: number;
   }
 
-  export enum ElevationStatus {
+  enum ElevationStatus {
     INVALID_REQUEST,
     OK,
     OVER_QUERY_LIMIT,
@@ -2029,20 +2029,20 @@ declare namespace google.maps {
     UNKNOWN_ERROR
   }
 
-  export class MaxZoomService {
+  class MaxZoomService {
     getMaxZoomAtLatLng(
         latlng: LatLng|LatLngLiteral,
         callback: (result: MaxZoomResult) => void): void;
   }
 
-  export interface MaxZoomResult {
+  interface MaxZoomResult {
     status: MaxZoomStatus;
     zoom: number;
   }
 
-  export enum MaxZoomStatus {ERROR, OK}
+  enum MaxZoomStatus {ERROR, OK}
 
-  export class DistanceMatrixService {
+  class DistanceMatrixService {
     getDistanceMatrix(
         request: DistanceMatrixRequest,
         callback:
@@ -2050,7 +2050,7 @@ declare namespace google.maps {
              status: DistanceMatrixStatus) => void): void;
   }
 
-  export interface DistanceMatrixRequest {
+  interface DistanceMatrixRequest {
     avoidFerries?: boolean;
     avoidHighways?: boolean;
     avoidTolls?: boolean;
@@ -2064,17 +2064,17 @@ declare namespace google.maps {
     unitSystem?: UnitSystem;
   }
 
-  export interface DistanceMatrixResponse {
+  interface DistanceMatrixResponse {
     destinationAddresses: string[];
     originAddresses: string[];
     rows: DistanceMatrixResponseRow[];
   }
 
-  export interface DistanceMatrixResponseRow {
+  interface DistanceMatrixResponseRow {
     elements: DistanceMatrixResponseElement[];
   }
 
-  export interface DistanceMatrixResponseElement {
+  interface DistanceMatrixResponseElement {
     distance: Distance;
     duration: Duration;
     duration_in_traffic: Duration;
@@ -2082,7 +2082,7 @@ declare namespace google.maps {
     status: DistanceMatrixElementStatus;
   }
 
-  export enum DistanceMatrixStatus {
+  enum DistanceMatrixStatus {
     INVALID_REQUEST,
     MAX_DIMENSIONS_EXCEEDED,
     MAX_ELEMENTS_EXCEEDED,
@@ -2092,22 +2092,22 @@ declare namespace google.maps {
     UNKNOWN_ERROR
   }
 
-  export enum DistanceMatrixElementStatus {NOT_FOUND, OK, ZERO_RESULTS}
+  enum DistanceMatrixElementStatus {NOT_FOUND, OK, ZERO_RESULTS}
 
   /***** Save to Google Maps *****/
-  export interface Attribution {
+  interface Attribution {
     iosDeepLinkId?: string;
     source?: string;
     webUrl?: string;
   }
 
-  export interface Place {
+  interface Place {
     location?: LatLng|LatLngLiteral;
     placeId?: string;
     query?: string;
   }
 
-  export class SaveWidget {
+  class SaveWidget {
     constructor(container: Node, opts?: SaveWidgetOptions);
     getAttribution(): Attribution;
     getPlace(): Place;
@@ -2116,13 +2116,13 @@ declare namespace google.maps {
     setPlace(place: Place): void;
   }
 
-  export interface SaveWidgetOptions {
+  interface SaveWidgetOptions {
     attribution?: Attribution;
     place?: Place;
   }
 
   /***** Map Types *****/
-  export interface MapType {
+  interface MapType {
     getTile(tileCoord: Point, zoom: number, ownerDocument: Document): Element;
     releaseTile(tile: Element): void;
     alt?: string;
@@ -2134,17 +2134,17 @@ declare namespace google.maps {
     tileSize?: Size;
   }
 
-  export class MapTypeRegistry extends MVCObject {
+  class MapTypeRegistry extends MVCObject {
     constructor();
     set(id: string, mapType: MapType): void;
   }
 
-  export interface Projection {
+  interface Projection {
     fromLatLngToPoint(latLng: LatLng, point?: Point): Point;
     fromPointToLatLng(pixel: Point, noWrap?: boolean): LatLng;
   }
 
-  export class ImageMapType extends MVCObject implements MapType {
+  class ImageMapType extends MVCObject implements MapType {
     constructor(opts: ImageMapTypeOptions);
     getOpacity(): number;
     getTile(tileCoord: Point, zoom: number, ownerDocument: Document): Element;
@@ -2159,7 +2159,7 @@ declare namespace google.maps {
     tileSize: Size;
   }
 
-  export interface ImageMapTypeOptions {
+  interface ImageMapTypeOptions {
     alt?: string;
     getTileUrl(tileCoord: Point, zoom: number): string;
     maxZoom?: number;
@@ -2169,7 +2169,7 @@ declare namespace google.maps {
     tileSize: Size;
   }
 
-  export class StyledMapType extends MVCObject implements MapType {
+  class StyledMapType extends MVCObject implements MapType {
     constructor(styles: MapTypeStyle[], options?: StyledMapTypeOptions);
     getTile(tileCoord: Point, zoom: number, ownerDocument: Document): Element;
     releaseTile(tile: Element): void;
@@ -2182,20 +2182,20 @@ declare namespace google.maps {
     tileSize: Size;
   }
 
-  export interface StyledMapTypeOptions {
+  interface StyledMapTypeOptions {
     alt?: string;
     maxZoom?: number;
     minZoom?: number;
     name?: string;
   }
 
-  export interface MapTypeStyle {
+  interface MapTypeStyle {
     elementType?: MapTypeStyleElementType;
     featureType?: MapTypeStyleFeatureType;
     stylers?: MapTypeStyler[];
   }
 
-  export type MapTypeStyleFeatureType =
+  type MapTypeStyleFeatureType =
       'all'|'administrative'|'administrative.country'|
       'administrative.land_parcel'|'administrative.locality'|
       'administrative.neighborhood'|'administrative.province'|'landscape'|
@@ -2207,11 +2207,11 @@ declare namespace google.maps {
       'transit.station'|'transit.station.airport'|'transit.station.bus'|
       'transit.station.rail'|'water';
 
-  export type MapTypeStyleElementType =
+  type MapTypeStyleElementType =
       'all'|'geometry'|'geometry.fill'|'geometry.stroke'|'labels'|'labels.icon'|
       'labels.text'|'labels.text.fill'|'labels.text.stroke';
 
-  export interface MapTypeStyler {
+  interface MapTypeStyler {
     color?: string;
     gamma?: number;
     hue?: string;
@@ -2223,20 +2223,20 @@ declare namespace google.maps {
   }
 
   /***** Layers *****/
-  export class BicyclingLayer extends MVCObject {
+  class BicyclingLayer extends MVCObject {
     constructor();
     getMap(): Map;
     setMap(map: Map|null): void;
   }
 
-  export class FusionTablesLayer extends MVCObject {
+  class FusionTablesLayer extends MVCObject {
     constructor(options: FusionTablesLayerOptions);
     getMap(): Map;
     setMap(map: Map|null): void;
     setOptions(options: FusionTablesLayerOptions): void;
   }
 
-  export interface FusionTablesLayerOptions {
+  interface FusionTablesLayerOptions {
     clickable?: boolean;
     heatmap?: FusionTablesHeatmap;
     map?: Map;
@@ -2245,7 +2245,7 @@ declare namespace google.maps {
     suppressInfoWindows?: boolean;
   }
 
-  export interface FusionTablesQuery {
+  interface FusionTablesQuery {
     from?: string;
     limit?: number;
     offset?: number;
@@ -2254,22 +2254,22 @@ declare namespace google.maps {
     where?: string;
   }
 
-  export interface FusionTablesStyle {
+  interface FusionTablesStyle {
     markerOptions?: FusionTablesMarkerOptions;
     polygonOptions?: FusionTablesPolygonOptions;
     polylineOptions?: FusionTablesPolylineOptions;
     where?: string;
   }
 
-  export interface FusionTablesHeatmap {
+  interface FusionTablesHeatmap {
     enabled: boolean;
   }
 
-  export interface FusionTablesMarkerOptions {
+  interface FusionTablesMarkerOptions {
     iconName: string;
   }
 
-  export interface FusionTablesPolygonOptions {
+  interface FusionTablesPolygonOptions {
     fillColor?: string;
     fillOpacity?: number;
     strokeColor?: string;
@@ -2277,25 +2277,25 @@ declare namespace google.maps {
     strokeWeight?: number;
   }
 
-  export interface FusionTablesPolylineOptions {
+  interface FusionTablesPolylineOptions {
     strokeColor?: string;
     strokeOpacity?: number;
     strokeWeight?: number;
   }
 
-  export interface FusionTablesMouseEvent {
+  interface FusionTablesMouseEvent {
     infoWindowHtml?: string;
     latLng?: LatLng;
     pixelOffset?: Size;
     row?: Object;  // Object<FusionTablesCell>
   }
 
-  export interface FusionTablesCell {
+  interface FusionTablesCell {
     columnName?: string;
     value?: string;
   }
 
-  export class KmlLayer extends MVCObject {
+  class KmlLayer extends MVCObject {
     constructor(opts?: KmlLayerOptions);
     getDefaultViewport(): LatLngBounds;
     getMap(): Map;
@@ -2309,7 +2309,7 @@ declare namespace google.maps {
     setOptions(options: KmlLayerOptions): void;
   }
 
-  export interface KmlLayerOptions {
+  interface KmlLayerOptions {
     clickable?: boolean;
     map?: Map;
     preserveViewport?: boolean;
@@ -2319,7 +2319,7 @@ declare namespace google.maps {
     zIndex?: number;
   }
 
-  export interface KmlLayerMetadata {
+  interface KmlLayerMetadata {
     author: KmlAuthor;
     description: string;
     hasScreenOverlays: boolean;
@@ -2327,7 +2327,7 @@ declare namespace google.maps {
     snippet: string;
   }
 
-  export enum KmlLayerStatus {
+  enum KmlLayerStatus {
     DOCUMENT_NOT_FOUND,
     DOCUMENT_TOO_LARGE,
     FETCH_ERROR,
@@ -2339,13 +2339,13 @@ declare namespace google.maps {
     UNKNOWN
   }
 
-  export interface KmlMouseEvent {
+  interface KmlMouseEvent {
     featureData: KmlFeatureData;
     latLng: LatLng;
     pixelOffset: Size;
   }
 
-  export interface KmlFeatureData {
+  interface KmlFeatureData {
     author: KmlAuthor;
     description: string;
     id: string;
@@ -2354,32 +2354,32 @@ declare namespace google.maps {
     snippet: string;
   }
 
-  export interface KmlAuthor {
+  interface KmlAuthor {
     email: string;
     name: string;
     uri: string;
   }
 
-  export class TrafficLayer extends MVCObject {
+  class TrafficLayer extends MVCObject {
     constructor(opts?: TrafficLayerOptions);
     getMap(): Map;
     setMap(map: Map|null): void;
     setOptions(options: TrafficLayerOptions): void;
   }
 
-  export interface TrafficLayerOptions {
+  interface TrafficLayerOptions {
     autoRefresh?: boolean;
     map?: Map;
   }
 
-  export class TransitLayer extends MVCObject {
+  class TransitLayer extends MVCObject {
     constructor();
     getMap(): void;
     setMap(map: Map|null): void;
   }
 
   /***** Street View *****/
-  export class StreetViewPanorama extends MVCObject {
+  class StreetViewPanorama extends MVCObject {
     constructor(container: Element, opts?: StreetViewPanoramaOptions);
     controls: MVCArray<Node>[];
     getLinks(): StreetViewLink[];
@@ -2405,7 +2405,7 @@ declare namespace google.maps {
   }
 
   /** Options for the rendering of the fullscreen control. */
-  export interface FullscreenControlOptions {
+  interface FullscreenControlOptions {
     /**
      * Position id. Used to specify the position of the control on the map.
      * The default position is RIGHT_TOP.
@@ -2413,7 +2413,7 @@ declare namespace google.maps {
     position?: ControlPosition;
   }
 
-  export interface StreetViewPanoramaOptions {
+  interface StreetViewPanoramaOptions {
     addressControl?: boolean;
     addressControlOptions?: StreetViewAddressControlOptions;
     clickToGo?: boolean;
@@ -2441,22 +2441,22 @@ declare namespace google.maps {
     zoomControlOptions?: ZoomControlOptions;
   }
 
-  export interface StreetViewAddressControlOptions {
+  interface StreetViewAddressControlOptions {
     position?: ControlPosition;
   }
 
-  export interface StreetViewLink {
+  interface StreetViewLink {
     description?: string;
     heading?: number;
     pano?: string;
   }
 
-  export interface StreetViewPov {
+  interface StreetViewPov {
     heading?: number;
     pitch?: number;
   }
 
-  export interface StreetViewPanoramaData {
+  interface StreetViewPanoramaData {
     copyright?: string;
     imageDate?: string;
     links?: StreetViewLink[];
@@ -2464,14 +2464,14 @@ declare namespace google.maps {
     tiles?: StreetViewTileData;
   }
 
-  export interface StreetViewLocation {
+  interface StreetViewLocation {
     description?: string;
     latLng?: LatLng;
     pano?: string;
     shortDescription?: string;
   }
 
-  export interface StreetViewTileData {
+  interface StreetViewTileData {
     getTileUrl(pano: string, tileZoom: number, tileX: number, tileY: number):
         string;
     centerHeading?: number;
@@ -2479,22 +2479,22 @@ declare namespace google.maps {
     worldSize?: Size;
   }
 
-  export enum StreetViewPreference {BEST, NEAREST}
+  enum StreetViewPreference {BEST, NEAREST}
 
-  export enum StreetViewSource {DEFAULT, OUTDOOR}
+  enum StreetViewSource {DEFAULT, OUTDOOR}
 
-  export interface StreetViewLocationRequest {
+  interface StreetViewLocationRequest {
     location: LatLng|LatLngLiteral;
     preference?: StreetViewPreference;
     radius?: number;
     source?: StreetViewSource;
   }
 
-  export interface StreetViewPanoRequest {
+  interface StreetViewPanoRequest {
     pano: string;
   }
 
-  export class StreetViewService {
+  class StreetViewService {
     getPanorama(
         request: StreetViewLocationRequest|StreetViewPanoRequest,
         cb: (data: StreetViewPanoramaData, status: StreetViewStatus) => void):
@@ -2511,19 +2511,19 @@ declare namespace google.maps {
              streetViewStatus: StreetViewStatus) => void): void;
   }
 
-  export enum StreetViewStatus {OK, UNKNOWN_ERROR, ZERO_RESULTS}
+  enum StreetViewStatus {OK, UNKNOWN_ERROR, ZERO_RESULTS}
 
-  export class StreetViewCoverageLayer extends MVCObject {
+  class StreetViewCoverageLayer extends MVCObject {
     getMap(): Map;
     setMap(map: Map|null): void;
   }
 
-  export interface MotionTrackingControlOptions {
+  interface MotionTrackingControlOptions {
     position?: ControlPosition;
   }
 
   /***** Events *****/
-  export interface MapsEventListener {
+  interface MapsEventListener {
     /**
      * Removes the listener.  Equivalent to calling
      * google.maps.event.removeListener(listener).
@@ -2531,7 +2531,7 @@ declare namespace google.maps {
     remove(): void;
   }
 
-  export class event {
+  class event {
     /**
      * Cross browser event handler registration. This listener is removed by
      * calling removeListener(handle) for the handle that is returned by this
@@ -2585,7 +2585,7 @@ declare namespace google.maps {
    * This object is returned from various mouse events on the map and overlays,
    * and contains all the fields shown below.
    */
-  export interface MouseEvent {
+  interface MouseEvent {
     /** Prevents this event from propagating further. */
     stop(): void;
     /**
@@ -2602,7 +2602,7 @@ declare namespace google.maps {
    * on this event to prevent it being propagated. Learn more about place IDs in
    * the Places API developer guide.
    */
-  export interface IconMouseEvent extends MouseEvent {
+  interface IconMouseEvent extends MouseEvent {
     /**
      * The place ID of the place that was clicked.
      * This place ID can be used to query more information about the feature
@@ -2632,7 +2632,7 @@ declare namespace google.maps {
    * Notice that you cannot modify the coordinates of a LatLng. If you want
    * to compute another point, you have to create a new one.
    */
-  export class LatLng {
+  class LatLng {
     /**
      * Creates a LatLng object representing a geographic point.
      * Note the ordering of latitude and longitude.
@@ -2674,7 +2674,7 @@ declare namespace google.maps {
    * when the Maps API encounters them.
    * @see {@link https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngLiteral Maps JavaScript API}
    */
-  export interface LatLngLiteral {
+  interface LatLngLiteral {
     /**
      * Latitude in degrees. Values will be clamped to the range [-90, 90]. This
      * means that if the value specified is less than -90, it will be set to
@@ -2691,14 +2691,14 @@ declare namespace google.maps {
   }
 
   /** @see {@link LatLngLiteral}. */
-  export interface ReadonlyLatLngLiteral {
+  interface ReadonlyLatLngLiteral {
     /** @see {@link LatLngLiteral#lat} */
     readonly lat: number;
     /** @see {@link LatLngLiteral#lng} */
     readonly lng: number;
   }
 
-  export type LatLngBoundsLiteral = {
+  type LatLngBoundsLiteral = {
     east: number; north: number; south: number; west: number
   }
 
@@ -2706,7 +2706,7 @@ declare namespace google.maps {
    * A LatLngBounds instance represents a rectangle in geographical coordinates,
    * including one that crosses the 180 degrees longitudinal meridian.
    */
-  export class LatLngBounds {
+  class LatLngBounds {
     /**
      * Constructs a rectangle from the points at its south-west and north-east
      * corners.
@@ -2749,7 +2749,7 @@ declare namespace google.maps {
     union(other: LatLngBounds|LatLngBoundsLiteral): LatLngBounds;
   }
 
-  export class Point {
+  class Point {
     /** A point on a two-dimensional plane. */
     constructor(x: number, y: number);
     /** The X coordinate */
@@ -2762,7 +2762,7 @@ declare namespace google.maps {
     toString(): string;
   }
 
-  export class Size {
+  class Size {
     constructor(
         width: number, height: number, widthUnit?: string, heightUnit?: string);
     height: number;
@@ -2773,7 +2773,7 @@ declare namespace google.maps {
 
   /***** MVC *****/
   /** Base class implementing KVO. */
-  export class MVCObject {
+  class MVCObject {
     /**
      * The MVCObject constructor is guaranteed to be an empty function, and so
      * you may inherit from MVCObject by simply writing MySubclass.prototype =
@@ -2816,7 +2816,7 @@ declare namespace google.maps {
   }
 
   /** This class extends MVCObject. */
-  export class MVCArray<T> extends MVCObject {
+  class MVCArray<T> extends MVCObject {
     /** A mutable MVC Array. */
     constructor(array?: T[]);
     /** Removes all elements from the array. */
@@ -2851,8 +2851,8 @@ declare namespace google.maps {
   }
 
   /***** Geometry Library *****/
-  export module geometry {
-    export class encoding {
+  module geometry {
+    class encoding {
       static decodePath(encodedPath: string): LatLng[];
       static encodePath(path: LatLng[]|MVCArray<LatLng>): string;
     }
@@ -2861,7 +2861,7 @@ declare namespace google.maps {
      * Utility functions for computing geodesic angles, distances and areas.
      * The default radius is Earth's radius of 6378137 meters.
      */
-    export class spherical {
+    class spherical {
       /**
        * Returns the area of a closed path.
        * The computed area uses the same units as the radius.
@@ -2919,7 +2919,7 @@ declare namespace google.maps {
       static interpolate(from: LatLng, to: LatLng, fraction: number): LatLng;
     }
 
-    export class poly {
+    class poly {
       static containsLocation(point: LatLng, polygon: Polygon): boolean;
       static isLocationOnEdge(
           point: LatLng, poly: Polygon|Polyline, tolerance?: number): boolean;
@@ -2927,8 +2927,8 @@ declare namespace google.maps {
   }
 
   /***** AdSense Library *****/
-  export module adsense {
-    export class AdUnit extends MVCObject {
+  module adsense {
+    class AdUnit extends MVCObject {
       constructor(container: Element, opts: AdUnitOptions);
       getBackgroundColor(): string;
       getBorderColor(): string;
@@ -2952,7 +2952,7 @@ declare namespace google.maps {
       setUrlColor(urlColor: string): void;
     }
 
-    export interface AdUnitOptions {
+    interface AdUnitOptions {
       backgroundColor?: string;
       borderColor?: string;
       channelNumber?: string;
@@ -2965,7 +2965,7 @@ declare namespace google.maps {
       urlColor?: string;
     }
 
-    export enum AdFormat {
+    enum AdFormat {
       BANNER,
       BUTTON,
       HALF_BANNER,
@@ -2988,8 +2988,8 @@ declare namespace google.maps {
   }
 
   /***** Places Library *****/
-  export module places {
-    export class Autocomplete extends MVCObject {
+  module places {
+    class Autocomplete extends MVCObject {
       constructor(inputField: HTMLInputElement, opts?: AutocompleteOptions);
       getBounds(): LatLngBounds;
       getPlace(): PlaceResult;
@@ -2998,7 +2998,7 @@ declare namespace google.maps {
       setTypes(types: string[]): void;
     }
 
-    export interface AutocompleteOptions {
+    interface AutocompleteOptions {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       componentRestrictions?: ComponentRestrictions;
       placeIdOnly?: boolean;
@@ -3008,7 +3008,7 @@ declare namespace google.maps {
       fields?: string[];
     }
 
-    export interface AutocompletePrediction {
+    interface AutocompletePrediction {
       description: string;
       matched_substrings: PredictionSubstring[];
       place_id: string;
@@ -3018,24 +3018,24 @@ declare namespace google.maps {
       types: string[];
     }
 
-    export interface AutocompleteStructuredFormatting {
+    interface AutocompleteStructuredFormatting {
       main_text: string;
       main_text_matched_substrings: PredictionSubstring[];
       secondary_text: string;
     }
 
-    export interface OpeningHours {
+    interface OpeningHours {
       open_now: boolean;
       periods: OpeningPeriod[];
       weekday_text: string[];
     }
 
-    export interface OpeningPeriod {
+    interface OpeningPeriod {
       open: OpeningHoursTime;
       close?: OpeningHoursTime;
     }
 
-    export interface OpeningHoursTime {
+    interface OpeningHoursTime {
       day: number;
       hours: number;
       minutes: number;
@@ -3043,17 +3043,17 @@ declare namespace google.maps {
       time: string;
     }
 
-    export interface PredictionTerm {
+    interface PredictionTerm {
       offset: number;
       value: string;
     }
 
-    export interface PredictionSubstring {
+    interface PredictionSubstring {
       length: number;
       offset: number;
     }
 
-    export class AutocompleteService {
+    class AutocompleteService {
       constructor();
       getPlacePredictions(
           request: AutocompletionRequest,
@@ -3067,11 +3067,11 @@ declare namespace google.maps {
                status: PlacesServiceStatus) => void): void;
     }
 
-    export class AutocompleteSessionToken {
+    class AutocompleteSessionToken {
       constructor();
     }
 
-    export interface AutocompletionRequest {
+    interface AutocompletionRequest {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       componentRestrictions?: ComponentRestrictions;
       input: string;
@@ -3082,42 +3082,42 @@ declare namespace google.maps {
       types?: string[];
     }
 
-    export interface ComponentRestrictions {
+    interface ComponentRestrictions {
       country: string|string[];
     }
 
-    export type LocationBias = LatLng|LatLngLiteral|LatLngBounds|
+    type LocationBias = LatLng|LatLngLiteral|LatLngBounds|
         LatLngBoundsLiteral|Circle|CircleLiteral|string;
 
-    export interface PlaceAspectRating {
+    interface PlaceAspectRating {
       rating: number;
       type: string;
     }
 
-    export interface PlaceDetailsRequest {
+    interface PlaceDetailsRequest {
       placeId: string;
       fields?: string[];
       sessionToken?: AutocompleteSessionToken;
     }
 
-    export interface PlaceGeometry {
+    interface PlaceGeometry {
       location: LatLng;
       viewport: LatLngBounds;
     }
 
-    export interface PlacePhoto {
+    interface PlacePhoto {
       height: number;
       html_attributions: string[];
       width: number;
       getUrl(opts: PhotoOptions): string;
     }
 
-    export interface PhotoOptions {
+    interface PhotoOptions {
       maxHeight?: number;
       maxWidth?: number;
     }
 
-    export interface PlaceResult {
+    interface PlaceResult {
       address_components?: GeocoderAddressComponent[];
       adr_address?: string;
       aspects?: PlaceAspectRating[];
@@ -3143,7 +3143,7 @@ declare namespace google.maps {
       website?: string;
     }
 
-    export interface PlaceReview {
+    interface PlaceReview {
       aspects: PlaceAspectRating[];
       author_name: string;
       author_url: string;
@@ -3151,12 +3151,12 @@ declare namespace google.maps {
       text: string;
     }
 
-    export interface PlaceSearchPagination {
+    interface PlaceSearchPagination {
       nextPage(): void;
       hasNextPage: boolean;
     }
 
-    export interface PlaceSearchRequest {
+    interface PlaceSearchRequest {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       keyword?: string;
       location?: LatLng|LatLngLiteral;
@@ -3170,7 +3170,7 @@ declare namespace google.maps {
       type?: string;
     }
 
-    export class PlacesService {
+    class PlacesService {
       constructor(attrContainer: HTMLDivElement|Map);
       findPlaceFromPhoneNumber(
           request: FindPlaceFromPhoneNumberRequest,
@@ -3207,7 +3207,7 @@ declare namespace google.maps {
                pagination: PlaceSearchPagination) => void): void;
     }
 
-    export enum PlacesServiceStatus {
+    enum PlacesServiceStatus {
       ERROR,
       INVALID_REQUEST,
       OK,
@@ -3218,14 +3218,14 @@ declare namespace google.maps {
       ZERO_RESULTS
     }
 
-    export interface QueryAutocompletePrediction {
+    interface QueryAutocompletePrediction {
       description: string;
       matched_substrings: PredictionSubstring[];
       place_id: string;
       terms: PredictionTerm[];
     }
 
-    export interface QueryAutocompletionRequest {
+    interface QueryAutocompletionRequest {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       input?: string;
       location?: LatLng;
@@ -3233,7 +3233,7 @@ declare namespace google.maps {
       radius?: number;
     }
 
-    export interface RadarSearchRequest {
+    interface RadarSearchRequest {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       keyword?: string;
       location?: LatLng|LatLngLiteral;
@@ -3243,20 +3243,20 @@ declare namespace google.maps {
       type?: string;
     }
 
-    export enum RankBy {DISTANCE, PROMINENCE}
+    enum RankBy {DISTANCE, PROMINENCE}
 
-    export class SearchBox extends MVCObject {
+    class SearchBox extends MVCObject {
       constructor(inputField: HTMLInputElement, opts?: SearchBoxOptions);
       getBounds(): LatLngBounds;
       getPlaces(): PlaceResult[];
       setBounds(bounds: LatLngBounds|LatLngBoundsLiteral): void;
     }
 
-    export interface SearchBoxOptions {
+    interface SearchBoxOptions {
       bounds: LatLngBounds|LatLngBoundsLiteral;
     }
 
-    export interface TextSearchRequest {
+    interface TextSearchRequest {
       bounds?: LatLngBounds|LatLngBoundsLiteral;
       location?: LatLng|LatLngLiteral;
       query: string;
@@ -3265,13 +3265,13 @@ declare namespace google.maps {
       type?: string;
     }
 
-    export interface FindPlaceFromQueryRequest {
+    interface FindPlaceFromQueryRequest {
       fields: string[];
       locationBias?: LocationBias;
       query: string;
     }
 
-    export interface FindPlaceFromPhoneNumberRequest {
+    interface FindPlaceFromPhoneNumberRequest {
       fields: string[];
       locationBias?: LocationBias;
       phoneNumber: string;
@@ -3279,8 +3279,8 @@ declare namespace google.maps {
   }
 
   /***** Drawing Library *****/
-  export module drawing {
-    export class DrawingManager extends MVCObject {
+  module drawing {
+    class DrawingManager extends MVCObject {
       constructor(options?: DrawingManagerOptions);
       getDrawingMode(): OverlayType;
       getMap(): Map;
@@ -3290,7 +3290,7 @@ declare namespace google.maps {
     }
 
     /** Options for the drawing manager. */
-    export interface DrawingManagerOptions {
+    interface DrawingManagerOptions {
       /**
        * Options to apply to any new circles created with this DrawingManager.
        * The center and radius properties are ignored, and the map property of a
@@ -3342,13 +3342,13 @@ declare namespace google.maps {
       rectangleOptions?: RectangleOptions;
     }
 
-    export interface DrawingControlOptions {
+    interface DrawingControlOptions {
       drawingModes?: OverlayType[];
       position?: ControlPosition;
     }
 
     /** The properties of an overlaycomplete event on a DrawingManager.. */
-    export interface OverlayCompleteEvent {
+    interface OverlayCompleteEvent {
       /** The completed overlay. */
       overlay: Marker|Polygon|Polyline|Rectangle|Circle;
       /** The completed overlay's type. */
@@ -3360,7 +3360,7 @@ declare namespace google.maps {
      * these by value, or by using the constant's name. For example, 'polygon'
      * or google.maps.drawing.OverlayType.POLYGON.
      */
-    export enum OverlayType {
+    enum OverlayType {
       /**
        * Specifies that the DrawingManager creates circles, and that the overlay
        * given in the overlaycomplete event is a circle.
@@ -3390,8 +3390,8 @@ declare namespace google.maps {
   }
 
   /***** Visualization Library *****/
-  export module visualization {
-    export class MapsEngineLayer extends MVCObject {
+  module visualization {
+    class MapsEngineLayer extends MVCObject {
       constructor(options: MapsEngineLayerOptions);
       getLayerId(): string;
       getLayerKey(): string;
@@ -3410,7 +3410,7 @@ declare namespace google.maps {
       setZIndex(zIndex: number): void;
     }
 
-    export interface MapsEngineLayerOptions {
+    interface MapsEngineLayerOptions {
       accessToken?: string;
       clickable?: boolean;
       fitBounds?: boolean;
@@ -3423,20 +3423,20 @@ declare namespace google.maps {
       zIndex?: number;
     }
 
-    export interface MapsEngineLayerProperties {
+    interface MapsEngineLayerProperties {
       name: string;
     }
 
-    export interface MapsEngineMouseEvent {
+    interface MapsEngineMouseEvent {
       featureId?: string;
       infoWindowHtml?: string;
       latLng?: LatLng;
       pixelOffset?: Size;
     }
 
-    export enum MapsEngineStatus {INVALID_LAYER, OK, UNKNOWN_ERROR}
+    enum MapsEngineStatus {INVALID_LAYER, OK, UNKNOWN_ERROR}
 
-    export class HeatmapLayer extends MVCObject {
+    class HeatmapLayer extends MVCObject {
       constructor(opts?: HeatmapLayerOptions);
       getData<T extends LatLng|WeightedLocation>(): MVCArray<T>;
       getMap(): Map;
@@ -3445,7 +3445,7 @@ declare namespace google.maps {
       setMap(map: Map|null): void;
     }
 
-    export interface HeatmapLayerOptions {
+    interface HeatmapLayerOptions {
       data: any;
       dissipating?: boolean;
       gradient?: string[];
@@ -3455,15 +3455,15 @@ declare namespace google.maps {
       radius?: number;
     }
 
-    export interface WeightedLocation {
+    interface WeightedLocation {
       location: LatLng;
       weight: number;
     }
 
-    export class MouseEvent {
+    class MouseEvent {
       stop(): void;
     }
 
-    export class MapsEventListener {}
+    class MapsEventListener {}
   }
 }

--- a/types/googlemaps/tslint.json
+++ b/types/googlemaps/tslint.json
@@ -69,7 +69,6 @@
         "semicolon": false,
         "space-before-function-paren": false,
         "space-within-parens": false,
-        "strict-export-declare-modifiers": false,
         "trim-file": false,
         "triple-equals": false,
         "typedef-whitespace": false,


### PR DESCRIPTION
- [x] Enable `strict-export-declare-modifiers` rule.
- [x] Fix `strict-export-declare-modifiers` errors.
- [x] Fix other tslint errors in the following PR.