### PR TITLE
[@types/highcharts] Added type for gridLineInterpolation

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -1008,7 +1008,7 @@ declare namespace Highcharts {
          */
         gridLineWidth?: number;
         /**
-         * Polar charts only. Whether the grid lines should draw as a polygon with straight lines between categories, or as circles. 
+         * Polar charts only. Whether the grid lines should draw as a polygon with straight lines between categories, or as circles.
          * @default undefined
          */
         gridLineInterpolation?: string;

--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -7,6 +7,7 @@
 //                 Johns Gresham <https://github.com/jgresham>
 //                 ArunkeshavaReddy Sankaramaddi <https://github.com/Arunkeshavareddy>
 //                 Dolan Miu <https://github.com/dolanmiu>
+//                 Jack Siman <https://github.com/jjsiman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1006,6 +1007,11 @@ declare namespace Highcharts {
          * @default 0
          */
         gridLineWidth?: number;
+        /**
+         * Polar charts only. Whether the grid lines should draw as a polygon with straight lines between categories, or as circles. 
+         * @default undefined
+         */
+        gridLineInterpolation?: string;
         /**
          * The Z index of the grid lines.
          * @default 1


### PR DESCRIPTION
gridLineInterpolation: string

Polar charts only. Whether the grid lines should draw as a polygon with straight lines between categories, or as circles. Can be either circle or polygon.

Defaults to undefined.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://api.highcharts.com/highcharts/yAxis.gridLineInterpolation>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

