### PR TITLE
Add type definition for leaflet-deepzoom

### DIFF
--- a/types/leaflet-deepzoom/index.d.ts
+++ b/types/leaflet-deepzoom/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for leaflet-deepzoom 2.0
+// Project: https://github.com/alfarisi/leaflet-deepzoom/
+// Definitions by: Håkon Løvdal <https://github.com/hlovdal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+    namespace TileLayer {
+        interface DeepZoomOptions {
+            width?: number;
+            height?: number;
+            imageFormat?: string;
+            tileSize?: number;
+            maxZoom?: number;
+        }
+
+        class DeepZoom extends TileLayer {
+            constructor(urlTemplate: string, options?: DeepZoomOptions);
+            // getTileUrl(tilePoint: Coords): string;
+        }
+    }
+
+    namespace tileLayer {
+        function deepzoom(urlTemplate: string, options?: TileLayer.DeepZoomOptions): TileLayer.DeepZoom;
+    }
+}

--- a/types/leaflet-deepzoom/leaflet-deepzoom-tests.ts
+++ b/types/leaflet-deepzoom/leaflet-deepzoom-tests.ts
@@ -1,0 +1,8 @@
+import * as L from 'leaflet';
+import 'leaflet-deepzoom';
+
+const map = L.map('image2d').setView(new L.LatLng(0, 0), 0);
+const dzLayer = L.tileLayer.deepzoom('DeepZoomImage/hubble_files/', {
+    width: 2400,
+    height: 3000,
+}).addTo(map);

--- a/types/leaflet-deepzoom/tsconfig.json
+++ b/types/leaflet-deepzoom/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "leaflet-deepzoom-tests.ts"
+    ]
+}

--- a/types/leaflet-deepzoom/tslint.json
+++ b/types/leaflet-deepzoom/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type definitions for https://github.com/alfarisi/leaflet-deepzoom/, https://www.npmjs.com/package/leaflet-deepzoom. The `leaflet-deepzoom-tests.ts` file is based on https://github.com/alfarisi/leaflet-deepzoom/blob/master/example/example.html.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

