### PR TITLE
[@types/slate] Support nested plugin stacks on the "plugins" c…

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1131,8 +1131,7 @@ export interface Plugin {
     schema?: SchemaProperties;
 }
 
-export type PluginOrPlugins = Plugin | Plugins;
-export interface Plugins extends Array<PluginOrPlugins> {}
+export interface Plugins extends Array<Plugin | Plugins> {}
 
 export interface EditorProperties {
     onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => void;

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1131,9 +1131,12 @@ export interface Plugin {
     schema?: SchemaProperties;
 }
 
+export type Plugins = Plugin | Plugin[] | PluginStack;
+export interface PluginStack extends Array<Plugins> {}
+
 export interface EditorProperties {
     onChange?: (change: { operations: Immutable.List<Operation>, value: Value }) => void;
-    plugins?: Plugin[];
+    plugins?: PluginStack;
     readOnly?: boolean;
     value?: Value;
 }

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1131,12 +1131,12 @@ export interface Plugin {
     schema?: SchemaProperties;
 }
 
-export type Plugins = Plugin | Plugin[] | PluginStack;
-export interface PluginStack extends Array<Plugins> {}
+export type Plugins = Plugin | NestedPlugins;
+export interface NestedPlugins extends Array<Plugins> {}
 
 export interface EditorProperties {
     onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => void;
-    plugins?: PluginStack;
+    plugins?: Plugins;
     readOnly?: boolean;
     value?: Value;
 }

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1131,8 +1131,8 @@ export interface Plugin {
     schema?: SchemaProperties;
 }
 
-export type Plugins = Plugin | NestedPlugins;
-export interface NestedPlugins extends Array<Plugins> {}
+export type PluginOrPlugins = Plugin | Plugins;
+export interface Plugins extends Array<PluginOrPlugins> {}
 
 export interface EditorProperties {
     onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => void;

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1135,7 +1135,7 @@ export type Plugins = Plugin | Plugin[] | PluginStack;
 export interface PluginStack extends Array<Plugins> {}
 
 export interface EditorProperties {
-    onChange?: (change: { operations: Immutable.List<Operation>, value: Value }) => void;
+    onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => void;
     plugins?: PluginStack;
     readOnly?: boolean;
     value?: Value;

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -114,7 +114,7 @@ const plugin: Plugin = {
     schema: {...schema},
 };
 
-const plugins = [plugin];
+const plugins = [plugin, [plugin, [plugin]]];
 
 const editor = new Editor({ value, plugins });
 const point = Point.create({ key: "a", offset: 0 });


### PR DESCRIPTION
Both [the docs (see example code)][1] and [the source][2] show that the `plugins` constructor argument can be a nested list of plugins. I'd even argue that this is quite pivotal when it comes to composing atomic behaviors to something more specific. 

As for the names of the intermediate types, I'm not super-opinionated here. Just let me know if you'd like to have them changed.   
   
[1]: https://docs.slatejs.org/guides/plugins#feature-plugins
[2]: https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/controllers/editor.js#L645-L649

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docs][1], [source][2]
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
