### PR TITLE
Improve the intellisense of lazypipe

### DIFF
--- a/types/gulp-rev-replace/index.d.ts
+++ b/types/gulp-rev-replace/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jamesknelson/gulp-rev-replace
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 

--- a/types/gulp-useref/index.d.ts
+++ b/types/gulp-useref/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jonkemp/gulp-useref
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 

--- a/types/lazypipe/index.d.ts
+++ b/types/lazypipe/index.d.ts
@@ -9,22 +9,25 @@
 
 
 interface IPipelineBuilder {
-    /**
-     * Returns a stream where all the internal steps are processed sequentially
-     * and the final result is passed on.
-     */
-    (): NodeJS.ReadWriteStream;
+    (): NodeJS.ReadWriteStream
 
     /**
-     * Creates a new lazy pipeline with all the previous steps, and the new step added to the end.
-     * @param fn A stream creation function to call when the pipeline is created later.
-     * @param args Any remaining arguments are saved and passed into fn when the pipeline is created.
+     * Adds a step to the end of the pipeline.
+     *
+     * @param destination
+     * The destination stream creation function to call when invoking the pipeline.
+     *
+     * @param args
+     * The arguments for the `destination`-function.
+     *
+     * A pipeline-builder.
      */
-    pipe<TArgs extends any[]>(fn: (...args: TArgs) => NodeJS.ReadWriteStream, ...args: TArgs): IPipelineBuilder;
+    pipe<TArgs extends any[]>(destination: (...args: TArgs) => NodeJS.ReadWriteStream, ...args: TArgs): IPipelineBuilder;
 }
 
 /**
- * Initializes a lazypipe.
+ * Returns a stream where all the internal steps are processed sequentially
+ * and the final result is passed on.
  */
 declare function lazypipe(): IPipelineBuilder;
 export = lazypipe;

--- a/types/lazypipe/index.d.ts
+++ b/types/lazypipe/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for lazypipe
 // Project: https://github.com/OverZealous/lazypipe
 // Definitions by: Thomas Corbière <https://github.com/tomc974>
+//                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -18,7 +19,7 @@ interface IPipelineBuilder {
      * @param fn A stream creation function to call when the pipeline is created later.
      * @param args Any remaining arguments are saved and passed into fn when the pipeline is created.
      */
-    pipe(fn: Function, ...args: any[]): IPipelineBuilder;
+    pipe<TArgs extends any[]>(fn: (...args: TArgs) => NodeJS.ReadWriteStream, ...args: TArgs): IPipelineBuilder;
 }
 
 /**

--- a/types/lazypipe/index.d.ts
+++ b/types/lazypipe/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Thomas Corbière <https://github.com/tomc974>
 //                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="node"/>
 

--- a/types/lazypipe/lazypipe-tests.ts
+++ b/types/lazypipe/lazypipe-tests.ts
@@ -5,8 +5,12 @@ import lazypipe = require("lazypipe");
 
 const pipeline = lazypipe()
     .pipe(size)
-    .pipe(minifyHtml, {})
-    .pipe(size);
+    .pipe(minifyHtml, {
+        cdata: true
+    })
+    .pipe(size, {
+        showTotal: true
+    });
 
 gulp.src("*.html")
     .pipe(pipeline())


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I've just noticed that there is no IntelliSense when using `lazypipe`.
This PR adds auto-completion to the `lazypipe`-module.