### PR TITLE
Add 'object' as allowed type for mongoose Query.lean

### DIFF
--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -1681,7 +1681,7 @@ declare module "mongoose" {
      * getters/setters or other Mongoose magic applied.
      * @param bool defaults to true
      */
-    lean(bool?: boolean): Query<object>;
+    lean(bool?: boolean | object): Query<object>;
 
     /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
     limit(val: number): this;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
    - Looks like there is already a test: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mongoose/mongoose-tests.ts#L1209
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/mongoose/blob/master/lib/query.js#L1657
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I think I've done this right. I'm a little surprised there wasn't already a binding for this given previous [discussions](https://github.com/vkarpov15/mongoose-lean-virtuals/issues/3), and it was added over [two years ago](https://github.com/Automattic/mongoose/blame/2a2c71ac776e743aabc39ec28fa8711565bf7242/lib/query.js#L1657).