### PR TITLE
[Bootstrap-3-Typeahead] change type of item param of Options.afterselect to any

### DIFF
--- a/types/bootstrap-3-typeahead/index.d.ts
+++ b/types/bootstrap-3-typeahead/index.d.ts
@@ -66,7 +66,7 @@ declare namespace Bootstrap3Typeahead {
         /**
          * Call back function to execute after selected an item
          */
-        afterSelect?: (item: any) => void;
+        afterSelect?: (item: string|object) => void;
 
         /**
          * Adds a delay between lookups

--- a/types/bootstrap-3-typeahead/index.d.ts
+++ b/types/bootstrap-3-typeahead/index.d.ts
@@ -66,7 +66,7 @@ declare namespace Bootstrap3Typeahead {
         /**
          * Call back function to execute after selected an item
          */
-        afterSelect?: (item: string) => void;
+        afterSelect?: (item: any) => void;
 
         /**
          * Adds a delay between lookups


### PR DESCRIPTION
The item passed in to the afterSelect callback will be whatever was passed to the callback of the source function, so it needs to have the same type - currently it is hard coded to string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Options](https://github.com/bassjobsen/Bootstrap-3-Typeahead#options)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
