### PR TITLE
@types/airtable fix: 'requestTimeout' is now an optional parameter

### DIFF
--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -24,7 +24,7 @@ declare global {
             apiVersion?: string;
             allowUnauthorizedSsl?: boolean;
             noRetryIfRateLimited?: boolean;
-            requestTimeout: number;
+            requestTimeout?: number;
         }
 
         interface Base {


### PR DESCRIPTION
* 'requestTimeout' is now an optional parameter