### PR TITLE
Create types for logfmt

### DIFF
--- a/types/logfmt/index.d.ts
+++ b/types/logfmt/index.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for logfmt 1.2
+// Project: https://github.com/csquared/node-logfmt#readme
+// Definitions by: Evan Broder <https://github.com/ebroder>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import { IncomingMessage, ServerResponse } from 'http';
+
+type HTTPHandler =
+  (req: IncomingMessage, res: ServerResponse, next: (err?: any) => void) => any;
+
+interface WritableStream {
+    write(data: string): void;
+}
+
+interface RequestLoggerOptions {
+    immediate?: boolean;
+    elapsed?: string;
+}
+type RequestLoggerFormatter =
+  (req: IncomingMessage, res: ServerResponse) => object;
+
+interface RequestLogger {
+    (options?: RequestLoggerOptions, formatter?: RequestLoggerFormatter): HTTPHandler;
+    (formatter: RequestLoggerFormatter): HTTPHandler;
+    commonFormatter: (req: IncomingMessage, res: ServerResponse) => {
+        ip: string;
+        time: string;
+        method: string;
+        path: string;
+        "status": number;
+        request_id?: string;
+        content_length?: string;
+        content_type?: string;
+    };
+}
+
+interface Logfmt {
+    stringify(data: object): string;
+    parse(line: string): object;
+
+    log(data?: object, stream?: WritableStream): void;
+    time(label?: string): Logfmt;
+    namespace(data: object): Logfmt;
+    error(err: Error, id?: string): void;
+
+    streamParser(options?: { end?: boolean; }): NodeJS.ReadWriteStream;
+    streamStringify(options?: { delimiter?: string }): NodeJS.ReadWriteStream;
+
+    bodyParser(options?: { contentType?: string }): HTTPHandler;
+    bodyParserStream(options?: { contentType?: string }): HTTPHandler;
+
+    requestLogger: RequestLogger;
+
+    stream: WritableStream;
+    maxErrorLines: number;
+}
+
+interface LogfmtStatic extends Logfmt {
+    new (): Logfmt;
+}
+
+// logfmt copies its prototype onto the exported class, so you can both use it
+// directly as an instance of the class and as a constructor to instantiate new
+// instances.
+declare const logfmt: LogfmtStatic;
+
+export = logfmt;

--- a/types/logfmt/logfmt-tests.ts
+++ b/types/logfmt/logfmt-tests.ts
@@ -1,0 +1,117 @@
+import * as logfmt from 'logfmt';
+import * as through from 'through';
+import * as http from 'http';
+import * as express from 'express';
+
+// Examples taken from project README
+
+logfmt.stringify({foo: 'bar'});
+logfmt.parse('foo=bar');
+
+const logfmt2 = new logfmt();
+logfmt2.stringify = JSON.stringify;
+logfmt2.log({foo: 'bar'});
+logfmt.log({foo: 'bar'});
+
+logfmt.stringify({foo: "bar", a: 14, baz: 'hello kitty'});
+logfmt.parse("foo=bar a=14 baz=\"hello kitty\" cool%story=bro f %^asdf code=H12");
+
+process.stdin.pipe(logfmt.streamParser());
+
+process.stdin
+  .pipe(logfmt.streamStringify())
+  .pipe(process.stdout);
+
+process.stdin
+  .pipe(logfmt.streamParser())
+  .pipe(through((object) => {
+    console.log(object);
+  }));
+
+http.createServer((req, res) => {
+  req.pipe(logfmt.streamParser())
+      .pipe(through((object) => {
+        console.log(object);
+      }));
+
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end('OK');
+}).listen(3000);
+
+const app = express();
+app.use(logfmt.bodyParserStream());
+app.post('/logs', (req, res) => {
+  if (!req.body) return res.send('OK');
+
+  req.body.pipe(through((line) => {
+    console.dir(line);
+  }));
+
+  res.send('OK');
+});
+
+const app2 = express();
+app2.use(logfmt.bodyParser());
+// req.body is now an array of objects
+app2.post('/logs', (req, res) => {
+  console.log('BODY: ' + JSON.stringify(req.body));
+  req.body.forEach((data: object) => {
+    console.log(data);
+  });
+  res.send('OK');
+});
+
+logfmt.log({foo: "bar", a: 14, baz: 'hello kitty'});
+logfmt.log({foo: "bar", a: 14, baz: 'hello kitty'});
+logfmt.log({foo: "bar", a: 14, baz: 'hello kitty'}, process.stderr);
+
+// logfmt's trick of copying the prototype onto itself seems to trip up
+// TypeScript on module-level member assignment, so this should work but doesn't
+//
+// $ExpectError
+logfmt.stream = process.stderr;
+logfmt.log({foo: "bar", a: 14, baz: 'hello kitty'});
+
+const errorLogger = new logfmt();
+errorLogger.stream = process.stderr;
+errorLogger.log({hello: 'stderr'});
+
+const namespaced = logfmt.namespace({app: 'logfmt'});
+namespaced.log({foo: "bar", a: 14, baz: 'hello kitty'});
+
+const timer = logfmt.time();
+timer.log();
+const timer2 = logfmt.time('time');
+timer2.log();
+timer2.log();
+const timer3 = logfmt.time('time').namespace({foo: 'bar'});
+timer3.log();
+timer3.log();
+
+logfmt.error(new Error('test error'));
+
+const app3 = express();
+app3.use(logfmt.requestLogger());
+app3.use(logfmt.requestLogger({immediate: true}, (req, _res) => {
+  return {
+    method: req.method
+  };
+}));
+app3.use(logfmt.requestLogger({elapsed: 'request.time'}, (req, _res) => {
+  return {
+    "request.method": req.method
+  };
+}));
+app3.use(logfmt.requestLogger((req, _res) => {
+  return {
+    method: req.method
+  };
+}));
+app3.use(logfmt.requestLogger((req, res) => {
+  const data = logfmt.requestLogger.commonFormatter(req, res);
+  return {
+    ip: data.ip,
+    time: data.time,
+    foo: 'bar'
+  };
+}));

--- a/types/logfmt/tsconfig.json
+++ b/types/logfmt/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2017",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "logfmt-tests.ts"
+    ]
+}

--- a/types/logfmt/tslint.json
+++ b/types/logfmt/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I've written up a type declaration for the [`logfmt` package](https://www.npmjs.com/package/logfmt). It has a pretty thorough README which seems to document all of the functionality that's exported from the main module of the package, so I used that to derive my tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

cc @csquared as the maintainer of the upstream package