### PR TITLE
[detox] Add two missing parameters to scroll

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -350,7 +350,12 @@ declare global {
              * await element(by.id('scrollView')).scroll(100, 'down');
              * await element(by.id('scrollView')).scroll(100, 'up');
              */
-            scroll(pixels: number, direction: Direction, startPositionX?: number, startPositionY?: number): Promise<Actions<R>>;
+            scroll(
+                pixels: number,
+                direction: Direction,
+                startPositionX?: number,
+                startPositionY?: number,
+            ): Promise<Actions<R>>;
             /**
              * Scroll to edge.
              * @param edge

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -350,7 +350,7 @@ declare global {
              * await element(by.id('scrollView')).scroll(100, 'down');
              * await element(by.id('scrollView')).scroll(100, 'up');
              */
-            scroll(pixels: number, direction: Direction): Promise<Actions<R>>;
+            scroll(pixels: number, direction: Direction, startPositionX?: number, startPositionY?: number): Promise<Actions<R>>;
             /**
              * Scroll to edge.
              * @param edge

--- a/types/detox/test/detox-module-tests.ts
+++ b/types/detox/test/detox-module-tests.ts
@@ -18,6 +18,7 @@ describe("Test", () => {
         await element(by.id("element")).replaceText("text");
         await element(by.id("element")).tap();
         await element(by.id("element")).scroll(50, "down");
+        await element(by.id("element")).scroll(50, "down", 0.5, 0.5);
         await element(by.id("scrollView")).scrollTo("bottom");
         await expect(element(by.id("element")).atIndex(0)).toNotExist();
         await element(by.id("scrollView")).swipe("down", "fast");


### PR DESCRIPTION
I noticed that two parameters in `scroll` function was missing. The missing parameters are documented here
https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md#scrollpixels-direction-startpositionxnan-startpositionynan

Should be easy to review since I added also tests 🔥

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md#scrollpixels-direction-startpositionxnan-startpositionynan
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
