### PR TITLE
Add typings for promises in requestretry module

### DIFF
--- a/types/requestretry/index.d.ts
+++ b/types/requestretry/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for requestretry 1.12
 // Project: https://github.com/FGRibreau/node-request-retry
-// Definitions by: Eric Byers <https://github.com/EricByers>
-// 				   Andrew Throener <https://github.com/trainerbill>
+// Definitions by: 	Eric Byers <https://github.com/EricByers>
+// 				   				Andrew Throener <https://github.com/trainerbill>
+// 									Aniket Patel <https://github.com/baaka-ani>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,7 +13,12 @@ import http = require('http');
 
 declare namespace requestretry {
 	type RetryStrategy = (err: Error, response: http.IncomingMessage, body: any) => boolean;
-	interface RetryRequestAPI extends request.RequestAPI<request.Request, RequestRetryOptions, request.RequiredUriUrl> {
+	interface RequestPromise extends request.Request {
+		then: Promise<any>["then"];
+		catch: Promise<any>["catch"];
+		promise(): Promise<any>;
+	}
+	interface RetryRequestAPI extends request.RequestAPI<RequestPromise, RequestRetryOptions, request.RequiredUriUrl> {
 		RetryStrategies: {
 			'HttpError': RetryStrategy;
 			'HTTPOrNetworkError': RetryStrategy;

--- a/types/requestretry/requestretry-tests.ts
+++ b/types/requestretry/requestretry-tests.ts
@@ -1,6 +1,21 @@
 import request = require('requestretry');
 import http = require('http');
 
+// Promisified request function
+request({
+	url: 'https://api.example.com/v1/a/b',
+	json: true,
+	// The below parameters are specific to request-retry
+	// (default) try 5 times
+	maxAttempts: 5,
+	// (default) wait for 5s before trying again
+	retryDelay: 5000,
+	// (default) retry on 5xx or network errors
+	retryStrategy: request.RetryStrategies.HTTPOrNetworkError
+}).then(res => {
+	// Body
+});
+
 // HTTPOrNetworkError strategy.
 request({
 	url: 'https://api.example.com/v1/a/b',


### PR DESCRIPTION
I have extended the `request.Request` to support promise methods like `then` and `catch`

@EricByers @trainerbill Please review my PR