### PR TITLE
underscore - add typing to pick

### DIFF
--- a/types/backbone-associations/index.d.ts
+++ b/types/backbone-associations/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for Backbone-associations 0.6.4
+// Type definitions for Backbone-associations 0.7.0
 // Project: http://dhruvaray.github.io/backbone-associations
 // Definitions by: Craig Brett <https://github.com/craigbrett17>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 

--- a/types/backbone-associations/index.d.ts
+++ b/types/backbone-associations/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone-associations 0.7.0
+// Type definitions for Backbone-associations 0.6
 // Project: http://dhruvaray.github.io/backbone-associations
 // Definitions by: Craig Brett <https://github.com/craigbrett17>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/backbone-fetch-cache/index.d.ts
+++ b/types/backbone-fetch-cache/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for backbone-fetch-cache 2.0.0
+// Type definitions for backbone-fetch-cache 1.4
 // Project: https://github.com/madglory/backbone-fetch-cache
 // Definitions by: delphinus <https://github.com/delphinus35>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/backbone-fetch-cache/index.d.ts
+++ b/types/backbone-fetch-cache/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for backbone-fetch-cache 1.4.0
+// Type definitions for backbone-fetch-cache 2.0.0
 // Project: https://github.com/madglory/backbone-fetch-cache
 // Definitions by: delphinus <https://github.com/delphinus35>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from "backbone";
 

--- a/types/backbone-relational/index.d.ts
+++ b/types/backbone-relational/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone-relational 0.11.0
+// Type definitions for Backbone-relational 0.10
 // Project: http://backbonerelational.org/
 // Definitions by: Eirik Hoem <https://github.com/eirikhm>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>

--- a/types/backbone-relational/index.d.ts
+++ b/types/backbone-relational/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for Backbone-relational 0.10.0
+// Type definitions for Backbone-relational 0.11.0
 // Project: http://backbonerelational.org/
 // Definitions by: Eirik Hoem <https://github.com/eirikhm>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jquery" />
 

--- a/types/backbone.layoutmanager/index.d.ts
+++ b/types/backbone.layoutmanager/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone.LayoutManager 1.0.0
+// Type definitions for Backbone.LayoutManager 0.9
 // Project: http://layoutmanager.org/
 // Definitions by: He Jiang <https://github.com/hejiang2000>
 // Definitions: https://github.com/hejiang2000/DefinitelyTyped

--- a/types/backbone.layoutmanager/index.d.ts
+++ b/types/backbone.layoutmanager/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for Backbone.LayoutManager 0.9.5
+// Type definitions for Backbone.LayoutManager 1.0.0
 // Project: http://layoutmanager.org/
 // Definitions by: He Jiang <https://github.com/hejiang2000>
 // Definitions: https://github.com/hejiang2000/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jquery" />
 

--- a/types/backbone.localstorage/index.d.ts
+++ b/types/backbone.localstorage/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for backbone.localStorage 1.0.0
+// Type definitions for backbone.localStorage 2.0.0
 // Project: https://github.com/jeromegn/Backbone.localStorage
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 

--- a/types/backbone.localstorage/index.d.ts
+++ b/types/backbone.localstorage/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for backbone.localStorage 2.0.0
+// Type definitions for backbone.localStorage 1.0
 // Project: https://github.com/jeromegn/Backbone.localStorage
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Marionette 4.0
+// Type definitions for Marionette 3.3
 // Project: https://github.com/marionettejs/, https://marionettejs.com
 // Definitions by: Zeeshan Hamid <https://github.com/zhamid>,
 //                 Natan Vivo <https://github.com/nvivo>,

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Marionette 3.3
+// Type definitions for Marionette 4.0
 // Project: https://github.com/marionettejs/, https://marionettejs.com
 // Definitions by: Zeeshan Hamid <https://github.com/zhamid>,
 //                 Natan Vivo <https://github.com/nvivo>,
@@ -8,7 +8,7 @@
 //                 J. Joe Koullas <https://github.com/jjoekoullas>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 import * as JQuery from 'jquery';

--- a/types/backbone.paginator/index.d.ts
+++ b/types/backbone.paginator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for backbone.paginator 3.0.0
+// Type definitions for backbone.paginator 2.0
 // Project: https://github.com/backbone-paginator/backbone.paginator
 // Definitions by: Nyamazing <https://github.com/Nyamazing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/backbone.paginator/index.d.ts
+++ b/types/backbone.paginator/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for backbone.paginator 2.0.2
+// Type definitions for backbone.paginator 3.0.0
 // Project: https://github.com/backbone-paginator/backbone.paginator
 // Definitions by: Nyamazing <https://github.com/Nyamazing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 

