### PR TITLE
mongoose: add Query.maxTimeMS()

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mongoose 5.5
+// Type definitions for Mongoose 5.5.1
 // Project: http://mongoosejs.com/
 // Definitions by: horiuchi <https://github.com/horiuchi>
 //                 lukasz-zak <https://github.com/lukasz-zak>
@@ -1967,6 +1967,9 @@ declare module "mongoose" {
     maxscan(val: number): this;
     /** Specifies the maxScan option. Cannot be used with distinct() */
     maxScan(val: number): this;
+
+    /** Specifies the maxTimeMS options. */
+    maxTimeMS(val: number): this;
 
     /**
      * Merges another Query or conditions object into this one.

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -1083,6 +1083,7 @@ query.find().lt('age', 21);
 query.find().where('age').lte(21);
 query.find().lte('age', 21);
 query.maxDistance('path', 21).maxDistance(21);
+query.maxTimeMS(1000);
 query.maxscan(100).maxScan(100);
 query.maxScan(100).maxScan(100);
 query.merge(query).merge({});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

# If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://mongoosejs.com/docs/api.html#query_Query-maxTimeMS

Actually it was added in mongoose 5.2.6 (underlying library [mquery 3.1.1, PR by me](https://github.com/aheckmann/mquery/commit/42499d33ecca1917e754b785a2381928638b566d)) but it's just not documented by mongoose.

Note: maxTime() is an alias of maxTimeMS() but it's not documented on mongoose either so I don't include it in type definition.

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

