### PR TITLE
Improve cast.framework.ContentProtection from

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -1,8 +1,8 @@
-import * as breaks from "./cast.framework.breaks";
-import * as events from "./cast.framework.events";
-import * as messages from "./cast.framework.messages";
-import * as system from "./cast.framework.system";
-import * as ui from "./cast.framework.ui";
+import * as breaks from './cast.framework.breaks';
+import * as events from './cast.framework.events';
+import * as messages from './cast.framework.messages';
+import * as system from './cast.framework.system';
+import * as ui from './cast.framework.ui';
 
 export import breaks = breaks;
 export import events = events;
@@ -11,16 +11,17 @@ export import system = system;
 export import messages = messages;
 
 export type HTMLMediaElement = any;
-export as namespace framework
-export type LoggerLevel =
-    | "DEBUG"
-    | "VERBOSE"
-    | "INFO"
-    | "WARNING"
-    | "ERROR"
-    | "NONE";
+export as namespace framework;
+export type LoggerLevel = 'DEBUG' | 'VERBOSE' | 'INFO' | 'WARNING' | 'ERROR' | 'NONE';
 
-export type ContentProtection = "NONE" | "CLEARKEY" | "PLAYREADY" | "WIDEVINE";
+export enum ContentProtection {
+    NONE = 'none',
+    CLEARKEY = 'clearkey',
+    PLAYREADY = 'playready',
+    WIDEVINE = 'widevine',
+    AES_128 = 'aes_128',
+    AES_128_CKP = 'aes_128_ckp',
+}
 
 /**
  * Manages text tracks.
@@ -146,9 +147,7 @@ export class QueueBase {
      * If this returns or resolves to null; our default queueing implementation will create a queue based on queueData.items or the single media
      *  in the load request data.
      */
-    initialize(
-        requestData: messages.LoadRequestData
-    ): messages.QueueData | Promise<messages.QueueData>;
+    initialize(requestData: messages.LoadRequestData): messages.QueueData | Promise<messages.QueueData>;
 
     /**
      * Returns next items after the reference item; often the end of the current queue; called by the receiver MediaManager.
@@ -192,20 +191,12 @@ export class PlayerManager {
     /**
      * Adds an event listener for player event.
      */
-    addEventListener: (
-        eventType: events.EventType | events.EventType[],
-        eventListener: EventHandler
-    ) => void;
+    addEventListener: (eventType: events.EventType | events.EventType[], eventListener: EventHandler) => void;
 
     /**
      * Sends a media status message to all senders (broadcast). Applications use this to send a custom state change.
      */
-    broadcastStatus(
-        includeMedia?: boolean,
-        requestId?: number,
-        customData?: any,
-        includeQueueItems?: boolean
-    ): void;
+    broadcastStatus(includeMedia?: boolean, requestId?: number, customData?: any, includeQueueItems?: boolean): void;
 
     getAudioTracksManager(): AudioTracksManager;
 
@@ -310,10 +301,7 @@ export class PlayerManager {
     /**
      * Removes the event listener added for given player event. If event listener is not added; it will be ignored.
      */
-    removeEventListener(
-        eventType: events.EventType | events.EventType[],
-        eventListener: EventHandler
-    ): void;
+    removeEventListener(eventType: events.EventType | events.EventType[], eventListener: EventHandler): void;
 
     /**
      * Seeks in current media.
@@ -363,10 +351,7 @@ export class PlayerManager {
     /**
      * Sets media information.
      */
-    setMediaInformation(
-        mediaInformation: messages.MediaInformation,
-        opt_broadcast?: boolean
-    ): void;
+    setMediaInformation(mediaInformation: messages.MediaInformation, opt_broadcast?: boolean): void;
 
     /**
      * Sets a handler to return or modify PlaybackConfig; for a specific load request. The handler paramaters are the load request data
@@ -374,19 +359,14 @@ export class PlayerManager {
      *  or null to prevent the media from playing. The return value can be a promise to allow waiting for data from the server.
      */
     setMediaPlaybackInfoHandler(
-        handler: (
-            loadRequestData: messages.LoadRequestData,
-            playbackConfig: PlaybackConfig
-        ) => void
+        handler: (loadRequestData: messages.LoadRequestData, playbackConfig: PlaybackConfig) => void
     ): void;
 
     /**
      * Sets a handler to return the media url for a load request. This handler can be used to avoid having the media content url published as part
      * of the media status. By default the media contentId is used as the content url.
      */
-    setMediaUrlResolver(
-        resolver: (loadRequestData: messages.LoadRequestData) => void
-    ): void;
+    setMediaUrlResolver(resolver: (loadRequestData: messages.LoadRequestData) => void): void;
 
     /**
      * Provide an interceptor of incoming and outgoing messages.
@@ -621,29 +601,17 @@ export class CastReceiverContext {
     /**
      * Sets message listener on custom message channel.
      */
-    addCustomMessageListener(
-        namespace: string,
-        listener: EventHandler
-    ): void;
+    addCustomMessageListener(namespace: string, listener: EventHandler): void;
 
     /**
      * Add listener to cast system events.
      */
-    addEventListener(
-        type: system.EventType | system.EventType[],
-        handler: EventHandler
-    ): void;
+    addEventListener(type: system.EventType | system.EventType[], handler: EventHandler): void;
 
     /**
      * Checks if the given media params of video or audio streams are supported by the platform.
      */
-    canDisplayType(
-        mimeType: string,
-        codecs?: string,
-        width?: number,
-        height?: number,
-        framerate?: number
-    ): boolean;
+    canDisplayType(mimeType: string, codecs?: string, width?: number, height?: number, framerate?: number): boolean;
 
     /**
      * Provides application information once the system is ready; otherwise it will be null.
@@ -701,10 +669,7 @@ export class CastReceiverContext {
     /**
      * Remove a message listener on custom message channel.
      */
-    removeCustomMessageListener(
-        namespace: string,
-        listener: EventHandler
-    ): void;
+    removeCustomMessageListener(namespace: string, listener: EventHandler): void;
 
     /**
      * Remove listener to cast system events.
@@ -714,11 +679,7 @@ export class CastReceiverContext {
     /**
      * Sends a message to a specific sender.
      */
-    sendCustomMessage(
-        namespace: string,
-        senderId: string,
-        message: any
-    ): void;
+    sendCustomMessage(namespace: string, senderId: string, message: any): void;
 
     /**
      * This function should be called in response to the feedbackstarted event if the application

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -118,3 +118,6 @@ const supportedCommands: number =
     cast.framework.messages.Command.ALL_BASIC_MEDIA |
     cast.framework.messages.Command.QUEUE_NEXT |
     cast.framework.messages.Command.QUEUE_PREV;
+
+const playbackConfig = new cast.framework.PlaybackConfig();
+playbackConfig.protectionSystem = cast.framework.ContentProtection.WIDEVINE;


### PR DESCRIPTION
@types/chromecast-caf-receiver

The best way to access those values are through the enumeration itself,
so if the value or the code handling it changes, we won't be affected.
(Using the upper case version was not working for us).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
![2019-06-18 at 17 39](https://user-images.githubusercontent.com/36221/59699407-d2b90f00-91f1-11e9-9fd3-75526d38e725.png)
