### PR TITLE
Package @types/reactour - Set ReactElement generic type to 'any'

### DIFF
--- a/types/reactour/index.d.ts
+++ b/types/reactour/index.d.ts
@@ -273,7 +273,7 @@ export interface ArrowProps {
     inverted?: boolean;
     label?: React.ReactNode;
 }
-export function Arrow(props: ArrowProps): React.ReactElement;
+export function Arrow(props: ArrowProps): React.ReactElement<any>;
 
 export interface BadgeProps extends React.ComponentPropsWithRef<'span'> {
     accentColor?: string;
@@ -284,7 +284,7 @@ export interface CloseProps {
     onClick: React.MouseEventHandler<HTMLButtonElement>;
     className?: string;
 }
-export function Close(props: CloseProps): React.ReactElement;
+export function Close(props: CloseProps): React.ReactElement<any>;
 
 export interface ControlsProps extends React.ComponentPropsWithRef<'div'> {}
 export const Controls: React.FC<ControlsProps>;


### PR DESCRIPTION
Fix to solve a compilation issue with @types/react where ReactElement is declared as ReactElemen<P>.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
