### PR TITLE
aws-lambda: Add CloudFrontRequestBody

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -768,8 +768,16 @@ export interface CloudFrontResponse {
     headers: CloudFrontHeaders;
 }
 
+export interface CloudFrontRequestBody {
+    action: 'read-only' | 'replace';
+    data: string;
+    encoding: 'base64' | 'text';
+    readonly inputTruncated: boolean;
+}
+
 export interface CloudFrontRequest {
     clientIp: string;
+    body?: CloudFrontRequestBody;
     method: string;
     uri: string;
     querystring: string;


### PR DESCRIPTION
CloudFront events can contain the body of the request by enabling a setting. This adds `CloudFrontRequestBody` which exposes that extra (optional field).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
- [ ] Increase the version number in the header if appropriate.
