### PR TITLE
nodemailer: correct typings for DKIM class

### DIFF
--- a/types/nodemailer/lib/base64.d.ts
+++ b/types/nodemailer/lib/base64.d.ts
@@ -13,10 +13,10 @@ export interface EncoderOptions extends TransformOptions {
 }
 
 export class Encoder extends Transform {
-    options: TransformOptions;
+    options: EncoderOptions;
 
     inputBytes: number;
     outputBytes: number;
 
-    constructor(options?: TransformOptions);
+    constructor(options?: EncoderOptions);
 }

--- a/types/nodemailer/lib/dkim/index.d.ts
+++ b/types/nodemailer/lib/dkim/index.d.ts
@@ -35,11 +35,11 @@ declare namespace DKIM {
 
 declare class DKIM {
     options: DKIM.Options;
-    keys: Array<string | { key: string; passphrase: string }>;
+    keys: DKIM.SingleKeyOptions[];
 
-    constructor(options: DKIM.Options);
+    constructor(options?: DKIM.Options);
 
-    sign(input: string | Buffer | Readable, extraOptions: DKIM.Options): PassThrough;
+    sign(input: string | Buffer | Readable, extraOptions?: DKIM.Options): PassThrough;
 }
 
 export = DKIM;

--- a/types/nodemailer/lib/dkim/relaxed-body.d.ts
+++ b/types/nodemailer/lib/dkim/relaxed-body.d.ts
@@ -13,6 +13,8 @@ declare namespace RelaxedBody {
  * Streams through a message body and calculates relaxed body hash
  */
 declare class RelaxedBody extends Transform {
+    constructor(options?: RelaxedBody.Options);
+
     addListener(event: 'hash', listener: (digest: Buffer, debugBody: Buffer | false) => void): this;
     addListener(event: 'close', listener: () => void): this;
     addListener(event: 'data', listener: (chunk: any) => void): this;

--- a/types/nodemailer/lib/dkim/sign.d.ts
+++ b/types/nodemailer/lib/dkim/sign.d.ts
@@ -2,10 +2,10 @@ import DKIM = require('.');
 import MessageParser = require('./message-parser');
 
 /** Returns DKIM signature header line */
-declare function relaxedHeaders(headers: MessageParser.Header[], hashAlgo: string, bodyHash: string, options: DKIM.SingleKeyOptions): string;
+declare function relaxedHeaders(headers: MessageParser.Header[], hashAlgo: string, bodyHash: string, options?: DKIM.SingleKeyOptions): string;
 
 declare namespace relaxedHeaders {
-    function relaxedHeaders(headers: MessageParser.Header[], hashAlgo: string, bodyHash: string, options: DKIM.SingleKeyOptions): string;
+    function relaxedHeaders(headers: MessageParser.Header[], hashAlgo: string, bodyHash: string, options?: DKIM.SingleKeyOptions): string;
 }
 
 export = relaxedHeaders;

--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -167,7 +167,7 @@ declare class Mail extends EventEmitter {
     /** Usage: typeof transporter.MailMessage */
     MailMessage: MailMessage;
 
-    constructor(transporter: Transport, options: TransportOptions, defaults: TransportOptions);
+    constructor(transporter: Transport, options?: TransportOptions, defaults?: TransportOptions);
 
     /** Closes all connections in the pool. If there is a message being sent, the connection is closed later */
     close(): void;

--- a/types/nodemailer/lib/mime-node/index.d.ts
+++ b/types/nodemailer/lib/mime-node/index.d.ts
@@ -46,7 +46,7 @@ declare namespace MimeNode {
  * the options, assumes this is the root.
  */
 declare class MimeNode {
-    constructor(contentType: string, options?: MimeNode.Options);
+    constructor(contentType?: string, options?: MimeNode.Options);
 
     /** Creates and appends a child node.Arguments provided are passed to MimeNode constructor */
     createChild(contentType: string, options?: MimeNode.Options): MimeNode;

--- a/types/nodemailer/lib/qp.d.ts
+++ b/types/nodemailer/lib/qp.d.ts
@@ -14,10 +14,10 @@ export interface EncoderOptions extends TransformOptions {
 
 /** Creates a transform stream for encoding data to Quoted-Printable encoding */
 export class Encoder extends Transform {
-    options: TransformOptions;
+    options: EncoderOptions;
 
     inputBytes: number;
     outputBytes: number;
 
-    constructor(options?: TransformOptions);
+    constructor(options?: EncoderOptions);
 }

--- a/types/nodemailer/lib/shared.d.ts
+++ b/types/nodemailer/lib/shared.d.ts
@@ -27,7 +27,7 @@ export interface ResolveHostnameValue {
   _cached?: true;
 }
 
-export function resolveHostname(options: ResolveHostnameValue, callback: (err: Error | null, value: ResolveHostnameValue) => void): void;
+export function resolveHostname(options: ResolveHostnameOptions | null | undefined, callback: (err: Error | null, value: ResolveHostnameValue) => void): void;
 
 /** Parses connection url to a structured configuration object */
 export function parseConnectionUrl(url: string): SMTPConnection.Options;

--- a/types/nodemailer/lib/smtp-pool/index.d.ts
+++ b/types/nodemailer/lib/smtp-pool/index.d.ts
@@ -54,7 +54,7 @@ declare class SMTPPool extends EventEmitter implements Transport {
 
     idling: boolean;
 
-    constructor(options: SMTPPool.Options | string);
+    constructor(options?: SMTPPool.Options | string);
 
     /** Placeholder function for creating proxy sockets. This method immediatelly returns without a socket */
     getSocket(options: SMTPPool.Options, callback: (err: Error | null, socketOptions: any) => void): void;

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -2,6 +2,7 @@ import * as nodemailer from 'nodemailer';
 
 import addressparser = require('nodemailer/lib/addressparser');
 import base64 = require('nodemailer/lib/base64');
+import DKIM = require('nodemailer/lib/dkim');
 import fetch = require('nodemailer/lib/fetch');
 import Cookies = require('nodemailer/lib/fetch/cookies');
 import JSONTransport = require('nodemailer/lib/json-transport');
@@ -1115,6 +1116,28 @@ function base64_test() {
     base64.encode('abcd= ÕÄÖÜ');
 
     base64.encode(new Buffer([0x00, 0x01, 0x02, 0x20, 0x03]));
+}
+
+// dkim
+
+function dkim_test_options() {
+    const dkim = new DKIM({
+        domainName: 'example.com',
+        keySelector: '2017',
+        privateKey: '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBg...'
+    });
+    const stream = dkim.sign('Message');
+    stream.pipe(process.stdout);
+}
+
+function dkim_test_extra_options() {
+    const dkim = new DKIM();
+    const stream = dkim.sign('Message', {
+        domainName: 'example.com',
+        keySelector: '2017',
+        privateKey: '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBg...'
+    });
+    stream.pipe(process.stdout);
 }
 
 // fetch


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/nodemailer/blob/master/lib/dkim/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This patch fixes some noticed errors in nodemailer's typings.
