### PR TITLE
lodash - better return type for _.get with path in array form

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1688,6 +1688,57 @@ declare module "../index" {
             defaultValue: TDefault
         ): Exclude<TObject[TKey], undefined> | TDefault;
 
+          /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2]
+        ): TObject[TKey1][TKey2] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2, TKey3]
+        ): TObject[TKey1][TKey2][TKey3] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2, TKey3],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2, TKey3, TKey4]
+        ): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(
+            object: TObject | null | undefined,
+            path: [TKey1, TKey2, TKey3, TKey4],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+
         /**
          * @see _.get
          */
@@ -1768,6 +1819,87 @@ declare module "../index" {
         /**
          * @see _.get
          */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1]>(
+            path: [TKey1, TKey2]
+        ): TValue[TKey1][TKey2];
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2],
+        ): TObject[TKey1][TKey2] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1], TKey3 extends keyof TValue[TKey1][TKey2], TKey4 extends keyof TValue[TKey1][TKey2][TKey3]>(
+            path: [TKey1, TKey2, TKey3, TKey4]
+        ): TValue[TKey1][TKey2][TKey3][TKey4];
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+        ): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1], TKey3 extends keyof TValue[TKey1][TKey2], TKey4 extends keyof TValue[TKey1][TKey2][TKey3]>(
+            path: [TKey1, TKey2, TKey3, TKey4]
+        ): TValue[TKey1][TKey2][TKey3][TKey4];
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+        ): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(
+            this: LoDashImplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+            defaultValue: TDefault
+        ): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+
+        /**
+         * @see _.get
+         */
         get<T>(
             this: LoDashImplicitWrapper<NumericDictionary<T>>,
             path: number
@@ -1840,6 +1972,78 @@ declare module "../index" {
             path: TKey | [TKey],
             defaultValue: TDefault
         ): LoDashExplicitWrapper<Exclude<TObject[TKey], undefined> | TDefault>;
+
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1]>(
+            path: [TKey1, TKey2]
+        ): LoDashExplicitWrapper<TValue[TKey1][TKey2]>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2],
+        ): LoDashExplicitWrapper<TObject[TKey1][TKey2] | undefined>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2],
+            defaultValue: TDefault
+        ): LoDashExplicitWrapper<Exclude<TObject[TKey1][TKey2], undefined> | TDefault>;
+
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1], TKey3 extends keyof TValue[TKey1][TKey2]>(
+            path: [TKey1, TKey2, TKey3]
+        ): LoDashExplicitWrapper<TValue[TKey1][TKey2][TKey3]>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3],
+        ): LoDashExplicitWrapper<TObject[TKey1][TKey2][TKey3] | undefined>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3],
+            defaultValue: TDefault
+        ): LoDashExplicitWrapper<Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault>;
+
+         /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof TValue, TKey2 extends keyof TValue[TKey1], TKey3 extends keyof TValue[TKey1][TKey2], TKey4 extends keyof TValue[TKey1][TKey2][TKey3]>(
+            path: [TKey1, TKey2, TKey3, TKey4]
+        ): LoDashExplicitWrapper<TValue[TKey1][TKey2][TKey3][TKey4]>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+        ): LoDashExplicitWrapper<TObject[TKey1][TKey2][TKey3][TKey4] | undefined>;
+
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(
+            this: LoDashExplicitWrapper<TObject | null | undefined>,
+            path: [TKey1, TKey2, TKey3, TKey4],
+            defaultValue: TDefault
+        ): LoDashExplicitWrapper<Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault>;
 
         /**
          * @see _.get

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1458,15 +1458,21 @@ declare namespace _ {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashGet2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashGet3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashGet3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashGet3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashGet4x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashGet5x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashGet6x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashGet6x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGet4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGet7x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashGet5x1;
-        (path: lodash.__, object: null | undefined): LodashGet5x2;
+        (path: lodash.PropertyPath): LodashGet8x1;
+        (path: lodash.__, object: null | undefined): LodashGet8x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashGet6x2;
+        (path: lodash.__, object: any): LodashGet9x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashGet1x1<TObject, TKey extends keyof TObject> {
@@ -1474,19 +1480,27 @@ declare namespace _ {
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
     type LodashGet1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashGet2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashGet3x1 {
+    interface LodashGet2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    type LodashGet3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2] | undefined;
+    type LodashGet4x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3] | undefined;
+    type LodashGet5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    interface LodashGet6x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashGet3x2<T> = (path: number) => T;
-    type LodashGet4x2<T> = (path: number) => T | undefined;
-    interface LodashGet5x1 {
+    type LodashGet6x2<T> = (path: number) => T;
+    type LodashGet7x2<T> = (path: number) => T | undefined;
+    interface LodashGet8x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashGet5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashGet6x2 = (path: lodash.PropertyPath) => any;
+    type LodashGet8x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashGet9x2 = (path: lodash.PropertyPath) => any;
     interface LodashGetOr {
         <TDefault>(defaultValue: TDefault): LodashGetOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashGetOr1x2<TObject, TKey>;
@@ -1495,34 +1509,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashGetOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashGetOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashGetOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashGetOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashGetOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashGetOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashGetOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashGetOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashGetOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashGetOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashGetOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashGetOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashGetOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashGetOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashGetOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashGetOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashGetOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashGetOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashGetOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashGetOr4x6;
+        (defaultValue: any): LodashGetOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashGetOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashGetOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashGetOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashGetOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashGetOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashGetOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashGetOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashGetOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashGetOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashGetOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashGetOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashGetOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashGetOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashGetOr1x2<TObject, TKey extends keyof TObject> {
@@ -1535,51 +1567,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashGetOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashGetOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashGetOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashGetOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashGetOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashGetOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x6<T>;
+    interface LodashGetOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashGetOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashGetOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashGetOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashGetOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashGetOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashGetOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashGetOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashGetOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashGetOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashGetOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashGetOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashGetOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashGetOr2x6<T>;
+    type LodashGetOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashGetOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashGetOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashGetOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashGetOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashGetOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashGetOr3x6;
+    type LodashGetOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashGetOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashGetOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashGetOr4x3;
-        (defaultValue: lodash.__, object: any): LodashGetOr4x6;
+        (defaultValue: any): LodashGetOr7x3;
+        (defaultValue: lodash.__, object: any): LodashGetOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashGetOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashGetOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr3x6;
+    type LodashGetOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashGetOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashGetOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashGetOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashGetOr4x1 {
-        (path: lodash.PropertyPath): LodashGetOr4x3;
-        (path: lodash.__, object: any): LodashGetOr4x5;
+    type LodashGetOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashGetOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashGetOr7x1 {
+        (path: lodash.PropertyPath): LodashGetOr7x3;
+        (path: lodash.__, object: any): LodashGetOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashGetOr4x3 = (object: any) => any;
-    interface LodashGetOr4x4 {
-        (defaultValue: any): LodashGetOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr4x6;
+    type LodashGetOr7x3 = (object: any) => any;
+    interface LodashGetOr7x4 {
+        (defaultValue: any): LodashGetOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashGetOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashGetOr4x6 = (defaultValue: any) => any;
+    type LodashGetOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashGetOr7x6 = (defaultValue: any) => any;
     interface LodashGroupBy {
         <T>(iteratee: lodash.ValueIteratee<T>): LodashGroupBy1x1<T>;
         <T>(iteratee: lodash.__, collection: lodash.List<T> | null | undefined): LodashGroupBy1x2<T>;
@@ -2726,15 +2790,21 @@ declare namespace _ {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPath2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashPath3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPath3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPath3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPath4x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPath5x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashPath6x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPath6x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPath4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPath7x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashPath5x1;
-        (path: lodash.__, object: null | undefined): LodashPath5x2;
+        (path: lodash.PropertyPath): LodashPath8x1;
+        (path: lodash.__, object: null | undefined): LodashPath8x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashPath6x2;
+        (path: lodash.__, object: any): LodashPath9x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPath1x1<TObject, TKey extends keyof TObject> {
@@ -2742,19 +2812,27 @@ declare namespace _ {
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
     type LodashPath1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashPath2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashPath3x1 {
+    interface LodashPath2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    type LodashPath3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2] | undefined;
+    type LodashPath4x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3] | undefined;
+    type LodashPath5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    interface LodashPath6x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashPath3x2<T> = (path: number) => T;
-    type LodashPath4x2<T> = (path: number) => T | undefined;
-    interface LodashPath5x1 {
+    type LodashPath6x2<T> = (path: number) => T;
+    type LodashPath7x2<T> = (path: number) => T | undefined;
+    interface LodashPath8x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashPath5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashPath6x2 = (path: lodash.PropertyPath) => any;
+    type LodashPath8x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashPath9x2 = (path: lodash.PropertyPath) => any;
     interface LodashPathOr {
         <TDefault>(defaultValue: TDefault): LodashPathOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPathOr1x2<TObject, TKey>;
@@ -2763,34 +2841,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashPathOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashPathOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashPathOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashPathOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPathOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPathOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashPathOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashPathOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPathOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPathOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPathOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPathOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPathOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPathOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPathOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPathOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashPathOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPathOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashPathOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPathOr4x6;
+        (defaultValue: any): LodashPathOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashPathOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPathOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashPathOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPathOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPathOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPathOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPathOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashPathOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashPathOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashPathOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashPathOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashPathOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashPathOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashPathOr1x2<TObject, TKey extends keyof TObject> {
@@ -2803,51 +2899,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashPathOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPathOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashPathOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashPathOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashPathOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashPathOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x6<T>;
+    interface LodashPathOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashPathOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashPathOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashPathOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashPathOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashPathOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashPathOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashPathOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashPathOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashPathOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashPathOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashPathOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashPathOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashPathOr2x6<T>;
+    type LodashPathOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashPathOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashPathOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashPathOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashPathOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashPathOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashPathOr3x6;
+    type LodashPathOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashPathOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashPathOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPathOr4x3;
-        (defaultValue: lodash.__, object: any): LodashPathOr4x6;
+        (defaultValue: any): LodashPathOr7x3;
+        (defaultValue: lodash.__, object: any): LodashPathOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashPathOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashPathOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr3x6;
+    type LodashPathOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashPathOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashPathOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashPathOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashPathOr4x1 {
-        (path: lodash.PropertyPath): LodashPathOr4x3;
-        (path: lodash.__, object: any): LodashPathOr4x5;
+    type LodashPathOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashPathOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashPathOr7x1 {
+        (path: lodash.PropertyPath): LodashPathOr7x3;
+        (path: lodash.__, object: any): LodashPathOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashPathOr4x3 = (object: any) => any;
-    interface LodashPathOr4x4 {
-        (defaultValue: any): LodashPathOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr4x6;
+    type LodashPathOr7x3 = (object: any) => any;
+    interface LodashPathOr7x4 {
+        (defaultValue: any): LodashPathOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashPathOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashPathOr4x6 = (defaultValue: any) => any;
+    type LodashPathOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashPathOr7x6 = (defaultValue: any) => any;
     interface LodashPick {
         <T extends object, U extends keyof T>(props: lodash.Many<U>): LodashPick1x1<T, U>;
         <T extends object>(props: lodash.__, object: T): LodashPick1x2<T>;
@@ -2896,15 +3024,21 @@ declare namespace _ {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashProp2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashProp3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProp3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashProp3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashProp4x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashProp5x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashProp6x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProp6x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProp4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProp7x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashProp5x1;
-        (path: lodash.__, object: null | undefined): LodashProp5x2;
+        (path: lodash.PropertyPath): LodashProp8x1;
+        (path: lodash.__, object: null | undefined): LodashProp8x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashProp6x2;
+        (path: lodash.__, object: any): LodashProp9x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashProp1x1<TObject, TKey extends keyof TObject> {
@@ -2912,34 +3046,48 @@ declare namespace _ {
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
     type LodashProp1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashProp2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashProp3x1 {
+    interface LodashProp2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    type LodashProp3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2] | undefined;
+    type LodashProp4x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3] | undefined;
+    type LodashProp5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    interface LodashProp6x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashProp3x2<T> = (path: number) => T;
-    type LodashProp4x2<T> = (path: number) => T | undefined;
-    interface LodashProp5x1 {
+    type LodashProp6x2<T> = (path: number) => T;
+    type LodashProp7x2<T> = (path: number) => T | undefined;
+    interface LodashProp8x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashProp5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashProp6x2 = (path: lodash.PropertyPath) => any;
+    type LodashProp8x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashProp9x2 = (path: lodash.PropertyPath) => any;
     interface LodashProperty {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashProperty1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashProperty1x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashProperty2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashProperty3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProperty3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashProperty3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashProperty4x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashProperty5x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashProperty6x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProperty6x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProperty4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProperty7x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashProperty5x1;
-        (path: lodash.__, object: null | undefined): LodashProperty5x2;
+        (path: lodash.PropertyPath): LodashProperty8x1;
+        (path: lodash.__, object: null | undefined): LodashProperty8x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashProperty6x2;
+        (path: lodash.__, object: any): LodashProperty9x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashProperty1x1<TObject, TKey extends keyof TObject> {
@@ -2947,34 +3095,48 @@ declare namespace _ {
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
     type LodashProperty1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashProperty2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashProperty3x1 {
+    interface LodashProperty2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    type LodashProperty3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2] | undefined;
+    type LodashProperty4x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3] | undefined;
+    type LodashProperty5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    interface LodashProperty6x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashProperty3x2<T> = (path: number) => T;
-    type LodashProperty4x2<T> = (path: number) => T | undefined;
-    interface LodashProperty5x1 {
+    type LodashProperty6x2<T> = (path: number) => T;
+    type LodashProperty7x2<T> = (path: number) => T | undefined;
+    interface LodashProperty8x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashProperty5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashProperty6x2 = (path: lodash.PropertyPath) => any;
+    type LodashProperty8x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashProperty9x2 = (path: lodash.PropertyPath) => any;
     interface LodashPropertyOf {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPropertyOf1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashPropertyOf1x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPropertyOf2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashPropertyOf3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPropertyOf3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPropertyOf3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPropertyOf4x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPropertyOf5x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashPropertyOf6x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPropertyOf6x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropertyOf4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropertyOf7x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashPropertyOf5x1;
-        (path: lodash.__, object: null | undefined): LodashPropertyOf5x2;
+        (path: lodash.PropertyPath): LodashPropertyOf8x1;
+        (path: lodash.__, object: null | undefined): LodashPropertyOf8x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashPropertyOf6x2;
+        (path: lodash.__, object: any): LodashPropertyOf9x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPropertyOf1x1<TObject, TKey extends keyof TObject> {
@@ -2982,19 +3144,27 @@ declare namespace _ {
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
     type LodashPropertyOf1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashPropertyOf2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashPropertyOf3x1 {
+    interface LodashPropertyOf2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    type LodashPropertyOf3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2] | undefined;
+    type LodashPropertyOf4x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3] | undefined;
+    type LodashPropertyOf5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = (object: TObject | null | undefined) => TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    interface LodashPropertyOf6x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashPropertyOf3x2<T> = (path: number) => T;
-    type LodashPropertyOf4x2<T> = (path: number) => T | undefined;
-    interface LodashPropertyOf5x1 {
+    type LodashPropertyOf6x2<T> = (path: number) => T;
+    type LodashPropertyOf7x2<T> = (path: number) => T | undefined;
+    interface LodashPropertyOf8x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashPropertyOf5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashPropertyOf6x2 = (path: lodash.PropertyPath) => any;
+    type LodashPropertyOf8x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashPropertyOf9x2 = (path: lodash.PropertyPath) => any;
     interface LodashPropOr {
         <TDefault>(defaultValue: TDefault): LodashPropOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPropOr1x2<TObject, TKey>;
@@ -3003,34 +3173,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashPropOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashPropOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashPropOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashPropOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPropOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPropOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashPropOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashPropOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPropOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPropOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPropOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPropOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPropOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPropOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPropOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPropOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashPropOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPropOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashPropOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPropOr4x6;
+        (defaultValue: any): LodashPropOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashPropOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPropOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashPropOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPropOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPropOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPropOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPropOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashPropOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashPropOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashPropOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashPropOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashPropOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashPropOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashPropOr1x2<TObject, TKey extends keyof TObject> {
@@ -3043,51 +3231,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashPropOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPropOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashPropOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashPropOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashPropOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashPropOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x6<T>;
+    interface LodashPropOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashPropOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashPropOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashPropOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashPropOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashPropOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashPropOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashPropOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashPropOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashPropOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashPropOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashPropOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashPropOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashPropOr2x6<T>;
+    type LodashPropOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashPropOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashPropOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashPropOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashPropOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashPropOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashPropOr3x6;
+    type LodashPropOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashPropOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashPropOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPropOr4x3;
-        (defaultValue: lodash.__, object: any): LodashPropOr4x6;
+        (defaultValue: any): LodashPropOr7x3;
+        (defaultValue: lodash.__, object: any): LodashPropOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashPropOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashPropOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr3x6;
+    type LodashPropOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashPropOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashPropOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashPropOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashPropOr4x1 {
-        (path: lodash.PropertyPath): LodashPropOr4x3;
-        (path: lodash.__, object: any): LodashPropOr4x5;
+    type LodashPropOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashPropOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashPropOr7x1 {
+        (path: lodash.PropertyPath): LodashPropOr7x3;
+        (path: lodash.__, object: any): LodashPropOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashPropOr4x3 = (object: any) => any;
-    interface LodashPropOr4x4 {
-        (defaultValue: any): LodashPropOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr4x6;
+    type LodashPropOr7x3 = (object: any) => any;
+    interface LodashPropOr7x4 {
+        (defaultValue: any): LodashPropOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashPropOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashPropOr4x6 = (defaultValue: any) => any;
+    type LodashPropOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashPropOr7x6 = (defaultValue: any) => any;
     interface LodashPull {
         <T>(values: T): LodashPull1x1<T>;
         <T>(values: lodash.__, array: ReadonlyArray<T>): LodashPull1x2<T>;

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -8,6 +8,7 @@
 //                 Georgii Dolzhykov <https://github.com/thorn0>,
 //                 Jack Moore <https://github.com/jtmthf>,
 //                 Dominique Rau <https://github.com/DomiR>
+//                 William Chelman <https://github.com/WilliamChelman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5178,7 +5178,8 @@ fp.now(); // $ExpectType number
     _.get([42], 0, -1); // $ExpectType number
     _.get({ a: { b: true } }, "a"); // $ExpectType { b: boolean; }
     _.get({ a: { b: true } }, ["a"]); // $ExpectType { b: boolean; }
-    _.get({ a: { b: true } }, ["a", "b"]); // $ExpectType any
+    _.get({ a: { b: true } }, ["a", "b"]); // $ExpectType boolean | undefined
+    _.get({ a: { b: { c: { d: true} } } }, ["a", "b", "c", "d"]); // $ExpectType boolean | undefined
     _.get({ a: undefined }, "a"); // $ExpectType undefined
     _.get({ a: value }, "a", defaultValue); // $ExpectType string | boolean
     _.get({ a: undefined }, "a", defaultValue); // $ExpectType boolean
@@ -5188,7 +5189,8 @@ fp.now(); // $ExpectType number
     _([42]).get(0, -1); // $ExpectType number
     _({ a: { b: true } }).get("a"); // $ExpectType { b: boolean; }
     _({ a: { b: true } }).get(["a"]); // $ExpectType { b: boolean; }
-    _({ a: { b: true } }).get(["a", "b"]); // $ExpectType any
+    _({ a: { b: true } }).get(["a", "b"]); // $ExpectType boolean
+    _({ a: { b: { c: { d: true}} } }).get(["a", "b", "c", "d"]); // $ExpectType boolean
     _({ a: undefined }).get("a"); // $ExpectType undefined
     _({ a: value }).get("a", defaultValue); // $ExpectType string | boolean
     _({ a: undefined }).get("a", defaultValue); // $ExpectType boolean
@@ -5198,7 +5200,8 @@ fp.now(); // $ExpectType number
     _.chain([42]).get(0, -1); // ExpectType LoDashExplicitWrapper<number>
     _.chain({ a: { b: true } }).get("a"); // $ExpectType LoDashExplicitWrapper<{ b: boolean; }>
     _.chain({ a: { b: true } }).get(["a"]); // $ExpectType LoDashExplicitWrapper<{ b: boolean; }>
-    _.chain({ a: { b: true } }).get(["a", "b"]); // $ExpectType LoDashExplicitWrapper<any>
+    _.chain({ a: { b: true } }).get(["a", "b"]); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain({ a: { b: { c: { d: true}} } }).get(["a", "b", "c", "d"]); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain({ a: undefined }).get("a"); // $ExpectType LoDashExplicitWrapper<undefined>
     _.chain({ a: value }).get("a", defaultValue); // $ExpectType LoDashExplicitWrapper<string | boolean>
     _.chain({ a: undefined }).get("a", defaultValue); // $ExpectType LoDashExplicitWrapper<boolean>

--- a/types/lodash/scripts/package.json
+++ b/types/lodash/scripts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "generate": "ts-node generate-fp",
-    "fp": "ts-node generate-fp",
+    "fp": "ts-node generate-fp"
   },
   "devDependencies": {
     "lodash": "^4.17.4",

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1041,6 +1041,42 @@ declare module "../index" {
         /**
          * @see _.get
          */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(object: TObject, path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(object: TObject | null | undefined, path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(object: TObject, path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(object: TObject, path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        /**
+         * @see _.get
+         */
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
         get<T>(object: NumericDictionary<T>, path: number): T;
         /**
          * @see _.get
@@ -1082,6 +1118,30 @@ declare module "../index" {
          * @see _.get
          */
         get<TKey extends keyof T, TDefault>(path: TKey | [TKey], defaultValue: TDefault): Exclude<T[TKey], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1]>(path: [TKey1, TKey2]): T[TKey1][TKey2];
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TDefault>(path: [TKey1, TKey2], defaultValue: TDefault): Exclude<T[TKey1][TKey2], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): T[TKey1][TKey2][TKey3];
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TDefault>(path: [TKey1, TKey2, TKey3], defaultValue: TDefault): Exclude<T[TKey1][TKey2][TKey3], undefined> | TDefault;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TKey4 extends keyof T[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): T[TKey1][TKey2][TKey3][TKey4];
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TKey4 extends keyof T[TKey1][TKey2][TKey3], TDefault>(path: [TKey1, TKey2, TKey3, TKey4], defaultValue: TDefault): Exclude<T[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
         /**
          * @see _.get
          */
@@ -1130,6 +1190,42 @@ declare module "../index" {
          * @see _.get
          */
         get<TKey extends keyof T, TDefault>(path: TKey | [TKey], defaultValue: TDefault): ExpChain<Exclude<T[TKey], undefined> | TDefault>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1]>(path: [TKey1, TKey2]): ExpChain<T[TKey1][TKey2]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1]>(path: [TKey1, TKey2], defaultValue: never[]): T[TKey1][TKey2] extends any[] ? ExpChain<Exclude<T[TKey1][TKey2], undefined>> : ExpChain<Exclude<T[TKey1][TKey2], undefined> | never[]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TDefault>(path: [TKey1, TKey2], defaultValue: TDefault): ExpChain<Exclude<T[TKey1][TKey2], undefined> | TDefault>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): ExpChain<T[TKey1][TKey2][TKey3]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], defaultValue: never[]): T[TKey1][TKey2][TKey3] extends any[] ? ExpChain<Exclude<T[TKey1][TKey2][TKey3], undefined>> : ExpChain<Exclude<T[TKey1][TKey2][TKey3], undefined> | never[]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TDefault>(path: [TKey1, TKey2, TKey3], defaultValue: TDefault): ExpChain<Exclude<T[TKey1][TKey2][TKey3], undefined> | TDefault>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TKey4 extends keyof T[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): ExpChain<T[TKey1][TKey2][TKey3][TKey4]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TKey4 extends keyof T[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], defaultValue: never[]): T[TKey1][TKey2][TKey3][TKey4] extends any[] ? ExpChain<Exclude<T[TKey1][TKey2][TKey3][TKey4], undefined>> : ExpChain<Exclude<T[TKey1][TKey2][TKey3][TKey4], undefined> | never[]>;
