### PR TITLE
Namespace JSX under React.JSX

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2803,7 +2803,7 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
             ? Defaultize<P, D>
             : P;
 
-declare global {
+namespace React {
     namespace JSX {
         // tslint:disable-next-line:no-empty-interface
         interface Element extends React.ReactElement<any, any> { }


### PR DESCRIPTION
When using both `preact` and `react` in typescript projects, the type checker gets conflicting type definitions because both projects declare global JSX definitions. Typescript since 2.8 has recommended libraries to internally namespace `JSX` to avoid conflicting definitions. See factory functions: https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions.

Preact 10.x already switched to internally namespaced JSX. See https://github.com/preactjs/preact/pull/1448

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.