### PR TITLE
Fix agent option for RequestOptions in @hapi/wreck

### DIFF
--- a/types/hapi__wreck/hapi__wreck-tests.ts
+++ b/types/hapi__wreck/hapi__wreck-tests.ts
@@ -1,4 +1,5 @@
 
+import Http = require('http');
 import Wreck = require('@hapi/wreck');
 
 Wreck.get('https://google.com/', {}).then((response) => {
@@ -18,6 +19,11 @@ var wreck = Wreck.defaults({
 var wreckWithTimeout = wreck.defaults({
     timeout: 5
 });
+
+// regression test for wreck with custom agent
+var wreckWithAgent = Wreck.defaults({
+    agent: new Http.Agent(),
+})
 
 // all attributes are optional
 var options = {

--- a/types/hapi__wreck/index.d.ts
+++ b/types/hapi__wreck/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Marcin Porębski <https://github.com/marcinporebski>
 //                 Rodrigo Saboya <https://github.com/saboya>
 //                 Silas Rech <https://github.com/lenovouser>
+//                 Geoff Goodman <https://github.com/ggoodman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -28,7 +29,7 @@ interface RequestOptions {
     maxBytes?: number;
     rejectUnauthorized?: boolean;
     downstreamRes?: any;
-    agent?: WreckObject["agents"] | false;
+    agent?: http.Agent | false;
     secureProtocol?: string;
     ciphers?: string;
     events?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/wreck/blob/v15.0.1/README.md#requestmethod-uri-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
