### PR TITLE
add type definitions for react-sizes

### DIFF
--- a/types/react-sizes/index.d.ts
+++ b/types/react-sizes/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for react-sizes 2.0
+// Project: https://github.com/renatorib/react-sizes#readme
+// Definitions by: {@janKir,@micahstubbs} <https://github.com/janKir> <https://github.com/micahstubbs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// adapted from https://github.com/renatorib/react-sizes/issues/13#issuecomment-483725124
+
+export interface Sizes {
+    width: number;
+    height: number;
+}
+
+type mapSizesToProps<SP extends object> = (sizes: Sizes) => SP;
+
+export function withSizes<SP extends object, P extends SP>(
+    mapSizesToProps: mapSizesToProps<SP>
+): (component: React.ComponentType<P>) => React.ComponentType<P>;
+
+export as namespace withSizes;

--- a/types/react-sizes/react-sizes-tests.tsx
+++ b/types/react-sizes/react-sizes-tests.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { withSizes, Sizes } from "react-sizes";
+
+interface TestProps {
+    foo: string;
+}
+
+type TestInnerProps = TestProps & Sizes;
+
+const mapSizesToProps = ({ width, height }: Sizes) => ({
+    width,
+    height
+});
+
+const TestComponent: React.ComponentType<TestInnerProps> = ({
+    foo,
+    width,
+    height
+}) => {
+    foo; // $ExpectType string
+    width; // $ExpectType number
+    height; // $ExpectType number
+    return (
+        <div>
+            <p>Foo: {foo}</p>
+            <p>Window width: {width}</p>
+            <p>Window height: {height}</p>
+        </div>
+    );
+};
+
+withSizes(mapSizesToProps)(TestComponent); // $ExpectType ComponentType<TestProps>

--- a/types/react-sizes/tsconfig.json
+++ b/types/react-sizes/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-sizes-tests.ts"
+    ]
+}

--- a/types/react-sizes/tslint.json
+++ b/types/react-sizes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
