### PR TITLE
[@types/ioredis] Correct callback types for zrank & zrevrank

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -253,11 +253,11 @@ declare namespace IORedis {
         zscore(key: KeyType, member: string, callback: (err: Error, res: string) => void): void;
         zscore(key: KeyType, member: string): Promise<string>;
 
-        zrank(key: KeyType, member: string, callback: (err: Error, res: number) => void): void;
-        zrank(key: KeyType, member: string): Promise<number>;
+        zrank(key: KeyType, member: string, callback: (err: Error, res: number | null) => void): void;
+        zrank(key: KeyType, member: string): Promise<number | null>;
 
-        zrevrank(key: KeyType, member: string, callback: (err: Error, res: number) => void): void;
-        zrevrank(key: KeyType, member: string): Promise<number>;
+        zrevrank(key: KeyType, member: string, callback: (err: Error, res: number | null) => void): void;
+        zrevrank(key: KeyType, member: string): Promise<number | null>;
 
         hset(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
         hset(key: KeyType, field: string, value: any): Promise<0 | 1>;


### PR DESCRIPTION
Both `zrank` and `zrevrank` return `null` if a member cannot be found.

----------------------------------------------------

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```js
const Redis = require('ioredis');
const redis = new Redis();

redis.zadd('foo', '1', 'bar').then(() => {
  redis.zrank('foo', 'bar').then((res) => console.log(res === 0));
  redis.zrank('foo', 'moo').then((res) => console.log(res === null));

  redis.zrank('foo', 'bar', (err, res) => console.log(res === 0));
  redis.zrank('foo', 'moo', (err, res) => console.log(res === null));
});
```
