### PR TITLE
react: add PropsWithChildren to memo return type

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -784,7 +784,7 @@ declare namespace React {
     function memo<P extends object>(
         Component: SFC<P>,
         propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean
-    ): NamedExoticComponent<P>;
+    ): NamedExoticComponent<PropsWithChildren<P>>;
     function memo<T extends ComponentType<any>>(
         Component: T,
         propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -208,12 +208,14 @@ componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, sn
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });
 <Memoized1 foo='string'/>;
+<Memoized1 foo='string'>Children</Memoized1>;
 
 const Memoized2 = React.memo(
     function Bar(props: { bar: string }) { return null; },
     (prevProps, nextProps) => prevProps.bar === nextProps.bar
 );
 <Memoized2 bar='string'/>;
+<Memoized2 bar='string'>Children</Memoized2>;
 
 const Memoized3 = React.memo(class Test extends React.Component<{ x?: string }> {});
 <Memoized3 ref={ref => { if (ref) { ref.props.x; } }}/>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-api.html#reactmemo
- [ ] Increase the version number in the header if appropriate. _- Not appropiate_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _- Not making substantial changes_

### The issue

When used on a `FunctionComponent`, which allow children by default, `memo` prevents the component from receiving children:

```typescript
import React, {FC, memo} from "react"

interface MyComponentProps {
	title: string
}

const MyComponentBase: FC<MyComponentProps> = ({children, title}) =>
	<div style={{backgroundColor: "cyan"}}>
		<h3>{title}</h3>
		{children}
	</div>

const MyComponent = memo(MyComponentBase)

const App: FC = () => <MyComponent title="Hello!">
	Hello world!
</MyComponent>

export default App
```

yields:

```
TypeScript error in /home/pablo/Projects/react-memo-children-test/src/App.tsx(15,24):
Type '{ children: string; title: string; }' is not assignable to type 'IntrinsicAttributes & MyComponentProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & MyComponentProps'.  TS2322
```

Even though this is perfectly valid React code. Nowhere on the react docs it says that memo-ized component can't accept children and in fact memo allows you to decide whether or not to update based on changes on the children.