### PR TITLE
Fix react-big-calendar onRangeChange return type

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -12,6 +12,7 @@
 //                 Lucas Silva Souza <https://github.com/lksilva>
 //                 Siarhey Belofost <https://github.com/SergeyBelofost>
 //                 Mark Nelissen <https://github.com/marknelissen>
+//                 Eric Kenney <https://github.com/KenneyE>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { Validator } from 'prop-types';
@@ -261,7 +262,7 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate, end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Array<Date | { start: stringOrDate, end: stringOrDate }>) => void;
+    onRangeChange?: (range: Array<Date> | { start: stringOrDate, end: stringOrDate }) => void;
     selected?: any;
     views?: Views;
     drilldownView?: View | null;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -262,7 +262,7 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate, end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Array<Date> | { start: stringOrDate, end: stringOrDate }) => void;
+    onRangeChange?: (range: Date[] | { start: stringOrDate, end: stringOrDate }) => void;
     selected?: any;
     views?: Views;
     drilldownView?: View | null;


### PR DESCRIPTION
onRangeChange returns either an array of Dates, or an object
with start and end. It doesn't not return an array of objects
with start and end.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/intljusticemission/react-big-calendar/blob/caa863fb78b9ddc9cfb6c06a5d6c27601f300ac9/src/Calendar.js#L253

```
    /**
     *
     * ```js
     * (dates: Date[] | { start: Date; end: Date }, view?: 'month'|'week'|'work_week'|'day'|'agenda') => void
     * ```
     *
     * Callback fired when the visible date range changes. Returns an Array of dates
     * or an object with start and end dates for BUILTIN views. Optionally new `view`
     * will be returned when callback called after view change.
     *
     * Custom views may return something different.
     */
    onRangeChange: PropTypes.func,
```