### PR TITLE
Feature/kafkajs  update kafka options to include log creator

### DIFF
--- a/types/kafkajs/index.d.ts
+++ b/types/kafkajs/index.d.ts
@@ -71,6 +71,31 @@ export enum ResourceTypes {
     DELEGATION_TOKEN = 6
 }
 
+export interface LoggerMessage {
+    /** @var namespace Context from which the logger was called. */
+    readonly namespace: string
+
+    /** @var level Logger level. */
+    readonly level: logLevel
+
+    /** @var label Logger level label. */
+    readonly label: string
+
+    /** @var log Content of the logger entry. */
+    readonly log: LoggerMessageContent
+}
+
+export interface LoggerMessageContent {
+    /** @var timestamp Message tiempstamp. */
+    readonly timestamp: Date
+
+    /** @var message Message sent to the logger. */
+    readonly message: string
+
+    // Other possible fields in the content, that depend on the context.
+    [key: string]: any
+}
+
 export interface KafkaOptions {
     clientId?: string;
     brokers: string[];
@@ -80,6 +105,7 @@ export interface KafkaOptions {
     requestTimeout?: number;
     retry?: RetryOptions;
     logLevel?: logLevel;
+    logCreator?: () => (message: LoggerMessage) => void;
 }
 
 export interface SASLOptions {

--- a/types/kafkajs/index.d.ts
+++ b/types/kafkajs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for kafkajs 1.4
+// Type definitions for kafkajs 1.8
 // Project: https://github.com/tulios/kafkajs, https://kafka.js.org
 // Definitions by: Michal Kaminski <https://github.com/michal-b-kaminski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/kafkajs/index.d.ts
+++ b/types/kafkajs/index.d.ts
@@ -73,27 +73,27 @@ export enum ResourceTypes {
 
 export interface LoggerMessage {
     /** @var namespace Context from which the logger was called. */
-    readonly namespace: string
+    readonly namespace: string;
 
     /** @var level Logger level. */
-    readonly level: logLevel
+    readonly level: logLevel;
 
     /** @var label Logger level label. */
-    readonly label: string
+    readonly label: string;
 
     /** @var log Content of the logger entry. */
-    readonly log: LoggerMessageContent
+    readonly log: LoggerMessageContent;
 }
 
 export interface LoggerMessageContent {
-    /** @var timestamp Message tiempstamp. */
-    readonly timestamp: Date
+    /** @var timestamp Message timestamp. */
+    readonly timestamp: Date;
 
     /** @var message Message sent to the logger. */
-    readonly message: string
+    readonly message: string;
 
     // Other possible fields in the content, that depend on the context.
-    [key: string]: any
+    [key: string]: any;
 }
 
 export interface KafkaOptions {

--- a/types/kafkajs/kafkajs-tests.ts
+++ b/types/kafkajs/kafkajs-tests.ts
@@ -8,7 +8,8 @@ import {
     CompressionTypes,
     CompressionCodecs,
     ResourceTypes,
-    PartitionAssigner
+    PartitionAssigner,
+    LoggerMessage
 } from "kafkajs";
 
 const { MemberMetadata, MemberAssignment } = AssignerProtocol;
@@ -17,6 +18,10 @@ const { roundRobin } = PartitionAssigners;
 // COMMON
 const host = "localhost";
 const topic = "topic-test";
+
+const logger = (loggerMessage: LoggerMessage): void => {
+    console.log(`[${loggerMessage.namespace}] ${loggerMessage.log.message}`)
+}
 
 const kafka = new Kafka({
     logLevel: logLevel.INFO,
@@ -31,7 +36,8 @@ const kafka = new Kafka({
         mechanism: "plain",
         username: "test",
         password: "testtest"
-    }
+    },
+    logCreator: () => logger
 });
 
 // CONSUMER

--- a/types/kafkajs/kafkajs-tests.ts
+++ b/types/kafkajs/kafkajs-tests.ts
@@ -20,8 +20,8 @@ const host = "localhost";
 const topic = "topic-test";
 
 const logger = (loggerMessage: LoggerMessage): void => {
-    console.log(`[${loggerMessage.namespace}] ${loggerMessage.log.message}`)
-}
+    console.log(`[${loggerMessage.namespace}] ${loggerMessage.log.message}`);
+};
 
 const kafka = new Kafka({
     logLevel: logLevel.INFO,


### PR DESCRIPTION
Include `logCreator` in `KafkaOptions`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tulios/kafkajs
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hello @michal-b-kaminski I have created this PR to include `logCreator` definition in `KafkaOptions`. This field is needed to change the default logger of the package, which is quite convenient :)