### PR TITLE
Luxon@1.15: Fixes type of ZoneOffsetOptions

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -494,7 +494,7 @@ export namespace Settings {
 
 export interface ZoneOffsetOptions {
     format?: 'short' | 'long';
-    localeCode?: string;
+    locale?: string;
 }
 
 export type ZoneOffsetFormat = 'narrow' | 'short' | 'techie';

--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -500,7 +500,7 @@ export interface ZoneOffsetOptions {
 export type ZoneOffsetFormat = 'narrow' | 'short' | 'techie';
 
 export class Zone {
-    offsetName(ts: number, options?: ZoneOffsetOptions): string;
+    offsetName(ts: number, options: ZoneOffsetOptions): string;
     formatOffset(ts: number, format: ZoneOffsetFormat): string;
     isValid: boolean;
     name: string;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -35,11 +35,13 @@ testIanaZone.formatOffset(dt.toMillis()); // $ExpectError
 testIanaZone.formatOffset(dt.toMillis(), 'narrow'); // $ExpectType string
 testIanaZone.formatOffset(dt.toMillis(), 'short'); // $ExpectType string
 testIanaZone.formatOffset(dt.toMillis(), 'techie'); // $ExpectType string
+testIanaZone.formatOffset(dt.toMillis(), 'other_string'); // $ExpectError
 testIanaZone.offsetName(dt.toMillis()); // $ExpectError
 testIanaZone.offsetName(dt.toMillis(), { format: 'short'}); // $ExpectType string
 testIanaZone.offsetName(dt.toMillis(), { format: 'long'}); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: 'other_string'}); // $ExpectError
 testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-us'}); // $ExpectType string
-testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-gb'}); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { locale: 'en-gb'}); // $ExpectType string
 const ianaZoneTest = DateTime.fromObject({
     zone: ianaZone,
 });

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -251,7 +251,7 @@ iso.zoneName; // $ExpectType string
 iso.toString(); // $ExpectType string
 
 DateTime.fromISO('2017-05-15T09:10:23', { zone: 'Europe/Paris', setZone: true }); // $ExpectType DateTime
-DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', 'yyyy-MM-dd'T'HH:mm:ss z'); // $ExpectType DateTime
+DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime
 
 Settings.defaultZoneName = 'Asia/Tokyo';
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -31,10 +31,11 @@ const testIanaZone = IANAZone.create('Europe/London');
 IANAZone.isValidSpecifier('Europe/London');
 IANAZone.isValidZone('Europe/London');
 IANAZone.resetCache();
+testIanaZone.formatOffset(dt.toMillis()); // $ExpectError
 testIanaZone.formatOffset(dt.toMillis(), 'narrow'); // $ExpectType string
 testIanaZone.formatOffset(dt.toMillis(), 'short'); // $ExpectType string
 testIanaZone.formatOffset(dt.toMillis(), 'techie'); // $ExpectType string
-testIanaZone.offsetName(dt.toMillis()); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis()); // $ExpectError
 testIanaZone.offsetName(dt.toMillis(), { format: 'short'}); // $ExpectType string
 testIanaZone.offsetName(dt.toMillis(), { format: 'long'}); // $ExpectType string
 testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-us'}); // $ExpectType string

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -27,13 +27,18 @@ const fromObject = DateTime.fromObject({
 });
 
 const ianaZone = new IANAZone('America/Los_Angeles');
-const testIanaZone = IANAZone.create("Europe/London");
-IANAZone.isValidSpecifier("Europe/London");
-IANAZone.isValidZone("Europe/London");
+const testIanaZone = IANAZone.create('Europe/London');
+IANAZone.isValidSpecifier('Europe/London');
+IANAZone.isValidZone('Europe/London');
 IANAZone.resetCache();
 testIanaZone.formatOffset(dt.toMillis(), 'narrow'); // => +1
 testIanaZone.formatOffset(dt.toMillis(), 'short'); // => +01:00
 testIanaZone.formatOffset(dt.toMillis(), 'techie'); // => +0100
+testIanaZone.offsetName(dt.toMillis()); // => asd
+testIanaZone.offsetName(dt.toMillis(), { format: 'short'}); // => asd
+testIanaZone.offsetName(dt.toMillis(), { format: 'long'}); // => asd
+testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-us'}); // => asd
+testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-gb'}); // => asd
 const ianaZoneTest = DateTime.fromObject({
     zone: ianaZone,
 });
@@ -41,7 +46,7 @@ const ianaZoneTest = DateTime.fromObject({
 FixedOffsetZone.utcInstance;
 
 FixedOffsetZone.instance(60);
-FixedOffsetZone.parseSpecifier("UTC+6");
+FixedOffsetZone.parseSpecifier('UTC+6');
 
 const fromIso = DateTime.fromISO('2017-05-15'); // => May 15, 2017 at midnight
 const fromIso2 = DateTime.fromISO('2017-05-15T08:30:00'); // => May 15, 2017 at midnight
@@ -246,7 +251,7 @@ iso.zoneName; // $ExpectType string
 iso.toString(); // $ExpectType string
 
 DateTime.fromISO('2017-05-15T09:10:23', { zone: 'Europe/Paris', setZone: true }); // $ExpectType DateTime
-DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime
+DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', 'yyyy-MM-dd'T'HH:mm:ss z'); // $ExpectType DateTime
 
 Settings.defaultZoneName = 'Asia/Tokyo';
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -31,14 +31,14 @@ const testIanaZone = IANAZone.create('Europe/London');
 IANAZone.isValidSpecifier('Europe/London');
 IANAZone.isValidZone('Europe/London');
 IANAZone.resetCache();
-testIanaZone.formatOffset(dt.toMillis(), 'narrow'); // => +1
-testIanaZone.formatOffset(dt.toMillis(), 'short'); // => +01:00
-testIanaZone.formatOffset(dt.toMillis(), 'techie'); // => +0100
-testIanaZone.offsetName(dt.toMillis()); // => asd
-testIanaZone.offsetName(dt.toMillis(), { format: 'short'}); // => asd
-testIanaZone.offsetName(dt.toMillis(), { format: 'long'}); // => asd
-testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-us'}); // => asd
-testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-gb'}); // => asd
+testIanaZone.formatOffset(dt.toMillis(), 'narrow'); // $ExpectType string
+testIanaZone.formatOffset(dt.toMillis(), 'short'); // $ExpectType string
+testIanaZone.formatOffset(dt.toMillis(), 'techie'); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis()); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: 'short'}); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: 'long'}); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-us'}); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: 'short', locale: 'en-gb'}); // $ExpectType string
 const ianaZoneTest = DateTime.fromObject({
     zone: ianaZone,
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The option here is not `localeCode` but `locale`: http://moment.github.io/luxon/docs/class/src/zone.js~Zone.html#instance-method-offsetName
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
