### PR TITLE
lodash: Make _.invert more precise

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1990,14 +1990,8 @@ declare module "../index" {
     // helpers
     type Keyify<T> = T extends PropertyKey ? T : string;
     type Stringify<T> = T extends string ? T : string;
-    type KeyValues<T> = {
-        [P in keyof T]: {
-            key: Stringify<P>,
-            value: Keyify<T[P]>,
-        }
-    }[keyof T];
-    type InvertResult<T> = {} & {
-        [P in Keyify<T[keyof T]>]: Extract<KeyValues<T>, { value: P }>['key']
+    type InvertResult<T> = {
+        [P in Keyify<T[keyof T]>]: Stringify<keyof T>;
     };
 
     interface LoDashStatic {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1988,12 +1988,17 @@ declare module "../index" {
     // invert
 
     // helpers
-    type InvertAllValues<T extends Record<PropertyKey, PropertyKey>> = {
-        [P in keyof T]: { key: P, value: T[P] }
-    }[keyof T]
-    type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {
-        [P in InvertAllValues<T>['value']]: Extract<InvertAllValues<T>, { value: P }>['key']
-    }
+    type Keyify<T> = T extends PropertyKey ? T : string;
+    type Stringify<T> = T extends string ? T : string;
+    type KeyValues<T> = {
+        [P in keyof T]: {
+            key: Stringify<P>,
+            value: Keyify<T[P]>,
+        }
+    }[keyof T];
+    type InvertResult<T> = {} & {
+        [P in Keyify<T[keyof T]>]: Extract<KeyValues<T>, { value: P }>['key']
+    };
 
     interface LoDashStatic {
         /**

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1991,7 +1991,7 @@ declare module "../index" {
     type InvertAllValues<T extends Record<PropertyKey, PropertyKey>> = {
         [P in keyof T]: { key: P, value: T[P] }
     }[keyof T]
-    type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {} & {
+    type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {
         [P in InvertAllValues<T>['value']]: Extract<InvertAllValues<T>, { value: P }>['key']
     }
 

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1987,32 +1987,47 @@ declare module "../index" {
 
     // invert
 
+    // helpers
+    type InvertAllValues<T extends Record<PropertyKey, PropertyKey>> = {
+        [P in keyof T]: { key: P, value: T[P] }
+    }[keyof T]
+    type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {} & {
+        [P in InvertAllValues<T>['value']]: Extract<InvertAllValues<T>, { value: P }>['key']
+    }
+
     interface LoDashStatic {
         /**
          * Creates an object composed of the inverted keys and values of object. If object contains duplicate values,
          * subsequent values overwrite property assignments of previous values unless multiValue is true.
          *
          * @param object The object to invert.
-         * @param multiValue Allow multiple values per key.
          * @return Returns the new inverted object.
          */
-        invert(
-            object: object
-        ): Dictionary<string>;
+        invert<T extends Record<PropertyKey, PropertyKey>>(
+            object: T
+        ): InvertResult<T>;
     }
 
     interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.invert
          */
-        invert(): LoDashImplicitWrapper<Dictionary<string>>;
+        invert(): LoDashImplicitWrapper<
+            TValue extends Record<PropertyKey, PropertyKey>
+            ? InvertResult<TValue>
+            : Dictionary<string>
+        >;
     }
 
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.invert
          */
-        invert(): LoDashExplicitWrapper<Dictionary<string>>;
+        invert(): LoDashExplicitWrapper<
+            TValue extends Record<PropertyKey, PropertyKey>
+            ? InvertResult<TValue>
+            : Dictionary<string>
+        >;
     }
 
     // invertBy

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1789,7 +1789,7 @@ declare namespace _ {
     }
     type LodashIntersectionWith1x5<T1> = (array: lodash.List<T1> | null | undefined) => T1[];
     type LodashIntersectionWith1x6<T1, T2> = (comparator: lodash.Comparator2<T1, T2>) => T1[];
-    type LodashInvert = (object: object) => lodash.Dictionary<string>;
+    type LodashInvert = <T extends Record<PropertyKey, PropertyKey>>(object: T) => lodash.InvertResult<T>;
     interface LodashInvertBy {
         <T>(interatee: lodash.ValueIteratee<T>): LodashInvertBy1x1<T>;
         <T>(interatee: lodash.__, object: lodash.List<T> | lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): LodashInvertBy1x2<T>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5256,21 +5256,25 @@ fp.now(); // $ExpectType number
     fp.invert({}); // $ExpectType {}
 
     const abxy: {
-        readonly a: 'x',
-        readonly b: 'y',
+        readonly a: 'x';
+        readonly b: 'y';
     } = {
         a: 'x',
         b: 'y',
     };
-    _.invert(abxy);  // $ExpectType { x: "a", y: "b" }
-    _(abxy).invert().value();  // $ExpectType { x: "a", y: "b" }
-    _.chain(abxy).invert().value();  // $ExpectType { x: "a", y: "b" }
-    fp.invert(abxy);  // $ExpectType { x: "a", y: "b" }
+    _.invert(abxy); // $ExpectType { x: "a", y: "b" }
+    _(abxy)
+        .invert()
+        .value(); // $ExpectType { x: "a", y: "b" }
+    _.chain(abxy)
+        .invert()
+        .value(); // $ExpectType { x: "a", y: "b" }
+    fp.invert(abxy); // $ExpectType { x: "a", y: "b" }
 
     _.invert({
         a: 'x',
         b: 'y',
-    });  // $ExpectType Dictionary<"a" | "b">
+    }); // $ExpectType Dictionary<"a" | "b">
 }
 
 // _.invertBy

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5262,14 +5262,14 @@ fp.now(); // $ExpectType number
         a: 'x',
         b: 'y',
     };
