### PR TITLE
[koa-websocket] Added generic types for ctx

### DIFF
--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jaco Greeff <https://github.com/jacogr>
 //                 Martin Ždila <https://github.com/zdila>
 //                 Eunchong Yu <https://github.com/Kroisse>
+//                 Christopher N. Katoyi-Kaba <https://github.com/Christopher2K>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -21,31 +22,32 @@ declare module "koa" {
 }
 
 declare namespace KoaWebsocket {
-    type Middleware = compose.Middleware<MiddlewareContext>;
+    type Middleware<StateT, CustomT> = compose.Middleware<MiddlewareContext<StateT> & CustomT>;
 
-    interface MiddlewareContext extends Koa.Context {
+    interface MiddlewareContext<StateT> extends Koa.Context {
         // Limitation: Declaration merging cannot overwrap existing properties.
         // That's why this property is here, not in the merged declaration above.
         app: App;
+        state: StateT;
     }
 
-    class Server {
-        app: App;
-        middleware: Middleware[];
+    class Server<StateT = any, CustomT = {}> {
+        app: App<StateT, CustomT>;
+        middleware: Middleware<StateT, CustomT>[];
         server?: ws.Server;
 
-        constructor(app: Koa);
+        constructor(app: Koa<StateT, CustomT>);
 
         listen(options: ws.ServerOptions): ws.Server;
         onConnection(socket: ws, request: http.IncomingMessage): void;
-        use(middleware: Middleware): this;
+        use(middleware: Middleware<StateT, CustomT>): this;
     }
 
-    interface App extends Koa {
-        ws: Server;
+    interface App<StateT = any, CustomT = {}> extends Koa<StateT, CustomT> {
+        ws: Server<StateT, CustomT>;
     }
 }
 
-declare function KoaWebsocket(app: Koa, wsOptions?: ws.ServerOptions, httpsOptions?: https.ServerOptions): KoaWebsocket.App;
+declare function KoaWebsocket<StateT = any, CustomT = {}>(app: Koa<StateT, CustomT>, wsOptions?: ws.ServerOptions, httpsOptions?: https.ServerOptions): KoaWebsocket.App<StateT, CustomT>;
 
 export = KoaWebsocket;

--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -33,7 +33,7 @@ declare namespace KoaWebsocket {
 
     class Server<StateT = any, CustomT = {}> {
         app: App<StateT, CustomT>;
-        middleware: Middleware<StateT, CustomT>[];
+        middleware: Array<Middleware<StateT, CustomT>>;
         server?: ws.Server;
 
         constructor(app: Koa<StateT, CustomT>);

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -20,3 +20,22 @@ app.ws.use(async (ctx, next) => {
 });
 
 app.listen(3000);
+
+type MyState = { persist: string }
+const typedApp = websocket(new Koa<MyState>())
+
+typedApp.ws.use(async (ctx, next) => {
+    ctx.websocket.on('message', (message) => {
+        console.log(message + ctx.state.persist);
+        const server = ctx.app.ws.server;
+        if (server) {
+            server.clients.forEach(client => {
+                if (client !== ctx.websocket) {
+                    client.send(message);
+                }
+            });
+        }
+    });
+    ctx.websocket.send('Hello world');
+    await next();
+})

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -21,8 +21,11 @@ app.ws.use(async (ctx, next) => {
 
 app.listen(3000);
 
-type MyState = { persist: string }
-const typedApp = websocket(new Koa<MyState>())
+interface MyState {
+    persist: string;
+}
+
+const typedApp = websocket(new Koa<MyState>());
 
 typedApp.ws.use(async (ctx, next) => {
     ctx.websocket.on('message', (message) => {
@@ -38,4 +41,4 @@ typedApp.ws.use(async (ctx, next) => {
     });
     ctx.websocket.send('Hello world');
     await next();
-})
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa/index.d.ts -- look at the `ParameterizedContext`
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

I used in my last project the `ParameterizedContext` to custom my `ctx` object and get a strong typing of this object. By adding the WS support I lost the feature. With this PR I try to recover the flexibility that the `ParameterizedContext` offers.