### PR TITLE
[pikaday] Remove `moment` from dependency of @types/pikaday

### DIFF
--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for pikaday 1.7
+// Type definitions for pikaday 1.8
 // Project: https://github.com/dbushell/Pikaday, https://pikaday.com
 // Definitions by: Rudolph Gottesheim <https://github.com/MidnightDesign>
 //                 Åke Wivänge <https://github.com/wake42>
 //                 Istvan Mezo <https://github.com/mezoistvan>
+//                 PikachuEXE <https://github.com/PikachuEXE>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/pikaday/package.json
+++ b/types/pikaday/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "moment": ">=2.14.0"
-    }
-}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Pikaday/Pikaday/issues/718 [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Pikaday 1.8 does **not** require `moment`
So using this typing package right now includes huge `moment` package in produced bundle as mentioned in #27942
Fixes #27942

Best fix is to have separate typing package for `moment` and reference it (without including the actual code)
