### PR TITLE
add types for 'level-js', add def to 'levelup'

### DIFF
--- a/types/level-js/index.d.ts
+++ b/types/level-js/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for level-js 4.0
+// Project: https://github.com/Level/level-js
+// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { AbstractLevelDOWN, AbstractOptions } from 'abstract-leveldown';
+
+export interface Level extends AbstractLevelDOWN {
+    readonly location: string;
+    readonly prefix: string;
+    readonly version: string | number;
+    destroy(location: string, cb: (err: Error | undefined) => void): void;
+    destroy(location: string, prefix: string, cb: (err: Error | undefined) => void): void;
+}
+
+export interface LevelOptions {
+    readonly prefix?: string;
+    readonly version?: string | number;
+}
+
+export interface LevelConstructor {
+    new (location: string, options?: LevelOptions): Level;
+    (location: string, options?: LevelOptions): Level;
+}
+
+export const Level: LevelConstructor;

--- a/types/level-js/level-js-tests.ts
+++ b/types/level-js/level-js-tests.ts
@@ -1,0 +1,24 @@
+/// <reference types="node" />
+import { Level } from 'level-js';
+
+const db = Level('bigData');
+const dbClass = new Level('bigData');
+
+db.put('hello', Buffer.from('world'), (err) => {
+    if (err) throw err;
+    db.get('hello', (err, value) => {
+        if (err) throw err;
+        console.log(value.toString());
+    });
+});
+
+db.location;
+db.prefix;
+db.version;
+
+db.destroy('bigData', (error) => console.log(error));
+
+db.iterator();
+db.iterator({keyAsBuffer: false});
+
+db.createReadStream({gt: new Date('2019-01-01')});

--- a/types/level-js/tsconfig.json
+++ b/types/level-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "level-js-tests.ts"
+    ]
+  }

--- a/types/level-js/tslint.json
+++ b/types/level-js/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';
-import { AbstractLevelDOWN, AbstractIteratorOptions, AbstractBatch, ErrorCallback, AbstractOptions, ErrorValueCallback, AbstractGetOptions } from 'abstract-leveldown';
+import { AbstractLevelDOWN, AbstractIteratorOptions, AbstractBatch, ErrorCallback, AbstractOptions, ErrorValueCallback, AbstractGetOptions, AbstractIterator } from 'abstract-leveldown';
 
 type LevelUpPut<K, V, O> =
     ((key: K, value: V, callback: ErrorCallback) => void) &
@@ -45,7 +45,7 @@ type InferDBDel<DB> =
     LevelUpDel<K, O> :
     LevelUpDel<any, AbstractOptions>;
 
-export interface LevelUp<DB = AbstractLevelDOWN> extends EventEmitter {
+export interface LevelUp<DB = AbstractLevelDOWN, Iterator = AbstractIterator<any, any>> extends EventEmitter {
     open(): Promise<void>;
     open(callback?: ErrorCallback): void;
     close(): Promise<void>;
@@ -60,6 +60,7 @@ export interface LevelUp<DB = AbstractLevelDOWN> extends EventEmitter {
     batch(array: AbstractBatch[], callback: (err?: any) => any): void;
 
     batch(): LevelUpChain;
+    iterator(options?: AbstractIteratorOptions): Iterator;
 
     isOpen(): boolean;
     isClosed(): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
-  [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Additionally I added [this](https://github.com/Level/levelup/blob/c56f863e41f1b00216837963be34d4ba74458b19/lib/levelup.js#L266) definition to LevelUP. Not sure why it wasn't present already. The type of options might need to change since the function itself is just a passthrough to the underlying DB.