### PR TITLE
fix: Add disableIdleTimeout to CastReceiverOptions

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -537,6 +537,12 @@ export class CastReceiverOptions {
     customNamespaces?: any;
 
     /**
+     * If true, the receiver will not set an idle timeout to close receiver if there is no activity.
+     * Should only be used for non media apps.
+     */
+    disableIdleTimeout?: boolean;
+
+    /**
      * Sender id used for local requests. Default value is 'local'.
      */
     localSenderId?: string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.CastReceiverOptions
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.