### PR TITLE
[@types/redux-orm] fix overly broad IdOrModelLike type to match libra…

### DIFF
--- a/types/redux-orm/QuerySet.d.ts
+++ b/types/redux-orm/QuerySet.d.ts
@@ -249,6 +249,8 @@ export default class QuerySet<M extends AnyModel = any, InstanceProps extends ob
 
 /**
  * {@link QuerySet} extensions available on {@link ManyToMany} fields of session bound {@link Model} instances.
+ *
+ * @see {@link IdOrModelLike}
  */
 export interface ManyToManyExtensions<M extends AnyModel> {
     add: (...entitiesToAdd: ReadonlyArray<IdOrModelLike<M>>) => void;

--- a/types/redux-orm/redux-orm-tests.ts
+++ b/types/redux-orm/redux-orm-tests.ts
@@ -171,20 +171,17 @@ const argPropertyTypeRestrictionsOnCreate = () => {
      * Properties associated to relational fields may be supplied with:
      *
      * - a primitive type matching id type of relation target
-     * - a Ref type derived from relation target
      * - Model/SessionBoundModel instance matching relation target
-     * - a map containing {Idkey:IdType} entry, where IdKey/IdType are compatible with relation target id key:type signature
      *
      * In case of MutableQuerySets/many-to-many relationships, an array of union of above-mentioned types is accepted
      */
     const authorModel = Person.create({ id: 'A1', firstName: 'A1', lastName: 'A1' });
     const publisherModel = Publisher.create({ name: 'P1' });
     Book.create({ title: 'B1', publisher: publisherModel, authors: [authorModel] });
-    Book.create({ title: 'B1', publisher: publisherModel.ref, authors: [authorModel.ref] });
     Book.create({
         title: 'B1',
-        publisher: { index: publisherModel.index },
-        authors: [{ id: authorModel.id }, 'A1', authorModel, authorModel.ref]
+        publisher: publisherModel.index ,
+        authors: [authorModel, 'A1', authorModel, authorModel.ref.id]
     });
 
     /** Id types are verified to match relation target */
@@ -223,13 +220,8 @@ const argPropertyTypeRestrictionsOnUpsert = () => {
      */
     const authorModel = Person.upsert({ id: 'A1', firstName: 'A1', lastName: 'A1' });
     const publisherModel = Publisher.upsert({ name: 'P1', index: 1 });
+    Book.upsert({ title: 'B1', publisher: 1, authors: [authorModel] });
     Book.upsert({ title: 'B1', publisher: publisherModel, authors: [authorModel] });
-    Book.upsert({ title: 'B1', publisher: publisherModel.ref, authors: [authorModel.ref] });
-    Book.upsert({
-        title: 'B1',
-        publisher: { index: publisherModel.index },
-        authors: [{ id: authorModel.id }, 'A1', authorModel, authorModel.ref]
-    });
 
     /** Id types are verified to match relation target */
     Book.create({ title: 'B1', publisher: authorModel }); // $ExpectError


### PR DESCRIPTION
`IdOrModelLike` was mistyped, since the union should not include {IdKey:IdType} objects. 
Internal `normalizeEntity` function accepts `{getId(): IdType}` interface instead.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ X Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [src/utils.js:116-130](https://github.com/redux-orm/redux-orm/blob/2eb51fa2c1a523c75ca5cd6c2873a799b0c1f526/src/utils.js#L116)
