### PR TITLE
fabric: Add freeDrawingBrush to StaticCanvas.

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1075,12 +1075,12 @@ export interface FreeDrawingBrush {
     /**
      * Can be any regular color value.
      */
-    public color: string;
+    color: string;
 
     /**
      * Brush width measured in pixels.
      */
-    public width: number;
+    width: number;
 }
 
 export interface StaticCanvas extends IObservable<StaticCanvas>, IStaticCanvasOptions, ICollection<StaticCanvas>, ICanvasAnimation<StaticCanvas> { }

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1075,12 +1075,12 @@ export interface FreeDrawingBrush {
     /**
      * Can be any regular color value.
      */
-    color: string;
+    public color: string;
 
     /**
      * Brush width measured in pixels.
      */
-    width: number;
+    public width: number;
 }
 
 export interface StaticCanvas extends IObservable<StaticCanvas>, IStaticCanvasOptions, ICollection<StaticCanvas>, ICanvasAnimation<StaticCanvas> { }
@@ -1094,7 +1094,7 @@ export class StaticCanvas {
 	constructor(element: HTMLCanvasElement | string, options?: ICanvasOptions);
 
 	_activeObject?: Object | Group;
-    
+
     public freeDrawingBrush: FreeDrawingBrush;
 
 	/**

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1072,15 +1072,15 @@ interface IStaticCanvasOptions {
 }
 
 export interface FreeDrawingBrush {
-    /**
-     * Can be any regular color value.
-     */
-    color: string;
+	/**
+	 * Can be any regular color value.
+	 */
+	color: string;
 
-    /**
-     * Brush width measured in pixels.
-     */
-    width: number;
+	/**
+	 * Brush width measured in pixels.
+	 */
+	width: number;
 }
 
 export interface StaticCanvas extends IObservable<StaticCanvas>, IStaticCanvasOptions, ICollection<StaticCanvas>, ICanvasAnimation<StaticCanvas> { }
@@ -1095,7 +1095,7 @@ export class StaticCanvas {
 
 	_activeObject?: Object | Group;
 
-    public freeDrawingBrush: FreeDrawingBrush;
+	freeDrawingBrush: FreeDrawingBrush;
 
 	/**
 	 * Calculates canvas element offset relative to the document

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1070,6 +1070,19 @@ interface IStaticCanvasOptions {
 	 */
 	svgViewportTransformation?: boolean;
 }
+
+export interface FreeDrawingBrush {
+    /**
+     * Can be any regular color value.
+     */
+    color: string;
+
+    /**
+     * Brush width measured in pixels.
+     */
+    width: number;
+}
+
 export interface StaticCanvas extends IObservable<StaticCanvas>, IStaticCanvasOptions, ICollection<StaticCanvas>, ICanvasAnimation<StaticCanvas> { }
 export class StaticCanvas {
 	/**
@@ -1081,6 +1094,8 @@ export class StaticCanvas {
 	constructor(element: HTMLCanvasElement | string, options?: ICanvasOptions);
 
 	_activeObject?: Object | Group;
+    
+    public freeDrawingBrush: FreeDrawingBrush;
 
 	/**
 	 * Calculates canvas element offset relative to the document


### PR DESCRIPTION
Add freedrawingBrush property to StaticCanvas class and accompanying FreeDrawingBrush interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Introduction to Fabric.js. Part 4.](http://fabricjs.com/fabric-intro-part-4)

> There's also 2 properties available to customize free drawing — freeDrawingBrush.color and freeDrawingBrush.width. Both are available on Fabric canvas instances through freeDrawingBrush instance. freeDrawingBrush.color can be any regular color value and represents the color of a brush. freeDrawingBrush.width is a number in pixels, and represents brush thickness.

- [ ] Increase the version number in the header if appropriate.
There is no definition for appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
