### PR TITLE
@types/react Event add event.target.xxx

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1059,7 +1059,7 @@ declare namespace React {
      * This might be a child element to the element on which the event listener is registered.
      * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
      */
-    interface SyntheticEvent<T = Element, E = Event> extends BaseSyntheticEvent<E, EventTarget & T, EventTarget> {}
+    interface SyntheticEvent<T = Element, E = Event> extends BaseSyntheticEvent<E, EventTarget & T, EventTarget & T> {}
 
     interface ClipboardEvent<T = Element> extends SyntheticEvent<T, NativeClipboardEvent> {
         clipboardData: DataTransfer;


### PR DESCRIPTION
### Reproduction problem
``` javascript
 <p data-type="p" onClick={e => {this.click(e)}}>click</p>
...
  click(e: MouseEvent<HTMLDivElement>): void {
    let target = e.target;

    console.log(target);
    console.log(target.innerHTML);  // Error:(46, 24) TS2339: Property 'innerHTML' does not exist on type 'EventTarget'.
    console.log(target.getAttribute("data-type"));  // Error:(48, 24) TS2339: Property 'getAttribute' does not exist on type 'EventTarget'.
  }
```