### PR TITLE
react big calender event fields not mandatory

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -33,9 +33,9 @@ export type Navigate = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 
 export interface Event {
     allDay?: boolean;
-    title: string;
-    start: Date;
-    end: Date;
+    title?: string;
+    start?: Date;
+    end?: Date;
     resource?: any;
 }
 export interface DateRange {

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -11,6 +11,7 @@
 //                 Tomas Hubelbauer <https://github.com/TomasHubelbauer>
 //                 Lucas Silva Souza <https://github.com/lksilva>
 //                 Siarhey Belofost <https://github.com/SergeyBelofost>
+//                 Mark Nelissen <https://github.com/marknelissen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { Validator } from 'prop-types';


### PR DESCRIPTION
The fields in Event cannot be mandatory, since it is allowed for them to not exist. That is what the different accessors are for (startAccessor, endAccessor, titleAccessor), to allow using the component with other entities that don't follow the default fields proposed on Event.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
