### PR TITLE
types for dis-gui

### DIFF
--- a/types/dis-gui/dis-gui-tests.ts
+++ b/types/dis-gui/dis-gui-tests.ts
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import * as dg from './index';
+
+React.createElement(
+    dg.GUI,
+    {
+        style : {width : '200px'},
+        expanded : false
+    },
+    React.createElement(
+        dg.Folder,
+        {
+            label : 'Some Folder',
+            onFinishChange : (value : boolean) => {}
+        },
+        React.createElement(
+            dg.Button,
+            {
+                label : 'Some Button',
+                onClick : () => {}
+            }
+        ),
+        React.createElement(
+            dg.Checkbox,
+            {
+                checked : true,
+                label : 'Check me out'
+            }
+        ),
+        React.createElement(
+            dg.Color,
+            {
+                red : 100,
+                green : 50,
+                blue : 25,
+                onChange : (value : {red : number, green : number, blue : number}) => {}
+            }
+        ),
+        React.createElement(
+            dg.Folder,
+            {
+                label : 'We must go deeper'
+            },
+            React.createElement(
+                dg.Gradient,
+                {
+                    stops : [{
+                        red : 10,
+                        green : 10,
+                        blue : 10,
+                        stop : 0.5
+                    }]
+                }
+            ),
+            React.createElement(
+                dg.Number,
+                {
+                    min : 0,
+                    max : 10,
+                    step : 1
+                }
+            ),
+            React.createElement(
+                dg.Select,
+                {
+                    options : ['inny', 'mini', 'myni', 'mo'],
+                    label : 'Choose your hero'
+                }
+            )
+        ),
+        React.createElement(
+            dg.Text,
+            {
+                value : 'Hello World'
+            }
+        )
+    )
+);

--- a/types/dis-gui/index.d.ts
+++ b/types/dis-gui/index.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import * as CSS from "csstype";
+
 type GUIProps = Partial<{
-    style : React.CSSProperties,
+    style : CSS.Properties<string | number>,
     expanded : boolean,
     alwaysOpen : boolean,
     className : string

--- a/types/dis-gui/index.d.ts
+++ b/types/dis-gui/index.d.ts
@@ -1,0 +1,71 @@
+import * as React from 'react';
+type GUIProps = Partial<{
+    style : React.CSSProperties,
+    expanded : boolean,
+    alwaysOpen : boolean,
+    className : string
+}>;
+type FolderProps = Partial<{
+    expanded : boolean,
+    label : string,
+    onChange(expanded : boolean) : void
+    onFinishChange(expanded : boolean) : void
+}>;
+interface ButtonProps {
+    label : string,
+    onClick?() : void
+}
+type CheckboxProps = Partial<{
+    checked : boolean,
+    label : string,
+    onChange(value : boolean) : void,
+    onFinishChange(value : boolean) : void
+}>;
+interface ColorSet {red : number, green : number, blue : number}
+type ColorProps = Partial<{
+    red : number,
+    green : number,
+    blue : number,
+    expanded : boolean,
+    label : string,
+    onChange(color : ColorSet) : void,
+    onFinishChange(color : ColorSet) : void
+}>;
+interface Stop extends ColorSet {stop : number}
+type GradientProps = Partial<{
+    expanded : boolean,
+    stops : Array<Stop>,
+    label : string,
+    onChange(stops : Array<Stop>) : void,
+    onFinishChange(stops : Array<Stop>) : void
+}>;
+type NumberProps = Partial<{
+    value : number,
+    min : number,
+    max : number,
+    step : number,
+    label : string,
+    onChange(value : number) : void,
+    onFinishChange(value : number) : void
+}>;
+interface SelectProps {
+    options : Array<string>,
+    label? : string,
+    onChange?(value : string) : void,
+    onFinishChange?(value : string) : void
+}
+type TextProps = Partial<{
+    value : string,
+    label : string,
+    onChange(value : string) : void
+    onFinishChange(value : string) : void
+}>;
+export class GUI extends React.PureComponent<GUIProps>{}
+export class Folder extends React.PureComponent<FolderProps>{}
+export class Button extends React.PureComponent<ButtonProps>{}
+export class Checkbox extends React.PureComponent<CheckboxProps>{}
+export class Color extends React.PureComponent<ColorProps>{}
+export class Gradient extends React.PureComponent<GradientProps>{}
+export class Number extends React.PureComponent<NumberProps>{}
+export class Select extends React.PureComponent<SelectProps>{}
+export class Text extends React.PureComponent<TextProps>{}

--- a/types/dis-gui/package.json
+++ b/types/dis-gui/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "csstype": "^2.0.0"
+    }
+}

--- a/types/dis-gui/tsconfig.json
+++ b/types/dis-gui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dis-gui-tests.ts"
+    ]
+}

--- a/types/dis-gui/tslint.json
+++ b/types/dis-gui/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [ ] Types for package dis-gui. Types do not exist anywhere else that I could find.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
