### PR TITLE
Update types of safe-json-stringify for v1.1

### DIFF
--- a/types/centra/centra-tests.ts
+++ b/types/centra/centra-tests.ts
@@ -1,0 +1,52 @@
+import centra = require('centra');
+import { URL } from 'url';
+
+function typeTests() {
+    // Test chaining
+    centra('http://google.com')
+        .query('param', 'value')
+        .path('mail')
+        .body({ a: 1, b: 2 })
+        .header({ a: 'b' })
+        .header('a', 'b')
+        .timeout(123)
+        .stream()
+        .compress()
+        .option('host', '123')
+        .option('port', 123)
+        .send().then(resp => {
+            resp.json().then((s: string) => s);
+            resp.text().then((s: string) => s);
+            resp.statusCode;
+            resp.coreRes;
+            resp.headers['asdf'];
+            resp.body.buffer.byteLength;
+        });
+
+    centra(new URL('google.com'))
+        .query('page', '2');
+}
+
+async function functionalTests() {
+    await centra('http://example.com').send().then(async r => {
+        if (r.statusCode !== 200) {
+            throw new Error('Bad status code');
+        }
+        r.text().then(t => t);
+    });
+
+    await centra(new URL('https://jsonplaceholder.typicode.com/todos'))
+        .query('userId', 1)
+        .timeout(1000)
+        .compress()
+        .send()
+        .then(r => {
+            r.json().then((todos: any[]) => {
+                if (!todos.every(t => t.userId === 1)) {
+                    throw new Error('Query params did not work');
+                }
+            });
+        });
+}
+
+functionalTests();

--- a/types/centra/index.d.ts
+++ b/types/centra/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for centra 2.2
+// Project: https://github.com/ethanent/centra
+// Definitions by: Tony Wooster <https://github.com/twooster>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+
+import { RequestOptions, IncomingMessage } from 'http';
+import { URL } from 'url';
+
+interface CentraFactory {
+    (url: URL | string, method?: string): Centra.Request;
+}
+
+declare const Centra: CentraFactory;
+
+declare namespace Centra {
+    interface Response {
+        coreRes: IncomingMessage;
+        headers: IncomingMessage['headers'];
+        statusCode: IncomingMessage['statusCode'];
+        body: Buffer;
+
+        json(): Promise<any>;
+        text(): Promise<string>;
+    }
+
+    interface Request {
+        url: URL;
+        method: string;
+        data: string | Buffer | null;
+        sendDataAs: 'form' | 'json' | 'buffer' | null;
+        reqHeaders: { [k: string]: string };
+        streamEnabled: boolean;
+        compressionEnabled: boolean;
+        timeoutTime: number | null;
+        coreOptions: RequestOptions;
+
+        query(key: string, value: any): this;
+        query(params: { [k: string]: any }): this;
+        path(relativePath: string): this;
+        body(data: any, sendAs?: 'json' | 'buffer' | 'form'): this;
+        header(key: string, value: string): this;
+        header(headers: { [k: string]: string }): this;
+        timeout(timeMs: number): this;
+        option<T extends keyof RequestOptions>(key: T, value: RequestOptions[T]): this;
+        stream(): this;
+        compress(): this;
+        send(): Promise<Response>;
+    }
+}
+
+export = Centra;

--- a/types/centra/tsconfig.json
+++ b/types/centra/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "centra-tests.ts"
+    ]
+}