+        /**
+         * @see _.get
+         */
+        get<TKey1 extends keyof T, TKey2 extends keyof T[TKey1], TKey3 extends keyof T[TKey1][TKey2], TKey4 extends keyof T[TKey1][TKey2][TKey3], TDefault>(path: [TKey1, TKey2, TKey3, TKey4], defaultValue: TDefault): ExpChain<Exclude<T[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault>;
         /**
          * @see _.get
          */

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -1387,35 +1387,66 @@ declare namespace _ {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashGet2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashGet3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashGet3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashGet3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject): TObject[TKey1][TKey2];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashGet5x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject): TObject[TKey1][TKey2][TKey3];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashGet7x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashGet9x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashGet9x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGet4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGet10x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashGet5x1;
-        (path: lodash.__, object: null | undefined): LodashGet5x2;
+        (path: lodash.PropertyPath): LodashGet11x1;
+        (path: lodash.__, object: null | undefined): LodashGet11x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashGet6x2;
+        (path: lodash.__, object: any): LodashGet12x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashGet1x1<TObject, TKey extends keyof TObject> {
         (object: TObject): TObject[TKey];
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
-    type LodashGet1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashGet2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashGet3x1 {
+    interface LodashGet1x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+    }
+    interface LodashGet2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashGet3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        (object: TObject): TObject[TKey1][TKey2];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+    }
+    interface LodashGet5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+    }
+    interface LodashGet7x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashGet9x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashGet3x2<T> = (path: number) => T;
-    type LodashGet4x2<T> = (path: number) => T | undefined;
-    interface LodashGet5x1 {
+    type LodashGet9x2<T> = (path: number) => T;
+    type LodashGet10x2<T> = (path: number) => T | undefined;
+    interface LodashGet11x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashGet5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashGet6x2 = (path: lodash.PropertyPath) => any;
+    type LodashGet11x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashGet12x2 = (path: lodash.PropertyPath) => any;
     interface LodashGetOr {
         <TDefault>(defaultValue: TDefault): LodashGetOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashGetOr1x2<TObject, TKey>;
@@ -1424,34 +1455,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashGetOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashGetOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashGetOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashGetOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashGetOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashGetOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashGetOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashGetOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashGetOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashGetOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashGetOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashGetOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashGetOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashGetOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashGetOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashGetOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashGetOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashGetOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashGetOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashGetOr4x6;
+        (defaultValue: any): LodashGetOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashGetOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashGetOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashGetOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashGetOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashGetOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashGetOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashGetOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashGetOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashGetOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashGetOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashGetOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashGetOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashGetOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashGetOr1x2<TObject, TKey extends keyof TObject> {
@@ -1464,51 +1513,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashGetOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashGetOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashGetOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashGetOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashGetOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashGetOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr2x6<T>;
+    interface LodashGetOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashGetOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashGetOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashGetOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashGetOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashGetOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashGetOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashGetOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashGetOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashGetOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashGetOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashGetOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashGetOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashGetOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashGetOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashGetOr2x6<T>;
+    type LodashGetOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashGetOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashGetOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashGetOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashGetOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashGetOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashGetOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashGetOr3x6;
+    type LodashGetOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashGetOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashGetOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashGetOr4x3;
-        (defaultValue: lodash.__, object: any): LodashGetOr4x6;
+        (defaultValue: any): LodashGetOr7x3;
+        (defaultValue: lodash.__, object: any): LodashGetOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashGetOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashGetOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashGetOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr3x6;
+    type LodashGetOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashGetOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashGetOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashGetOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashGetOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashGetOr4x1 {
-        (path: lodash.PropertyPath): LodashGetOr4x3;
-        (path: lodash.__, object: any): LodashGetOr4x5;
+    type LodashGetOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashGetOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashGetOr7x1 {
+        (path: lodash.PropertyPath): LodashGetOr7x3;
+        (path: lodash.__, object: any): LodashGetOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashGetOr4x3 = (object: any) => any;
-    interface LodashGetOr4x4 {
-        (defaultValue: any): LodashGetOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr4x6;
+    type LodashGetOr7x3 = (object: any) => any;
+    interface LodashGetOr7x4 {
+        (defaultValue: any): LodashGetOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashGetOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashGetOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashGetOr4x6 = (defaultValue: any) => any;
+    type LodashGetOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashGetOr7x6 = (defaultValue: any) => any;
     interface LodashGroupBy {
         <T>(iteratee: lodash.ValueIteratee<T>): LodashGroupBy1x1<T>;
         <T>(iteratee: lodash.__, collection: lodash.List<T> | null | undefined): LodashGroupBy1x2<T>;
@@ -1831,7 +1912,6 @@ declare namespace _ {
     }
     interface LodashIsArrayLikeObject {
         <T extends { __lodashAnyHack: any }>(value: T): boolean;
-        // tslint:disable-next-line:ban-types (type guard doesn't seem to work correctly without the lodash.Function type)
         (value: ((...args: any[]) => any) | lodash.FunctionBase | string | boolean | number | null | undefined): value is never;
         (value: any): value is object & { length: number };
     }
@@ -2604,50 +2684,87 @@ declare namespace _ {
     type LodashPartialRight27x1 = (args: ReadonlyArray<any>) => (...args: any[]) => any;
     type LodashPartialRight27x2 = (func: (...args: any[]) => any) => (...args: any[]) => any;
     interface LodashPartition {
-        <T>(callback: lodash.ValueIteratee<T>): LodashPartition1x1<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): LodashPartition1x1<T, U>;
         <T>(callback: lodash.__, collection: lodash.List<T> | null | undefined): LodashPartition1x2<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>, collection: lodash.List<T> | null | undefined): [U[], Array<Exclude<T, U>>];
+        <T>(callback: lodash.ValueIteratee<T>): LodashPartition2x1<T>;
         <T>(callback: lodash.ValueIteratee<T>, collection: lodash.List<T> | null | undefined): [T[], T[]];
-        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition2x2<T>;
+        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition3x2<T>;
         <T extends object>(callback: lodash.ValueIteratee<T[keyof T]>, collection: T | null | undefined): [Array<T[keyof T]>, Array<T[keyof T]>];
     }
-    type LodashPartition1x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
-    type LodashPartition1x2<T> = (callback: lodash.ValueIteratee<T>) => [T[], T[]];
-    type LodashPartition2x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
+    type LodashPartition1x1<T, U> = (collection: lodash.List<T> | null | undefined) => [U[], Array<Exclude<T, U>>];
+    interface LodashPartition1x2<T> {
+        <U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): [U[], Array<Exclude<T, U>>];
+        (callback: lodash.ValueIteratee<T>): [T[], T[]];
+    }
+    type LodashPartition2x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
+    type LodashPartition3x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
     interface LodashPath {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPath1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashPath1x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPath2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashPath3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPath3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPath3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject): TObject[TKey1][TKey2];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPath5x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject): TObject[TKey1][TKey2][TKey3];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPath7x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashPath9x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPath9x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPath4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPath10x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashPath5x1;
-        (path: lodash.__, object: null | undefined): LodashPath5x2;
+        (path: lodash.PropertyPath): LodashPath11x1;
+        (path: lodash.__, object: null | undefined): LodashPath11x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashPath6x2;
+        (path: lodash.__, object: any): LodashPath12x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPath1x1<TObject, TKey extends keyof TObject> {
         (object: TObject): TObject[TKey];
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
-    type LodashPath1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashPath2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashPath3x1 {
+    interface LodashPath1x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+    }
+    interface LodashPath2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashPath3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        (object: TObject): TObject[TKey1][TKey2];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+    }
+    interface LodashPath5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+    }
+    interface LodashPath7x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashPath9x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashPath3x2<T> = (path: number) => T;
-    type LodashPath4x2<T> = (path: number) => T | undefined;
-    interface LodashPath5x1 {
+    type LodashPath9x2<T> = (path: number) => T;
+    type LodashPath10x2<T> = (path: number) => T | undefined;
+    interface LodashPath11x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashPath5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashPath6x2 = (path: lodash.PropertyPath) => any;
+    type LodashPath11x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashPath12x2 = (path: lodash.PropertyPath) => any;
     interface LodashPathOr {
         <TDefault>(defaultValue: TDefault): LodashPathOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPathOr1x2<TObject, TKey>;
@@ -2656,34 +2773,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashPathOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashPathOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashPathOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashPathOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPathOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPathOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashPathOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashPathOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPathOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPathOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPathOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPathOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPathOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPathOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPathOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPathOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashPathOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPathOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashPathOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPathOr4x6;
+        (defaultValue: any): LodashPathOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashPathOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPathOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashPathOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPathOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPathOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPathOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPathOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashPathOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashPathOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashPathOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashPathOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashPathOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashPathOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashPathOr1x2<TObject, TKey extends keyof TObject> {
@@ -2696,51 +2831,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashPathOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPathOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashPathOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashPathOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashPathOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashPathOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr2x6<T>;
+    interface LodashPathOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashPathOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashPathOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashPathOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashPathOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashPathOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashPathOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPathOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashPathOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashPathOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashPathOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPathOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashPathOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashPathOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashPathOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashPathOr2x6<T>;
+    type LodashPathOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashPathOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashPathOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashPathOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashPathOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashPathOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashPathOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashPathOr3x6;
+    type LodashPathOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashPathOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashPathOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPathOr4x3;
-        (defaultValue: lodash.__, object: any): LodashPathOr4x6;
+        (defaultValue: any): LodashPathOr7x3;
+        (defaultValue: lodash.__, object: any): LodashPathOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashPathOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashPathOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashPathOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr3x6;
+    type LodashPathOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashPathOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashPathOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashPathOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashPathOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashPathOr4x1 {
-        (path: lodash.PropertyPath): LodashPathOr4x3;
-        (path: lodash.__, object: any): LodashPathOr4x5;
+    type LodashPathOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashPathOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashPathOr7x1 {
+        (path: lodash.PropertyPath): LodashPathOr7x3;
+        (path: lodash.__, object: any): LodashPathOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashPathOr4x3 = (object: any) => any;
-    interface LodashPathOr4x4 {
-        (defaultValue: any): LodashPathOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr4x6;
+    type LodashPathOr7x3 = (object: any) => any;
+    interface LodashPathOr7x4 {
+        (defaultValue: any): LodashPathOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPathOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashPathOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashPathOr4x6 = (defaultValue: any) => any;
+    type LodashPathOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashPathOr7x6 = (defaultValue: any) => any;
     interface LodashPick {
         <T extends object, U extends keyof T>(props: lodash.Many<U>): LodashPick1x1<T, U>;
         <T extends object>(props: lodash.__, object: T): LodashPick1x2<T>;
@@ -2789,105 +2956,198 @@ declare namespace _ {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashProp2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashProp3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProp3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashProp3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject): TObject[TKey1][TKey2];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashProp5x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject): TObject[TKey1][TKey2][TKey3];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashProp7x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashProp9x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProp9x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProp4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProp10x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashProp5x1;
-        (path: lodash.__, object: null | undefined): LodashProp5x2;
+        (path: lodash.PropertyPath): LodashProp11x1;
+        (path: lodash.__, object: null | undefined): LodashProp11x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashProp6x2;
+        (path: lodash.__, object: any): LodashProp12x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashProp1x1<TObject, TKey extends keyof TObject> {
         (object: TObject): TObject[TKey];
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
-    type LodashProp1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashProp2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashProp3x1 {
+    interface LodashProp1x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+    }
+    interface LodashProp2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashProp3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        (object: TObject): TObject[TKey1][TKey2];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+    }
+    interface LodashProp5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+    }
+    interface LodashProp7x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashProp9x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashProp3x2<T> = (path: number) => T;
-    type LodashProp4x2<T> = (path: number) => T | undefined;
-    interface LodashProp5x1 {
+    type LodashProp9x2<T> = (path: number) => T;
+    type LodashProp10x2<T> = (path: number) => T | undefined;
+    interface LodashProp11x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashProp5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashProp6x2 = (path: lodash.PropertyPath) => any;
+    type LodashProp11x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashProp12x2 = (path: lodash.PropertyPath) => any;
     interface LodashProperty {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashProperty1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashProperty1x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashProperty2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashProperty3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProperty3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashProperty3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject): TObject[TKey1][TKey2];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashProperty5x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject): TObject[TKey1][TKey2][TKey3];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashProperty7x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashProperty9x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashProperty9x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProperty4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashProperty10x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashProperty5x1;
-        (path: lodash.__, object: null | undefined): LodashProperty5x2;
+        (path: lodash.PropertyPath): LodashProperty11x1;
+        (path: lodash.__, object: null | undefined): LodashProperty11x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashProperty6x2;
+        (path: lodash.__, object: any): LodashProperty12x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashProperty1x1<TObject, TKey extends keyof TObject> {
         (object: TObject): TObject[TKey];
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
-    type LodashProperty1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashProperty2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashProperty3x1 {
+    interface LodashProperty1x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+    }
+    interface LodashProperty2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashProperty3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        (object: TObject): TObject[TKey1][TKey2];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+    }
+    interface LodashProperty5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+    }
+    interface LodashProperty7x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashProperty9x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashProperty3x2<T> = (path: number) => T;
-    type LodashProperty4x2<T> = (path: number) => T | undefined;
-    interface LodashProperty5x1 {
+    type LodashProperty9x2<T> = (path: number) => T;
+    type LodashProperty10x2<T> = (path: number) => T | undefined;
+    interface LodashProperty11x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashProperty5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashProperty6x2 = (path: lodash.PropertyPath) => any;
+    type LodashProperty11x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashProperty12x2 = (path: lodash.PropertyPath) => any;
     interface LodashPropertyOf {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPropertyOf1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashPropertyOf1x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject): TObject[TKey];
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPropertyOf2x2<TObject>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): TObject[TKey] | undefined;
-        (path: number): LodashPropertyOf3x1;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPropertyOf3x2<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPropertyOf3x1<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject): TObject[TKey1][TKey2];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPropertyOf5x1<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject): TObject[TKey1][TKey2][TKey3];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPropertyOf7x1<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        (path: number): LodashPropertyOf9x1;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T>): LodashPropertyOf9x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T>): T;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropertyOf4x2<T>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropertyOf10x2<T>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
-        (path: lodash.PropertyPath): LodashPropertyOf5x1;
-        (path: lodash.__, object: null | undefined): LodashPropertyOf5x2;
+        (path: lodash.PropertyPath): LodashPropertyOf11x1;
+        (path: lodash.__, object: null | undefined): LodashPropertyOf11x2;
         (path: lodash.PropertyPath, object: null | undefined): undefined;
-        (path: lodash.__, object: any): LodashPropertyOf6x2;
+        (path: lodash.__, object: any): LodashPropertyOf12x2;
         (path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPropertyOf1x1<TObject, TKey extends keyof TObject> {
         (object: TObject): TObject[TKey];
         (object: TObject | null | undefined): TObject[TKey] | undefined;
     }
-    type LodashPropertyOf1x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey];
-    type LodashPropertyOf2x2<TObject> = <TKey extends keyof TObject>(path: TKey | [TKey]) => TObject[TKey] | undefined;
-    interface LodashPropertyOf3x1 {
+    interface LodashPropertyOf1x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3];
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4];
+    }
+    interface LodashPropertyOf2x2<TObject> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): TObject[TKey] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashPropertyOf3x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        (object: TObject): TObject[TKey1][TKey2];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2] | undefined;
+    }
+    interface LodashPropertyOf5x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3] | undefined;
+    }
+    interface LodashPropertyOf7x1<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        (object: TObject): TObject[TKey1][TKey2][TKey3][TKey4];
+        (object: TObject | null | undefined): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+    }
+    interface LodashPropertyOf9x1 {
         <T>(object: lodash.NumericDictionary<T>): T;
         <T>(object: lodash.NumericDictionary<T> | null | undefined): T | undefined;
     }
