### PR TITLE
Fix react-native-platform-touchable

### DIFF
--- a/types/react-native-platform-touchable/index.d.ts
+++ b/types/react-native-platform-touchable/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native-platform-touchable 1.1
 // Project: https://github.com/react-native-community/react-native-platform-touchable
 // Definitions by: Toni Granados <https://github.com/tngranados>
+//                 Joel Nordström <https://github.com/iwikal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -12,7 +13,7 @@ export interface PlatformTouchableProps extends TouchableWithoutFeedbackProps {
     activeOpacity?: number;
     // TouchableNativeFeedback (default Android)
     background?: BackgroundPropType;
-    foreground?: boolean;
+    foreground?: BackgroundPropType;
     // TouchableHighlight
     underlayColor?: string;
     onHideUnderlay?: () => void;

--- a/types/react-native-platform-touchable/react-native-platform-touchable-tests.tsx
+++ b/types/react-native-platform-touchable/react-native-platform-touchable-tests.tsx
@@ -9,6 +9,13 @@ class PlatformTouchableExample extends React.Component {
         <Touchable
           onPress={() => {}}
           style={{ backgroundColor: "#eee", padding: 30 }}
+          foreground={Touchable.Ripple("pink", false)}
+        >
+          <Text>Hello there!</Text>
+        </Touchable>
+        <Touchable
+          onPress={() => {}}
+          style={{ backgroundColor: "#eee", padding: 30 }}
           background={Touchable.Ripple("pink", false)}
         >
           <Text>Hello there!</Text>


### PR DESCRIPTION
The type of the `foreground` prop is a BackgroundPropType, not a
boolean. In fact, if you pass a boolean like the previous types
suggested, you get a crash.

https://github.com/react-native-community/react-native-platform-touchable#additional-props-used-by-touchablenativefeedback--default-android
> `foreground` - same as `background`