### PR TITLE
Fix 'co' for strict generators

### DIFF
--- a/types/co/index.d.ts
+++ b/types/co/index.d.ts
@@ -4,7 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-type ExtractType<T> = T extends IterableIterator<infer R> ? R : never;
+type ExtractType<T> =
+    T extends { [Symbol.iterator](): { next(): { done: true, value: infer U } } } ? U :
+    T extends { [Symbol.iterator](): { next(): { done: false } } } ? never :
+    T extends { [Symbol.iterator](): { next(): { value: infer U } } } ? U :
+    T extends { [Symbol.iterator](): any } ? unknown :
+    never;
 
 interface Co {
     <F extends (...args: any[]) => Iterator<any>>(fn: F, ...args: Parameters<F>): Promise<ExtractType<ReturnType<F>>>;


### PR DESCRIPTION
Fixes [an error](https://typescript.visualstudio.com/TypeScript/_build/results?buildId=32320&view=logs&jobId=71179031-6417-5a2f-3d87-af6fce2011e4&taskId=09806ef2-5cdf-53f5-53d4-1d17eec887e2&lineStart=4250&lineEnd=4251&colStart=1&colEnd=1) in `co` that will appear when https://github.com/microsoft/TypeScript/pull/30790 is merged.