### PR TITLE
@types/react-dom: Allow ReactNode as first argument to ReactDOM.render

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -91,4 +91,10 @@ export interface Renderer {
         container: Element | null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;
+    
+    (
+        element: ReactNode,
+        container: Element | null,
+        callback?: () => void
+    ): void;
 }

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -63,7 +63,7 @@ export interface Renderer {
     ): Element;
 
     (
-        element: SFCElement<any> | Array<SFCElement<any>>,
+        element: SFCElement<any> | Array<SFCElement<any>> | ReactNode,
         container: Element | null,
         callback?: () => void
     ): void;
@@ -91,10 +91,4 @@ export interface Renderer {
         container: Element | null,
         callback?: () => void
     ): Component<any, ComponentState> | Element | void;
-    
-    (
-        element: ReactNode,
-        container: Element | null,
-        callback?: () => void
-    ): void;
 }

--- a/types/react-dom/react-dom-tests.tsx
+++ b/types/react-dom/react-dom-tests.tsx
@@ -15,6 +15,16 @@ describe('ReactDOM', () => {
         ReactDOM.render(React.createElement('div'), rootElement);
     });
 
+    it('render primitive', () => {
+        const rootElement = document.createElement('div');
+        ReactDOM.render('foo', rootElement);
+    });
+
+    it('render fragment', () => {
+        const rootElement = document.createElement('div');
+        ReactDOM.render([React.createElement('div'), 'foo'], rootElement);
+    });
+
     it('hydrate', () => {
         const rootElement = document.createElement('div');
         ReactDOM.hydrate(React.createElement('div'), rootElement);


### PR DESCRIPTION
It definitely works:

```
> var div = document.createElement('div')
< undefined

> ReactDOM.render('sdf', div)
< "sdf"

> div
< <div>​sdf​</div>​
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: undocumented
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
