### PR TITLE
@types/react-test-renderer fix: children type of JSON output

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -17,8 +17,9 @@ import { ReactElement, ReactType } from "react";
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | ReactTestRendererJSON[];
+    children: null | ReactTestRendererNode[];
 }
+export type ReactTestRendererNode = ReactTestRendererJSON | string;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
     nodeType: "component" | "host";
     instance: any;


### PR DESCRIPTION
ReactTestRendererJSON interface did not match the flow type. 

https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js#L39

The `children` attribute is now an array of `ReactTestRendererJSON | string` or null.