### PR TITLE
mongodb: added type parameters to some aggregation methods

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1849,7 +1849,7 @@ export class AggregationCursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#geoNear */
     geoNear(document: object): AggregationCursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#group */
-    group(document: object): AggregationCursor<T>;
+    group<U = T>(document: object): AggregationCursor<U>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#hasNext */
     hasNext(): Promise<boolean>;
     hasNext(callback: MongoCallback<boolean>): void;
@@ -1867,7 +1867,7 @@ export class AggregationCursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#out */
     out(destination: string): AggregationCursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#project */
-    project(document: object): AggregationCursor<T>;
+    project<U = T>(document: object): AggregationCursor<U>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#read */
     read(size: number): string | Buffer | void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#redact */
@@ -1884,7 +1884,7 @@ export class AggregationCursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unshift */
     unshift(stream: Buffer | string): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unwind */
-    unwind(field: string): AggregationCursor<T>;
+    unwind<U = T>(field: string): AggregationCursor<U>;
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#~resultCallback */

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -163,6 +163,34 @@ mongodb.MongoClient.connect(connectionString, options, (err: mongodb.MongoError,
                 cursor.match({ bar: 1 }).limit(10);
             }
         );
+
+        interface Employee {
+            firstName: string;
+            lastName: string;
+            department: string;
+        }
+
+        interface EmployeeName {
+            fullName: string;
+        }
+
+        const cursor1: mongodb.AggregationCursor<EmployeeName> = (
+          collection.aggregate<Employee>().project<EmployeeName>({
+            fullName: { $concat: ['$firstName', ' ', '$lastName'] },
+          })
+        );
+
+        interface DepartmentSummary {
+            _id: string;
+            count: number;
+        }
+
+        const cursor2: mongodb.AggregationCursor<DepartmentSummary> = (
+          collection.aggregate<Employee>().group<DepartmentSummary>({
+            _id: '$department',
+            count: { $sum: 1 },
+          })
+        );
     }
 
     // test for new typings
@@ -173,11 +201,11 @@ mongodb.MongoClient.connect(connectionString, options, (err: mongodb.MongoError,
             fruitTags: string[];
         }
         const testCollection = db.collection<TestCollection>('testCollection');
-		testCollection.insertOne({
+        testCollection.insertOne({
             stringField: 'hola',
             fruitTags: ['Strawberry'],
         });
-		testCollection.insertMany([
+        testCollection.insertMany([
             { stringField: 'hola', fruitTags: ['Apple', 'Lemon'] },
             { stringField: 'hola', numberField: 1, fruitTags: [] },
         ]);


### PR DESCRIPTION
AggregationCursor has a type parameter, but certain pipeline stages can change the shape of the data.
By adding optional type parameters (which default to the cursor's type) to the cursor's methods, the actual runtime types can be annotated more accurately.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: -
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.