### PR TITLE
[@wordpress/data] add strongly typed "rich-text" data store functions

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -19,9 +19,15 @@ export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) 
 export type DispatcherMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
 export type Subscriber = (callback: () => void) => void;
 
-export function dispatch(key: string): DispatcherMap;
-export function select(key: string): SelectorMap;
 export const subscribe: Subscriber;
+
+// Dispatch overloads
+export function dispatch(key: 'core/rich-text'): typeof import('./stores/rich-text/actions');
+export function dispatch(key: string): DispatcherMap;
+
+// Select overloads
+export function select(key: 'core/rich-text'): typeof import('./stores/rich-text/selectors');
+export function select(key: string): SelectorMap;
 
 //
 // Stores

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// TypeScript Version: 3.5
 
 import { ComponentType, Consumer, Provider, useContext } from 'react';
 import { AnyAction as Action, combineReducers, Reducer } from 'redux';

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
-import { ComponentType, Consumer, Provider, useContext } from "react";
-import { AnyAction as Action, combineReducers, Reducer } from "redux";
+import { ComponentType, Consumer, Provider, useContext } from 'react';
+import { AnyAction as Action, combineReducers, Reducer } from 'redux';
 
 /**
  * Re-exports
@@ -15,14 +15,8 @@ export { Action, combineReducers };
 //
 // Core functionality
 //
-export type SelectorMap = Record<
-    string,
-    <T = unknown>(...args: readonly any[]) => T
->;
-export type DispatcherMap = Record<
-    string,
-    <T = unknown>(...args: readonly any[]) => T
->;
+export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
+export type DispatcherMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
 export type Subscriber = (callback: () => void) => void;
 
 export function dispatch(key: string): DispatcherMap;
@@ -40,9 +34,7 @@ export interface GenericStoreConfig {
 export interface StoreConfig<S> {
     reducer: Reducer<S>;
     actions?: {
-        [k: string]: (
-            ...args: readonly any[]
-        ) => Action | IterableIterator<any>;
+        [k: string]: (...args: readonly any[]) => Action | IterableIterator<any>;
     };
     selectors?: {
         [k: string]: (state: S, ...args: readonly any[]) => any;
@@ -61,14 +53,8 @@ export interface Store<S, A extends Action = Action> {
     dispatch(action: A): A;
 }
 
-export function registerGenericStore(
-    key: string,
-    config: GenericStoreConfig
-): void;
-export function registerStore<T = {}>(
-    key: string,
-    config: StoreConfig<T>
-): void;
+export function registerGenericStore(key: string, config: GenericStoreConfig): void;
+export function registerStore<T = {}>(key: string, config: StoreConfig<T>): void;
 
 //
 // Registry
@@ -81,10 +67,7 @@ export interface DataRegistry {
     subscribe: typeof subscribe;
 }
 
-export function createRegistry(
-    storeConfigs?: object,
-    parent?: DataRegistry
-): DataRegistry;
+export function createRegistry(storeConfigs?: object, parent?: DataRegistry): DataRegistry;
 
 export const RegistryConsumer: Consumer<DataRegistry>;
 export const RegistryProvider: Provider<DataRegistry>;
@@ -93,10 +76,7 @@ export const RegistryProvider: Provider<DataRegistry>;
 // React Hooks
 //
 export function useRegistry(): DataRegistry;
-export function useSelect<T>(
-    mapSelect: (s: typeof select) => T,
-    deps?: readonly any[]
-): T;
+export function useSelect<T>(mapSelect: (s: typeof select) => T, deps?: readonly any[]): T;
 export function useDispatch(storeName: string): DispatcherMap;
 export function useDispatch(): typeof dispatch;
 
@@ -104,32 +84,23 @@ export function useDispatch(): typeof dispatch;
 // React HOCs
 //
 export function withDispatch<DP, P = {}, IP = {}>(
-    mapDispatchToProps: (
-        disp: typeof dispatch,
-        ownProps: P & IP,
-        registry: { select: typeof select }
-    ) => DP
+    mapDispatchToProps: (disp: typeof dispatch, ownProps: P & IP, registry: { select: typeof select }) => DP
 ): (component: ComponentType<P & IP & DP>) => ComponentType<P>;
 
 export function withSelect<SP, P = {}, IP = {}>(
     mapSelectToProps: (sel: typeof select, ownProps: P & IP) => SP
 ): (component: ComponentType<P & IP & SP>) => ComponentType<P>;
 
-export function withRegistry<P = {}>(
-    component: ComponentType<P>
-): ComponentType<P & { registry: DataRegistry }>;
+export function withRegistry<P = {}>(component: ComponentType<P>): ComponentType<P & { registry: DataRegistry }>;
 
 //
 // Plugins
 //
-export type Plugin<T extends Record<string, any>> = (
-    registry: DataRegistry,
-    options: T
-) => Partial<DataRegistry>;
+export type Plugin<T extends Record<string, any>> = (registry: DataRegistry, options: T) => Partial<DataRegistry>;
 
 export const plugins: {
     persistence: Plugin<{
-        storage?: Pick<Storage, "getItem" | "setItem"> & Partial<Storage>;
+        storage?: Pick<Storage, 'getItem' | 'setItem'> & Partial<Storage>;
         storageKey?: string;
     }>;
 };

--- a/types/wordpress__data/stores/rich-text/actions.d.ts
+++ b/types/wordpress__data/stores/rich-text/actions.d.ts
@@ -1,0 +1,11 @@
+import { NamedFormatConfiguration } from '@wordpress/rich-text';
+
+/**
+ * Returns an action object used in signalling that format types have been added.
+ */
+export function addFormatTypes(configs: NamedFormatConfiguration | NamedFormatConfiguration[]): void;
+
+/**
+ * Returns an action object used to remove a registered format type.
+ */
+export function removeFormatTypes(names: string | string[]): void;

