### PR TITLE
Adding the base_url option to connect-datadog type definition

### DIFF
--- a/types/connect-datadog/connect-datadog-tests.ts
+++ b/types/connect-datadog/connect-datadog-tests.ts
@@ -8,6 +8,7 @@ const middleware = connectDD({});
 const middleware2 = connectDD({
     stat: 'foo',
     path: true,
+    base_url: true,
     method: true,
     protocol: true,
     response_code: true,

--- a/types/connect-datadog/index.d.ts
+++ b/types/connect-datadog/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/datadog/node-connect-datadog
 // Definitions by: Moshe Good <https://github.com/moshegood>
 //                 Michael Mifsud <https://github.com/xzyfer>
+//                 Lewis Vail <https://github.com/lewisvail3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -17,6 +18,7 @@ declare namespace Factory {
         stat?: string;
         tags?: string[];
         path?: boolean;
+        base_url?: boolean;
         method?: boolean;
         protocol?: boolean;
         response_code?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DataDog/node-connect-datadog/blob/master/README.md#options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
