### PR TITLE
Add webpack-bugsnag-plugins types

### DIFF
--- a/types/webpack-bugsnag-plugins/index.d.ts
+++ b/types/webpack-bugsnag-plugins/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/bugsnag/webpack-bugsnag-plugins#readme
 // Definitions by: Spencer Miskoviak <https://github.com/skovy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
 
 import * as webpack from "webpack";
 

--- a/types/webpack-bugsnag-plugins/index.d.ts
+++ b/types/webpack-bugsnag-plugins/index.d.ts
@@ -1,39 +1,150 @@
 // Type definitions for webpack-bugsnag-plugins 1.4
 // Project: https://github.com/bugsnag/webpack-bugsnag-plugins#readme
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Spencer Miskoviak <https://github.com/skovy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+import * as webpack from "webpack";
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+export interface SourceMapUploaderOptions {
+    /**
+     * Your Bugsnag API key
+     */
+    apiKey: string;
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+    /**
+     * The path to your bundled assets (as the browser will see them).
+     * This option must either be provided here, or as `output.publicPath` in
+     * your Webpack config.
+     *
+     * @default output.publicPath
+     */
+    publicPath?: string;
+
+    /**
+     * The version of the application you are building
+     */
+    appVersion?: string;
+
+    /**
+     * Whether you want to overwrite previously uploaded sourcemaps
+     */
+    overwrite?: boolean;
+
+    /**
+     * Post the build payload to a URL other than the default
+     *
+     * @default https://upload.bugsnag.com
+     */
+    endpoint?: string;
+
+    /**
+     * A list of bundle file extensions which shouldn't be uploaded
+     *
+     * @default ['.css']
+     */
+    ignoredBundleExtensions?: string[];
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
+export class BugsnagSourceMapUploaderPlugin extends webpack.Plugin {
+    constructor(options: SourceMapUploaderOptions);
+}
 
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
+export interface BuildReporterBuild {
+    /**
+     * Your Bugsnag API key
      */
-    export function foo(): void;
+    apiKey: string;
+
+    /**
+     * The version of the application you are building (this should match the
+     * `appVersion` configured in your notifier)
+     */
+    appVersion: string;
+
+    /**
+     * 'production', 'staging' etc. (leave blank if this build can be released to
+     * different releaseStages)
+     */
+    releaseStage?: string;
+
+    /**
+     * An object describing the source control of the build (if not specified,
+     * the module will attempt to detect source control information from .git, .
+     * hg and the nearest package.json)
+     */
+    sourceControl?: {
+        /**
+         *  The source control provider.
+         */
+        provider:
+            | "github"
+            | "github-enterprise"
+            | "gitlab"
+            | "gitlab-onpremise"
+            | "bitbucket"
+            | "bitbucket-server";
+
+        /**
+         * A URL (git/ssh/https) pointing to the repository, or webpage representing
+         * the repository
+         */
+        repository: string;
+
+        /**
+         * The unique identifier for the commit (e.g. git SHA)
+         */
+        revision: string;
+    };
+
+    /**
+     * The name of the person/machine that created this build (defaults to the
+     * result of the `whoami` command)
+     */
+    builderName?: string;
+
+    /**
+     * Automatically associate this build with any new error events and sessions
+     * that are received for the releaseStage until a subsequent build
+     * notification is received. If this is set to true and no `releaseStage`
+     * is provided the build will be applied to 'production'. You should only use
+     * this option if you aren’t able to set an `appVersion` in your notifier.
+     */
+    autoAssignRelease?: boolean;
+}
+
+export interface BuildReporterOptions {
+    /**
+     * The minimum severity of log to output
+     *
+     * @default warn
+     */
+    logLevel?: "debug" | "info" | "warn" | "error";
+
+    /**
+     * Provide a different logger object
+     */
+    logger?: {
+        debug?: any;
+        info?: any;
+        warn?: any;
+        error?: any;
+    };
+
+    /**
+     * The path to search for source control info
+     *
+     * @default process.cwd()
+     */
+    path?: string;
+
+    /**
+     * Post the build payload to a specified URL
+     *
+     * @default https://build.bugsnag.com
+     */
+    endpoint?: string;
+}
+
+export class BugsnagBuildReporterPlugin extends webpack.Plugin {
+    constructor(build: BuildReporterBuild, options?: BuildReporterOptions);
 }

--- a/types/webpack-bugsnag-plugins/index.d.ts
+++ b/types/webpack-bugsnag-plugins/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for webpack-bugsnag-plugins 1.4
+// Project: https://github.com/bugsnag/webpack-bugsnag-plugins#readme
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    export function foo(): void;
+}

