### PR TITLE
@types/jquery: jqXHR.abort has an optional statusText parameter

### DIFF
--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -677,6 +677,7 @@ declare namespace JQuery {
             'setRequestHeader' | 'status' | 'statusText'>,
         Partial<Pick<XMLHttpRequest, 'responseXML'>> {
         responseJSON?: any;
+        abort(statusText?: string): void;
 
         /**
          * Determine the current state of a Deferred object.


### PR DESCRIPTION
Hi! After installing `@types/jquery@3.3.29` I noticed we get an error with our code:
```ts
var xhr: JQueryXHR = jQuery.ajax(settings);
// ...
xhr.abort(`timeout`);
```
Indicating `abort()` expects 0 arguments but got 1.

The [`XMLHttpRequest.abort`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort) does expect 0 arguments but the [`jQueryXHR.abort`](https://api.jquery.com/jquery.ajax/#jqXHR) has an optional `statusText: string` argument.

![Screen Shot 2019-06-20 at 2 56 10 PM](https://user-images.githubusercontent.com/99604/59884010-bf31b380-936b-11e9-996e-4e762ef7d297.png)

This used to exist in the type: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e5367543765eba7280913a08a1185aa14eb0579f

Here is the `abort` function defined in the jQuery src: https://github.com/jquery/jquery/blob/438b1a3e8a52d3e4efd8aba45498477038849c97/src/ajax.js#L520

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/jquery.ajax/#jqXHR
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
