### PR TITLE
[react] Only allow thunks in useState when setting state that is a function

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -805,7 +805,7 @@ declare namespace React {
     // based on the code in https://github.com/facebook/react/pull/13968
 
     // Unlike the class component setState, the updates are not allowed to be partial
-    type SetStateAction<S> = S | ((prevState: S) => S);
+    type SetStateAction<S> = S extends ((...args: any[]) => any) ? ((prevState: S) => S) : S | ((prevState: S) => S);
     // this technically does accept a second argument, but it's already under a deprecation warning
     // and it's not even released so probably better to not define it.
     type Dispatch<A> = (value: A) => void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -806,7 +806,9 @@ declare namespace React {
     // based on the code in https://github.com/facebook/react/pull/13968
 
     // Unlike the class component setState, the updates are not allowed to be partial
-    type SetStateAction<S> = S extends ((...args: any[]) => any) ? ((prevState: S) => S) : S | ((prevState: S) => S);
+    type SetStateAction<S> = S extends ((...args: never[]) => unknown) ?
+        (prevState: S) => S :
+        (S | ((prevState: S) => S));
     // this technically does accept a second argument, but it's already under a deprecation warning
     // and it's not even released so probably better to not define it.
     type Dispatch<A> = (value: A) => void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -806,7 +806,7 @@ declare namespace React {
     // based on the code in https://github.com/facebook/react/pull/13968
 
     // Unlike the class component setState, the updates are not allowed to be partial
-    type SetStateAction<S> = S extends ((...args: never[]) => unknown) ?
+    type SetStateAction<S> = S extends ((...args: any[]) => any) ?
         (prevState: S) => S :
         (S | ((prevState: S) => S));
     // this technically does accept a second argument, but it's already under a deprecation warning

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -22,6 +22,7 @@
 //                 Saransh Kataria <https://github.com/saranshkataria>
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Chris Sauve <https://github.com/lemonmade>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -201,6 +201,14 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // make sure the generic argument does reject actual potentially undefined inputs
     // $ExpectError
     React.useState<number>(undefined)[0];
+    // When state is a function type, it must be returned from a function,
+    // not provided directly.
+    // $ExpectError
+    React.useState<(() => boolean)>(() => true)[1](() => false);
+    // Returning a function for state is fine
+    React.useState<(() => boolean)>(() => true)[1](() => () => false);
+    // As is returning non-function members of a union
+    React.useState<(() => boolean) | number>(() => true)[1](() => 42);
 
     // useReducer convenience overload
 


### PR DESCRIPTION
This PR updates the typing for `useState` from React. Currently, the following is considered valid during type check:

```ts
const [state, setState] = useState<() => boolean | null>(null);
setState(() => false);
```

However, this is actually incorrect at runtime, because React sees the function form of the state setter and calls it. So, after this call, `state` will be `boolean`, which it should never be given the type definition. Yes, it's an unusual case (and probably an anti pattern in most cases), but saving a function in state does have some valid use cases.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~[ ] Provide a URL to documentation or source code which provides context for the suggested changes:~~ this change is just reflective of the reality of `useState` when a function is provided.
- ~~[ ] Increase the version number in the header if appropriate.~~
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~