### PR TITLE
fix(nodejs): remove undefined from OutgoingHttpHeaders

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -65,7 +65,7 @@ declare module "http" {
 
     // outgoing headers allows numbers (as they are converted internally to strings)
     interface OutgoingHttpHeaders {
-        [header: string]: number | string | string[] | undefined;
+        [header: string]: number | string | string[];
     }
 
     interface ClientRequestArgs {
@@ -134,7 +134,7 @@ declare module "http" {
         setTimeout(msecs: number, callback?: () => void): this;
         setHeader(name: string, value: number | string | string[]): void;
         getHeader(name: string): number | string | string[] | undefined;
-        getHeaders(): OutgoingHttpHeaders;
+        getHeaders(): Partial<OutgoingHttpHeaders>;
         getHeaderNames(): string[];
         hasHeader(name: string): boolean;
         removeHeader(name: string): void;


### PR DESCRIPTION
In Node, if a request header is `undefined`, then making a http.request `throws` (synchronously) with a TypeError - [ERR_HTTP_INVALID_HEADER_VALUE](https://nodejs.org/api/errors.html#errors_err_http_invalid_header_value). This is something that should be caught at compile time.

For example,

```js
const http = require("http");

try {
  http.request({
    host: "localhost",
    headers: {
      "Something": undefined
    }
  }, (res) => {
    console.log("Success");
  });
} catch (e) {
  console.log("Sending request with undefined header throws this error - ");
  throw e;
}
```

I've attempted a fix where the OutgoingHttpHeaders used as the input path of a request does not allow `undefined` as one of the possible values and the OutgoingHttpHeaders at the output path - such as `getHeaders()` - undefined is one of the possible values.

I will change the types for older node versions after receiving an initial feedback

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