-    type LodashPropertyOf3x2<T> = (path: number) => T;
-    type LodashPropertyOf4x2<T> = (path: number) => T | undefined;
-    interface LodashPropertyOf5x1 {
+    type LodashPropertyOf9x2<T> = (path: number) => T;
+    type LodashPropertyOf10x2<T> = (path: number) => T | undefined;
+    interface LodashPropertyOf11x1 {
         (object: null | undefined): undefined;
         (object: any): any;
     }
-    type LodashPropertyOf5x2 = (path: lodash.PropertyPath) => undefined;
-    type LodashPropertyOf6x2 = (path: lodash.PropertyPath) => any;
+    type LodashPropertyOf11x2 = (path: lodash.PropertyPath) => undefined;
+    type LodashPropertyOf12x2 = (path: lodash.PropertyPath) => any;
     interface LodashPropOr {
         <TDefault>(defaultValue: TDefault): LodashPropOr1x1<TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPropOr1x2<TObject, TKey>;
@@ -2896,34 +3156,52 @@ declare namespace _ {
         <TObject extends object, TDefault>(defaultValue: TDefault, path: lodash.__, object: TObject | null | undefined): LodashPropOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey], object: TObject | null | undefined): LodashPropOr1x6<TObject, TKey>;
         <TObject extends object, TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (defaultValue: lodash.__, path: number): LodashPropOr2x2;
-        <TDefault>(defaultValue: TDefault, path: number): LodashPropOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x4<T>;
-        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x5<T, TDefault>;
-        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x6<T>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPropOr2x2<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2], object: TObject | null | undefined): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPropOr3x2<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x2<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (defaultValue: lodash.__, path: number): LodashPropOr5x2;
+        <TDefault>(defaultValue: TDefault, path: number): LodashPropOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x4<T>;
+        <T, TDefault>(defaultValue: TDefault, path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x5<T, TDefault>;
+        <T>(defaultValue: lodash.__, path: number, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr3x2;
-        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPropOr3x3<TDefault>;
-        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPropOr3x4;
-        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPropOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPropOr3x6;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr6x2;
+        <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): LodashPropOr6x3<TDefault>;
+        (defaultValue: lodash.__, path: lodash.__, object: null | undefined): LodashPropOr6x4;
+        <TDefault>(defaultValue: TDefault, path: lodash.__, object: null | undefined): LodashPropOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: null | undefined): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPropOr4x1;
-        (defaultValue: any, path: lodash.PropertyPath): LodashPropOr4x3;
-        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPropOr4x4;
-        (defaultValue: any, path: lodash.__, object: any): LodashPropOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPropOr4x6;
+        (defaultValue: any): LodashPropOr7x1;
+        (defaultValue: any, path: lodash.PropertyPath): LodashPropOr7x3;
+        (defaultValue: lodash.__, path: lodash.__, object: any): LodashPropOr7x4;
+        (defaultValue: any, path: lodash.__, object: any): LodashPropOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath, object: any): LodashPropOr7x6;
         (defaultValue: any, path: lodash.PropertyPath, object: any): any;
     }
     interface LodashPropOr1x1<TDefault> {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPropOr1x3<TObject, TKey, TDefault>;
         <TObject extends object>(path: lodash.__, object: TObject | null | undefined): LodashPropOr1x5<TObject, TDefault>;
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey], object: TObject | null | undefined): Exclude<TObject[TKey], undefined> | TDefault;
-        (path: number): LodashPropOr2x3<TDefault>;
-        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x5<T, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        <TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4], object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        (path: number): LodashPropOr5x3<TDefault>;
+        <T>(path: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x5<T, TDefault>;
         <T>(path: number, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
-        (path: lodash.PropertyPath): LodashPropOr3x3<TDefault>;
-        (path: lodash.__, object: null | undefined): LodashPropOr3x5<TDefault>;
+        (path: lodash.PropertyPath): LodashPropOr6x3<TDefault>;
+        (path: lodash.__, object: null | undefined): LodashPropOr6x5<TDefault>;
         (path: lodash.PropertyPath, object: null | undefined): TDefault;
     }
     interface LodashPropOr1x2<TObject, TKey extends keyof TObject> {
@@ -2936,51 +3214,83 @@ declare namespace _ {
         <TDefault>(defaultValue: TDefault): LodashPropOr1x5<TObject, TDefault>;
         <TKey extends keyof TObject>(defaultValue: lodash.__, path: TKey | [TKey]): LodashPropOr1x6<TObject, TKey>;
         <TKey extends keyof TObject, TDefault>(defaultValue: TDefault, path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(defaultValue: lodash.__, path: [TKey1, TKey2]): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3]): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(defaultValue: lodash.__, path: [TKey1, TKey2, TKey3, TKey4]): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(defaultValue: TDefault, path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
     }
-    type LodashPropOr1x5<TObject, TDefault> = <TKey extends keyof TObject>(path: TKey | [TKey]) => Exclude<TObject[TKey], undefined> | TDefault;
+    interface LodashPropOr1x5<TObject, TDefault> {
+        <TKey extends keyof TObject>(path: TKey | [TKey]): Exclude<TObject[TKey], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(path: [TKey1, TKey2]): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(path: [TKey1, TKey2, TKey3]): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        <TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(path: [TKey1, TKey2, TKey3, TKey4]): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
     type LodashPropOr1x6<TObject, TKey extends keyof TObject> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey], undefined> | TDefault;
-    interface LodashPropOr2x2 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr2x3<TDefault>;
-        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr2x6<T>;
+    interface LodashPropOr2x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr2x3<TObject, TKey1, TKey2, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr2x6<TObject, TKey1, TKey2>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    }
+    type LodashPropOr2x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    type LodashPropOr2x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+    interface LodashPropOr3x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr3x3<TObject, TKey1, TKey2, TKey3, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr3x6<TObject, TKey1, TKey2, TKey3>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    }
+    type LodashPropOr3x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    type LodashPropOr3x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+    interface LodashPropOr4x2<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr4x3<TObject, TKey1, TKey2, TKey3, TKey4, TDefault>;
+        (defaultValue: lodash.__, object: TObject | null | undefined): LodashPropOr4x6<TObject, TKey1, TKey2, TKey3, TKey4>;
+        <TDefault>(defaultValue: TDefault, object: TObject | null | undefined): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    }
+    type LodashPropOr4x3<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault> = (object: TObject | null | undefined) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    type LodashPropOr4x6<TObject, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]> = <TDefault>(defaultValue: TDefault) => Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+    interface LodashPropOr5x2 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr5x3<TDefault>;
+        <T>(defaultValue: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPropOr5x6<T>;
         <T, TDefault>(defaultValue: TDefault, object: lodash.NumericDictionary<T> | null | undefined): T | TDefault;
     }