--- a/types/centra/tslint.json
+++ b/types/centra/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/phin/index.d.ts
+++ b/types/phin/index.d.ts
@@ -1,0 +1,123 @@
+// Type definitions for phin 3.3
+// Project: https://github.com/ethanent/phin
+// Definitions by: Tony Wooster <https://github.com/twooster>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="node" />
+
+import { ClientRequestArgs, IncomingMessage } from 'http';
+import { URL } from 'url';
+import { Response as CentraResponse } from 'centra';
+
+type Options = Phin.Options;
+type BufferResponse = Phin.BufferResponse;
+type StreamResponse = Phin.StreamResponse;
+type JsonResponse = Phin.JsonResponse;
+type DefaultOpts = Phin.DefaultOpts;
+type BatchResponse = JsonResponse | BufferResponse;
+type AnyResponse = BatchResponse | StreamResponse;
+
+interface PhinFactory {
+    (optsOrUrl: (Options & { parse?: 'none', stream?: false }) | string): Promise<BufferResponse>;
+    (optsOrUrl: Options & { parse: 'json', stream?: false }): Promise<JsonResponse>;
+    (optsOrUrl: Options & { stream: true }): Promise<StreamResponse>;
+    (optsOrUrl: Options): Promise<AnyResponse>;
+
+    promisified(optsOrUrl: (Options & { parse?: 'none', stream?: false }) | string): Promise<BufferResponse>;
+    promisified(optsOrUrl: Options & { parse: 'json', stream?: false }): Promise<JsonResponse>;
+    promisified(optsOrUrl: Options & { stream: true }): Promise<StreamResponse>;
+    promisified(optsOrUrl: Options): Promise<AnyResponse>;
+
+    unpromisified(optsOrUrl: (Options & { parse?: 'none', stream?: false }) | string, cb: (err: unknown, resp: BufferResponse) => unknown): void;
+    unpromisified(optsOrUrl: Options & { parse: 'json', stream?: false }, cb: (err: unknown, resp: JsonResponse) => unknown): void;
+    unpromisified(optsOrUrl: Options & { stream: true }, cb: (err: unknown, resp: StreamResponse) => unknown): void;
+    unpromisified(optsOrUrl: Options, cb: (err: unknown, resp: AnyResponse) => unknown): void;
+
+    defaults(defaultOpts: DefaultOpts & { parse: 'json', stream?: false }):
+    {
+        (optsOrUrl: Options & { stream: true }): Promise<StreamResponse>
+        (optsOrUrl: Options & { parse: 'none', stream?: false }): Promise<BufferResponse>
+        (optsOrUrl: (Options & { parse?: 'json', stream?: false }) | string): Promise<JsonResponse>
+        (optsOrUrl: Options): Promise<AnyResponse>
+    };
+
+    defaults(defaultOpts: DefaultOpts & { parse?: 'none', stream?: false }):
+    {
+        (optsOrUrl: Options & { stream: true }): Promise<StreamResponse>
+        (optsOrUrl: Options & { parse: 'json', stream?: false }): Promise<JsonResponse>
+        (optsOrUrl: (Options & { parse?: 'none', stream?: false }) | string): Promise<BufferResponse>
+        (optsOrUrl: Options): Promise<AnyResponse>
+    };
+
+    defaults(defaultOpts: DefaultOpts & { parse: 'json', stream: true }):
+    {
+        (optsOrUrl: Options & { parse: 'none', stream: false }): Promise<BufferResponse>
+        (optsOrUrl: Options & { parse?: 'json', stream: false }): Promise<JsonResponse>
+        (optsOrUrl: (Options & { stream?: true }) | string): Promise<StreamResponse>
+        (optsOrUrl: Options | string): Promise<AnyResponse>
+    };
+
+    defaults(defaultOpts: DefaultOpts & { parse?: 'none', stream: true }):
+    {
+        (opts: Options & { parse: 'json', stream: false }): Promise<JsonResponse>
+        (opts: Options & { parse?: 'none', stream: false }): Promise<BufferResponse>
+        (opts: (Options & { stream?: true }) | string): Promise<StreamResponse>
+        (opts: Options): Promise<AnyResponse>
+    };
+
+    defaults(defaultOpts: DefaultOpts):
+    {
+        (optsOrUrl: Options & { stream: true }): Promise<StreamResponse>
+        (optsOrUrl: Options & { parse: 'json', stream: false }): Promise<JsonResponse>
+        (optsOrUrl: Options & { parse: 'none', stream: false }): Promise<BufferResponse>
+        (optsOrUrl: Options | string): Promise<AnyResponse>
+    };
+}
+
+declare const Phin: PhinFactory;
+
+declare namespace Phin {
+    interface DefaultOpts {
+        url?: string;
+        method?: string;
+        data?: any;
+        form?: { [k: string]: string };
+        headers?: { [k: string]: string };
+        core?: ClientRequestArgs;
+        parse?: 'none' | 'json';
+        followRedirects?: boolean;
+        compression?: boolean;
+        timeout?: number | null;
+        hostname?: string;
+        port?: number;
+        path?: string;
+        stream?: boolean;
+    }
+
+    interface Options extends DefaultOpts {
+        url: string;
+    }
+
+    interface BatchOptions extends Options {
+        stream: false;
+    }
+
+    interface StreamOptions extends Options {
+        stream: true;
+    }
+
+    interface StreamResponse extends IncomingMessage {
+        stream: StreamResponse;
+    }
+
+    interface BufferResponse extends IncomingMessage {
+        body: Buffer;
+    }
+
+    interface JsonResponse extends IncomingMessage {
+        body: any;
+    }
+}
+
+export = Phin;

