### PR TITLE
fix(hapi): make the auth settings property a separate type on routes

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -201,6 +201,8 @@ export interface AuthCredentials {
     app?: AppCredentials;
 }
 
+export type AuthMode = 'required' | 'optional' | 'try';
+
 /**
  * Authentication information:
  * * artifacts - an artifact object received from the authentication strategy and used in authentication-related actions.
@@ -228,7 +230,7 @@ export interface RequestAuth {
      */
     isAuthorized: boolean;
     /** the route authentication mode. */
-    mode: string;
+    mode: AuthMode;
     /** the name of the strategy used. */
     strategy: string;
 }
@@ -1112,14 +1114,14 @@ export interface ResponseToolkit {
 
 export type RouteOptionsAccessScope = false | string | string[];
 
-export type RouteOptionsAccessEntity = 'any' | 'user' | 'app';
+export type RouteAccessEntity = 'any' | 'user' | 'app';
 
 export interface RouteOptionsAccessScopeObject {
     scope: RouteOptionsAccessScope;
 }
 
 export interface RouteOptionsAccessEntityObject {
-    entity: RouteOptionsAccessEntity;
+    entity: RouteAccessEntity;
 }
 
 export type RouteOptionsAccessObject =
@@ -1158,7 +1160,7 @@ export interface RouteOptionsAccess {
      * strategy.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsauthaccessentity)
      */
-    entity?: RouteOptionsAccessEntity;
+    entity?: RouteAccessEntity;
 
     /**
      * Default value: 'required'.
@@ -1168,7 +1170,7 @@ export interface RouteOptionsAccess {
      * * 'try' - similar to 'optional', any request credentials are attempted authentication, but if the credentials are invalid, the request proceeds regardless of the authentication error.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsauthmode)
      */
-    mode?: 'required' | 'optional' | 'try';
+    mode?: AuthMode;
 
     /**
      * Default value: false, unless the scheme requires payload authentication.
@@ -1725,26 +1727,7 @@ export type RouteCompressionEncoderSettings = object;
 export interface RouteOptionsApp {
 }
 
-/**
- * Each route can be customized to change the default behavior of the request lifecycle.
- * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#route-options)
- */
-export interface RouteOptions {
-    /**
-     * Application-specific route configuration state. Should not be used by plugins which should use options.plugins[name] instead.
-     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsapp)
-     */
-    app?: RouteOptionsApp;
-
-    /**
-     * Route authentication configuration. Value can be:
-     * false to disable authentication if a default strategy is set.
-     * a string with the name of an authentication strategy registered with server.auth.strategy(). The strategy will be set to 'required' mode.
-     * an authentication configuration object.
-     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsapp)
-     */
-    auth?: false | string | RouteOptionsAccess;
-
+export interface CommonRouteProperties {
     /**
      * Default value: null.
      * An object passed back to the provided handler (via this) when called. Ignored if the method is an arrow function.
@@ -1975,6 +1958,48 @@ export interface RouteOptions {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsvalidate)
      */
     validate?: RouteOptionsValidate;
+}
+
+export interface AccessScopes {
+    forbidden?: string[];
+    required?: string[];
+    selection?: string[];
+}
+
+export interface AccessSetting {
+    entity?: RouteAccessEntity;
+    scopes: AccessScopes | false;
+}
+
+export interface AuthSettings {
+    strategies: string[];
+    mode: AuthMode;
+    access?: AccessSetting[];
+}
+
+export interface RouteSettings extends CommonRouteProperties {
+    auth?: AuthSettings;
+}
+
+/**
+ * Each route can be customized to change the default behavior of the request lifecycle.
+ * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#route-options)
+ */
+export interface RouteOptions extends CommonRouteProperties {
+    /**
+     * Application-specific route configuration state. Should not be used by plugins which should use options.plugins[name] instead.
+     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsapp)
+     */
+    app?: RouteOptionsApp;
+
+    /**
+     * Route authentication configuration. Value can be:
+     * false to disable authentication if a default strategy is set.
+     * a string with the name of an authentication strategy registered with server.auth.strategy(). The strategy will be set to 'required' mode.
+     * an authentication configuration object.
+     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsapp)
+     */
+    auth?: false | string | RouteOptionsAccess;
 }
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +

--- a/types/hapi__hapi/test/route/settings.ts
+++ b/types/hapi__hapi/test/route/settings.ts
@@ -1,0 +1,14 @@
+import { RouteSettings, AuthSettings, AccessSetting, AuthMode, RouteAccessEntity as AccessEntity, AccessScopes } from '@hapi/hapi';
+
+declare let set: RouteSettings;
+
+const auth: AuthSettings | undefined = set.auth;
+const strats: string[] = auth!.strategies;
+const mode: AuthMode = auth!.mode;
+const access: AccessSetting[] | undefined = auth!.access;
+const data: AccessEntity | undefined = access![0].entity;
+const scope: AccessScopes | false = access![0].scopes;
+let perms: string[] | undefined;
+perms = (<AccessScopes> scope).selection;
+perms = (<AccessScopes> scope).required;
+perms = (<AccessScopes> scope).forbidden;

--- a/types/hapi__hapi/tsconfig.json
+++ b/types/hapi__hapi/tsconfig.json
@@ -63,6 +63,7 @@
         "test/route/handler.ts",
         "test/route/route-options-pre.ts",
         "test/route/route-options.ts",
+        "test/route/settings.ts",
         "test/route/validation.ts",
         "test/server/server-app.ts",
         "test/server/server-auth-api.ts",


### PR DESCRIPTION
Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/blob/74e523d68282838fbceca21d584df48ce6a3f181/lib/auth.js#L494
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `settings` property in general is hydrated or  'cleaned up' version the initial route options, there is more that needs fixing but this is a start :)