### PR TITLE
Add types for commander-remaining-args

### DIFF
--- a/types/commander-remaining-args/commander-remaining-args-tests.ts
+++ b/types/commander-remaining-args/commander-remaining-args-tests.ts
@@ -1,0 +1,6 @@
+import cli = require('commander');
+import getRemainingArgs = require('commander-remaining-args');
+
+cli.allowUnknownOption().option('--some-flag');
+
+getRemainingArgs(cli); // ['--unknown-flag', '--unknown-arg=value', '-x'])

--- a/types/commander-remaining-args/index.d.ts
+++ b/types/commander-remaining-args/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for commander-remaining-args 1.2
+// Project: https://github.com/axelchalon/commander-remaining-args#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import { Command } from 'commander';
+
+declare function getRemainingArgs(cli: Command): string[];
+
+export = getRemainingArgs;

--- a/types/commander-remaining-args/package.json
+++ b/types/commander-remaining-args/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "commander": "^2.20.0"
+    }
+}

--- a/types/commander-remaining-args/tsconfig.json
+++ b/types/commander-remaining-args/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "commander-remaining-args-tests.ts"
+    ]
+}

--- a/types/commander-remaining-args/tslint.json
+++ b/types/commander-remaining-args/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
