### PR TITLE
[styled-components] Omit overlapping props from the base type of wrapped components.

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -74,13 +74,10 @@ export type StyledComponentProps<
     A extends keyof any
 > = WithOptionalTheme<
     Omit<
-        OmitOverlapping<
-            ReactDefaultizedProps<
-                C,
-                React.ComponentPropsWithRef<C>
-            >,
-            O
-        > & O,
+        ReactDefaultizedProps<
+            C,
+            OmitOverlapping<React.ComponentPropsWithRef<C>, O> & O
+        >,
         A
     > & Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
     T

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -56,6 +56,13 @@ type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D; }
     ? Defaultize<P, D>
     : P;
 
+// Omit props from P that are also contained in O. Follows similar logic to Defaultize
+type OmitOverlapping<P, O> = P extends any
+    ? string extends keyof P
+        ? P
+        : Pick<P, Exclude<keyof P, keyof O>>
+    : never;
+
 export type StyledComponentProps<
     // The Component from whose props are derived
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
@@ -67,9 +74,12 @@ export type StyledComponentProps<
     A extends keyof any
 > = WithOptionalTheme<
     Omit<
-        ReactDefaultizedProps<
-            C,
-            React.ComponentPropsWithRef<C>
+        OmitOverlapping<
+            ReactDefaultizedProps<
+                C,
+                React.ComponentPropsWithRef<C>
+            >,
+            O
         > & O,
         A
     > & Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1056,3 +1056,31 @@ function unionTest() {
     <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
+
+// when a styled component defines props that overlap with its wrapped component,
+// the types conflicting props should probably be replaced by the type in the
+// wrapped component.
+function overlappedProps() {
+    type ArrayOrInstance<T> = T | T[];
+
+    interface Props {
+        color: ArrayOrInstance<string>;
+    }
+
+    function resolve<T>(rv: ArrayOrInstance<T>): T {
+        // simplified
+        if (Array.isArray(rv) && rv.length) {
+            return rv[0];
+        }
+        throw new Error("don't care");
+    }
+
+    const Box = styled.div`
+        color: ${(p: Props) => resolve(p.color)}
+    `;
+
+    const Wrapped = styled(Box)``;
+
+    // color prop type should not be merged with div's
+    <Wrapped color={["red"]}>This has children</Wrapped>;
+}

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1083,4 +1083,19 @@ function overlappedProps() {
 
     // color prop type should not be merged with div's
     <Wrapped color={["red"]}>This has children</Wrapped>;
+
+    // color should be required
+    <Wrapped>No color!</Wrapped>; // $ExpectError
+
+    // color should accept array
+    const WrappedDefaulted = styled(Box).attrs({color: ["blue"]})``;
+
+    // should not allow attrs to change type of prop
+    const WrappedDefaultedErr = styled(Box).attrs({color: 123})``; // $ExpectError
+
+    // should allow defaulted prop
+    <WrappedDefaulted>No color!</WrappedDefaulted>;
+
+    // should allow array prop
+    <WrappedDefaulted color={["green"]}>Color!</WrappedDefaulted>;
 }


### PR DESCRIPTION
Context:

We, internally, are building a UI Component Library based on Styled Components & Styled System.
Styled System leverages helper functions that accept arrays or maps of potential values and translate those to the appropriate string. This exposed the issue demonstrated in the test I've added which I've added functionality to cover: _that props that overlap with provided html attributes intersect incorrectly resulting in TS errors  but working functionality_.

I've tried to think of reasons why overlapping props should have their types merged with the base component, and couldn't think of a valid example. Nonetheless, I'm concerned that this touches the core type.