### PR TITLE
fix(jest): The `mock` function `factory` argument is a callback

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Jest 24.0
-// Project: https://jestjs.io
-// Definitions by: Asana <https://asana.com>
+// Project: https://jestjs.io/
+// Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
 //                 jwbay <https://github.com/jwbay>
 //                 Alexey Svetliakov <https://github.com/asvetliakov>
@@ -20,6 +20,7 @@
 //                 Antoine Brault <https://github.com/antoinebrault>
 //                 Jeroen Claassens <https://github.com/favna>
 //                 Gregor Stamać <https://github.com/gstamac>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -106,7 +107,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function doMock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
+    function doMock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
     /**
      * Indicates that the module system should never return a mocked version
      * of the specified module from require() (e.g. that it should always return the real module).
@@ -135,7 +136,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function mock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
+    function mock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.

--- a/types/jest/tslint.json
+++ b/types/jest/tslint.json
@@ -2,10 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         // TODOs
-        "dt-header": false,
-        "npm-naming": false,
         "no-mergeable-namespace": false,
-        "no-void-expression": false,
         "no-unnecessary-generics": false
     }
 }

--- a/types/jest/v16/index.d.ts
+++ b/types/jest/v16/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for Jest 16.0.0
+// Type definitions for Jest 16.0
 // Project: http://facebook.github.io/jest/
-// Definitions by: Asana <https://asana.com>, Ivo Stratev <https://github.com/NoHomey>, jwbay <https://github.com/jwbay>
+// Definitions by: Asana (https://asana.com)
+//                 Ivo Stratev <https://github.com/NoHomey>
+//                 jwbay <https://github.com/jwbay>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var beforeAll: jest.Lifecycle;
@@ -40,7 +43,7 @@ declare namespace jest {
     /** Disables automatic mocking in the module loader. */
     function disableAutomock(): typeof jest;
     /** Mocks a module with an auto-mocked version when it is being required. */
-    function doMock(moduleName: string): typeof jest;
+    function doMock(moduleName: string, factory?: () => any, options?: MockOptions): typeof jest;
     /** Indicates that the module system should never return a mocked version of the specified module from require() (e.g. that it should always return the real module). */
     function dontMock(moduleName: string): typeof jest;
     /** Enables automatic mocking in the module loader. */
@@ -52,7 +55,7 @@ declare namespace jest {
     /** Returns whether the given function is a mock function. */
     function isMockFunction(fn: any): fn is Mock<any>;
     /** Mocks a module with an auto-mocked version when it is being required. */
-    function mock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
+    function mock(moduleName: string, factory?: () => any, options?: MockOptions): typeof jest;
     /** Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests. */
     function resetModuleRegistry(): typeof jest;
     /** Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests. */

--- a/types/jest/v16/tslint.json
+++ b/types/jest/v16/tslint.json
@@ -7,7 +7,6 @@
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,
-        "dt-header": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options>
  - <https://jestjs.io/docs/en/jest-object#jestdomockmodulename-factory-options>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This applies to **Jest 16** as well, all the way back to **Jest 11**, which introduced `jest.mock(…)` and `jest.doMock(…)`.

I also cleaned up `tslint.json` by removing rules that are no longer being violated.