### PR TITLE
Fixed typescript error "Generic type 'ReactElement<P>' requires 1 type argument(s)."

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -170,9 +170,9 @@ export interface AreaProps extends EventAttributes, Partial<PresentationAttribut
     stackId?: string | number;
     legendType?: LegendType;
     connectNulls?: boolean;
-    activeDot?: boolean | object | React.ReactElement | ContentRenderer<any>;
-    dot?: boolean | object | React.ReactElement | ContentRenderer<DotProps>;
-    label?: boolean | object | ContentRenderer<any> | React.ReactElement;
+    activeDot?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
+    dot?: boolean | object | React.ReactElement<any> | ContentRenderer<DotProps>;
+    label?: boolean | object | ContentRenderer<any> | React.ReactElement<any>;
     hide?: boolean;
     layout?: LayoutType;
     baseLine?: number | any[];
@@ -214,9 +214,9 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     minPointSize?: number;
     maxBarSize?: number;
     hide?: boolean;
-    shape?: React.ReactElement | ContentRenderer<RectangleProps>;
+    shape?: React.ReactElement<any> | ContentRenderer<RectangleProps>;
     data?: BarData[];
-    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
+    background?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
     // see label section at http://recharts.org/#/en-US/api/Bar
     label?: boolean | Label | LabelProps | React.SFC<LabelProps> | React.ReactElement<LabelProps> | ContentRenderer<any>;
 }
@@ -258,7 +258,7 @@ export interface CartesianAxisProps extends EventAttributes, Partial<Presentatio
     height?: number;
     orientation?: 'top' | 'bottom' | 'left' | 'right';
     viewBox?: ViewBox;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     mirror?: boolean;
@@ -284,8 +284,8 @@ export interface CartesianGridProps extends Partial<PresentationAttributes> {
     y?: number;
     width?: number;
     height?: number;
-    horizontal?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
-    vertical?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    horizontal?: object | React.ReactElement<any> | ContentRenderer<LineProps & CartesianGridProps> | boolean;
+    vertical?: object | React.ReactElement<any> | ContentRenderer<LineProps & CartesianGridProps> | boolean;
     horizontalPoints?: number[];
     verticalPoints?: number[];
     horizontalCoordinatesGenerator?: CoordinatesGenerator;
@@ -375,7 +375,7 @@ export interface LegendPayload {
 export type BBoxUpdateCallback = (box: { width: number; height: number; }) => void;
 
 export interface LegendProps {
-    content?: React.ReactElement | ContentRenderer<LegendProps>;
+    content?: React.ReactElement<any> | ContentRenderer<LegendProps>;
     wrapperStyle?: object;
     chartWidth?: number;
     chartHeight?: number;
@@ -410,15 +410,15 @@ export interface LineProps extends EventAttributes, Partial<PresentationAttribut
     layout?: LayoutType;
     connectNulls?: boolean;
     hide?: boolean;
-    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
+    activeDot?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactElement<any> | ContentRenderer<DotProps> | boolean;
     top?: number;
     left?: number;
     width?: number;
     height?: number;
     data?: object[];
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    label?: boolean | object | React.ReactElement | ContentRenderer<any>;
+    label?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
     points?: Point[];
 }
 
@@ -449,11 +449,11 @@ export interface PieProps extends EventAttributes, Partial<PresentationAttribute
     maxRadius?: number;
     sectors?: object[];
     hide?: boolean;
-    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement | boolean;
+    labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement<any> | boolean;
     label?: {
         offsetRadius: number;
-    } | React.ReactElement | ContentRenderer<PieLabelRenderProps> | boolean;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement;
+    } | React.ReactElement<any> | ContentRenderer<PieLabelRenderProps> | boolean;
+    activeShape?: object | ContentRenderer<any> | React.ReactElement<any>;
     activeIndex?: number | number[];
     blendStroke?: boolean;
 }
@@ -500,7 +500,7 @@ export interface PolarAngleAxisProps extends EventAttributes, Partial<Presentati
     axisLine?: boolean | object;
     axisLineType?: 'polygon' | 'circle';
     tickLine?: boolean | object;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
     ticks?: PolarAngleAxisTick[];
     stroke?: string;
     orientation?: 'inner' | 'outer';
@@ -539,7 +539,7 @@ export interface PolarRadiusAxisProps extends EventAttributes, Partial<Presentat
     ticks?: PolarRadiusAxisTick[];
     orientation?: "left" | "right" | "middle";
     axisLine?: boolean | object;
-    tick?: boolean | object | React.ReactElement | ContentRenderer<any>;
+    tick?: boolean | object | React.ReactElement<any> | ContentRenderer<any>;
     stroke?: string;
     tickFormatter?: TickFormatterFunction;
     domain?: [PolarRadiusAxisDomain, PolarRadiusAxisDomain];
@@ -576,10 +576,10 @@ export interface RadarProps extends EventAttributes, Partial<PresentationAttribu
     className?: string;
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     points?: RadarPoint[];
-    shape?: React.ReactElement | ContentRenderer<RadarProps>;
-    activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
-    dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
-    label?: object | React.ReactElement | ContentRenderer<any> | boolean;
+    shape?: React.ReactElement<any> | ContentRenderer<RadarProps>;
+    activeDot?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
+    dot?: object | React.ReactElement<any> | ContentRenderer<DotProps> | boolean;
+    label?: object | React.ReactElement<any> | ContentRenderer<any> | boolean;
     legendType?: LegendType;
     hide?: boolean;
 }
@@ -611,15 +611,15 @@ export interface RadialBarProps extends EventAttributes, Partial<PresentationAtt
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     angleAxisId?: string | number;
     radiusAxisId?: string | number;
