### PR TITLE
Copied user-event definition to new organization name

### DIFF
--- a/types/testing-library__user-event/index.d.ts
+++ b/types/testing-library__user-event/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for @testing-library/user-event 4.0
+// Project: https://github.com/testing-library/user-event
+// Definitions by: Wu Haotian <https://github.com/whtsky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface UserOpts {
+    allAtOnce?: boolean;
+    delay?: number;
+}
+declare const userEvent: {
+    click: (element: Element | Window) => void;
+    dblClick: (element: Element | Window) => void;
+    type: (
+        element: Element | Window,
+        text: string,
+        userOpts?: UserOpts
+    ) => Promise<void>;
+};
+
+export default userEvent;

--- a/types/testing-library__user-event/testing-library__user-event-tests.ts
+++ b/types/testing-library__user-event/testing-library__user-event-tests.ts
@@ -1,0 +1,11 @@
+import userEvent, { UserOpts } from "user-event";
+
+userEvent.click(document.body); // $ExpectType void
+userEvent.dblClick(window); // $ExpectType void
+userEvent.type(document.body, "s"); // $ExpectType Promise<void>
+userEvent.type(document.body, "s", {}); // $ExpectType Promise<void>
+userEvent.type(document.body, "s", { delay: 5000 }); // $ExpectType Promise<void>
+userEvent.type(document.body, "s", { allAtOnce: true }); // $ExpectType Promise<void>
+userEvent.type(document.body, "s", { delay: 1000, allAtOnce: false }); // $ExpectType Promise<void>
+
+const u: UserOpts = { delay: 20 };

--- a/types/testing-library__user-event/tsconfig.json
+++ b/types/testing-library__user-event/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["dom", "es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "testing-library__user-event-tests.ts"]
+}

--- a/types/testing-library__user-event/tslint.json
+++ b/types/testing-library__user-event/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The `user-event` package was moved into the `testing-library` organization. I just copied the type definitions to the new name and renamed the test file accordingly.