### PR TITLE
[googlemaps] Fix googlemaps StreetViewService#getPanorama callback param type

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -666,6 +666,32 @@ var panorama = new google.maps.StreetViewPanorama(document.createElement('div'),
 // MVCObject method on StreetViewPanorama
 var panoramaEvent = panorama.addListener('pano_changed', () => {});
 
+/***** StreetViewService *****/
+var street_view_service = new google.maps.StreetViewService();
+street_view_service.getPanorama({
+    location: new google.maps.LatLng(37.782551, -122.445368),
+    radius: 50
+}, (data, status) => {
+    if (status === google.maps.StreetViewStatus.OK) {
+        const location_pano = (data == null || data.location == null) ? null : data.location.pano
+        if (location_pano == null) {
+            // Not good
+            return;
+        }
+
+        const new_panorama = new google.maps.StreetViewPanorama(document.createElement('div'), panoramaOptions);
+        new_panorama.setPano(location_pano);
+        new_panorama.setPov({
+            heading:  0,
+            pitch:    0
+        });
+    }
+    else {
+        // Not good
+        return;
+    }
+})
+
 /***** MVCArray *****/
 
 // MVCArray should be generic

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2587,7 +2587,7 @@ declare namespace google.maps {
     class StreetViewService {
         getPanorama(
             request: StreetViewLocationRequest | StreetViewPanoRequest,
-            cb: (data: StreetViewPanoramaData, status: StreetViewStatus) => void
+            cb: (data: StreetViewPanoramaData | null, status: StreetViewStatus) => void
         ): void;
         getPanoramaById(
             pano: string,


### PR DESCRIPTION
data can be null sometimes

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/street-view-service#StreetViewService.getPanorama
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I know in their doc they claim to have data all the time
But in real life I encounter `null` values for `data` in callbacks:

![Screen Shot 2019-06-14 at 16 43 19](https://user-images.githubusercontent.com/1018543/59497395-f9abd400-8ec5-11e9-823f-6396f9113471.png)
![Screen Shot 2019-06-14 at 16 43 28](https://user-images.githubusercontent.com/1018543/59497396-f9abd400-8ec5-11e9-92ad-9b87e09890d5.png)

