### PR TITLE
1.5.0.Leaflet.fix type for html property in DivIconOptions

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1511,7 +1511,7 @@ export namespace Icon {
 export function icon(options: IconOptions): Icon;
 
 export interface DivIconOptions extends BaseIconOptions {
-    html?: string | false;
+    html?: string | false | Element;
     bgPos?: PointExpression;
     iconSize?: PointExpression;
     iconAnchor?: PointExpression;


### PR DESCRIPTION
According https://leafletjs.com/reference-1.5.0.html#divicon-html we can use HTMLElement for html property. I pick 'Element' type instead of 'HTMLElement', because also we can use SVGElement
<<https://leafletjs.com/reference-1.5.0.html#divicon-html >>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


