### PR TITLE
[@types/fbemitter] Make the EventEmitter more typesafe

### DIFF
--- a/types/fbemitter/index.d.ts
+++ b/types/fbemitter/index.d.ts
@@ -15,7 +15,7 @@ export declare class EventSubscription {
 
 }
 
-export declare class EventEmitter {
+export declare class EventEmitter<T extends string = string> {
 
     constructor();
 
@@ -24,19 +24,19 @@ export declare class EventEmitter {
      * emitted. An optional calling context may be provided. The data arguments
      * emitted will be passed to the listener function.
      */
-    addListener(eventType: string, listener: Function, context?: any): EventSubscription;
+    addListener(eventType: T, listener: Function, context?: any): EventSubscription;
 
     /**
      * Similar to addListener, except that the listener is removed after it is
      * invoked once.
      */
-    once(eventType: string, listener: Function, context?: any): EventSubscription;
+    once(eventType: T, listener: Function, context?: any): EventSubscription;
 
     /**
      * Removes all of the registered listeners, including those registered as
      * listener maps.
      */
-    removeAllListeners(eventType?: string): void;
+    removeAllListeners(eventType?: T): void;
 
     /**
      * Provides an API that can be called during an eventing cycle to remove the
@@ -52,12 +52,12 @@ export declare class EventEmitter {
      * Returns an array of listeners that are currently registered for the given
      * event.
      */
-    listeners(eventType: string): Function[];
+    listeners(eventType: T): Function[];
 
     /**
      * Emits an event of the given type with the given data. All handlers of that
      * particular type will be notified.
      */
-    emit(eventType: string, ...data: any[]): void;
+    emit(eventType: T, ...data: any[]): void;
 
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  Just read the description bellow

The `EventEmitter` type could be improved using a generic type `T` that extends a `string` and defaults to it
That way we could write this:
```typescript

type Events = 'save' | 'delete'
const eventEmitter = new EventEmitter<Events>()
const anyEmitter = new EventEmitter() 
const noop = () => {}

eventEmitter.addListener('save', noop) // 'save' ok
eventEmitter.addListener('ave', noop) // 'ave' not ok

eventEmitter.emit('ave') // not ok
eventEmitter.emit('save') // ok

anyEmitter.addListener('save', noop) // ok
anyEmitter.addListener('ave', noop) // ok

anyEmitter.emit('ave') // ok
anyEmitter.emit('save') // ok


```

We could also use dependent types to make the emit `data` typesafe, but i did not spend time on this idea..
