### PR TITLE
[Cytoscape] Fix BFS/DFS typings and mark some optional types

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -517,6 +517,18 @@ nodes.forEach((child) => {
   });
 });
 
+// position is not required for an animation
+nodes.forEach((child) => {
+  child.animate({
+    style: {
+      backgroundColor: '#f185dc',
+      width: '30px',
+      height: '30px'
+    },
+    duration: 300
+  });
+});
+
 nodes.animate({
   renderedPosition: node.position()
 }, {
@@ -574,6 +586,50 @@ nodes.min(n => n.degree(false));
 nodes.max(n => n.degree(false));
 edges.max(n => n.source().id().length);
 edges.max(n => n.source().id().length);
+
+// directly from the doc: http://js.cytoscape.org/#eles.stop
+cy.nodes().animate({
+  style: { 'background-color': 'cyan' }
+}, {
+  duration: 5000,
+  complete: () => {
+    console.log('Animation complete');
+  }
+}).delay(100);
+
+setTimeout(() => {
+  console.log('Stopping nodes animation');
+  cy.nodes().stop();
+}, 2500);
+
+// directly from the doc: http://js.cytoscape.org/#eles.breadthFirstSearch
+const bfs = cy.elements().bfs({
+  roots: '#e',
+  visit: (v, e, u, i, depth) => {
+    console.log('visit ' + v.id());
+
+    // example of finding desired node
+    if (v.data('weight') > 70) {
+      return true;
+    }
+
+    // example of exiting search early
+    if (v.data('weight') < 0) {
+      return false;
+    }
+  },
+  directed: false
+});
+
+const path = bfs.path; // path to found node
+const found = bfs.found; // found node
+
+// select the path
+path.select();
+
+// root || roots are both ok
+cy.elements(':grabbable').bfs({ root: '#1' });
+cy.elements(':grabbable').dfs({ roots: '#1' });
 
 // TODO: traversing (need to actively check the nodes/edges distinction)
 // TODO: algorithms

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -2098,11 +2098,11 @@ declare namespace cytoscape {
     }
     interface ElementAnimateOptionPos extends ElementAnimateOptionsBase {
         /** A position to which the elements will be animated. */
-        position: Position;
+        position?: Position;
     }
     interface ElementAnimateOptionRen extends ElementAnimateOptionsBase {
         /** A rendered position to which the elements will be animated. */
-        renderedPosition: Position;
+        renderedPosition?: Position;
     }
     interface CollectionAnimation {
         /**
@@ -2117,14 +2117,14 @@ declare namespace cytoscape {
          * @param complete A function to call when the delay is complete.
          * http://js.cytoscape.org/#eles.delay
          */
-        delay(duration: number, complete: () => void): this;
+        delay(duration: number, complete?: () => void): this;
         /**
          * Stop all animations that are currently running.
          * @param clearQueue A boolean, indicating whether the queue of animations should be emptied.
          * @param jumpToEnd A boolean, indicating whether the currently-running animations should jump to their ends rather than just stopping midway.
          * http://js.cytoscape.org/#eles.stop
          */
-        stop(clearQueue: boolean, jumpToEnd: boolean): this;
+        stop(clearQueue?: boolean, jumpToEnd?: boolean): this;
         /**
          * Remove all queued animations for the elements.
          * http://js.cytoscape.org/#eles.clearQueue
@@ -2853,12 +2853,8 @@ declare namespace cytoscape {
      * i - The index indicating this node is the ith visited node.
      * depth - How many edge hops away this node is from the root nodes.
      */
-    type SearchVisitFunction = (v: NodeCollection,  e: EdgeCollection, u: NodeCollection, i: number, depth: number) => boolean | void;
-    interface SearchFirstOptions {
-        /**
-         * The root nodes (selector or collection) to start the search from.
-         */
-        roots: Selector | CollectionArgument;
+    type SearchVisitFunction = (v: NodeSingular,  e: EdgeSingular, u: NodeSingular, i: number, depth: number) => boolean | void;
+    interface SearchFirstOptionsBase {
         /**
          * A handler function that is called when a node is visited in the search.
          */
@@ -2868,6 +2864,19 @@ declare namespace cytoscape {
          */
         directed?: boolean;
     }
+    interface SearchFirstOptions1 extends SearchFirstOptionsBase {
+        /**
+         * The root nodes (selector or collection) to start the search from.
+         */
+        root: Selector | CollectionArgument;
+    }
+    interface SearchFirstOptions2 extends SearchFirstOptionsBase {
+        /**
+         * The root nodes (selector or collection) to start the search from.
+         */
+        roots: Selector | CollectionArgument;
+    }
+    type SearchFirstOptions = SearchFirstOptions1 | SearchFirstOptions2;
     interface SearchFirstResult {
         /**
          * The path of the search.
@@ -3197,13 +3206,17 @@ declare namespace cytoscape {
          * Perform a breadth-first search within the elements in the collection.
          * @param options
          * http://js.cytoscape.org/#eles.breadthFirstSearch
+         * @alias bfs
          */
         breadthFirstSearch(options: SearchFirstOptions): SearchFirstResult;
+        bfs(options: SearchFirstOptions): SearchFirstResult;
         /**
          * Perform a depth-first search within the elements in the collection.
          * http://js.cytoscape.org/#eles.depthFirstSearch
+         * @alias dfs
          */
         depthFirstSearch(options: SearchFirstOptions): SearchFirstResult;
+        dfs(options: SearchFirstOptions): SearchFirstResult;
 
         /**
          * Perform Dijkstra's algorithm on the elements in the collection.
@@ -3223,7 +3236,7 @@ declare namespace cytoscape {
          * This finds the shortest path between all pairs of nodes.
          * http://js.cytoscape.org/#eles.floydWarshall
          */
-        aStar(options: SearchFloydWarshallOptions): SearchFloydWarshallResult;
+        floydWarshall(options: SearchFloydWarshallOptions): SearchFloydWarshallResult;
         /**
          * Perform the Bellman-Ford search algorithm on the elements in the collection.
          * This finds the shortest path from the starting node to all other nodes in the collection.


### PR DESCRIPTION
Add eles.bfs and eles.dfs as the aliases of eles.breadthFirstSearch and eles.depthFirstSearch
Make both root and roots as the acceptable argument for bfs/dfs options
Make the arguments to eles.stop optional and make the callback for eles.delay optional
Fix the name of floydWarshall (previously it was mistakenly named aStar)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://js.cytoscape.org/#eles.breadthFirstSearch 
http://js.cytoscape.org/#eles.stop http://js.cytoscape.org/#eles.delay
https://github.com/cytoscape/cytoscape.js/blob/2205c12fe4c6925a1727d7387c84e12b169c1a9e/src/collection/algorithms/bfs-dfs.js#L14
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.