### PR TITLE
[got] Fix got.extend types

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -264,6 +264,10 @@ got('http://todomvc.com', { cookieJar: new tough.CookieJar() });
 // Test extension
 got.extend({ method: 'POST' })('/example');
 got.extend({ method: 'POST' }).extend({ headers: {} }).stream('/example');
+got.extend({ timeout: 100 })('/example', { body: {}, json: true });
+got.extend({ timeout: 100 })('/example', { body: { foo: 'bar' }, json: true });
+got.extend({ timeout: 100 })('/example', { body: {}, form: true });
+got.extend({ timeout: 100 })('/example', { body: { foo: 'bar' }, form: true });
 
 // JSON options:
 // $ExpectType Promise<any>

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -120,6 +120,7 @@ declare namespace got {
     };
 
     interface GotExtend {
+        (options: GotOptions<string | null>): GotInstance;
         (options: GotJSONOptions): GotInstance<GotJSONFn>;
         (options: GotFormOptions<string>): GotInstance<GotFormFn<string>>;
         (options: GotFormOptions<null>): GotInstance<GotFormFn<null>>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR changes the types so that the following code is valid:

```js
const extended = got.extend({ timeout: 100 });

extended('/example', {
	body: { foo: 'bar' },
	form: true
});
```