-    type LodashPropOr2x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
-    interface LodashPropOr2x4<T> {
-        <TDefault>(defaultValue: TDefault): LodashPropOr2x5<T, TDefault>;
-        (defaultValue: lodash.__, path: number): LodashPropOr2x6<T>;
+    type LodashPropOr5x3<TDefault> = <T>(object: lodash.NumericDictionary<T> | null | undefined) => T | TDefault;
+    interface LodashPropOr5x4<T> {
+        <TDefault>(defaultValue: TDefault): LodashPropOr5x5<T, TDefault>;
+        (defaultValue: lodash.__, path: number): LodashPropOr5x6<T>;
         <TDefault>(defaultValue: TDefault, path: number): T | TDefault;
     }
-    type LodashPropOr2x5<T, TDefault> = (path: number) => T | TDefault;
-    type LodashPropOr2x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
-    interface LodashPropOr3x2 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr3x3<TDefault>;
-        (defaultValue: lodash.__, object: null | undefined): LodashPropOr3x6;
+    type LodashPropOr5x5<T, TDefault> = (path: number) => T | TDefault;
+    type LodashPropOr5x6<T> = <TDefault>(defaultValue: TDefault) => T | TDefault;
+    interface LodashPropOr6x2 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr6x3<TDefault>;
+        (defaultValue: lodash.__, object: null | undefined): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, object: null | undefined): TDefault;
-        (defaultValue: any): LodashPropOr4x3;
-        (defaultValue: lodash.__, object: any): LodashPropOr4x6;
+        (defaultValue: any): LodashPropOr7x3;
+        (defaultValue: lodash.__, object: any): LodashPropOr7x6;
         (defaultValue: any, object: any): any;
     }
