### PR TITLE
#35708 OptionsType is an array again and not only a single method interface

### DIFF
--- a/types/react-select/lib/types.d.ts
+++ b/types/react-select/lib/types.d.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
-export type OptionsType<OptionType> = ReadonlyArray<OptionType>;
+export type OptionsType<OptionType> = ReadonlyArray<OptionType> & OptionType[];
 
 export interface GroupType<OptionType> {
   options: OptionsType<OptionType>;
   [key: string]: any;
 }
 
-export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>>;
+export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>> & GroupType<UnionOptionType>[];
 
 export type ValueType<OptionType> = OptionType | OptionsType<OptionType> | null | undefined;
 


### PR DESCRIPTION
The previous commit bd1dc274c424de8f8155cead9fdd33fb3c4a1520 prevented OptionsType to be used as a regular array whereas it was impossible to iterate in it or to use the indexer. For OptionsType to be an Array with the suitable method, an union of types must be done.