--- a/types/backbone.radio/index.d.ts
+++ b/types/backbone.radio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone.Radio v1.0.0
+// Type definitions for Backbone.Radio 0.8
 // Project: https://github.com/marionettejs/backbone.radio
 // Definitions by: Peter Palotas <https://github.com/alphaleonis>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>

--- a/types/backbone.radio/index.d.ts
+++ b/types/backbone.radio/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for Backbone.Radio v0.8.3
+// Type definitions for Backbone.Radio v1.0.0
 // Project: https://github.com/marionettejs/backbone.radio
 // Definitions by: Peter Palotas <https://github.com/alphaleonis>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone 1.4.0
+// Type definitions for Backbone 2.0
 // Project: http://backbonejs.org/
 //          https://github.com/jashkenas/backbone
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
@@ -8,7 +8,7 @@
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 //                 Kyle Scully <https://github.com/zieka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jquery" />
 

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backbone 2.0
+// Type definitions for Backbone 1.4
 // Project: http://backbonejs.org/
 //          https://github.com/jashkenas/backbone
 // Definitions by: Boris Yankov <https://github.com/borisyankov>

--- a/types/backgrid/index.d.ts
+++ b/types/backgrid/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for Backgrid 0.2.6
+// Type definitions for Backgrid 0.3.0
 // Project: http://backgridjs.com/
 // Definitions by: Jeremy Lujan <https://github.com/jlujan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Backbone from 'backbone';
 

--- a/types/backgrid/index.d.ts
+++ b/types/backgrid/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Backgrid 0.3.0
+// Type definitions for Backgrid 0.2
 // Project: http://backgridjs.com/
 // Definitions by: Jeremy Lujan <https://github.com/jlujan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/giraffe/index.d.ts
+++ b/types/giraffe/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matt McCray <https://github.com/darthapo>
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="backbone" />
 /// <reference types="jquery" />

--- a/types/knockback/index.d.ts
+++ b/types/knockback/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://kmalakoff.github.com/knockback
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="knockout" />
 /// <reference types="backbone" />

--- a/types/parse-mockdb/index.d.ts
+++ b/types/parse-mockdb/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for parse-mockdb v0.1.14
+// Type definitions for parse-mockdb v0.2.0
 // Project: https://github.com/HustleInc/parse-mockdb
 // Definitions by: David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 declare namespace ParseMockDB {
     function mockDB(): void;

--- a/types/parse-mockdb/index.d.ts
+++ b/types/parse-mockdb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse-mockdb v0.2.0
+// Type definitions for parse-mockdb 0.1
 // Project: https://github.com/HustleInc/parse-mockdb
 // Definitions by: David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/parse/v1/index.d.ts
+++ b/types/parse/v1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse 1.11.1
+// Type definitions for parse 1.12.0
 // Project: https://parseplatform.org/
 // Definitions by:  Ullisen Media Group <http://ullisenmedia.com>
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>
@@ -7,7 +7,7 @@
 //                  Wes Grimes <https://github.com/wesleygrimes>
 //                  Otherwise SAS <https://github.com/owsas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 /// <reference types="jquery" />

--- a/types/parse/v1/index.d.ts
+++ b/types/parse/v1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse 1.12.0
+// Type definitions for parse 1.11
 // Project: https://parseplatform.org/
 // Definitions by:  Ullisen Media Group <http://ullisenmedia.com>
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>

--- a/types/rappid/index.d.ts
+++ b/types/rappid/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Rappid 2.0
+// Type definitions for non-npm package Rappid 1.5
 // Project: http://jointjs.com/about-rappid
 // Definitions by: Ewout Van Gossum <https://github.com/DenEwout>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/rappid/index.d.ts
+++ b/types/rappid/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for non-npm package Rappid 1.5
+// Type definitions for non-npm package Rappid 2.0
 // Project: http://jointjs.com/about-rappid
 // Definitions by: Ewout Van Gossum <https://github.com/DenEwout>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as joint from 'jointjs';
 import * as Backbone from "backbone";

--- a/types/underscore-ko/index.d.ts
+++ b/types/underscore-ko/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for Underscore-ko 1.2.2 with underscore 1.4
+// Type definitions for Underscore-ko 1.2.2 with underscore 2.0
 // Project: https://github.com/kamranayub/UnderscoreKO
 // Definitions by: Maurits Elbers <https://github.com/MagicMau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="knockout" />
 

--- a/types/underscore-ko/index.d.ts
+++ b/types/underscore-ko/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Underscore-ko 1.2.2 with underscore 2.0
+// Type definitions for Underscore-ko 1.2.2 with underscore 1.4
 // Project: https://github.com/kamranayub/UnderscoreKO
 // Definitions by: Maurits Elbers <https://github.com/MagicMau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/underscore.string/index.d.ts
