### PR TITLE
Update Ember tests to treat 'string & number' and 'never' the same

### DIFF
--- a/types/ember/test/core-object.ts
+++ b/types/ember/test/core-object.ts
@@ -76,7 +76,7 @@ const co6 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo; // $ExpectType string & number
+        this.foo || (0 as never); // $ExpectType never
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
     }
@@ -110,7 +110,7 @@ const co7 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo; // $ExpectType string & number
+        this.foo || (0 as never); // $ExpectType never
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
     }
@@ -156,7 +156,7 @@ const co8 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo; // $ExpectType string & number
+        this.foo || (0 as never); // $ExpectType never
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
         // this does not include stuff from later extend args

--- a/types/ember/test/core-object.ts
+++ b/types/ember/test/core-object.ts
@@ -76,7 +76,7 @@ const co6 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo || (0 as never); // $ExpectType never
+        this.foo;
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
     }
@@ -110,7 +110,7 @@ const co7 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo || (0 as never); // $ExpectType never
+        this.foo;
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
     }
@@ -156,7 +156,7 @@ const co8 = Ember.CoreObject.extend({
         this.init; // $ExpectType () => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo || (0 as never); // $ExpectType never
+        this.foo;
         // this includes stuff from earlier extend-args
         this.bar; // $ExpectType number
         // this does not include stuff from later extend args

--- a/types/ember/test/detect-instance.ts
+++ b/types/ember/test/detect-instance.ts
@@ -9,7 +9,7 @@ class ES6Class extends Ember.Object {
     bar: string;
 }
 
-const testObject = null;
+const testObject: any = null;
 
 if (ExtendClass.detectInstance(testObject)) {
     assertType<string>(testObject.foo);

--- a/types/ember/v2/test/detect-instance.ts
+++ b/types/ember/v2/test/detect-instance.ts
@@ -9,7 +9,7 @@ class ES6Class extends Ember.Object {
     bar: string;
 }
 
-let testObject = null;
+let testObject: any = null;
 
 if (ExtendClass.detectInstance(testObject)) {
     assertType<string>(testObject.foo);

--- a/types/ember__object/test/core.ts
+++ b/types/ember__object/test/core.ts
@@ -78,7 +78,7 @@ const co6 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo; // $ExpectType string & number
+            this.foo || (0 as never); // $ExpectType never
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
         }
@@ -115,7 +115,7 @@ const co7 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo; // $ExpectType string & number
+            this.foo || (0 as never); // $ExpectType never
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
         }
@@ -165,7 +165,7 @@ const co8 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo; // $ExpectType string & number
+            this.foo || (0 as never); // $ExpectType never
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
             // this does not include stuff from later extend args

--- a/types/ember__object/test/core.ts
+++ b/types/ember__object/test/core.ts
@@ -78,7 +78,7 @@ const co6 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo || (0 as never); // $ExpectType never
+            this.foo;
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
         }
@@ -115,7 +115,7 @@ const co7 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo || (0 as never); // $ExpectType never
+            this.foo;
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
         }
@@ -165,7 +165,7 @@ const co8 = CoreObject.extend(
             this.init; // $ExpectType () => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-            this.foo || (0 as never); // $ExpectType never
+            this.foo;
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
             // this does not include stuff from later extend args

--- a/types/ember__object/test/detect-instance.ts
+++ b/types/ember__object/test/detect-instance.ts
@@ -9,7 +9,7 @@ class ES6Class extends EmberObject {
     bar: string;
 }
 
-const testObject = null;
+const testObject: any = null;
 
 if (ExtendClass.detectInstance(testObject)) {
     assertType<string>(testObject.foo);


### PR DESCRIPTION
In preparation for https://github.com/microsoft/TypeScript/pull/31838 this modifies Ember's tests to treat empty intersection types like `string & number` the same as `never`.