### PR TITLE
Add request option 'accessType' to passport-google-oauth20

### DIFF
--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -16,6 +16,7 @@ export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
 >;
 
 export interface _StrategyOptionsBase extends OAuth2StrategyOptionsWithoutRequiredURLs {
+    accessType?: 'offline' | 'online';
     authorizationURL?: string;
     callbackURL?: string;
     clientID: string;


### PR DESCRIPTION
There are many other request options. This URL mainly goes over PHP definitions because Google has its own client library for Node. Still, this and other request options would be useful to define.

https://developers.google.com/identity/protocols/OAuth2WebServer