### PR TITLE
prettier-package-json: Add type definitions

### DIFF
--- a/types/prettier-package-json/index.d.ts
+++ b/types/prettier-package-json/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for prettier-package-json 2.1
+// Project: https://github.com/cameronhunter/prettier-package-json
+// Definitions by: Daniel Cassidy <https://github.com/djcsdy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export type CompareFn = (a: string, b: string) => number;
+
+export interface Options {
+    tabWidth?: number;
+    useTabs?: boolean;
+    expandUsers?: boolean;
+    keyOrder?: ReadonlyArray<string> | CompareFn;
+}
+
+export function format(json: object, options?: Options): string;
+
+export function check(json: string | object, options?: Options): boolean;

--- a/types/prettier-package-json/prettier-package-json-tests.ts
+++ b/types/prettier-package-json/prettier-package-json-tests.ts
@@ -1,0 +1,69 @@
+import { format, check } from "prettier-package-json";
+
+const json = {
+    name: "some-package",
+    version: "0.0.0"
+};
+
+// $ExpectType string
+format(json);
+
+// $ExpectType string
+format(json, {});
+
+// $ExpectType string
+format(json, {
+    tabWidth: 2,
+    useTabs: false,
+    expandUsers: false,
+    keyOrder: ["name", "version"]
+});
+
+// $ExpectType string
+format(json, {
+    tabWidth: 4,
+    useTabs: true,
+    expandUsers: true,
+    keyOrder: (a, b) => {
+        // $ExpectType string
+        a;
+
+        // ExpectType string
+        b;
+
+        return b < a ? -1 : b > a ? 1 : 0;
+    }
+});
+
+// $ExpectType boolean
+check("");
+
+// $ExpectType boolean
+check(json);
+
+// $ExpectType boolean
+check("", {});
+
+// $ExpectType boolean
+check(json, {});
+
+// $ExpectType boolean
+check("", {
+    tabWidth: 8,
+    useTabs: true,
+    expandUsers: false,
+    keyOrder: ["private", "version"]
+});
+
+// $ExpectType boolean
+check(json, {
+    keyOrder: (a, b) => {
+        // $ExpectType string
+        a;
+
+        // $ExpectType string
+        b;
+
+        return b < a ? -1 : b > a ? 1 : 0;
+    }
+});

--- a/types/prettier-package-json/tsconfig.json
+++ b/types/prettier-package-json/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "prettier-package-json-tests.ts"
+    ]
+}

--- a/types/prettier-package-json/tslint.json
+++ b/types/prettier-package-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.