-    _.invert(abxy); // $ExpectType { x: "a", y: "b" }
+    _.invert(abxy); // $ExpectType { x: "a" | "b", y: "a" | "b" }
     _(abxy)
         .invert()
-        .value(); // $ExpectType { x: "a", y: "b" }
+        .value(); // $ExpectType { x: "a" | "b", y: "a" | "b" }
     _.chain(abxy)
         .invert()
-        .value(); // $ExpectType { x: "a", y: "b" }
-    fp.invert(abxy); // $ExpectType { x: "a", y: "b" }
+        .value(); // $ExpectType { x: "a" | "b", y: "a" | "b" }
+    fp.invert(abxy); // $ExpectType { x: "a" | "b", y: "a" | "b" }
 
     _.invert({
         a: 'x',

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5251,9 +5251,9 @@ fp.now(); // $ExpectType number
 // _.invert
 {
     _.invert({}); // $ExpectType Dictionary<string>
-    _({}).invert(); // $ExpectType LoDashImplicitWrapper<Dictionary<string>>
-    _.chain({}).invert(); // $ExpectType LoDashExplicitWrapper<Dictionary<string>>
-    fp.invert({}); // $ExpectType Dictionary<string>
+    _({}).invert(); // $ExpectType LoDashImplicitWrapper<{}>
+    _.chain({}).invert(); // $ExpectType LoDashExplicitWrapper<{}>
+    fp.invert({}); // $ExpectType {}
 
     const abxy: {
         readonly a: 'x',
@@ -5262,10 +5262,10 @@ fp.now(); // $ExpectType number
         a: 'x',
         b: 'y',
     };
-    _.invert(abxy);  // $ExpectType { readonly x: "a", readonly y: "b" }
-    _(abxy).invert().value();  // $ExpectType { readonly x: "a", readonly y: "b" }
-    _.chain(abxy).invert().value();  // $ExpectType { readonly x: "a", readonly y: "b" }
-    fp.invert(abxy);  // $ExpectType { readonly x: "a", readonly y: "b" }
+    _.invert(abxy);  // $ExpectType { x: "a", y: "b" }
+    _(abxy).invert().value();  // $ExpectType { x: "a", y: "b" }
+    _.chain(abxy).invert().value();  // $ExpectType { x: "a", y: "b" }
+    fp.invert(abxy);  // $ExpectType { x: "a", y: "b" }
 
     _.invert({
         a: 'x',

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5254,6 +5254,23 @@ fp.now(); // $ExpectType number
     _({}).invert(); // $ExpectType LoDashImplicitWrapper<Dictionary<string>>
     _.chain({}).invert(); // $ExpectType LoDashExplicitWrapper<Dictionary<string>>
     fp.invert({}); // $ExpectType Dictionary<string>
+
+    const abxy: {
+        readonly a: 'x',
+        readonly b: 'y',
+    } = {
+        a: 'x',
+        b: 'y',
+    };
+    _.invert(abxy);  // $ExpectType { readonly x: "a", readonly y: "b" }
+    _(abxy).invert().value();  // $ExpectType { readonly x: "a", readonly y: "b" }
+    _.chain(abxy).invert().value();  // $ExpectType { readonly x: "a", readonly y: "b" }
+    fp.invert(abxy);  // $ExpectType { readonly x: "a", readonly y: "b" }
+
+    _.invert({
+        a: 'x',
+        b: 'y',
+    });  // $ExpectType Dictionary<"a" | "b">
 }
 
 // _.invertBy

--- a/types/lodash/scripts/package.json
+++ b/types/lodash/scripts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "generate": "ts-node generate-fp",
-    "fp": "ts-node generate-fp",
+    "fp": "ts-node generate-fp"
   },
   "devDependencies": {
     "lodash": "^4.17.4",

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1222,28 +1222,51 @@ declare module "../index" {
          */
         hasIn(path: PropertyPath): PrimitiveChain<boolean>;
     }
+
+    // helpers for invert
+    type Keyify<T> = T extends PropertyKey ? T : string;
+    type Stringify<T> = T extends string ? T : string;
+    type KeyValues<T> = {
+        [P in keyof T]: {
+            key: Stringify<P>,
+            value: Keyify<T[P]>,
+        }
+    }[keyof T];
+    type InvertResult<T> = {} & {
+        [P in Keyify<T[keyof T]>]: Extract<KeyValues<T>, { value: P }>['key']
+    };
+
     interface LoDashStatic {
         /**
          * Creates an object composed of the inverted keys and values of object. If object contains duplicate values,
          * subsequent values overwrite property assignments of previous values unless multiValue is true.
          *
          * @param object The object to invert.
-         * @param multiValue Allow multiple values per key.
          * @return Returns the new inverted object.
          */
-        invert(object: object): Dictionary<string>;
+        invert<T extends Record<PropertyKey, PropertyKey>>(
+            object: T
+        ): InvertResult<T>;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.invert
          */
-        invert(): Object<Dictionary<string>>;
+        invert(): Object<
+            TValue extends Record<PropertyKey, PropertyKey>
+            ? InvertResult<TValue>
+            : Dictionary<string>
+        >;
     }
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.invert
          */
-        invert(): ObjectChain<Dictionary<string>>;
+        invert(): ObjectChain<
+            TValue extends Record<PropertyKey, PropertyKey>
+            ? InvertResult<TValue>
+            : Dictionary<string>
+        >;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1226,14 +1226,8 @@ declare module "../index" {
     // helpers for invert
     type Keyify<T> = T extends PropertyKey ? T : string;
     type Stringify<T> = T extends string ? T : string;
-    type KeyValues<T> = {
-        [P in keyof T]: {
-            key: Stringify<P>,
-            value: Keyify<T[P]>,
-        }
-    }[keyof T];
     type InvertResult<T> = {} & {
-        [P in Keyify<T[keyof T]>]: Extract<KeyValues<T>, { value: P }>['key']
+        [P in Keyify<T[keyof T]>]: Stringify<keyof T>;
     };
 
     interface LoDashStatic {

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -1718,7 +1718,7 @@ declare namespace _ {
     }
     type LodashIntersectionWith1x5<T1> = (array: lodash.List<T1> | null | undefined) => T1[];
     type LodashIntersectionWith1x6<T1, T2> = (comparator: lodash.Comparator2<T1, T2>) => T1[];
-    type LodashInvert = (object: object) => lodash.Dictionary<string>;
+    type LodashInvert = <T extends Record<PropertyKey, PropertyKey>>(object: T) => lodash.InvertResult<T>;
     interface LodashInvertBy {
         <T>(interatee: lodash.ValueIteratee<T>): LodashInvertBy1x1<T>;
         <T>(interatee: lodash.__, object:  lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): LodashInvertBy1x2<T>;
@@ -1831,7 +1831,6 @@ declare namespace _ {
     }
     interface LodashIsArrayLikeObject {
         <T extends { __lodashAnyHack: any }>(value: T): boolean;
-        // tslint:disable-next-line:ban-types (type guard doesn't seem to work correctly without the lodash.Function type)
         (value: ((...args: any[]) => any) | lodash.FunctionBase | string | boolean | number | null | undefined): value is never;
         (value: any): value is object & { length: number };
     }
@@ -2032,40 +2031,36 @@ declare namespace _ {
     type LodashMapKeys2x1 = <T extends object>(object: T | null | undefined) => lodash.Dictionary<T[keyof T]>;
     type LodashMapKeys2x2<T> = (iteratee: lodash.ValueIteratee<string>) => lodash.Dictionary<T[keyof T]>;
     interface LodashMapValues {
-        <T, TResult>(callback: (value: T) => TResult): LodashMapValues1x1<T, TResult>;
-        <T>(callbackOrIterateeOrIterateeOrIteratee: lodash.__, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): LodashMapValues1x2<T>;
-        <T, TResult>(callback: (value: T) => TResult, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<TResult>;
-        <T extends object, TResult>(callback: (value: T[keyof T]) => TResult): LodashMapValues2x1<T, TResult>;
-        <T extends object>(callbackOrIterateeOrIteratee: lodash.__, obj: T | null | undefined): LodashMapValues2x2<T>;
+        <T extends object, TResult>(callback: (value: T[keyof T]) => TResult): LodashMapValues1x1<T, TResult>;
+        <T extends object>(callbackOrIterateeOrIteratee: lodash.__, obj: T | null | undefined): LodashMapValues1x2<T>;
         <T extends object, TResult>(callback: (value: T[keyof T]) => TResult, obj: T | null | undefined): { [P in keyof T]: TResult };
-        (iteratee: object): LodashMapValues3x1;
+        (iteratee: object): LodashMapValues2x1;
+        <T>(iteratee: lodash.__, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): LodashMapValues2x2;
         <T>(iteratee: object, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<boolean>;
         <T extends object>(iteratee: object, obj: T | null | undefined): { [P in keyof T]: boolean };
-        <T, TKey extends keyof T>(iteratee: TKey): LodashMapValues5x1<T, TKey>;
+        <T, TKey extends keyof T>(iteratee: TKey): LodashMapValues4x1<T, TKey>;
         <T, TKey extends keyof T>(iteratee: TKey, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<T[TKey]>;
-        (iteratee: string): LodashMapValues6x1;
+        (iteratee: string): LodashMapValues5x1;
         <T>(iteratee: string, obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<any>;
         <T extends object>(iteratee: string, obj: T | null | undefined): { [P in keyof T]: any };
     }
-    type LodashMapValues1x1<T, TResult> = (obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined) => lodash.Dictionary<TResult>;
+    type LodashMapValues1x1<T, TResult> = (obj: T | null | undefined) => { [P in keyof T]: TResult };
     interface LodashMapValues1x2<T> {
-        <TResult>(callback: (value: T) => TResult): lodash.Dictionary<TResult>;
-        (iteratee: object): lodash.Dictionary<boolean>;
-        <TKey extends keyof T>(iteratee: TKey): lodash.Dictionary<T[TKey]>;
-        (iteratee: string): lodash.Dictionary<any>;
-    }
-    type LodashMapValues2x1<T, TResult> = (obj: T | null | undefined) => { [P in keyof T]: TResult };
-    interface LodashMapValues2x2<T> {
         <TResult>(callback: (value: T[keyof T]) => TResult): { [P in keyof T]: TResult };
         (iteratee: object): { [P in keyof T]: boolean };
         (iteratee: string): { [P in keyof T]: any };
     }
-    interface LodashMapValues3x1 {
+    interface LodashMapValues2x1 {
         <T>(obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<boolean>;
         <T extends object>(obj: T | null | undefined): { [P in keyof T]: boolean };
     }
-    type LodashMapValues5x1<T, TKey extends keyof T> = (obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined) => lodash.Dictionary<T[TKey]>;
-    interface LodashMapValues6x1 {
+    interface LodashMapValues2x2 {
+        (iteratee: object): lodash.Dictionary<boolean>;
+        <TKey extends keyof T>(iteratee: TKey): lodash.Dictionary<T[TKey]>;
+        (iteratee: string): lodash.Dictionary<any>;
+    }
+    type LodashMapValues4x1<T, TKey extends keyof T> = (obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined) => lodash.Dictionary<T[TKey]>;
+    interface LodashMapValues5x1 {
         <T>(obj: lodash.Dictionary<T> | lodash.NumericDictionary<T> | null | undefined): lodash.Dictionary<any>;
         <T extends object>(obj: T | null | undefined): { [P in keyof T]: any };
     }
@@ -2604,15 +2599,21 @@ declare namespace _ {
     type LodashPartialRight27x1 = (args: ReadonlyArray<any>) => (...args: any[]) => any;
     type LodashPartialRight27x2 = (func: (...args: any[]) => any) => (...args: any[]) => any;
     interface LodashPartition {
-        <T>(callback: lodash.ValueIteratee<T>): LodashPartition1x1<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): LodashPartition1x1<T, U>;
         <T>(callback: lodash.__, collection: lodash.List<T> | null | undefined): LodashPartition1x2<T>;
+        <T, U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>, collection: lodash.List<T> | null | undefined): [U[], Array<Exclude<T, U>>];
+        <T>(callback: lodash.ValueIteratee<T>): LodashPartition2x1<T>;
         <T>(callback: lodash.ValueIteratee<T>, collection: lodash.List<T> | null | undefined): [T[], T[]];
-        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition2x2<T>;
+        <T extends object>(callback: lodash.__, collection: T | null | undefined): LodashPartition3x2<T>;
         <T extends object>(callback: lodash.ValueIteratee<T[keyof T]>, collection: T | null | undefined): [Array<T[keyof T]>, Array<T[keyof T]>];
     }
-    type LodashPartition1x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
-    type LodashPartition1x2<T> = (callback: lodash.ValueIteratee<T>) => [T[], T[]];
-    type LodashPartition2x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
+    type LodashPartition1x1<T, U> = (collection: lodash.List<T> | null | undefined) => [U[], Array<Exclude<T, U>>];
+    interface LodashPartition1x2<T> {
+        <U extends T>(callback: lodash.ValueIteratorTypeGuard<T, U>): [U[], Array<Exclude<T, U>>];
+        (callback: lodash.ValueIteratee<T>): [T[], T[]];
+    }
+    type LodashPartition2x1<T> = (collection: lodash.List<T> | object | null | undefined) => [T[], T[]];
+    type LodashPartition3x2<T> = (callback: lodash.ValueIteratee<T[keyof T]>) => [Array<T[keyof T]>, Array<T[keyof T]>];
     interface LodashPath {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashPath1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashPath1x2<TObject>;

--- a/types/lodash/ts3.1/scripts/package.json
+++ b/types/lodash/ts3.1/scripts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "generate": "ts-node generate-fp",
-    "fp": "ts-node generate-fp",
+    "fp": "ts-node generate-fp"
   },
   "devDependencies": {
     "lodash": "^4.17.11",


### PR DESCRIPTION
Context: [this question/answer][1] on Stack Overflow.

The idea is that if you invert an `as const` object, its type can be more precise:

```ts
const kv = {
  x: 'a',
  y: 'b'
} as const;
_.invert(kv);  // type should be { readonly a: 'x', readonly b: 'y' }, not Dictionary<string>.
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

[1]: https://stackoverflow.com/questions/56415826/is-it-possible-to-precisely-type-invert-in-typescript/56416192