### PR TITLE
[@types/react-virtualized] Use correct types for two props

### DIFF
--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -404,7 +404,7 @@ export class Table extends PureComponent<TableProps> {
             (params: RowMouseEventHandlerParams) => void
         >;
         onRowsRendered: Requireable<
-            (params: RowMouseEventHandlerParams) => void
+            (params: IndexRange & OverscanIndexRange) => void
         >;
         onScroll: Requireable<(params: ScrollEventData) => void>;
         overscanRowCount: Validator<number>;

--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -441,7 +441,7 @@ export class Table extends PureComponent<TableProps> {
         onScroll: () => null;
         overscanRowCount: 10;
         rowRenderer: TableRowRenderer;
-        headerRowRenderer: TableHeaderRenderer;
+        headerRowRenderer: TableHeaderRowRenderer;
         rowStyle: {};
         scrollToAlignment: "auto";
         scrollToIndex: -1;


### PR DESCRIPTION
I encountered TS errors this while trying to use TableProps with styled-components. It looks like the type definitions in propTypes & defaultProps in the Table class do not match up with the types defined in TableProps, while the types in TableProps match the documentation. Correcting this has resolved my errors.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) (I haven't bothered with this as I'm not sure how to effectively test these static values in a clean way and it seems like a pretty common-sense change)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.