### PR TITLE
node-hid: add new definitions

### DIFF
--- a/types/node-hid/index.d.ts
+++ b/types/node-hid/index.d.ts
@@ -30,7 +30,11 @@ export class HID {
     getFeatureReport(report_id: number, report_length: number): number[];
     resume(): void;
     on(event: string, handler: (value: any) => void): void;
+    once(event: string, handler: (value: any) => void): void;
+    removeListener(event: string, handler: (value: any) => void): void;
+    removeAllListeners(event: string): void;
     write(values: number[]): number;
+    setNonBlocking(no_block: boolean): void;
 }
 export function devices(): Device[];
 export function setDriverType(type: 'hidraw' | 'libusb'): void;

--- a/types/node-hid/node-hid-tests.ts
+++ b/types/node-hid/node-hid-tests.ts
@@ -5,8 +5,17 @@ const devices = HID.devices();
 let device = new HID.HID("path");
 
 device = new HID.HID(12, 22);
+device.setNonBlocking(true);
 
 device.on("data", data => {});
+device.once("data", data => {});
 device.on("error", err => {});
 
 device.write([0x00, 0x01, 0x01, 0x05, 0xff, 0xff]);
+
+device.pause();
+device.resume();
+
+device.removeListener("data", data => {});
+device.removeAllListeners("data");
+device.close();


### PR DESCRIPTION
Updating based on https://github.com/node-hid/node-hid/commit/0ff75bf17212243d7f1d05e445a3dbead0f5ab08
Additional event handles added as HID class inherits directly from Node's EventEmitter: https://github.com/node-hid/node-hid/blob/0ff75bf17212243d7f1d05e445a3dbead0f5ab08/nodehid.js#L33
