### PR TITLE
sinon: resolve any in worst case

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -404,7 +404,7 @@ declare namespace Sinon {
          * The Promise library can be overwritten using the usingPromise method.
          * Since sinon@2.0.0
          */
-        resolves(value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : never): SinonStub<TArgs, TReturnValue>;
+        resolves(value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any): SinonStub<TArgs, TReturnValue>;
         /**
          * Causes the stub to return a Promise which resolves to the argument at the provided index.
          * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -491,6 +491,7 @@ function testStub() {
         foo(arg: string): number { return 1; }
         promiseFunc() { return Promise.resolve('foo'); }
         promiseLikeFunc() { return Promise.resolve('foo') as PromiseLike<string>; }
+        unresolvableReturnFunc(): any { return Promise.resolve(); }
         fooDeep(arg: { s: string }): void { return undefined; }
     };
     const instance = new obj();
@@ -501,6 +502,10 @@ function testStub() {
 
     const promiseStub = sinon.stub(instance, 'promiseFunc');
     promiseStub.resolves('test');
+
+    const promiseUnresolvableReturn =
+        sinon.stub(instance, 'unresolvableReturnFunc');
+    promiseUnresolvableReturn.resolves(['anything', 123, true]);
 
     const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
     promiseLikeStub.resolves('test');

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -502,6 +502,7 @@ function testStub() {
 
     const promiseStub = sinon.stub(instance, 'promiseFunc');
     promiseStub.resolves('test');
+    promiseStub.resolves(123); // $ExpectError
 
     const promiseUnresolvableReturn =
         sinon.stub(instance, 'unresolvableReturnFunc');


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

If we have an uninferrable return type by one of these cases (for example):

* Multiple overloads of a function or method
* `any`
* `unknown`

`resolves` will be typed as accepting `never`, making it completely unusable.

we should instead fallback to `any`, as "better typing when possible" is better than "better typing or nothing".