### PR TITLE
node: Correct type of SpawnSyncReturns.

### DIFF
--- a/types/cross-spawn/cross-spawn-tests.ts
+++ b/types/cross-spawn/cross-spawn-tests.ts
@@ -12,8 +12,8 @@ const r1: Error | undefined = spawn.sync('foo').error;
 const r2: string[] = spawn.sync('foo').output;
 const r3: Buffer = spawn.sync('foo').stdout;
 const r4: Buffer = spawn.sync('foo').stderr;
-const r5: number = spawn.sync('foo').status;
-const r6: string = spawn.sync('foo').signal;
+const r5: number | null = spawn.sync('foo').status;
+const r6: string | null = spawn.sync('foo').signal;
 const r7: string = spawn.sync('foo', {encoding: 'utf8'}).stdout;
 
 spawn.sync('foo', ['bar']);

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -310,8 +310,8 @@ declare module "child_process" {
         output: string[];
         stdout: T;
         stderr: T;
-        status: number;
-        signal: string;
+        status: number | null;
+        signal: string | null;
         error?: Error;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;

--- a/types/node/v10/child_process.d.ts
+++ b/types/node/v10/child_process.d.ts
@@ -292,8 +292,8 @@ declare module "child_process" {
         output: string[];
         stdout: T;
         stderr: T;
-        status: number;
-        signal: string;
+        status: number | null;
+        signal: string | null;
         error?: Error;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;

--- a/types/node/v11/child_process.d.ts
+++ b/types/node/v11/child_process.d.ts
@@ -310,8 +310,8 @@ declare module "child_process" {
         output: string[];
         stdout: T;
         stderr: T;
-        status: number;
-        signal: string;
+        status: number | null;
+        signal: string | null;
         error?: Error;
     }
     function spawnSync(command: string): SpawnSyncReturns<Buffer>;


### PR DESCRIPTION
From [node API docs](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options):

> * `status` \<number> | \<null> The exit code of the subprocess, or `null` if the subprocess terminated due to a signal.
> * `signal` \<string> | \<null> The signal used to kill the subprocess, or `null` if the subprocess did not terminate due to a signal.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.