### PR TITLE
@types/graphql - provide type definitions for mergeAST utility

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -353,6 +353,8 @@ export {
     valueFromASTUntyped,
     // Create a GraphQL language AST from a JavaScript value.
     astFromValue,
+    // Inline fragment definitions from AST
+    mergeAST,
     // A helper to use within recursive-descent visitors which need to be aware of
     // the GraphQL type system.
     TypeInfo,

--- a/types/graphql/utilities/index.d.ts
+++ b/types/graphql/utilities/index.d.ts
@@ -80,6 +80,9 @@ export { TypeInfo } from "./TypeInfo";
 // Coerces a JavaScript value to a GraphQL type, or produces errors.
 export { coerceValue } from "./coerceValue";
 
+// Inline fragment definitions from AST
+export { mergeAST } from "./mergeAST";
+
 // @deprecated use coerceValue - will be removed in v15
 export { isValidJSValue } from "./isValidJSValue";
 

--- a/types/graphql/utilities/mergeAST.d.ts
+++ b/types/graphql/utilities/mergeAST.d.ts
@@ -1,0 +1,8 @@
+import { DocumentNode } from "../language/ast";
+
+/**
+ * Given a document AST, merge all fragment definitions into the
+ * provided operations using inline fragments.
+ */
+
+export function mergeAST(ast: DocumentNode): DocumentNode


### PR DESCRIPTION
For a simple new utility we are introducing: https://github.com/graphql/graphql-js/pull/1948

Needed because we are converting GraphiQL to typescript, and moving this utility from GraphiQL to graphql-js.

We should wait until the aforementioned PR is merged, of course