### PR TITLE
Options type no compile35708

### DIFF
--- a/types/react-select/lib/types.d.ts
+++ b/types/react-select/lib/types.d.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
-export type OptionsType<OptionType> = ReadonlyArray<OptionType> & OptionType[];
+export type OptionsType<OptionType> = ReadonlyArray<OptionType> & Array<OptionType>;
 
 export interface GroupType<OptionType> {
   options: OptionsType<OptionType>;
   [key: string]: any;
 }
 
-export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>> & GroupType<UnionOptionType>[];
+export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>> & Array<GroupType<UnionOptionType>>;
 
 export type ValueType<OptionType> = OptionType | OptionsType<OptionType> | null | undefined;
 

--- a/types/react-select/lib/types.d.ts
+++ b/types/react-select/lib/types.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
-export type OptionsType<OptionType> = ReadonlyArray<OptionType> & Array<OptionType>;
+export type OptionsType<OptionType> = ReadonlyArray<OptionType> & OptionType[];
 
 export interface GroupType<OptionType> {
   options: OptionsType<OptionType>;

--- a/types/react-select/lib/types.d.ts
+++ b/types/react-select/lib/types.d.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
-export type OptionsType<OptionType> = ReadonlyArray<OptionType>;
+export type OptionsType<OptionType> = ReadonlyArray<OptionType> & OptionType[];
 
 export interface GroupType<OptionType> {
   options: OptionsType<OptionType>;
   [key: string]: any;
 }
 
-export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>>;
+export type GroupedOptionsType<UnionOptionType> = ReadonlyArray<GroupType<UnionOptionType>> & GroupType<UnionOptionType>[];
 
 export type ValueType<OptionType> = OptionType | OptionsType<OptionType> | null | undefined;
 

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -1,13 +1,13 @@
 import { GroupedOptionsType, GroupType } from "react-select/lib/types";
 
 export interface ColourOption {
-    value: string;
-    label: string;
-    color: string;
-    disabled?: boolean;
+  value: string;
+  label: string;
+  color: string;
+  disabled?: boolean;
 }
 
-export const colourOptions: ReadonlyArray<ColourOption> = [
+export const colourOptions: ReadonlyArray<ColourOption> & ColourOption[] = [
   { value: 'ocean', label: 'Ocean', color: '#00B8D9' },
   { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },
@@ -21,9 +21,9 @@ export const colourOptions: ReadonlyArray<ColourOption> = [
 ];
 
 export interface FlavourOption {
-    value: string;
-    label: string;
-    rating: 'safe' | 'good' | 'wild' | 'crazy';
+  value: string;
+  label: string;
+  rating: 'safe' | 'good' | 'wild' | 'crazy';
 }
 
 export const flavourOptions: FlavourOption[] = [
@@ -34,8 +34,8 @@ export const flavourOptions: FlavourOption[] = [
 ];
 
 export interface StateOption {
-    value: string;
-    label: string;
+  value: string;
+  label: string;
 }
 
 export const stateOptions: StateOption[] = [
@@ -121,12 +121,12 @@ export const optionLength = [
 // }
 
 const colourGroup: GroupType<ColourOption> = {
-    label: 'Colours',
-    options: colourOptions
+  label: 'Colours',
+  options: colourOptions
 };
 const flavourGroup: GroupType<FlavourOption> = {
-    label: 'Flavours',
-    options: flavourOptions,
+  label: 'Flavours',
+  options: flavourOptions,
 };
 
-export const groupedOptions: GroupedOptionsType<ColourOption | FlavourOption> = [ colourGroup, flavourGroup ];
+export const groupedOptions: GroupedOptionsType<ColourOption | FlavourOption> = [colourGroup, flavourGroup];

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -1,4 +1,4 @@
-import { GroupedOptionsType, GroupType } from "react-select/lib/types";
+import { GroupedOptionsType, GroupType, OptionsType } from "react-select/lib/types";
 
 export interface ColourOption {
   value: string;
@@ -7,7 +7,7 @@ export interface ColourOption {
   disabled?: boolean;
 }
 
-export const colourOptions: ReadonlyArray<ColourOption> & ColourOption[] = [
+export const colourOptions: OptionsType<ColourOption> = [
   { value: 'ocean', label: 'Ocean', color: '#00B8D9' },
   { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },


### PR DESCRIPTION
The previous commit bd1dc274c424de8f8155cead9fdd33fb3c4a1520 prevented OptionsType to be used as a regular array whereas it was impossible to iterate in it or to use the indexer. For OptionsType to be an Array with the suitable method, an union of types must be done.