### PR TITLE
Add missing types in cesium

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Also see the [definitelytyped.org](http://definitelytyped.org) website, although
 This section tracks the health of the repository and publishing process.
 It may be helpful for contributors experiencing any issues with their PRs and packages.
 
-* All packages are [type-checking/linting](https://github.com/Microsoft/dtslint) cleanly: [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.svg?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
+* Most recent build [type-checked/linted](https://github.com/Microsoft/dtslint) cleanly: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+* All packages are type-checking/linting cleanly on typescript@next: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.dtslint-runner?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=2&branchName=master)
 * All packages are being [published to npm](https://github.com/Microsoft/types-publisher) in under an hour: [![Publish Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.types-publisher-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=13)
 * [typescript-bot](https://github.com/typescript-bot) has been active on DefinitelyTyped [![Activity Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.typescript-bot-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=14)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This section tracks the health of the repository and publishing process.
 It may be helpful for contributors experiencing any issues with their PRs and packages.
 
 * All packages are [type-checking/linting](https://github.com/Microsoft/dtslint) cleanly: [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.svg?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
+* All packages are being [published to npm](https://github.com/Microsoft/types-publisher) in under an hour: [![Publish Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.types-publisher-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=13)
 * [typescript-bot](https://github.com/typescript-bot) has been active on DefinitelyTyped [![Activity Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.typescript-bot-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=14)
 
 If anything here seems wrong, or any of the above are failing, please raise an issue in [the DefinitelyTyped Gitter channel](https://gitter.im/DefinitelyTyped/DefinitelyTyped).

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Also see the [definitelytyped.org](http://definitelytyped.org) website, although
 This section tracks the health of the repository and publishing process.
 It may be helpful for contributors experiencing any issues with their PRs and packages.
 
-* Most recent build [type-checked/linted](https://github.com/Microsoft/dtslint) cleanly: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* All packages are type-checking/linting cleanly on typescript@next: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.dtslint-runner?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=2&branchName=master)
-* All packages are being [published to npm](https://github.com/Microsoft/types-publisher) in under an hour: [![Publish Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.types-publisher-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=13)
+* All packages are [type-checking/linting](https://github.com/Microsoft/dtslint) cleanly: [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.svg?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
 * [typescript-bot](https://github.com/typescript-bot) has been active on DefinitelyTyped [![Activity Status](https://typescript.visualstudio.com/TypeScript/_apis/build/status/sandersn.typescript-bot-watchdog)](https://typescript.visualstudio.com/TypeScript/_build/latest?definitionId=14)
 
 If anything here seems wrong, or any of the above are failing, please raise an issue in [the DefinitelyTyped Gitter channel](https://gitter.im/DefinitelyTyped/DefinitelyTyped).

--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -3056,6 +3056,9 @@ declare namespace Cesium {
     }
 
     class Globe {
+        atmosphereBrightnessShift: number;
+        atmosphereSaturationShift: number;
+        atmosphereHueShift: number;
         terrainProvider: TerrainProvider;
         northPoleColor: Cartesian3;
         southPoleColor: Cartesian3;
@@ -3634,6 +3637,45 @@ declare namespace Cesium {
         constructor(options?: { translucent?: boolean; material?: Material; vertexShaderSource?: string; fragmentShaderSource?: string; renderState?: RenderState });
     }
 
+    class PostProcessStage {
+        readonly clearColor: Color;
+        enabled: boolean;
+        readonly forcePowerOfTwo: boolean;
+        readonly fragmentShader: string;
+        readonly name: string;
+        readonly pixelFormat: PixelFormat;
+        readonly ready: boolean;
+        readonly scissorRectangle: BoundingRectangle;
+        selected: any[];
+        readonly textureScale: number;
+        readonly uniforms: object;
+        constructor(options?: {
+            fragmentShader: string;
+            uniforms?: object;
+            textureScale?: number;
+            forcePowerOfTwo?: boolean;
+            pixelFormat?: PixelFormat;
+            clearColor?: Color;
+            scissorRectangle?: BoundingRectangle;
+            name?: string;
+        });
+        destroy(): void;
+        isDestroyed(): boolean;
+    }
+
+    class PostProcessStageCollection {
+        readonly fxaa: PostProcessStage;
+        readonly length: number;
+        readonly ready: boolean;
+        add(stage: PostProcessStage): PostProcessStage;
+        contains(stage: PostProcessStage): boolean;
+        destroy(): void;
+        get(index: number): PostProcessStage;
+        isDestroyed(): boolean;
+        remove(stage: PostProcessStage): boolean;
+        removeAll(): void;
+    }
+
     class Primitive {
         readonly allowPicking: boolean;
         appearance: Appearance;
@@ -3741,6 +3783,8 @@ declare namespace Cesium {
         fxaa: boolean;
         globe: Globe;
         readonly groundPrimitives: PrimitiveCollection;
+        highDynamicRange: boolean;
+        highDynamicRangeSupported: boolean;
         readonly id: string;
         readonly imageryLayers: ImageryLayerCollection;
         imagerySplitPosition: number;
@@ -3755,7 +3799,7 @@ declare namespace Cesium {
         maximumRenderTimeChange: number;
         minimumDisableDepthTestDistance: number;
         mode: SceneMode;
-        moon: Moon;
+        moon?: Moon;
         morphComplete: Event;
         morphStart: Event;
         morphTime: number;
@@ -3763,6 +3807,7 @@ declare namespace Cesium {
         readonly orderIndependentTranslucency: boolean;
         readonly pickPositionSupported: boolean;
         pickTranslucentDepth: boolean;
+        postProcessStages: PostProcessStageCollection;
         readonly postRender: Event;
         readonly preRender: Event;
         readonly preUpdate: Event;
@@ -3773,9 +3818,9 @@ declare namespace Cesium {
         readonly scene3DOnly: boolean;
         readonly screenSpaceCameraController: ScreenSpaceCameraController;
         shadowMap: ShadowMap;
-        skyAtmosphere: SkyAtmosphere;
-        skyBox: SkyBox;
-        sun: Sun;
+        skyAtmosphere?: SkyAtmosphere;
+        skyBox?: SkyBox;
+        sun?: Sun;
         sunBloom: boolean;
         terrainExaggeration: number;
         terrainProvider: TerrainProvider;
@@ -3846,6 +3891,9 @@ declare namespace Cesium {
     class SkyAtmosphere {
         show: boolean;
         ellipsoid: Ellipsoid;
+        saturationShift: number;
+        hueShift: number;
+        brightnessShift: number;
         constructor(ellipsoid?: Ellipsoid);
         isDestroyed(): boolean;
         destroy(): void;


### PR DESCRIPTION
These fields were all added before 1.54 which is the current version supported with this file.
https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md
Globe properties: 1.51 - 2018-11-01
SkyAtmosphere properties: 1.22 - 2016-06-01
Scene property highDynamicRange: 1.52 - 2018-12-03
Scene properties some can be undefined to empty out the sky (default is actually undefined)
PostProcessStages: - 2018-06-01


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

