### PR TITLE
Improve MetadataType definition in @types/chromecast-caf-receiver

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -196,12 +196,14 @@ export type QueueType =
     | "LIVE_TV"
     | "MOVIE";
 
-export type MetadataType =
-    | "GENERIC"
-    | "MOVIE"
-    | "TV_SHOW"
-    | "MUSIC_TRACK"
-    | "PHOTO";
+export enum MetadataType {
+    GENERIC = 0,
+    MOVIE = 1,
+    TV_SHOW = 2,
+    MUSIC_TRACK = 3,
+    PHOTO = 4,
+    AUDIOBOOK_CHAPTER = 5
+}
 
 /**
  * RefreshCredentials request data.

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -1,9 +1,12 @@
 import { MediaMetadata } from "chromecast-caf-receiver/cast.framework.messages";
+import { CastReceiverContext } from "./cast.framework";
 
 // The following test showcases how you can import individual types directly from the namespace:
 
-const mediaMetadata = new MediaMetadata("GENERIC");
-mediaMetadata.metadataType = "TV_SHOW";
+const mediaMetadata = new MediaMetadata(
+    cast.framework.messages.MetadataType.GENERIC
+);
+mediaMetadata.metadataType = cast.framework.messages.MetadataType.TV_SHOW;
 
 // The following tests showcase how you can globally access 'cast' types using
 // the nested namespace style. This is the preferred method as it
@@ -65,7 +68,9 @@ const lrd: cast.framework.messages.LoadRequestData = {
         tracks: [],
         textTrackStyle: {},
         streamType: "BUFFERED",
-        metadata: { metadataType: "GENERIC" },
+        metadata: {
+            metadataType: cast.framework.messages.MetadataType.GENERIC
+        },
         hlsSegmentFormat: "aac",
         contentId: "id",
         contentType: "type",
@@ -100,7 +105,9 @@ const pData: cast.framework.ui.PlayerData = {
     isPlayingBreak: false,
     isSeeking: true,
     // tslint:disable-next-line
-    metadata: new cast.framework.messages.MediaMetadata("GENERIC"),
+    metadata: new cast.framework.messages.MediaMetadata(
+        cast.framework.messages.MetadataType.GENERIC
+    ),
     nextSubtitle: "sub",
     nextThumbnailUrl: "url",
     nextTitle: "title",

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -1,5 +1,4 @@
 import { MediaMetadata } from "chromecast-caf-receiver/cast.framework.messages";
-import { CastReceiverContext } from "./cast.framework";
 
 // The following test showcases how you can import individual types directly from the namespace:
 


### PR DESCRIPTION
According to [documentation,
MetadataType](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.MetadataType)
is a number, not a string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.MetadataType