-    shape?: ContentRenderer<any> | React.ReactElement;
-    activeShape?: object | ContentRenderer<any> | React.ReactElement;
+    shape?: ContentRenderer<any> | React.ReactElement<any>;
+    activeShape?: object | ContentRenderer<any> | React.ReactElement<any>;
     cornerRadius?: number | string;
     minPointSize?: number;
     maxBarSize?: number;
     data?: RadialBarData[];
     legendType?: LegendType;
-    label?: boolean | React.ReactElement | ContentRenderer<any> | object;
-    background?: boolean | React.ReactElement | ContentRenderer<any> | object;
+    label?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
+    background?: boolean | React.ReactElement<any> | ContentRenderer<any> | object;
     hide?: boolean;
 }
 
@@ -661,7 +661,7 @@ export interface ReferenceAreaProps extends Partial<PresentationAttributes> {
     y2?: number | string;
     xAxisId?: string | number;
     yAxisId?: string | number;
-    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactElement;
+    shape?: ContentRenderer<ReferenceAreaProps & RectangleProps> | React.ReactElement<any>;
 }
 
 export class ReferenceArea extends React.Component<ReferenceAreaProps> { }
@@ -687,7 +687,7 @@ export interface ReferenceDotProps extends EventAttributes, Partial<Presentation
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { cx: number; cy: number; }
-    > | React.ReactElement;
+    > | React.ReactElement<any>;
 }
 
 export class ReferenceDot extends React.Component<ReferenceDotProps> { }
@@ -702,14 +702,14 @@ export interface ReferenceLineProps extends Partial<PresentationAttributes<numbe
     ifOverflow?: IfOverflowType;
     x?: number | string;
     y?: number | string;
-    label?: string | number | ContentRenderer<any> | React.ReactElement;
+    label?: string | number | ContentRenderer<any> | React.ReactElement<any>;
     xAxisId?: string | number;
     yAxisId?: string | number;
     shape?: ContentRenderer<
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>
         & { x1: number; y1: number; x2: number; y2: number; }
-    > | React.ReactElement;
+    > | React.ReactElement<any>;
 }
 
 export class ReferenceLine extends React.Component<ReferenceLineProps> { }
@@ -745,13 +745,13 @@ export interface ScatterProps extends EventAttributes, Partial<PresentationAttri
     xAxisId?: string | number;
     yAxisId?: string | number;
     zAxisId?: string | number;
-    line?: boolean | object | RechartsFunction | React.ReactElement;
+    line?: boolean | object | RechartsFunction | React.ReactElement<any>;
     lineType?: 'joint' | 'fitting';
     lineJointType?: LineType;
     legendType?: LegendType;
     activeIndex?: number;
-    activeShape?: object | RechartsFunction | React.ReactElement;
-    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement | ContentRenderer<any>;
+    activeShape?: object | RechartsFunction | React.ReactElement<any>;
+    shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement<any> | ContentRenderer<any>;
     points?: ScatterPoint[];
     hide?: boolean;
     data?: object[];
@@ -823,7 +823,7 @@ export interface TooltipPayload {
 }
 
 export interface TooltipProps extends Animatable {
-    content?: React.ReactElement | React.StatelessComponent<any> | ContentRenderer<TooltipProps>;
+    content?: React.ReactElement<any> | React.StatelessComponent<any> | ContentRenderer<TooltipProps>;
     viewBox?: ViewBox;
     active?: boolean;
     separator?: string;
@@ -832,7 +832,7 @@ export interface TooltipProps extends Animatable {
     itemStyle?: object;
     labelStyle?: object;
     wrapperStyle?: object;
-    cursor?: boolean | object | React.ReactElement | React.StatelessComponent<any>;
+    cursor?: boolean | object | React.ReactElement<any> | React.StatelessComponent<any>;
     coordinate?: Coordinate;
     position?: Coordinate;
     label?: string | number;
@@ -851,7 +851,7 @@ export interface TreemapProps extends EventAttributes, Animatable {
     data?: any[];
     style?: object;
     aspectRatio?: number;
-    content?: React.ReactElement | ContentRenderer<any>;
+    content?: React.ReactElement<any> | ContentRenderer<any>;
     fill?: string;
     stroke?: string;
     className?: string;
@@ -873,7 +873,7 @@ export interface LabelProps extends Partial<PresentationAttributes> {
     position?: PositionType;
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
-    content?: React.ReactElement | ContentRenderer<any>;
+    content?: React.ReactElement<any> | ContentRenderer<any>;
 }
 
 export class LabelList extends React.Component<LabelListProps> { }
@@ -883,7 +883,7 @@ export interface LabelListProps {
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
     clockWise?: boolean;
-    content?: React.ReactElement | ContentRenderer<LabelProps>;
+    content?: React.ReactElement<any> | ContentRenderer<LabelProps>;
     data?: number;
     dataKey: string | number | RechartsFunction;
     formatter?: LabelFormatter;
@@ -934,7 +934,7 @@ export interface XAxisProps extends EventAttributes {
     padding?: XPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;
@@ -988,7 +988,7 @@ export interface YAxisProps extends EventAttributes {
     padding?: YPadding;
     allowDataOverflow?: boolean;
     scale?: ScaleType | RechartsFunction;
-    tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
+    tick?: boolean | ContentRenderer<any> | object | React.ReactElement<any>;
     axisLine?: boolean | object;
     tickLine?: boolean | object;
     minTickGap?: number;


### PR DESCRIPTION
Fixed typescript error "Generic type 'ReactElement<P>' requires 1 type argument(s)."

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.