### PR TITLE
Fixed type for Kefir.Observable#takeUntilBy

### DIFF
--- a/types/kefir/index.d.ts
+++ b/types/kefir/index.d.ts
@@ -119,7 +119,7 @@ export class Observable<T, S> {
     sampledBy(otherObs: Observable<any, any>): Observable<T, S>;
     sampledBy<U, W>(otherObs: Observable<U, any>, combinator: (a: T, b: U) => W): Observable<W, S>;
     skipUntilBy<U, V>(otherObs: Observable<U, V>): Observable<U, V>;
-    takeUntilBy<U, V>(otherObs: Observable<U, V>): Observable<U, V>;
+    takeUntilBy<U, V>(otherObs: Observable<U, V>): Observable<T, S>;
     bufferBy<U, V>(otherObs: Observable<U, V>, options?: { flushOnEnd: boolean }): Observable<T[], S>;
     bufferWhileBy<U>(otherObs: Observable<boolean, U>, options?: { flushOnEnd?: boolean, flushOnChange?: boolean }): Observable<T[], S>;
     awaiting<U, V>(otherObs: Observable<U, V>): Observable<boolean, S>;

--- a/types/kefir/kefir-tests.ts
+++ b/types/kefir/kefir-tests.ts
@@ -219,8 +219,8 @@ import { Observable, Pool, Stream, Property, Event, Emitter } from 'kefir';
 	}
 	{
 		let foo: Stream<number, void>  = Kefir.sequentially(100, [1, 2, 3, 4]);
-		let bar: Stream<number, void>  = Kefir.later(250, 0);
-		let observable04: Stream<number, void> = foo.takeUntilBy<number, void>(bar);
+		let bar: Stream<string, void>  = Kefir.later(250, 'hello');
+		let observable04: Stream<number, void> = foo.takeUntilBy<string, void>(bar);
 	}
 	{
 		let foo: Stream<number, void>  = Kefir.sequentially(100, [1, 2, 3, 4, 5, 6, 7, 8]).delay(40);


### PR DESCRIPTION
The return value of this method is an Observable of the same type
as the source. Because the test uses the same type twice, change
the test to use different types so the test asserts the return value
has the correct type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://kefirjs.github.io/kefir/#take-until-by
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.