### PR TITLE
[atlaskit__tree] Accept null innerRef argument

### DIFF
--- a/types/atlaskit__tree/index.d.ts
+++ b/types/atlaskit__tree/index.d.ts
@@ -65,7 +65,7 @@ interface TreeDraggableProvided {
     // will be null if the draggable is disabled
     dragHandleProps?: DraggableProvidedDragHandleProps;
     // The following props will be removed once we move to react 16
-    innerRef: (element?: HTMLElement) => void;
+    innerRef: (element?: HTMLElement | null) => void;
 }
 
 export interface RenderItemParams {


### PR DESCRIPTION
The current type doesn't match the type [Ref](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L85) for React's ref prop:

```
  TS2322: Type '(element?: HTMLElement | undefined) => void' is not assignable to type 'string | ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined'.
    Type '(element?: HTMLElement | undefined) => void' is not assignable to type '(instance: HTMLDivElement | null) => void'.
      Types of parameters 'element' and 'instance' are incompatible.
        Type 'HTMLDivElement | null' is not assignable to type 'HTMLElement | undefined'.
          Type 'null' is not assignable to type 'HTMLElement | undefined'.
```

This change allows the argument to innerRef to be null, which makes the types match.