### PR TITLE
Fix passReqToCallback type in passport-azure-ad

### DIFF
--- a/types/passport-azure-ad/index.d.ts
+++ b/types/passport-azure-ad/index.d.ts
@@ -16,6 +16,7 @@ export {
     OIDCStrategy,
     IOIDCStrategyOption,
     IOIDCStrategyOptionWithRequest,
+    IOIDCStrategyOptionWithoutRequest,
     IProfile,
     VerifyOIDCFunction,
     VerifyOIDCFunctionWithReq

--- a/types/passport-azure-ad/oidc-strategy.d.ts
+++ b/types/passport-azure-ad/oidc-strategy.d.ts
@@ -21,6 +21,10 @@ export interface IOIDCStrategyOptionWithRequest extends IOIDCStrategyOption {
     passReqToCallback: boolean;
 }
 
+export interface IOIDCStrategyOptionWithoutRequest extends IOIDCStrategyOption {
+    passReqToCallback: false;
+}
+
 export interface IProfile {
     sub?: string;
     oid?: string;
@@ -37,7 +41,7 @@ export interface IProfile {
 }
 
 export type VerifyOIDCFunction =
-    ((profile: IProfile, done: VerifyCallback) => void) | 
+    ((profile: IProfile, done: VerifyCallback) => void) |
     ((iss: string, sub: string, done: VerifyCallback) => void) |
     ((iss: string, sub: string, profile: IProfile, done: VerifyCallback) => void) |
     ((iss: string, sub: string, profile: IProfile, access_token: string, refresh_token: string, done: VerifyCallback) => void) |
@@ -45,7 +49,7 @@ export type VerifyOIDCFunction =
     ((iss: string, sub: string, profile: IProfile, jwtClaims: any, access_token: string, refresh_token: string, params: any, done: VerifyCallback) => void);
 
 export type VerifyOIDCFunctionWithReq =
-    ((req: Request, profile: IProfile, done: VerifyCallback) => void) | 
+    ((req: Request, profile: IProfile, done: VerifyCallback) => void) |
     ((req: Request, iss: string, sub: string, done: VerifyCallback) => void) |
     ((req: Request, iss: string, sub: string, profile: IProfile, done: VerifyCallback) => void) |
     ((req: Request, iss: string, sub: string, profile: IProfile, access_token: string, refresh_token: string, done: VerifyCallback) => void) |
@@ -57,7 +61,7 @@ export class OIDCStrategy implements passport.Strategy {
         options: IOIDCStrategyOptionWithRequest,
         verify: VerifyOIDCFunctionWithReq
     );
-    constructor(options: IOIDCStrategyOption, verify: VerifyOIDCFunction);
+    constructor(options: IOIDCStrategyOptionWithoutRequest, verify: VerifyOIDCFunction);
 
     name: string;
 

--- a/types/passport-azure-ad/oidc-strategy.d.ts
+++ b/types/passport-azure-ad/oidc-strategy.d.ts
@@ -18,7 +18,7 @@ export interface IOIDCStrategyOption extends IBaseStrategyOption {
 }
 
 export interface IOIDCStrategyOptionWithRequest extends IOIDCStrategyOption {
-    passReqToCallback: true;
+    passReqToCallback: boolean;
 }
 
 export interface IProfile {

--- a/types/passport-azure-ad/oidc-strategy.d.ts
+++ b/types/passport-azure-ad/oidc-strategy.d.ts
@@ -18,7 +18,7 @@ export interface IOIDCStrategyOption extends IBaseStrategyOption {
 }
 
 export interface IOIDCStrategyOptionWithRequest extends IOIDCStrategyOption {
-    passReqToCallback: boolean;
+    passReqToCallback: true;
 }
 
 export interface IOIDCStrategyOptionWithoutRequest extends IOIDCStrategyOption {

--- a/types/passport-azure-ad/passport-azure-ad-tests.ts
+++ b/types/passport-azure-ad/passport-azure-ad-tests.ts
@@ -4,7 +4,9 @@ import {
     OIDCStrategy,
     IBearerStrategyOptionWithRequest,
     IOIDCStrategyOptionWithRequest,
+    IOIDCStrategyOptionWithoutRequest,
     VerifyBearerFunctionWithReq,
+    VerifyOIDCFunction,
     VerifyOIDCFunctionWithReq,
     IProfile,
     VerifyCallback
@@ -25,6 +27,15 @@ const oidcStrategyOptions: IOIDCStrategyOptionWithRequest = {
     redirectUrl: "https://api.test.com"
 };
 
+const oidcStrategyOptionWithoutRequest: IOIDCStrategyOptionWithoutRequest = {
+    identityMetadata: "https://api.test.com",
+    clientID: "XXXXX",
+    passReqToCallback: false,
+    responseType: "id_token",
+    responseMode: "query",
+    redirectUrl: "https://api.test.com"
+};
+
 const verifyBearer: VerifyBearerFunctionWithReq = (req, token, done) => {
     if (!token.oid)
         done(null, token);
@@ -37,6 +48,14 @@ const verifyOidc: VerifyOIDCFunctionWithReq = (req: Request, profile: IProfile, 
     else done(new Error("Invalid token"));
 };
 
+const verifyOidcWithoutReq: VerifyOIDCFunction = (profile: IProfile, done: VerifyCallback) => {
+    if (!profile.oid)
+        done(null, profile);
+    else done(new Error("Invalid token"));
+};
+
 new BearerStrategy(bearerStrategyOptions, verifyBearer);
 
 new OIDCStrategy(oidcStrategyOptions, verifyOidc);
+
+new OIDCStrategy(oidcStrategyOptionWithoutRequest, verifyOidcWithoutReq);


### PR DESCRIPTION
Fixes the following compilation error:

error TS2345: Argument of type '{ allowHttpForRedirectUrl: true; clientID: string; clientSecret: string | undefined; identityMetadata: string; passReqToCallback: boolean; redirectUrl: string; responseMode: "form_post"; responseType: "code id_token"; scope: string[]; validateIssuer: false; }' is not assignable to parameter of type 'IOIDCStrategyOption'.
  Object literal may only specify known properties, and 'passReqToCallback' does not exist in type 'IOIDCStrategyOption'.

69     passReqToCallback: false,

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).


