### PR TITLE
stripe: Allow coupon to be removed from subscription

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -6104,9 +6104,9 @@ declare namespace Stripe {
 
             /**
              * The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that
-             * particular subscription.
+             * particular subscription.  Passing null will remove any coupon previously applied to a subscription.
              */
-            coupon?: string;
+            coupon?: string | null;
 
             /**
              * @deprecated Use items property instead.


### PR DESCRIPTION
To remove a coupon from a subscription, you pass `null` when
updating the subscription.  The types previously did not
allow `null` for this field.

See https://stripe.com/docs/api/subscriptions/update#update_subscription-coupon
