### PR TITLE
[stripe-v3] improve support for new PaymentIntents API

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -733,7 +733,6 @@ declare namespace stripe {
         | 'void_invoice'
         | 'automatic';
 
-
         interface PaymentIntentNextActionRedirectToUrl {
             /**
              * Type of the next action to perform
@@ -877,9 +876,7 @@ declare namespace stripe {
              * If present, this property tells you what actions you need to take in order
              * for your customer to fulfill a payment using the provided source.
              */
-            next_action:
-                | PaymentIntentNextActionUseStripeSdk
-                | PaymentIntentNextActionRedirectToUrl;
+            next_action: PaymentIntentNextActionUseStripeSdk | PaymentIntentNextActionRedirectToUrl;
 
             /**
              * The account (if any) for which the funds of the PaymentIntent are intended.

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -28,58 +28,58 @@ declare namespace stripe {
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
         redirectToCheckout(options: StripeCheckoutOptions): Promise<StripeRedirectResponse>;
-        paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;        
+        paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;
         createPaymentMethod(
-            type: paymentMethod.paymentMethodType, 
-            element: elements.Element, 
+            type: paymentMethod.paymentMethodType,
+            element: elements.Element,
             options?: CreatePaymentMethodOptions,
         ): Promise<PaymentMethodResponse>;
         retrievePaymentIntent(
             clientSecret: string,
         ): Promise<PaymentIntentResponse>;
         handleCardPayment(
-            clientSecret: string, 
-            element: elements.Element, 
+            clientSecret: string,
+            element: elements.Element,
             options?: HandleCardPaymentOptions,
         ): Promise<PaymentIntentResponse>;
         handleCardPayment(
-            clientSecret: string, 
+            clientSecret: string,
             options?: HandleCardPaymentWithoutElementsOptions,
         ): Promise<PaymentIntentResponse>;
         handleCardAction(
             clientSecret: string,
         ): Promise<PaymentIntentResponse>;
         confirmPaymentIntent(
-            clientSecret: string, 
-            element: elements.Element, 
+            clientSecret: string,
+            element: elements.Element,
             options?: ConfirmPaymentIntentOptions,
         ): Promise<PaymentIntentResponse>;
         confirmPaymentIntent(
-            clientSecret: string, 
+            clientSecret: string,
             options?: ConfirmPaymentIntentWithoutElementsOptions,
         ): Promise<PaymentIntentResponse>;
     }
-    
+
     type StripeRedirectResponse = never | {
         error: Error;
-    }
+    };
 
     type billingAddressCollectionType = 'required' | 'auto' | '';
-    interface StripeCheckoutOptions {	
-        items: StripeCheckoutItem[];	
-        successUrl: string;	
-        cancelUrl: string;	
-        clientReferenceId?: string;	
-        customerEmail?: string;	
-        billingAddressCollection?: billingAddressCollectionType;	
-        sessionId?: string;	
-        locale?: string;	
+    interface StripeCheckoutOptions {
+        items: StripeCheckoutItem[];
+        successUrl: string;
+        cancelUrl: string;
+        clientReferenceId?: string;
+        customerEmail?: string;
+        billingAddressCollection?: billingAddressCollectionType;
+        sessionId?: string;
+        locale?: string;
     }
 
-    interface StripeCheckoutItem {	
-        sku?: string;	
-        plan?: string;	
-        quantity: number;	
+    interface StripeCheckoutItem {
+        sku?: string;
+        plan?: string;
+        quantity: number;
     }
 
     interface StripeOptions {
@@ -215,7 +215,7 @@ declare namespace stripe {
     interface Error {
         /**
          * The type of error returned.
-         */        
+         */
         type: ErrorType;
 
         /**
@@ -224,14 +224,14 @@ declare namespace stripe {
         charge: string;
 
         /**
-         * For some errors that could be handled programmatically, 
+         * For some errors that could be handled programmatically,
          * a short string indicating the error code reported.
          */
         code?: string;
 
         /**
-         * For card errors resulting from a card issuer decline, 
-         * a short string indicating the card issuer’s reason for 
+         * For card errors resulting from a card issuer decline,
+         * a short string indicating the card issuer’s reason for
          * the decline if they provide one.
          */
         decline_code?: string;
@@ -242,33 +242,33 @@ declare namespace stripe {
         doc_url?: string;
 
         /**
-         * A human-readable message providing more details about the 
-         * error. For card errors, these messages can be shown to 
+         * A human-readable message providing more details about the
+         * error. For card errors, these messages can be shown to
          * your users.
          */
         message?: string;
 
         /**
-         * If the error is parameter-specific, the parameter related 
-         * to the error. For example, you can use this to display a 
+         * If the error is parameter-specific, the parameter related
+         * to the error. For example, you can use this to display a
          * message near the correct form field.
          */
         param?: string;
 
         /**
-         * The PaymentIntent object for errors returned on a request 
+         * The PaymentIntent object for errors returned on a request
          * involving a PaymentIntent.
          */
         payment_intent?: paymentIntents.PaymentIntent;
 
         /**
-         * The PaymentMethod object for errors returned on a 
+         * The PaymentMethod object for errors returned on a
          * request involving a PaymentMethod.
          */
         payment_method?: paymentMethod.PaymentMethod;
 
         /**
-         * The source object for errors returned on a request involving 
+         * The source object for errors returned on a request involving
          * a source.
          */
         source?: Source;
@@ -390,8 +390,8 @@ declare namespace stripe {
 
     interface CreatePaymentMethodOptions {
         /**
-         * Billing information associated with the PaymentMethod 
-         * that may be used or required by particular types of 
+         * Billing information associated with the PaymentMethod
+         * that may be used or required by particular types of
          * payment methods.
          */
         billing_details?: BillingDetails;
@@ -400,12 +400,12 @@ declare namespace stripe {
 
     interface HandleCardPaymentOptions {
         /**
-         * Use this parameter to supply additional data relevant to 
+         * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
          */
         payment_method_data?: {
             /**
-             * The billing details associated with the card. [Recommended] 
+             * The billing details associated with the card. [Recommended]
              */
             billing_details?: BillingDetails,
         };
@@ -418,8 +418,8 @@ declare namespace stripe {
          */
         receipt_email?: string;
         /**
-         * If the PaymentIntent is associated with a customer and this parameter 
-         * is set to true, the provided payment method will be attached to the 
+         * If the PaymentIntent is associated with a customer and this parameter
+         * is set to true, the provided payment method will be attached to the
          * customer. Default is false.
          */
         save_payment_method?: boolean;
@@ -428,22 +428,22 @@ declare namespace stripe {
     interface HandleCardPaymentWithoutElementsOptions extends HandleCardPaymentOptions {
         /**
          * Only one of payment_method_data and payment_method is required.
-         * Use payment_method to specify an existing PaymentMethod to use 
+         * Use payment_method to specify an existing PaymentMethod to use
          * for this payment.
          */
         payment_method?: string;
         /**
-         * Use this parameter to supply additional data relevant to 
+         * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
          */
         payment_method_data?: {
             /**
-             * The billing details associated with the card. [Recommended] 
+             * The billing details associated with the card. [Recommended]
              */
             billing_details?: BillingDetails,
             card?: {
                 /**
-                 * Converts the provided token into a PaymentMethod to 
+                 * Converts the provided token into a PaymentMethod to
                  * use for the payment.
                  */
                 token: string;
@@ -453,20 +453,20 @@ declare namespace stripe {
 
     interface ConfirmPaymentIntentOptions {
         /**
-         * A return_url may be supplied if you are not planning to use 
-         * stripe.handleCardPayment to complete the payment. If you are 
-         * handling next actions yourself, pass in a return_url. If the 
-         * subsequent action is redirect_to_url, this URL will be used 
+         * A return_url may be supplied if you are not planning to use
+         * stripe.handleCardPayment to complete the payment. If you are
+         * handling next actions yourself, pass in a return_url. If the
+         * subsequent action is redirect_to_url, this URL will be used
          * on the return path for the redirect.
          */
         return_url?: string;
         /**
-         * Use this parameter to supply additional data relevant to 
+         * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
          */
         payment_method_data?: {
             /**
-             * The billing details associated with the card. [Recommended] 
+             * The billing details associated with the card. [Recommended]
              */
             billing_details?: BillingDetails,
         };
@@ -479,8 +479,8 @@ declare namespace stripe {
          */
         receipt_email?: string;
         /**
-         * If the PaymentIntent is associated with a customer and this parameter 
-         * is set to true, the provided payment method will be attached to the 
+         * If the PaymentIntent is associated with a customer and this parameter
+         * is set to true, the provided payment method will be attached to the
          * customer. Default is false.
          */
         save_payment_method?: boolean;
@@ -489,22 +489,22 @@ declare namespace stripe {
     interface ConfirmPaymentIntentWithoutElementsOptions extends ConfirmPaymentIntentOptions {
         /**
          * Only one of payment_method_data and payment_method is required.
-         * Use payment_method to specify an existing PaymentMethod to use 
+         * Use payment_method to specify an existing PaymentMethod to use
          * for this payment.
          */
         payment_method?: string;
         /**
-         * Use this parameter to supply additional data relevant to 
+         * Use this parameter to supply additional data relevant to
          * the payment method, such as billing details
          */
         payment_method_data?: {
             /**
-             * The billing details associated with the card. [Recommended] 
+             * The billing details associated with the card. [Recommended]
              */
             billing_details?: BillingDetails,
             card?: {
                 /**
-                 * Converts the provided token into a PaymentMethod to 
+                 * Converts the provided token into a PaymentMethod to
                  * use for the payment.
                  */
                 token: string;
@@ -716,7 +716,6 @@ declare namespace stripe {
     }
 
     namespace paymentIntents {
-
         type PaymentIntentStatus =
         | 'requires_payment_method'
         | 'requires_confirmation'
@@ -726,11 +725,11 @@ declare namespace stripe {
         | 'canceled'
         | 'succeeded';
 
-        type PaymentIntentCancelationReason = 
+        type PaymentIntentCancelationReason =
         // User Provided:
-        | 'duplicate' 
-        | 'fraudulent' 
-        | 'requested_by_customer' 
+        | 'duplicate'
+        | 'fraudulent'
+        | 'requested_by_customer'
         | 'abandoned'
         // Generated by Stripe internally:
         | 'failed_invoice'
@@ -744,19 +743,19 @@ declare namespace stripe {
              */
             type: 'redirect_to_url';
             /**
-             * Contains instructions for authenticating a payment by 
+             * Contains instructions for authenticating a payment by
              * redirecting your customer to another page or application.
              */
-            redirect_to_url: { 
+            redirect_to_url: {
                 /**
-                 * If the customer does not exit their browser while 
-                 * authenticating, they will be redirected to this 
+                 * If the customer does not exit their browser while
+                 * authenticating, they will be redirected to this
                  * specified URL after completion.
                  */
-                return_url: string; 
+                return_url: string;
 
                 /**
-                 * The URL you must redirect your customer to in 
+                 * The URL you must redirect your customer to in
                  * order to authenticate the payment.
                  */
                 url: string;
@@ -769,9 +768,9 @@ declare namespace stripe {
              */
             type: 'use_stripe_sdk';
             /**
-             * When confirming a PaymentIntent with Stripe.js, 
-             * Stripe.js depends on the contents of this dictionary 
-             * to invoke authentication flows. The shape of the contents 
+             * When confirming a PaymentIntent with Stripe.js,
+             * Stripe.js depends on the contents of this dictionary
+             * to invoke authentication flows. The shape of the contents
              * is subject to change and is only intended to be used by Stripe.js.
              */
             use_stripe_sdk: any;
@@ -870,16 +869,15 @@ declare namespace stripe {
             last_payment_error: Error | null;
 
             /**
-             * Has the value true if the object exists in live mode or the value false 
+             * Has the value true if the object exists in live mode or the value false
              * if the object exists in test mode.
              */
             livemode: boolean;
 
-        
             metadata: Metadata;
 
             /**
-             * If present, this property tells you what actions you need to take in order 
+             * If present, this property tells you what actions you need to take in order
              * for your customer to fulfill a payment using the provided source.
              */
             next_action:
@@ -887,7 +885,7 @@ declare namespace stripe {
                 | PaymentIntentNextActionRedirectToUrl;
 
             /**
-             * The account (if any) for which the funds of the PaymentIntent are intended. 
+             * The account (if any) for which the funds of the PaymentIntent are intended.
              * See the PaymentIntents Connect usage guide for details.
              */
             on_behalf_of: string | null;
@@ -903,7 +901,7 @@ declare namespace stripe {
             receipt_email: string | null;
 
             /**
-             * ID of the review associated with this PaymentIntent, if any. 
+             * ID of the review associated with this PaymentIntent, if any.
              */
             review: string | null;
 
@@ -913,7 +911,7 @@ declare namespace stripe {
             shipping: ShippingDetails | null;
 
             /**
-             * Extra information about a PaymentIntent. This will appear on your 
+             * Extra information about a PaymentIntent. This will appear on your
              * customer’s statement when this PaymentIntent succeeds in creating a charge.
              */
             statement_descriptor: string | null;
@@ -928,7 +926,7 @@ declare namespace stripe {
              */
             transfer_data: {
                 /**
-                 * The account (if any) the payment will be attributed to for tax reporting, 
+                 * The account (if any) the payment will be attributed to for tax reporting,
                  * and where funds from the payment will be transferred to upon payment success.
                  */
                 destination: string;
@@ -945,7 +943,7 @@ declare namespace stripe {
              * Unique identifier for the object.
              */
             id: string;
-            
+
             /**
              * Value is 'charge'
              */
@@ -974,7 +972,7 @@ declare namespace stripe {
             application_fee: string | null;
 
             /**
-             * The amount of the application fee (if any) for the charge. See the Connect 
+             * The amount of the application fee (if any) for the charge. See the Connect
              * documentation for details.
              */
             application_fee_amount: number | null;
@@ -1054,11 +1052,11 @@ declare namespace stripe {
             invoice: string | null;
 
             /**
-             * Has the value true if the object exists in live mode or the value false if 
+             * Has the value true if the object exists in live mode or the value false if
              * the object exists in test mode.
              */
             livemode: boolean;
-            
+
             metadata: Metadata;
 
             /**
@@ -1179,7 +1177,6 @@ declare namespace stripe {
             transfer_group?: string | null;
         }
 
-
         interface Refund {
             /**
              * Unique identifier for the object.
@@ -1217,14 +1214,14 @@ declare namespace stripe {
             currency: string;
 
             /**
-             * An arbitrary string attached to the object. Often useful for 
+             * An arbitrary string attached to the object. Often useful for
              * displaying to users. (Available on non-card refunds only)
              */
             description?: string;
 
             /**
-             * If the refund failed, this balance transaction describes the 
-             * adjustment made on your account balance that reverses the 
+             * If the refund failed, this balance transaction describes the
+             * adjustment made on your account balance that reverses the
              * initial balance transaction.
              */
             failure_balance_transaction?: string;
@@ -1232,7 +1229,7 @@ declare namespace stripe {
             /**
              * If the refund failed, the reason for refund failure if known
              */
-            failure_reason?: 
+            failure_reason?:
             | 'lost_or_stolen_card'
             | 'expired_or_canceled_card'
             | 'unknown';
@@ -1245,28 +1242,28 @@ declare namespace stripe {
             reason: 'duplicate' | 'fraudulent' | 'requested_by_customer' | null;
 
             /**
-             * This is the transaction number that appears on email 
+             * This is the transaction number that appears on email
              * receipts sent for this refund.
              */
             receipt_number: string | null;
 
             /**
-             * The transfer reversal that is associated with the refund. 
-             * Only present if the charge came from another Stripe account. 
+             * The transfer reversal that is associated with the refund.
+             * Only present if the charge came from another Stripe account.
              * See the Connect documentation for details.
              */
             source_transfer_reversal: string | null;
 
             /**
-             * Status of the refund. For credit card refunds, this can be 
-             * pending, succeeded, or failed. For other types of refunds, 
+             * Status of the refund. For credit card refunds, this can be
+             * pending, succeeded, or failed. For other types of refunds,
              * it can be pending, succeeded, failed, or canceled. Refer to
              * our refunds documentation for more details.
              */
             status: 'pending' | 'succeeded' | 'failed' | 'canceled';
 
             /**
-             * If the accompanying transfer was reversed, the transfer reversal object. 
+             * If the accompanying transfer was reversed, the transfer reversal object.
              * Only applicable if the charge was created using the destination parameter.
              */
             transfer_reversal: string | null;
@@ -1288,7 +1285,7 @@ declare namespace stripe {
             object: 'payment_method';
 
             /**
-             * Billing information associated with the PaymentMethod that may be 
+             * Billing information associated with the PaymentMethod that may be
              * used or required by particular types of payment methods.
              */
             billing_details: BillingDetails;
@@ -1299,25 +1296,25 @@ declare namespace stripe {
             card?: PaymentMethodCard;
 
             /**
-             * If this is an card_present PaymentMethod, this hash contains details 
+             * If this is an card_present PaymentMethod, this hash contains details
              * about the Card Present payment method.
              */
             card_present?: any;
 
             /**
-             * Time at which the object was created. Measured in seconds since the 
+             * Time at which the object was created. Measured in seconds since the
              * Unix epoch.
              */
             created: number;
 
             /**
-             * The ID of the Customer to which this PaymentMethod is saved. 
+             * The ID of the Customer to which this PaymentMethod is saved.
              * This will not be set when the PaymentMethod has not been saved to a Customer.
              */
             customer: string | null;
 
             /**
-             * Has the value true if the object exists in live mode or the value 
+             * Has the value true if the object exists in live mode or the value
              * false if the object exists in test mode.
              */
             livemode: boolean;
@@ -1332,7 +1329,7 @@ declare namespace stripe {
             type: string;
         }
 
-        type paymentMethodCardBrand = 
+        type paymentMethodCardBrand =
         | 'amex'
         | 'diners'
         | 'discover'
@@ -1344,7 +1341,7 @@ declare namespace stripe {
 
         interface PaymentMethodCard {
             /**
-             * Card brand 
+             * Card brand
              * */
             brand: paymentMethodCardBrand;
 
@@ -1358,7 +1355,7 @@ declare namespace stripe {
             };
 
             /**
-             * Two-letter ISO code representing the country of the card. You 
+             * Two-letter ISO code representing the country of the card. You
              * could use this attribute to get a sense of the international
              * breakdown of cards you’ve collected.
              */
@@ -1375,8 +1372,8 @@ declare namespace stripe {
             exp_year: number;
 
             /**
-             * Uniquely identifies this particular card number. You can use 
-             * this attribute to check whether two customers who’ve signed 
+             * Uniquely identifies this particular card number. You can use
+             * this attribute to check whether two customers who’ve signed
              * up with you are using the same card number, for example.
              */
             fingerprint: string;
@@ -1398,7 +1395,7 @@ declare namespace stripe {
              * The last four digits of the card.
              */
             last4: string;
-          
+
             /**
              * Contains details on how this Card maybe be used for 3D Secure authentication.
              */
@@ -1407,16 +1404,16 @@ declare namespace stripe {
             };
 
             /**
-             * If this Card is part of a card wallet, this contains the details of 
+             * If this Card is part of a card wallet, this contains the details of
              * the card wallet.
              */
             wallet: {
-                type: 
-                | 'amex_express_checkout' 
-                | 'apple_pay' 
-                | 'google_pay' 
-                | 'masterpass' 
-                | 'samsung_pay' 
+                type:
+                | 'amex_express_checkout'
+                | 'apple_pay'
+                | 'google_pay'
+                | 'masterpass'
+                | 'samsung_pay'
                 | 'visa_checkout';
                 amex_express_checkout?: any;
                 apple_pay?: any;
@@ -1435,7 +1432,7 @@ declare namespace stripe {
             /**
              * The type of transaction-specific details of the payment method used in the payment
              */
-            type: 
+            type:
             | 'ach_credit_transfer'
             | 'ach_debit'
             | 'alipay'
@@ -1504,7 +1501,7 @@ declare namespace stripe {
         }
 
         interface IdealDetails {
-            bank: 
+            bank:
             | 'abn_amro'
             | 'asn_bank'
             | 'bunq'
@@ -1548,6 +1545,6 @@ declare namespace stripe {
             country: string;
             iban_last4: string;
             verified_name: string;
-        }        
+        }
     }
 }

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -26,68 +26,41 @@ declare namespace stripe {
         createSource(element: elements.Element, options?: {owner?: OwnerInfo}): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
-        paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;
-        createPaymentMethod(type: paymentMethodType, element: elements.Element, data?: StripePaymentMethodIncomplete): Promise<StripePaymentMethodResponse>;
-        redirectToCheckout(options: StripeCheckoutOptions): Promise<StripeRedirectResponse>;
-        retrievePaymentIntent(clientSecret: string): Promise<paymentIntent.PaymentIntentResponse>;
-        handleCardPayment(clientSecret: string, element: elements.Element, data?: paymentIntent.CardPaymentData): Promise<paymentIntent.PaymentIntentResponse>;
-        handleCardPayment(clientSecret: string, data?: paymentIntent.CardPaymentData): Promise<paymentIntent.PaymentIntentResponse>;
-        handleCardAction(clientSecret: string): Promise<paymentIntent.PaymentIntentResponse>;
-        confirmPaymentIntent(clientSecret: string, element: elements.Element, data: paymentIntent.PaymentIntentConfirmationData): Promise<paymentIntent.PaymentIntentResponse>;
-        confirmPaymentIntent(clientSecret: string, data: paymentIntent.PaymentIntentConfirmationData): Promise<paymentIntent.PaymentIntentResponse>;
-    }
-
-    type StripeRedirectResponse = never | {
-        error: Error;
-    };
-
-    interface StripePaymentMethodResponse {
-        paymentMethod?: StripePaymentMethod;
-        error?: Error;
-    }
-
-    type paymentMethodType = 'card' | 'card_present';
-    interface StripePaymentMethod extends StripePaymentMethodIncomplete {
-        id: string;
-        type: paymentMethodType;
-    }
-
-    interface StripePaymentMethodIncomplete {
-        type?: paymentMethodType;
-        billing_details?: OwnerInfo;
-        card?: StripePaymentMethodCard;
-        metadata?: any;
-    }
-
-    type billingAddressCollectionType = 'required' | 'auto' | '';
-    interface StripeCheckoutOptions {
-        items: StripeCheckoutItem[];
-        successUrl: string;
-        cancelUrl: string;
-        clientReferenceId?: string;
-        customerEmail?: string;
-        billingAddressCollection?: billingAddressCollectionType;
-        sessionId?: string;
-        locale?: string;
-    }
-
-    interface StripeCheckoutItem {
-        sku?: string;
-        plan?: string;
-        quantity: number;
-    }
-
-    interface StripePaymentMethodCard {
-        exp_month: number;
-        exp_year: number;
-        number: string;
-        cvc?: string;
+        paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;        
+        createPaymentMethod(
+            type: paymentMethod.paymentMethodType, 
+            element: elements.Element, 
+            options?: CreatePaymentMethodOptions,
+        ): Promise<PaymentMethodResponse>;
+        retrievePaymentIntent(
+            clientSecret: string,
+        ): Promise<PaymentIntentResponse>;
+        handleCardPayment(
+            clientSecret: string, 
+            element: elements.Element, 
+            options?: HandleCardPaymentOptions,
+        ): Promise<PaymentIntentResponse>;
+        handleCardPayment(
+            clientSecret: string, 
+            options?: HandleCardPaymentWithoutElementsOptions,
+        ): Promise<PaymentIntentResponse>;
+        handleCardAction(
+            clientSecret: string,
+        ): Promise<PaymentIntentResponse>;
+        confirmPaymentIntent(
+            clientSecret: string, 
+            element: elements.Element, 
+            options?: ConfirmPaymentIntentOptions,
+        ): Promise<PaymentIntentResponse>;
+        confirmPaymentIntent(
+            clientSecret: string, 
+            options?: ConfirmPaymentIntentWithoutElementsOptions,
+        ): Promise<PaymentIntentResponse>;
     }
 
     interface StripeOptions {
-        stripeAccount?: string;
-        betas?: string[];
-        locale?: string;
+      stripeAccount?: string;
+      betas?: string[];
     }
 
     interface TokenOptions {
@@ -206,13 +179,74 @@ declare namespace stripe {
         error?: Error;
     }
 
+    type ErrorType = 'api_connection_error'
+    | 'api_error'
+    | 'authentication_error'
+    | 'card_error'
+    | 'idempotency_error'
+    | 'invalid_request_error'
+    | 'rate_limit_error';
+
     interface Error {
-        type: string;
+        /**
+         * The type of error returned.
+         */        
+        type: ErrorType;
+
+        /**
+         * For card errors, the ID of the failed charge.
+         */
         charge: string;
-        message?: string;
+
+        /**
+         * For some errors that could be handled programmatically, 
+         * a short string indicating the error code reported.
+         */
         code?: string;
+
+        /**
+         * For card errors resulting from a card issuer decline, 
+         * a short string indicating the card issuer’s reason for 
+         * the decline if they provide one.
+         */
         decline_code?: string;
+
+        /**
+         * A URL to more information about the error code reported.
+         */
+        doc_url?: string;
+
+        /**
+         * A human-readable message providing more details about the 
+         * error. For card errors, these messages can be shown to 
+         * your users.
+         */
+        message?: string;
+
+        /**
+         * If the error is parameter-specific, the parameter related 
+         * to the error. For example, you can use this to display a 
+         * message near the correct form field.
+         */
         param?: string;
+
+        /**
+         * The PaymentIntent object for errors returned on a request 
+         * involving a PaymentIntent.
+         */
+        payment_intent?: paymentIntents.PaymentIntent;
+
+        /**
+         * The PaymentMethod object for errors returned on a 
+         * request involving a PaymentMethod.
+         */
+        payment_method?: paymentMethod.PaymentMethod;
+
+        /**
+         * The source object for errors returned on a request involving 
+         * a source.
+         */
+        source?: Source;
     }
 
     type statusType = 'new' | 'validated' | 'verified' | 'verification_failed' | 'errored';
@@ -266,65 +300,201 @@ declare namespace stripe {
         client_secret: string;
     }
 
-    namespace paymentIntent {
-        interface PaymentIntentResponse {
-            paymentIntent?: StripePaymentIntent;
-            error?: Error;
-        }
+    /**
+     * A set of key/value pairs that you can attach to an object. It can be useful for storing
+     * additional information about the object in a structured format.
+     */
+    interface Metadata {
+        [x: string]: string;
+    }
 
-        type paymentIntentStatus = 'requires_payment_method' | 'requires_confirmation' | 'requires_action' | 'processing' | 'requires_capture' | 'canceled' | 'succeeded';
-        interface StripePaymentIntent {
-            id: string;
-            object: 'payment_intent';
-            amount: number;
-            canceled_at: number;
-            client_secret: string;
-            created: number;
-            currency: string;
-            description: string;
-            livemode: boolean;
-            next_action: NextAction;
-            payment_method: string;
-            receipt_email: string;
-            shipping: ShippingInformation;
-            status: paymentIntentStatus;
-        }
+    interface List<T> {
+        /**
+         * Value is 'list'
+         */
+        object: 'list';
 
-        type nextActionType = 'redirect_to_url' | 'use_stripe_sdk';
-        interface NextAction {
-            redirect_to_url: RedirectOptions;
-            type: nextActionType;
-        }
+        /**
+         * An array containing the actual response elements, paginated by any request parameters.
+         */
+        data: T[];
 
-        interface RedirectOptions {
-            return_url: string;
-            url: string;
-        }
+        /**
+         * Whether or not there are more elements available after this set. If false, this set comprises the end of the list.
+         */
+        has_more: boolean;
 
-        interface ShippingInformation {
-            address: OwnerAddress;
-            carrier: string;
-            name: string;
-            phone: string;
-            tracking_number: string;
-        }
+        /**
+         * The URL for accessing this list.
+         */
+        url: string;
+    }
 
-        interface CardPaymentData {
-            payment_method?: string;
-            payment_method_data?: PaymentMethodData;
-            shipping?: ShippingInformation;
-            receipt_email?: string;
-            save_payment_method?: boolean;
-        }
+    interface BillingDetailsAddress {
+        city?: string;
+        country?: string;
+        line1?: string;
+        line2?: string;
+        postal_code?: string;
+        state?: string;
+    }
 
-        interface PaymentMethodData {
-            billing_details?: OwnerInfo;
-            card?: {[token: string]: string};
-        }
+    interface BillingDetails {
+        address: BillingDetailsAddress | null;
+        email?: string | null;
+        name?: string | null;
+        phone?: string | null;
+    }
 
-        interface PaymentIntentConfirmationData extends CardPaymentData {
-            return_url?: string;
-        }
+    interface ShippingDetailsAddress {
+        line1: string;
+        city?: string;
+        country?: string;
+        line2?: string;
+        postal_code?: string;
+        state?: string;
+    }
+
+    interface ShippingDetails {
+        address: ShippingDetailsAddress;
+        name: string | null;
+        carrier: string | null;
+        phone: string | null;
+        tracking_number: string | null;
+    }
+
+    interface CreatePaymentMethodOptions {
+        /**
+         * Billing information associated with the PaymentMethod 
+         * that may be used or required by particular types of 
+         * payment methods.
+         */
+        billing_details?: BillingDetails;
+        metadata?: Metadata;
+    }
+
+    interface HandleCardPaymentOptions {
+        /**
+         * Use this parameter to supply additional data relevant to 
+         * the payment method, such as billing details
+         */
+        payment_method_data?: {
+            /**
+             * The billing details associated with the card. [Recommended] 
+             */
+            billing_details?: BillingDetails,
+        };
+        /**
+         * The shipping details for the payment, if collected. [Recommended]
+         */
+        shipping?: ShippingDetails;
+        /**
+         * Email address that the receipt for the resulting payment will be sent to.
+         */
+        receipt_email?: string;
+        /**
+         * If the PaymentIntent is associated with a customer and this parameter 
+         * is set to true, the provided payment method will be attached to the 
+         * customer. Default is false.
+         */
+        save_payment_method?: boolean;
+    }
+
+    interface HandleCardPaymentWithoutElementsOptions extends HandleCardPaymentOptions {
+        /**
+         * Only one of payment_method_data and payment_method is required.
+         * Use payment_method to specify an existing PaymentMethod to use 
+         * for this payment.
+         */
+        payment_method?: string;
+        /**
+         * Use this parameter to supply additional data relevant to 
+         * the payment method, such as billing details
+         */
+        payment_method_data?: {
+            /**
+             * The billing details associated with the card. [Recommended] 
+             */
+            billing_details?: BillingDetails,
+            card?: {
+                /**
+                 * Converts the provided token into a PaymentMethod to 
+                 * use for the payment.
+                 */
+                token: string;
+            }
+        };
+    }
+
+    interface ConfirmPaymentIntentOptions {
+        /**
+         * A return_url may be supplied if you are not planning to use 
+         * stripe.handleCardPayment to complete the payment. If you are 
+         * handling next actions yourself, pass in a return_url. If the 
+         * subsequent action is redirect_to_url, this URL will be used 
+         * on the return path for the redirect.
+         */
+        return_url?: string;
+        /**
+         * Use this parameter to supply additional data relevant to 
+         * the payment method, such as billing details
+         */
+        payment_method_data?: {
+            /**
+             * The billing details associated with the card. [Recommended] 
+             */
+            billing_details?: BillingDetails,
+        };
+        /**
+         * The shipping details for the payment, if collected. [Recommended]
+         */
+        shipping?: ShippingDetails;
+        /**
+         * Email address that the receipt for the resulting payment will be sent to.
+         */
+        receipt_email?: string;
+        /**
+         * If the PaymentIntent is associated with a customer and this parameter 
+         * is set to true, the provided payment method will be attached to the 
+         * customer. Default is false.
+         */
+        save_payment_method?: boolean;
+    }
+
+    interface ConfirmPaymentIntentWithoutElementsOptions extends ConfirmPaymentIntentOptions {
+        /**
+         * Only one of payment_method_data and payment_method is required.
+         * Use payment_method to specify an existing PaymentMethod to use 
+         * for this payment.
+         */
+        payment_method?: string;
+        /**
+         * Use this parameter to supply additional data relevant to 
+         * the payment method, such as billing details
+         */
+        payment_method_data?: {
+            /**
+             * The billing details associated with the card. [Recommended] 
+             */
+            billing_details?: BillingDetails,
+            card?: {
+                /**
+                 * Converts the provided token into a PaymentMethod to 
+                 * use for the payment.
+                 */
+                token: string;
+            }
+        };
+    }
+
+    interface PaymentMethodResponse {
+        payment_method?: paymentMethod.PaymentMethod;
+        error?: Error;
+    }
+
+    interface PaymentIntentResponse {
+        paymentIntent?: paymentIntents.PaymentIntent;
+        error?: Error;
     }
 
     // Container for all payment request related types
@@ -518,5 +688,841 @@ declare namespace stripe {
             theme: 'dark' | 'light' | 'light-outline';
             height: string;
         }
+    }
+
+    namespace paymentIntents {
+
+        type PaymentIntentStatus =
+        | 'requires_payment_method'
+        | 'requires_confirmation'
+        | 'requires_action'
+        | 'processing'
+        | 'requires_capture'
+        | 'canceled'
+        | 'succeeded';
+
+        type PaymentIntentCancelationReason = 
+        // User Provided:
+        | 'duplicate' 
+        | 'fraudulent' 
+        | 'requested_by_customer' 
+        | 'abandoned'
+        // Generated by Stripe internally:
+        | 'failed_invoice'
+        | 'void_invoice'
+        | 'automatic';
+
+
+        interface PaymentIntentNextActionRedirectToUrl {
+            /**
+             * Type of the next action to perform
+             */
+            type: 'redirect_to_url';
+            /**
+             * Contains instructions for authenticating a payment by 
+             * redirecting your customer to another page or application.
+             */
+            redirect_to_url: { 
+                /**
+                 * If the customer does not exit their browser while 
+                 * authenticating, they will be redirected to this 
+                 * specified URL after completion.
+                 */
+                return_url: string; 
+
+                /**
+                 * The URL you must redirect your customer to in 
+                 * order to authenticate the payment.
+                 */
+                url: string;
+            };
+        }
+
+        interface PaymentIntentNextActionUseStripeSdk {
+            /**
+             * Type of the next action to perform
+             */
+            type: 'use_stripe_sdk';
+            /**
+             * When confirming a PaymentIntent with Stripe.js, 
+             * Stripe.js depends on the contents of this dictionary 
+             * to invoke authentication flows. The shape of the contents 
+             * is subject to change and is only intended to be used by Stripe.js.
+             */
+            use_stripe_sdk: any;
+        }
+
+        interface PaymentIntent {
+            /**
+             * Unique identifier for the object.
+             */
+            id: string;
+
+            /**
+             * Value is "payment_intent".
+             */
+            object: 'payment_intent';
+
+            /**
+             * The amount in cents that is to be collected from this PaymentIntent.
+             */
+            amount: number;
+
+            /**
+             * The amount that can be captured with from this PaymentIntent (in cents).
+             */
+            amount_capturable: number;
+
+            /**
+             * The amount that was collected from this PaymentIntent (in cents).
+             */
+            amount_received: number;
+
+            /**
+             * ID of the Connect application that created the PaymentIntent.
+             */
+            application: string | null;
+
+            /**
+             * A fee in cents that will be applied to the invoice and transferred to the application owner's Stripe account.
+             */
+            application_fee_amount: number | null;
+
+            /**
+             * Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled.
+             * Measured in seconds since the Unix epoch.
+             */
+            canceled_at: number | null;
+
+            /**
+             * User-given reason for cancellation of this PaymentIntent.
+             */
+            cancelation_reason: PaymentIntentCancelationReason | null;
+
+            /**
+             * Capture method of this PaymentIntent.
+             */
+            capture_method: 'automatic' | 'manual';
+
+            /**
+             * Charges that were created by this PaymentIntent, if any.
+             */
+            charges: List<Charge>;
+
+            /**
+             * The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key. Please refer to dynamic authentication guide on how client_secret should be handled.
+             */
+            client_secret: string;
+
+            /**
+             * Confirmation method of this PaymentIntent.
+             */
+            confirmation_method: 'automatic' | 'manual';
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+
+            /**
+             * Three-letter ISO currency code, in lowercase. Must be a supported currency.
+             */
+            currency: string;
+
+            /**
+             * ID of the Customer this PaymentIntent is for if one exists.
+             */
+            customer: string | null;
+
+            /**
+             * An arbitrary string attached to the object. Often useful for displaying to users.
+             */
+            description?: string;
+
+            /**
+             * The payment error encountered in the previous PaymentIntent confirmation.
+             */
+            last_payment_error: Error | null;
+
+            /**
+             * Has the value true if the object exists in live mode or the value false 
+             * if the object exists in test mode.
+             */
+            livemode: boolean;
+
+        
+            metadata: Metadata;
+
+            /**
+             * If present, this property tells you what actions you need to take in order 
+             * for your customer to fulfill a payment using the provided source.
+             */
+            next_action:
+                | PaymentIntentNextActionUseStripeSdk
+                | PaymentIntentNextActionRedirectToUrl;
+
+            /**
+             * The account (if any) for which the funds of the PaymentIntent are intended. 
+             * See the PaymentIntents Connect usage guide for details.
+             */
+            on_behalf_of: string | null;
+
+            /**
+             * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
+             */
+            payment_method_types: string[];
+
+            /**
+             * Email address that the receipt for the resulting payment will be sent to.
+             */
+            receipt_email: string | null;
+
+            /**
+             * ID of the review associated with this PaymentIntent, if any. 
+             */
+            review: string | null;
+
+            /**
+             * Shipping information for this PaymentIntent.
+             */
+            shipping: ShippingDetails | null;
+
+            /**
+             * Extra information about a PaymentIntent. This will appear on your 
+             * customer’s statement when this PaymentIntent succeeds in creating a charge.
+             */
+            statement_descriptor: string | null;
+
+            /**
+             * The several states the PaymentIntent goes through until it it either canceled or succeeds.
+             */
+            status: PaymentIntentStatus;
+
+            /**
+             * The data with which to automatically create a Transfer when the payment is finalized.
+             */
+            transfer_data: {
+                /**
+                 * The account (if any) the payment will be attributed to for tax reporting, 
+                 * and where funds from the payment will be transferred to upon payment success.
+                 */
+                destination: string;
+            } | null;
+
+            /**
+             * A string that identifies the resulting payment as part of a group.
+             */
+            transfer_group: string | null;
+        }
+
+        interface Charge {
+            /**
+             * Unique identifier for the object.
+             */
+            id: string;
+            
+            /**
+             * Value is 'charge'
+             */
+            object: "charge";
+
+            /**
+             * Amount charged in cents/pence, positive integer or zero.
+             */
+            amount: number;
+
+            /**
+             * Amount in cents/pence refunded (can be less than the amount attribute on the
+             * charge if a partial refund was issued), positive integer or zero.
+             */
+            amount_refunded: number;
+
+            /**
+             * ID of the Connect application that created the charge.
+             */
+            application: string | null;
+
+            /**
+             * The application fee (if any) for the charge. See the Connect documentation
+             * for details.
+             */
+            application_fee: string | null;
+
+            /**
+             * The amount of the application fee (if any) for the charge. See the Connect 
+             * documentation for details.
+             */
+            application_fee_amount: number | null;
+
+            /**
+             * ID of the balance transaction that describes the impact of this charge on
+             * your account balance (not including refunds or disputes).
+             */
+            balance_transaction: string;
+
+            /**
+             * Billing information associated with the payment method at the time of the transaction.
+             */
+            billing_details: BillingDetails;
+
+            /**
+             * If the charge was created without capturing, this boolean represents whether or not it is
+             * still uncaptured or has since been captured.
+             */
+            captured: boolean;
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+
+            /**
+             * Three-letter ISO currency code representing the currency in which the
+             * charge was made.
+             */
+            currency: string;
+
+            /**
+             * ID of the customer this charge is for if one exists.
+             */
+            customer: string | null;
+
+            /**
+             * An arbitrary string attached to the object. Often useful for displaying to users.
+             */
+            description: string | null;
+
+            /**
+             * Details about the dispute if the charge has been disputed.
+             */
+            dispute: string | null;
+
+            /**
+             * Error code explaining reason for charge failure if available (see the errors section for a list of
+             * codes: https://stripe.com/docs/api#errors).
+             */
+            failure_code: string | null;
+
+            /**
+             * Message to user further explaining reason for charge failure if available.
+             */
+            failure_message: string | null;
+
+            /**
+             * Hash with information on fraud assessments for the charge.
+             */
+            fraud_details: {
+                /**
+                 * Assessments reported by you have the key user_report and, if set, possible values of "safe" and "fraudulent".
+                 */
+                user_report?: "fraudulent" | "safe";
+
+                /**
+                 * Assessments from Stripe have the key stripe_report and, if set, the value "fraudulent".
+                 */
+                stripe_report?: "fraudulent";
+            };
+
+            /**
+             * ID of the invoice this charge is for if one exists. [Expandable]
+             */
+            invoice: string | null;
+
+            /**
+             * Has the value true if the object exists in live mode or the value false if 
+             * the object exists in test mode.
+             */
+            livemode: boolean;
+            
+            metadata: Metadata;
+
+            /**
+             * The Stripe account ID for which these funds are intended. Automatically
+             * set if you use the destination parameter. For details, see [Creating
+             * Separate Charges and Transfers]
+             * <https://stripe.com/docs/connect/charges-transfers#on-behalf-of>.
+             */
+            on_behalf_of: string | null;
+
+            /**
+             * ID of the order this charge is for if one exists.
+             */
+            order: string | null;
+
+            /**
+             * Details about whether the payment was accepted, and why. See
+             * understanding declines for details.
+             */
+            outcome: {
+                network_status: 'approved_by_network' | 'declined_by_network' | 'not_sent_to_network' | 'reversed_after_approval';
+                reason: 'highest_risk_level' | 'elevated_risk_level' | 'rule' | null;
+                risk_level: 'normal' | 'elevated' | 'highest' | 'not_assessed' | 'unknown';
+                risk_score: number;
+                rule?: string;
+                seller_message: string;
+                type: 'authorized' | 'manual_review' | 'issuer_declined' | 'blocked' | 'invalid';
+            } | null;
+
+            /**
+             * true if the charge succeeded, or was successfully authorized for later capture.
+             */
+            paid: boolean;
+
+            /**
+             * ID of the PaymentIntent associated with this charge, if one exists.
+             */
+            payment_intent: string;
+
+            /**
+             * ID of the payment method used in this charge.
+             */
+            payment_method: string | null;
+
+            payment_method_details: paymentMethod.PaymentMethodDetails;
+
+            /**
+             * This is the email address that the receipt for this charge was sent to.
+             */
+            receipt_email: string | null;
+
+            /**
+             * This is the transaction number that appears on email receipts sent for this charge.
+             */
+            receipt_number: string | null;
+
+            /**
+             * This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the
+             * latest state of the charge, including any refunds. If the charge is for an Invoice, the
+             * receipt will be stylized as an Invoice receipt.
+             */
+            receipt_url: string;
+
+            /**
+             * Whether or not the charge has been fully refunded. If the charge is only partially refunded,
+             * this attribute will still be false.
+             */
+            refunded: boolean;
+
+            /**
+             * A list of refunds that have been applied to the charge.
+             */
+            refunds: List<Refund>;
+
+            /**
+             * ID of the review associated with this charge if one exists.
+             */
+            review?: string | null;
+
+            /**
+             * Shipping information for the charge.
+             */
+            shipping?: ShippingDetails | null;
+
+            /**
+             * For most Stripe users, the source of every charge is a credit or debit card.
+             * This hash is then the card object describing that card.
+             */
+            source?: Source;
+
+            /**
+             * The transfer ID which created this charge. Only present if the charge came
+             * from another Stripe account. See the Connect documentation for details.
+             */
+            source_transfer: string | null;
+
+            /**
+             * Extra information about a charge. This will appear on your customer’s
+             * credit card statement.
+             */
+            statement_descriptor: string | null;
+
+            /**
+             * The status of the payment is either "succeeded", "pending", or "failed".
+             */
+            status: "succeeded" | "pending" | "failed";
+
+            /**
+             * ID of the transfer to the destination account (only applicable if the
+             * charge was created using the destination parameter).
+             */
+            transfer?: string | null;
+
+            /**
+             * A string that identifies this transaction as part of a group.
+             * See the Connect documentation for details.
+             */
+            transfer_group?: string | null;
+        }
+
+
+        interface Refund {
+            /**
+             * Unique identifier for the object.
+             */
+            id: string;
+
+            /**
+             * Value is "refund"
+             */
+            object: 'refund';
+
+            /**
+             * Refund amount, in cents.
+             */
+            amount: number;
+
+            /**
+             * Balance transaction that describes the impact on your account balance.
+             */
+            balance_transaction: string | null;
+
+            /**
+             * ID of the charge that was refunded.
+             */
+            charge: string;
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+
+            /**
+             * Three-letter ISO currency code, in lowercase. Must be a supported currency.
+             */
+            currency: string;
+
+            /**
+             * An arbitrary string attached to the object. Often useful for 
+             * displaying to users. (Available on non-card refunds only)
+             */
+            description?: string;
+
+            /**
+             * If the refund failed, this balance transaction describes the 
+             * adjustment made on your account balance that reverses the 
+             * initial balance transaction.
+             */
+            failure_balance_transaction?: string;
+
+            /**
+             * If the refund failed, the reason for refund failure if known
+             */
+            failure_reason?: 
+            | 'lost_or_stolen_card'
+            | 'expired_or_canceled_card'
+            | 'unknown';
+
+            metadata: Metadata;
+
+            /**
+             * Reason for the refund
+             */
+            reason: 'duplicate' | 'fraudulent' | 'requested_by_customer' | null;
+
+            /**
+             * This is the transaction number that appears on email 
+             * receipts sent for this refund.
+             */
+            receipt_number: string | null;
+
+            /**
+             * The transfer reversal that is associated with the refund. 
+             * Only present if the charge came from another Stripe account. 
+             * See the Connect documentation for details.
+             */
+            source_transfer_reversal: string | null;
+
+            /**
+             * Status of the refund. For credit card refunds, this can be 
+             * pending, succeeded, or failed. For other types of refunds, 
+             * it can be pending, succeeded, failed, or canceled. Refer to
+             * our refunds documentation for more details.
+             */
+            status: 'pending' | 'succeeded' | 'failed' | 'canceled';
+
+            /**
+             * If the accompanying transfer was reversed, the transfer reversal object. 
+             * Only applicable if the charge was created using the destination parameter.
+             */
+            transfer_reversal: string | null;
+        }
+    }
+
+    namespace paymentMethod {
+        type paymentMethodType = 'card' | 'card_present';
+
+        interface PaymentMethod {
+            /**
+             * The unique identifier for the object
+             */
+            id: string;
+
+            /**
+             * Value is "payment_method"
+             */
+            object: 'payment_method';
+
+            /**
+             * Billing information associated with the PaymentMethod that may be 
+             * used or required by particular types of payment methods.
+             */
+            billing_details: BillingDetails;
+
+            /**
+             * If this is a card PaymentMethod, this hash contains details about the card.
+             */
+            card?: PaymentMethodCard;
+
+            /**
+             * If this is an card_present PaymentMethod, this hash contains details 
+             * about the Card Present payment method.
+             */
+            card_present?: any;
+
+            /**
+             * Time at which the object was created. Measured in seconds since the 
+             * Unix epoch.
+             */
+            created: number;
+
+            /**
+             * The ID of the Customer to which this PaymentMethod is saved. 
+             * This will not be set when the PaymentMethod has not been saved to a Customer.
+             */
+            customer: string | null;
+
+            /**
+             * Has the value true if the object exists in live mode or the value 
+             * false if the object exists in test mode.
+             */
+            livemode: boolean;
+
+            metadata: Metadata;
+
+            /**
+             * The type of the PaymentMethod. An additional hash is included on the
+             * PaymentMethod with a name matching this value. It contains additional
+             * information specific to the PaymentMethod type.
+             */
+            type: string;
+        }
+
+        type paymentMethodCardBrand = 
+        | 'amex'
+        | 'diners'
+        | 'discover'
+        | 'jcb'
+        | 'mastercard'
+        | 'unionpay'
+        | 'visa'
+        | 'unknown';
+
+        interface PaymentMethodCard {
+            /**
+             * Card brand 
+             * */
+            brand: paymentMethodCardBrand;
+
+            /**
+             * Checks on Card address and CVC if provided.
+             */
+            checks: {
+                address_line1_check: boolean | null;
+                address_postal_code_check: boolean | null;
+                cvc_check: boolean | null;
+            };
+
+            /**
+             * Two-letter ISO code representing the country of the card. You 
+             * could use this attribute to get a sense of the international
+             * breakdown of cards you’ve collected.
+             */
+            country: string;
+
+            /**
+             * Two-digit number representing the card’s expiration month.
+             */
+            exp_month: number;
+
+            /**
+             * Four-digit number representing the card’s expiration year.
+             */
+            exp_year: number;
+
+            /**
+             * Uniquely identifies this particular card number. You can use 
+             * this attribute to check whether two customers who’ve signed 
+             * up with you are using the same card number, for example.
+             */
+            fingerprint: string;
+
+            /**
+             * Card funding type
+             */
+            funding: fundingType;
+
+            /**
+             * Details of the original PaymentMethod that created this object.
+             */
+            generated_from: {
+                charge?: string | null;
+                payment_method_details?: PaymentMethodDetails | null;
+            };
+
+            /**
+             * The last four digits of the card.
+             */
+            last4: string;
+          
+            /**
+             * Contains details on how this Card maybe be used for 3D Secure authentication.
+             */
+            three_d_secure_usage?: {
+                supported?: boolean;
+            };
+
+            /**
+             * If this Card is part of a card wallet, this contains the details of 
+             * the card wallet.
+             */
+            wallet: {
+                type: 
+                | 'amex_express_checkout' 
+                | 'apple_pay' 
+                | 'google_pay' 
+                | 'masterpass' 
+                | 'samsung_pay' 
+                | 'visa_checkout';
+                amex_express_checkout?: any;
+                apple_pay?: any;
+                dynamic_last4?: any;
+                google_pay?: any;
+                masterpass?: any;
+                samsung_pay?: any;
+                visa_checkout?: any;
+            } | null;
+        }
+
+        /**
+         * Details about the payment method at the time of the transaction.
+         */
+        interface PaymentMethodDetails {
+            /**
+             * The type of transaction-specific details of the payment method used in the payment
+             */
+            type: 
+            | 'ach_credit_transfer'
+            | 'ach_debit'
+            | 'alipay'
+            | 'bancontact'
+            | 'card'
+            | 'eps'
+            | 'giropay'
+            | 'ideal'
+            | 'multibanco'
+            | 'p24'
+            | 'sepa_debit'
+            | 'sofort'
+            | 'stripe_account'
+            | 'wechat';
+
+            ach_credit_transfer?: AchCreditTransferDetails | null;
+            ach_debit?: AchDebitDetails | null;
+            alipay?: any | null;
+            bancontact?: BanContactDetails | null;
+            card?: PaymentMethodCard | null;
+            eps?: EpsDetails | null;
+            giropay?: GiropayDetails | null;
+            ideal?: IdealDetails | null;
+            multibanco?: MultibancoDetails | null;
+            p24?: P24Details | null;
+            sepa_debit?: SepaDebitDetails | null;
+            sofort?: SofortDetails | null;
+            stripe_account?: any | null;
+            wechat?: any | null;
+        }
+
+        interface AchCreditTransferDetails {
+            account_number: string;
+            bank_name: string;
+            routing_number: string;
+            swift_coode: string;
+        }
+
+        interface AchDebitDetails {
+            account_holder_type: 'individual' | 'company';
+            bank_name: string;
+            country: string;
+            fingerprint: string;
+            last4: string;
+            routing_number: string;
+        }
+
+        interface BanContactDetails {
+            bank_code: string;
+            bank_name: string;
+            bic: string;
+            iban_last4: string;
+            preferred_language: 'en' | 'de' | 'fr' | 'nl';
+            verified_name: string;
+        }
+
+        interface EpsDetails {
+            verified_name: string;
+        }
+
+        interface GiropayDetails {
+            bank_code: string;
+            bank_name: string;
+            bic: string;
+            verified_name: string;
+        }
+
+        interface IdealDetails {
+            bank: 
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+
+            bic: string;
+            iban_last4: string;
+            verified_name: string;
+        }
+
+        interface MultibancoDetails {
+            entity: string;
+            reference: string;
+        }
+
+        interface P24Details {
+            reference: string;
+            verified_name: string;
+        }
+
+        interface SepaDebitDetails {
+            bank_code: string;
+            branch_code: string;
+            country: string;
+            fingerprint: string;
+            last4: string;
+        }
+
+        interface SofortDetails {
+            bank_code: string;
+            bank_name: string;
+            bic: string;
+            country: string;
+            iban_last4: string;
+            verified_name: string;
+        }        
     }
 }

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -8,6 +8,7 @@
 //                 Kamil Gałuszka <https://github.com/galuszkak>
 //                 Stefan Langeder <https://github.com/slangeder>
 //                 Marlos Borges <https://github.com/marlosin>
+//                 Thomas Marek <https://github.com/ttmarek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var Stripe: stripe.StripeStatic;
@@ -26,6 +27,7 @@ declare namespace stripe {
         createSource(element: elements.Element, options?: {owner?: OwnerInfo}): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
+        redirectToCheckout(options: StripeCheckoutOptions): Promise<StripeRedirectResponse>;
         paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;        
         createPaymentMethod(
             type: paymentMethod.paymentMethodType, 
@@ -57,10 +59,33 @@ declare namespace stripe {
             options?: ConfirmPaymentIntentWithoutElementsOptions,
         ): Promise<PaymentIntentResponse>;
     }
+    
+    type StripeRedirectResponse = never | {
+        error: Error;
+    }
+
+    type billingAddressCollectionType = 'required' | 'auto' | '';
+    interface StripeCheckoutOptions {	
+        items: StripeCheckoutItem[];	
+        successUrl: string;	
+        cancelUrl: string;	
+        clientReferenceId?: string;	
+        customerEmail?: string;	
+        billingAddressCollection?: billingAddressCollectionType;	
+        sessionId?: string;	
+        locale?: string;	
+    }
+
+    interface StripeCheckoutItem {	
+        sku?: string;	
+        plan?: string;	
+        quantity: number;	
+    }
 
     interface StripeOptions {
       stripeAccount?: string;
       betas?: string[];
+      locale?: string;
     }
 
     interface TokenOptions {
@@ -340,7 +365,7 @@ declare namespace stripe {
     }
 
     interface BillingDetails {
-        address: BillingDetailsAddress | null;
+        address?: BillingDetailsAddress | null;
         email?: string | null;
         name?: string | null;
         phone?: string | null;
@@ -488,7 +513,7 @@ declare namespace stripe {
     }
 
     interface PaymentMethodResponse {
-        payment_method?: paymentMethod.PaymentMethod;
+        paymentMethod?: paymentMethod.PaymentMethod;
         error?: Error;
     }
 

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -716,8 +716,7 @@ declare namespace stripe {
     }
 
     namespace paymentIntents {
-        type PaymentIntentStatus =
-        | 'requires_payment_method'
+        type PaymentIntentStatus = 'requires_payment_method'
         | 'requires_confirmation'
         | 'requires_action'
         | 'processing'
@@ -725,9 +724,7 @@ declare namespace stripe {
         | 'canceled'
         | 'succeeded';
 
-        type PaymentIntentCancelationReason =
-        // User Provided:
-        | 'duplicate'
+        type PaymentIntentCancelationReason = 'duplicate'
         | 'fraudulent'
         | 'requested_by_customer'
         | 'abandoned'
@@ -1229,8 +1226,7 @@ declare namespace stripe {
             /**
              * If the refund failed, the reason for refund failure if known
              */
-            failure_reason?:
-            | 'lost_or_stolen_card'
+            failure_reason?: 'lost_or_stolen_card'
             | 'expired_or_canceled_card'
             | 'unknown';
 
@@ -1329,8 +1325,7 @@ declare namespace stripe {
             type: string;
         }
 
-        type paymentMethodCardBrand =
-        | 'amex'
+        type paymentMethodCardBrand = 'amex'
         | 'diners'
         | 'discover'
         | 'jcb'
@@ -1342,7 +1337,7 @@ declare namespace stripe {
         interface PaymentMethodCard {
             /**
              * Card brand
-             * */
+             */
             brand: paymentMethodCardBrand;
 
             /**
@@ -1408,8 +1403,7 @@ declare namespace stripe {
              * the card wallet.
              */
             wallet: {
-                type:
-                | 'amex_express_checkout'
+                type: 'amex_express_checkout'
                 | 'apple_pay'
                 | 'google_pay'
                 | 'masterpass'
@@ -1432,8 +1426,7 @@ declare namespace stripe {
             /**
              * The type of transaction-specific details of the payment method used in the payment
              */
-            type:
-            | 'ach_credit_transfer'
+            type: 'ach_credit_transfer'
             | 'ach_debit'
             | 'alipay'
             | 'bancontact'
@@ -1501,8 +1494,7 @@ declare namespace stripe {
         }
 
         interface IdealDetails {
-            bank:
-            | 'abn_amro'
+            bank: 'abn_amro'
             | 'asn_bank'
             | 'bunq'
             | 'handelsbanken'

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -191,7 +191,7 @@ describe("Stripe elements", () => {
             if (result.error) {
                 console.error(result.error.param);
             } else if (result.paymentMethod) {
-                console.log(result.paymentMethod.card && result.paymentMethod.card.number);
+                console.log(result.paymentMethod.card && result.paymentMethod.card.brand);
             }
         });
     });
@@ -246,7 +246,7 @@ describe("Stripe elements", () => {
             if (result.error) {
                 console.error(result.error.message);
             } else if (result.paymentIntent) {
-                console.log(result.paymentIntent.shipping.address);
+                console.log(result.paymentIntent.shipping && result.paymentIntent.shipping.address);
             }
         });
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/stripe-js/reference
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### Summary

This pull request improves support for the new PaymentIntents API. I started on this last week, since then it looks like we've gotten basic support for the API. Some types were incomplete so I figured I'd add these enhancements anyway. I've added JSDocs where possible which should improve the experience for new users to the API greatly. For example, here's what you now see when filling in the options in the new handleCardPayment method:

<img width="676" alt="example" src="https://user-images.githubusercontent.com/7446702/58960906-1c2b4800-8776-11e9-9e67-388b98a846cb.png">

