### PR TITLE
[express-winston] Add function type for options.msg

### DIFF
--- a/types/express-winston/express-winston-tests.ts
+++ b/types/express-winston/express-winston-tests.ts
@@ -67,6 +67,19 @@ app.use(expressWinston.errorLogger({
   winstonInstance: logger,
 }));
 
+// Request and error logger with function type msg
+app.use(expressWinston.logger({
+  msg: (req, res) => `HTTP ${req.method} ${req.url} - ${res.statusCode}`,
+  transports: [
+    new winston.transports.Console({})
+  ],
+}));
+
+app.use(expressWinston.errorLogger({
+  msg: (req, res) => `HTTP ${req.method} ${req.url} - ${res.statusCode}`,
+  winstonInstance: logger,
+}));
+
 expressWinston.bodyBlacklist.push('potato');
 expressWinston.bodyWhitelist.push('apple');
 expressWinston.defaultRequestFilter = (req: expressWinston.FilterRequest, prop: string) => req[prop];

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -65,7 +65,7 @@ export interface BaseErrorLoggerOptions {
   dynamicMeta?: DynamicMetaFunction;
   level?: string | DynamicLevelFunction;
   metaField?: string;
-  msg?: string;
+  msg?: MessageTemplate;
   requestFilter?: RequestFilter;
   requestWhitelist?: string[];
 }

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -21,6 +21,7 @@ export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => 
 export type RequestFilter = (req: FilterRequest, propName: string) => any;
 export type ResponseFilter = (res: FilterResponse, propName: string) => any;
 export type RouteFilter = (req: Request, res: Response) => boolean;
+export type MessageTemplate = string | ((req: Request, res: Response) => string);
 
 export interface BaseLoggerOptions {
   baseMeta?: object;
@@ -34,7 +35,7 @@ export interface BaseLoggerOptions {
   level?: string | DynamicLevelFunction;
   meta?: boolean;
   metaField?: string;
-  msg?: string;
+  msg?: MessageTemplate;
   requestFilter?: RequestFilter;
   requestWhitelist?: string[];
   responseFilter?: ResponseFilter;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bithavoc/express-winston/#options - note that msg can be a function, and at https://github.com/bithavoc/express-winston/blob/master/index.js#L125 it is called with req and res 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
