### PR TITLE
Add types for the "npm-which" module

### DIFF
--- a/types/npm-which/index.d.ts
+++ b/types/npm-which/index.d.ts
@@ -1,0 +1,176 @@
+// Type definitions for npm-which 3.0
+// Project: https://github.com/timoxley/npm-which
+// Definitions by: Manuel Thalmann <https://github.com/manuth>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import "node";
+
+/**
+ * Provides options for the `npmwhich`-module.
+ */
+interface NpmWhichOptions {
+    /**
+     * The environment to use for resolving the binary.
+     */
+    env?: NodeJS.ProcessEnv;
+
+    /**
+     * The directory to find the binary for.
+     */
+    cwd?: string;
+}
+
+/**
+ * Provides options for the `npmwhich`-module.
+ */
+interface StaticWhichOptions {
+    /**
+     * The environment to use for resolving the binary.
+     */
+    env?: NodeJS.ProcessEnv;
+
+    /**
+     * The directory to find the binary for.
+     */
+    cwd: string;
+}
+
+/**
+ * Represents a callback for handling the result of `NpmWhich`.
+ */
+interface NpmWhichCallback {
+    /**
+     * Handles the result of `NpmWhich`.
+     *
+     * @param error
+     * The error-message.
+     *
+     * @param result
+     * The result.
+     */
+    (error: string, result: string): void;
+}
+
+/**
+ * Represents a basic interface for `npm-which`.
+ */
+interface WhichBase<TOptions> {
+    /**
+     * Creates a searcher for the specified command.
+     *
+     * @param cmd
+     * The command to look for.
+     *
+     * @param options
+     * The default options.
+     *
+     * @return
+     * A searcher for the specified command.
+     */
+    (cmd: string, options?: TOptions): InnerWhich;
+
+    /**
+     * Searches for the specified command.
+     *
+     * @param cmd
+     * The command to look for.
+     *
+     * @param callback
+     * A callback for handling the result.
+     */
+    (cmd: string, callback: NpmWhichCallback): void;
+
+    /**
+     * Searches for the specified command.
+     *
+     * @param cmd
+     * The command to look for.
+     *
+     * @param options
+     * The options for searching the command.
+     *
+     * @param callback
+     * A callback for handling the result.
+     */
+    (cmd: string, options: TOptions, callback: NpmWhichCallback): void;
+}
+
+/**
+ * Represents the static instance of `npm-which`.
+ */
+interface StaticWhich extends WhichBase<StaticWhichOptions> {
+    /**
+     * Initializes an `NpmWhich`-instance for the specified working-directory.
+     *
+     * @param cwd
+     * The working-directory to browse.
+     */
+    (cwd?: string): NpmWhich;
+
+    /**
+     * Searches for the specified command.
+     *
+     * @param cmd
+     * The command to look for.
+     *
+     * @param options
+     * The options for searching the command.
+     */
+    sync(cmd: string, options: StaticWhichOptions): string;
+}
+
+/**
+ * Provides the functionality to search for a command.
+ */
+interface NpmWhich extends WhichBase<NpmWhichOptions> {
+    /**
+     * Searches for the specified command.
+     *
+     * @param cmd
+     * The command to look for.
+     *
+     * @param options
+     * The options for searching the command.
+     */
+    sync(cmd: string, options?: StaticWhichOptions): string;
+}
+
+interface InnerWhich {
+    /**
+     * Creates a searcher for the specified command.
+     *
+     * @param options
+     * The options for searching the command.
+     */
+    (options?: NpmWhichOptions): InnerWhich;
+
+    /**
+     * Searches for the command.
+     *
+     * @param callback
+     * A callback for handling the result.
+     */
+    (callback: NpmWhichCallback): void;
+
+    /**
+     * Searches for the command.
+     *
+     * @param options
+     * The options for searching the command.
+     *
+     * @param callback
+     * A callback for handling the result.
+     */
+    (options: NpmWhichOptions, callback: NpmWhichCallback): void;
+
+    /**
+     * Searches for the command.
+     *
+     * @param options
+     * The options for searching the command.
+     */
+    sync(options?: NpmWhichOptions): string;
+}
+
+declare let npmWhich: StaticWhich;
+export = npmWhich;

--- a/types/npm-which/npm-which-tests.ts
+++ b/types/npm-which/npm-which-tests.ts
@@ -1,0 +1,25 @@
+import npmWhich = require("npm-which");
+
+const which = npmWhich("");
+// $ExpectError
+npmWhich("", { });
+npmWhich("", { cwd: "" });
+npmWhich(
+    "",
+    { cwd: "" },
+    (error, result) => {
+        // $ExpectType string
+        error;
+        // $ExpectType string
+        result;
+    });
+// $ExpectError
+npmWhich.sync("", { });
+npmWhich.sync("", { cwd: "" });
+which("", () => null);
+which("", { cwd: "" }, () => null);
+which.sync("");
+const innerWhich = which("");
+innerWhich({});
+innerWhich({}, () => null);
+innerWhich.sync({});

--- a/types/npm-which/tsconfig.json
+++ b/types/npm-which/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "npm-which-tests.ts"
+    ]
+}

--- a/types/npm-which/tslint.json
+++ b/types/npm-which/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.