### PR TITLE
commonmark: add "softbreak" option to HtmlRenderer

### DIFF
--- a/types/commonmark/commonmark-tests.ts
+++ b/types/commonmark/commonmark-tests.ts
@@ -36,7 +36,13 @@ const xmlRenderer = new commonmark.XmlRenderer({ sourcepos: true, time: true });
 const xml = xmlRenderer.render(node);
 console.log(xml);
 
-const htmlRenderer = new commonmark.HtmlRenderer({ safe: true, smart: true, sourcepos: true, time: true });
+const htmlRenderer = new commonmark.HtmlRenderer({
+    safe: true,
+    smart: true,
+    sourcepos: true,
+    time: true,
+    softbreak: "<br/>",
+ });
 const html = htmlRenderer.render(node);
 console.log(html);
 

--- a/types/commonmark/index.d.ts
+++ b/types/commonmark/index.d.ts
@@ -216,6 +216,12 @@ export interface HtmlRenderingOptions extends XmlRenderingOptions {
      *  if true, source position information for block-level elements will be rendered in the data-sourcepos attribute (for HTML) or the sourcepos attribute (for XML).
      */
     sourcepos?: boolean;
+
+    /**
+     * A raw string to be used for a softbreak.
+     * For example, `{ softbreak: "<br/>" }` treats a softbreak as `<br/>`.
+     */
+    softbreak?: string;
 }
 
 export interface XmlRenderingOptions {


### PR DESCRIPTION
https://github.com/commonmark/commonmark.js

FYI you can always ignore the type definition., for example `new commonmark.HtmlRenderer({ softbreak: "<br/>" } as any)`.

## checklist


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- <del>[ ] Increase the version number in the header if appropriate.</del>
- <del>[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.</del>
