### PR TITLE
tar-stream: fixed the extract fn return type to be Extract

### DIFF
--- a/types/tar-stream/index.d.ts
+++ b/types/tar-stream/index.d.ts
@@ -37,6 +37,6 @@ export interface Extract extends stream.Writable {
     on(event: "entry", listener: (headers: Headers, stream: stream.PassThrough, next: () => void) => void): this;
 }
 
-export function extract(opts?: stream.WritableOptions): stream.Writable;
+export function extract(opts?: stream.WritableOptions): Extract;
 
 export function pack(opts?: stream.ReadableOptions): Pack;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mafintosh/tar-stream#extracting
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `Extract` type was defined properly, but, the return type of the `extract` function failed to utilize it as expected.

This PR fixes that.
