### PR TITLE
Genericize ReactTimeago by ComponentType

### DIFF
--- a/types/react-timeago/index.d.ts
+++ b/types/react-timeago/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
 //                 Mike Martin <https://github.com/mcmar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from "react";
 

--- a/types/react-timeago/index.d.ts
+++ b/types/react-timeago/index.d.ts
@@ -1,35 +1,48 @@
 // Type definitions for react-timeago 4.1
 // Project: https://github.com/nmn/react-timeago
 // Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+//                 Mike Martin <https://github.com/mcmar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
 
 declare namespace ReactTimeago {
-    type Unit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+    type Unit =
+        | "second"
+        | "minute"
+        | "hour"
+        | "day"
+        | "week"
+        | "month"
+        | "year";
 
-    type Suffix = 'ago' | 'from now';
+    type Suffix = "ago" | "from now";
 
     type Formatter = (
-      value: number,
-      unit: Unit,
-      suffix: Suffix,
-      epochMiliseconds: number,
-      nextFormatter?: Formatter
+        value: number,
+        unit: Unit,
+        suffix: Suffix,
+        epochMiliseconds: number,
+        nextFormatter?: Formatter
     ) => React.ReactNode;
 
-    interface ReactTimeagoProps {
-      readonly live?: boolean;
-      readonly minPeriod?: number;
-      readonly maxPeriod?: number;
-      readonly component?: string | React.ComponentType<any>;
-      readonly title?: string;
-      readonly formatter?: Formatter;
-      readonly date: string | number | Date;
-      readonly now?: () => number;
+    interface ReactTimeagoProps<T extends React.ComponentType> {
+        readonly live?: boolean;
+        readonly minPeriod?: number;
+        readonly maxPeriod?: number;
+        readonly component?: string | T;
+        readonly title?: string;
+        readonly formatter?: Formatter;
+        readonly date: string | number | Date;
+        readonly now?: () => number;
     }
 }
 
-declare const ReactTimeago: React.ComponentClass<ReactTimeago.ReactTimeagoProps>;
+declare class ReactTimeago<
+    T extends React.ComponentType
+> extends React.Component<
+    ReactTimeago.ReactTimeagoProps<T> & React.ComponentProps<T>
+> {}
+
 export = ReactTimeago;

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -1,16 +1,20 @@
 import ReactTimeago, { Unit, Suffix } from "react-timeago";
 import * as React from "react";
+import { Text } from "react-native";
 
 const ReactTimeagoRequiredOptions: JSX.Element = (
-    <ReactTimeago
-        date={new Date()}
-    />
+    <ReactTimeago date={new Date()} />
 );
 
-const customFormatter = (value: number, unit: Unit, suffix: Suffix, epochMiliseconds: number) => {
-    return (
-        <div />
-    );
+const customFormatter = (
+    value: number,
+    unit: Unit,
+    suffix: Suffix,
+    epochMiliseconds: number
+) => {
+    return epochMiliseconds > 300000
+        ? `${value}${unit[0]} ${suffix}`
+        : "a really long time ago";
 };
 
 const ReactTimeagoAllOptions: JSX.Element = (
@@ -22,6 +26,17 @@ const ReactTimeagoAllOptions: JSX.Element = (
         component={() => <div />}
         title="Timeago"
         formatter={customFormatter}
+    />
+);
 
+const ReactTimeagoCustomComponent: JSX.Element = (
+    <ReactTimeago<typeof Text>
+        date={new Date()}
+        component={Text}
+        // props passed down to Text
+        style={[{ textAlign: "center" }, { fontSize: 24 }]}
+        numberOfLines={2}
+        ellipsizeMode="middle"
+        allowFontScaling
     />
 );

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -1,6 +1,5 @@
 import ReactTimeago, { Unit, Suffix } from "react-timeago";
 import * as React from "react";
-import { Text } from "react-native";
 
 const ReactTimeagoRequiredOptions: JSX.Element = (
     <ReactTimeago date={new Date()} />
@@ -28,6 +27,14 @@ const ReactTimeagoAllOptions: JSX.Element = (
         formatter={customFormatter}
     />
 );
+
+// inspired by react-native
+class Text extends React.Component<{
+    style?: {}[];
+    numberOfLines?: number;
+    ellipsizeMode?: "head" | "middle" | "tail" | "clip";
+    allowFontScaling?: boolean;
+}> {}
 
 const ReactTimeagoCustomComponent: JSX.Element = (
     <ReactTimeago<typeof Text>

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -30,7 +30,7 @@ const ReactTimeagoAllOptions: JSX.Element = (
 
 // inspired by react-native
 class Text extends React.Component<{
-    style?: {}[];
+    style?: Array<{}>;
     numberOfLines?: number;
     ellipsizeMode?: "head" | "middle" | "tail" | "clip";
     allowFontScaling?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

npm run lint react-timeago was already giving error, commented in this [Issue: Cannot find module 'csstype'](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24788)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nmn/react-timeago#anything-else-optional>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

More details:
This allows properties from `component` to be added to `TimeAgo` without throwing an error.

e.g.
```
<TimeAgo<typeof Text>
  component={Text}
  style={[styles.lastActiveText, { fontSize: activeBubbleSize * 0.588 }]}
  date={lastActiveAt}
/>
```

Type inferencing not working yet, so must specify generic in order to add properties from `component`