### PR TITLE
Support Yup nullable derived types

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -71,7 +71,8 @@ export interface Schema<T> {
     withMutation(fn: (current: this) => void): void;
     default(value: any): this;
     default(): T;
-    nullable(isNullable?: boolean): this;
+    nullable(isNullable?: true): Schema<T | null>;
+    nullable(isNullable: false): Schema<Exclude<T, null>>;
     required(message?: TestOptionsMessage): this;
     notRequired(): this;
     typeError(message?: TestOptionsMessage): this;
@@ -169,7 +170,9 @@ export interface ArraySchema<T> extends Schema<T[]> {
     min(limit: number | Ref, message?: TestOptionsMessage): ArraySchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage): ArraySchema<T>;
     ensure(): ArraySchema<T>;
-    compact(rejector?: (value: T, index: number, array: T[]) => boolean): ArraySchema<T>;
+    compact(
+        rejector?: (value: T, index: number, array: T[]) => boolean
+    ): ArraySchema<T>;
 }
 
 export type ObjectSchemaDefinition<T extends object> = {
@@ -206,11 +209,11 @@ export interface ObjectSchema<T extends object> extends Schema<T> {
     constantCase(): ObjectSchema<T>;
 }
 
-export type TransformFunction<T> = ((
+export type TransformFunction<T> = (
     this: T,
     value: any,
     originalValue: any
-) => any);
+) => any;
 
 export interface WhenOptionsBuilder<T> {
     (value: any, schema: T): T;
@@ -230,7 +233,10 @@ export interface TestContext {
     parent: any;
     schema: Schema<any>;
     resolve: (value: any) => any;
-    createError: (params?: { path?: string; message?: string }) => ValidationError;
+    createError: (params?: {
+        path?: string;
+        message?: string;
+    }) => ValidationError;
 }
 
 export interface ValidateOptions {
@@ -297,7 +303,7 @@ export interface SchemaDescription {
     type: string;
     label: string;
     meta: object;
-    tests: Array<{ name: string, params: object }>;
+    tests: Array<{ name: string; params: object }>;
     fields: object;
 }
 
@@ -371,18 +377,16 @@ export class Ref {
 export interface Lazy extends Schema<any> {}
 
 export interface FormatErrorParams {
-  path: string;
-  type: string;
-  value?: any;
-  originalValue?: any;
+    path: string;
+    type: string;
+    value?: any;
+    originalValue?: any;
 }
 
-export type LocaleValue =
-    | string
-    | ((params: FormatErrorParams) => string);
+export type LocaleValue = string | ((params: FormatErrorParams) => string);
 
 export interface LocaleObject {
-    mixed?: { [key in keyof MixedSchema]?: string; } & { notType?: LocaleValue };
+    mixed?: { [key in keyof MixedSchema]?: string } & { notType?: LocaleValue };
     string?: { [key in keyof StringSchema]?: string };
     number?: { [key in keyof NumberSchema]?: string };
     boolean?: { [key in keyof BooleanSchema]?: string };

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -108,7 +108,7 @@ export interface StringSchemaConstructor {
     new (): StringSchema;
 }
 
-export interface StringSchema<T = string> extends Schema<T> {
+export interface StringSchema<T extends string | null = string> extends Schema<T> {
     length(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
     min(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
@@ -133,7 +133,8 @@ export interface NumberSchemaConstructor {
     new (): NumberSchema;
 }
 
-export interface NumberSchema<T = number> extends Schema<T> {
+export interface NumberSchema<T extends number | null = number>
+    extends Schema<T> {
     min(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
     lessThan(
@@ -169,7 +170,7 @@ export interface DateSchemaConstructor {
     new (): DateSchema;
 }
 
-export interface DateSchema<T = Date> extends Schema<T> {
+export interface DateSchema<T extends Date | null= Date> extends Schema<T> {
     min(
         limit: Date | string | Ref,
         message?: TestOptionsMessage

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -107,22 +107,24 @@ export interface StringSchemaConstructor {
     new (): StringSchema;
 }
 
-export interface StringSchema extends Schema<string> {
-    length(limit: number | Ref, message?: TestOptionsMessage): StringSchema;
-    min(limit: number | Ref, message?: TestOptionsMessage): StringSchema;
-    max(limit: number | Ref, message?: TestOptionsMessage): StringSchema;
+export interface StringSchema<T = string> extends Schema<T> {
+    length(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
+    min(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
+    max(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
     matches(
         regex: RegExp,
         messageOrOptions?:
             | TestOptionsMessage
             | { message?: TestOptionsMessage; excludeEmptyString?: boolean }
-    ): StringSchema;
-    email(message?: TestOptionsMessage): StringSchema;
-    url(message?: TestOptionsMessage): StringSchema;
-    ensure(): StringSchema;
-    trim(message?: TestOptionsMessage): StringSchema;
-    lowercase(message?: TestOptionsMessage): StringSchema;
-    uppercase(message?: TestOptionsMessage): StringSchema;
+    ): StringSchema<T>;
+    email(message?: TestOptionsMessage): StringSchema<T>;
+    url(message?: TestOptionsMessage): StringSchema<T>;
+    ensure(): StringSchema<T>;
+    trim(message?: TestOptionsMessage): StringSchema<T>;
+    lowercase(message?: TestOptionsMessage): StringSchema<T>;
+    uppercase(message?: TestOptionsMessage): StringSchema<T>;
+    nullable(isNullable?: true): StringSchema<T | null>;
+    nullable(isNullable: false): StringSchema<Exclude<T, null>>;
 }
 
 export interface NumberSchemaConstructor {
@@ -130,16 +132,24 @@ export interface NumberSchemaConstructor {
     new (): NumberSchema;
 }
 
-export interface NumberSchema extends Schema<number> {
-    min(limit: number | Ref, message?: TestOptionsMessage): NumberSchema;
-    max(limit: number | Ref, message?: TestOptionsMessage): NumberSchema;
-    lessThan(limit: number | Ref, message?: TestOptionsMessage): NumberSchema;
-    moreThan(limit: number | Ref, message?: TestOptionsMessage): NumberSchema;
-    positive(message?: TestOptionsMessage): NumberSchema;
-    negative(message?: TestOptionsMessage): NumberSchema;
-    integer(message?: TestOptionsMessage): NumberSchema;
-    truncate(): NumberSchema;
-    round(type: "floor" | "ceil" | "trunc" | "round"): NumberSchema;
+export interface NumberSchema<T = number> extends Schema<T> {
+    min(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
+    max(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
+    lessThan(
+        limit: number | Ref,
+        message?: TestOptionsMessage
+    ): NumberSchema<T>;
+    moreThan(
+        limit: number | Ref,
+        message?: TestOptionsMessage
+    ): NumberSchema<T>;
+    positive(message?: TestOptionsMessage): NumberSchema<T>;
+    negative(message?: TestOptionsMessage): NumberSchema<T>;
+    integer(message?: TestOptionsMessage): NumberSchema<T>;
+    truncate(): NumberSchema<T>;
+    round(type: "floor" | "ceil" | "trunc" | "round"): NumberSchema<T>;
+    nullable(isNullable?: true): NumberSchema<T | null>;
+    nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
 }
 
 export interface BooleanSchemaConstructor {
@@ -148,16 +158,27 @@ export interface BooleanSchemaConstructor {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface BooleanSchema extends Schema<boolean> {}
+export interface BooleanSchema<T = boolean> extends Schema<T> {
+    nullable(isNullable?: true): BooleanSchema<T | null>;
+    nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
+}
 
 export interface DateSchemaConstructor {
     (): DateSchema;
     new (): DateSchema;
 }
 
-export interface DateSchema extends Schema<Date> {
-    min(limit: Date | string | Ref, message?: TestOptionsMessage): DateSchema;
-    max(limit: Date | string | Ref, message?: TestOptionsMessage): DateSchema;
+export interface DateSchema<T = Date> extends Schema<T> {
+    min(
+        limit: Date | string | Ref,
+        message?: TestOptionsMessage
+    ): DateSchema<T>;
+    max(
+        limit: Date | string | Ref,
+        message?: TestOptionsMessage
+    ): DateSchema<T>;
+    nullable(isNullable?: true): DateSchema<T | null>;
+    nullable(isNullable: false): DateSchema<Exclude<T, null>>;
 }
 
 export interface ArraySchemaConstructor {

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -108,7 +108,8 @@ export interface StringSchemaConstructor {
     new (): StringSchema;
 }
 
-export interface StringSchema<T extends string | null = string> extends Schema<T> {
+export interface StringSchema<T extends string | null = string>
+    extends Schema<T> {
     length(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
     min(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage): StringSchema<T>;
@@ -160,7 +161,8 @@ export interface BooleanSchemaConstructor {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface BooleanSchema<T = boolean> extends Schema<T> {
+export interface BooleanSchema<T extends boolean | null = boolean>
+    extends Schema<T> {
     nullable(isNullable?: true): BooleanSchema<T | null>;
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
 }
@@ -170,7 +172,7 @@ export interface DateSchemaConstructor {
     new (): DateSchema;
 }
 
-export interface DateSchema<T extends Date | null= Date> extends Schema<T> {
+export interface DateSchema<T extends Date | null = Date> extends Schema<T> {
     min(
         limit: Date | string | Ref,
         message?: TestOptionsMessage

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -10,6 +10,7 @@
 //                 Yusuke Sato <https://github.com/sat0yu>
 //                 Dan Rumney <https://github.com/dancrumb>
 //                 Desmond Koh <https://github.com/deskoh>
+//                 Maurice de Beijer <https://github.com/mauricedb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -245,7 +246,11 @@ export interface WhenOptionsBuilder<T> {
 
 export type WhenOptions<T> =
     | WhenOptionsBuilder<T>
-    | { is: boolean | ((...values: any[]) => boolean); then: any; otherwise: any }
+    | {
+          is: boolean | ((...values: any[]) => boolean);
+          then: any;
+          otherwise: any;
+      }
     | object;
 
 export interface TestContext {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -293,7 +293,7 @@ yup.object()
     });
 
 // String schema
-const strSchema = yup.string(); // $ExpectType StringSchema
+const strSchema = yup.string(); // $ExpectType StringSchema<string>
 strSchema.isValid("hello"); // => true
 strSchema.required();
 strSchema.required("req");
@@ -325,7 +325,7 @@ strSchema.uppercase("upper");
 strSchema.uppercase(() => "upper");
 
 // Number schema
-const numSchema = yup.number(); // $ExpectType NumberSchema
+const numSchema = yup.number(); // $ExpectType NumberSchema<number>
 numSchema.isValid(10); // => true
 numSchema.min(5);
 numSchema.min(5, "message");
@@ -508,8 +508,8 @@ interface SubInterface {
 
 // $ExpectType ObjectSchema<MyInterface>
 const typedSchema = yup.object<MyInterface>({
-    stringField: yup.string().required(), // $ExpectType StringSchema
-    numberField: yup.number().required(), // $ExpectType NumberSchema
+    stringField: yup.string().required(), // $ExpectType StringSchema<string>
+    numberField: yup.number().required(), // $ExpectType NumberSchema<number>
     subFields: yup
         .object({
             testField: yup.string().required()
@@ -606,7 +606,7 @@ yup.object<MyInterface>({
 });
 
 const personSchema = yup.object({
-    firstName: yup.string(),
+    firstName: yup.string(), // $ExpectType StringSchema<string>
     email: yup
         .string()
         .nullable()
@@ -615,16 +615,12 @@ const personSchema = yup.object({
         .date()
         .nullable()
         .min(new Date(1900, 0, 1)),
-    canBeNull: yup
-        .string()
-        .nullable(true),
+    canBeNull: yup.string().nullable(true), // $ExpectType StringSchema<string | null>
     mustBeAString: yup
         .string()
         .nullable(true)
         .nullable(false),
-    children: yup
-        .array(yup.string())
-        .nullable()
+    children: yup.array(yup.string()).nullable()
 });
 
 type Person = ReturnType<typeof personSchema.cast>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -214,7 +214,7 @@ const testContext = function(this: TestContext) {
     // $ExpectType ValidationError
     this.createError({ message: "1" });
     // $ExpectType ValidationError
-    this.createError({ path: "1"});
+    this.createError({ path: "1" });
     // $ExpectType ValidationError
     this.createError();
     return true;
@@ -473,14 +473,19 @@ const localeNotType2: LocaleObject = {
 const localeNotType3: LocaleObject = {
     mixed: {
         required: "message",
-        notType: (_ref) => {
-            const isCast: boolean = _ref.originalValue != null && _ref.originalValue !== _ref.value;
+        notType: _ref => {
+            const isCast: boolean =
+                _ref.originalValue != null && _ref.originalValue !== _ref.value;
             const finalPartOfTheMessage = isCast
                 ? ` (cast from the value '${_ref.originalValue}').`
-                : '.';
+                : ".";
 
-            return `${_ref.path} must be a '${_ref.type}'` +
-                ` but the final value was: '${_ref.value}'${finalPartOfTheMessage}`;
+            return (
+                `${_ref.path} must be a '${_ref.type}'` +
+                ` but the final value was: '${
+                    _ref.value
+                }'${finalPartOfTheMessage}`
+            );
         }
     }
 };
@@ -599,3 +604,32 @@ yup.object<MyInterface>({
         .required(),
     arrayField: yup.array(yup.string()).required()
 });
+
+const personSchema = yup.object({
+    firstName: yup.string(),
+    email: yup
+        .string()
+        .email()
+        .nullable(),
+    canBeNull: yup.string().nullable(true),
+    mustBeAString: yup
+        .string()
+        .nullable(true)
+        .nullable(false)
+});
+
+type Person = ReturnType<typeof personSchema.cast>;
+// Equivalent to:
+// type Person = {
+//     firstName: string;
+//     email: string | null;
+//     canBeNull: string | null;
+//     mustBeAString: string;
+// }
+
+const person: Person = {
+    firstName: "",
+    email: null,
+    canBeNull: null,
+    mustBeAString: ""
+};

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -616,6 +616,7 @@ const personSchema = yup.object({
         .nullable()
         .min(new Date(1900, 0, 1)),
     canBeNull: yup.string().nullable(true), // $ExpectType StringSchema<string | null>
+    isAlive: yup.boolean().nullable(),
     mustBeAString: yup
         .string()
         .nullable(true)
@@ -630,6 +631,7 @@ type Person = ReturnType<typeof personSchema.cast>;
 //     email: string | null;
 //     birthDate: Date | null;
 //     canBeNull: string | null;
+//     isAlive: boolean | null;
 //     mustBeAString: string;
 //     children: string[] | null;
 // }
@@ -639,6 +641,17 @@ const person: Person = {
     email: null,
     birthDate: null,
     canBeNull: null,
+    isAlive: null,
     mustBeAString: "",
     children: null
 };
+
+person.email = "some@email.com";
+person.birthDate = new Date();
+person.isAlive = true;
+person.children = ["1", "2", "3"];
+
+// $ExpectError
+person.firstName = null;
+// $ExpectError
+person.mustBeAString = null;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -609,13 +609,22 @@ const personSchema = yup.object({
     firstName: yup.string(),
     email: yup
         .string()
-        .email()
-        .nullable(),
-    canBeNull: yup.string().nullable(true),
+        .nullable()
+        .email(),
+    birthDate: yup
+        .date()
+        .nullable()
+        .min(new Date(1900, 0, 1)),
+    canBeNull: yup
+        .string()
+        .nullable(true),
     mustBeAString: yup
         .string()
         .nullable(true)
-        .nullable(false)
+        .nullable(false),
+    children: yup
+        .array(yup.string())
+        .nullable()
 });
 
 type Person = ReturnType<typeof personSchema.cast>;
@@ -623,13 +632,17 @@ type Person = ReturnType<typeof personSchema.cast>;
 // type Person = {
 //     firstName: string;
 //     email: string | null;
+//     birthDate: Date | null;
 //     canBeNull: string | null;
 //     mustBeAString: string;
+//     children: string[] | null;
 // }
 
 const person: Person = {
     firstName: "",
     email: null,
+    birthDate: null,
     canBeNull: null,
-    mustBeAString: ""
+    mustBeAString: "",
+    children: null
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] ~Increase the version number in the header if appropriate.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

It would be really nice if we can derive a TypeScript type alias from the Yup definition instead of having to redefine it. Using the `ReturnType` of the `cast()` function this is possible. The problem with this is that nullable defintions are lost. With this PR these are preserved.

Given the following Yup schema:
``` TypeScript
const personSchema = yup.object({
    firstName: yup.string(), // $ExpectType StringSchema<string>
    email: yup
        .string()
        .nullable()
        .email(),
    birthDate: yup
        .date()
        .nullable()
        .min(new Date(1900, 0, 1)),
    canBeNull: yup.string().nullable(true), // $ExpectType StringSchema<string | null>
    mustBeAString: yup
        .string()
        .nullable(true)
        .nullable(false),
    children: yup.array(yup.string()).nullable()
});
```

We can derive the `Person` type as follows:
``` TypeScript
type Person = ReturnType<typeof personSchema.cast>;
```

This is with this PR equivalent to:
``` TypeScript
type Person = {
    firstName: string;
    email: string | null;
    birthDate: Date | null;
    canBeNull: string | null;
    mustBeAString: string;
    children: string[] | null;
}
```

Without this PR it would lose the null types and be equivalent to:
``` TypeScript
type Person = {
    firstName: string;
    email: string;
    birthDate: Date;
    canBeNull: string;
    mustBeAString: string;
    children: string[];
}
```

Now we can create a new `Person` object as follows:
``` TypeScript
const person: Person = {
    firstName: "",
    email: null,
    birthDate: null,
    canBeNull: null,
    mustBeAString: "",
    children: null
};
```