-    type LodashPropOr3x3<TDefault> = (object: null | undefined) => TDefault;
-    interface LodashPropOr3x4 {
-        <TDefault>(defaultValue: TDefault): LodashPropOr3x5<TDefault>;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr3x6;
+    type LodashPropOr6x3<TDefault> = (object: null | undefined) => TDefault;
+    interface LodashPropOr6x4 {
+        <TDefault>(defaultValue: TDefault): LodashPropOr6x5<TDefault>;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr6x6;
         <TDefault>(defaultValue: TDefault, path: lodash.PropertyPath): TDefault;
     }
-    type LodashPropOr3x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
-    type LodashPropOr3x6 = <TDefault>(defaultValue: TDefault) => TDefault;
-    interface LodashPropOr4x1 {
-        (path: lodash.PropertyPath): LodashPropOr4x3;
-        (path: lodash.__, object: any): LodashPropOr4x5;
+    type LodashPropOr6x5<TDefault> = (path: lodash.PropertyPath) => TDefault;
+    type LodashPropOr6x6 = <TDefault>(defaultValue: TDefault) => TDefault;
+    interface LodashPropOr7x1 {
+        (path: lodash.PropertyPath): LodashPropOr7x3;
+        (path: lodash.__, object: any): LodashPropOr7x5;
         (path: lodash.PropertyPath, object: any): any;
     }
-    type LodashPropOr4x3 = (object: any) => any;
-    interface LodashPropOr4x4 {
-        (defaultValue: any): LodashPropOr4x5;
-        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr4x6;
+    type LodashPropOr7x3 = (object: any) => any;
+    interface LodashPropOr7x4 {
+        (defaultValue: any): LodashPropOr7x5;
+        (defaultValue: lodash.__, path: lodash.PropertyPath): LodashPropOr7x6;
         (defaultValue: any, path: lodash.PropertyPath): any;
     }
-    type LodashPropOr4x5 = (path: lodash.PropertyPath) => any;
-    type LodashPropOr4x6 = (defaultValue: any) => any;
+    type LodashPropOr7x5 = (path: lodash.PropertyPath) => any;
+    type LodashPropOr7x6 = (defaultValue: any) => any;
     interface LodashPull {
         <T>(values: T): LodashPull1x1<T>;
         <T>(values: lodash.__, array: ReadonlyArray<T>): LodashPull1x2<T>;

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5182,7 +5182,8 @@ fp.now(); // $ExpectType number
     _.get([42], 0, -1); // $ExpectType number
     _.get({ a: { b: true } }, "a"); // $ExpectType { b: boolean; }
     _.get({ a: { b: true } }, ["a"]); // $ExpectType { b: boolean; }
-    _.get({ a: { b: true } }, ["a", "b"]); // $ExpectType any
+    _.get({ a: { b: true } }, ["a", "b"]); // $ExpectType boolean
+    _.get({ a: { b: { c: { d: true } } } }, ["a", "b", "c", "d"]); // $ExpectType boolean
     _.get({ a: undefined }, "a"); // $ExpectType undefined
     _.get({ a: value }, "a", defaultValue); // $ExpectType string | boolean
     _.get({ a: undefined }, "a", defaultValue); // $ExpectType boolean
@@ -5192,7 +5193,8 @@ fp.now(); // $ExpectType number
     _([42]).get(0, -1); // $ExpectType number
     _({ a: { b: true } }).get("a"); // $ExpectType { b: boolean; }
     _({ a: { b: true } }).get(["a"]); // $ExpectType { b: boolean; }
-    _({ a: { b: true } }).get(["a", "b"]); // $ExpectType any
+    _({ a: { b: true } }).get(["a", "b"]); // $ExpectType boolean
+    _({ a: { b: { c: {d: true } } } }).get(["a", "b", "c", "d"]); // $ExpectType boolean
     _({ a: undefined }).get("a"); // $ExpectType undefined
     _({ a: value }).get("a", defaultValue); // $ExpectType string | boolean
     _({ a: undefined }).get("a", defaultValue); // $ExpectType boolean
@@ -5202,7 +5204,10 @@ fp.now(); // $ExpectType number
     _.chain([42]).get(0, -1); // ExpectType PrimitiveChain<number>
     _.chain({ a: { b: true } }).get("a"); // $ExpectType ObjectChain<{ b: boolean; }>
     _.chain({ a: { b: true } }).get(["a"]); // $ExpectType ObjectChain<{ b: boolean; }>
-    _.chain({ a: { b: true } }).get(["a", "b"]); // $ExpectType LoDashExplicitWrapper<any>
+    _.chain({ a: { b: true } }).get(["a", "b"]); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
+    _.chain({ a: { b: { c: { d: true } } } }).get(["a", "b"]); // $ExpectType ObjectChain<{ c: { d: boolean; }; }>
+    _.chain({ a: { b: { c: { d: true } } } }).get(["a", "b", "c", "d"]); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
+    _.chain({ a: { b: { c: { d: true } } } }).get(["a", "b", "c", "d2"]); // $ExpectType LoDashExplicitWrapper<any>
     _.chain({ a: undefined }).get("a"); // $ExpectType never
     _.chain({ a: value }).get("a", defaultValue); // $ExpectType StringChain | PrimitiveChain<false> | PrimitiveChain<true>
     _.chain({ a: undefined }).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>

--- a/types/lodash/ts3.1/scripts/package.json
+++ b/types/lodash/ts3.1/scripts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "generate": "ts-node generate-fp",
-    "fp": "ts-node generate-fp",
+    "fp": "ts-node generate-fp"
   },
   "devDependencies": {
     "lodash": "^4.17.11",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.11#get
- [x] Increase the version number in the header if appropriate. => could not find version anywhere in source ?

With this, we can have something like
```typescript
const x = { a: { b: { c: { d: true } } } };
_.get(x, ["a", "b", "c", "d"]); // boolean | undefined
_.get(x, ["a", "b", "c2", "d"]); // any

type BS = {
  bool: boolean;
  s: string;
}

type NS = {
  n: number;
  s: string;
}

const y: { a: { b: BS | NS } } = {} as any;
_.get(y, ["a", "b"]); // BS | NS
_.get(y, ["a", "b", "bool"]); // any
_.get(y, ["a", "b", "n"]); // any
_.get(y, ["a", "b", "s"]); // string
```
with that we can have correct typing for path array of length up to 4, and it's still "any" for funkier scenarios.