### PR TITLE
Add support for pay_immediately=false when creating Stripe subscriptions

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -6046,6 +6046,14 @@ declare namespace Stripe {
              * the anchor date. If false, the anchor period will be free (similar to a trial).
              */
             prorate?: boolean;
+
+            /**
+             * Boolean (default true). Used to prevent Stripe Invoicing from automatically paying the subscription on creation. This can be set
+             * to false when used with services like Avalara that need to augment an invoice before the subscription is paid.
+             *
+             * Using this flag requires contacting Stripe support in order to have the account whitelisted.
+             */
+            pay_immediately?: boolean;
         }
 
         interface ISubscriptionCreationOptions extends ISubscriptionCustCreationOptions {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -480,6 +480,14 @@ stripe.customers.createSource(
     }
 );
 
+stripe.customers.createSubscription(
+    "cus_5rfJKDJkuxzh5Q",
+    {
+        items: [{plan: "some_plan", quantity: 2}],
+        pay_immediately: false
+    }
+);
+
 stripe.customers.retrieveCard(
     "cus_5rfJKDJkuxzh5Q",
     "card_15fvyXEe31JkLCeQ9KMktP5S",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://help.avalara.com/Frequently_Asked_Questions/Stripe_Invoicing_FAQ/How_do_I_charge_tax_on_subscription_invoice_in_Stripe%3F