### PR TITLE
[styled-components] Apply forwarded as property definition

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -190,6 +190,7 @@ export interface StyledComponentBase<
              * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
              */
             as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+            forwardedAs?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
         }
     ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
 

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -7,6 +7,7 @@
 //                 Jason Killian <https://github.com/jkillian>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 David Ruisinger <https://github.com/flavordaaave>
+//                 Sota Ohara <https://github.com/sottar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -202,9 +203,7 @@ export interface StyledComponentBase<
         O & StyledComponentInnerOtherProps<WithC>,
         A | StyledComponentInnerAttrs<WithC>
     >;
-    withComponent<
-        WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-    >(
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
         component: WithC
     ): StyledComponent<WithC, T, O, A>;
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1049,10 +1049,23 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => props.kind === 'book' ? 16 : 14};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
     <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
+}
+
+/* forwardedAs test */
+function forwardedAsTest() {
+    const ChildComponent = () => <div>foo</div>;
+    const StyledChildComponent = styled(ChildComponent)``;
+    const ParentComponent = () => (
+        <>
+            <StyledChildComponent as="p" />
+            <StyledChildComponent as="a" />
+        </>
+    );
+    const Error = () => <StyledChildComponent as="string" />; // $ExpectError
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.styled-components.com/docs/api#forwardedas-prop>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
