### PR TITLE
[@types/codemirror] Add boolean type to autoCloseBrackets option

### DIFF
--- a/types/codemirror/addon/edit/closebrackets.d.ts
+++ b/types/codemirror/addon/edit/closebrackets.d.ts
@@ -42,6 +42,6 @@ declare module "codemirror" {
          * By default, it'll auto-close ()[]{}''"", but you can pass it a string similar to that (containing pairs of matching characters),
          * or an object with pairs and optionally explode properties to customize it.
          */
-        autoCloseBrackets?: AutoCloseBrackets | string;
+        autoCloseBrackets?: AutoCloseBrackets | boolean | string;
     }
 }

--- a/types/codemirror/test/addon/edit/closebrackets.ts
+++ b/types/codemirror/test/addon/edit/closebrackets.ts
@@ -4,3 +4,7 @@
 var myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
     autoCloseBrackets: "()[]{}''\"\""
 });
+
+var myCodeMirror2: CodeMirror.Editor = CodeMirror(document.body, {
+    autoCloseBrackets: true
+});


### PR DESCRIPTION
Currently definition for `autoCloseBrackets` doesn't allow boolean values, which is wrong. Setting autoCloseBrackets to true enables autoclosing feature with the default settings, as is visible in the source code of a demo on the CodeMirror's official website: https://codemirror.net/demo/closebrackets.html

```js
var editor = CodeMirror.fromTextArea(document.getElementById("code"), {autoCloseBrackets: true});
```
---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/codemirror/CodeMirror/blob/master/demo/closebrackets.html#L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
