### PR TITLE
[koa-session] types were overwriting a Class with an interface FIX

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -205,11 +205,6 @@ declare module "koa" {
         session: session.Session | null;
         readonly sessionOptions: session.opts | undefined;
     }
-
-    interface Application {
-        on(name: "session:missed" | "session:expired" | "session:invalid", data: { key?: string, value?: Partial<session.Session>, ctx: Context }): void;
-        once(name: "session:missed" | "session:expired" | "session:invalid", data: { key?: string, value?: Partial<session.Session>, ctx: Context }): void;
-    }
 }
 
 export = session;

--- a/types/koa-session/koa-session-tests.ts
+++ b/types/koa-session/koa-session-tests.ts
@@ -41,16 +41,16 @@ app.use(session({
 }, app));
 
 // can still use koa-session events, although without autocomplete
-app.on('session:missed', () => {})
-app.on('session:expired', () => {})
-app.on('session:invalid', () => {})
+app.on('session:missed', () => {});
+app.on('session:expired', () => {});
+app.on('session:invalid', () => {});
 
 app.use((ctx, next) => {
     // reset the session
     ctx.session = null;
 
     // does not interfere with Application->EventEmitter #32389
-    ctx.app.emit('error', new Error('this is an user-generated Error'))
+    ctx.app.emit('error', new Error('this is an user-generated Error'));
 
     return next();
 });

--- a/types/koa-session/koa-session-tests.ts
+++ b/types/koa-session/koa-session-tests.ts
@@ -40,9 +40,17 @@ app.use(session({
     path: "/",
 }, app));
 
+// can still use koa-session events, although without autocomplete
+app.on('session:missed', () => {})
+app.on('session:expired', () => {})
+app.on('session:invalid', () => {})
+
 app.use((ctx, next) => {
     // reset the session
     ctx.session = null;
+
+    // does not interfere with Application->EventEmitter #32389
+    ctx.app.emit('error', new Error('this is an user-generated Error'))
 
     return next();
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
Issue #32389

As linked in the Issue above (#32389) the type definitions try to extend a Class with an Interface

In @types/koa the `Application` [is so defined](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa/index.d.ts#L434):
```ts
declare class Application<StateT = any, CustomT = {}> extends EventEmitter {
   // many properties here ...
}
```

The small extension in koa-session has been removed, it implies 3 events are not autocompleted, but they can still be used. I have even used them in the test file.p

Pinging other `koa-session` contributors: @kerol2r20 @tlaziuk @hirochachacha