### PR TITLE
[dirty-chai] fix 'esModuleInterop' requirement

### DIFF
--- a/types/dirty-chai/index.d.ts
+++ b/types/dirty-chai/index.d.ts
@@ -1,28 +1,30 @@
 // Type definitions for dirty-chai 2.0
 // Project: https://github.com/prodatakey/dirty-chai
 // Definitions by: Piotr Roszatycki <https://github.com/dex4er>
+//                 Gregor Stamać <https://github.com/gstamac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="chai" />
 /// <reference types="chai-as-promised" />
 
-declare global {
-    namespace Chai {
-        interface LanguageChains {
-            always: Assertion;
-        }
+import Assertion = Chai.Assertion;
 
-        interface Assertion {
-            (message?: string): Assertion;
-            ensure: Assertion;
-        }
+declare module 'dirty-chai' {
+    function dirtyChai(chai: any, utils: any): void;
 
-        interface PromisedAssertion extends Eventually, PromiseLike<any> {
-            (message?: string): Assertion;
-            ensure: Assertion;
-        }
-    }
+    namespace dirtyChai { }
+
+    export = dirtyChai;
 }
 
-declare function dirtyChai(chai: any, utils: any): void;
-export = dirtyChai;
+declare namespace Chai {
+    interface Assertion {
+        (message?: string): Assertion;
+        ensure(): Assertion;
+    }
+
+    interface PromisedAssertion extends Eventually, PromiseLike<any> {
+        (message?: string): Assertion;
+        ensure(): Assertion;
+    }
+}

--- a/types/dirty-chai/tsconfig.json
+++ b/types/dirty-chai/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/dirty-chai/tslint.json
+++ b/types/dirty-chai/tslint.json
@@ -1,1 +1,7 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+      "no-single-declare-module": false,
+      "no-declare-current-package": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
Change was required since the definitions resulted in "error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.".