--- a/types/webpack-bugsnag-plugins/index.d.ts
+++ b/types/webpack-bugsnag-plugins/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bugsnag/webpack-bugsnag-plugins#readme
 // Definitions by: Spencer Miskoviak <https://github.com/skovy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// TypeScript Version: 2.3
 
 import * as webpack from "webpack";
 

--- a/types/webpack-bugsnag-plugins/tsconfig.json
+++ b/types/webpack-bugsnag-plugins/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/webpack-bugsnag-plugins/tsconfig.json
+++ b/types/webpack-bugsnag-plugins/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-bugsnag-plugins-tests.ts"
+    ]
+}

--- a/types/webpack-bugsnag-plugins/tslint.json
+++ b/types/webpack-bugsnag-plugins/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-bugsnag-plugins/webpack-bugsnag-plugins-tests.ts
+++ b/types/webpack-bugsnag-plugins/webpack-bugsnag-plugins-tests.ts
@@ -1,0 +1,81 @@
+import {
+    BugsnagSourceMapUploaderPlugin,
+    BugsnagBuildReporterPlugin
+} from "webpack-bugsnag-plugins";
+
+/**
+ * Missing or invalid options
+ */
+
+// $ExpectError
+new BugsnagSourceMapUploaderPlugin();
+
+// $ExpectError
+new BugsnagBuildReporterPlugin();
+
+// $ExpectError
+new BugsnagSourceMapUploaderPlugin({});
+
+// $ExpectError
+new BugsnagBuildReporterPlugin({});
+
+// $ExpectError
+new BugsnagBuildReporterPlugin({
+    apiKey: "123456789"
+});
+
+/**
+ * Minimal valid options
+ */
+
+// $ExpectType BugsnagSourceMapUploaderPlugin
+new BugsnagSourceMapUploaderPlugin({
+    apiKey: "123456789"
+});
+
+// $ExpectType BugsnagBuildReporterPlugin
+new BugsnagBuildReporterPlugin({
+    apiKey: "123456789",
+    appVersion: "1.2.3"
+});
+
+/**
+ * All possible options
+ */
+
+// $ExpectType BugsnagSourceMapUploaderPlugin
+new BugsnagSourceMapUploaderPlugin({
+    apiKey: "123456789",
+    publicPath: "*/dist",
+    appVersion: "1.2.3",
+    overwrite: true,
+    endpoint: "https://upload.bugsnag.com",
+    ignoredBundleExtensions: [".css"]
+});
+
+// $ExpectType BugsnagBuildReporterPlugin
+new BugsnagBuildReporterPlugin(
+    {
+        apiKey: "123456789",
+        appVersion: "1.2.3",
+        releaseStage: "staging",
+        sourceControl: {
+            provider: "github",
+            repository: "https://github.com/bugsnag/webpack-bugsnag-plugins",
+            revision: "123456789"
+        },
+        builderName: "whoami",
+        autoAssignRelease: false
+    },
+    {
+        logLevel: "debug",
+        logger: {
+            debug: () => null,
+            info: () => null,
+            warn: () => null,
+            error: () => null
+        },
+        path: process.cwd(),
+        endpoint: "https://build.bugsnag.com"
+    }
+);


### PR DESCRIPTION
This was originally proposed here: https://github.com/bugsnag/webpack-bugsnag-plugins/pull/33.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
