### PR TITLE
Emscripten: Add EmscriptenModule interface type, make Module an instance of it.

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -8,7 +8,7 @@ function ModuleTest(): void {
     Module.preinitializedWebGLContext = new WebGLRenderingContext();
 
     let package: ArrayBuffer = Module.getPreloadedPackage("package-name", 100);
-    let exports: Module.WebAssemblyExports = Module.instantiateWasm(
+    let exports: Emscripten.WebAssemblyExports = Module.instantiateWasm(
         [{name: "func-name", kind: "function"}],
         (module: WebAssembly.Module) => {}
     );

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -13,9 +13,6 @@ declare namespace WebAssembly {
 declare namespace Emscripten {
     interface FileSystemType {
     }
-}
-
-declare namespace Module {
     type EnvironmentType = "WEB" | "NODE" | "SHELL" | "WORKER";
 
     type WebAssemblyImports =  Array<{
@@ -28,95 +25,103 @@ declare namespace Module {
         name: string;
         kind: string;
     }>;
+}
 
-    function print(str: string): void;
-    function printErr(str: string): void;
-    var arguments: string[];
-    var environment: EnvironmentType;
-    var preInit: { ():  void }[];
-    var preRun: { ():  void }[];
-    var postRun: { ():  void }[];
-    var preinitializedWebGLContext: WebGLRenderingContext;
-    var noInitialRun: boolean;
-    var noExitRuntime: boolean;
-    var logReadFiles: boolean;
-    var filePackagePrefixURL: string;
-    var wasmBinary: ArrayBuffer;
+declare interface EmscriptenModule {
 
-    function destroy(object: object): void;
-    function getPreloadedPackage(remotePackageName: string, remotePackageSize: number): ArrayBuffer;
-    function instantiateWasm(
-        imports: WebAssemblyImports,
+    print(str: string): void;
+    printErr(str: string): void;
+    arguments: string[];
+    environment: Emscripten.EnvironmentType;
+    preInit: { ():  void }[];
+    preRun: { ():  void }[];
+    postRun: { ():  void }[];
+    preinitializedWebGLContext: WebGLRenderingContext;
+    noInitialRun: boolean;
+    noExitRuntime: boolean;
+    logReadFiles: boolean;
+    filePackagePrefixURL: string;
+    wasmBinary: ArrayBuffer;
+
+    destroy(object: object): void;
+    getPreloadedPackage(remotePackageName: string, remotePackageSize: number): ArrayBuffer;
+    instantiateWasm(
+        imports: Emscripten.WebAssemblyImports,
         successCallback: (module: WebAssembly.Module) => void
-    ): WebAssemblyExports;
-    function locateFile(url: string): string;
-    function onCustomMessage(event: MessageEvent): void;
+    ): Emscripten.WebAssemblyExports;
+    locateFile(url: string): string;
+    onCustomMessage(event: MessageEvent): void;
 
-    var Runtime: any;
+    Runtime: any;
 
-    function ccall(ident: string, returnType: string | null, argTypes: string[], args: any[]): any;
-    function cwrap(ident: string, returnType: string | null, argTypes: string[]): any;
+    ccall(ident: string, returnType: string | null, argTypes: string[], args: any[]): any;
+    cwrap(ident: string, returnType: string | null, argTypes: string[]): any;
 
-    function setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
-    function getValue(ptr: number, type: string, noSafe?: boolean): number;
+    setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
+    getValue(ptr: number, type: string, noSafe?: boolean): number;
 
-    var ALLOC_NORMAL: number;
-    var ALLOC_STACK: number;
-    var ALLOC_STATIC: number;
-    var ALLOC_DYNAMIC: number;
-    var ALLOC_NONE: number;
+    ALLOC_NORMAL: number;
+    ALLOC_STACK: number;
+    ALLOC_STATIC: number;
+    ALLOC_DYNAMIC: number;
+    ALLOC_NONE: number;
 
-    function allocate(slab: any, types: string, allocator: number, ptr: number): number;
-    function allocate(slab: any, types: string[], allocator: number, ptr: number): number;
+    allocate(slab: any, types: string, allocator: number, ptr: number): number;
+    allocate(slab: any, types: string[], allocator: number, ptr: number): number;
 
-    function Pointer_stringify(ptr: number, length?: number): string;
-    function UTF16ToString(ptr: number): string;
-    function stringToUTF16(str: string, outPtr: number): void;
-    function UTF32ToString(ptr: number): string;
-    function stringToUTF32(str: string, outPtr: number): void;
+    Pointer_stringify(ptr: number, length?: number): string;
+    UTF16ToString(ptr: number): string;
+    stringToUTF16(str: string, outPtr: number): void;
+    UTF32ToString(ptr: number): string;
+    stringToUTF32(str: string, outPtr: number): void;
 
     // USE_TYPED_ARRAYS == 1
-    var HEAP: Int32Array;
-    var IHEAP: Int32Array;
-    var FHEAP: Float64Array;
+    HEAP: Int32Array;
+    IHEAP: Int32Array;
+    FHEAP: Float64Array;
 
     // USE_TYPED_ARRAYS == 2
-    var HEAP8: Int8Array;
-    var HEAP16: Int16Array;
-    var HEAP32: Int32Array;
-    var HEAPU8:  Uint8Array;
-    var HEAPU16: Uint16Array;
-    var HEAPU32: Uint32Array;
-    var HEAPF32: Float32Array;
-    var HEAPF64: Float64Array;
+    HEAP8: Int8Array;
+    HEAP16: Int16Array;
+    HEAP32: Int32Array;
+    HEAPU8:  Uint8Array;
+    HEAPU16: Uint16Array;
+    HEAPU32: Uint32Array;
+    HEAPF32: Float32Array;
+    HEAPF64: Float64Array;
 
-    var TOTAL_STACK: number;
-    var TOTAL_MEMORY: number;
-    var FAST_MEMORY: number;
+    TOTAL_STACK: number;
+    TOTAL_MEMORY: number;
+    FAST_MEMORY: number;
 
-    function addOnPreRun(cb: () => any): void;
-    function addOnInit(cb: () => any): void;
-    function addOnPreMain(cb: () => any): void;
-    function addOnExit(cb: () => any): void;
-    function addOnPostRun(cb: () => any): void;
+    addOnPreRun(cb: () => any): void;
+    addOnInit(cb: () => any): void;
+    addOnPreMain(cb: () => any): void;
+    addOnExit(cb: () => any): void;
+    addOnPostRun(cb: () => any): void;
 
     // Tools
-    function intArrayFromString(stringy: string, dontAddNull?: boolean, length?: number): number[];
-    function intArrayToString(array: number[]): string;
-    function writeStringToMemory(str: string, buffer: number, dontAddNull: boolean): void;
-    function writeArrayToMemory(array: number[], buffer: number): void;
-    function writeAsciiToMemory(str: string, buffer: number, dontAddNull: boolean): void;
+    intArrayFromString(stringy: string, dontAddNull?: boolean, length?: number): number[];
+    intArrayToString(array: number[]): string;
+    writeStringToMemory(str: string, buffer: number, dontAddNull: boolean): void;
+    writeArrayToMemory(array: number[], buffer: number): void;
+    writeAsciiToMemory(str: string, buffer: number, dontAddNull: boolean): void;
 
-    function addRunDependency(id: any): void;
-    function removeRunDependency(id: any): void;
+    addRunDependency(id: any): void;
+    removeRunDependency(id: any): void;
 
 
-    var preloadedImages: any;
-    var preloadedAudios: any;
+    preloadedImages: any;
+    preloadedAudios: any;
 
-    function _malloc(size: number): number;
-    function _free(ptr: number): void;
+    _malloc(size: number): number;
+    _free(ptr: number): void;
 }
+
+// By default Emscripten emits a single global Module.  Users setting -s
+// MODULARIZE=1 -s EXPORT_NAME=MyMod should declare their own types, e.g.
+// declare var MyMod: EmscriptenModule;
+declare var Module: EmscriptenModule;
 
 declare namespace FS {
     interface Lookup {


### PR DESCRIPTION
Fixes #24791.  I plan to use this when sending code to Emscripten for [generating TypeScript typings from embind bindings](https://github.com/emscripten-core/emscripten/issues/7083).

Note that this changed some type names:

 * `Module.WebAssemblyImports` → `Emscripten.WebAssemblyImports`
 * `Module.WebAssemblyExports` → `Emscripten.WebAssemblyExports`

This was required because `Module` is now an instance of the `EmscriptenModule` interface, and can't host type aliases.

@cpitclaudel @periklis please review and comment if this meets your needs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
