### PR TITLE
[@types/slate-react] Support nested plugin stacks on the "plugins" property of the Editor React component

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -111,8 +111,8 @@ export interface Plugin extends CorePlugin {
     onSelect?: EventHook;
 }
 
-export type Plugins = Plugin | NestedPlugins;
-export interface NestedPlugins extends Array<Plugins> {}
+export type PluginOrPlugins = Plugin | Plugins;
+export interface Plugins extends Array<PluginOrPlugins> {}
 
 export interface BasicEditorProps {
     value: Value;

--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -111,14 +111,17 @@ export interface Plugin extends CorePlugin {
     onSelect?: EventHook;
 }
 
+export type Plugins = Plugin | Plugin[] | PluginStack;
+export interface PluginStack extends Array<Plugins> {}
+
 export interface BasicEditorProps {
     value: Value;
     autoCorrect?: boolean;
     autoFocus?: boolean;
     className?: string;
-    onChange?: (change: { operations: Immutable.List<Operation>, value: Value }) => any;
+    onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => any;
     placeholder?: any;
-    plugins?: Plugin[];
+    plugins?: PluginStack;
     readOnly?: boolean;
     role?: string;
     schema?: SchemaProperties;

--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -111,8 +111,8 @@ export interface Plugin extends CorePlugin {
     onSelect?: EventHook;
 }
 
-export type Plugins = Plugin | Plugin[] | PluginStack;
-export interface PluginStack extends Array<Plugins> {}
+export type Plugins = Plugin | NestedPlugins;
+export interface NestedPlugins extends Array<Plugins> {}
 
 export interface BasicEditorProps {
     value: Value;
@@ -121,7 +121,7 @@ export interface BasicEditorProps {
     className?: string;
     onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => any;
     placeholder?: any;
-    plugins?: PluginStack;
+    plugins?: Plugins;
     readOnly?: boolean;
     role?: string;
     schema?: SchemaProperties;

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -32,6 +32,7 @@ class MyPlugin implements Plugin {
 }
 
 const myPlugin = new MyPlugin();
+const plugins = [myPlugin, [myPlugin, [myPlugin]]];
 
 interface MyEditorState {
     value: Value;
@@ -47,11 +48,15 @@ class MyEditor extends React.Component<EditorProps, MyEditorState> {
         };
     }
     render() {
-        return <Editor
-            value={this.state.value}
-            renderBlock={ myPlugin.renderBlock }
-            renderInline={ myPlugin.renderInline }
-            onChange={ myPlugin.onChange }/>;
+        return (
+            <Editor
+                plugins={plugins}
+                value={this.state.value}
+                renderBlock={myPlugin.renderBlock}
+                renderInline={myPlugin.renderInline}
+                onChange={myPlugin.onChange}
+            />
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up of #36349
It's basically the exact same solution to the exact same problem, so I'll repost the summary of the other PR here.

Both [the docs (see example code)][1] and [the source][2] show that the `plugins` constructor argument can be a nested list of plugins. I'd even argue that this is quite pivotal when it comes to composing atomic behaviors to something more specific. 

As for the names of the intermediate types, I'm not super-opinionated here. Just let me know if you'd like to have them changed.   
   
[1]: https://docs.slatejs.org/guides/plugins#feature-plugins
[2]: https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/controllers/editor.js#L645-L649

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docs][1], [source][2]
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
