### PR TITLE
[proxy-from-env] Added type definitions for proxy-from-env 1.0

### DIFF
--- a/types/proxy-from-env/index.d.ts
+++ b/types/proxy-from-env/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for proxy-from-env 1.0
+// Project: https://github.com/Rob--W/proxy-from-env#readme
+// Definitions by: JasonHK <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Takes an input URL and returns the desired proxy URL. If no proxy is set, an
+ * empty string is returned.
+ * @param url The URL
+ * @returns The URL of the proxy that should handle the request to the given
+ *          URL.
+ */
+export function getProxyForUrl(url: string): string;

--- a/types/proxy-from-env/proxy-from-env-tests.ts
+++ b/types/proxy-from-env/proxy-from-env-tests.ts
@@ -1,0 +1,4 @@
+import { getProxyForUrl } from "proxy-from-env";
+
+// $ExpectType string
+getProxyForUrl("http://microsoft.github.io/TypeSearch/");

--- a/types/proxy-from-env/tsconfig.json
+++ b/types/proxy-from-env/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "proxy-from-env-tests.ts"
+    ]
+}

--- a/types/proxy-from-env/tslint.json
+++ b/types/proxy-from-env/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
