### PR TITLE
react-big-calendar: add missing optional property `onShowMore`

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -298,6 +298,7 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     defaultDate?: Date;
     className?: string;
     elementProps?: React.HTMLAttributes<HTMLElement>;
+    onShowMore?: (events: TEvent[], date: Date) => void;
 }
 
 export interface ViewStatic {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -135,7 +135,7 @@ class CalendarResource {
               toolbar={true}
               popup={true}
               popupOffset={20}
-              onShowMore={(events, date)=>{
+              onShowMore={(events, date) => {
                   console.log('onShowMore fired, events: %O, date: %O', events, date);
               }}
               selectable={true}

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -135,6 +135,9 @@ class CalendarResource {
               toolbar={true}
               popup={true}
               popupOffset={20}
+              onShowMore={(events, date)=>{
+                  console.log('onShowMore fired, events: %O, date: %O', events, date);
+              }}
               selectable={true}
               step={20}
               rtl={true}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the property is declared [here](https://github.com/intljusticemission/react-big-calendar/blob/master/src/Calendar.js#L333). 
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### Increase the version number in the header if appropriate?

The property is appropriately used in version >= 0.20.4. Check [issue](https://github.com/intljusticemission/react-big-calendar/issues/1214). The tracked package version in the typings is 0.20. Do we track patch versioning too?