### PR TITLE
[react-elemental] Fix Image component imgStyle typing

### DIFF
--- a/types/react-elemental/index.d.ts
+++ b/types/react-elemental/index.d.ts
@@ -78,7 +78,7 @@ export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
     readonly lazy?: boolean;
     readonly showIntermediate?: boolean;
     readonly style?: CSSProperties;
-    readonly imgStyle?: object;
+    readonly imgStyle?: CSSProperties;
 }
 export interface ImageState {
     readonly load: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-elemental-docs.static.kevinlin.info/component/image
`imgStyle: Optional style overrides on the <img> element itself.`
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.