+++ b/types/underscore.string/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/epeli/underscore.string
 // Definitions by: Ry Racherbaumer <https://github.com/rygine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as _ from 'underscore';
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -4115,7 +4115,7 @@ declare module _ {
         chain<T extends {}>(obj: T): _Chain<T>;
     }
 
-    interface Underscore<T, V> {
+    interface Underscore<T, V = T> {
 
         /* *************
         * Collections *

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Underscore 2.0
+// Type definitions for Underscore 1.9
 // Project: http://underscorejs.org/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>,
 //                 Josh Baldwin <https://github.com/jbaldwin>,

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Underscore 1.8
+// Type definitions for Underscore 2.0
 // Project: http://underscorejs.org/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>,
 //                 Josh Baldwin <https://github.com/jbaldwin>,
@@ -8,7 +8,7 @@
 //                 Florian Keller <https://github.com/ffflorian>
 //                 Regev Brody <https://github.com/regevbr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 declare var _: _.UnderscoreStatic;
 export = _;
@@ -104,16 +104,18 @@ declare module _ {
         cancel(): void;
     }
 
+    type TypeOfDictionary<T> = T extends _.Dictionary<infer V> ? V : never;
+
     interface UnderscoreStatic {
         /**
         * Underscore OOP Wrapper, all Underscore functions that take an object
         * as the first parameter can be invoked through this function.
         * @param key First argument to Underscore object functions.
         **/
-        <T>(value: _.Dictionary<T>): Underscore<T>;
-        <T>(value: _.List<T>): Underscore<T>;
-        <T>(value: Array<T>): Underscore<T>;
-        <T>(value: T): Underscore<T>;
+        <T>(value: _.List<T>): Underscore<T, _.List<T>>;
+        <T>(value: Array<T>): Underscore<T, Array<T>>;
+        <T extends TypeOfDictionary<V>, V extends _.Dictionary<any> = _.Dictionary<T>>(value: V): Underscore<T, V>;
+        <T>(value: T): Underscore<T, T>;
 
         /* *************
         * Collections *
@@ -3716,13 +3718,6 @@ declare module _ {
         pick<T, K extends keyof T>(obj: T, predicate: ObjectIterator<T[K], boolean>): Pick<T, K>;
 
         /**
-        * @see _.pick
-        **/
-        pick(
-            object: any,
-            fn: (value: any, key: any, object: any) => any): any;
-
-        /**
         * Return a copy of the object, filtered to omit the blacklisted keys (or array of keys).
         * @param object Object to strip unwanted key/value pairs.
         * @param keys The key/value pairs to remove on `object`.
@@ -4115,12 +4110,12 @@ declare module _ {
         * @param obj Object to chain.
         * @return Wrapped `obj`.
         **/
-        chain<T>(obj: T[]): _Chain<T>;
-        chain<T>(obj: _.Dictionary<T>): _Chain<T>;
+        chain<T>(obj: T[]): _Chain<T, T[]>;
+        chain<T extends TypeOfDictionary<V>, V extends _.Dictionary<any> = _.Dictionary<T>>(obj: V): _Chain<T, V>;
         chain<T extends {}>(obj: T): _Chain<T>;
     }
 
-    interface Underscore<T> {
+    interface Underscore<T, V> {
 
         /* *************
         * Collections *
@@ -4789,9 +4784,9 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.pick
         **/
-        pick(...keys: any[]): any;
-        pick(keys: any[]): any;
-        pick(fn: (value: any, key: any, object: any) => any): any;
+        pick<K extends keyof V>(...keys: K[]): Pick<V, K>;
+        pick<K extends keyof V>(keys: K[]): Pick<V, K>;
+        pick<K extends keyof V>(predicate: ObjectIterator<V[K], boolean>): Pick<V, K>;
 
         /**
         * Wrapped type `object`.
@@ -5058,7 +5053,7 @@ declare module _ {
         * Wrapped type `any`.
         * @see _.chain
         **/
-        chain(): _Chain<T>;
+        chain(): _Chain<T, V>;
 
         /**
         * Wrapped type `any`.
@@ -5068,7 +5063,7 @@ declare module _ {
         value<TResult>(): TResult;
     }
 
-    interface _Chain<T> {
+    interface _Chain<T, V = T> {
 
         /* *************
         * Collections *
@@ -5755,9 +5750,9 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.pick
         **/
-        pick(...keys: any[]): _Chain<T>;
-        pick(keys: any[]): _Chain<T>;
-        pick(fn: (value: any, key: any, object: any) => any): _Chain<T>;
+        pick<K extends keyof V>(...keys: K[]): _Chain<TypeOfDictionary<Pick<V, K>>, Pick<V, K>>;
+        pick<K extends keyof V>(keys: K[]): _Chain<TypeOfDictionary<Pick<V, K>>, Pick<V, K>>;
+        pick<K extends keyof V>(predicate: ObjectIterator<V[K], boolean>): _Chain<TypeOfDictionary<Pick<V, K>>, Pick<V, K>>;
 
         /**
         * Wrapped type `object`.
@@ -6111,7 +6106,7 @@ declare module _ {
         * Wrapped type `any`.
         * @see _.value
         **/
-        value<TResult>(): T[];
+        value(): V;
     }
     interface _ChainSingle<T> {
         value(): T;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -115,7 +115,7 @@ declare module _ {
         <T>(value: _.List<T>): Underscore<T, _.List<T>>;
         <T>(value: Array<T>): Underscore<T, Array<T>>;
         <T extends TypeOfDictionary<V>, V extends _.Dictionary<any> = _.Dictionary<T>>(value: V): Underscore<T, V>;
-        <T>(value: T): Underscore<T, T>;
+        <T>(value: T): Underscore<T>;
 
         /* *************
         * Collections *

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -347,6 +347,19 @@ _.pick({ name: 'moe', age: 50, userid: 'moe1' }, (value, key) => {
     return key === 'name' || key === 'age';
 }).age = 5;
 
+_({ name: 'moe', age: 50, userid: 'moe1' }).pick('name', 'age').age = 5;
+_({ name: 'moe', age: 50, userid: 'moe1' }).pick(['name', 'age']).age = 5;
+_({ name: 'moe', age: 50, userid: 'moe1' }).pick((value, key) => {
+    return key === 'name' || key === 'age';
+}).age = 5;
+
+_.chain({ name: 'moe', age: 50, userid: 'moe1' }).pick('name', 'age').value().age = 5;
+_.chain({ name: 'moe', age: 50, userid: 'moe1' }).pick(['name', 'age']).value().age = 5;
+_.chain({ name: 'moe', age: 50, userid: 'moe1' }).pick((value, key) => {
+    return key === 'name' || key === 'age';
+}).value().age = 5;
+
+
 _.omit({ name: 'moe', age: 50, userid: 'moe1' }, 'name');
 _.omit({ name: 'moe', age: 50, userid: 'moe1' }, 'name', 'age');
 _.omit({ name: 'moe', age: 50, userid: 'moe1' }, ['name', 'age']);
@@ -502,8 +515,6 @@ template2({ name: "Mustache" });
 _.template("Using 'with': <%= data.answer %>", oldTemplateSettings)({ variable: 'data' });
 
 _.template("Using 'with': <%= data.answer %>", { variable: 'data' })({ answer: 'no' });
-
-_(['test', 'test']).pick(['test2', 'test2']);
 
 //////////////// Chain Tests
 function chain_tests() {

--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for web3 1.0
+// Type definitions for web3 2.0
 // Project: https://github.com/ethereum/web3.js
 // Definitions by: Simon Jentzsch <https://github.com/simon-jentzsch>
 //                 Nitzan Tomer <https://github.com/nitzantomer>
@@ -21,7 +21,7 @@
 //                 Daniel Zhou <https://github.com/nerddan>
 //                 Alex Kvak <https://github.com/alexkvak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import Providers, { Provider } from "./providers";
 import { Bzz, Shh } from "./types";

--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for web3 2.0
+// Type definitions for web3 1.0
 // Project: https://github.com/ethereum/web3.js
 // Definitions by: Simon Jentzsch <https://github.com/simon-jentzsch>
 //                 Nitzan Tomer <https://github.com/nitzantomer>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/#pick

To continue #35977

@jgonggrijp I just noticed that I didn't take care of the typings for the chain and wrapped object use cases.
I fixed the code, but my tests failed, then I realized that the Generic type of Underscore<T> and Chain<T> when using a dictionary, is the union of the value types of the dictionary - which can be completely wrong for some methods, since, for example - pick is operating on the type of the object and not its value types.

I'll give an example in order to clarify the issue:

When using the current static wrapped "constructor"
```typescript
        <T>(value: _.Dictionary<T>): Underscore<T>;
```
You have no way to describe Pick on it, as you are loosing the type of the object itself which is essential here...

I added non breaking changes to support the use case, but in time more methods will need to be revised as there are a lot of wrongly types methods in the chain process, at they can probably be better handled now with the new typing.

I did however had to change the typescript version to 2.8 which caused a chain reaction of changing the typescript version for 18 more dependent libraries. I'm not sure what I did is correct, but I increased the major version and updated the typescript version in all related libraries.

as to the following complicated line:

```typescript
        <T extends TypeOfDictionary<V>, V extends _.Dictionary<any> = _.Dictionary<T>>(value: V): Underscore<T, V>;
```

This was the only way I could get Typescript to properly infer T. If using the obvious typing

```typescript
        <T, V extends _.Dictionary<T> = _.Dictionary<T>>(value: V): Underscore<T, V>;
```

The last test fails as it infers T as `{}`