### PR TITLE
Prevent `@types/node` and `@types/requirejs`-confusion

### DIFF
--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -29,15 +29,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */
 
-declare module 'requirejs/module' {
-	var mod: {
-		config: () => any;
-		id: string;
-		uri: string;
-	}
-	export = mod;
-}
-
 interface RequireError extends Error {
 
 	/**

--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -29,7 +29,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */
 
-declare module 'module' {
+declare module 'requirejs/module' {
 	var mod: {
 		config: () => any;
 		id: string;

--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RequireJS 2.1.20
+// Type definitions for RequireJS 3.0.0
 // Project: http://requirejs.org/
 // Definitions by: Josh Baldwin <https://github.com/jbaldwin>
 //                 Manuel Thalmann <https://github.com/manuth>

--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for RequireJS 2.1.20
 // Project: http://requirejs.org/
 // Definitions by: Josh Baldwin <https://github.com/jbaldwin>
+//                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*

--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -419,5 +419,4 @@ interface RequireDefine {
 
 // Ambient declarations for 'require' and 'define'
 declare var requirejs: Require;
-declare var require: Require;
 declare var define: RequireDefine;

--- a/types/requirejs/requirejs-tests.ts
+++ b/types/requirejs/requirejs-tests.ts
@@ -40,12 +40,3 @@ requirejs(['main'], (main: any, $: any, _: any, Backbone: any) => {
 
 var recOne = requirejs.config({ baseUrl: 'js' });
 recOne(['core'], function (core: any) {/*some code*/});
-
-// Tests for 'module' magic module typings
-// (Using 'module' only actually makes sense in an external module)
-
-import module = require('requirejs/module');
-
-var moduleConfig: any = module.config();
-var moduleId: string = module.id;
-var moduleUri: string = module.uri;

--- a/types/requirejs/requirejs-tests.ts
+++ b/types/requirejs/requirejs-tests.ts
@@ -2,7 +2,7 @@
 
 // this test does not actually reference amd module 'main.ts', create one yourself.
 
-require.config({
+requirejs.config({
 	baseUrl: '../Definitions',
 
 	// Requires versions afaik
@@ -31,20 +31,20 @@ require.config({
 // load AMD module main.ts (compiled to main.js)
 // and include shims $, _, Backbone
 
-require(['main'], (main: any, $: any, _: any, Backbone: any) => {
+requirejs(['main'], (main: any, $: any, _: any, Backbone: any) => {
 
 	var app = main.AppMain();
 	app.run();
 
 });
 
-var recOne = require.config({ baseUrl: 'js' });
+var recOne = requirejs.config({ baseUrl: 'js' });
 recOne(['core'], function (core: any) {/*some code*/});
 
 // Tests for 'module' magic module typings
 // (Using 'module' only actually makes sense in an external module)
 
-import module = require('module');
+import module = require('requirejs/module');
 
 var moduleConfig: any = module.config();
 var moduleId: string = module.id;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  I created this PR as many people are having trouble with `requirejs` overriding the variable `require`:
    - #31628
    - #15851
    - <https://github.com/rollup/rollup/issues/2142>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## About this PR
According to the documentation, `@types/requirejs` can be invoked through `require()` and `requirejs()`.  
As `require()` is declared by `@types/node`, too, which is part of most projects.

For that reason I decided to make `@types/requirejs` exporting `requirejs()` rather than `require()`.