### PR TITLE
jasmine-given: make done arg non-optional

### DIFF
--- a/types/jasmine-given/index.d.ts
+++ b/types/jasmine-given/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for jasmine-given 2.6
 // Project: https://github.com/searls/jasmine-given
-// Definitions by: Shai Reznik <https://github.com/shairez>, Dmitry Efimenko <https://github.com/DmitryEfimenko>
+// Definitions by: Shai Reznik <https://github.com/shairez>
+//                 Dmitry Efimenko <https://github.com/DmitryEfimenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/jasmine-given/index.d.ts
+++ b/types/jasmine-given/index.d.ts
@@ -12,9 +12,9 @@ interface DoneFn {
   fail: (message?: Error | string) => void;
 }
 
-declare function Given(func: ((done: DoneFn) => void) | (() => void)): void;
-declare function When(func: ((done: DoneFn) => void) | (() => void)): void;
-declare function Then(func: ((done: DoneFn) => void) | (() => void)): void;
-declare function Then(label: string, func: ((done: DoneFn) => void) | (() => void)): void;
-declare function And(func: ((done: DoneFn) => void) | (() => void)): void;
-declare function Invariant(func: ((done: DoneFn) => void) | (() => void)): void;
+declare function Given(func: ((done: DoneFn) => void)): void;
+declare function When(func: ((done: DoneFn) => void)): void;
+declare function Then(func: ((done: DoneFn) => void)): void;
+declare function Then(label: string, func: ((done: DoneFn) => void)): void;
+declare function And(func: ((done: DoneFn) => void)): void;
+declare function Invariant(func: ((done: DoneFn) => void)): void;

--- a/types/jasmine-given/index.d.ts
+++ b/types/jasmine-given/index.d.ts
@@ -13,9 +13,9 @@ interface DoneFn {
   fail: (message?: Error | string) => void;
 }
 
-declare function Given(func: ((done: DoneFn) => void)): void;
-declare function When(func: ((done: DoneFn) => void)): void;
-declare function Then(func: ((done: DoneFn) => void)): void;
-declare function Then(label: string, func: ((done: DoneFn) => void)): void;
-declare function And(func: ((done: DoneFn) => void)): void;
-declare function Invariant(func: ((done: DoneFn) => void)): void;
+declare function Given(func: (done: DoneFn) => void): void;
+declare function When(func: (done: DoneFn) => void): void;
+declare function Then(func: (done: DoneFn) => void): void;
+declare function Then(label: string, func: (done: DoneFn) => void): void;
+declare function And(func: (done: DoneFn) => void): void;
+declare function Invariant(func: (done: DoneFn) => void): void;

--- a/types/jasmine-given/index.d.ts
+++ b/types/jasmine-given/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for jasmine-given 2.6
 // Project: https://github.com/searls/jasmine-given
-// Definitions by: Shai Reznik <https://github.com/shairez>
+// Definitions by: Shai Reznik <https://github.com/shairez>, Dmitry Efimenko <https://github.com/DmitryEfimenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /** Action method that should be called when the async work is complete */
 interface DoneFn {
@@ -11,9 +12,9 @@ interface DoneFn {
   fail: (message?: Error | string) => void;
 }
 
-declare function Given(func: (done?: DoneFn) => void): void;
-declare function When(func: (done?: DoneFn) => void): void;
-declare function Then(func: (done?: DoneFn) => void): void;
-declare function Then(label: string, func: (done?: DoneFn) => void): void;
-declare function And(func: (done?: DoneFn) => void): void;
-declare function Invariant(func: (done?: DoneFn) => void): void;
+declare function Given(func: ((done: DoneFn) => void) | (() => void)): void;
+declare function When(func: ((done: DoneFn) => void) | (() => void)): void;
+declare function Then(func: ((done: DoneFn) => void) | (() => void)): void;
+declare function Then(label: string, func: ((done: DoneFn) => void) | (() => void)): void;
+declare function And(func: ((done: DoneFn) => void) | (() => void)): void;
+declare function Invariant(func: ((done: DoneFn) => void) | (() => void)): void;

--- a/types/jasmine-given/jasmine-given-tests.ts
+++ b/types/jasmine-given/jasmine-given-tests.ts
@@ -11,61 +11,41 @@ And(() => { });
 Invariant(() => { });
 
 Given((done) => {
-  if (done) {
-    done();
-  }
+  done();
 });
 
 When((done) => {
-  if (done) {
-    done();
-  }
+  done();
 });
 
 Then('expected condition 2', (done) => {
-  if (done) {
-    done();
-  }
+  done();
 });
 
 And((done) => {
-  if (done) {
-    done();
-  }
+  done();
 });
 
 Invariant((done) => {
-  if (done) {
-    done();
-  }
+  done();
 });
 
 Given((done) => {
-  if (done) {
-    done.fail();
-  }
+  done.fail();
 });
 
 When((done) => {
-  if (done) {
-    done.fail();
-  }
+  done.fail();
 });
 
 Then('expected condition 2', (done) => {
-  if (done) {
-    done.fail();
-  }
+  done.fail();
 });
 
 And((done) => {
-  if (done) {
-    done.fail();
-  }
+  done.fail();
 });
 
 Invariant((done) => {
-  if (done) {
-    done.fail();
-  }
+  done.fail();
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/searls/jasmine-given/blob/master/app/js/jasmine-given.coffee#L71>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
---
Having `done` argument as optional requires to have an `if` statement to check if it's defined:
```ts
Given((done) => {
  if (done) {
    done();
  }
});
```
However, this `if` statement is not actually required by *jasmine-given*. With new typings you can simply write:
```ts
Given((done) => {
  done();
});
```
