### PR TITLE
[@types/sequelize] Removed the where property from options of findByI…

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -19,6 +19,7 @@
 //                 Duy Truong <https://github.com/truongkhanhduy95>
 //                 Emmanuel Gautier <https://github.com/emmanuelgautier>
 //                 Dan Rumney <https://github.com/dancrumb>
+//                 Kan Yueh Chen <https://github.com/lalayueh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -35,6 +36,8 @@
 import * as _ from "lodash";
 import Promise = require("bluebird");
 import * as cls from "continuation-local-storage"
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 declare namespace sequelize {
 
@@ -3939,9 +3942,18 @@ declare namespace sequelize {
          * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
          * always be called with a single instance.
          */
-        findById<TCustomAttributes>(identifier?: number | string | Buffer, options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
-        findByPrimary<TCustomAttributes>(identifier?: number | string | Buffer, options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
-        findByPk<TCustomAttributes>(identifier?: number | string | Buffer, options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
+        findById<TCustomAttributes>(
+          identifier?: number | string | Buffer,
+          options?: Omit<FindOptions<TAttributes & TCustomAttributes>, 'where'>,
+        ): Promise<TInstance | null>;
+        findByPrimary<TCustomAttributes>(
+          identifier?: number | string | Buffer,
+          options?: Omit<FindOptions<TAttributes & TCustomAttributes>, 'where'>,
+        ): Promise<TInstance | null>;
+        findByPk<TCustomAttributes>(
+          identifier?: number | string | Buffer,
+          options?: Omit<FindOptions<TAttributes & TCustomAttributes>, 'where'>,
+        ): Promise<TInstance | null>;
 
         /**
          * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single


### PR DESCRIPTION
Removed the where property from options of findById, findByPrimary and findByPk, please refers https://github.com/sequelize/sequelize/issues/10925

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/sequelize/sequelize/issues/10925>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.