### PR TITLE
[@types/react-mentions] add classNames prop

### DIFF
--- a/types/react-mentions/index.d.ts
+++ b/types/react-mentions/index.d.ts
@@ -40,6 +40,7 @@ export interface MentionsInputProps extends Omit<React.TextareaHTMLAttributes<HT
     onKeyDown?: (event: React.KeyboardEvent<HTMLTextAreaElement> | React.KeyboardEvent<HTMLInputElement>) => void;
     children: React.ReactElement<MentionProps> | Array<React.ReactElement<MentionProps>>;
     className?: string;
+    classNames?: any;
     style?: any;
     suggestionsPortalHost?: Element;
     inputRef?: React.RefObject<HTMLTextAreaElement> | React.RefObject<HTMLInputElement>;


### PR DESCRIPTION
In order to use css module, we need to use a prop `classNames` which is missing here. See the doc: https://github.com/signavio/react-mentions#styling

