### PR TITLE
Add most components of ListIteratee to Collection.orderBy

### DIFF
--- a/types/lodash/ts3.1/common/collection.d.ts
+++ b/types/lodash/ts3.1/common/collection.d.ts
@@ -1330,7 +1330,7 @@ declare module "../index" {
         /**
          * @see _.orderBy
          */
-        orderBy(iteratees?: Many<ListIterator<T, NotVoid>>, orders?: Many<boolean|"asc"|"desc">): Collection<T>;
+        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialDeep<T>>, orders?: Many<boolean|"asc"|"desc">): Collection<T>;
     }
     interface Object<T> {
         /**
@@ -1342,7 +1342,7 @@ declare module "../index" {
         /**
          * @see _.orderBy
          */
-        orderBy(iteratees?: Many<ListIterator<T, NotVoid>>, orders?: Many<boolean|"asc"|"desc">): CollectionChain<T>;
+        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialDeep<T>>, orders?: Many<boolean|"asc"|"desc">): CollectionChain<T>;
     }
     interface ObjectChain<T> {
         /**

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -3157,7 +3157,7 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.orderBy("acbd", [(value) => 1, (value) => 2], [true, false]); // $ExpectType string[]
     _.orderBy(list, (value) => 1); // $ExpectType AbcObject[]
     _.orderBy(list, (value) => 1, true); // $ExpectType AbcObject[]
-    _.orderBy(list, [(value) => 1, (value) => 2], [true, false]); // $ExpectType AbcObject[]
+    _.orderBy(list, [(value) => 1, 'third', (value) => 2], [true, false]); // $ExpectType AbcObject[]
     _.orderBy(dictionary, (value) => 1); // $ExpectType AbcObject[]
     _.orderBy(dictionary, (value) => 1, true); // $ExpectType AbcObject[]
     _.orderBy(numericDictionary, (value) => 1); // $ExpectType AbcObject[]
@@ -3173,7 +3173,7 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
     _.chain(list).orderBy((value) => 1); // $ExpectType CollectionChain<AbcObject>
     _.chain(list).orderBy((value) => 1, true); // $ExpectType CollectionChain<AbcObject>
-    _.chain(list).orderBy([(value) => 1, (value) => 2], true); // $ExpectType CollectionChain<AbcObject>
+    _.chain(list).orderBy([(value) => 1, 'third', (value) => 2], true); // $ExpectType CollectionChain<AbcObject>
     _.chain(dictionary).orderBy((value) => 1); // $ExpectType CollectionChain<AbcObject>
     _.chain(dictionary).orderBy((value) => 1, true); // $ExpectType CollectionChain<AbcObject>
     _.chain(numericDictionary).orderBy((value) => 1); // $ExpectType CollectionChain<AbcObject>


### PR DESCRIPTION
`[PropertyName, any]` breaks contextual typing of ListIterator such that the modified test lines got `any` for the type of the second `value` instead of `AbcObject`, so I left it out.

Fixes #35623 