### PR TITLE
[styled-system] Update typings to v5

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -783,7 +783,7 @@ export interface GridTemplateRowsProps<TLength = TLengthStyledSystem> {
 
 export const gridTemplateRows: styleFn;
 
-export interface GridTemplatesAreasProps {
+export interface GridTemplateAreasProps {
     /**
      * The grid-template-areas CSS property specifies named grid areas.
      *

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -984,9 +984,8 @@ export const border: styleFn;
 
 export interface BoxShadowProps {
     /**
-     * The box-shadow CSS property adds shadow effects around an element's frame. You can set multiple effects
-     * separated by commas. A box shadow is described by X and Y offsets relative to the element, blur and spread
-     * radii, and color.
+     * The box-shadow CSS property adds shadow effects around an element's frame. You can set multiple effects separated
+     * by commas. A box shadow is described by X and Y offsets relative to the element, blur and spread radii and color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)
      */
@@ -994,6 +993,24 @@ export interface BoxShadowProps {
 }
 
 export const boxShadow: styleFn;
+
+export interface TextShadowProps {
+    /**
+     * The `text-shadow` CSS property adds shadows to text. It accepts a comma-separated list of shadows to be applied
+     * to the text and any of its `decorations`. Each shadow is described by some combination of X and Y offsets from
+     * the element, blur radius, and color.
+     *
+     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow)
+     */
+    textShadow?: ResponsiveValue<CSS.TextShadowProperty | number>;
+}
+
+export const textShadow: styleFn;
+
+export interface ShadowsProps
+    extends BoxShadowProps, TextShadowProps {}
+
+export const shadows: styleFn;
 
 export interface OpacityProps {
     /**

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -51,7 +51,8 @@ export interface CustomStyleDefinition {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
     property?: string;
     /** an array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
-      * assigned (overrides `property` when present). */
+      * assigned (overrides `property` when present).
+      */
     properties?: string[];
     /** A string referencing a key in the `theme` object. */
     scale?: string;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -50,9 +50,10 @@ export interface styleFn {
 export interface CustomStyleDefinition {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
     property?: string;
-    /** an array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
-      * assigned (overrides `property` when present).
-      */
+    /**
+     * An array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
+     * assigned (overrides `property` when present).
+     */
     properties?: string[];
     /** A string referencing a key in the `theme` object. */
     scale?: string;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -79,6 +79,8 @@ export interface Config {
 
 export function compose(...parsers: styleFn[]): styleFn;
 export function system(styleDefinitions: Config): styleFn;
+export function createParser(config: ConfigStyle): styleFn;
+export function createStyleFunction(args: ConfigStyle): styleFn;
 
 export interface VariantArgs {
     key?: string;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-system 4.2
+// Type definitions for styled-system 5.0
 // Project: https://github.com/jxnblk/styled-system#readme
 // Definitions by: Marshall Bowers <https://github.com/maxdeviant>
 //                 Ben McCormick <https://github.com/phobon>
@@ -13,50 +13,61 @@
 //                 Chris LoPresto <https://github.com/chrislopresto>
 //                 Pedro Duarte <https://github.com/peduarte>
 //                 Dhalton Huber <https://github.com/Dhalton>
+//                 Elliot Bonneville <https://github.com/elliotbonneville>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as CSS from "csstype";
 
-export const defaultBreakpoints: string[];
-
-export function cloneFunc(fn: (...args: any[]) => any): (...args: any[]) => any;
 export function get(obj: any, ...paths: Array<string | number>): any;
-export function themeGet(keys: string, fallback?: string): any;
-
-export function is(n: any): boolean;
-export function isObject(n: any): boolean;
-export function num(n: any): boolean;
-export function px(n: any): string;
-
-export function createMediaQuery(n: number | string): string;
-
-export interface styleFn {
-    (...args: any[]): any;
-    propTypes?: string[];
-}
 
 export type Scale = object | Array<string | number>;
 
-export interface LowLevelStylefunctionArguments<N, S> {
-  prop: string;
-  cssProperty?: string;
-  alias?: string;
-  key?: string;
-  transformValue?: (n: N, scale?: S) => any;
-  scale?: S;
+// Preserved to support v4 shim:
+// https://github.com/styled-system/styled-system/blob/master/packages/styled-system/src/index.js#L108
+export interface LowLevelStyleFunctionArguments<N, S> {
+    prop: string;
+    cssProperty?: string;
+    alias?: string;
+    key?: string;
+    transformValue?: (n: N, scale?: S) => any;
+    scale?: S;
+    // new v5 api
+    properties?: string[];
 }
 
 export function style<N = string | number, S = Scale>(
-  // tslint:disable-next-line no-unnecessary-generics
-  args: LowLevelStylefunctionArguments<N, S>
-): { [cssProp: string]: string };
+    // tslint:disable-next-line no-unnecessary-generics
+    args: LowLevelStyleFunctionArguments<N, S>
+): {
+    [cssProp: string]: string;
+};
 
-export function compose(
-    ...funcs: Array<(...args: any[]) => any>
-): (...args: any[]) => any;
+export interface styleFn {
+    (...args: any[]): any;
+}
 
-export function mapProps(mapper: (...args: any[]) => any): (func: any) => (...props: any[]) => any;
+export interface CustomStyleDefinition {
+    /** The CSS property to use in the returned style object (overridden by `properties` if present). */
+    property?: string;
+    /** an array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
+     * assigned (overrides `property` when present). */
+    properties?: string[];
+    /** A string referencing a key in the `theme` object. */
+    scale?: string;
+    /** A fallback scale object for when there isn't one defined in the `theme` object. */
+    defaultScale?: any[];
+    /** A function to transform the raw value based on the scale. */
+    transform?: (value: any, scale?: Scale) => any;
+}
+
+export interface CustomStyleDefinitions {
+    /** Property name exposed for use in components */
+    [customStyleName: string]: CustomStyleDefinition | boolean;
+}
+
+export function compose(...parsers: styleFn[]): styleFn;
+export function system(styleDefinitions: CustomStyleDefinitions): styleFn;
 
 export interface VariantArgs {
     key?: string;
@@ -67,7 +78,12 @@ export interface VariantArgs {
 export function variant(props: VariantArgs): (...args: any[]) => any;
 
 export type TLengthStyledSystem = string | 0 | number;
-export type ResponsiveValue<T> = T | Array<T | null> | { [key: string]: T };
+export type ResponsiveValue<T> =
+    | T
+    | Array<T | null>
+    | {
+          [key: string]: T;
+      };
 
 /**
  * Converts shorthand or longhand margin and padding props to margin and padding CSS declarations
@@ -100,9 +116,13 @@ export interface SpaceProps<TLength = TLengthStyledSystem> {
     /** Margin on left */
     marginLeft?: ResponsiveValue<CSS.MarginLeftProperty<TLength>>;
     /** Margin on left and right */
-    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    mx?: ResponsiveValue<CSS.MarginProperty<TLength>>;
+    /** Margin on left and right */
+    marginX?: ResponsiveValue<CSS.MarginProperty<TLength>>;
     /** Margin on top and bottom */
-    my?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    my?: ResponsiveValue<CSS.MarginProperty<TLength>>;
+    /** Margin on top and bottom */
+    marginY?: ResponsiveValue<CSS.MarginProperty<TLength>>;
     /** Padding on top, left, bottom and right */
     p?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Padding on top, left, bottom and right */
@@ -125,17 +145,39 @@ export interface SpaceProps<TLength = TLengthStyledSystem> {
     paddingLeft?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>>;
     /** Padding on left and right */
     px?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    /** Padding on left and right */
+    paddingX?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Padding on top and bottom */
     py?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+    /** Padding on top and bottom */
+    paddingY?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
 }
 
 export const space: styleFn;
 
-export interface MarginProps extends Pick<SpaceProps, 'm' | 'margin' | 'mt' | 'marginTop' | 'mb' | 'marginBottom' | 'ml' | 'marginLeft' | 'mr' | 'marginRight' | 'my' | 'mx'> {}
-export interface MarginTopProps extends Pick<SpaceProps, 'mt' | 'marginTop'> {}
-export interface MarginBottomProps extends Pick<SpaceProps, 'mb' | 'marginBottom'> {}
-export interface MarginLeftProps extends Pick<SpaceProps, 'ml' | 'marginLeft'> {}
-export interface MarginRightProps extends Pick<SpaceProps, 'mr' | 'marginRight'> {}
+export interface MarginProps
+    extends Pick<
+        SpaceProps,
+        | "m"
+        | "margin"
+        | "mt"
+        | "marginTop"
+        | "mb"
+        | "marginBottom"
+        | "ml"
+        | "marginLeft"
+        | "mr"
+        | "marginRight"
+        | "my"
+        | "mx"
+    > {}
+export interface MarginTopProps extends Pick<SpaceProps, "mt" | "marginTop"> {}
+export interface MarginBottomProps
+    extends Pick<SpaceProps, "mb" | "marginBottom"> {}
+export interface MarginLeftProps
+    extends Pick<SpaceProps, "ml" | "marginLeft"> {}
+export interface MarginRightProps
+    extends Pick<SpaceProps, "mr" | "marginRight"> {}
 
 export const margin: styleFn;
 export const marginTop: styleFn;
@@ -143,11 +185,30 @@ export const marginBottom: styleFn;
 export const marginLeft: styleFn;
 export const marginRight: styleFn;
 
-export interface PaddingProps extends Pick<SpaceProps, 'p' | 'padding' | 'pt' | 'paddingTop' | 'pb' | 'paddingBottom' | 'pl' | 'paddingLeft' | 'pr' | 'paddingRight' | 'py' | 'px'> {}
-export interface PaddingTopProps extends Pick<SpaceProps, 'pt' | 'paddingTop'> {}
-export interface PaddingBottomProps extends Pick<SpaceProps, 'pb' | 'paddingBottom'> {}
-export interface PaddingLeftProps extends Pick<SpaceProps, 'pl' | 'paddingLeft'> {}
-export interface PaddingRightProps extends Pick<SpaceProps, 'pr' | 'paddingRight'> {}
+export interface PaddingProps
+    extends Pick<
+        SpaceProps,
+        | "p"
+        | "padding"
+        | "pt"
+        | "paddingTop"
+        | "pb"
+        | "paddingBottom"
+        | "pl"
+        | "paddingLeft"
+        | "pr"
+        | "paddingRight"
+        | "py"
+        | "px"
+    > {}
+export interface PaddingTopProps
+    extends Pick<SpaceProps, "pt" | "paddingTop"> {}
+export interface PaddingBottomProps
+    extends Pick<SpaceProps, "pb" | "paddingBottom"> {}
+export interface PaddingLeftProps
+    extends Pick<SpaceProps, "pl" | "paddingLeft"> {}
+export interface PaddingRightProps
+    extends Pick<SpaceProps, "pr" | "paddingRight"> {}
 
 export const padding: styleFn;
 export const paddingTop: styleFn;
@@ -155,7 +216,11 @@ export const paddingBottom: styleFn;
 export const paddingLeft: styleFn;
 export const paddingRight: styleFn;
 
-export type ObjectOrArray<T> = T[] | { [K: string]: T | ObjectOrArray<T> };
+export type ObjectOrArray<T> =
+    | T[]
+    | {
+          [K: string]: T | ObjectOrArray<T>;
+      };
 
 export interface BaseTheme {
     breakpoints?: string[] | number[] | object;
@@ -309,6 +374,23 @@ export interface LetterSpacingProps<TLength = TLengthStyledSystem> {
     letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>>;
 }
 export const letterSpacing: styleFn;
+
+/**
+ * A convenience style group containing props related to typography such as fontFamily, fontSize, fontWeight, etc.
+ *
+ * - String values are passed as raw CSS values.
+ * - Array values are converted into responsive values.
+ */
+export interface TypographyProps
+    extends FontFamilyProps,
+        FontSizeProps,
+        FontWeightProps,
+        LineHeightProps,
+        LetterSpacingProps,
+        FontStyleProps,
+        TextAlignProps {}
+
+export const typography: styleFn;
 
 /**
  * Layout
@@ -556,6 +638,37 @@ export interface OrderProps {
 
 export const order: styleFn;
 
+export interface FlexGrowProps {
+    flexGrow?: ResponsiveValue<CSS.GlobalsNumber>;
+}
+
+export interface FlexShrinkProps {
+    flexShrink?: ResponsiveValue<CSS.GlobalsNumber>;
+}
+
+/**
+ * A convenience style group containing props related to flexbox.
+ *
+ * - String values are passed as raw CSS values.
+ * - Array values are converted into responsive values.
+ */
+export interface FlexboxProps
+    extends AlignItemsProps,
+        AlignContentProps,
+        JustifyItemsProps,
+        JustifyContentProps,
+        FlexWrapProps,
+        FlexDirectionProps,
+        FlexProps,
+        FlexGrowProps,
+        FlexShrinkProps,
+        FlexBasisProps,
+        JustifySelfProps,
+        AlignSelfProps,
+        OrderProps {}
+
+export const flexbox: styleFn;
+
 /**
  * Grid Layout
  */
@@ -709,20 +822,51 @@ export interface GridAreaProps {
 export const gridArea: styleFn;
 
 /**
+ * A convenience style group containing props related to grid.
+ *
+ * - String values are passed as raw CSS values.
+ * - Array values are converted into responsive values.
+ */
+export interface GridProps
+    extends GridGapProps,
+        GridColumnGapProps,
+        GridRowGapProps,
+        GridColumnProps,
+        GridRowProps,
+        GridAutoFlowProps,
+        GridAutoColumnsProps,
+        GridAutoRowsProps,
+        GridTemplateColumnsProps,
+        GridTemplateRowsProps,
+        GridTemplatesAreasProps,
+        GridAreaProps {}
+
+export const grid: styleFn;
+
+/**
+ * A convenience style group containing props related to layout such as width, height, and display.
+ *
+ * - For length props, Numbers from 0-4 (or the length of theme.sizes) are converted to values on the spacing scale.
+ * - For length props, Numbers greater than the length of the theme.sizes array are converted to raw pixel values.
+ * - String values are passed as raw CSS values.
+ * - Array values are converted into responsive values.
+ */
+export interface LayoutProps
+    extends WidthProps,
+        HeightProps,
+        MinWidthProps,
+        MinHeightProps,
+        MaxWidthProps,
+        MaxHeightProps,
+        DisplayProps,
+        VerticalAlignProps,
+        SizeProps {}
+
+export const layout: styleFn;
+
+/**
  * Borders
  */
-
-export interface BorderProps<TLength = TLengthStyledSystem> {
-    /**
-     * The border CSS property sets an element's border. It's a shorthand for border-width, border-style,
-     * and border-color.
-     *
-     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
-     */
-    border?: ResponsiveValue<CSS.BorderProperty<TLength>>;
-}
-
-export const border: styleFn;
 
 export interface BorderWidthProps<TLength = TLengthStyledSystem> {
     /**
@@ -830,6 +974,28 @@ export interface BordersProps
 
 export const borders: styleFn;
 
+export interface BorderProps<TLength = TLengthStyledSystem>
+    extends BorderWidthProps,
+        BorderStyleProps,
+        BorderColorProps,
+        BorderRadiusProps,
+        BorderTopProps,
+        BorderRightProps,
+        BorderBottomProps,
+        BorderLeftProps {
+    /**
+     * The border CSS property sets an element's border. It's a shorthand for border-width, border-style,
+     * and border-color.
+     *
+     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
+     */
+    border?: ResponsiveValue<CSS.BorderProperty<TLength>>;
+    borderX?: ResponsiveValue<CSS.BorderProperty<TLength>>;
+    borderY?: ResponsiveValue<CSS.BorderProperty<TLength>>;
+}
+
+export const border: styleFn;
+
 export interface BoxShadowProps {
     /**
      * The box-shadow CSS property adds shadow effects around an element's frame. You can set multiple effects
@@ -869,18 +1035,6 @@ export const overflow: styleFn;
 /**
  * Background
  */
-
-export interface BackgroundProps<TLength = TLengthStyledSystem> {
-    /**
-     * The background shorthand CSS property sets all background style properties at once,
-     * such as color, image, origin and size, repeat method, and others.
-     *
-     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
-     */
-    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
-}
-
-export const background: styleFn;
 
 export interface BackgroundImageProps {
     /**
@@ -931,21 +1085,25 @@ export interface BackgroundRepeatProps {
 
 export const backgroundRepeat: styleFn;
 
+export interface BackgroundProps<TLength = TLengthStyledSystem>
+    extends BackgroundImageProps,
+        BackgroundSizeProps,
+        BackgroundPositionProps,
+        BackgroundRepeatProps {
+    /**
+     * The background shorthand CSS property sets all background style properties at once,
+     * such as color, image, origin and size, repeat method, and others.
+     *
+     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
+     */
+    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
+}
+
+export const background: styleFn;
+
 /**
  * Position
  */
-
-export interface PositionProps {
-    /**
-     * The position CSS property specifies how an element is positioned in a document.
-     * The top, right, bottom, and left properties determine the final location of positioned elements.
-     *
-     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
-     */
-    position?: ResponsiveValue<CSS.PositionProperty>;
-}
-
-export const position: styleFn;
 
 export interface ZIndexProps {
     /**
@@ -1006,6 +1164,23 @@ export interface LeftProps<TLength = TLengthStyledSystem> {
 }
 
 export const left: styleFn;
+
+export interface PositionProps
+    extends ZIndexProps,
+        TopProps,
+        RightProps,
+        BottomProps,
+        LeftProps {
+    /**
+     * The position CSS property specifies how an element is positioned in a document.
+     * The top, right, bottom, and left properties determine the final location of positioned elements.
+     *
+     * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+     */
+    position?: ResponsiveValue<CSS.PositionProperty>;
+}
+
+export const position: styleFn;
 
 export interface ButtonStyleProps {
     variant?: ResponsiveValue<string>;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -824,7 +824,7 @@ export interface GridProps
         GridAutoRowsProps,
         GridTemplateColumnsProps,
         GridTemplateRowsProps,
-        GridTemplatesAreasProps,
+        GridTemplateAreasProps,
         GridAreaProps {}
 
 export const grid: styleFn;

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -51,7 +51,7 @@ export interface CustomStyleDefinition {
     /** The CSS property to use in the returned style object (overridden by `properties` if present). */
     property?: string;
     /** an array of multiple properties (e.g. `['marginLeft', 'marginRight']`) to which this style's value will be
-     * assigned (overrides `property` when present). */
+      * assigned (overrides `property` when present). */
     properties?: string[];
     /** A string referencing a key in the `theme` object. */
     scale?: string;

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -9,8 +9,6 @@ import {
     BorderProps,
     borders,
     BordersProps,
-    boxShadow,
-    BoxShadowProps,
     buttonStyle,
     ButtonStyleProps,
     color,
@@ -38,6 +36,8 @@ import {
     FlexboxProps,
     grid,
     GridProps,
+    shadows,
+    ShadowsProps,
 } from "styled-system";
 
 // tslint:disable-next-line:strict-export-declare-modifiers
@@ -56,7 +56,7 @@ interface BoxProps
         BackgroundProps,
         BorderProps,
         BordersProps,
-        BoxShadowProps,
+        ShadowsProps,
         TypographyProps,
         ColorStyleProps,
         ColorProps {
@@ -75,7 +75,7 @@ const boxStyles = compose(
     background,
     borders,
     position,
-    boxShadow,
+    shadows,
     colorStyle,
     boxStyle,
 );
@@ -180,6 +180,10 @@ const test = () => (
         and up
         <Box width={[1, 1 / 2]} />
         <Box width={{ sm: 1, md: 1 / 2 }} />
+        <Box boxShadow="1px 1px 1px black" />
+        <Box boxShadow={{ sm: "1px 1px 1px black", md: "2px 2px 2px black" }} />
+        <Box textShadow="1px 1px 1px black" />
+        <Box textShadow={{ sm: "1px 1px 1px black", md: "2px 2px 2px black" }} />
         // examples // font-size of `theme.fontSizes[3]`
         <Text fontSize={3} />
         // font-size `32px`

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -303,6 +303,10 @@ const test = () => (
         <Grid gridTemplateColumns="auto" />
         <Grid gridTemplateColumns={["auto", "1fr"]} />
         <Grid gridTemplateColumns={{ sm: "auto", md: "1fr" }} />
+        // gridTemplateAreas
+        <Grid gridTemplateAreas="a a a" />
+        <Grid gridTemplateAreas={["a a a", "b b b"]} />
+        <Grid gridTemplateAreas={{ sm: "a a a", md: "b b b"}} />
         // flex (responsive)
         <Box flex="1 1 auto" />
         <Box flex={["1 1 auto"]} />

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -196,7 +196,7 @@ const test = () => (
         `theme.colors['gray'][0]`
         <Box color="gray.0" />
         // raw CSS color value
-        <Box color="#f00" />
+        <Box color="#00f" />
         // fontFamily
         <Text fontFamily="mono" />
         // textAlign (responsive)
@@ -425,14 +425,8 @@ export const themeA: Theme = {
     },
     fontWeights: [100, 400, 700],
     fontSizes: [12, 14, 16],
-    heights: [0, '50vh', '100vh'],
     letterSpacings: [-1, 1, 3],
     lineHeights: [1, 1.25, 2],
-    maxHeights: ['50vh', '100vh'],
-    maxWidths: ['50%', '100%'],
-    minHeights: ['50vh', '100vh'],
-    minWidths: ['50%', '100%'],
-    opacity: [0, 0.25, 0.5, 0.75],
     radii: [0, 3, 9],
     shadows: ['1 1 3px -1 gray', '1 2 6px -1 gray'],
     sizes: [0, '33%', '50%', '100%'],
@@ -443,7 +437,13 @@ export const themeA: Theme = {
             letterSpacing: '0.2em'
         }
     },
-    zIndeces: [-1, 0, 1, 9999]
+    zIndices: [-1, 0, 1, 9999]
+};
+
+themeA.mediaQueries = {
+    small: '@media screen and (min-width: 32em)',
+    medium: '@media screen and (min-width: 64em)',
+    large: '@media screen and (min-width: 96em)',
 };
 
 // Some properties can be formatted differently
@@ -505,3 +505,6 @@ const buttonSizeWithGeneric = style<keyof typeof buttonSizes, typeof buttonSizes
     cssProperty: 'font-size',
     transformValue: (size, sizes) => sizes && sizes[size]
 });
+
+// Test that we can read `propNames` from `styleFn`
+const spacePropNames = space.propNames;

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -1,37 +1,14 @@
 import * as React from "react";
 import {
-    alignContent,
-    AlignContentProps,
-    alignItems,
-    AlignItemsProps,
-    alignSelf,
-    AlignSelfProps,
+    compose,
+    system,
+    get,
     background,
-    backgroundColor,
-    BackgroundColorProps,
-    backgroundImage,
-    BackgroundImageProps,
-    backgroundPosition,
-    BackgroundPositionProps,
     BackgroundProps,
-    backgroundRepeat,
-    BackgroundRepeatProps,
-    backgroundSize,
-    BackgroundSizeProps,
     border,
-    borderBottom,
-    borderColor,
-    BorderColorProps,
-    borderLeft,
     BorderProps,
-    borderRadius,
-    BorderRadiusProps,
-    borderRight,
     borders,
     BordersProps,
-    borderTop,
-    bottom,
-    BottomProps,
     boxShadow,
     BoxShadowProps,
     buttonStyle,
@@ -40,115 +17,31 @@ import {
     ColorProps,
     colorStyle,
     ColorStyleProps,
-    compose,
     display,
-    DisplayProps,
-    flex,
-    flexBasis,
-    FlexBasisProps,
-    flexDirection,
-    FlexDirectionProps,
-    FlexProps,
-    flexWrap,
-    FlexWrapProps,
-    fontFamily,
-    FontFamilyProps,
-    fontSize,
-    FontSizeProps,
-    fontWeight,
-    FontWeightProps,
-    get,
-    gridAutoColumns,
-    GridAutoColumnsProps,
-    gridAutoFlow,
-    GridAutoFlowProps,
-    gridAutoRows,
-    GridAutoRowsProps,
-    gridColumn,
-    gridColumnGap,
-    GridColumnGapProps,
-    GridColumnProps,
-    gridGap,
-    GridGapProps,
-    gridRow,
-    gridRowGap,
-    GridRowGapProps,
-    GridRowProps,
-    gridTemplateColumns,
-    GridTemplateColumnsProps,
-    gridTemplateRows,
-    GridTemplateRowsProps,
-    height,
-    HeightProps,
-    is,
-    justifyContent,
-    JustifyContentProps,
-    justifyItems,
-    JustifyItemsProps,
-    justifySelf,
-    JustifySelfProps,
-    left,
-    LeftProps,
-    letterSpacing,
-    LetterSpacingProps,
-    lineHeight,
-    LineHeightProps,
-    mapProps,
     margin,
-    marginBottom,
-    marginLeft,
     MarginProps,
-    marginRight,
-    marginTop,
-    maxHeight,
-    MaxHeightProps,
-    maxWidth,
-    MaxWidthProps,
-    minHeight,
-    MinHeightProps,
-    minWidth,
-    MinWidthProps,
     padding,
     PaddingProps,
     position,
     PositionProps,
-    right,
-    RightProps,
-    size,
-    SizeProps,
     space,
     SpaceProps,
     style,
-    textAlign,
-    TextAlignProps,
-    TextColorProps,
-    textStyle,
-    TextStyleProps,
-    top,
-    TopProps,
     variant,
-    VariantArgs,
-    verticalAlign,
-    VerticalAlignProps,
-    width,
-    WidthProps,
-    zIndex,
-    ZIndexProps,
-    px,
-    createMediaQuery,
     styles,
-    themeGet,
     Theme,
+    layout,
+    LayoutProps,
+    typography,
+    TypographyProps,
+    flexbox,
+    FlexboxProps,
+    grid,
+    GridProps,
 } from "styled-system";
 
 // tslint:disable-next-line:strict-export-declare-modifiers
 declare const styled: (...props: any[]) => React.ComponentType;
-
-const breakpoints = [480, 960];
-
-const breakpointsPx = breakpoints.map(px);
-
-const mediaQueries = breakpoints.map(createMediaQuery);
 
 const boxStyle = variant({
     prop: 'boxStyle',
@@ -156,161 +49,60 @@ const boxStyle = variant({
 });
 
 interface BoxProps
-    extends AlignSelfProps,
-        BackgroundColorProps,
-        BackgroundImageProps,
-        BackgroundPositionProps,
+    extends SpaceProps,
+        LayoutProps,
+        FlexboxProps,
+        PositionProps,
         BackgroundProps,
-        BackgroundRepeatProps,
-        BackgroundSizeProps,
-        BorderColorProps,
         BorderProps,
         BordersProps,
-        BottomProps,
         BoxShadowProps,
-        ColorProps,
+        TypographyProps,
         ColorStyleProps,
-        DisplayProps,
-        FlexProps,
-        FontSizeProps,
-        HeightProps,
-        JustifySelfProps,
-        LeftProps,
-        MaxHeightProps,
-        MaxWidthProps,
-        MinHeightProps,
-        MinWidthProps,
-        PositionProps,
-        RightProps,
-        SizeProps,
-        SpaceProps,
-        TextStyleProps,
-        TopProps,
-        WidthProps,
-        ZIndexProps,
-        VerticalAlignProps {
+        ColorProps {
             boxStyle?: string;
         }
-const Box: React.ComponentType<BoxProps> = styled`
-  border-radius: ${themeGet("radii.small", "4px")};
-  ${space}
-  ${width}
-  ${fontSize}
-  ${color}
-  ${display}
-  ${background}
-  ${maxWidth}
-  ${minWidth}
-  ${height}
-  ${maxHeight}
-  ${minHeight}
-  ${size}
-  ${borderColor}
-  ${flex}
-  ${justifySelf}
-  ${alignSelf}
-  ${borders}
-  ${position}
-  ${zIndex}
-  ${top}
-  ${bottom}
-  ${left}
-  ${right}
-  ${boxShadow}
-  ${backgroundImage}
-  ${backgroundPosition}
-  ${backgroundRepeat}
-  ${backgroundSize}
-  ${alignContent}
-  ${alignItems}
-  ${backgroundColor}
-  ${backgroundImage}
-  ${textStyle}
-  ${colorStyle}
-  ${verticalAlign}
-`;
+
+const boxStyles = compose(
+    space,
+    layout,
+    typography,
+    flexbox,
+    border,
+    background,
+    color,
+    display,
+    background,
+    borders,
+    position,
+    boxShadow,
+    colorStyle,
+    boxStyle,
+);
+
+const Box: React.ComponentType<BoxProps> = styled(boxStyles);
 
 Box.defaultProps = {
     boxStyle: 'normal',
 };
 
-interface TextProps
-    extends FontSizeProps,
-        FontFamilyProps,
-        TextAlignProps,
-        LineHeightProps,
-        FontWeightProps,
-        LetterSpacingProps {}
-const Text: React.ComponentType<TextProps> = styled`
-    ${fontSize};
-    ${fontFamily};
-    ${textAlign};
-    ${lineHeight};
-    ${fontWeight};
-    ${letterSpacing};
-`;
-
-interface FlexComponentProps
-    extends AlignItemsProps,
-        AlignContentProps,
-        JustifyContentProps,
-        FlexWrapProps,
-        FlexBasisProps,
-        FlexDirectionProps,
-        JustifyItemsProps {}
-const Flex: React.ComponentType<FlexComponentProps> = styled`
-    ${alignItems};
-    ${alignContent};
-    ${justifyContent};
-    ${flexWrap};
-    ${flexBasis};
-    ${flexDirection};
-    ${justifyItems};
-`;
-
-interface GridComponentProps
-    extends GridGapProps,
-        GridRowGapProps,
-        GridColumnGapProps,
-        GridRowProps,
-        GridColumnProps,
-        GridAutoFlowProps,
-        GridAutoColumnsProps,
-        GridAutoRowsProps,
-        GridTemplateRowsProps,
-        GridTemplateColumnsProps {}
-const Grid: React.ComponentType<GridComponentProps> = styled`
-    ${gridGap};
-    ${gridRowGap};
-    ${gridColumnGap};
-    ${gridRow};
-    ${gridColumn};
-    ${gridAutoFlow};
-    ${gridAutoRows};
-    ${gridAutoColumns};
-    ${gridTemplateRows};
-    ${gridTemplateColumns};
-`;
+const Text: React.ComponentType<TypographyProps> = styled(typography);
+const Flex: React.ComponentType<FlexboxProps> = styled(flexbox);
+const Grid: React.ComponentType<GridProps> = styled(grid);
 
 interface ButtonProps
     extends SpaceProps,
         ButtonStyleProps,
-        TextColorProps {}
+        ColorProps {}
 
-const TestButton: React.ComponentType<ButtonProps> = styled`
-    ${buttonStyle}
-    ${space}
-    ${styles.textColor}
-`;
+const testButtonStyles = compose(buttonStyle, space, styles.textColor);
+const TestButton: React.ComponentType<ButtonProps> = styled(testButtonStyles);
 
 interface SpacerProps
     extends MarginProps,
         PaddingProps {}
 
-const Spacer: React.ComponentType<SpacerProps> = styled`
-    ${margin};
-    ${padding};
-`;
+const Spacer: React.ComponentType<SpacerProps> = styled(compose(margin, padding));
 
 const test = () => (
     <div>
@@ -347,6 +139,8 @@ const test = () => (
         <Box marginRight={[1, 2, 3]} />
         <Box marginTop={[1, 2, 3]} />
         <Box marginBottom={[1, 2, 3]} />
+        <Box marginX={[1, 2, 3]} />
+        <Box marginY={[1, 2, 3]} />
         // responsive padding
         <Box p={[1, 2, 3]} />
         <Box pl={[1, 2, 3]} />
@@ -360,6 +154,8 @@ const test = () => (
         <Box paddingRight={[1, 2, 3]} />
         <Box paddingTop={[1, 2, 3]} />
         <Box paddingBottom={[1, 2, 3]} />
+        <Box paddingX={[1, 2, 3]} />
+        <Box paddingY={[1, 2, 3]} />
         <Box p={{ sm: 1, md: 2, lg: 3 }} />
         // examples (margin prop) // sets margin value of `theme.space[2]`
         <Box m={2} />
@@ -560,13 +356,16 @@ const test = () => (
         <Box borderRight="1px solid red" />
         <Box borderBottom="1px solid red" />
         <Box borderLeft="1px solid red" />
+        <Box borderX="1px solid red" />
+        <Box borderY="1px solid red" />
         // borders (responsive)
         <Box border={["1px solid red", "2px solid red"]} />
         <Box borderTop={["1px solid red", "2px solid red"]} />
         <Box borderRight={["1px solid red", "2px solid red"]} />
         <Box borderBottom={["1px solid red", "2px solid red"]} />
         <Box borderLeft={["1px solid red", "2px solid red"]} />
-
+        <Box borderX={["1px solid red", "2px solid red"]} />
+        <Box borderY={["1px solid red", "2px solid red"]} />
         <TestButton variant="primary" m={2} color="tomato" />
 
         <Spacer m={[1, 2, 3]} p={[1, 2, 3]} />
@@ -665,33 +464,25 @@ export const themeC: Theme = {
     },
 };
 
-// Test that the mapProps definition is correct.
-// https://github.com/styled-system/styled-system/blob/master/src/index.js#L149
-const margins = mapProps(props => ({
-    ...props,
-    mt: is(props.my) ? props.my : props.mt,
-    mb: is(props.my) ? props.my : props.mb,
-    ml: is(props.mx) ? props.mx : props.ml,
-    mr: is(props.mx) ? props.mx : props.mr,
-}))(
-    compose(
-      margin,
-      marginTop,
-      marginBottom,
-      marginLeft,
-      marginRight
-    )
-  );
-
 // Test that the style definition is correct.
-// https://github.com/styled-system/styled-system/blob/master/src/index.js#L62
+// https://github.com/styled-system/styled-system/blob/master/packages/styled-system/src/index.js#L108
 const customFontSize = style({
     prop: 'fontSize',
     cssProperty: 'fontSize',
     alias: 'fs',
     key: 'fontSizes',
-    transformValue: (n, scale) => px(get(scale, n)),
+    transformValue: (n, scale) => `${(get(scale, n))}px`,
     scale: [8, 16, 32]
+});
+
+// Test that the system definition is correct.
+// https://github.com/styled-system/styled-system/blob/master/packages/core/src/index.js#L131
+const customFontStyles = system({
+    fontWeight: {
+        property: "fontWeight",
+        scale: "fontWeights",
+    },
+    letterSpacing: true,
 });
 
 const centerWithGenerics = style<boolean>({
@@ -711,68 +502,3 @@ const buttonSizeWithGeneric = style<keyof typeof buttonSizes, typeof buttonSizes
     cssProperty: 'font-size',
     transformValue: (size, sizes) => sizes && sizes[size]
 });
-
-// All Style Functions contain `propTypes`
-export const alignContentPropTypes = alignContent.propTypes;
-export const alignItemsPropTypes = alignItems.propTypes;
-export const alignSelfPropTypes = alignSelf.propTypes;
-export const backgroundPropTypes = background.propTypes;
-export const backgroundColorPropTypes = backgroundColor.propTypes;
-export const backgroundImagePropTypes = backgroundImage.propTypes;
-export const backgroundPositionPropTypes = backgroundPosition.propTypes;
-export const backgroundRepeatPropTypes = backgroundRepeat.propTypes;
-export const backgroundSizePropTypes = backgroundSize.propTypes;
-export const borderPropTypes = border.propTypes;
-export const borderBottomPropTypes = borderBottom.propTypes;
-export const borderColorPropTypes = borderColor.propTypes;
-export const borderLeftPropTypes = borderLeft.propTypes;
-export const borderRadiusPropTypes = borderRadius.propTypes;
-export const borderRightPropTypes = borderRight.propTypes;
-export const bordersPropTypes = borders.propTypes;
-export const borderTopPropTypes = borderTop.propTypes;
-export const bottomPropTypes = bottom.propTypes;
-export const boxShadowPropTypes = boxShadow.propTypes;
-export const buttonStylePropTypes = buttonStyle.propTypes;
-export const colorPropTypes = color.propTypes;
-export const colorStylePropTypes = colorStyle.propTypes;
-export const displayPropTypes = display.propTypes;
-export const flexPropTypes = flex.propTypes;
-export const flexBasisPropTypes = flexBasis.propTypes;
-export const flexDirectionPropTypes = flexDirection.propTypes;
-export const flexWrapPropTypes = flexWrap.propTypes;
-export const fontFamilyPropTypes = fontFamily.propTypes;
-export const fontSizePropTypes = fontSize.propTypes;
-export const fontWeightPropTypes = fontWeight.propTypes;
-export const gridAutoColumnsPropTypes = gridAutoColumns.propTypes;
-export const gridAutoFlowPropTypes = gridAutoFlow.propTypes;
-export const gridAutoRowsPropTypes = gridAutoRows.propTypes;
-export const gridColumnPropTypes = gridColumn.propTypes;
-export const gridColumnGapPropTypes = gridColumnGap.propTypes;
-export const gridGapPropTypes = gridGap.propTypes;
-export const gridRowPropTypes = gridRow.propTypes;
-export const gridRowGapPropTypes = gridRowGap.propTypes;
-export const gridTemplateColumnsPropTypes = gridTemplateColumns.propTypes;
-export const gridTemplateRowsPropTypes = gridTemplateRows.propTypes;
-export const heightPropTypes = height.propTypes;
-export const justifyContentPropTypes = justifyContent.propTypes;
-export const justifyItemsPropTypes = justifyItems.propTypes;
-export const justifySelfPropTypes = justifySelf.propTypes;
-export const leftPropTypes = left.propTypes;
-export const letterSpacingPropTypes = letterSpacing.propTypes;
-export const lineHeightPropTypes = lineHeight.propTypes;
-export const marginPropTypes = margin.propTypes;
-export const maxHeightPropTypes = maxHeight.propTypes;
-export const maxWidthPropTypes = maxWidth.propTypes;
-export const minHeightPropTypes = minHeight.propTypes;
-export const minWidthPropTypes = minWidth.propTypes;
-export const paddingPropTypes = padding.propTypes;
-export const positionPropTypes = position.propTypes;
-export const rightPropTypes = right.propTypes;
-export const sizePropTypes = size.propTypes;
-export const spacePropTypes = space.propTypes;
-export const textAlignPropTypes = textAlign.propTypes;
-export const textStylePropTypes = textStyle.propTypes;
-export const topPropTypes = top.propTypes;
-export const verticalAlignPropTypes = verticalAlign.propTypes;
-export const widthPropTypes = width.propTypes;
-export const zIndexPropTypes = zIndex.propTypes;

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -480,7 +480,10 @@ const customFontSize = style({
 const customFontStyles = system({
     fontWeight: {
         property: "fontWeight",
+        properties: ["fontWeight"],
         scale: "fontWeights",
+        defaultScale: [200, 400, 600],
+        transform: (n, scale) => get(scale, n),
     },
     letterSpacing: true,
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-system.com/guides/migrating
- [x] Increase the version number in the header if appropriate.

## Update notes

I'm relatively new to TypeScript, so the `system` and `compose` typings may not be totally correct. I tried to make sure they were accurate, but they would certainly benefit from a more experienced eye. In particular, both functions accept and return `styleFn`, which just accepts and returns `any` values. This seems necessary to allow `styled-system` to be slurped up by the flavor-of-the-day CSS-in-JS library, but I would be much happier with stricter typings.

### Testing

With the introduction of groupings by category for built in style functions, testing becomes much simpler. We can simply import the typings for each category (which in turn contain the individual style function typings) and test on those instead. I think this should be fine, but let me know if it isn't and we can revert to the more verbose style.

### New typings

I added `paddingX`, `paddingY`, `marginX`, and `marginY` typings to the `SpaceProps` interface. I'm not sure if these were introduced in v5 or if there was a reason for not including them in previous version, but happy to remove these if needed.

I also added `borderX` and `borderY` typings to the `BorderProps` interface.

Finally, I introduced `FlexGrowProps` and `FlexShrinkProps` interfaces, which did not previously exist but are used in the new `flexbox` style functions category.