### PR TITLE
[@types/google-protobuf] Fix for breaking changes of PR #35299

### DIFF
--- a/types/google-protobuf/google/protobuf/any_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/any_pb.d.ts
@@ -12,6 +12,10 @@ export class Any extends jspb.Message {
   getValue_asB64(): string;
   setValue(value: Uint8Array | string): void;
 
+  getTypeName(): string;
+  pack(serialized: Uint8Array, name: string, typeUrlPrefix?: string): void;
+  unpack<T extends jspb.Message>(deserialize: (packed: Uint8Array) => T, name: string): T | null;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Any.AsObject;
   static toObject(includeInstance: boolean, msg: Any): Any.AsObject;

--- a/types/google-protobuf/google/protobuf/struct_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/struct_pb.d.ts
@@ -6,6 +6,10 @@ import * as jspb from "../../index";
 export class Struct extends jspb.Message {
   getFieldsMap(): jspb.Map<string, Value>;
   clearFieldsMap(): void;
+
+  toJavaScript(): {[key: string]: JavaScriptValue};
+  static fromJavaScript(value: {[key: string]: JavaScriptValue}): Struct;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Struct.AsObject;
   static toObject(includeInstance: boolean, msg: Struct): Struct.AsObject;
@@ -54,6 +58,10 @@ export class Value extends jspb.Message {
   setListValue(value?: ListValue): void;
 
   getKindCase(): Value.KindCase;
+
+  toJavaScript(): JavaScriptValue;
+  static fromJavaScript(value: JavaScriptValue): Value;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Value.AsObject;
   static toObject(includeInstance: boolean, msg: Value): Value.AsObject;
@@ -91,6 +99,9 @@ export class ListValue extends jspb.Message {
   setValuesList(value: Array<Value>): void;
   addValues(value?: Value, index?: number): Value;
 
+  toJavaScript(): Array<JavaScriptValue>;
+  static fromJavaScript(value: Array<JavaScriptValue>): ListValue;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListValue.AsObject;
   static toObject(includeInstance: boolean, msg: ListValue): ListValue.AsObject;
@@ -111,3 +122,4 @@ export enum NullValue {
   NULL_VALUE = 0,
 }
 
+export type JavaScriptValue = null | number | string | boolean | Array<any> | {};

--- a/types/google-protobuf/google/protobuf/timestamp_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/timestamp_pb.d.ts
@@ -10,6 +10,9 @@ export class Timestamp extends jspb.Message {
   getNanos(): number;
   setNanos(value: number): void;
 
+  toDate(): Date;
+  fromDate(date: Date): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Timestamp.AsObject;
   static toObject(includeInstance: boolean, msg: Timestamp): Timestamp.AsObject;


### PR DESCRIPTION
The original PR #35299 was to fix #34825.

While it was nice, it (unintentionally?) ended up removing important definitions from some of the well known types.

This PR adds the definitions back and can be used to release a new working version.