### PR TITLE
[webpack] Add publicPath to SourceMapDevToolPlugin.Options

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1583,6 +1583,7 @@ declare namespace webpack {
             module?: boolean;
             moduleFilenameTemplate?: string;
             noSources?: boolean;
+            publicPath?: string;
             sourceRoot?: null | string;
             test?: Condition | Condition[];
         }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Tests fails with the following on master.  Seems like it shouldn't block this change.
```
Error: Errors in typescript@next for external dependencies:
../uglify-js/index.d.ts(9,30): error TS7016: Could not find a declaration file for module 'source-map'. 'C:/Users/alexpo/code/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm install @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
```

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/plugins/source-map-dev-tool-plugin/
- [ ] Increase the version number in the header if appropriate.