### PR TITLE
[@types/styletron-engine-atomic] foundation for styletron-engine-atomic

### DIFF
--- a/types/styletron-engine-atomic/index.d.ts
+++ b/types/styletron-engine-atomic/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/styletron/styletron
 // Definitions by: Jhey Tompkins <https://github.com/jh3y>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 import { KeyframesObject, FontFace as FontFaceObject, StandardEngine } from 'styletron-standard'
 

--- a/types/styletron-engine-atomic/index.d.ts
+++ b/types/styletron-engine-atomic/index.d.ts
@@ -4,28 +4,62 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import { KeyframesObject, FontFace as FontFaceObject, StandardEngine } from 'styletron-standard'
+import { KeyframesObject, FontFace as FontFaceObject, StandardEngine, StyleObject } from 'styletron-standard';
 
-export = StyletronEngineAtomic
+export class SequentialIDGenerator {
+    prefix: string;
+    count: number;
+    offset: number;
+    msb: number;
+    power: number;
+    constructor(prefix: string);
+    next(): string;
+    increment(): number;
+  }
 
-type hydrateType = HTMLCollectionOf<HTMLStyleElement> | Array<HTMLStyleElement> | NodeListOf<HTMLStyleElement>
-type sheetType = {
-  css: string,
-  attrs: { [key: string]: string }
+export class Cache<T> {
+    cache: {[key: string]: string};
+    idGenerator: SequentialIDGenerator;
+    key: string;
+    onNewValue: (cache: Cache<T>, id: string, value: any) => any;
+    constructor(
+      idGenerator: SequentialIDGenerator,
+      onNewValue: (cache: Cache<T>, id: string, value: any) => any,
+    );
+    addValue(key: string, value: T): number;
+}
+export class MultiCache<T> {
+    caches: {[key: string]: Cache<T>};
+    idGenerator: SequentialIDGenerator;
+    onNewCache: (key: string, cache: Cache<T>, insertAtIndex: number) => any;
+    onNewValue: (cache: Cache<T>, id: string, value: T) => any;
+    sortedCacheKeys: string[];
+    constructor(
+      idGenerator: SequentialIDGenerator,
+      onNewCache: () => any,
+      onNewValue: () => any,
+    );
+    getCache(key: string): Cache<T>;
+    getSortedCacheKeys(): string[];
 }
 
-interface ClientOptions {
+export type hydrateType = HTMLCollectionOf<HTMLStyleElement> | HTMLStyleElement[] | NodeListOf<HTMLStyleElement>;
+export interface Sheet {
+  css: string;
+  attrs: { [key: string]: string };
+}
+
+export interface ClientOptions {
   hydrate?: hydrateType;
   container?: Element;
   prefix?: string;
 }
 
-interface ServerOptions {
+export interface ServerOptions {
   prefix?: string;
 }
 
-declare namespace StyletronEngineAtomic {
-  class Client implements StandardEngine {
+export class Client implements StandardEngine {
     constructor(opts?: ClientOptions);
     styleElements: { [key: string]: HTMLStyleElement };
     fontFaceSheet: HTMLStyleElement;
@@ -33,14 +67,19 @@ declare namespace StyletronEngineAtomic {
     styleCache: MultiCache<{pseudo: string, block: string}>;
     keyframesCache: Cache<KeyframesObject>;
     fontFaceCache: Cache<FontFaceObject>;
-  }
-  class Server implements StandardEngine {
+    renderStyle(style: StyleObject): string;
+    renderKeyframes(keyframes: KeyframesObject): string;
+    renderFontFace(fontFace: FontFaceObject): string;
+}
+export class Server implements StandardEngine {
     constructor(opts?: ServerOptions)
     styleRules: { [key: string]: string };
     keyframesRules: string;
     fontFaceRules: string;
-    getStylesheets(): Array<sheetType>;
+    getStylesheets(): Sheet[];
     getStylesheetsHtml(className?: string): string;
     getCss(): string;
-  }
+    renderStyle(style: StyleObject): string;
+    renderKeyframes(keyframes: KeyframesObject): string;
+    renderFontFace(fontFace: FontFaceObject): string;
 }

--- a/types/styletron-engine-atomic/index.d.ts
+++ b/types/styletron-engine-atomic/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for styletron-engine-atomic 1.1
+// Project: https://github.com/styletron/styletron
+// Definitions by: Jhey Tompkins <https://github.com/jh3y>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { KeyframesObject, FontFace as FontFaceObject, StandardEngine } from 'styletron-standard'
+
+export = StyletronEngineAtomic
+
+type hydrateType = HTMLCollectionOf<HTMLStyleElement> | Array<HTMLStyleElement> | NodeListOf<HTMLStyleElement>
+type sheetType = {
+  css: string,
+  attrs: { [key: string]: string }
+}
+
+interface ClientOptions {
+  hydrate?: hydrateType;
+  container?: Element;
+  prefix?: string;
+}
+
+interface ServerOptions {
+  prefix?: string;
+}
+
+declare namespace StyletronEngineAtomic {
+  class Client implements StandardEngine {
+    constructor(opts?: ClientOptions);
+    styleElements: { [key: string]: HTMLStyleElement };
+    fontFaceSheet: HTMLStyleElement;
+    keyframesSheet: HTMLStyleElement;
+    styleCache: MultiCache<{pseudo: string, block: string}>;
+    keyframesCache: Cache<KeyframesObject>;
+    fontFaceCache: Cache<FontFaceObject>;
+  }
+  class Server implements StandardEngine {
+    constructor(opts?: ServerOptions)
+    styleRules: { [key: string]: string };
+    keyframesRules: string;
+    fontFaceRules: string;
+    getStylesheets(): Array<sheetType>;
+    getStylesheetsHtml(className?: string): string;
+    getCss(): string;
+  }
+}

--- a/types/styletron-engine-atomic/styletron-engine-atomic-tests.ts
+++ b/types/styletron-engine-atomic/styletron-engine-atomic-tests.ts
@@ -5,11 +5,11 @@ import {
 
 const validOptions = {
     prefix: 'test-prefix__'
-}
+};
 
 const invalidOptions = {
     hydrate: 'erroneous hydration'
-}
+};
 
 new Client(validOptions);
 new Client(invalidOptions); // $ExpectError

--- a/types/styletron-engine-atomic/styletron-engine-atomic-tests.ts
+++ b/types/styletron-engine-atomic/styletron-engine-atomic-tests.ts
@@ -1,0 +1,20 @@
+import {
+    Client,
+    Server
+} from 'styletron-engine-atomic';
+
+const validOptions = {
+    prefix: 'test-prefix__'
+}
+
+const invalidOptions = {
+    hydrate: 'erroneous hydration'
+}
+
+new Client(validOptions);
+new Client(invalidOptions); // $ExpectError
+
+new Server({prefix: 1234}); // $ExpectError
+const myServer = new Server(validOptions);
+myServer.getCss(); // $ExpectType string
+myServer.getStylesheetsHtml(); // $ExpectType string

--- a/types/styletron-engine-atomic/tsconfig.json
+++ b/types/styletron-engine-atomic/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/styletron-engine-atomic/tsconfig.json
+++ b/types/styletron-engine-atomic/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "styletron-engine-atomic-tests.ts"
+    ]
+}

--- a/types/styletron-engine-atomic/tslint.json
+++ b/types/styletron-engine-atomic/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds typings for `styletron-engine-atomic`. I've had issues compiling and running tests locally.

On a fresh clone, I get an error about not being able to write files when trying to compile.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.