### PR TITLE
command-line-args: added template type merging in function commandLineArgs

### DIFF
--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for command-line-args 5.0.1
 // Project: https://github.com/75lb/command-line-args
 // Definitions by: Lloyd Brookes <https://github.com/75lb>
+//                 Bisius <https://github.com/Bisius>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for command-line-args 5.0
+// Type definitions for command-line-args 5.0.1
 // Project: https://github.com/75lb/command-line-args
 // Definitions by: Lloyd Brookes <https://github.com/75lb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,7 +8,7 @@
  * Returns an object containing option values parsed from the command line. By default it parses the global `process.argv` array.
  * Parsing is strict by default. To be more permissive, enable `partial` or `stopAtFirstUnknown` modes.
  */
-declare function commandLineArgs(optionDefinitions: commandLineArgs.OptionDefinition[], options?: commandLineArgs.ParseOptions): commandLineArgs.CommandLineOptions;
+declare function commandLineArgs<T>(optionDefinitions: commandLineArgs.OptionDefinition[], options?: commandLineArgs.ParseOptions): T & commandLineArgs.CommandLineOptions;
 
 declare namespace commandLineArgs {
     interface CommandLineOptions {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Explanation:
With this change it's possible to assign a type to the return value of the `CommandLineArgs` function.
Returning a typed variable it's easier access to variable property and methods.

Example:
```typescript
import CommandLineArgs from 'command-line-args'
interface options_t {
   foo:number,
   bar?:string,
}

let options = CommandLineArgs<options_t>([
   { name: 'foo', type: Number, defaultValue: 1 },
   { name: 'bar', type: String }
])

options.foo // number
options.bar // string | undefined

let fixed = options.foo.toFixed(1)
// Now you know that fixed is a string
```