### PR TITLE
[min-css-extract-plugin] Fix MiniCssExtractPlugin.loader type

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for mini-css-extract-plugin 0.2
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
+//                 Katsuya Hino <https://github.com/dobogo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Loader, Plugin } from 'webpack';
+import { Plugin } from 'webpack';
 
 /**
  * Lightweight CSS extraction webpack plugin
@@ -13,7 +14,7 @@ import { Loader, Plugin } from 'webpack';
  */
 declare class MiniCssExtractPlugin extends Plugin {
     /** webpack loader used always at the end of loaders list */
-    static loader: Loader;
+    static loader: string;
 
     constructor(options?: MiniCssExtractPlugin.PluginOptions);
 }

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -21,6 +21,15 @@ configuration = {
                 test: /\.css$/,
                 use: [MiniCssExtractPlugin.loader, 'css-loader'],
             },
+            {
+                test: /\.css$/,
+                use: {
+                    loader: MiniCssExtractPlugin.loader,
+                    options: {
+                        publicPath: '/',
+                    },
+                },
+            },
             // Optionally extract less files
             // or any other compile-to-css language
             {


### PR DESCRIPTION
Type of `MiniCssExtractPlugin.loader` is `string` because it is returned from `require.resolve()`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/webpack-contrib/mini-css-extract-plugin/blob/392c4ae68c9384230d6652e7fee277a702deacd7/src/index.js#L608>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
