### PR TITLE
mongoose: model.discriminator() to accept both document and model interface

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2923,6 +2923,13 @@ declare module "mongoose" {
      */
     discriminator<U extends Document>(name: string, schema: Schema): Model<U>;
 
+    /**
+     * Adds a discriminator type.
+     * @param name discriminator model name
+     * @param schema discriminator model schema
+     */
+    discriminator<U extends Document, M extends Model<U>>(name: string, schema: Schema): M;
+
     /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
     distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]> & QueryHelpers;
     distinct(field: string, conditions: any,


### PR DESCRIPTION
Model.discriminator() should accept both document and model interface, so we can define custom functions for each discriminator. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Automattic/mongoose/blob/6a8607bd1718b6fc65595bb19d6ec3ac9e9a19a3/lib/model.js#L1053>>