### PR TITLE
UUID:  reverse overloaded intersection so that ReturnType<T> will come up with string

### DIFF
--- a/types/uuid/interfaces.d.ts
+++ b/types/uuid/interfaces.d.ts
@@ -14,12 +14,12 @@ export type V4Options = {random: number[]} | {rng(): number[]};
 
 export type v1String = (options?: V1Options) => string;
 export type v1Buffer = <T extends OutputBuffer>(options: V1Options | null | undefined, buffer: T, offset?: number) => T;
-export type v1 = v1String & v1Buffer;
+export type v1 = v1Buffer & v1String;
 
 export type v4String = (options?: V4Options) => string;
 export type v4Buffer = <T extends OutputBuffer>(options: V4Options | null | undefined, buffer: T, offset?: number) => T;
-export type v4 = v4String & v4Buffer;
+export type v4 = v4Buffer & v4String;
 
 export type v5String = (name: string | number[], namespace: string | number[]) => string;
 export type v5Buffer = <T extends OutputBuffer>(name: string | number[], namespace: string | number[], buffer: T, offset?: number) => T;
-export type v5 = v5String & v5Buffer;
+export type v5 = v5Buffer & v5String;


### PR DESCRIPTION

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/Microsoft/TypeScript/issues/24275#issuecomment-390701982

ReturnType defaults to the last overload's return type since it is assumed to be the most general. Unfortunately, this isn't true with intersections which are treated as overloads like these ones. I assume the string implementation is the much more common case and should probably be the default return type since we sadly have to choose. Use case: this is currently breaking our use of jest types at 23 and above as it uses ReturnType in the mock types. 