### PR TITLE
Add type field to simple-peer/SignalData

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -40,6 +40,7 @@ declare namespace SimplePeer {
     type SimplePeerData = string | Buffer | TypedArray | ArrayBuffer | Blob;
 
     interface SignalData {
+        type?: RTCSdpType;
         sdp?: any;
         candidate?: any;
     }

--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -40,7 +40,7 @@ declare namespace SimplePeer {
     type SimplePeerData = string | Buffer | TypedArray | ArrayBuffer | Blob;
 
     interface SignalData {
-        type?: RTCSdpType;
+        type?: "offer" | "pranswer" | "answer" | "rollback";
         sdp?: any;
         candidate?: any;
     }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription)

The SignalData should have `type` field according to [https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription), or it will cause error when calling `setRemoteDescription` function.
