### PR TITLE
[express-serve-static-core] Fix listen callback type

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -2,3 +2,6 @@ import * as express from 'express-serve-static-core';
 
 const app: express.Application = {} as any;
 app.listen(3000);
+app.listen(3000, (err: any) => {
+    // no-op error callback
+});

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -1,3 +1,4 @@
 import * as express from 'express-serve-static-core';
 
-// null test file - everything should be tested from express.d.ts and serve-static.d.ts
+const app: express.Application = {} as any;
+app.listen(3000);

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -5,6 +5,7 @@
 //                 Kacper Polak <https://github.com/kacepe>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Sami Jaber <https://github.com/samijaber>
+//                 aereal <https://github.com/aereal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -996,11 +996,11 @@ export interface Application extends EventEmitter, IRouter, Express.Application 
      *    http.createServer(app).listen(80);
      *    https.createServer({ ... }, app).listen(443);
      */
-    listen(port: number, hostname: string, backlog: number, callback?: () => void): http.Server;
-    listen(port: number, hostname: string, callback?: () => void): http.Server;
-    listen(port: number, callback?: () => void): http.Server;
-    listen(callback?: () => void): http.Server;
-    listen(path: string, callback?: () => void): http.Server;
+    listen(port: number, hostname: string, backlog: number, callback?: (...args: any[]) => void): http.Server;
+    listen(port: number, hostname: string, callback?: (...args: any[]) => void): http.Server;
+    listen(port: number, callback?: (...args: any[]) => void): http.Server;
+    listen(callback?: (...args: any[]) => void): http.Server;
+    listen(path: string, callback?: (...args: any[]) => void): http.Server;
     listen(handle: any, listeningListener?: () => void): http.Server;
 
     router: string;


### PR DESCRIPTION
#35539 changes `Application.listen`'s callback type to `() => void` from `Function` but the actual implementation's `callback` parameter still take some parameters like a error object, so those changes **break** any code refers callback's parameter.

> Binds and listens for connections on the specified host and port. This method is identical to Node’s http.Server.listen().

https://expressjs.com/en/4x/api.html#app.listen

This PR fixes broken code after #35539 with current lint options.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/4x/api.html#app.listen
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.