### PR TITLE
@types/node: add doc to Buffer#slice and Buffer#subarray (and fix the type of Buffer#subarray)

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -244,8 +244,24 @@ interface Buffer extends Uint8Array {
     equals(otherBuffer: Uint8Array): boolean;
     compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
     copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(start?: number, end?: number): Buffer;
-    subarray(begin: number, end?: number): Buffer;
+    /**
+     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+     *
+     * This method is incompatible with `Uint8Array#slice()`, which returns a copy of the original memory.
+     *
+     * @param begin Where the new `Buffer` will start. Default: `0`.
+     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+     */
+    slice(begin?: number, end?: number): Buffer;
+    /**
+     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+     *
+     * This method is compatible with `Uint8Array#subarray()`.
+     *
+     * @param begin Where the new `Buffer` will start. Default: `0`.
+     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+     */
+    subarray(begin?: number, end?: number): Buffer;
     writeUIntLE(value: number, offset: number, byteLength: number): number;
     writeUIntBE(value: number, offset: number, byteLength: number): number;
     writeIntLE(value: number, offset: number, byteLength: number): number;

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -207,7 +207,9 @@ b.fill('a').fill('b');
 {
     const b = Buffer.from('asd');
     let res: Buffer = b.reverse();
+    res = b.subarray();
     res = b.subarray(1);
+    res = b.subarray(1, 2);
 }
 
 // Buffer module, transcode function


### PR DESCRIPTION
Add a compatibility notice to `Buffer#slice` and `Buffer#subarray`.

* `Buffer#slice` is incompatible with its superclass's method (i.e. `Uint8Array#slice`).
* `Buffer#subarray` is compatible with its superclass's method.

This incompatibility is significant, so I've added these notices.

Additionally, I have fixed a signature of `Buffer#subarray()`; its first param `begin` is optional.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://nodejs.org/api/buffer.html#buffer_buf_slice_start_end
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
