### PR TITLE
[@types/joi] Missing validation options in params of assert/attempt m…

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -1164,21 +1164,15 @@ export function compile(schema: SchemaLike): Schema;
 
 /**
  * Validates a value against a schema and throws if validation fails.
- *
- * @param value - the value to validate.
- * @param schema - the schema object.
- * @param message - optional message string prefix added in front of the error message. may also be an Error object.
  */
-export function assert(value: any, schema: SchemaLike, message?: string | Error): void;
+export function assert(value: any, schema: SchemaLike, param?: string | Error | ValidationOptions): void;
+export function assert(value: any, schema: SchemaLike, message?: string, options?: ValidationOptions): void;
 
 /**
- * Validates a value against a schema, returns valid object, and throws if validation fails where:
- *
- * @param value - the value to validate.
- * @param schema - the schema object.
- * @param message - optional message string prefix added in front of the error message. may also be an Error object.
+ * Validates a value against a schema, returns valid object, and throws if validation fails.
  */
-export function attempt<T>(value: T, schema: SchemaLike, message?: string | Error): T;
+export function attempt<T>(value: T, schema: SchemaLike, param?: string | Error | ValidationOptions): T;
+export function attempt<T>(value: T, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): T;
 
 /**
  * Generates a reference to the value of the named key.


### PR DESCRIPTION
If you know how to fix the issue, make a pull request instead.

- [x] I tried using the `@types/joi` package and had problems.
- [x] I tried using the latest stable version of tsc. https://www.npmjs.com/package/typescript
- [ ] I have a question that is inappropriate for [StackOverflow](https://stackoverflow.com/).  (Please ask any appropriate questions there).
- [x] [Mention](https://github.com/blog/821-mention-somebody-they-re-notified) the authors (see `Definitions by:` in `index.d.ts`) so they can respond.
  - Authors: @SimonSchick @pavel1992 @afharo @Bartvds  @faustbrian ...

If you do not mention the authors the issue will be ignored.

Joi api reference:
https://github.com/hapijs/joi/blob/master/API.md#assertvalue-schema-message-options

@types/joi
```
/**
 * Validates a value against a schema and throws if validation fails.
 *
 * @param value - the value to validate.
 * @param schema - the schema object.
 * @param message - optional message string prefix added in front of the error message. may also be an Error object.
 */
export function assert(value: any, schema: SchemaLike, message?: string | Error): void;
```

lib/index.js
https://github.com/hapijs/joi/blob/master/lib/index.js#L173
```
    root.attempt = function (value, schema, ...args/* [message], [options]*/) {
        const first = args[0];
        const message = first instanceof Error || typeof first === 'string' ? first : null;
        const options = message ? args[1] : args[0];
        ...
    };
```

Expected result:
function definition have correct params list

Actual result:
function definition missing validation options param