### PR TITLE
[leaflet-mouse-position] Add new wrapLng option

### DIFF
--- a/types/leaflet-mouse-position/index.d.ts
+++ b/types/leaflet-mouse-position/index.d.ts
@@ -24,6 +24,7 @@ declare module 'leaflet' {
             lngFormatter?: (lng: number) => string;
             latFormatter?: (lat: number) => string;
             prefix?: string;
+            wrapLng?: boolean;
         }
 
         class MousePosition extends LControl {

--- a/types/leaflet-mouse-position/index.d.ts
+++ b/types/leaflet-mouse-position/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for leaflet-mouse-position 1.1
+// Type definitions for leaflet-mouse-position 1.2
 // Project: https://github.com/danwild/Leaflet.MousePosition
 // Definitions by: Hanyon <https://github.com/Hanyon>
 //                 Håkon <https://github.com/hlovdal>
@@ -24,6 +24,7 @@ declare module 'leaflet' {
             numDigits?: number;
             lngFormatter?: (lng: number) => string;
             latFormatter?: (lat: number) => string;
+            formatter?: (lng: number, lat: number) => string;
             prefix?: string;
             wrapLng?: boolean;
         }

--- a/types/leaflet-mouse-position/index.d.ts
+++ b/types/leaflet-mouse-position/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for leaflet-mouse-position 1.1
 // Project: https://github.com/danwild/Leaflet.MousePosition
 // Definitions by: Hanyon <https://github.com/Hanyon>
+//                 Håkon <https://github.com/hlovdal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Version 1.1.0 of [Leaflet.MousePosition](https://github.com/danwild/Leaflet.MousePosition) adds a new `wrapLng` option.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[Pull request](https://github.com/danwild/Leaflet.MousePosition/pull/1)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
