### PR TITLE
Add typings for connect-trim-body npm module

### DIFF
--- a/types/connect-trim-body/connect-trim-body-tests.ts
+++ b/types/connect-trim-body/connect-trim-body-tests.ts
@@ -1,0 +1,6 @@
+import connectTrimBody from 'connect-trim-body';
+import express from 'express';
+
+const app = express();
+
+app.use(connectTrimBody());

--- a/types/connect-trim-body/index.d.ts
+++ b/types/connect-trim-body/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for connect-trim-body 0.0.3
+// Type definitions for connect-trim-body 0.0
 // Project: https://github.com/samora/connect-trim-body
 // Definitions by: Levi Bostian <https://github.com/levibostian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/connect-trim-body/index.d.ts
+++ b/types/connect-trim-body/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for connect-trim-body 0.0.3
+// Project: https://github.com/samora/connect-trim-body
+// Definitions by: Levi Bostian <https://github.com/levibostian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+import { RequestHandler } from "express";
+
+declare function connectTrimBodyMiddleware(): RequestHandler;
+
+export = connectTrimBodyMiddleware;

--- a/types/connect-trim-body/tsconfig.json
+++ b/types/connect-trim-body/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "connect-trim-body-tests.ts"
+    ]
+}

--- a/types/connect-trim-body/tslint.json
+++ b/types/connect-trim-body/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/connect-trim-body/tslint.json
+++ b/types/connect-trim-body/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Note: The npm module these typings are created for only uses patch as version releases. Therefore, I had to disable the dt-header rule for tslint as it was not liking that I included the patch version in my header of the index.d.ts file.