### PR TITLE
[paper] Fix toJSON return type

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -74,7 +74,7 @@ declare module paper {
         /**
          * Same as `exportJSON({ asString: false })`.
          */
-        toJSON(): string;
+        toJSON(): object | any[];
     }
 
     /**

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -15281,9 +15281,11 @@ function APIReferenceExamples() {
         const str = src.exportJSON(); // "['Point', 50, 25]"
         // not type save import
         const res0 = paper.Point.importJSON(str);
+        // not type save import
+        const res1 = paper.Point.importJSON(src.toJSON());
         // type save import to existing object
         // if object is not same type with json, object will not be updated
-        const res1 = new paper.Point(0, 0);
+        const res2 = new paper.Point(0, 0);
         paper.Point.importJSON(str, res1);
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Explanation:
"Copy/paste" fix. As mentioned in jsdoc: `toJSON()` is the same as `export({ asString: false })`, which returns `object | any[]`.