### PR TITLE
react-text-mask : conformToMask - mask param can be a function

### DIFF
--- a/types/react-text-mask/index.d.ts
+++ b/types/react-text-mask/index.d.ts
@@ -46,6 +46,6 @@ export default class MaskedInput extends React.Component<
 
 export function conformToMask(
     text: string,
-    mask: maskArray,
+    mask: maskArray | ((value: string) => maskArray),
     config: any
 ): conformToMaskResult;


### PR DESCRIPTION
The `mask` param of the `conformToMask ` function can, like in `MaskedInputProps`, be a function.

https://github.com/text-mask/text-mask/blob/master/core/src/conformToMask.js#L15
