### PR TITLE
react-stripe-elements: add definition for createPaymentMethod

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-stripe-elements 1.1
+// Type definitions for react-stripe-elements 1.2
 // Project: https://github.com/stripe/react-stripe-elements#readme
 // Definitions by: dan-j <https://github.com/dan-j>
 //                 Santiago Doldan <https://github.com/santiagodoldan>

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -20,7 +20,10 @@ export namespace ReactStripeElements {
 	type TokenResponse = stripe.TokenResponse;
 	type SourceResponse = stripe.SourceResponse;
 	type SourceOptions = stripe.SourceOptions;
-	type HTMLStripeElement = stripe.elements.Element;
+  type HTMLStripeElement = stripe.elements.Element;
+  type PaymentMethodType = stripe.paymentMethodType;
+  type PaymentMethodIncomplete = stripe.StripePaymentMethodIncomplete;
+  type PaymentMethodResponse = stripe.StripePaymentMethodResponse;
 
 	/**
 	 * There's a bug in @types/stripe which defines the property as
@@ -35,7 +38,8 @@ export namespace ReactStripeElements {
 	}
 	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null; } & StripeProviderOptions;
 
-	interface StripeProps {
+  interface StripeProps {
+    createPaymentMethod(type: PaymentMethodType, data: PaymentMethodIncomplete): Promise<PaymentMethodResponse>;
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
 		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
 		paymentRequest: stripe.Stripe['paymentRequest'];

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -20,10 +20,10 @@ export namespace ReactStripeElements {
 	type TokenResponse = stripe.TokenResponse;
 	type SourceResponse = stripe.SourceResponse;
 	type SourceOptions = stripe.SourceOptions;
-  type HTMLStripeElement = stripe.elements.Element;
-  type PaymentMethodType = stripe.paymentMethodType;
-  type PaymentMethodIncomplete = stripe.StripePaymentMethodIncomplete;
-  type PaymentMethodResponse = stripe.StripePaymentMethodResponse;
+	type HTMLStripeElement = stripe.elements.Element;
+	type PaymentMethodType = stripe.paymentMethodType;
+	type PaymentMethodIncomplete = stripe.StripePaymentMethodIncomplete;
+	type PaymentMethodResponse = stripe.StripePaymentMethodResponse;
 
 	/**
 	 * There's a bug in @types/stripe which defines the property as
@@ -38,8 +38,8 @@ export namespace ReactStripeElements {
 	}
 	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null; } & StripeProviderOptions;
 
-  interface StripeProps {
-    createPaymentMethod(type: PaymentMethodType, data: PaymentMethodIncomplete): Promise<PaymentMethodResponse>;
+	interface StripeProps {
+		createPaymentMethod(type: PaymentMethodType, data: PaymentMethodIncomplete): Promise<PaymentMethodResponse>;
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
 		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
 		paymentRequest: stripe.Stripe['paymentRequest'];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/stripe/react-stripe-elements#setting-up-your-payment-form-injectstripe>> (used in the first example under `handleSubmit` in that section)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
