### PR TITLE
selenium-webdriver: add "defineCommand" method to executor class

### DIFF
--- a/types/selenium-webdriver/http.d.ts
+++ b/types/selenium-webdriver/http.d.ts
@@ -105,21 +105,6 @@ export class Executor {
    */
   constructor(client: HttpClient|Promise<HttpClient>);
 
-  /**
-   * Defines a new command for use with this executor. When a command is sent,
-   * the {@code path} will be preprocessed using the command's parameters; any
-   * path segments prefixed with ':' will be replaced by the parameter of the
-   * same name. For example, given '/person/:name' and the parameters
-   * '{name: 'Bob'}', the final command path will be '/person/Bob'.
-   *
-   * @param {string} name The command name.
-   * @param {string} method The HTTP method to use when sending this command.
-   * @param {string} path The path to send the command to, relative to
-   *     the WebDriver server's command root and of the form
-   *     '/path/:variable/segment'.
-   */
-  defineCommand(name: string, method: string, path: string): void;
-
   /** @override */
   execute(command: any): any;
 }

--- a/types/selenium-webdriver/http.d.ts
+++ b/types/selenium-webdriver/http.d.ts
@@ -105,6 +105,21 @@ export class Executor {
    */
   constructor(client: HttpClient|Promise<HttpClient>);
 
+  /**
+   * Defines a new command for use with this executor. When a command is sent,
+   * the {@code path} will be preprocessed using the command's parameters; any
+   * path segments prefixed with ':' will be replaced by the parameter of the
+   * same name. For example, given '/person/:name' and the parameters
+   * '{name: 'Bob'}', the final command path will be '/person/Bob'.
+   *
+   * @param {string} name The command name.
+   * @param {string} method The HTTP method to use when sending this command.
+   * @param {string} path The path to send the command to, relative to
+   *     the WebDriver server's command root and of the form
+   *     '/path/:variable/segment'.
+   */
+  defineCommand(name: string, method: string, path: string): void;
+
   /** @override */
   execute(command: any): any;
 }

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1461,6 +1461,21 @@ export class Capabilities {
  */
 export class Executor {
   /**
+   * Defines a new command for use with this executor. When a command is sent,
+   * the {@code path} will be preprocessed using the command's parameters; any
+   * path segments prefixed with ':' will be replaced by the parameter of the
+   * same name. For example, given '/person/:name' and the parameters
+   * '{name: 'Bob'}', the final command path will be '/person/Bob'.
+   *
+   * @param {string} name The command name.
+   * @param {string} method The HTTP method to use when sending this command.
+   * @param {string} path The path to send the command to, relative to
+   *     the WebDriver server's command root and of the form
+   *     '/path/:variable/segment'.
+   */
+  defineCommand(name: string, method: string, path: string): void;
+  
+  /**
    * Executes the given {@code command}. If there is an error executing the
    * command, the provided callback will be invoked with the offending error.
    * Otherwise, the callback will be invoked with a null Error and non-null

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -15,7 +15,8 @@ import * as edge from './edge';
 import * as firefox from './firefox';
 import * as ie from './ie';
 import { By, ByHash } from './lib/by';
-import { Command, ICommandName, Name } from './lib/command';
+import * as command from './lib/command';
+import * as http from './http';
 import { Actions, Button, Key, Origin } from './lib/input';
 import { promise } from './lib/promise';
 import * as until from './lib/until';
@@ -1457,39 +1458,6 @@ export class Capabilities {
 }
 
 /**
- * Handles the execution of WebDriver {@link Command commands}.
- * @interface
- */
-export class Executor {
-  /**
-   * Defines a new command for use with this executor. When a command is sent,
-   * the {@code path} will be preprocessed using the command's parameters; any
-   * path segments prefixed with ':' will be replaced by the parameter of the
-   * same name. For example, given '/person/:name' and the parameters
-   * '{name: 'Bob'}', the final command path will be '/person/Bob'.
-   *
-   * @param {string} name The command name.
-   * @param {string} method The HTTP method to use when sending this command.
-   * @param {string} path The path to send the command to, relative to
-   *     the WebDriver server's command root and of the form
-   *     '/path/:variable/segment'.
-   */
-  defineCommand(name: string, method: string, path: string): void;
-
-  /**
-   * Executes the given {@code command}. If there is an error executing the
-   * command, the provided callback will be invoked with the offending error.
-   * Otherwise, the callback will be invoked with a null Error and non-null
-   * response object.
-   *
-   * @param {!Command} command The command to execute.
-   * @return {!Promise<?>} A promise that will be fulfilled with
-   *     the command result.
-   */
-  execute(command: Command): Promise<any>;
-}
-
-/**
  * Describes an event listener registered on an {@linkplain EventEmitter}.
  */
 export class Listener {
@@ -2088,7 +2056,7 @@ export class WebDriver {
    * @param {!command.Executor} executor The executor to use when sending
    *     commands to the browser.
    */
-  constructor(session: Session|Promise<Session>, executor: Executor);
+  constructor(session: Session|Promise<Session>, executor: http.Executor);
 
   // endregion
 
@@ -2169,7 +2137,7 @@ export class WebDriver {
    *     with the command result.
    * @template T
    */
-  execute<T>(command: Command, description?: string): Promise<T>;
+  execute<T>(command: command.Command, description?: string): Promise<T>;
 
   /**
    * Sets the {@linkplain input.FileDetector file detector} that should be
@@ -2178,7 +2146,7 @@ export class WebDriver {
    */
   setFileDetector(detector: FileDetector): void;
 
-  getExecutor(): Executor;
+  getExecutor(): command.Executor;
 
   /**
    * @return {!Promise.<!Session>} A promise for this

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -6,6 +6,7 @@
 //   Simon Gellis <https://github.com/SupernaviX>,
 //   Ben Dixon <https://github.com/bendxn>,
 //   Ziyu <https://github.com/oddui>
+//   Johann Wolf <https://github.com/beta-vulgaris>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1475,7 +1475,7 @@ export class Executor {
    *     '/path/:variable/segment'.
    */
   defineCommand(name: string, method: string, path: string): void;
-  
+
   /**
    * Executes the given {@code command}. If there is an error executing the
    * command, the provided callback will be invoked with the offending error.

--- a/types/selenium-webdriver/lib/command.d.ts
+++ b/types/selenium-webdriver/lib/command.d.ts
@@ -199,3 +199,36 @@ export class Command {
 
   // endregion
 }
+
+/**
+ * Handles the execution of WebDriver {@link Command commands}.
+ * @interface
+ */
+export class Executor {
+  /**
+   * Defines a new command for use with this executor. When a command is sent,
+   * the {@code path} will be preprocessed using the command's parameters; any
+   * path segments prefixed with ':' will be replaced by the parameter of the
+   * same name. For example, given '/person/:name' and the parameters
+   * '{name: 'Bob'}', the final command path will be '/person/Bob'.
+   *
+   * @param {string} name The command name.
+   * @param {string} method The HTTP method to use when sending this command.
+   * @param {string} path The path to send the command to, relative to
+   *     the WebDriver server's command root and of the form
+   *     '/path/:variable/segment'.
+   */
+  defineCommand(name: string, method: string, path: string): void;
+
+  /**
+   * Executes the given {@code command}. If there is an error executing the
+   * command, the provided callback will be invoked with the offending error.
+   * Otherwise, the callback will be invoked with a null Error and non-null
+   * response object.
+   *
+   * @param {!Command} command The command to execute.
+   * @return {!Promise<?>} A promise that will be fulfilled with
+   *     the command result.
+   */
+  execute(command: Command): Promise<any>;
+}

--- a/types/selenium-webdriver/lib/input.d.ts
+++ b/types/selenium-webdriver/lib/input.d.ts
@@ -1,4 +1,5 @@
-import { Executor, ILocation, WebDriver, WebElement } from '../';
+import { ILocation, WebDriver, WebElement } from '../';
+import { Executor } from './command';
 
 /**
  * Defines the reference point from which to compute offsets for

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -3,6 +3,7 @@ import * as chrome from 'selenium-webdriver/chrome';
 import * as edge from 'selenium-webdriver/edge';
 import * as firefox from 'selenium-webdriver/firefox';
 import * as http from 'selenium-webdriver/http';
+import { Command } from 'selenium-webdriver/lib/command';
 
 function TestBuilder() {
     let builder: webdriver.Builder = new webdriver.Builder();
@@ -390,12 +391,20 @@ function TestWebDriver() {
     let executor: http.Executor = new http.Executor(httpClient);
     let driver: webdriver.WebDriver = new webdriver.WebDriver(session, executor);
     driver = new webdriver.WebDriver(sessionPromise, executor);
+    let cmdExecutor = driver.getExecutor();
 
     let voidPromise: Promise<void>;
     let stringPromise: Promise<string>;
     let webElementPromise: webdriver.WebElementPromise;
 
     voidPromise = driver.close();
+
+    // executeCommand
+    cmdExecutor.defineCommand('SEND_COMMAND', 'POST', `/session/${session.getId()}/chromium/send_command`);
+    const cmd = new Command('SEND_COMMAND')
+        .setParameter('cmd', 'Page.setDownloadBehavior')
+        .setParameter('params', {behavior: 'allow', downloadPath: './'});
+    voidPromise = driver.execute(cmd);
 
     // executeAsyncScript
     stringPromise = driver.executeAsyncScript<string>('function(){}');


### PR DESCRIPTION
method "defineCommand" was missing that would block executing custom commands, that are needed e.g. for enabling file download in headless testing.