### PR TITLE
kue: `ms` argument to `watchStuckJobs` is optional

### DIFF
--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -31,7 +31,7 @@ export declare class Queue extends events.EventEmitter {
     setupTimer(): void;
     checkJobPromotion(ms: number): void;
     checkActiveJobTtl(ttlOptions: Object): void;
-    watchStuckJobs(ms: number): void;
+    watchStuckJobs(ms?: number): void;
     setting(name: string, fn: Function): Queue;
     process(type: string, fn?: ProcessCallback): void;
     process(type: string, n: number, fn?: ProcessCallback): void;


### PR DESCRIPTION
See https://github.com/Automattic/kue/blob/87d61503d3d9cc024633efc7611bd25551f0f87d/lib/kue.js#L270-L273 and documentation:

> ```js
> queue.watchStuckJobs(interval)
> ```
> `interval` is in milliseconds and defaults to 1000ms

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/kue/blob/87d61503d3d9cc024633efc7611bd25551f0f87d/lib/kue.js#L270-L273

