### PR TITLE
[@types/Redux-form] - Update FieldArray to type custom field arrays correctly in TS > 3.2

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -7,6 +7,7 @@
 //                 Alex Young <https://github.com/alsiola>
 //                 Anton Novik <https://github.com/tehbi4>
 //                 Huw Martin <https://github.com/huwmartin>
+//                 Matt Davis <https://github.com/m-b-davis>
 //                 Ethan Resnick <https://github.com/ethanresnick>
 //                 Tim de Koning <https://github.com/reggino>
 //                 Maddi Joyce <https://github.com/maddijoyce>

--- a/types/redux-form/lib/FieldArray.d.ts
+++ b/types/redux-form/lib/FieldArray.d.ts
@@ -1,29 +1,30 @@
 import { Component, ComponentType } from "react";
 import { Validator } from "../index";
 
-export interface BaseFieldArrayProps<P = {}> {
+interface _BaseFieldArrayProps<P = {}, FieldValue = any> {
     name: string;
-    component: ComponentType<P>;
+    component: ComponentType<WrappedFieldArrayProps<FieldValue> & P>;
     validate?: Validator | Validator[];
     warn?: Validator | Validator[];
-    forwardRef?: boolean;
-    props?: P;
+    withRef?: boolean;
     rerenderOnEveryChange?: boolean;
 }
 
-export interface GenericFieldArray<Field, P = {}> extends Component<BaseFieldArrayProps<P> & Partial<P>> {
+export type BaseFieldArrayProps<P = {}, FieldValue = any> = (P | { props: P}) & _BaseFieldArrayProps<P, FieldValue>;
+
+export interface GenericFieldArray<FieldValue = any, P = {}> extends Component<BaseFieldArrayProps<P, FieldValue>> {
     name: string;
     valid: boolean;
-    getRenderedComponent(): Component<WrappedFieldArrayProps<Field> & P>;
+    getRenderedComponent(): Component<WrappedFieldArrayProps<FieldValue> & P>;
 }
 
-export class FieldArray<P = {}> extends Component<BaseFieldArrayProps<P> & Partial<P>> implements GenericFieldArray<any, P> {
+export class FieldArray<P = {}, FieldValue = any> extends Component<BaseFieldArrayProps<P, FieldValue>> implements GenericFieldArray<FieldValue, P> {
     name: string;
     valid: boolean;
-    getRenderedComponent(): Component<WrappedFieldArrayProps<any> & P>;
+    getRenderedComponent(): Component<WrappedFieldArrayProps<FieldValue> & P>;
 }
 
-export interface WrappedFieldArrayProps<FieldValue> {
+export interface WrappedFieldArrayProps<FieldValue = any> {
     fields: FieldArrayFieldsProps<FieldValue>;
     meta: FieldArrayMetaProps;
 }
@@ -35,12 +36,13 @@ export interface FieldArrayFieldsProps<FieldValue> {
     get(index: number): FieldValue;
     getAll(): FieldValue[];
     removeAll(): void;
+
     insert(index: number, value: FieldValue): void;
     name: string;
     length: number;
     map<R>(callback: FieldIterate<FieldValue, R>): R[];
     pop(): FieldValue;
-    push(value?: FieldValue): void;
+    push(value: FieldValue): void;
     remove(index: number): void;
     shift(): FieldValue;
     swap(indexA: number, indexB: number): void;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -160,7 +160,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.StatelessComponent = ({
+const MyArrayField: React.StatelessComponent<WrappedFieldArrayProps> = ({
     children
 }) => null;
 
@@ -169,20 +169,19 @@ const MyArrayField: React.StatelessComponent = ({
 interface MyFieldValue {
     num: number;
 }
+
 interface MyFieldArrayCustomProps {
     foo: string;
+    bar: number;
 }
 
-const MyCustomArrayField: React.StatelessComponent<MyFieldArrayCustomProps> = ({
+const MyCustomArrayField: React.StatelessComponent<MyFieldArrayCustomProps & WrappedFieldArrayProps<MyFieldValue>> = ({
     children,
-    foo
+    fields,
+    foo,
+    bar
 }) => null;
 
-type MyFieldArrayProps = MyFieldArrayCustomProps & WrappedFieldArrayProps<MyFieldValue>;
-const MyFieldArray: React.StatelessComponent<MyFieldArrayProps> = ({
-    children,
-    fields
-}) => null;
 const FieldArrayCustom = FieldArray as new () => GenericFieldArray<MyFieldValue, MyFieldArrayCustomProps>;
 
 /* Tests */
@@ -329,10 +328,22 @@ const Test = reduxForm<TestFormData>({
                                 component={ MyArrayField }
                             />
 
+                            {/* Passing child props via explicit props arg (TS-preferable)*/}
+                            <FieldArrayCustom
+                                name="field10"
+                                component={ MyCustomArrayField }
+                                props={{
+                                    foo: 'bar',
+                                    bar: 123
+                                }}
+                            />
+
+                            {/* Passing child props via extra props passed to parent */}
                             <FieldArrayCustom
                                 name="field10"
                                 component={ MyCustomArrayField }
                                 foo="bar"
+                                bar={23}
                             />
                         </FormSection>
                     </FormCustom>

--- a/types/redux-form/v7/lib/FieldArray.d.ts
+++ b/types/redux-form/v7/lib/FieldArray.d.ts
@@ -1,29 +1,30 @@
 import { Component, ComponentType } from "react";
 import { Validator } from "../index";
 
-export interface BaseFieldArrayProps<P = {}> {
+interface _BaseFieldArrayProps<P = {}, FieldValue = any> {
     name: string;
-    component: ComponentType<P>;
+    component: ComponentType<WrappedFieldArrayProps<FieldValue> & P>;
     validate?: Validator | Validator[];
     warn?: Validator | Validator[];
     withRef?: boolean;
-    props?: P;
     rerenderOnEveryChange?: boolean;
 }
 
-export interface GenericFieldArray<Field, P = {}> extends Component<BaseFieldArrayProps<P> & Partial<P>> {
+export type BaseFieldArrayProps<P = {}, FieldValue = any> = (P | { props: P}) & _BaseFieldArrayProps<P, FieldValue>;
+
+export interface GenericFieldArray<FieldValue = any, P = {}> extends Component<BaseFieldArrayProps<P, FieldValue>> {
     name: string;
     valid: boolean;
-    getRenderedComponent(): Component<WrappedFieldArrayProps<Field> & P>;
+    getRenderedComponent(): Component<WrappedFieldArrayProps<FieldValue> & P>;
 }
 
-export class FieldArray<P = {}> extends Component<BaseFieldArrayProps<P> & Partial<P>> implements GenericFieldArray<any, P> {
+export class FieldArray<P = {}, FieldValue = any> extends Component<BaseFieldArrayProps<P, FieldValue>> implements GenericFieldArray<FieldValue, P> {
     name: string;
     valid: boolean;
-    getRenderedComponent(): Component<WrappedFieldArrayProps<any> & P>;
+    getRenderedComponent(): Component<WrappedFieldArrayProps<FieldValue> & P>;
 }
 
-export interface WrappedFieldArrayProps<FieldValue> {
+export interface WrappedFieldArrayProps<FieldValue = any> {
     fields: FieldArrayFieldsProps<FieldValue>;
     meta: FieldArrayMetaProps;
 }
@@ -35,6 +36,7 @@ export interface FieldArrayFieldsProps<FieldValue> {
     get(index: number): FieldValue;
     getAll(): FieldValue[];
     removeAll(): void;
+
     insert(index: number, value: FieldValue): void;
     name: string;
     length: number;

--- a/types/redux-form/v7/redux-form-tests.tsx
+++ b/types/redux-form/v7/redux-form-tests.tsx
@@ -160,7 +160,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.StatelessComponent = ({
+const MyArrayField: React.StatelessComponent<WrappedFieldArrayProps> = ({
     children
 }) => null;
 
@@ -171,18 +171,16 @@ interface MyFieldValue {
 }
 interface MyFieldArrayCustomProps {
     foo: string;
+    bar: number;
 }
 
-const MyCustomArrayField: React.StatelessComponent<MyFieldArrayCustomProps> = ({
+const MyCustomArrayField: React.StatelessComponent<MyFieldArrayCustomProps & WrappedFieldArrayProps<MyFieldValue>> = ({
     children,
-    foo
+    fields,
+    foo,
+    bar
 }) => null;
 
-type MyFieldArrayProps = MyFieldArrayCustomProps & WrappedFieldArrayProps<MyFieldValue>;
-const MyFieldArray: React.StatelessComponent<MyFieldArrayProps> = ({
-    children,
-    fields
-}) => null;
 const FieldArrayCustom = FieldArray as new () => GenericFieldArray<MyFieldValue, MyFieldArrayCustomProps>;
 
 /* Tests */
@@ -329,11 +327,24 @@ const Test = reduxForm<TestFormData>({
                                 component={ MyArrayField }
                             />
 
+                            {/* Passing child props via explicit props arg (TS-preferable)*/}
+                            <FieldArrayCustom
+                                name="field10"
+                                component={ MyCustomArrayField }
+                                props={{
+                                    foo: 'bar',
+                                    bar: 123
+                                }}
+                            />
+
+                            {/* Passing child props via extra props passed to parent */}
                             <FieldArrayCustom
                                 name="field10"
                                 component={ MyCustomArrayField }
                                 foo="bar"
+                                bar={23}
                             />
+
                         </FormSection>
                     </FormCustom>
                 </div>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR fixes the issue specified at https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32858.

Currently, typing your own custom field arrays creates errors with later versions of typescript (>3.2 and throws the following error: 

```Type 'FunctionComponent<WrappedFieldArrayProps<any>>' is not assignable to type '(ComponentClass<{ name: "test"; component: FunctionComponent<WrappedFieldArrayProps<any>>; }, any> & FunctionComponent<WrappedFieldArrayProps<any>>) | (FunctionComponent<{ name: "test"; component: FunctionComponent<...>; }> & FunctionComponent<...>)'.
  Type 'FunctionComponent<WrappedFieldArrayProps<any>>' is not assignable to type 'ComponentClass<{ name: "test"; component: FunctionComponent<WrappedFieldArrayProps<any>>; }, any> & FunctionComponent<WrappedFieldArrayProps<any>>'.
    Type 'FunctionComponent<WrappedFieldArrayProps<any>>' is not assignable to type 'ComponentClass<{ name: "test"; component: FunctionComponent<WrappedFieldArrayProps<any>>; }, any>'.
      Types of property 'propTypes' are incompatible.
        Type 'WeakValidationMap<WrappedFieldArrayProps<any>> | undefined' is not assignable to type 'WeakValidationMap<{ name: "test"; component: FunctionComponent<WrappedFieldArrayProps<any>>; }> | undefined'.
          Type 'WeakValidationMap<WrappedFieldArrayProps<any>>' has no properties in common with type 'WeakValidationMap<{ name: "test"; component: FunctionComponent<WrappedFieldArrayProps<any>>; }>'.
```

This PR makes it possible to create custom field arrays like so:

```
type MyFieldValue = { foo: string };
type MyProps = { extraProp: number; }

class MyCustomFieldArray extends FieldArray<MyProps, MyFieldValue> {}

const MyFieldComponent = (props: MyFieldProps & WrappedFieldArrayProps<MyFieldValue>) => null;
...
    <MyCustomFieldArray
          component={MyFieldComponent}
          props={{ myProps }}
     />

```
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://redux-form.com/7.2.3/docs/api/fieldarray.md/>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
