### PR TITLE
[types/google-apps-script] Blob extends BlobSource

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -103,3 +103,8 @@ function doPost(e: GoogleAppsScript.Events.DoPost) {
 function doGet(e: GoogleAppsScript.Events.DoGet) {
   const params: object = e.parameters;
 }
+
+// Base Service
+function createFileFromBlob(blob: GoogleAppsScript.Base.Blob){
+  const file: GoogleAppsScript.Drive.File = DriveApp.createFile(blob);
+}

--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -317,9 +317,9 @@ declare namespace GoogleAppsScript {
       warn(): void;
       warn(formatOrObject: object, ...values: object[]): void;
     }
-    /**
+    /** 
      * Apps Script has a non-standard Date Class
-     *
+     * 
      * @see https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts
      * Enables basic storage and retrieval of dates and times.
      */

--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -10,7 +10,7 @@ declare namespace GoogleAppsScript {
     /**
      * A data interchange object for Apps Script services.
      */
-    export interface Blob {
+    export interface Blob extends BlobSource {
       copyBlob(): Blob;
       getAs(contentType: string): Blob;
       getBytes(): Byte[];
@@ -317,9 +317,9 @@ declare namespace GoogleAppsScript {
       warn(): void;
       warn(formatOrObject: object, ...values: object[]): void;
     }
-    /** 
+    /**
      * Apps Script has a non-standard Date Class
-     * 
+     *
      * @see https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts
      * Enables basic storage and retrieval of dates and times.
      */


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/base/blob-source

Based on the question https://stackoverflow.com/questions/53965253

As I can see the `Class Blob` implements `Interface BlobSource`. We use the namespace with the interfaces (not in the types).  A reference to the extension of the Interface is possible instead of a direct reference to the implementation of a Class. It does not violate the heritage.

Just reject it if I'm wrong.

Thanks.