### PR TITLE
[@types/react-redux] Move overloads with less defined parameters upper

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -190,6 +190,12 @@ export interface Connect {
         TOwnProps
     >;
 
+    <no_state = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: null | undefined,
+        mapDispatchToProps: null | undefined,
+        mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
@@ -200,19 +206,6 @@ export interface Connect {
         mapStateToProps: null | undefined,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
-    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
-
-    <no_state = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
-        mapStateToProps: null | undefined,
-        mapDispatchToProps: null | undefined,
-        mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
-    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
-
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
-        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-        mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-        options?: Options<State, TStateProps, TOwnProps, TMergedProps>
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
@@ -255,6 +248,13 @@ export interface Connect {
         TStateProps & ResolveThunks<TDispatchProps>,
         TOwnProps
     >;
+
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+        options?: Options<State, TStateProps, TOwnProps, TMergedProps>
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
     // tslint:enable:no-unnecessary-generics
 }
 


### PR DESCRIPTION
Currently with `strictNullCheck` set to `false` (we use such settings for some legacy parts of project) TypeScript takes incorrect overload of `connect` function. This PR should fix such behaviour.

Here's the issue itself reproducible with `@types/react-redux@7.0.9` (check error in `index.tsx`)
https://codesandbox.io/s/parcel-sandbox-tmkwr