--- a/types/wordpress__data/stores/rich-text/selectors.d.ts
+++ b/types/wordpress__data/stores/rich-text/selectors.d.ts
@@ -1,0 +1,24 @@
+import { NamedFormatConfiguration } from '@wordpress/rich-text';
+
+/**
+ * Returns all the available format types.
+ */
+export function getFormatTypes(): NamedFormatConfiguration[];
+
+/**
+ * Returns a format type by name.
+ */
+export function getFormatType(name: string): NamedFormatConfiguration | undefined;
+
+/**
+ * Gets the format type, if any, that can handle a bare element (without a
+ * data-format-type attribute), given the tag name of this element.
+ */
+export function getFormatTypeForBareElement(
+    bareElementTagName: keyof HTMLElementTagNameMap
+): NamedFormatConfiguration | undefined;
+
+/**
+ * Gets the format type, if any, that can handle an element, given its classes.
+ */
+export function getFormatTypeForClassName(elementClassName: string): NamedFormatConfiguration | undefined;

--- a/types/wordpress__data/tsconfig.json
+++ b/types/wordpress__data/tsconfig.json
@@ -13,8 +13,15 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "@wordpress/data": ["wordpress__data"]
+            "@wordpress/element": ["wordpress__element"],
+            "@wordpress/data": ["wordpress__data"],
+            "@wordpress/rich-text": ["wordpress__rich-text"]
         }
     },
-    "files": ["index.d.ts", "wordpress__data-tests.tsx"]
+    "files": [
+        "index.d.ts",
+        "stores/rich-text/actions.d.ts",
+        "stores/rich-text/selectors.d.ts",
+        "wordpress__data-tests.tsx"
+    ]
 }

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -1,4 +1,5 @@
 import * as data from '@wordpress/data';
+import { NamedFormatConfiguration } from '@wordpress/rich-text';
 
 data.select('core/block-editor').isTyping<boolean>();
 data.dispatch('core/block-editor').resetBlocks('');
@@ -34,3 +35,22 @@ const HookComponent = () => {
         </button>
     );
 };
