### PR TITLE
amqp-connection-manager: fix type of connection options

### DIFF
--- a/types/amqp-connection-manager/amqp-connection-manager-tests.ts
+++ b/types/amqp-connection-manager/amqp-connection-manager-tests.ts
@@ -23,3 +23,43 @@ channelWrapper.sendToQueue("foo", Buffer.from("bar"))
     .catch((error: Error): void => {
         // nothing
     });
+
+// Checking connection options
+amqpConMgr.connect(["foo", "bar"], {
+    findServers(callback) {
+        callback("x");
+    }
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    findServers(callback) {
+        callback(["x", "y"]);
+    }
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    findServers() {
+        return Promise.resolve("x");
+    }
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    findServers() {
+        return Promise.resolve(["x", "y"]);
+    }
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    reconnectTimeInSeconds: 123
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    heartbeatIntervalInSeconds: 123
+});
+
+amqpConMgr.connect(["foo", "bar"], {
+    connectionOptions: {
+        ca: "some CA",
+        servername: "foo.example.com"
+    }
+});

--- a/types/amqp-connection-manager/index.d.ts
+++ b/types/amqp-connection-manager/index.d.ts
@@ -6,7 +6,7 @@
 
 import { ConfirmChannel, Connection, Message, Options, Replies } from "amqplib";
 import { EventEmitter } from "events";
-import { SecureContextOptions } from "tls";
+import { ConnectionOptions } from "tls";
 
 /**
  * connect() options
@@ -32,7 +32,7 @@ export interface AmqpConnectionManagerOptions {
 	/**
 	 * TLS options
 	 */
-	connectionOptions?: SecureContextOptions;
+	connectionOptions?: ConnectionOptions;
 }
 
 /**

--- a/types/amqp-connection-manager/index.d.ts
+++ b/types/amqp-connection-manager/index.d.ts
@@ -31,6 +31,9 @@ export interface AmqpConnectionManagerOptions {
 
 	/**
 	 * TLS options
+	 *
+	 * These are passed through directly to amqplib (http://www.squaremobius.net/amqp.node/channel_api.html#connect),
+	 * which in turn passes them through to tls.connect (https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)
 	 */
 	connectionOptions?: ConnectionOptions;
 }


### PR DESCRIPTION
The connection options parameter for amqp-connection-manager was erroneously referencing `SecureContextOptions` from the `tls` package, rather than `ConnectionOptions`. This fixes that issue and adds tests for all of the connection options. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/benbria/node-amqp-connection-manager#connecturls-options says options are passed to http://www.squaremobius.net/amqp.node/channel_api.html#connect which says they're passed to https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.