### PR TITLE
[@types/enzyme] Add missing optional callback arg to setProps

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -382,11 +382,13 @@ function ShallowWrapperTest() {
     }
 
     function test_setState() {
+        shallowWrapper = shallowWrapper.setState({ stateProperty: 'state' });
         shallowWrapper = shallowWrapper.setState({ stateProperty: 'state' }, () => console.log('state updated'));
     }
 
     function test_setProps() {
         shallowWrapper = shallowWrapper.setProps({ stringProp: 'foo' });
+        shallowWrapper = shallowWrapper.setProps({ stringProp: 'foo' }, () => console.log('props update'));
     }
 
     function test_setContext() {
@@ -782,10 +784,12 @@ function ReactWrapperTest() {
 
     function test_setState() {
         reactWrapper = reactWrapper.setState({ stateProperty: 'state' });
+        reactWrapper = reactWrapper.setState({ stateProperty: 'state' }, () => console.log('state set'))
     }
 
     function test_setProps() {
-        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' }, () => { });
+        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' });
+        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' }, () => console.log('props set'));
     }
 
     function test_setContext() {

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -784,7 +784,7 @@ function ReactWrapperTest() {
 
     function test_setState() {
         reactWrapper = reactWrapper.setState({ stateProperty: 'state' });
-        reactWrapper = reactWrapper.setState({ stateProperty: 'state' }, () => console.log('state set'))
+        reactWrapper = reactWrapper.setState({ stateProperty: 'state' }, () => console.log('state set'));
     }
 
     function test_setProps() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -10,6 +10,7 @@
 //                 Martin Hochel <https://github.com/hotell>
 //                 Christian Rackerseder <https://github.com/screendriver>
 //                 Mateusz Sokoła <https://github.com/mateuszsokola>
+//                 Braiden Cutforth <https://github.com/braidencutforth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -254,7 +255,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      *
      * NOTE: can only be called on a wrapper instance that is also the root instance.
      */
-    setProps<K extends keyof P>(props: Pick<P, K>): this;
+    setProps<K extends keyof P>(props: Pick<P, K>, callback?: () => void): this;
 
     /**
      * A method that sets the context of the root component, and re-renders. Useful for when you are wanting to
@@ -557,18 +558,6 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      * Returns a wrapper with the direct parent of the node in the current wrapper.
      */
     parent(): ReactWrapper<any, any>;
-
-    /**
-     * A method that sets the props of the root component, and re-renders. Useful for when you are wanting to test
-     * how the component behaves over time with changing props. Calling this, for instance, will call the
-     * componentWillReceiveProps lifecycle method.
-     *
-     * Similar to setState, this method accepts a props object and will merge it in with the already existing props.
-     * Returns itself.
-     *
-     * NOTE: can only be called on a wrapper instance that is also the root instance.
-     */
-    setProps<K extends keyof P>(props: Pick<P, K>, callback?: () => void): this;
 }
 
 export interface ShallowRendererProps {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://airbnb.io/enzyme/docs/api/ShallowWrapper/setProps.html>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.