### PR TITLE
stripe-v3: Add :disabled pseudoclass to Style interface.

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -483,6 +483,7 @@ declare namespace stripe {
             '::placeholder'?: StyleOptions;
             '::selection'?: StyleOptions;
             ':-webkit-autofill'?: StyleOptions;
+            ':disabled'?: StyleOptions;
             '::-ms-clear'?: StyleOptions;
         }
 


### PR DESCRIPTION
The property is missing.  See: https://github.com/stripe/react-stripe-elements/issues/250 

The property is documented here: https://stripe.com/docs/stripe-js/reference#element-options

This property was recently-ish added, which is why it's not currently included in these type definitions: https://github.com/stripe/react-stripe-elements/issues/136#issuecomment-404015039

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes:  https://stripe.com/docs/stripe-js/reference#element-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
