### PR TITLE
[mailgun-js] Add missing SendData typings

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -61,13 +61,30 @@ declare namespace Mailgun {
         interface SendData {
             from?: string;
             to: string | string[];
-            cc?: string;
-            bcc?: string;
+            cc?: string | string[];
+            bcc?: string | string[];
             subject?: string;
             text?: string;
             html?: string;
+            'amp-html'?: string;
             attachment?: AttachmentData | ReadonlyArray<AttachmentData>;
             inline?: AttachmentData | ReadonlyArray<AttachmentData>;
+
+            // Mailgun options
+            'o:tag'?: string[];
+            'o:deliverytime'?: string;
+            'o:dkim'?: 'yes' | 'no' | boolean;
+            'o:tracking'?: 'yes' | 'no' | boolean;
+            'o:tracking-opens'?: 'yes' | 'no' | boolean;
+            'o:tracking-clicks'?: 'yes' | 'no' | 'htmlonly' | boolean;
+            'o:require-tls'?: 'yes' | 'no' | 'True' | 'False';
+            'o:skip-verification'?: 'yes' | 'no' | 'True' | 'False';
+
+            // Standard email headers
+            'h:Reply-To'?: string;
+            'h:In-Reply-To'?: string;
+            'h:References'?: string;
+            'h:Importance'?: string;
         }
 
         interface BatchData extends SendData {

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -38,6 +38,21 @@ const exampleSendData: mailgunFactory.messages.SendData = {
 
 mailgun.messages().send(exampleSendData, (err, body) => {});
 
+const arraySendData: mailgunFactory.messages.SendData = {
+    to: ["someone@email.com", "else@email.com"],
+    cc: ["cc1@email.com", "cc2@email.com"],
+    bcc: ["bcc1@email.com", "bcc2@email.com"],
+    attachment: [
+        new mailgun.Attachment({
+            data: "filepath",
+            filename: "my_custom_name.png"
+        })
+    ],
+    "o:tag": ["cats", "rainbows"],
+  };
+
+mailgun.messages().send(arraySendData, (err, body) => {});
+
 let validationResultPromise: Promise<mailgunFactory.validation.ValidateResponse>;
 validationResultPromise = mailgun.validate("foo@mailgun.net");
 validationResultPromise = mailgun.validate("foo@mailgun.net", true);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Additional sending options from: https://documentation.mailgun.com/en/latest/api-sending.html#sending. I tried adding `[key: string]: string` for `v:` and `h:` keys, but TS didn't like that, so I just encoded the most common headers. Using `boolean` is valid for some of the boolean params because mailgun-js casts booleans to string first. 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
