### PR TITLE
Add missing types for aliases querystring.encode and querystring.decode to v12 & v11

### DIFF
--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -19,6 +19,14 @@ declare module "querystring" {
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    /**
+    * The querystring.encode() function is an alias for querystring.stringify().
+    */
+    function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    /**
+    * The querystring.encode() function is an alias for querystring.stringify().
+    */
+    function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;
     function unescape(str: string): string;
 }

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -20,12 +20,12 @@ declare module "querystring" {
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     /**
-    * The querystring.encode() function is an alias for querystring.stringify().
-    */
+     * The querystring.encode() function is an alias for querystring.stringify().
+     */
     function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     /**
-    * The querystring.encode() function is an alias for querystring.stringify().
-    */
+     * The querystring.encode() function is an alias for querystring.stringify().
+     */
     function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;
     function unescape(str: string): string;

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -24,7 +24,7 @@ declare module "querystring" {
      */
     function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     /**
-     * The querystring.encode() function is an alias for querystring.stringify().
+     * The querystring.decode() function is an alias for querystring.parse().
      */
     function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -12,9 +12,9 @@ declare module "querystring" {
 
     interface ParsedUrlQueryInput {
         [key: string]:
-            // The value type here is a "poor man's `unknown`". When these types support TypeScript
-            // 3.0+, we can replace this with `unknown`.
-            {} | null | undefined;
+        // The value type here is a "poor man's `unknown`". When these types support TypeScript
+        // 3.0+, we can replace this with `unknown`.
+        {} | null | undefined;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
@@ -22,11 +22,11 @@ declare module "querystring" {
     /**
      * The querystring.encode() function is an alias for querystring.stringify().
      */
-    function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    const encode: typeof stringify;
     /**
      * The querystring.decode() function is an alias for querystring.parse().
      */
-    function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    const decode: typeof parse;
     function escape(str: string): string;
     function unescape(str: string): string;
 }

--- a/types/node/v11/querystring.d.ts
+++ b/types/node/v11/querystring.d.ts
@@ -20,12 +20,12 @@ declare module "querystring" {
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     /**
-    * The querystring.encode() function is an alias for querystring.stringify().
-    */
-    function encode(obj?: ParsedQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+     * The querystring.encode() function is an alias for querystring.stringify().
+     */
+    function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     /**
-    * The querystring.decode() function is an alias for querystring.parse().
-    */
+     * The querystring.decode() function is an alias for querystring.parse().
+     */
     function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;
     function unescape(str: string): string;

--- a/types/node/v11/querystring.d.ts
+++ b/types/node/v11/querystring.d.ts
@@ -18,14 +18,14 @@ declare module "querystring" {
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     /**
     * The querystring.encode() function is an alias for querystring.stringify().
     */
-    function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    function encode(obj?: ParsedQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     /**
     * The querystring.decode() function is an alias for querystring.parse().
     */
-    function encode(obj?: ParsedQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
     function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;
     function unescape(str: string): string;

--- a/types/node/v11/querystring.d.ts
+++ b/types/node/v11/querystring.d.ts
@@ -18,7 +18,15 @@ declare module "querystring" {
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    /**
+    * The querystring.encode() function is an alias for querystring.stringify().
+    */
     function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    /**
+    * The querystring.decode() function is an alias for querystring.parse().
+    */
+    function encode(obj?: ParsedQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
     function escape(str: string): string;
     function unescape(str: string): string;
 }

--- a/types/node/v11/querystring.d.ts
+++ b/types/node/v11/querystring.d.ts
@@ -12,9 +12,9 @@ declare module "querystring" {
 
     interface ParsedUrlQueryInput {
         [key: string]:
-            // The value type here is a "poor man's `unknown`". When these types support TypeScript
-            // 3.0+, we can replace this with `unknown`.
-            {} | null | undefined;
+        // The value type here is a "poor man's `unknown`". When these types support TypeScript
+        // 3.0+, we can replace this with `unknown`.
+        {} | null | undefined;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
@@ -22,11 +22,11 @@ declare module "querystring" {
     /**
      * The querystring.encode() function is an alias for querystring.stringify().
      */
-    function encode(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;
+    const encode: typeof stringify;
     /**
      * The querystring.decode() function is an alias for querystring.parse().
      */
-    function decode(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    const decode: typeof parse;
     function escape(str: string): string;
     function unescape(str: string): string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
v11.x:  https://nodejs.org/docs/latest-v11.x/api/querystring.html#querystring_querystring_encode
v12.x:  https://nodejs.org/api/querystring.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.