### PR TITLE
Minor react-intl types fixes

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -124,7 +124,7 @@ declare namespace ReactIntl {
             /*
              * one of "best fit" (default) | "numeric"
              */
-            style?: "best-fit" | "numeric";
+            style?: "best fit" | "numeric";
             format?: string;
             updateInterval?: number;
             initialNow?: any;
@@ -176,7 +176,7 @@ declare namespace ReactIntl {
         }
 
         interface PropsBase extends Base {
-            other?: any;
+            other: any;
             zero?: any;
             one?: any;
             two?: any;

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,6 +11,7 @@
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 obedm503 <https://github.com/obedm503>
 //                 anion155 <https://github.com/anion155>
+//                 tkryskiewicz <https://github.com/tkryskiewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: SEE BELOW
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Summary

Since at least v2.3 `other` prop of `FormattedPlural` is requierd. Some `formatXXX()` functions use component prop types as options, but not in this case (only `style` is used from `FormattedPlural.Base`).

https://github.com/formatjs/react-intl/blob/707ee4b2cf92fd0dc3bca06b183f521db45979aa/src/components/plural.js#L21

Also there was a typo in possible values for `style` in `FormattedRelative.PropsBase` - `'best fit'` instead of `'best-fit'`.

https://github.com/formatjs/react-intl/blob/707ee4b2cf92fd0dc3bca06b183f521db45979aa/src/types.js#L95