### PR TITLE
rename `findDescendants` to `findDescendant`

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -406,7 +406,7 @@ declare class BaseNode<
     createRange(properties: RangeProperties | Range): Range;
     createSelection(properties: SelectionProperties | Selection): Selection;
     filterDescendants(iterator: (node: Node) => boolean): Immutable.List<Node>;
-    findDescendants(iterator: (node: Node) => boolean): Node | null;
+    findDescendant(iterator: (node: Node) => boolean): Node | null;
     getActiveMarksAtRange(range: Range): Immutable.Set<Mark>;
     getAncestors(path: Path): Immutable.List<Node> | null;
     getBlocks(): Immutable.List<Block>;


### PR DESCRIPTION
Slate doesn't have a `findDescendants` method on `BaseNode` but `findDescendant`.

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/interfaces/element.js#L395