### PR TITLE
@types/airtable Added constructor definition.

### DIFF
--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -24,6 +24,7 @@ declare global {
             apiVersion?: string;
             allowUnauthorizedSsl?: boolean;
             noRetryIfRateLimited?: boolean;
+            requestTimeout: number;
         }
 
         interface Base {

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for airtable 0.5
 // Project: https://github.com/airtable/airtable.js
 // Definitions by: Brandon Valosek <https://github.com/bvalosek>
+//                 Max Chehab <https://github.com/maxchehab>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -8,12 +9,21 @@ export = Airtable;
 
 declare global {
     class Airtable {
+        constructor(options?: Airtable.AirtableOptions);
         base(appId: string): Airtable.Base;
     }
 
     namespace Airtable {
         interface FieldSet {
-            [ key: string ]: undefined | string | ReadonlyArray<Attachment>;
+            [key: string]: undefined | string | ReadonlyArray<Attachment>;
+        }
+
+        interface AirtableOptions {
+            apiKey?: string;
+            endpointUrl?: string;
+            apiVersion?: string;
+            allowUnauthorizedSsl?: boolean;
+            noRetryIfRateLimited?: boolean;
         }
 
         interface Base {


### PR DESCRIPTION
* Added constructor definition.
* Added constructor parameter definition as `AirtableOptions`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Airtable/airtable.js/blob/master/lib/airtable.js#L62-L66>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
