### PR TITLE
lusca: support new csrf options: `blacklist` and `whitelist` for v1.6

### DIFF
--- a/types/lusca/index.d.ts
+++ b/types/lusca/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for lusca 1.5
+// Type definitions for lusca 1.6
 // Project: https://github.com/krakenjs/lusca#readme
-// Definitions by: Corbin Crutchley <https://github.com/crutchcorn>
+// Definitions by: Corbin Crutchley <https://github.com/crutchcorn>, Naoto Yokoyama <https://github.com/builtinnya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -37,12 +37,15 @@ declare namespace lusca {
         preload?: boolean;
     }
 
-    type csrfOptions = csrfOptionsAngular | csrfOptionsNonAngular;
+    type csrfOptions = csrfOptionsBase & csrfOptionsAngularOrNonAngular & csrfOptionsBlacklistOrWhitelist;
 
-    interface csrfOptionsAngular  {
+    interface csrfOptionsBase {
         key?: string;
         secret?: string;
         impl?: () => any;
+    }
+
+    interface csrfOptionsAngular {
         cookie?: string | {
             options?: object;
         };
@@ -50,15 +53,26 @@ declare namespace lusca {
     }
 
     interface csrfOptionsNonAngular {
-        key?: string;
-        secret?: string;
-        impl?: () => any;
         cookie?: string | {
             name: string;
             options?: object;
         };
         angular?: false;
     }
+
+    type csrfOptionsAngularOrNonAngular = csrfOptionsAngular | csrfOptionsNonAngular;
+
+    interface csrfOptionsBlacklist {
+        blacklist?: string[];
+        whitelist?: never;
+    }
+
+    interface csrfOptionsWhitelist {
+        blacklist?: never;
+        whitelist?: string[];
+    }
+
+    type csrfOptionsBlacklistOrWhitelist = csrfOptionsBlacklist | csrfOptionsWhitelist;
 
     interface xssProtectionOptions {
         enabled?: boolean;

--- a/types/lusca/lusca-tests.ts
+++ b/types/lusca/lusca-tests.ts
@@ -15,6 +15,10 @@ app.use(lusca({
 }));
 
 app.use(lusca.csrf());
+app.use(lusca.csrf({cookie: {name: 'csrf'}}));
+app.use(lusca.csrf({cookie: 'csrf', angular: true}));
+app.use(lusca.csrf({blacklist: ['/blacklist']}));
+app.use(lusca.csrf({whitelist: ['/whitelist']}));
 app.use(lusca.csp({policy: [{ "img-src": "'self' http:" }, "block-all-mixed-content"], reportOnly: false}));
 app.use(lusca.xframe('SAMEORIGIN'));
 app.use(lusca.p3p('ABCDEF'));


### PR DESCRIPTION
This PR updates [lusca](https://github.com/krakenjs/lusca) type definitions for v1.6.

## Changes

- Support new csrf options: `blacklist` and `whitelist` (ref: https://github.com/krakenjs/lusca#luscacsrfoptions)
- Refactor `csrfOptions` to make it scalable for later changes
- Add some tests for `angular`-related options in addition to tests for newly supported options

## Pull Request Template Answers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [v1.6.0 release note](https://github.com/krakenjs/lusca/releases/tag/v1.6.0)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.