--- a/types/phin/phin-tests.ts
+++ b/types/phin/phin-tests.ts
@@ -1,0 +1,172 @@
+import phin = require('phin');
+
+export function typeTests() {
+    function testParseNoneStreamFalse(o: { url: string, parse?: 'none', stream?: false } | string) {
+        phin(o); // $ExpectType Promise<BufferResponse>
+    }
+
+    function testParseJsonStreamFalse(o: { url: string, parse: 'json', stream?: false }) {
+        phin(o); // $ExpectType Promise<JsonResponse>
+    }
+
+    function testStreamTrue(o: { url: string, parse?: 'json' | 'none', stream: true }) {
+        phin(o); // $ExpectType Promise<StreamResponse>
+    }
+
+    function testCallbackParseNoneStreamFalse(o: { url: string, parse?: 'none', stream?: false } | string) {
+        phin.unpromisified(o, (_err, r) => {
+            r; // $ExpectType BufferResponse
+        });
+    }
+
+    function testCallbackParseJsonStreamFalse(o: { url: string, parse: 'json', stream?: false }) {
+        phin.unpromisified(o, (_err, r) => {
+            r; // $ExpectType JsonResponse
+        });
+    }
+
+    function testCallbackStreamTrue(o: { url: string, parse?: 'json' | 'none', stream: true }) {
+        phin.unpromisified(o, (_err, r) => {
+            r; // $ExpectType StreamResponse
+        });
+    }
+
+    function testCallbackAny(o: { url: string, parse?: 'json' | 'none', stream?: boolean }) {
+        phin.unpromisified(o, (_err, r) => {
+            r; // $ExpectType AnyResponse
+        });
+    }
+
+    function testDefaultsParseNoneStreamFalse(d: { parse?: 'none', stream?: false }) {
+        const p = phin.defaults(d);
+        return {
+            testSame(o: phin.Options & { parse?: 'none', stream?: false } | string) {
+                p(o); // $ExpectType Promise<BufferResponse>
+            },
+
+            testJson(o: phin.Options & { parse: 'json', stream?: false }) {
+                p(o); // $ExpectType Promise<JsonResponse>
+            },
+
+            testStream(o: phin.Options & { stream: true }) {
+                p(o); // $ExpectType Promise<StreamResponse>
+            },
+
+            testOthers(o: phin.Options) {
+                p(o); // $ExpectType Promise<AnyResponse>
+            }
+        };
+    }
+
+    function testDefaultsParseJsonStreamFalse(d: { parse: 'json', stream?: false }) {
+        const p = phin.defaults(d);
+        return {
+            testSame(o: phin.Options & { parse: 'none', stream?: false }) {
+                p(o); // $ExpectType Promise<BufferResponse>
+            },
+
+            testJson(o: phin.Options & { parse?: 'json', stream?: false } | string) {
+                p(o); // $ExpectType Promise<JsonResponse>
+            },
+
+            testStream(o: phin.Options & { stream: true }) {
+                p(o); // $ExpectType Promise<StreamResponse>
+            },
+
+            testOthers(o: phin.Options) {
+                p(o); // $ExpectType Promise<AnyResponse>
+            }
+        };
+    }
+
+    function testDefaultsParseJsonStreamTrue(d: { parse: 'json', stream: true }) {
+        const p = phin.defaults(d);
+        return {
+            testSame(o: phin.Options & { parse: 'none', stream: false }) {
+                p(o); // $ExpectType Promise<BufferResponse>
+            },
+
+            testJson(o: phin.Options & { parse?: 'json', stream: false }) {
+                p(o); // $ExpectType Promise<JsonResponse>
+            },
+
+            testStream(o: phin.Options & { stream?: true } | string) {
+                p(o); // $ExpectType Promise<StreamResponse>
+            },
+
+            testOthers(o: phin.Options) {
+                p(o); // $ExpectType Promise<AnyResponse>
+            }
+        };
+    }
+
+    function testDefaultsParseNoneStreamTrue(d: { parse?: 'none', stream: true }) {
+        const p = phin.defaults(d);
+        return {
+            testSame(o: phin.Options & { parse?: 'none', stream: false }) {
+                p(o); // $ExpectType Promise<BufferResponse>
+            },
+
+            testJson(o: phin.Options & { parse: 'json', stream: false }) {
+                p(o); // $ExpectType Promise<JsonResponse>
+            },
+
+            testStream(o: phin.Options & { stream?: true } | string) {
+                p(o); // $ExpectType Promise<StreamResponse>
+            },
+
+            testOthers(o: phin.Options) {
+                p(o); // $ExpectType Promise<AnyResponse>
+            }
+        };
+    }
+
+    function testDefaultsAny(d: { parse?: 'none' | 'json', stream?: boolean }) {
+        const p = phin.defaults(d);
+        return {
+            testSame(o: phin.Options & { parse: 'none', stream: false }) {
+                p(o); // $ExpectType Promise<BufferResponse>
+            },
+
+            testJson(o: phin.Options & { parse: 'json', stream: false }) {
+                p(o); // $ExpectType Promise<JsonResponse>
+            },
+
+            testStream(o: phin.Options & { stream: true }) {
+                p(o); // $ExpectType Promise<StreamResponse>
+            },
+
+            testOthers(o: phin.Options | string) {
+                p(o); // $ExpectType Promise<AnyResponse>
+            }
+        };
+    }
+}
+
+async function functionalTests() {
+    await phin('http://example.com').then(r => {
+        if (!Buffer.isBuffer(r.body)) { throw new Error('Not a buffer?'); }
+    });
+
+    await phin('http://placekitten.com/50/50').then(r => {
+        if (r.headers['content-type'] !== 'image/jpeg') {
+            throw new Error('expected a jpeg');
+        }
+    });
+
+    await phin({ url: 'https://jsonplaceholder.typicode.com/todos/1', parse: 'json' }).then(r => {
+        if (typeof r.body === 'string') {
+            throw new Error('Did not parse json');
+        }
+
+        if (typeof r.body.userId !== 'number') {
+            throw new Error('Did not get userId');
+        }
+    });
+
+    await phin({ url: 'https://jsonplaceholder.typicode.com/todos/1', stream: true }).then(r => {
+        r.on('end', () => {});
+    });
+}
+
+functionalTests();

