### PR TITLE
Fix string compatiblity on react-color

### DIFF
--- a/types/react-color/v2/index.d.ts
+++ b/types/react-color/v2/index.d.ts
@@ -41,7 +41,7 @@ export interface HSVColor {
     source?: string;
 }
 
-export type Color = HEXColor | HSLColor | RGBColor | HSVColor;
+export type Color = string | HEXColor | HSLColor | RGBColor | HSVColor;
 
 export interface ColorState {
     hex: string;
@@ -57,7 +57,7 @@ export interface RenderersProps {
         canvas: any;
     };
 }
-export type ColorChangeHandler = (color: Color) => void;
+export type ColorChangeHandler = (color: ColorState) => void;
 
 export { default as AlphaPicker, AlphaPickerProps } from "./lib/components/alpha/Alpha";
 export { default as BlockPicker, BlockPickerProps } from "./lib/components/block/Block";

--- a/types/react-color/v2/react-color-tests.tsx
+++ b/types/react-color/v2/react-color-tests.tsx
@@ -79,6 +79,7 @@ const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) =
 };
 const Custom = CustomPicker(CustomComponent);
 
+const stringColor = '#000000';
 const color = { hex: "#000000" };
 const colors = ["#000", "#333"];
 
@@ -277,3 +278,5 @@ render(
     />,
     document.getElementById("main")
 );
+
+render(<GithubPicker color={stringColor} />, document.getElementById('main'));


### PR DESCRIPTION
As mentioned in the [docs](http://casesandberg.github.io/react-color/#api-color)

>Color accepts either a string of a hex color '#333' or a object of rgb or hsl values { r: 51, g: 51, b: 51 } or { h: 0, s: 0, l: .10 }

The component is supposed to accept string as the color input.

Also as mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35844#issuecomment-500319570, the function signature for the `ColorChangeHandler` seems to be off as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://casesandberg.github.io/react-color/#api-color
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
