### PR TITLE
Add definitions for jscodeshift/src/testUtils

### DIFF
--- a/types/jscodeshift/index.d.ts
+++ b/types/jscodeshift/index.d.ts
@@ -5,7 +5,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-/// <reference path="./src/testUtils.d.ts" />
 import core = require("./src/core");
 
 export = core;

--- a/types/jscodeshift/index.d.ts
+++ b/types/jscodeshift/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
+/// <reference path="./src/testUtils.d.ts" />
 import core = require("./src/core");
-import testUtils = require('./src/testUtils');
 
 export = core;

--- a/types/jscodeshift/index.d.ts
+++ b/types/jscodeshift/index.d.ts
@@ -1,9 +1,11 @@
 // Type definitions for jscodeshift 0.6
 // Project: https://github.com/facebook/jscodeshift#readme
 // Definitions by: Brie Bunge <https://github.com/brieb>
+//                 Brian Jacobel <https://github.com/bjacobel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
 import core = require("./src/core");
+import testUtils = require('./src/testUtils');
 
 export = core;

--- a/types/jscodeshift/src/testUtils.d.ts
+++ b/types/jscodeshift/src/testUtils.d.ts
@@ -1,0 +1,6 @@
+export function defineTest(
+  dirName: string,
+  transformName: string,
+  options: any,
+  testFilePrefix?: string
+): () => any;

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -1,4 +1,5 @@
 import { ASTNode, FileInfo, API, Transform, Parser } from "jscodeshift";
+import * as testUtils from "jscodeshift/src/testUtils";
 
 // Can define transform with `function`.
 function replaceWithFooTransform(fileInfo: FileInfo, api: API) {
@@ -73,3 +74,10 @@ const transformWithRecastParseOptions: Transform = (file, { j }) => {
         }
     }
 }
+
+// Can define a test
+testUtils.defineTest(
+    "directory",
+    "transformName",
+    { opt: true },
+);

--- a/types/jscodeshift/tsconfig.json
+++ b/types/jscodeshift/tsconfig.json
@@ -24,6 +24,7 @@
         "src/collections/Node.d.ts",
         "src/collections/VariableDeclarator.d.ts",
         "src/template.d.ts",
+        "src/testUtils.d.ts",
         "test/jscodeshift-tests.ts",
         "test/js-transforms/bind-this-to-bind-expression.ts",
         "test/js-transforms/call-expression-bind-this-to-arrow-function-expression.ts",


### PR DESCRIPTION
Adds types for a helper module exported as `/src/testUtils` from jscodeshift. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

(No lint errors introduced to the ones already on master.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jscodeshift/blob/master/src/testUtils.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
