### PR TITLE
[react-big-calendar] Change TEvent restriction to object

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -133,7 +133,7 @@ export interface ResourceHeaderProps {
     resource: object;
 }
 
-export interface Components<TEvent extends Event = Event> {
+export interface Components<TEvent extends object = Event> {
     event?: React.ComponentType<EventProps<TEvent>>;
     eventWrapper?: React.ComponentType<EventWrapperProps<TEvent>>;
     eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
@@ -179,12 +179,12 @@ export interface ToolbarProps {
     children?: React.ReactNode;
 }
 
-export interface EventProps<TEvent extends Event = Event> {
+export interface EventProps<TEvent extends object = Event> {
     event: TEvent;
     title: string;
 }
 
-export interface EventWrapperProps<TEvent extends Event = Event> {
+export interface EventWrapperProps<TEvent extends object = Event> {
     // https://github.com/intljusticemission/react-big-calendar/blob/27a2656b40ac8729634d24376dff8ea781a66d50/src/TimeGridEvent.js#L28
     style?: React.CSSProperties & { xOffset: number };
     className: string;
@@ -248,7 +248,8 @@ export class DateLocalizer {
     format(value: FormatInput, format: string, culture: Culture): string;
 }
 
-export interface BigCalendarProps<TEvent extends Event = Event, TResource extends object = object> extends React.Props<BigCalendar<TEvent, TResource>> {
+export interface BigCalendarProps<TEvent extends object = Event, TResource extends object = object>
+    extends React.Props<BigCalendar<TEvent, TResource>> {
     localizer: DateLocalizer;
 
     date?: stringOrDate;
@@ -258,11 +259,16 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     onNavigate?: (newDate: Date, view: View, action: Navigate) => void;
     onView?: (view: View) => void;
     onDrillDown?: (date: Date, view: View) => void;
-    onSelectSlot?: (slotInfo: { start: stringOrDate, end: stringOrDate, slots: Date[] | string[], action: 'select' | 'click' | 'doubleClick' }) => void;
+    onSelectSlot?: (slotInfo: {
+        start: stringOrDate;
+        end: stringOrDate;
+        slots: Date[] | string[];
+        action: 'select' | 'click' | 'doubleClick';
+    }) => void;
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
-    onSelecting?: (range: { start: stringOrDate, end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: stringOrDate, end: stringOrDate }) => void;
+    onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
+    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }) => void;
     selected?: any;
     views?: Views;
     drilldownView?: View | null;
@@ -270,7 +276,7 @@ export interface BigCalendarProps<TEvent extends Event = Event, TResource extend
     length?: number;
     toolbar?: boolean;
     popup?: boolean;
-    popupOffset?: number | { x: number, y: number };
+    popupOffset?: number | { x: number; y: number };
     selectable?: boolean | 'ignoreEvents';
     longPressThreshold?: number;
     step?: number;
@@ -313,11 +319,14 @@ export interface MoveOptions {
     today: Date;
 }
 
-export default class BigCalendar<TEvent extends Event = Event, TResource extends object = object> extends React.Component<BigCalendarProps<TEvent, TResource>> {
+export default class BigCalendar<
+    TEvent extends object = Event,
+    TResource extends object = object
+> extends React.Component<BigCalendarProps<TEvent, TResource>> {
     components: {
-        dateCellWrapper: React.ComponentType,
-        dayWrapper: React.ComponentType,
-        eventWrapper: React.ComponentType<TEvent>,
+        dateCellWrapper: React.ComponentType;
+        dayWrapper: React.ComponentType;
+        eventWrapper: React.ComponentType<TEvent>;
     };
     /**
      * create DateLocalizer from globalize
@@ -331,10 +340,10 @@ export default class BigCalendar<TEvent extends Event = Event, TResource extends
      * action constants for Navigate
      */
     static Navigate: {
-        PREVIOUS: 'PREV',
-        NEXT: 'NEXT',
-        TODAY: 'TODAY',
-        DATE: 'DATE',
+        PREVIOUS: 'PREV';
+        NEXT: 'NEXT';
+        TODAY: 'TODAY';
+        DATE: 'DATE';
     };
     /**
      * action constants for View

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -16,16 +16,16 @@ class CalendarEvent {
     title: string;
     allDay: boolean;
     start: Date;
-    end: Date;
+    endDate: Date;
     desc: string;
     resourceId?: string;
     tooltip?: string;
 
-    constructor(_title: string, _start: Date, _end: Date, _allDay?: boolean, _desc?: string, _resourceId?: string) {
+    constructor(_title: string, _start: Date, _endDate: Date, _allDay?: boolean, _desc?: string, _resourceId?: string) {
         this.title = _title;
         this.allDay = _allDay || false;
         this.start = _start;
-        this.end = _end;
+        this.endDate = _endDate;
         this.desc = _desc || '';
         this.resourceId = _resourceId;
     }
@@ -113,85 +113,87 @@ class CalendarResource {
     class FullAPIExample extends React.Component<BigCalendarProps<CalendarEvent, CalendarResource>> {
         render() {
             return (
-              <MyCalendar {...this.props}
-              date={new Date()}
-              getNow={() => new Date()}
-              view={'day'}
-              events={getEvents()}
-              onNavigate={(newDate: Date, view: View, action: Navigate) => { }}
-              onView={(view: View) => { }}
-              onSelectSlot={(slotInfo) => {
-                  const start = slotInfo.start;
-                  const end = slotInfo.end;
-                  const slots = slotInfo.slots;
-              }}
-              onSelectEvent={(event) => { }}
-              onSelecting={(slotInfo) => {
-                  const start = slotInfo.start;
-                  const end = slotInfo.end;
-                  return true;
-              }}
-              views={['day']}
-              toolbar={true}
-              popup={true}
-              popupOffset={20}
-              onShowMore={(events, date) => {
-                  console.log('onShowMore fired, events: %O, date: %O', events, date);
-              }}
-              selectable={true}
-              step={20}
-              rtl={true}
-              eventPropGetter={(event, start, end, isSelected) => ({ className: 'some-class' })}
-              titleAccessor={'title'}
-              tooltipAccessor={'tooltip'}
-              allDayAccessor={(event: CalendarEvent) => !!event.allDay}
-              startAccessor={'start'}
-              endAccessor={(event: CalendarEvent) => event.end || event.start}
-              min={new Date()}
-              max={new Date()}
-              scrollToTime={new Date()}
-              formats={{
-                  dateFormat: "h a",
-                  agendaDateFormat: (date: Date, culture?: string, localizer?: object) => "some-format",
-                  dayRangeHeaderFormat: (range: DateRange, culture?: string, localizer?: object) => "some-format"
-              }}
-              messages={{
-                date: 'Date',
-                time: 'Time',
-                event: 'Event',
-                allDay: 'All Day',
-                week: 'Week',
-                work_week: 'Work Week',
-                day: 'Day',
-                month: 'Month',
-                previous: 'Back',
-                next: 'Next',
-                yesterday: 'Yesterday',
-                tomorrow: 'Tomorrow',
-                today: 'Today',
-                agenda: 'Agenda',
-                noEventsInRange: 'There are no events in this range.',
-                showMore: total => `+${total} more`,
-              }}
-              timeslots={24}
-              defaultView={'month'}
-              className={'my-calendar'}
-              elementProps={{ id: 'myCalendar' }}
-              components={{
-                  event: Event,
-                  agenda: {
-                      event: EventAgenda
-                  },
-                  toolbar: Toolbar,
-                  eventWrapper: EventWrapper,
-              }}
-              dayPropGetter={customDayPropGetter}
-              slotPropGetter={customSlotPropGetter}
-              defaultDate={new Date()}
-              resources={getResources()}
-              resourceAccessor={event => event.resourceId}
-              resourceIdAccessor={resource => resource.id}
-              resourceTitleAccessor={resource => resource.title} />
+                <MyCalendar
+                    {...this.props}
+                    date={new Date()}
+                    getNow={() => new Date()}
+                    view={'day'}
+                    events={getEvents()}
+                    onNavigate={(newDate: Date, view: View, action: Navigate) => {}}
+                    onView={(view: View) => {}}
+                    onSelectSlot={slotInfo => {
+                        const start = slotInfo.start;
+                        const end = slotInfo.end;
+                        const slots = slotInfo.slots;
+                    }}
+                    onSelectEvent={event => {}}
+                    onSelecting={slotInfo => {
+                        const start = slotInfo.start;
+                        const end = slotInfo.end;
+                        return true;
+                    }}
+                    views={['day']}
+                    toolbar={true}
+                    popup={true}
+                    popupOffset={20}
+                    onShowMore={(events, date) => {
+                        console.log('onShowMore fired, events: %O, date: %O', events, date);
+                    }}
+                    selectable={true}
+                    step={20}
+                    rtl={true}
+                    eventPropGetter={(event, start, end, isSelected) => ({ className: 'some-class' })}
+                    titleAccessor={'title'}
+                    tooltipAccessor={'tooltip'}
+                    allDayAccessor={(event: CalendarEvent) => !!event.allDay}
+                    startAccessor={'start'}
+                    endAccessor={(event: CalendarEvent) => event.endDate || event.start}
+                    min={new Date()}
+                    max={new Date()}
+                    scrollToTime={new Date()}
+                    formats={{
+                        dateFormat: 'h a',
+                        agendaDateFormat: (date: Date, culture?: string, localizer?: object) => 'some-format',
+                        dayRangeHeaderFormat: (range: DateRange, culture?: string, localizer?: object) => 'some-format',
+                    }}
+                    messages={{
+                        date: 'Date',
+                        time: 'Time',
+                        event: 'Event',
+                        allDay: 'All Day',
+                        week: 'Week',
+                        work_week: 'Work Week',
+                        day: 'Day',
+                        month: 'Month',
+                        previous: 'Back',
+                        next: 'Next',
+                        yesterday: 'Yesterday',
+                        tomorrow: 'Tomorrow',
+                        today: 'Today',
+                        agenda: 'Agenda',
+                        noEventsInRange: 'There are no events in this range.',
+                        showMore: total => `+${total} more`,
+                    }}
+                    timeslots={24}
+                    defaultView={'month'}
+                    className={'my-calendar'}
+                    elementProps={{ id: 'myCalendar' }}
+                    components={{
+                        event: Event,
+                        agenda: {
+                            event: EventAgenda,
+                        },
+                        toolbar: Toolbar,
+                        eventWrapper: EventWrapper,
+                    }}
+                    dayPropGetter={customDayPropGetter}
+                    slotPropGetter={customSlotPropGetter}
+                    defaultDate={new Date()}
+                    resources={getResources()}
+                    resourceAccessor={event => event.resourceId}
+                    resourceIdAccessor={resource => resource.id}
+                    resourceTitleAccessor={resource => resource.title}
+                />
             );
         }
     }


### PR DESCRIPTION
`TEvent` can have any shape when using property accessors.
The only restriction is to be `object`.
This change fixes Typescript errors when using a custom event structure that doesn't match the default `Event` interface.

There are only a few changes but prettier/linting adds quite a lot of formatting.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
