### PR TITLE
Add types for purdy@3.5

### DIFF
--- a/types/purdy/index.d.ts
+++ b/types/purdy/index.d.ts
@@ -7,15 +7,13 @@
 declare function Purdy(obj: object, options: Purdy.Options): void;
 
 declare namespace Purdy {
-    // tslint:disable-next-line strict-export-declare-modifiers
-    export interface Instance {
+    interface Instance {
         (obj: object, options: Options): void;
         print: (...args: any[]) => void;
         stringify: (...args: any[]) => string;
     }
 
-    // tslint:disable-next-line strict-export-declare-modifiers
-    export interface Options {
+    interface Options {
         depth?: number|null;
         plain?: boolean;
         json?: boolean;
@@ -27,11 +25,8 @@ declare namespace Purdy {
         pathPrefix?: string;
     }
 
-    // tslint:disable-next-line strict-export-declare-modifiers
-    export function purdy(options: Options): Instance;
-
-    // tslint:disable-next-line strict-export-declare-modifiers
-    export function stringify(obj: object, options: Options): string;
+    function purdy(options: Options): Instance;
+    function stringify(obj: object, options: Options): string;
 }
 
 export = Purdy;

--- a/types/purdy/index.d.ts
+++ b/types/purdy/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for purdy 3.5
+// Project: https://github.com/danielb2/purdy.js
+// Definitions by: YellowKirby <https://github.com/YellowKirby>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare function Purdy(obj: object, options: Purdy.Options): void;
+
+declare namespace Purdy {
+    // tslint:disable-next-line strict-export-declare-modifiers
+    export interface Instance {
+        (obj: object, options: Options): void;
+        print: (...args: any[]) => void;
+        stringify: (...args: any[]) => string;
+    }
+
+    // tslint:disable-next-line strict-export-declare-modifiers
+    export interface Options {
+        depth?: number|null;
+        plain?: boolean;
+        json?: boolean;
+        path?: boolean;
+        proto?: boolean;
+        indent?: number;
+        align?: 'left'|'right';
+        arrayIndex?: boolean;
+        pathPrefix?: string;
+    }
+
+    // tslint:disable-next-line strict-export-declare-modifiers
+    export function purdy(options: Options): Instance;
+
+    // tslint:disable-next-line strict-export-declare-modifiers
+    export function stringify(obj: object, options: Options): string;
+}
+
+export = Purdy;

--- a/types/purdy/purdy-tests.ts
+++ b/types/purdy/purdy-tests.ts
@@ -1,0 +1,27 @@
+import Purdy = require('purdy');
+
+const obj: object = {
+    str: 'string',
+    num: 5,
+    nil: null,
+    bool: false,
+    nested: {
+        hello: "world"
+    }
+};
+
+const options: Purdy.Options = {
+    pathPrefix: "",
+    arrayIndex: true,
+    indent: 2,
+    align: "left",
+    depth: null,
+    json: true
+};
+
+Purdy(obj, options); // $ExpectType void
+Purdy.stringify(obj, options); // $ExpectType string
+
+const inst = Purdy.purdy(options); // $ExpectType Instance
+inst.print("string", 5, true, obj); // $ExpectType void
+inst.stringify("string", 5, true, obj); // $ExpectType string

--- a/types/purdy/tsconfig.json
+++ b/types/purdy/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "purdy-tests.ts"
+    ]
+}

--- a/types/purdy/tslint.json
+++ b/types/purdy/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

----

I was running into some issues with the linter, specifically with the `strict-export-declare-modifiers` rule. [purdy exports a function that also has methods on it](https://github.com/danielb2/purdy.js/blob/master/lib/index.js#L56-L90), so I'm not entirely sure if the function + namespace declaration is the right way to define the types (or if there's a better way to handle it without needing to ignore the `strict-export-declare-modifiers` error).