### PR TITLE
added definitions for postcss-load-config

### DIFF
--- a/types/postcss-load-config/index.d.ts
+++ b/types/postcss-load-config/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for postcss-load-config 2.0
+// Project: https://github.com/michael-ciniawsky/postcss-load-config#readme
+// Definitions by: Bob Matcuk <https://github.com/bmatcuk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { Parser, Plugin, ProcessOptions, Processor, Stringifier, Syntax, Transformer } from "postcss";
+import cosmiconfig = require("cosmiconfig");
+
+// In the ConfigContext, these three options can be instances of the
+// appropriate class, or strings. If they are strings, postcss-load-config will
+// require() them and pass the instances along.
+interface ProcessOptionsPreload {
+    parser?: string | ProcessOptions['parser'];
+    stringifier?: string | ProcessOptions['stringifier'];
+    syntax?: string | ProcessOptions['syntax'];
+}
+
+// The remaining ProcessOptions, sans the three above.
+type RemainingProcessOptions =
+    Pick<ProcessOptions, Exclude<keyof ProcessOptions, keyof ProcessOptionsPreload>>;
+
+// Additional context options that postcss-load-config understands.
+interface Context {
+    cwd?: string;
+    env?: string;
+}
+
+// The full shape of the ConfigContext.
+type ConfigContext = Context & ProcessOptionsPreload & RemainingProcessOptions;
+
+// Result of postcssrc is a Promise containing the filename plus the options
+// and plugins that are ready to pass on to postcss.
+type ResultPlugin = Plugin<any> | Transformer | Processor;
+interface Result {
+    file: string;
+    options: ProcessOptions;
+    plugins: ResultPlugin[];
+}
+
+declare function postcssrc(ctx?: ConfigContext, path?: string, options?: cosmiconfig.ExplorerOptions): Promise<Result>;
+
+declare namespace postcssrc {
+    function sync(ctx?: ConfigContext, path?: string, options?: cosmiconfig.ExplorerOptions): Result;
+}
+
+export = postcssrc;

--- a/types/postcss-load-config/package.json
+++ b/types/postcss-load-config/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^7.0.0"
+    }
+}

--- a/types/postcss-load-config/postcss-load-config-tests.ts
+++ b/types/postcss-load-config/postcss-load-config-tests.ts
@@ -1,0 +1,11 @@
+import postcss = require("postcss");
+import postcssrc = require("postcss-load-config");
+
+postcssrc();
+postcssrc({ map: { inline: true } });
+postcssrc({ env: 'development' }, 'path');
+postcssrc({ from: 'from', to: 'to' }, 'path', { cache: true }).then(({ options, plugins }) => {
+    postcss(plugins).process('css', options);
+});
+
+postcssrc.sync({ parser: 'my-parser' }, 'path', { cache: true });

--- a/types/postcss-load-config/tsconfig.json
+++ b/types/postcss-load-config/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-load-config-tests.ts"
+    ]
+}

--- a/types/postcss-load-config/tslint.json
+++ b/types/postcss-load-config/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR depends on [adding @types/cosmiconfig to dependenciesWhitelist.txt](https://github.com/microsoft/types-publisher/pull/621)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.