### PR TITLE
npmlog: Add missing functions by extending EventEmitter

### DIFF
--- a/types/npmlog/index.d.ts
+++ b/types/npmlog/index.d.ts
@@ -26,9 +26,12 @@ declare namespace npmlog {
         silly(prefix: string, message: string, ...args: any[]): void;
         verbose(prefix: string, message: string, ...args: any[]): void;
         info(prefix: string, message: string, ...args: any[]): void;
+        timing(prefix: string, message: string, ...args: any[]): void;
         http(prefix: string, message: string, ...args: any[]): void;
+        notice(prefix: string, message: string, ...args: any[]): void;
         warn(prefix: string, message: string, ...args: any[]): void;
         error(prefix: string, message: string, ...args: any[]): void;
+        silent(prefix: string, message: string, ...args: any[]): void;
 
         enableColor(): void;
         disableColor(): void;

--- a/types/npmlog/index.d.ts
+++ b/types/npmlog/index.d.ts
@@ -2,65 +2,74 @@
 // Project: https://github.com/npm/npmlog#readme
 // Definitions by: Daniel Schmidt <https://github.com/DanielMSchmidt>
 //                 Zhu Zijia <https://github.com/littlepiggy03>
+//                 Joseph Wynn <https://github.com/wildlyinaccurate>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-export enum LogLevels {
-    silly = "silly",
-    verbose = "verbose",
-    info = "info",
-    http = "http",
-    warn = "warn",
-    error = "error",
+import { EventEmitter } from "events";
+
+declare namespace npmlog {
+    // TODO: newStream, newGroup, setGaugeTemplate and setGaugeTemplateSet need to be added
+    interface Logger extends EventEmitter {
+        (): any;
+
+        level: string;
+        record: MessageObject[];
+        maxRecordSize: number;
+        prefixStyle: StyleObject;
+        headingStyle: StyleObject;
+        heading: string;
+        stream: any; // Defaults to process.stderr
+
+        log(level: LogLevels | string, prefix: string, message: string, ...args: any[]): void;
+
+        silly(prefix: string, message: string, ...args: any[]): void;
+        verbose(prefix: string, message: string, ...args: any[]): void;
+        info(prefix: string, message: string, ...args: any[]): void;
+        http(prefix: string, message: string, ...args: any[]): void;
+        warn(prefix: string, message: string, ...args: any[]): void;
+        error(prefix: string, message: string, ...args: any[]): void;
+
+        enableColor(): void;
+        disableColor(): void;
+
+        enableProgress(): void;
+        disableProgress(): void;
+        progressEnabled(): boolean;
+
+        enableUnicode(): void;
+        disableUnicode(): void;
+
+        pause(): void;
+        resume(): void;
+
+        addLevel(level: string, n: number, style?: StyleObject, disp?: string): void;
+
+        // Allows for custom log levels
+        // npmlog.addLevel("custom", level)
+        // npmlog.custom(prefix, message)
+        [key: string]: any;
+    }
+
+    type LogLevels = "silly" | "verbose" | "info" | "timing" | "http" | "notice" | "warn" | "error" | "silent";
+
+    interface StyleObject {
+        fg?: string;
+        bg?: string;
+        bold?: boolean;
+        inverse?: boolean;
+        underline?: boolean;
+        bell?: boolean;
+    }
+
+    interface MessageObject {
+        id: number;
+        level: string;
+        prefix: string;
+        message: string;
+        messageRaw: string;
+    }
 }
 
-export interface StyleObject {
-    fg?: string;
-    bg?: string;
-    bold?: boolean;
-    inverse?: boolean;
-    underline?: boolean;
-
-    bell?: boolean;
-}
-
-export interface MessageObject {
-    id: number;
-    level: string;
-    prefix: string;
-    message: string;
-    messageRaw: string;
-}
-
-// TODO: newStream, newGroup, setGaugeTemplate and setGaugeTemplateSet need to be added
-
-export function log(level: LogLevels | string, prefix: string, message: string, ...args: any[]): void;
-
-export function silly(prefix: string, message: string, ...args: any[]): void;
-export function verbose(prefix: string, message: string, ...args: any[]): void;
-export function info(prefix: string, message: string, ...args: any[]): void;
-export function http(prefix: string, message: string, ...args: any[]): void;
-export function warn(prefix: string, message: string, ...args: any[]): void;
-export function error(prefix: string, message: string, ...args: any[]): void;
-
-export let level: string;
-export let record: MessageObject[];
-export let maxRecordSize: number;
-export let prefixStyle: StyleObject;
-export let headingStyle: StyleObject;
-export let heading: string;
-export let stream: any; // Defaults to process.stderr
-
-export function enableColor(): void;
-export function disableColor(): void;
-
-export function enableProgress(): void;
-export function disableProgress(): void;
-
-export function enableUnicode(): void;
-export function disableUnicode(): void;
-
-export function pause(): void;
-export function resume(): void;
-
-export function addLevel(level: string, n: number, style?: StyleObject, disp?: string): void;
+declare var npmlog: npmlog.Logger;
+export = npmlog;

--- a/types/npmlog/npmlog-tests.ts
+++ b/types/npmlog/npmlog-tests.ts
@@ -1,5 +1,4 @@
 import * as npmlog from "npmlog";
-import { MessageObject } from "npmlog";
 
 const prefix = "str";
 const message = "otherStr";
@@ -52,7 +51,7 @@ npmlog.broadcast(message);
 
 npmlog.on("broadcast", () => {});
 
-const msg: MessageObject = {
+const msg: npmlog.MessageObject = {
     id: 1,
     level: "broadcast",
     prefix,

--- a/types/npmlog/npmlog-tests.ts
+++ b/types/npmlog/npmlog-tests.ts
@@ -4,7 +4,7 @@ import { MessageObject } from "npmlog";
 const prefix = "str";
 const message = "otherStr";
 
-['silly', 'verbose', 'info', 'http', 'warn', 'error'].forEach(lvl => npmlog.log(lvl, prefix, message));
+["silly", "verbose", "info", "timing", "http", "notice", "warn", "error", "silent"].forEach(lvl => npmlog.log(lvl, prefix, message));
 
 npmlog.silly(prefix, message);
 npmlog.verbose(prefix, message);

--- a/types/npmlog/npmlog-tests.ts
+++ b/types/npmlog/npmlog-tests.ts
@@ -1,4 +1,5 @@
 import * as npmlog from "npmlog";
+import { MessageObject } from "npmlog";
 
 const prefix = "str";
 const message = "otherStr";
@@ -20,6 +21,7 @@ npmlog.disableColor();
 
 npmlog.enableProgress();
 npmlog.disableProgress();
+npmlog.progressEnabled();
 
 npmlog.enableUnicode();
 npmlog.disableUnicode();
@@ -42,3 +44,20 @@ npmlog.addLevel("styled-level", 42, {
     bold: false,
     underline: true,
 }, 'display name');
+
+npmlog.addLevel("broadcast", 10);
+
+npmlog.broadcast(prefix, message);
+npmlog.broadcast(message);
+
+npmlog.on("broadcast", () => {});
+
+const msg: MessageObject = {
+    id: 1,
+    level: "broadcast",
+    prefix,
+    message,
+    messageRaw: message,
+};
+
+npmlog.emit("broadcast", msg);

--- a/types/npmlog/tslint.json
+++ b/types/npmlog/tslint.json
@@ -1,1 +1,11 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-duplicate-imports": {
+            "severity": "error",
+            "options": {
+                "allow-namespace-imports": true
+            }
+        }
+    }
+}

--- a/types/npmlog/tslint.json
+++ b/types/npmlog/tslint.json
@@ -1,11 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-duplicate-imports": {
-            "severity": "error",
-            "options": {
-                "allow-namespace-imports": true
-            }
-        }
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Hello! This change is slightly more substantial than I hoped it would be. The [object exported by npmlog](https://github.com/npm/npmlog/blob/master/log.js#L4-L5) is an instance of EventEmitter, and I wanted this to be reflected in the types.

The only thing I'm not happy about with this PR is my use of `any`. I'm not proficient enough to be able to come up with a type that dynamically adds properties to the npmlog object. If anyone has advice on this, I'd be happy to update the PR.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/npmlog/blob/master/log.js#L4-L5
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
