### PR TITLE
[moment] Create types: @types/moment

### DIFF
--- a/types/moment/index.d.ts
+++ b/types/moment/index.d.ts
@@ -1,0 +1,751 @@
+// Type definitions for moment 2.24
+// Project: http://momentjs.com
+// Definitions by: PikachuEXE <https://github.com/PikachuEXE>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// tslint:disable:typedef-whitespace
+// tslint:disable:whitespace
+// tslint:disable:array-type
+// tslint:disable:unified-signatures
+// tslint:disable:no-redundant-undefined
+// tslint:disable:no-padding
+// tslint:disable:strict-export-declare-modifiers
+// tslint:disable:void-return
+// tslint:disable:ban-types
+// tslint:disable:no-var-keyword
+declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, strict?: boolean): moment.Moment;
+declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean): moment.Moment;
+
+declare namespace moment {
+    type RelativeTimeKey = 's' | 'ss' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'M' | 'MM' | 'y' | 'yy';
+    type CalendarKey = 'sameDay' | 'nextDay' | 'lastDay' | 'nextWeek' | 'lastWeek' | 'sameElse' | string;
+    type LongDateFormatKey = 'LTS' | 'LT' | 'L' | 'LL' | 'LLL' | 'LLLL' | 'lts' | 'lt' | 'l' | 'll' | 'lll' | 'llll';
+
+    interface Locale {
+        calendar(key?: CalendarKey, m?: Moment, now?: Moment): string;
+
+        longDateFormat(key: LongDateFormatKey): string;
+        invalidDate(): string;
+        ordinal(n: number): string;
+
+        preparse(inp: string): string;
+        postformat(inp: string): string;
+        relativeTime(n: number, withoutSuffix: boolean,
+                     key: RelativeTimeKey, isFuture: boolean): string;
+        pastFuture(diff: number, absRelTime: string): string;
+        set(config: Object): void;
+
+        months(): string[];
+        months(m: Moment, format?: string): string;
+        monthsShort(): string[];
+        monthsShort(m: Moment, format?: string): string;
+        monthsParse(monthName: string, format: string, strict: boolean): number;
+        monthsRegex(strict: boolean): RegExp;
+        monthsShortRegex(strict: boolean): RegExp;
+
+        week(m: Moment): number;
+        firstDayOfYear(): number;
+        firstDayOfWeek(): number;
+
+        weekdays(): string[];
+        weekdays(m: Moment, format?: string): string;
+        weekdaysMin(): string[];
+        weekdaysMin(m: Moment): string;
+        weekdaysShort(): string[];
+        weekdaysShort(m: Moment): string;
+        weekdaysParse(weekdayName: string, format: string, strict: boolean): number;
+        weekdaysRegex(strict: boolean): RegExp;
+        weekdaysShortRegex(strict: boolean): RegExp;
+        weekdaysMinRegex(strict: boolean): RegExp;
+
+        isPM(input: string): boolean;
+        meridiem(hour: number, minute: number, isLower: boolean): string;
+    }
+
+    interface StandaloneFormatSpec {
+        format: string[];
+        standalone: string[];
+        isFormat?: RegExp;
+    }
+
+    interface WeekSpec {
+        dow: number;
+        doy?: number;
+    }
+
+    type CalendarSpecVal = string | ((m?: MomentInput, now?: Moment) => string);
+    interface CalendarSpec {
+        sameDay?: CalendarSpecVal;
+        nextDay?: CalendarSpecVal;
+        lastDay?: CalendarSpecVal;
+        nextWeek?: CalendarSpecVal;
+        lastWeek?: CalendarSpecVal;
+        sameElse?: CalendarSpecVal;
+
+        // any additional properties might be used with moment.calendarFormat
+        [x: string]: CalendarSpecVal | void; // undefined
+    }
+
+    type RelativeTimeSpecVal = (
+        string |
+        ((n: number, withoutSuffix: boolean,
+          key: RelativeTimeKey, isFuture: boolean) => string)
+        );
+    type RelativeTimeFuturePastVal = string | ((relTime: string) => string);
+
+    interface RelativeTimeSpec {
+        future?: RelativeTimeFuturePastVal;
+        past?: RelativeTimeFuturePastVal;
+        s?: RelativeTimeSpecVal;
+        ss?: RelativeTimeSpecVal;
+        m?: RelativeTimeSpecVal;
+        mm?: RelativeTimeSpecVal;
+        h?: RelativeTimeSpecVal;
+        hh?: RelativeTimeSpecVal;
+        d?: RelativeTimeSpecVal;
+        dd?: RelativeTimeSpecVal;
+        M?: RelativeTimeSpecVal;
+        MM?: RelativeTimeSpecVal;
+        y?: RelativeTimeSpecVal;
+        yy?: RelativeTimeSpecVal;
+    }
+
+    interface LongDateFormatSpec {
+        LTS: string;
+        LT: string;
+        L: string;
+        LL: string;
+        LLL: string;
+        LLLL: string;
+
+        // lets forget for a sec that any upper/lower permutation will also work
+        lts?: string;
+        lt?: string;
+        l?: string;
+        ll?: string;
+        lll?: string;
+        llll?: string;
+    }
+
+    type MonthWeekdayFn = (momentToFormat: Moment, format?: string) => string;
+    type WeekdaySimpleFn = (momentToFormat: Moment) => string;
+
+    interface LocaleSpecification {
+        months?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+        monthsShort?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+
+        weekdays?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+        weekdaysShort?: string[] | StandaloneFormatSpec | WeekdaySimpleFn;
+        weekdaysMin?: string[] | StandaloneFormatSpec | WeekdaySimpleFn;
+
+        meridiemParse?: RegExp;
+        meridiem?: (hour: number, minute:number, isLower: boolean) => string;
+
+        isPM?: (input: string) => boolean;
+
+        longDateFormat?: LongDateFormatSpec;
+        calendar?: CalendarSpec;
+        relativeTime?: RelativeTimeSpec;
+        invalidDate?: string;
+        ordinal?: (n: number) => string;
+        ordinalParse?: RegExp;
+
+        week?: WeekSpec;
+
+        // Allow anything: in general any property that is passed as locale spec is
+        // put in the locale object so it can be used by locale functions
+        [x: string]: any;
+    }
+
+    interface MomentObjectOutput {
+        years: number;
+        /* One digit */
+        months: number;
+        /* Day of the month */
+        date: number;
+        hours: number;
+        minutes: number;
+        seconds: number;
+        milliseconds: number;
+    }
+
+    interface Duration {
+        clone(): Duration;
+
+        humanize(withSuffix?: boolean): string;
+
+        abs(): Duration;
+
+        as(units: unitOfTime.Base): number;
+        get(units: unitOfTime.Base): number;
+
+        milliseconds(): number;
+        asMilliseconds(): number;
+
+        seconds(): number;
+        asSeconds(): number;
+
+        minutes(): number;
+        asMinutes(): number;
+
+        hours(): number;
+        asHours(): number;
+
+        days(): number;
+        asDays(): number;
+
+        weeks(): number;
+        asWeeks(): number;
+
+        months(): number;
+        asMonths(): number;
+
+        years(): number;
+        asYears(): number;
+
+        add(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+        subtract(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+
+        locale(): string;
+        locale(locale: LocaleSpecifier): Duration;
+        localeData(): Locale;
+
+        toISOString(): string;
+        toJSON(): string;
+
+        isValid(): boolean;
+
+        /**
+         * @deprecated since version 2.8.0
+         */
+        lang(locale: LocaleSpecifier): Moment;
+        /**
+         * @deprecated since version 2.8.0
+         */
+        lang(): Locale;
+        /**
+         * @deprecated
+         */
+        toIsoString(): string;
+    }
+
+    interface MomentRelativeTime {
+        future: any;
+        past: any;
+        s: any;
+        ss: any;
+        m: any;
+        mm: any;
+        h: any;
+        hh: any;
+        d: any;
+        dd: any;
+        M: any;
+        MM: any;
+        y: any;
+        yy: any;
+    }
+
+    interface MomentLongDateFormat {
+        L: string;
+        LL: string;
+        LLL: string;
+        LLLL: string;
+        LT: string;
+        LTS: string;
+
+        l?: string;
+        ll?: string;
+        lll?: string;
+        llll?: string;
+        lt?: string;
+        lts?: string;
+    }
+
+    interface MomentParsingFlags {
+        empty: boolean;
+        unusedTokens: string[];
+        unusedInput: string[];
+        overflow: number;
+        charsLeftOver: number;
+        nullInput: boolean;
+        invalidMonth: string | void; // null
+        invalidFormat: boolean;
+        userInvalidated: boolean;
+        iso: boolean;
+        parsedDateParts: any[];
+        meridiem: string | void; // null
+    }
+
+    interface MomentParsingFlagsOpt {
+        empty?: boolean;
+        unusedTokens?: string[];
+        unusedInput?: string[];
+        overflow?: number;
+        charsLeftOver?: number;
+        nullInput?: boolean;
+        invalidMonth?: string;
+        invalidFormat?: boolean;
+        userInvalidated?: boolean;
+        iso?: boolean;
+        parsedDateParts?: any[];
+        meridiem?: string;
+    }
+
+    interface MomentBuiltinFormat {
+        __momentBuiltinFormatBrand: any;
+    }
+
+    type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
+
+    namespace unitOfTime {
+        type Base = (
+            "year" | "years" | "y" |
+            "month" | "months" | "M" |
+            "week" | "weeks" | "w" |
+            "day" | "days" | "d" |
+            "hour" | "hours" | "h" |
+            "minute" | "minutes" | "m" |
+            "second" | "seconds" | "s" |
+            "millisecond" | "milliseconds" | "ms"
+            );
+
+        type _quarter = "quarter" | "quarters" | "Q";
+        type _isoWeek = "isoWeek" | "isoWeeks" | "W";
+        type _date = "date" | "dates" | "D";
+        type DurationConstructor = Base | _quarter;
+
+        type DurationAs = Base;
+
+        type StartOf = Base | _quarter | _isoWeek | _date | void; // null
+
+        type Diff = Base | _quarter;
+
+        type MomentConstructor = Base | _date;
+
+        type All = Base | _quarter | _isoWeek | _date |
+            "weekYear" | "weekYears" | "gg" |
+            "isoWeekYear" | "isoWeekYears" | "GG" |
+            "dayOfYear" | "dayOfYears" | "DDD" |
+            "weekday" | "weekdays" | "e" |
+            "isoWeekday" | "isoWeekdays" | "E";
+    }
+
+    interface MomentInputObject {
+        years?: number;
+        year?: number;
+        y?: number;
+
+        months?: number;
+        month?: number;
+        M?: number;
+
+        days?: number;
+        day?: number;
+        d?: number;
+
+        dates?: number;
+        date?: number;
+        D?: number;
+
+        hours?: number;
+        hour?: number;
+        h?: number;
+
+        minutes?: number;
+        minute?: number;
+        m?: number;
+
+        seconds?: number;
+        second?: number;
+        s?: number;
+
+        milliseconds?: number;
+        millisecond?: number;
+        ms?: number;
+    }
+
+    interface DurationInputObject extends MomentInputObject {
+        quarters?: number;
+        quarter?: number;
+        Q?: number;
+
+        weeks?: number;
+        week?: number;
+        w?: number;
+    }
+
+    interface MomentSetObject extends MomentInputObject {
+        weekYears?: number;
+        weekYear?: number;
+        gg?: number;
+
+        isoWeekYears?: number;
+        isoWeekYear?: number;
+        GG?: number;
+
+        quarters?: number;
+        quarter?: number;
+        Q?: number;
+
+        weeks?: number;
+        week?: number;
+        w?: number;
+
+        isoWeeks?: number;
+        isoWeek?: number;
+        W?: number;
+
+        dayOfYears?: number;
+        dayOfYear?: number;
+        DDD?: number;
+
+        weekdays?: number;
+        weekday?: number;
+        e?: number;
+
+        isoWeekdays?: number;
+        isoWeekday?: number;
+        E?: number;
+    }
+
+    interface FromTo {
+        from: MomentInput;
+        to: MomentInput;
+    }
+
+    type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | void; // null | undefined
+    type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | void; // null | undefined
+    type DurationInputArg2 = unitOfTime.DurationConstructor;
+    type LocaleSpecifier = string | Moment | Duration | string[] | boolean;
+
+    interface MomentCreationData {
+        input: MomentInput;
+        format?: MomentFormatSpecification;
+        locale: Locale;
+        isUTC: boolean;
+        strict?: boolean;
+    }
+
+    interface Moment extends Object {
+        format(format?: string): string;
+
+        startOf(unitOfTime: unitOfTime.StartOf): Moment;
+        endOf(unitOfTime: unitOfTime.StartOf): Moment;
+
+        add(amount?: DurationInputArg1, unit?: DurationInputArg2): Moment;
+        /**
+         * @deprecated reverse syntax
+         */
+        add(unit: unitOfTime.DurationConstructor, amount: number|string): Moment;
+
+        subtract(amount?: DurationInputArg1, unit?: DurationInputArg2): Moment;
+        /**
+         * @deprecated reverse syntax
+         */
+        subtract(unit: unitOfTime.DurationConstructor, amount: number|string): Moment;
+
+        calendar(time?: MomentInput, formats?: CalendarSpec): string;
+
+        clone(): Moment;
+
+        /**
+         * @return Unix timestamp in milliseconds
+         */
+        valueOf(): number;
+
+        // current date/time in local mode
+        local(keepLocalTime?: boolean): Moment;
+        isLocal(): boolean;
+
+        // current date/time in UTC mode
+        utc(keepLocalTime?: boolean): Moment;
+        isUTC(): boolean;
+        /**
+         * @deprecated use isUTC
+         */
+        isUtc(): boolean;
+
+        parseZone(): Moment;
+        isValid(): boolean;
+        invalidAt(): number;
+
+        hasAlignedHourOffset(other?: MomentInput): boolean;
+
+        creationData(): MomentCreationData;
+        parsingFlags(): MomentParsingFlags;
+
+        year(y: number): Moment;
+        year(): number;
+        /**
+         * @deprecated use year(y)
+         */
+        years(y: number): Moment;
+        /**
+         * @deprecated use year()
+         */
+        years(): number;
+        quarter(): number;
+        quarter(q: number): Moment;
+        quarters(): number;
+        quarters(q: number): Moment;
+        month(M: number|string): Moment;
+        month(): number;
+        /**
+         * @deprecated use month(M)
+         */
+        months(M: number|string): Moment;
+        /**
+         * @deprecated use month()
+         */
+        months(): number;
+        day(d: number|string): Moment;
+        day(): number;
+        days(d: number|string): Moment;
+        days(): number;
+        date(d: number): Moment;
+        date(): number;
+        /**
+         * @deprecated use date(d)
+         */
+        dates(d: number): Moment;
+        /**
+         * @deprecated use date()
+         */
+        dates(): number;
+        hour(h: number): Moment;
+        hour(): number;
+        hours(h: number): Moment;
+        hours(): number;
+        minute(m: number): Moment;
+        minute(): number;
+        minutes(m: number): Moment;
+        minutes(): number;
+        second(s: number): Moment;
+        second(): number;
+        seconds(s: number): Moment;
+        seconds(): number;
+        millisecond(ms: number): Moment;
+        millisecond(): number;
+        milliseconds(ms: number): Moment;
+        milliseconds(): number;
+        weekday(): number;
+        weekday(d: number): Moment;
+        isoWeekday(): number;
+        isoWeekday(d: number|string): Moment;
+        weekYear(): number;
+        weekYear(d: number): Moment;
+        isoWeekYear(): number;
+        isoWeekYear(d: number): Moment;
+        week(): number;
+        week(d: number): Moment;
+        weeks(): number;
+        weeks(d: number): Moment;
+        isoWeek(): number;
+        isoWeek(d: number): Moment;
+        isoWeeks(): number;
+        isoWeeks(d: number): Moment;
+        weeksInYear(): number;
+        isoWeeksInYear(): number;
+        dayOfYear(): number;
+        dayOfYear(d: number): Moment;
+
+        from(inp: MomentInput, suffix?: boolean): string;
+        to(inp: MomentInput, suffix?: boolean): string;
+        fromNow(withoutSuffix?: boolean): string;
+        toNow(withoutPrefix?: boolean): string;
+
+        diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
+
+        toArray(): number[];
+        toDate(): Date;
+        toISOString(keepOffset?: boolean): string;
+        inspect(): string;
+        toJSON(): string;
+        unix(): number;
+
+        isLeapYear(): boolean;
+        /**
+         * @deprecated in favor of utcOffset
+         */
+        zone(): number;
+        zone(b: number|string): Moment;
+        utcOffset(): number;
+        utcOffset(b: number|string, keepLocalTime?: boolean): Moment;
+        isUtcOffset(): boolean;
+        daysInMonth(): number;
+        isDST(): boolean;
+
+        zoneAbbr(): string;
+        zoneName(): string;
+
+        isBefore(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+        isAfter(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+        isSame(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+        isSameOrAfter(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+        isSameOrBefore(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+        isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf | null, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
+
+        /**
+         * @deprecated as of 2.8.0, use locale
+         */
+        lang(language: LocaleSpecifier): Moment;
+        /**
+         * @deprecated as of 2.8.0, use locale
+         */
+        lang(): Locale;
+
+        locale(): string;
+        locale(locale: LocaleSpecifier): Moment;
+
+        localeData(): Locale;
+
+        /**
+         * @deprecated no reliable implementation
+         */
+        isDSTShifted(): boolean;
+
+        // NOTE(constructor): Same as moment constructor
+        /**
+         * @deprecated as of 2.7.0, use moment.min/max
+         */
+        max(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+        /**
+         * @deprecated as of 2.7.0, use moment.min/max
+         */
+        max(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+        // NOTE(constructor): Same as moment constructor
+        /**
+         * @deprecated as of 2.7.0, use moment.min/max
+         */
+        min(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+        /**
+         * @deprecated as of 2.7.0, use moment.min/max
+         */
+        min(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+        get(unit: unitOfTime.All): number;
+        set(unit: unitOfTime.All, value: number): Moment;
+        set(objectLiteral: MomentSetObject): Moment;
+
+        toObject(): MomentObjectOutput;
+    }
+
+    export var version: string;
+    export var fn: Moment;
+
+    // NOTE(constructor): Same as moment constructor
+    export function utc(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+    export function utc(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+    export function unix(timestamp: number): Moment;
+
+    export function invalid(flags?: MomentParsingFlagsOpt): Moment;
+    export function isMoment(m: any): m is Moment;
+    export function isDate(m: any): m is Date;
+    export function isDuration(d: any): d is Duration;
+
+    /**
+     * @deprecated in 2.8.0
+     */
+    export function lang(language?: string): string;
+    /**
+     * @deprecated in 2.8.0
+     */
+    export function lang(language?: string, definition?: Locale): string;
+
+    export function locale(language?: string): string;
+    export function locale(language?: string[]): string;
+    export function locale(language?: string, definition?: LocaleSpecification | void): string; // null | undefined
+
+    export function localeData(key?: string | string[]): Locale;
+
+    export function duration(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+
+    // NOTE(constructor): Same as moment constructor
+    export function parseZone(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+    export function parseZone(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+    export function months(): string[];
+    export function months(index: number): string;
+    export function months(format: string): string[];
+    export function months(format: string, index: number): string;
+    export function monthsShort(): string[];
+    export function monthsShort(index: number): string;
+    export function monthsShort(format: string): string[];
+    export function monthsShort(format: string, index: number): string;
+
+    export function weekdays(): string[];
+    export function weekdays(index: number): string;
+    export function weekdays(format: string): string[];
+    export function weekdays(format: string, index: number): string;
+    export function weekdays(localeSorted: boolean): string[];
+    export function weekdays(localeSorted: boolean, index: number): string;
+    export function weekdays(localeSorted: boolean, format: string): string[];
+    export function weekdays(localeSorted: boolean, format: string, index: number): string;
+    export function weekdaysShort(): string[];
+    export function weekdaysShort(index: number): string;
+    export function weekdaysShort(format: string): string[];
+    export function weekdaysShort(format: string, index: number): string;
+    export function weekdaysShort(localeSorted: boolean): string[];
+    export function weekdaysShort(localeSorted: boolean, index: number): string;
+    export function weekdaysShort(localeSorted: boolean, format: string): string[];
+    export function weekdaysShort(localeSorted: boolean, format: string, index: number): string;
+    export function weekdaysMin(): string[];
+    export function weekdaysMin(index: number): string;
+    export function weekdaysMin(format: string): string[];
+    export function weekdaysMin(format: string, index: number): string;
+    export function weekdaysMin(localeSorted: boolean): string[];
+    export function weekdaysMin(localeSorted: boolean, index: number): string;
+    export function weekdaysMin(localeSorted: boolean, format: string): string[];
+    export function weekdaysMin(localeSorted: boolean, format: string, index: number): string;
+
+    export function min(moments: Moment[]): Moment;
+    export function min(...moments: Moment[]): Moment;
+    export function max(moments: Moment[]): Moment;
+    export function max(...moments: Moment[]): Moment;
+
+    /**
+     * Returns unix time in milliseconds. Overwrite for profit.
+     */
+    export function now(): number;
+
+    export function defineLocale(language: string, localeSpec: LocaleSpecification | void): Locale; // null
+    export function updateLocale(language: string, localeSpec: LocaleSpecification | void): Locale; // null
+
+    export function locales(): string[];
+
+    export function normalizeUnits(unit: unitOfTime.All): string;
+    export function relativeTimeThreshold(threshold: string): number | boolean;
+    export function relativeTimeThreshold(threshold: string, limit: number): boolean;
+    export function relativeTimeRounding(fn: (num: number) => number): boolean;
+    export function relativeTimeRounding(): (num: number) => number;
+    export function calendarFormat(m: Moment, now: Moment): string;
+
+    export function parseTwoDigitYear(input: string): number;
+
+    /**
+     * Constant used to enable explicit ISO_8601 format parsing.
+     */
+    export var ISO_8601: MomentBuiltinFormat;
+    export var RFC_2822: MomentBuiltinFormat;
+
+    export var defaultFormat: string;
+    export var defaultFormatUtc: string;
+
+    export var HTML5_FMT: {
+        DATETIME_LOCAL: string,
+        DATETIME_LOCAL_SECONDS: string,
+        DATETIME_LOCAL_MS: string,
+        DATE: string,
+        TIME: string,
+        TIME_SECONDS: string,
+        TIME_MS: string,
+        WEEK: string,
+        MONTH: string
+    };
+
+}
+
+export = moment;

--- a/types/moment/moment-tests.ts
+++ b/types/moment/moment-tests.ts
@@ -1,0 +1,531 @@
+// tslint:disable:object-literal-shorthand
+// tslint:disable:space-before-function-paren
+// tslint:disable:only-arrow-functions
+// tslint:disable:prefer-template
+// tslint:disable:prefer-const
+// tslint:disable:no-var-keyword
+// tslint:disable:whitespace
+// tslint:disable:object-literal-key-quotes
+// tslint:disable:semicolon
+import moment = require('moment');
+
+moment.parseTwoDigitYear("50");
+
+moment().add('hours', 1).fromNow();
+
+var day = new Date(2011, 9, 16);
+var dayWrapper = moment(day);
+var otherDay = moment(new Date(2020, 3, 7));
+
+var day1 = moment(1318781876406);
+var day2 = moment.unix(1318781876);
+var day3 = moment("Dec 25, 1995");
+var day4 = moment("12-25-1995", "MM-DD-YYYY");
+var day5 = moment("12-25-1995", ["MM-DD-YYYY", "YYYY-MM-DD"]);
+var day6 = moment("05-06-1995", ["MM-DD-YYYY", "DD-MM-YYYY"]);
+var now = moment();
+var day7 = moment([2010, 1, 14, 15, 25, 50, 125]);
+var day8 = moment([2010]);
+var day9 = moment([2010, 6]);
+var day10 = moment([2010, 6, 10]);
+var array = [2010, 1, 14, 15, 25, 50, 125];
+var day11 = moment(Date.UTC.apply({}, array));
+var day12 = moment.unix(1318781876);
+
+// TODO: reenable in 2.0
+// moment(null);
+moment(undefined);
+moment({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
+moment("20140101", "YYYYMMDD", true);
+moment("20140101", "YYYYMMDD", "en");
+moment("20140101", "YYYYMMDD", "en", true);
+moment("20140101", ["YYYYMMDD"], true);
+moment("20140101", ["YYYYMMDD"], "en");
+moment("20140101", ["YYYYMMDD"], "en", true);
+
+moment(day.toISOString(), moment.ISO_8601);
+moment(day.toISOString(), moment.ISO_8601, true);
+moment(day.toISOString(), moment.ISO_8601, "en", true);
+moment(day.toISOString(), [moment.ISO_8601]);
+moment(day.toISOString(), [moment.ISO_8601], true);
+moment(day.toISOString(), [moment.ISO_8601], "en", true);
+
+moment(day.toUTCString(), moment.RFC_2822);
+moment(day.toUTCString(), moment.RFC_2822, true);
+moment(day.toUTCString(), moment.RFC_2822, "en", true);
+moment(day.toUTCString(), [moment.RFC_2822]);
+moment(day.toUTCString(), [moment.RFC_2822], true);
+moment(day.toUTCString(), [moment.RFC_2822], "en", true);
+
+var a = moment([2012]);
+var b = moment(a);
+a.year(2000);
+b.year(); // 2012
+
+moment.utc();
+moment.utc(12345);
+moment.utc([12, 34, 56]);
+moment.utc({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
+moment.utc("1-2-3");
+moment.utc("1-2-3", "3-2-1");
+moment.utc("1-2-3", "3-2-1", true);
+moment.utc("1-2-3", "3-2-1", "en");
+moment.utc("1-2-3", "3-2-1", "en", true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"]);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en");
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en", true);
+
+var a2 = moment.utc([2011, 0, 1, 8]);
+a.hours();
+a.local();
+a.hours();
+
+moment("2011-10-10", "YYYY-MM-DD").isValid();
+moment("2011-10-50", "YYYY-MM-DD").isValid();
+moment("2011-10-10T10:20:90").isValid();
+moment([2011, 0, 1]).isValid();
+moment([2011, 0, 50]).isValid();
+moment("not a date").isValid();
+
+moment().add('days', 7).subtract('months', 1).year(2009).hours(0).minutes(0).seconds(0);
+
+moment().add('days', 7);
+moment().add('days', 7).add('months', 1);
+moment().add({days:7,months:1});
+moment().add('milliseconds', 1000000);
+moment().add('days', 360);
+moment([2010, 0, 31]);
+moment([2010, 0, 31]).add('months', 1);
+var m = moment(new Date(2011, 2, 12, 5, 0, 0));
+m.hours();
+m.add('days', 1).hours();
+var m2 = moment(new Date(2011, 2, 12, 5, 0, 0));
+m2.hours();
+m2.add('hours', 24).hours();
+var duration = moment.duration({'days': 1});
+moment([2012, 0, 31]).add(duration);
+
+moment().add('seconds', 1);
+moment().add(1, 'seconds');
+
+moment().add('1', 'seconds');
+
+moment().subtract('days', 7);
+
+moment().seconds(30);
+moment().minutes(30);
+
+moment().hours(12);
+moment().date(5);
+moment().day(5);
+moment().day("Sunday");
+moment().month(5);
+moment().month("January");
+moment().year(1984);
+moment().startOf('year');
+moment().month(0).date(1).hours(0).minutes(0).seconds(0).milliseconds(0);
+moment().startOf('hour');
+moment().minutes(0).seconds(0).milliseconds(0);
+moment().weekday();
+moment().weekday(0);
+moment().isoWeekday(1);
+moment().isoWeekday();
+moment().weekYear(2);
+moment().weekYear();
+moment().isoWeekYear(3);
+moment().isoWeekYear();
+moment().week();
+moment().week(45);
+moment().weeks();
+moment().weeks(45);
+moment().isoWeek();
+moment().isoWeek(45);
+moment().isoWeeks();
+moment().isoWeeks(45);
+moment().dayOfYear();
+moment().dayOfYear(45);
+
+moment().set('year', 2013);
+moment().set('month', 3);  // April
+moment().set('date', 1);
+moment().set('hour', 13);
+moment().set('minute', 20);
+moment().set('second', 30);
+moment().set('millisecond', 123);
+moment().set({'year': 2013, 'month': 3});
+
+var getMilliseconds: number = moment().milliseconds();
+var getSeconds: number = moment().seconds();
+var getMinutes: number = moment().minutes();
+var getHours: number = moment().hours();
+var getDate: number = moment().date();
+var getDay: number = moment().day();
+var getMonth: number = moment().month();
+var getQuater: number = moment().quarter();
+var getYear: number = moment().year();
+
+moment().hours(0).minutes(0).seconds(0).milliseconds(0);
+
+var a3 = moment([2011, 0, 1, 8]);
+a3.hours();
+a3.utc();
+a3.hours();
+
+var a4 = moment([2010, 1, 14, 15, 25, 50, 125]);
+a4.format("dddd, MMMM Do YYYY, h:mm:ss a");
+a4.format("ddd, hA");
+
+moment().format('\\L');
+moment().format('[today] DDDD');
+
+var a5 = moment([2007, 0, 29]);
+var b5 = moment([2007, 0, 28]);
+a5.from(b5);
+
+var a6 = moment([2007, 0, 29]);
+var b6 = moment([2007, 0, 28]);
+a6.from(b6);
+a6.from([2007, 0, 28]);
+a6.from(new Date(2007, 0, 28));
+a6.from("1-28-2007");
+
+var a7 = moment();
+var b7 = moment("10-10-1900", "MM-DD-YYYY");
+a7.from(b7);
+
+var start = moment([2007, 0, 5]);
+var end = moment([2007, 0, 10]);
+start.from(end);
+start.from(end, true);
+
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow(true);
+
+var a8 = moment([2007, 0, 29]);
+var b8 = moment([2007, 0, 28]);
+a8.diff(b8) ;
+a8.diff(b8, 'days');
+a8.diff(b8, 'years')
+a8.diff(b8, 'years', true);
+
+moment.min([a8, b8]);
+moment.min(a8, b8);
+moment.max([a8, b8]);
+moment.max(a8, b8);
+
+moment([2007, 0, 29]).toDate();
+moment([2007, 1, 23]).toISOString();
+moment(1318874398806).valueOf();
+moment(1318874398806).unix();
+moment([2000]).isLeapYear();
+moment().zone();
+moment().utcOffset();
+moment("2012-2", "YYYY-MM").daysInMonth();
+moment([2011, 2, 12]).isDST();
+
+moment.isMoment(new Date());
+moment.isMoment(moment());
+
+moment.isDate(new Date());
+moment.isDate(/regexp/);
+
+moment.isDuration(new Date());
+moment.isDuration(moment.duration());
+
+moment().isBetween(moment(), moment());
+moment().isBetween(new Date(), new Date());
+moment().isBetween([1,1,2000], [1,1,2001], "year");
+moment().isBetween([1,1,2000], [1,1,2001], null, "()");
+
+moment.localeData('fr');
+moment(1316116057189).fromNow();
+
+moment.localeData('en');
+var globalLang = moment();
+var localLang = moment();
+localLang.localeData();
+localLang.format('LLLL');
+globalLang.format('LLLL');
+
+// TODO: reenable in 2.0
+// moment.duration(null);
+moment.duration(undefined);
+moment.duration(100);
+moment.duration(2, 'seconds');
+moment.duration({
+    seconds: 2,
+    minutes: 2,
+    hours: 2,
+    days: 2,
+    weeks: 2,
+    months: 2,
+    years: 2
+});
+moment.duration({
+    s: 2,
+    m: 2,
+    h: 2,
+    d: 2,
+    w: 2,
+    M: 2,
+    y: 2,
+});
+moment.duration(1, "minute").clone();
+moment.duration(1, "minutes").humanize();
+moment.duration(500).milliseconds();
+moment.duration(500).asMilliseconds();
+moment.duration(500).seconds();
+moment.duration(500).asSeconds();
+moment.duration().minutes();
+moment.duration().asMinutes();
+moment.duration().toISOString();
+moment.duration().toJSON();
+
+var adur = moment.duration(3, 'd');
+var bdur = moment.duration(2, 'd');
+adur.subtract(bdur).days();
+adur.subtract(1).days();
+adur.subtract(1, 'd').days();
+
+// Selecting a language
+moment.locale();
+moment.locale('en');
+moment.locale(['en', 'fr']);
+
+// TODO: Reenable in 2.0
+// moment.defineLocale('en', null);
+// moment.updateLocale('en', null);
+// moment.locale('en', null);
+
+// Defining a custom language:
+moment.locale('en', {
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    weekdaysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    weekdaysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+    longDateFormat: {
+        LTS: "h:mm:ss A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        LL: "MMMM D YYYY",
+        LLL: "MMMM D YYYY LT",
+        LLLL: "dddd, MMMM D YYYY LT"
+    },
+    relativeTime: {
+        future: "in %s",
+        past: "%s ago",
+        s: "seconds",
+        ss: "%d seconds",
+        m: "a minute",
+        mm: "%d minutes",
+        h: "an hour",
+        hh: "%d hours",
+        d: "a day",
+        dd: "%d days",
+        M: "a month",
+        MM: "%d months",
+        y: "a year",
+        yy: "%d years"
+    },
+    meridiem: function (hour, minute, isLower) {
+        if (hour < 9) {
+            return "??";
+        } else if (hour < 11 && minute < 30) {
+            return "??";
+        } else if (hour < 13 && minute < 30) {
+            return "??";
+        } else if (hour < 18) {
+            return "??";
+        } else {
+            return "??";
+        }
+    },
+    calendar: {
+        lastDay: '[Yesterday at] LT',
+        sameDay: '[Today at] LT',
+        nextDay: '[Tomorrow at] LT',
+        lastWeek: '[last] dddd [at] LT',
+        nextWeek: 'dddd [at] LT',
+        sameElse: 'L'
+    },
+    ordinal: function (number) {
+        var b = number % 10;
+        return (~~(number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                    (b === 3) ? 'rd' : 'th';
+    },
+    week: {
+        dow: 1,
+        doy: 4
+    }
+});
+
+moment.locale('en', {
+    months : [
+        "January", "February", "March", "April", "May", "June", "July",
+        "August", "September", "October", "November", "December"
+    ]
+});
+
+const nominative = 'январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь'.split('_');
+const subjective = 'январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь'.split('_');
+moment.locale('en', {
+    months : function (momentToFormat: moment.Moment, format?: string) {
+        // momentToFormat is the moment currently being formatted
+        // format is the formatting string
+        if (format != null && /^MMMM/.test(format)) { // if the format starts with 'MMMM'
+            return nominative[momentToFormat.month()];
+        } else {
+            return subjective[momentToFormat.month()];
+        }
+    }
+});
+
+moment.locale('en', {
+    monthsShort : [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ]
+});
+
+moment.locale('en', {
+    monthsShort : function (momentToFormat: moment.Moment, format?: string) {
+        if (format != null && /^MMMM/.test(format)) {
+            return nominative[momentToFormat.month()];
+        } else {
+            return subjective[momentToFormat.month()];
+        }
+    }
+});
+
+moment.locale('en', {
+    weekdays : [
+        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+    ]
+});
+
+const weekday_labels = [
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+];
+moment.locale('en', {
+    weekdays : function (momentToFormat: moment.Moment) {
+        return weekday_labels[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    weekdaysShort : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+});
+
+const weekday_short_labels = [
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+];
+moment.locale('en', {
+    weekdaysShort : function (momentToFormat: moment.Moment) {
+        return weekday_short_labels[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    weekdaysMin : ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+});
+
+const weekday_min_labels = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+moment.locale('en', {
+    weekdaysMin : function (momentToFormat: moment.Moment) {
+        return weekday_min_labels[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    longDateFormat : {
+        LTS: "h:mm:ss A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        l: "M/D/YYYY",
+        LL: "MMMM Do YYYY",
+        ll: "MMM D YYYY",
+        LLL: "MMMM Do YYYY LT",
+        lll: "MMM D YYYY LT",
+        LLLL: "dddd, MMMM Do YYYY LT",
+        llll: "ddd, MMM D YYYY LT"
+    }
+});
+
+moment.locale('en', {
+    longDateFormat : {
+        LTS: "h:mm A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        LL: "MMMM Do YYYY",
+        LLL: "MMMM Do YYYY LT",
+        LLLL: "dddd, MMMM Do YYYY LT"
+    }
+});
+
+moment.locale('en', {
+    relativeTime : {
+        future: "in %s",
+        past:   "%s ago",
+        s:  "seconds",
+        ss: "%d seconds",
+        m:  "a minute",
+        mm: "%d minutes",
+        h:  "an hour",
+        hh: "%d hours",
+        d:  "a day",
+        dd: "%d days",
+        M:  "a month",
+        MM: "%d months",
+        y:  "a year",
+        yy: "%d years"
+    }
+});
+
+moment.locale('en', {
+    meridiem : function (hour, minute, isLowercase) {
+        if (hour < 9) {
+            return "早上";
+        } else if (hour < 11 && minute < 30) {
+            return "上午";
+        } else if (hour < 13 && minute < 30) {
+            return "中午";
+        } else if (hour < 18) {
+            return "下午";
+        } else {
+            return "晚上";
+        }
+    }
+});
+
+moment.locale('en', {
+    calendar : {
+        lastDay : '[Yesterday at] LT',
+        sameDay : '[Today at] LT',
+        nextDay : function () {
+            return '[hoy a la' + ((moment.duration().hours() !== 1) ? 's' : '') + '] LT';
+        },
+        lastWeek : '[last] dddd [at] LT',
+        nextWeek : 'dddd [at] LT',
+        sameElse : 'L'
+    }
+});
+
+moment.locale('en', {
+    ordinal : function (number) {
+        var b = number % 10;
+        var output = (~~ (number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                    (b === 3) ? 'rd' : 'th';
+        return number + output;
+    }
+});
+
+console.log(moment.version);
+
+moment.defaultFormat = 'YYYY-MM-DD HH:mm';

--- a/types/moment/tsconfig.json
+++ b/types/moment/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "moment-tests.ts"
+    ]
+}

--- a/types/moment/tslint.json
+++ b/types/moment/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## Details
This is for fixing #27942 
Since including `moment` in dependency makes it included in final JS bundle

To make tslint pass I disabled many rules
Made 1 fix to `isBetween`
https://momentjs.com/docs/
```ts
// Before
isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
// After (granularity accepts null)
isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf | null, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
```
Other changes are made on test code (missing var, incorrect function type, etc)
