### PR TITLE
fix(react-overlay): fix types for some of ref properties

### DIFF
--- a/types/react-overlays/lib/DropdownToggle.d.ts
+++ b/types/react-overlays/lib/DropdownToggle.d.ts
@@ -10,7 +10,7 @@ declare namespace DropdownToggle {
         show: boolean;
         toggle(show: boolean): void;
         props: {
-            ref: (popperNode: HTMLElement|null) => void;
+            ref: (popperNode: HTMLElement | null) => void;
             'aria-haspopup': true;
             'aria-expanded': boolean;
         };

--- a/types/react-overlays/lib/DropdownToggle.d.ts
+++ b/types/react-overlays/lib/DropdownToggle.d.ts
@@ -10,7 +10,7 @@ declare namespace DropdownToggle {
         show: boolean;
         toggle(show: boolean): void;
         props: {
-            ref?(element: HTMLElement): void;
+            ref: (popperNode: HTMLElement|null) => void;
             'aria-haspopup': true;
             'aria-expanded': boolean;
         };

--- a/types/react-overlays/lib/Overlay.d.ts
+++ b/types/react-overlays/lib/Overlay.d.ts
@@ -18,12 +18,12 @@ declare namespace Overlay {
         outOfBoundaries?: boolean;
         scheduleUpdate(): void;
         props: {
-            ref?(element: HTMLElement): void;
+            ref: (popperNode: HTMLElement|null) => void;
             style: { [key: string]: string | number };
             'aria-labelledby'?: string;
         };
         arrowProps: {
-            ref?(element: HTMLElement): void;
+            ref: (popperNode: HTMLElement|null) => void;
             style: { [key: string]: string | number };
         };
     }

--- a/types/react-overlays/lib/Overlay.d.ts
+++ b/types/react-overlays/lib/Overlay.d.ts
@@ -18,12 +18,12 @@ declare namespace Overlay {
         outOfBoundaries?: boolean;
         scheduleUpdate(): void;
         props: {
-            ref: (popperNode: HTMLElement|null) => void;
+            ref: (popperNode: HTMLElement | null) => void;
             style: { [key: string]: string | number };
             'aria-labelledby'?: string;
         };
         arrowProps: {
-            ref: (popperNode: HTMLElement|null) => void;
+            ref: (popperNode: HTMLElement | null) => void;
             style: { [key: string]: string | number };
         };
     }

--- a/types/react-overlays/test/react-overlays-tests-individual.tsx
+++ b/types/react-overlays/test/react-overlays-tests-individual.tsx
@@ -22,8 +22,14 @@ interface OverlayTriggerProps extends Overlay.OverlayProps {
     overlay: any;
 }
 
-function renderOverlayContent({ props }: Overlay.OverlayRenderProps) {
-    return <div {...props}>Popover content</div>;
+function renderOverlayContent({ props, arrowProps }: Overlay.OverlayRenderProps) {
+    return (
+        <div ref={props.ref} {...props}>
+            <div ref={arrowProps.ref}>
+                Popover content
+            </div>
+        </div>
+    );
 }
 class TestOverlay extends React.Component<{}, { open: boolean }> {
     target: HTMLElement | null = null;

--- a/types/react-overlays/test/react-overlays-tests.tsx
+++ b/types/react-overlays/test/react-overlays-tests.tsx
@@ -17,8 +17,14 @@ class TestAffix extends React.Component {
     }
 }
 
-function renderOverlayContent({ props }: OverlayRenderProps) {
-    return <div {...props}>Popover content</div>;
+function renderOverlayContent({ props, arrowProps }: OverlayRenderProps) {
+    return (
+        <div ref={props.ref} {...props}>
+            <div ref={arrowProps.ref}>
+                Popover content
+            </div>
+        </div>
+    );
 }
 
 class TestOverlay extends React.Component<{}, { open: boolean }> {


### PR DESCRIPTION
Fix types for ref properties
- OverlayRenderProps.props.ref
- OverlayRenderProps.arrowProps.ref
- DropdownToggleRenderProps.props.ref

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

According to react-overlays, ref is come from react-popper
https://github.com/react-bootstrap/react-overlays/blob/master/src/Overlay.js#L81-L91

And then, according to react-popper
ref is 
https://github.com/FezVrasta/react-popper/blob/master/src/Popper.js#L195
https://github.com/FezVrasta/react-popper/blob/master/src/Popper.js#L76-L83

arrowProps.ref is 
https://github.com/FezVrasta/react-popper/blob/master/src/Popper.js#L201
https://github.com/FezVrasta/react-popper/blob/master/src/Popper.js#L85-L87

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
