### PR TITLE
Remove PartialDeep from lodash, replace with Partial

### DIFF
--- a/types/lodash/ts3.1/common/collection.d.ts
+++ b/types/lodash/ts3.1/common/collection.d.ts
@@ -1342,7 +1342,7 @@ declare module "../index" {
         /**
          * @see _.orderBy
          */
-        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialDeep<T>>, orders?: Many<boolean|"asc"|"desc">): Collection<T>;
+        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialObject<T>>, orders?: Many<boolean|"asc"|"desc">): Collection<T>;
     }
     interface Object<T> {
         /**
@@ -1354,7 +1354,7 @@ declare module "../index" {
         /**
          * @see _.orderBy
          */
-        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialDeep<T>>, orders?: Many<boolean|"asc"|"desc">): CollectionChain<T>;
+        orderBy(iteratees?: Many<ListIterator<T, NotVoid> | PropertyName | PartialObject<T>>, orders?: Many<boolean|"asc"|"desc">): CollectionChain<T>;
     }
     interface ObjectChain<T> {
         /**

--- a/types/lodash/ts3.1/common/common.d.ts
+++ b/types/lodash/ts3.1/common/common.d.ts
@@ -210,7 +210,7 @@ declare module "../index" {
     interface PrimitiveChain<T> extends LoDashExplicitWrapper<T> {
     }
     type NotVoid = unknown;
-    type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialDeep<T>;
+    type IterateeShorthand<T> = PropertyName | [PropertyName, any] | GlobalPartial<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
     type ListIteratee<T> = ListIterator<T, NotVoid> | IterateeShorthand<T>;
@@ -258,9 +258,6 @@ declare module "../index" {
         cancel(): void;
         flush(): void;
     }
-    type PartialDeep<T> = {
-        [P in keyof T]?: PartialDeep<T[P]>;
-    };
     // For backwards compatibility
     type LoDashImplicitArrayWrapper<T> = LoDashImplicitWrapper<T[]>;
     type LoDashImplicitNillableArrayWrapper<T> = LoDashImplicitWrapper<T[] | null | undefined>;

--- a/types/lodash/ts3.1/common/common.d.ts
+++ b/types/lodash/ts3.1/common/common.d.ts
@@ -210,7 +210,7 @@ declare module "../index" {
     interface PrimitiveChain<T> extends LoDashExplicitWrapper<T> {
     }
     type NotVoid = unknown;
-    type IterateeShorthand<T> = PropertyName | [PropertyName, any] | GlobalPartial<T>;
+    type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialObject<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
     type ListIteratee<T> = ListIterator<T, NotVoid> | IterateeShorthand<T>;

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1902,7 +1902,7 @@ declare module "../index" {
         /**
          * @see _.pick
          */
-        pick<T>(object: T | null | undefined, ...props: PropertyPath[]): PartialDeep<T>;
+        pick<T>(object: T | null | undefined, ...props: PropertyPath[]): PartialObject<T>;
     }
     interface Object<T> {
         /**

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -2747,12 +2747,12 @@ declare namespace _ {
         <T extends object, U extends keyof T>(props: lodash.Many<U>, object: T): Pick<T, U>;
         (props: lodash.PropertyPath): LodashPick2x1;
         <T>(props: lodash.__, object: T | null | undefined): LodashPick2x2<T>;
-        <T>(props: lodash.PropertyPath, object: T | null | undefined): lodash.PartialDeep<T>;
+        <T>(props: lodash.PropertyPath, object: T | null | undefined): lodash.PartialObject<T>;
     }
     type LodashPick1x1<T, U extends keyof T> = (object: T) => Pick<T, U>;
     type LodashPick1x2<T> = <U extends keyof T>(props: lodash.Many<U>) => Pick<T, U>;
-    type LodashPick2x1 = <T>(object: T | null | undefined) => lodash.PartialDeep<T>;
-    type LodashPick2x2<T> = (props: lodash.PropertyPath) => lodash.PartialDeep<T>;
+    type LodashPick2x1 = <T>(object: T | null | undefined) => lodash.PartialObject<T>;
+    type LodashPick2x2<T> = (props: lodash.PropertyPath) => lodash.PartialObject<T>;
     interface LodashPickBy {
         <T, S extends T>(predicate: lodash.ValueKeyIterateeTypeGuard<T, S>): LodashPickBy1x1<T, S>;
         <T>(predicate: lodash.__, object: lodash.Dictionary<T> | null | undefined): LodashPickBy1x2<T>;

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5623,10 +5623,10 @@ fp.now(); // $ExpectType number
     const literalsArray: Array<"a" | "b"> = ["a", "b"];
     const roLiteralsArray: ReadonlyArray<"a" | "b"> = literalsArray;
 
-    _.pick(obj1, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, 0, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, ["b", 1], 0, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, readonlyArray); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj1, "a"); // $ExpectType Partial<AbcObject>
+    _.pick(obj1, 0, "a"); // $ExpectType Partial<AbcObject>
+    _.pick(obj1, ["b", 1], 0, "a"); // $ExpectType Partial<AbcObject>
+    _.pick(obj1, readonlyArray); // $ExpectType Partial<AbcObject>
     _.pick(obj2, "a", "b"); // $ExpectType Pick<AbcObject, "a" | "b">
     // We can't use ExpectType here because typescript keeps changing what order the types appear.
     let result1: Pick<AbcObject, "a" | "b">;


### PR DESCRIPTION
Fixes the most common occurrence of microsoft/TypeScript#21592. 

I don't think anybody uses the full capability of `PartialDeep` as a iteratee parameter, and it doesn't really make sense as the return type of `pick`.
