### PR TITLE
[webpack-dev-server] Use HistoryApiFallbackOptions from connect-history-api-fallback

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -6,6 +6,7 @@
 //                 Alan Agius <https://github.com/alan-agius4>
 //                 Artur Androsovych <https://github.com/arturovt>
 //                 Dave Cardwell <https://github.com/davecardwell>
+//                 Katsuya Hino <https://github.com/dobogo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -15,7 +16,7 @@ import * as express from 'express';
 import * as serveStatic from 'serve-static';
 import * as https from 'https';
 import * as http from 'http';
-import { Url } from "url";
+import * as connectHistoryApiFallback from 'connect-history-api-fallback';
 
 declare namespace WebpackDevServer {
     interface ListeningApp {
@@ -32,23 +33,6 @@ declare namespace WebpackDevServer {
     } & httpProxyMiddleware.Config;
 
     type ProxyConfigArray = ProxyConfigArrayItem[];
-
-    interface Context {
-        match: RegExpMatchArray;
-        parsedUrl: Url;
-    }
-
-    type RewriteTo = (context: Context) => string;
-
-    interface Rewrite {
-        from: RegExp;
-        to: string | RegExp | RewriteTo;
-    }
-
-    interface HistoryApiFallbackConfig {
-        disableDotRule?: boolean;
-        rewrites?: Rewrite[];
-    }
 
     interface Configuration {
         /** Provides the ability to execute custom middleware after all other middleware internally within the server. */
@@ -87,7 +71,7 @@ declare namespace WebpackDevServer {
             [key: string]: string;
         };
         /** When using the HTML5 History API, the index.html page will likely have to be served in place of any 404 responses. */
-        historyApiFallback?: boolean | HistoryApiFallbackConfig;
+        historyApiFallback?: boolean | connectHistoryApiFallback.Options;
         /** Specify a host to use. By default this is localhost. */
         host?: string;
         /** Enable webpack's Hot Module Replacement feature. */

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -90,6 +90,25 @@ const c4: WebpackDevServer.Configuration = {
 const c5: WebpackDevServer.Configuration = {
     proxy: [{context: (pathname: string) => true}]
 };
+const c6: WebpackDevServer.Configuration = {
+    historyApiFallback: {
+        disableDotRule: true,
+        htmlAcceptHeaders: ['text/html'],
+        index: '/app/',
+        logger: () => {},
+        rewrites: [
+            {
+                from: /\/page/,
+                to: '/page.html'
+            },
+            {
+                from: /^\/images\/.*$/,
+                to: (context) => '/assets/' + context.parsedUrl.pathname
+            }
+        ],
+        verbose: true
+    }
+};
 
 // API example
 server = new WebpackDevServer(compiler, config);


### PR DESCRIPTION
`historyApiFallback` will be directly passed to connect-history-api-fallback middleware.
connect-history-api-fallback provides complete definition of HistoryApiFallbackOptions.
This PR makes webpack-dev-server use it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/webpack/webpack-dev-server/blob/5a6f77f155029de4c06d3914f7fc8f4db15a3be3/lib/Server.js#L346>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
