### PR TITLE
[sharepoint] add missing get_zoneId method for WebPartDefinition

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Microsoft SharePoint: 2016.2
+// Type definitions for Microsoft SharePoint: 2016.1
 // Project: https://msdn.microsoft.com/en-us/library/office/jj193034.aspx
 // Definitions by: Stanislav Vyshchepan <https://github.com/gandjustas>
 //                 Andrey Markeev <https://github.com/andrei-markeev>

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -8156,6 +8156,7 @@ declare namespace SP {
         class WebPartDefinition extends SP.ClientObject {
             get_id(): SP.Guid;
             get_webPart(): SP.WebParts.WebPart;
+            get_zoneId(): string;
             saveWebPartChanges(): void;
             closeWebPart(): void;
             openWebPart(): void;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -5,6 +5,7 @@
 //                 Vincent Biret <https://github.com/baywet>
 //                 Tero Arvola <https://github.com/teroarvola>
 //                 Dennis George <https://github.com/dennispg>
+//                 SPWizard01 <https://github.com/SPWizard01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.5
 

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Microsoft SharePoint: 2016.1
+// Type definitions for Microsoft SharePoint: 2016.2
 // Project: https://msdn.microsoft.com/en-us/library/office/jj193034.aspx
 // Definitions by: Stanislav Vyshchepan <https://github.com/gandjustas>
 //                 Andrey Markeev <https://github.com/andrei-markeev>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
although not directly documented here https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-visio/jj244932(v%3doffice.15)
still available in the .NET version and is available through JSOM 
https://docs.microsoft.com/en-us/dotnet/api/microsoft.sharepoint.client.webparts.webpartdefinition.zoneid
- [x] Increase the version number in the header if appropriate.