+
+//
+// `dispatch` overload tests
+//
+data.dispatch('core/rich-text').addFormatTypes({
+    className: null,
+    edit: () => null,
+    name: 'my/foo',
+    tagName: 'a',
+    title: 'foo',
+});
+data.dispatch('core/rich-text').removeFormatTypes('my/foo');
+data.dispatch('core/rich-text').removeFormatTypes(['my/foo', 'my/bar']);
+
+//
+// `select` overload tests
+//
+data.select('core/rich-text').getFormatTypes(); // $ExpectType NamedFormatConfiguration[]
+data.select('core/rich-text').getFormatTypeForBareElement('a'); // $ExpectType NamedFormatConfiguration | undefined

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -1,7 +1,7 @@
-import * as data from "@wordpress/data";
+import * as data from '@wordpress/data';
 
-data.select("core/block-editor").isTyping<boolean>();
-data.dispatch("core/block-editor").resetBlocks("");
+data.select('core/block-editor').isTyping<boolean>();
+data.dispatch('core/block-editor').resetBlocks('');
 
 data.use(data.plugins.persistence, { storage: window.localStorage });
 
@@ -10,32 +10,26 @@ interface FooBar {
     bar: number;
 }
 
-data.registerStore<FooBar>("foo", {
-    reducer(state = { foo: "foo", bar: 21 }, action) {
+data.registerStore<FooBar>('foo', {
+    reducer(state = { foo: 'foo', bar: 21 }, action) {
         return state;
     },
     selectors: {
         getFoo: ({ foo }) => foo,
         getBar: ({ bar }) => bar,
-        getSomething: (state, thing: keyof FooBar) => state[thing]
+        getSomething: (state, thing: keyof FooBar) => state[thing],
     },
     actions: {
-        setFoo: (text: "foo") => ({ type: "SET_FOO", text })
-    }
+        setFoo: (text: 'foo') => ({ type: 'SET_FOO', text }),
+    },
 });
 
 const HookComponent = () => {
-    const isTyping = data.useSelect(select =>
-        select("core/block-editor").isTyping<boolean>()
-    );
-    const { resetBlocks } = data.useDispatch("core/block-editor");
+    const isTyping = data.useSelect(select => select('core/block-editor').isTyping<boolean>());
+    const { resetBlocks } = data.useDispatch('core/block-editor');
     const dispatch = data.useDispatch();
     return (
-        <button
-            disabled={isTyping}
-            onClick={resetBlocks}
-            onBlur={() => dispatch("core/data").resetBlocks()}
-        >
+        <button disabled={isTyping} onClick={resetBlocks} onBlur={() => dispatch('core/data').resetBlocks()}>
             Reset
         </button>
     );

--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -28,6 +28,10 @@ export interface FormatConfiguration {
     edit: ComponentType<FormatProps>;
 }
 
+export interface NamedFormatConfiguration extends FormatConfiguration {
+    name: string;
+}
+
 export interface Format {
     type: string;
     attributes?: Record<string, string>;
@@ -210,10 +214,9 @@ export function join(values: readonly Value[], separator?: Value | string): Valu
  * @param name - Format name.
  * @param config - Format settings.
  *
- * @returns The same `FormatConfiguration` that was passed in if it has been
- * successfully registered, otherwise `undefined`.
+ * @returns `NamedFormatConfiguration` if successful, otherwise `undefined`.
  */
-export function registerFormatType(name: string, config: FormatConfiguration): FormatConfiguration | undefined;
+export function registerFormatType(name: string, config: FormatConfiguration): NamedFormatConfiguration | undefined;
 
 /**
  * Remove content from a Rich Text value between the given `startIndex` and
@@ -311,4 +314,4 @@ export function toggleFormat(value: Value, format: Format): Value;
  * @returns The previous format value, if it has been successfully
  *   unregistered; otherwise `undefined`.
  */
-export function unregisterFormatType(name: string): FormatConfiguration | undefined;
+export function unregisterFormatType(name: string): NamedFormatConfiguration | undefined;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/src/store
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Note to reviewer:** I also edited `@wordpress__rich-text` directly to add in a type and adjust the return type of a couple methods to be more accurate. This was a very very minor edit though, and I'm the original (and so far only) author of that package's types.