### PR TITLE
dockerode - Add to NetworkInspectInfo

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -375,19 +375,38 @@ declare namespace Dockerode {
     MacAddress: string;
   }
 
-  // not complete definition of network inspection
-  // info which is returned by list / inspect
+  // Information returned from inspecting a network
   interface NetworkInspectInfo {
-    Id: string;
     Name: string;
-    Driver: string;
+    Id: string;
     Created: string;
     Scope: string;
+    Driver: string;
     EnableIPv6: boolean;
+    IPAM?: IPAM;
     Internal: boolean;
     Attachable: boolean;
     Ingress: boolean;
+    Containers?: { [id: string]: NetworkContainer };
+    Options?: { [key: string]: string };
+    Labels?: { [key: string]: string };
   }
+
+  interface NetworkContainer {
+    Name: string;
+    EndpointID: string;
+    MacAddress: string;
+    Ipv4Address: string;
+    IPv6Address: string;
+  }
+
+  /* tslint:disable:interface-name */
+  interface IPAM {
+    Driver: string;
+    Config?: { [key: string]: string };
+    Options?: Array<{ [key: string]: string }>;
+  }
+  /* tslint:enable:interface-name */
 
   interface VolumeInspectInfo {
     Name: string;


### PR DESCRIPTION
I added some missing properties to the network inspect info, as per: https://docs.docker.com/engine/api/v1.39/swagger.yaml

Added fields are:

- IPAM
- Containers
- Options
- Label

### Template
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.docker.com/engine/api/v1.39/#>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
