### PR TITLE
Create typings for "Kythe"

### DIFF
--- a/types/kythe/index.d.ts
+++ b/types/kythe/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for non-npm package Kythe 0.0
+// Project: https://github.com/kythe/kythe
+// Definitions by: Ayaz Hafiz <https://github.com/ayazhafiz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A VName (Vector Name) for a node in the Kythe schema consists of:
+ *  - `signature`: a unique, opaque signature for a node
+ *  - `corpus`: a collection of related files the node is defined in
+ *  - `root`: a label denoting a distinct subset of the corpus
+ *  - `path`: the relative path of the file containing the node
+ *  - `language`: programming language the node belongs to
+ */
+export interface VName {
+    signature: string;
+    corpus: string;
+    root: string;
+    path: string;
+    language: string;
+}
+
+/**
+ * An Entry in the Kythe schema is either a Fact or an Edge that describes at least one node.
+ */
+export interface Entry {
+    source: VName;
+    label: string;
+}
+
+/**
+ * A Fact is an Entry that also has a fact `value`.
+ */
+export interface Fact extends Entry {
+    value: string;
+}
+
+/**
+ * An Edge is an Entry that also has a `target` and an edge `kind`.
+ */
+export interface Edge extends Entry {
+    target: VName;
+    kind: string;
+}

--- a/types/kythe/kythe-tests.ts
+++ b/types/kythe/kythe-tests.ts
@@ -1,0 +1,40 @@
+import { VName, Fact, Edge } from "kythe";
+
+const vname: VName = {
+    signature: "sig#0",
+    corpus: "types",
+    root: "",
+    path: "tests",
+    language: "typescript",
+};
+
+const fact: Fact = {
+    source: vname,
+    label: "fact",
+    value: "complete",
+};
+
+const edge: Edge = {
+    source: vname,
+    target: vname,
+    kind: "edge",
+    label: "fact",
+};
+
+const incompleteVName: VName = { // $ExpectError
+    signature: "sig#0",
+    root: "",
+    language: "typescript"
+};
+
+const incompleteFact: Fact = {
+    source: vname,
+    label: "incomplete",
+    kind: "notEdge", // $ExpectError
+};
+
+const incompleteEdge: Edge = {
+    source: vname,
+    target: vname,
+    value: "notFact", // $ExpectError
+};

--- a/types/kythe/tsconfig.json
+++ b/types/kythe/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "kythe-tests.ts"
+    ]
+}

--- a/types/kythe/tslint.json
+++ b/types/kythe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds typings for [Kythe](https://github.com/kythe/kythe) schema objects.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.