### PR TITLE
Added mark.js accuracy with limiters definition

### DIFF
--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -13,8 +13,8 @@ declare namespace Mark {
     type MarkAccuracy = 'partially' | 'complementary' | 'exactly';
 
     interface MarkAccuracyObject {
-        value: MarkAccuracy,
-        limiters?: string[]
+        value: MarkAccuracy;
+        limiters?: string[];
     }
 
     interface MarkOptions {

--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Soner Köksal <https://github.com/renjfk>
 //                 Roman Hotsiy <https://github.com/RomanGotsiy>
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>
+//                 Joao Lourenco <https://github.com/blackstarzes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -11,12 +12,17 @@
 declare namespace Mark {
     type MarkAccuracy = 'partially' | 'complementary' | 'exactly';
 
+    interface MarkAccuracyObject {
+        value: MarkAccuracy,
+        limiters?: string[]
+    }
+
     interface MarkOptions {
         element?: string;
         className?: string;
         exclude?: string[];
         separateWordSearch?: boolean;
-        accuracy?: MarkAccuracy | { value: MarkAccuracy };
+        accuracy?: MarkAccuracy | MarkAccuracyObject;
         diacritics?: boolean;
         synonyms?: { [index: string]: string };
         iframes?: boolean;


### PR DESCRIPTION
There was an incomplete definition for mark.js when specifying the accuracy option. It is also supported to provide a complex object as defined in the commit.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://markjs.io/#accuracy
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
