### PR TITLE
fixing typing for CurrentRefinementsProvided in react-instantsearch-core

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -227,7 +227,7 @@ export interface CurrentRefinementsExposed {
 
 export interface CurrentRefinementsProvided {
   /** a function to remove a single filter */
-  refine: (refinement: RefinementValue | RefinementValue[]) => void;
+  refine: (refinement: Refinement | Refinement[]) => void;
   /**
    * all the filters, the value is to pass to the refine function for removing all currentrefinements,
    * label is for the display. When existing several refinements for the same atribute name, then you

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -299,14 +299,15 @@ import {
 };
 
 () => {
-  const MyCurrentRefinements = ({refine, items, query}: CurrentRefinementsProvided) =>
-    <>
-      {items.map((refinement) => (
-        <div key={refinement.id} onClick={() => refine(refinement.value) }>
-          <label>{refinement.label}</label>
-        </div>
-      ))}
-    </>;
+  const MyCurrentRefinements = ({ refine, items, query }: CurrentRefinementsProvided) => (
+      <>
+          {items.map(refinement => (
+              <div key={refinement.id} onClick={() => refine(refinement)}>
+                  <label>{refinement.label}</label>
+              </div>
+          ))}
+      </>
+  );
 
   const ConnectedCurrentRefinements = connectCurrentRefinements(MyCurrentRefinements);
 
@@ -314,34 +315,18 @@ import {
 };
 
 () => {
-  function renderRefinement(
-    label: string,
-    value: Refinement['value'],
-    refine: CurrentRefinementsProvided['refine'],
-  ) {
-    return <button className="badge badge-secondary" onClick={() => refine(value)}>
-        {label}
-      </button>;
+  function renderRefinement(label: string, value: Refinement, refine: CurrentRefinementsProvided['refine']) {
+      return (
+          <button className="badge badge-secondary" onClick={() => refine(value)}>
+              {label}
+          </button>
+      );
   }
 
   const MyCurrentRefinements = connectCurrentRefinements(({refine, items, query}: CurrentRefinementsProvided) => {
     return <>
         {items.map((refinement) => {
-          let str: string = refinement.currentRefinement; // $ExpectError
-          /*
-           * When existing several refinements for the same atribute name, then you get a
-           * nested items object that contains a label and a value function to use to remove a single filter.
-           * https://community.algolia.com/react-instantsearch/connectors/connectCurrentRefinements.html
-           */
-          if ('items' in refinement) {
-            str = refinement.currentRefinement; // $ExpectError
-            return <>
-              {refinement.items.map((i) => renderRefinement(i.label, i.value, refine))}
-            </>;
-          }
-
-          console.log(refinement.items); // $ExpectError
-          return renderRefinement(refinement.currentRefinement, refinement.value, refine);
+          return renderRefinement(refinement.label, refinement, refine);
         })}
       </>;
   });


### PR DESCRIPTION
This PR is fixing a small error in **react-instantsearch-core**.

The `CurrentRefinementsProvided` interface has a `refine` function, which argument should be of type `Refinement | Refinement[]` (instead of `RefinementValue | RefinementValue[]`).

If this `refine` function is called with a `RefinementValue[]` it throws an error.
Whereas it works as expected when calling it with a `Refinement[]`.

_relevant part of the doc:_
https://www.algolia.com/doc/api-reference/widgets/current-refinements/react/?language=react#full-example
