### PR TITLE
[restify] add Router.render() missing method

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -387,6 +387,14 @@ export class Router {
     defaultRoute(req: Request, res: Response, next: Next): void;
 
     /**
+     * takes an object of route params and query params, and 'renders' a URL.
+     * @param    routeName the route name
+     * @param    params    an object of route params
+     * @param    query     an object of query params
+     */
+    render(routeName: string, params: object, query?: object): string;
+
+    /**
      * toString() serialization.
      */
     toString(): string;
@@ -1263,7 +1271,7 @@ export namespace plugins {
     interface JsonBodyParserOptions {
         mapParams?: boolean;
         overrideParams?: boolean;
-        reviver?: (key: any, value: any) => any;
+        reviver?(key: any, value: any): any;
         bodyReader?: boolean;
     }
 

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -196,3 +196,6 @@ requestCaptureStream.toString();
 const asStream: stream.Stream = requestCaptureStream;
 
 const logger2: Logger = restify.bunyan.createLogger("horse");
+
+server.router.render("a-route-name", {});
+server.router.render("a-route-name", {}, {});


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://restify.com/docs/home/ and scroll to "hypermedia" section. The API docs don't have the `Router` object for unknown reasons.