--- a/types/phin/tsconfig.json
+++ b/types/phin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "phin-tests.ts"
+    ]
+}

--- a/types/phin/tslint.json
+++ b/types/phin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/safe-json-stringify/index.d.ts
+++ b/types/safe-json-stringify/index.d.ts
@@ -1,13 +1,19 @@
-// Type definitions for safe-json-stringify 1.0
+// Type definitions for safe-json-stringify 1.1
 // Project: https://github.com/debitoor/safe-json-stringify
 // Definitions by: Eric Byers <https://github.com/ericbyers>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped"
+//                 Tony Wooster <https://github.com/twooster>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 declare namespace safeJsonStringify {
-	function ensureProperties(obj: any): object;
+    function ensureProperties(value: object): object;
+    function ensureProperties<T>(value: T): T;
 }
 
-declare function safeJsonStringify(data: object): string;
+declare function safeJsonStringify(
+    value: any,
+    replacer?: ((this: any, key: string, value: any) => any) | Array<number | string> | null,
+    space?: string | number
+): string;
 
 export = safeJsonStringify;

--- a/types/safe-json-stringify/safe-json-stringify-tests.ts
+++ b/types/safe-json-stringify/safe-json-stringify-tests.ts
@@ -1,5 +1,32 @@
 import safeJsonStringify = require('safe-json-stringify');
 
 const obj1 = {foo: 'bar'};
+// $ExpectType string
 safeJsonStringify(obj1);
+
+class A {
+  a() { }
+}
+
+// Ensure that concrete classes are widened to `object`
+// $ExpectError
+const a: A = safeJsonStringify.ensureProperties(new A());
+// $ExpectType object
+safeJsonStringify.ensureProperties(new A());
+// $ExpectType object
 safeJsonStringify.ensureProperties(obj1);
+// $ExpectType true
+safeJsonStringify.ensureProperties(true);
+// $ExpectType null
+safeJsonStringify.ensureProperties(null);
+// $ExpectType 10
+safeJsonStringify.ensureProperties(10);
+// $ExpectType "wat"
+safeJsonStringify.ensureProperties('wat');
+
+safeJsonStringify(obj1, null, 2);
+safeJsonStringify(obj1, null, ' ');
+safeJsonStringify(obj1, (_k: string, v) => 'wat', 2);
+safeJsonStringify(obj1, (_k: string, v: any) => v, '  ');
+safeJsonStringify(obj1, ['foo'], 2);
+safeJsonStringify(obj1, ['foo', 0], '  ');


### PR DESCRIPTION
`safe-json-stringify` >= 1.1 accepts the same parameters as
JSON.stringify.  This commit changes the definitions to match the
signature defined for JSON.stringify in the `lib.es5.d.ts`
definitions.

Also, updated the type of `ensureProperties` to accept `any` value,
because it does, and support some type narrowing in case you
need it.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/debitoor/safe-json-stringify/commit/434de820ca301f311b5571291a1ba284d83b6b9e
- [X] Increase the version number in the header if appropriate.
- [(n/a)] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.