### PR TITLE
Move message namespace interfaces to classes in chromecast-caf-receiver

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -208,14 +208,16 @@ export enum MetadataType {
 /**
  * RefreshCredentials request data.
  */
-export interface RefreshCredentialsRequestData {
+export class RefreshCredentialsRequestData {
     [key: string]: any;
 }
 
 /**
  * Media event SET_VOLUME request data.
  */
-export interface VolumeRequestData extends RequestData {
+export class VolumeRequestData extends RequestData {
+    constructor();
+
     /**
      * The media stream volume
      */
@@ -225,7 +227,7 @@ export interface VolumeRequestData extends RequestData {
 /**
  * Represents the volume of a media session stream.
  */
-export interface Volume {
+export class Volume {
     /**
      * Value from 0 to 1 that represents the current stream volume level.
      */
@@ -253,7 +255,7 @@ export class VideoInformation {
 /**
  * VAST ad request configuration.
  */
-export interface VastAdsRequest {
+export class VastAdsRequest {
     /**
      * Specifies a VAST document to be used as the ads response instead of making a
      * request via an ad tag url.
@@ -271,7 +273,7 @@ export interface VastAdsRequest {
 /**
  * UserAction request data.
  */
-export interface UserActionRequestData {
+export class UserActionRequestData {
     /**
      * Optional request source.
      * It contain the assistent query that initiate the request.
@@ -292,7 +294,7 @@ export interface UserActionRequestData {
 /**
  * A TV episode media description.
  */
-export interface TvShowMediaMetadata {
+export class TvShowMediaMetadata {
     /**
      * TV episode number. A positive integer.
      */
@@ -400,7 +402,7 @@ export class Track {
 /**
  * Describes style information for a text track.
  */
-export interface TextTrackStyle {
+export class TextTrackStyle {
     /**
      * The background 32 bit RGBA color. The alpha channel should be used for transparent backgrounds.
      */
@@ -463,7 +465,9 @@ export interface TextTrackStyle {
 /**
  * Media event playback rate request data.
  */
-export interface SetPlaybackRateRequestData extends RequestData {
+export class SetPlaybackRateRequestData extends RequestData {
+    constructor();
+
     /**
      * New playback rate (>0).
      */
@@ -481,7 +485,7 @@ export interface SetPlaybackRateRequestData extends RequestData {
 /**
  * SetCredentials request data.
  */
-export interface SetCredentialsRequestData {
+export class SetCredentialsRequestData extends RequestData {
     /**
      * Credentials to use by receiver.
      */
@@ -502,7 +506,9 @@ export interface SetCredentialsRequestData {
 /**
  * Media event SEEK request data.
  */
-export interface SeekRequestData extends RequestData {
+export class SeekRequestData extends RequestData {
+    constructor();
+
     /**
      * Seconds since beginning of content.
      */
@@ -564,7 +570,7 @@ export class RequestData {
 /**
  * Media event UPDATE queue request data.
  */
-export interface QueueUpdateRequestData {
+export class QueueUpdateRequestData extends RequestData {
     /**
      * ID of the current media Item after the deletion
      * (if not provided; the currentItem value will be the same as before the deletion;
@@ -853,7 +859,7 @@ export class QueueInsertRequestData extends RequestData {
 /**
  * Represents a data message containing the full list of queue ids.
  */
-export interface QueueIds {
+export class QueueIds {
     /**
      * List of queue item ids.
      */
@@ -930,7 +936,7 @@ export class QueueData {
 /**
  * Represents a queue change message; such as insert; remove; and update.
  */
-export interface QueueChange {
+export class QueueChange {
     /**
      * The actual queue change type.
      */
@@ -963,7 +969,7 @@ export interface QueueChange {
 /**
  * Media event PRELOAD request data.
  */
-export class PreloadRequestData implements LoadRequestData {
+export class PreloadRequestData extends LoadRequestData {
     /**
      * Array of trackIds that are active. If the array is not provided;
      *  the default tracks will be active.
@@ -1029,7 +1035,7 @@ export class PreloadRequestData implements LoadRequestData {
  * Media event PRECACHE request data. (Some fields of the load request;
  * like autoplay and queueData; are ignored).
  */
-export class PrecacheRequestData implements LoadRequestData {
+export class PrecacheRequestData extends LoadRequestData {
     /**
      * Array of trackIds that are active. If the array is not provided;
      * the default tracks will be active.
@@ -1111,7 +1117,7 @@ export class PlayStringRequestData {
 /**
  * A photo media description.
  */
-export interface PhotoMediaMetadata {
+export class PhotoMediaMetadata {
     /**
      * Name of the photographer.
      */
@@ -1161,7 +1167,7 @@ export interface PhotoMediaMetadata {
 /**
  * A music track media description.
  */
-export interface MusicTrackMediaMetadata {
+export class MusicTrackMediaMetadata {
     /**
      * Album artist name.
      */
@@ -1227,7 +1233,7 @@ export interface MusicTrackMediaMetadata {
 /**
  * A movie media description.
  */
-export interface MovieMediaMetadata {
+export class MovieMediaMetadata {
     /**
      * Content images. Examples would include cover art or a thumbnail of the
      * currently playing media.
@@ -1262,7 +1268,7 @@ export interface MovieMediaMetadata {
 /**
  * Represents the status of a media session.
  */
-export interface MediaStatus {
+export class MediaStatus {
     /**
      * List of IDs corresponding to the active tracks.
      */
@@ -1386,7 +1392,7 @@ export class MediaMetadata {
 /**
  * Represents the media information.
  */
-export interface MediaInformation {
+export class MediaInformation {
     /**
      * Partial list of break clips that includes current break clip that receiver
      * is playing or ones that receiver will play shortly after; instead of sending
@@ -1472,7 +1478,9 @@ export interface MediaInformation {
 /**
  * Media event LOAD request data.
  */
-export interface LoadRequestData extends RequestData {
+export class LoadRequestData extends RequestData {
+    constructor();
+
     /**
      * Array of trackIds that are active. If the array is not provided; the
      * default tracks will be active.
@@ -1525,7 +1533,7 @@ export interface LoadRequestData extends RequestData {
 /**
  * LoadByEntity request data.
  */
-export interface LoadByEntityRequestData {
+export class LoadByEntityRequestData {
     /**
      * Content entity information; typically represented by a stringified JSON object
      */
@@ -1571,7 +1579,7 @@ export class LiveSeekableRange {
 /**
  * Represents a data message containing item information for each requested ids.
  */
-export interface ItemsInfo {
+export class ItemsInfo {
     /**
      * List of changed itemIds.
      */
@@ -1608,7 +1616,9 @@ export class Image {
     width?: number;
 }
 /** Media event GET_STATUS request data. */
-export interface GetStatusRequestData extends RequestData {
+export class GetStatusRequestData extends RequestData {
+    constructor();
+
     /**
      * The options of a GET_STATUS request.
      */
@@ -1629,7 +1639,9 @@ export class GetItemsInfoRequestData extends RequestData {
 /**
  * A generic media description.
  */
-export interface GenericMediaMetadata extends MediaMetadata {
+export class GenericMediaMetadata extends MediaMetadata {
+    constructor();
+
     /**
      * Content images. Examples would include cover art or a thumbnail of the
      * currently playing media.
@@ -1660,7 +1672,7 @@ export interface GenericMediaMetadata extends MediaMetadata {
 /**
  * Focus state change message.
  */
-export interface FocusStateRequestData {
+export class FocusStateRequestData {
     /**
      * The focus state of the app.
      */
@@ -1733,7 +1745,9 @@ export class ErrorData {
 }
 
 /**  Media event EDIT_TRACKS_INFO request data. */
-export interface EditTracksInfoRequestData extends RequestData {
+export class EditTracksInfoRequestData extends RequestData {
+    constructor();
+
     /**
      * Array of the Track trackIds that should be active.
      * If it is not provided; the active tracks will not change.
@@ -1769,7 +1783,9 @@ export interface EditTracksInfoRequestData extends RequestData {
  * Media event EDIT_AUDIO_TRACKS request data. If language is not provided;
  * the default audio track for the media will be enabled.
  */
-export interface EditAudioTracksRequestData extends RequestData {
+export class EditAudioTracksRequestData extends RequestData {
+    constructor();
+
     /**
      * Indicates that the provided language was not explicit user request;
      * but rather inferred from used language in voice query.
@@ -1781,7 +1797,7 @@ export interface EditAudioTracksRequestData extends RequestData {
 }
 
 /** DisplayStatus request data. */
-export interface DisplayStatusRequestData {
+export class DisplayStatusRequestData {
     /**
      * Optional request source. It contain the assistent query that initiate the request.
      */
@@ -1789,7 +1805,7 @@ export interface DisplayStatusRequestData {
 }
 
 /** CustomCommand request data. */
-export interface CustomCommandRequestData {
+export class CustomCommandRequestData {
     /**
      * Custom Data; typically represented by a stringified JSON object.
      */

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -60,24 +60,23 @@ const breakManager: cast.framework.breaks.BreakManager = {
 };
 
 // tslint:disable-next-line
-const lrd: cast.framework.messages.LoadRequestData = {
-    requestId: 1,
-    activeTrackIds: [1, 2],
-    media: {
-        tracks: [],
-        textTrackStyle: {},
-        streamType: "BUFFERED",
-        metadata: {
-            metadataType: cast.framework.messages.MetadataType.GENERIC
-        },
-        hlsSegmentFormat: "aac",
-        contentId: "id",
-        contentType: "type",
-        breakClips: [breakClip],
-        breaks: [adBreak]
+const lrd = new cast.framework.messages.LoadRequestData();
+lrd.requestId = 1;
+lrd.activeTrackIds = [1, 2];
+lrd.media = {
+    tracks: [],
+    textTrackStyle: {},
+    streamType: "BUFFERED",
+    metadata: {
+        metadataType: cast.framework.messages.MetadataType.GENERIC
     },
-    queueData: {}
+    hlsSegmentFormat: "aac",
+    contentId: "id",
+    contentType: "type",
+    breakClips: [breakClip],
+    breaks: [adBreak]
 };
+lrd.queueData = {};
 
 // tslint:disable-next-line
 const appData: cast.framework.system.ApplicationData = {

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/googlecast
 // Definitions by: Craig Bruce <https://github.com/craigrbruce>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference path="./cast.framework.d.ts" />
 /// <reference path="./cast.framework.breaks.d.ts" />


### PR DESCRIPTION
All of these are meant to be used with `new`.

For those overriding the constructor with one without parameter, I provide the minified source code, which shows it calls parent constructor with the needed data.

For those adding `extends RequestData`, I provide the minified source code which shows it is calling `R.call(this, ...)` which is the same as other classes extending `RequestData`.

![2019-06-11 at 15 45](https://user-images.githubusercontent.com/36221/59278641-aab23480-8c62-11e9-98a1-d449845fb398.png)
![2019-06-11 at 15 51](https://user-images.githubusercontent.com/36221/59278647-abe36180-8c62-11e9-8a2e-8db189462947.png)


Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.