### PR TITLE
Add type definitions for expression-evaluator package

### DIFF
--- a/types/expression-evaluator/expression-evaluator-tests.ts
+++ b/types/expression-evaluator/expression-evaluator-tests.ts
@@ -1,0 +1,11 @@
+import * as expressionEvaluator from 'expression-evaluator';
+
+expressionEvaluator.evaluate({type: 'experiment', fields: []}, {}); // $ExpectType boolean
+
+expressionEvaluator.eq({type: 'experiment', key: 'someKey', value: 'someValue'}, {}); // $ExpectType boolean
+
+expressionEvaluator.neq({type: 'experiment', key: 'someKey', value: 'someValue'}, {}); // $ExpectType boolean
+
+expressionEvaluator.and({type: 'experiment', fields: []}, {}); // $ExpectType boolean
+
+expressionEvaluator.or({type: 'experiment', fields: []}, {}); // $ExpectType boolean

--- a/types/expression-evaluator/index.d.ts
+++ b/types/expression-evaluator/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for expression-evaluator 0.2
+// Project: https://github.com/GreetzNL/expression-evaluator#readme
+// Definitions by: GreetzNL <https://github.com/GreetzNL>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace expressionEvaluator;
+
+export function evaluate(q: IComparisonOperator | ILogicalOperator, props?: any): boolean;
+export function and(query: ILogicalOperator, props: any): boolean;
+export function or(query: ILogicalOperator, props: any): boolean;
+export function eq(field: IComparisonOperator, props: any): boolean;
+export function neq(field: IComparisonOperator, props: any): boolean;
+
+export interface IComparisonOperator {
+    type: string;
+    key: string;
+    value: string | number | boolean;
+}
+
+export interface ILogicalOperator {
+    type: string;
+    fields: ILogicalOperator[] | IComparisonOperator[] | any[];
+}

--- a/types/expression-evaluator/tsconfig.json
+++ b/types/expression-evaluator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "expression-evaluator-tests.ts"
+    ]
+}

--- a/types/expression-evaluator/tslint.json
+++ b/types/expression-evaluator/tslint.json
@@ -1,0 +1,6 @@
+{ 
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "interface-name": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.