### PR TITLE
Make Google Analytics support correct types (google.analytics)

### DIFF
--- a/types/google.analytics/google.analytics-tests.ts
+++ b/types/google.analytics/google.analytics-tests.ts
@@ -106,6 +106,9 @@ describe("tester Google Analytics Code  _gaq object", () => {
         _gaq.push(['_gat._anonymizeIp']);
         _gaq.push(['_trackPageview']);
 
+        // more details: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEventTracking#_trackevent
+        _gaq.push(['_trackEvent', 'category', 'action_name', undefined, undefined, true]);
+
         _gaq.push(() => {
                 const tracker = _gat._getTrackerByName('UA-65432-1');
                 tracker._trackPageview();

--- a/types/google.analytics/index.d.ts
+++ b/types/google.analytics/index.d.ts
@@ -19,7 +19,7 @@ declare class Tracker {
 }
 
 interface GoogleAnalyticsCode {
-    push(commandArray: string[]): void;
+    push(commandArray: Array<string|boolean|number>): void;
     push(func: Function): void;
 }
 


### PR DESCRIPTION
It seems that `_gaq.push` can accept not only strings but booleans and numbers as well.
This PR fixes the types declarations for it according to the documentation:
https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEventTracking#_trackevent

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEventTracking#_trackevent
