### PR TITLE
[react-router-config] Add render key in route config.

### DIFF
--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -23,7 +23,7 @@ export interface RouteConfig {
     exact?: boolean;
     strict?: boolean;
     routes?: RouteConfig[];
-    render?: (props?: RouteConfigComponentProps<any>) => React.ComponentType;
+    render?: (props: RouteComponentProps<any>) => React.ReactNode;
     [propName: string]: any;
 }
 

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -23,7 +23,7 @@ export interface RouteConfig {
     exact?: boolean;
     strict?: boolean;
     routes?: RouteConfig[];
-    render?: (props: RouteComponentProps<any>) => React.ReactNode;
+    render?: (props: RouteConfigComponentProps<any>) => React.ReactNode;
     [propName: string]: any;
 }
 

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for react-router-config 1.1
+// Type definitions for react-router-config 5.0
 // Project: https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config, https://github.com/reacttraining/react-router
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Phoenix He <https://github.com/NullMDR>
+//                 Mathieu TUDISCO <https://github.com/mathieutu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -22,6 +23,7 @@ export interface RouteConfig {
     exact?: boolean;
     strict?: boolean;
     routes?: RouteConfig[];
+    render?: (props?: RouteConfigComponentProps<any>) => React.ComponentType;
     [propName: string]: any;
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/ReactTraining/react-router/blob/a38ef042697ccc1c70bcdaf07d05ad994a31594d/packages/react-router-config/modules/renderRoutes.js
- [x] Increase the version number in the header if appropriate.

Relevant type in react-router: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts
