### PR TITLE
Update catbox and catbox-memory defaults and options extension

### DIFF
--- a/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
+++ b/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
@@ -1,4 +1,5 @@
 import * as CatboxMemory from '@hapi/catbox-memory';
+import { Client } from '@hapi/catbox';
 
 const client = new CatboxMemory<string>({
     allowMixedContent: true,
@@ -8,3 +9,12 @@ const client = new CatboxMemory<string>({
 });
 
 const client2 = new CatboxMemory<string>();
+
+const catboxMemoryOptions: CatboxMemory.Options = {
+    allowMixedContent: true,
+    cloneBuffersOnGet: false,
+    maxByteSize: 1024,
+    minCleanupIntervalMsec: 1000,
+};
+
+const client3 = new Client<string>(CatboxMemory, catboxMemoryOptions);

--- a/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
+++ b/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
@@ -6,3 +6,5 @@ const client = new CatboxMemory<string>({
     maxByteSize: 1024,
     minCleanupIntervalMsec: 1000,
 });
+
+const client2 = new CatboxMemory<string>();

--- a/types/hapi__catbox-memory/index.d.ts
+++ b/types/hapi__catbox-memory/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ClientApi } from '@hapi/catbox';
+import { ClientApi, ClientOptions } from '@hapi/catbox';
 
 interface CatboxMemory<T> extends ClientApi<T> {}
 
@@ -15,7 +15,7 @@ declare class CatboxMemory<T> implements ClientApi<T> {
 }
 
 declare namespace CatboxMemory {
-    interface Options {
+    interface Options extends ClientOptions {
         /**
          * Sets an upper limit on the number of bytes that can be stored in the cache.
          * Once this limit is reached no additional items will be added to the cache until some expire.

--- a/types/hapi__catbox/hapi__catbox-tests.ts
+++ b/types/hapi__catbox/hapi__catbox-tests.ts
@@ -21,6 +21,11 @@ const client = new Client<string>(Memory, { partition: 'cache' });
 client.start().then(() => {});
 client.stop().then(() => {});
 
+const client2 = new Client<string>(Memory);
+
+client2.start().then(() => {});
+client2.stop().then(() => {});
+
 const cache = new Policy({
     expiresIn: 5000,
 }, client, 'cache');

--- a/types/hapi__catbox/index.d.ts
+++ b/types/hapi__catbox/index.d.ts
@@ -114,7 +114,7 @@ export interface ClientOptions {
     /**
      * this will store items under keys that start with this value.
      */
-    partition: string;
+    partition?: string;
 }
 
 export type PolicyOptionVariants<T> = PolicyOptions<T> | DecoratedPolicyOptions<T>;


### PR DESCRIPTION
Make partition optional (as catbox provides a good default) and make catbox-memory options extend catbox options like other adapters

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/catbox/blob/0686579bc81308e6c696d1bca4654a14660d8825/lib/client.js#L13
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
