### PR TITLE
Export ancillary types from node-memwatch

### DIFF
--- a/types/node-memwatch/index.d.ts
+++ b/types/node-memwatch/index.d.ts
@@ -7,44 +7,7 @@ import { EventEmitter } from 'events';
 
 export = memwatch;
 
-declare const memwatch: MemWatch;
-
-interface MemWatch extends EventEmitter {
-    on(eventName: "leak", callback: (event: LeakInformation) => void): this;
-    on(eventName: "stats", callback: (event: StatsInformation) => void): this;
-
-    /**
-     * Force V8 to do a full GC and heap compaction.
-     *
-     * It's intended to be used for debugging. Calling it in production is highly discouraged.
-     */
-    gc(): void;
-
-    HeapDiff: typeof HeapDiff;
-}
-
-interface StatsInformation {
-    current_base: number;
-    estimated_base: number;
-    heap_compactions: number;
-    max: number;
-    min: number;
-    num_full_gc: number;
-    num_inc_gc: number;
-    usage_trend: number;
-}
-
-interface LeakInformation {
-    /**
-     * Amount of heap growth in bytes.
-     */
-    growth: number;
-
-    /**
-     * Human-readable description.
-     */
-    reason: string;
-}
+declare const memwatch: memwatch.MemWatch;
 
 /**
  * Compare the state of your heap between two points in time, telling you what has been allocated, and what has been released.
@@ -55,33 +18,72 @@ declare class HeapDiff {
     /**
      * Compute the diff.
      */
-    end: () => HeapDiffInformation;
+    end: () => memwatch.HeapDiffInformation;
 }
 
-interface HeapDiffInformation {
-    before: HeapDiffSnapshot;
-    after: HeapDiffSnapshot;
-    change: HeapDiffChange;
-}
+declare namespace memwatch {
+    interface MemWatch extends EventEmitter {
+        on(eventName: "leak", callback: (event: LeakInformation) => void): this;
+        on(eventName: "stats", callback: (event: StatsInformation) => void): this;
 
-interface HeapDiffSnapshot {
-    nodes: number;
-    size_bytes: number;
-    size: string;
-}
+        /**
+         * Force V8 to do a full GC and heap compaction.
+         *
+         * It's intended to be used for debugging. Calling it in production is highly discouraged.
+         */
+        gc(): void;
 
-interface HeapDiffChange {
-    size_bytes: number;
-    size: string;
-    freed_nodes: number;
-    allocated_nodes: number;
-    details: HeapDiffDetail[];
-}
+        HeapDiff: typeof HeapDiff;
+    }
 
-interface HeapDiffDetail {
-    what: string;
-    size_bytes: number;
-    size: string;
-    "+": number;
-    "-": number;
+    interface StatsInformation {
+        current_base: number;
+        estimated_base: number;
+        heap_compactions: number;
+        max: number;
+        min: number;
+        num_full_gc: number;
+        num_inc_gc: number;
+        usage_trend: number;
+    }
+
+    interface LeakInformation {
+        /**
+         * Amount of heap growth in bytes.
+         */
+        growth: number;
+
+        /**
+         * Human-readable description.
+         */
+        reason: string;
+    }
+
+    interface HeapDiffInformation {
+        before: HeapDiffSnapshot;
+        after: HeapDiffSnapshot;
+        change: HeapDiffChange;
+    }
+
+    interface HeapDiffSnapshot {
+        nodes: number;
+        size_bytes: number;
+        size: string;
+    }
+
+    interface HeapDiffChange {
+        size_bytes: number;
+        size: string;
+        freed_nodes: number;
+        allocated_nodes: number;
+        details: HeapDiffDetail[];
+    }
+
+    interface HeapDiffDetail {
+        what: string;
+        size_bytes: number;
+        size: string;
+        "+": number;
+        "-": number;
+    }
 }

--- a/types/node-memwatch/node-memwatch-tests.ts
+++ b/types/node-memwatch/node-memwatch-tests.ts
@@ -8,7 +8,7 @@ memwatch.on("leak", info => {
     info.growth;
 });
 
-const hd = new memwatch.HeapDiff();
+const hd = new memwatch.HeapDiff(); // $ExpectType HeapDiff
 const diff = hd.end();
 diff.change.allocated_nodes;
 diff.change.details[0].what;


### PR DESCRIPTION
No functional changes - just making it easier to work with the types used in this package by exporting those definitions. Exporting via a namespace of the same name, but had to move `HeapDiff` out of the scope of the exported namespace (see https://github.com/Microsoft/TypeScript/issues/13536).

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

