### PR TITLE
@types/algoliasearch-helper: Add missing method getQueryParams to SearchParameters

### DIFF
--- a/types/algoliasearch-helper/algoliasearch-helper-tests.ts
+++ b/types/algoliasearch-helper/algoliasearch-helper-tests.ts
@@ -129,6 +129,13 @@ helper.hasRefinements('categories'); // false
 helper.toggleFacetRefinement('categories', 'kitchen > knife');
 helper.hasRefinements('categories'); // true
 
+const params = helper.getState().getQueryParams();
+client.search([{
+  indexName: 'test',
+  query: '',
+  params
+}]);
+
 // https://community.algolia.com/algoliasearch-helper-js/reference.html#SearchResults#getFacetValues
 helper.on('result', (content) => {
   // get values ordered only by name ascending using the string predicate

--- a/types/algoliasearch-helper/index.d.ts
+++ b/types/algoliasearch-helper/index.d.ts
@@ -460,7 +460,7 @@ declare namespace algoliasearchHelper {
       'index',
       'facets', 'disjunctiveFacets', 'facetsRefinements',
       'facetsExcludes', 'disjunctiveFacetsRefinements',
-      'numericRefinements', 'tagRefinements', 'hierarchicalFacets', 'hierarchicalFacetsRefinements'  
+      'numericRefinements', 'tagRefinements', 'hierarchicalFacets', 'hierarchicalFacetsRefinements'
     ];
 
     constructor(newParameters?: QueryParameters)

--- a/types/algoliasearch-helper/index.d.ts
+++ b/types/algoliasearch-helper/index.d.ts
@@ -385,6 +385,11 @@ declare namespace algoliasearchHelper {
     enableExactOnSingleWordQuery?: boolean;
   }
 
+  type ValueTypes<T> = T extends Array<infer U> ? U : never;
+  type ManagedParameters = {
+    [K in ValueTypes<SearchParameters["managedParameters"]>]: SearchParameters[K]
+  };
+
   export class SearchParameters implements QueryParameters {
     index?: string ;
     disjunctiveFacets?: string[] ;
@@ -451,6 +456,13 @@ declare namespace algoliasearchHelper {
     nbShards?: number ;
     userData?: string | object ;
 
+    managedParameters: [
+      'index',
+      'facets', 'disjunctiveFacets', 'facetsRefinements',
+      'facetsExcludes', 'disjunctiveFacetsRefinements',
+      'numericRefinements', 'tagRefinements', 'hierarchicalFacets', 'hierarchicalFacetsRefinements'  
+    ];
+
     constructor(newParameters?: QueryParameters)
 
     /* Add a disjunctive facet to the disjunctiveFacets attribute of the helper configuration, if it isn't already present. */
@@ -478,7 +490,7 @@ declare namespace algoliasearchHelper {
     getHierarchicalRefinement(facetName: string): string[];
     getNumericRefinements(facetName: string): SearchParameters.OperatorList[];
     getNumericRefinement(attribute: string, operator: SearchParameters.Operator): Array<number | number[]>;
-    getQueryParams(): QueryParameters;
+    getQueryParams(): Partial<ManagedParameters>;
     getQueryParameter(paramName: string): any;
     getRefinedDisjunctiveFacets(facet: string, value: any): string[];
     getRefinedHierarchicalFacets(facet: string, value: any): string[];

--- a/types/algoliasearch-helper/index.d.ts
+++ b/types/algoliasearch-helper/index.d.ts
@@ -478,7 +478,7 @@ declare namespace algoliasearchHelper {
     getHierarchicalRefinement(facetName: string): string[];
     getNumericRefinements(facetName: string): SearchParameters.OperatorList[];
     getNumericRefinement(attribute: string, operator: SearchParameters.Operator): Array<number | number[]>;
-    getQueryParams(): any;
+    getQueryParams(): QueryParameters;
     getQueryParameter(paramName: string): any;
     getRefinedDisjunctiveFacets(facet: string, value: any): string[];
     getRefinedHierarchicalFacets(facet: string, value: any): string[];

--- a/types/algoliasearch-helper/index.d.ts
+++ b/types/algoliasearch-helper/index.d.ts
@@ -478,6 +478,7 @@ declare namespace algoliasearchHelper {
     getHierarchicalRefinement(facetName: string): string[];
     getNumericRefinements(facetName: string): SearchParameters.OperatorList[];
     getNumericRefinement(attribute: string, operator: SearchParameters.Operator): Array<number | number[]>;
+    getQueryParams(): any;
     getQueryParameter(paramName: string): any;
     getRefinedDisjunctiveFacets(facet: string, value: any): string[];
     getRefinedHierarchicalFacets(facet: string, value: any): string[];


### PR DESCRIPTION
Adds typings for method getQueryParams() from https://github.com/algolia/algoliasearch-helper-js/blob/develop/src/SearchParameters/index.js#L1534

This is useful for example for using searchOnce and using the SearchParameters API:
```ts
        const originalState = helperWithSearchRequest.getState();
        // SearchParameters is immutable - this does not modify the original search
        const sameSearchButForTrips: SearchParameters = originalState.addFacetRefinement('type', 'trip');
        return helper.searchOnce(sameSearchButForTrips.getQueryParams());
``` 
(if any of the original maintainers read this, it would also be nice to have a 'searchOnce' method that accepts a SearchParameters object)
#### Template Info

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/algolia/algoliasearch-helper-js/blob/develop/src/SearchParameters/index.js#L1534
- [x] Increase the version number in the header if appropriate: Not needed, present in current version
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
