### PR TITLE
Fixes for early June TS3.6 DOM update

### DIFF
--- a/types/apollo-upload-client/index.d.ts
+++ b/types/apollo-upload-client/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaydenseric/apollo-upload-client#readme
 // Definitions by: Edward Sammut Alessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
+// TypeScript Version: 3.1
 
 import { ApolloLink } from "apollo-link";
 import { HttpOptions } from "apollo-link-http-common";
@@ -11,7 +11,7 @@ export { ReactNativeFile } from "extract-files";
 
 declare global {
     interface GlobalFetch {
-        fetch: (input: string | Request, init?: RequestInit) => Promise<Response>; // WindowOrWorkerGlobalScope['fetch'];
+        fetch: WindowOrWorkerGlobalScope["fetch"];
     }
 }
 

--- a/types/apollo-upload-client/index.d.ts
+++ b/types/apollo-upload-client/index.d.ts
@@ -9,6 +9,12 @@ import { HttpOptions } from "apollo-link-http-common";
 
 export { ReactNativeFile } from "extract-files";
 
+declare global {
+    interface GlobalFetch {
+        fetch: WindowOrWorkerGlobalScope['fetch'];
+    }
+}
+
 /**
  * `createUploadLink` options match `createHttpLink` options
  * @param linkOptions `HttpOptions`

--- a/types/apollo-upload-client/index.d.ts
+++ b/types/apollo-upload-client/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaydenseric/apollo-upload-client#readme
 // Definitions by: Edward Sammut Alessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.7
 
 import { ApolloLink } from "apollo-link";
 import { HttpOptions } from "apollo-link-http-common";
@@ -11,7 +11,7 @@ export { ReactNativeFile } from "extract-files";
 
 declare global {
     interface GlobalFetch {
-        fetch: WindowOrWorkerGlobalScope['fetch'];
+        fetch: (input: string | Request, init?: RequestInit) => Promise<Response>; // WindowOrWorkerGlobalScope['fetch'];
     }
 }
 

--- a/types/dom-inputevent/index.d.ts
+++ b/types/dom-inputevent/index.d.ts
@@ -4,14 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface InputEventInit extends UIEventInit {
-    data?: string;
-    isComposing: boolean;
+    data?: string | null | undefined;
+    isComposing?: boolean;
 }
 
 // tslint:disable-next-line no-empty-interface
-interface InputEvent extends UIEvent {}
-declare class InputEvent {
-    constructor(typeArg: 'input' | 'beforeinput', inputEventInit?: InputEventInit);
-    readonly data: string;
+interface InputEvent extends UIEvent {
+    readonly data: string | null;
     readonly isComposing: boolean;
 }
+declare var InputEvent: {
+    prototype: InputEvent;
+    new(type: string, eventInitDict?: InputEventInit): InputEvent;
+};

--- a/types/dom-inputevent/index.d.ts
+++ b/types/dom-inputevent/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface InputEventInit extends UIEventInit {
-    data?: string | null | undefined;
+    data?: string | null;
     isComposing?: boolean;
 }
 

--- a/types/to-markdown/to-markdown-tests.ts
+++ b/types/to-markdown/to-markdown-tests.ts
@@ -34,7 +34,7 @@ toMarkdown(`
     {
       filter(node) {
         return node.nodeName === 'SPAN'
-               && /italic/i.test(node.style.fontStyle!);
+               && /italic/i.test(node.style.fontStyle || "");
       },
       replacement(innerHTML) {
         return `*${innerHTML}*`;
@@ -43,7 +43,7 @@ toMarkdown(`
     {
       filter(node) {
         return node.nodeName === 'SPAN'
-               && /italic/i.test(node.style.fontStyle!);
+               && /italic/i.test(node.style.fontStyle || "");
       },
       replacement(innerHTML, node) {
         return `${innerHTML}(node: \`${node.nodeName}\`)`;

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -57,7 +57,7 @@ interface CMRequestInit {
  * interface.
  */
 interface Navigator {
-    credentials?: CredentialsContainer;
+    readonly credentials: CredentialsContainer;
 }
 
 /**
@@ -73,7 +73,7 @@ interface CredentialsContainer {
      *     return.
      * @see {@link https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-get}
      */
-    get(options?: CredentialRequestOptions): Promise<Credential|null>;
+    get(options?: CredentialRequestOptions): Promise<CredentialType|null>;
 
     /**
      * Ask the credential manager to store a {@link Credential} for the user.
@@ -82,14 +82,14 @@ interface CredentialsContainer {
      *
      * @see {@link https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-store}
      */
-    store(credential: Credential): Promise<Credential>;
+    store(credential: CredentialType): Promise<CredentialType>;
 
     /**
      * Create a {@link Credential} asynchronously.
      *
      * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dom-credentialscontainer-create}
      */
-    create(options: CredentialCreationOptions): Promise<Credential|null>;
+    create(options: CredentialCreationOptions): Promise<CredentialType|null>;
 
     /**
      * Ask the credential manager to require user mediation before returning
@@ -126,7 +126,7 @@ interface CredentialData {
     id: string;
 }
 
-type Credential = PasswordCredential|FederatedCredential|PublicKeyCredential;
+type CredentialType = PasswordCredential|FederatedCredential|PublicKeyCredential;
 
 /**
  * A generic and extensible Credential interface from which all credentials
@@ -280,11 +280,6 @@ declare class FederatedCredential extends SiteBoundCredential {
 }
 
 /**
- * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#enumdef-credentialmediationrequirement}
- */
-type CredentialMediationRequirement = 'silent'|'optional'|'required';
-
-/**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-credentialrequestoptions}
  */
 interface CredentialRequestOptions {
@@ -312,7 +307,7 @@ interface CredentialRequestOptions {
      * This property specifies the mediation requirements for a given credential
      * request.
      */
-    mediation?: CredentialMediationRequirement;
+    mediation?: 'silent' | 'optional' | 'required';
 
     /**
      * This property specifies options for requesting a public-key signature.

--- a/types/webappsec-credential-management/webappsec-credential-management-tests.ts
+++ b/types/webappsec-credential-management/webappsec-credential-management-tests.ts
@@ -164,7 +164,7 @@ function passwordPostSignInConfirmation() {
             const c = new PasswordCredential(formElem);
             fetch(formElem.action, { method: 'POST', credentials: c }).then(r => {
                 if (r.status === 200) {
-                    navigator.credentials!.store(c);
+                    navigator.credentials.store(c);
                 }
             });
         }


### PR DESCRIPTION
1. Apollo-link used GlobalFetch, which has been removed. Until my PR goes in (apollographql/apollo-link#1095), I added a shim in apollo-upload-client, which uses apollo-link-http-common.
2. dom-inputevent is updated to match the spec-standard InputEvent types that will ship with Typescript 3.6.
3. Same for webappsec-credential-management
4. Fixed to-markdown's tests to work with the new, non-nullable definition of node.style.fontStyle.