### PR TITLE
[storybook__addon-knobs] Add missing type overload for optionsKnob

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -85,6 +85,15 @@ export function optionsKnob<T>(
     options?: OptionsKnobOptions
 ): T;
 
+export function optionsKnob<T>(
+    label: string,
+    values: {
+        [key: string]: T;
+    },
+    defaultValue?: T[],
+    options?: OptionsKnobOptions
+): T[];
+
 export interface WrapStoryProps {
     context?: object;
     storyFn?: RenderFunction;

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -15,6 +15,7 @@ import {
   button,
   knob,
   radios,
+  optionsKnob as options,
 } from '@storybook/addon-knobs';
 
 enum SomeEnum {
@@ -132,3 +133,19 @@ select<any>('label', { option: 'Option' }, null, groupId);
 files('label', 'image/*', []);
 date('label', new Date(), groupId);
 button('label', () => undefined, groupId);
+
+// optionsKnob
+type Tool = 'hammer' | 'saw' | 'drill';
+const visibleToolOptions: { [key: string]: Tool } = { hammer: 'hammer', saw: 'saw', drill: 'drill' };
+
+// test selecting one option
+const defaultVisibleTool = 'hammer';
+const singleSelection: Tool = options<Tool>('visibleTools', visibleToolOptions, defaultVisibleTool, {
+  display: 'check',
+});
+
+// test selecting multiple options
+const defaultVisibleTools: Tool[] = ['hammer'];
+const multiSelection: Tool[] = options<Tool>('visibleTools', visibleToolOptions, defaultVisibleTools, {
+  display: 'check',
+});


### PR DESCRIPTION
When using the `optionsKnob`, it's possible to pass an array of default options and receive an array of selected options as a return value.

For example:

```ts
import { Dictionary } from 'lodash';

type Tool = 'hammer' | 'saw' | 'drill';
const visibleToolOptions: Dictionary<Tool> = { hammer: 'hammer', saw: 'saw', drill: 'drill' };
const defaultVisibleTools: Tool[] = ['hammer'];

options<Tool>('visibleTools', visibleToolOptions, defaultVisibleTools, {
  display: 'check',
})
```

This PR adds an overloaded definition to `optionsKnob` that enables this to work properly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~