### PR TITLE
FEAT(koa): add ExtendableContext interface to extends context

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -686,7 +686,7 @@ declare namespace Application {
         request: Request;
     }
 
-    type ParameterizedContext<StateT = any, CustomT = {}> = BaseContext & {
+    interface ExtendableContext extends BaseContext {
         app: Application;
         request: Request;
         response: Response;
@@ -695,11 +695,14 @@ declare namespace Application {
         originalUrl: string;
         cookies: Cookies;
         accept: accepts.Accepts;
-        state: StateT;
         /**
          * To bypass Koa's built-in response handling, you may explicitly set `ctx.respond = false;`
          */
         respond?: boolean;
+    }
+
+    type ParameterizedContext<StateT = any, CustomT = {}> = ExtendableContext & {
+        state: StateT;
     } & CustomT;
 
     interface Context extends ParameterizedContext {}


### PR DESCRIPTION
When developing a koa middleware, sometimes we need to extend ctx. We can extend it with BaseContext, but can't extend ctx instead of app.context. Now add a new interface to resolve it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.