### PR TITLE
@types/draft-js fix mixed immutable version problem

### DIFF
--- a/types/braft-editor/index.d.ts
+++ b/types/braft-editor/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for braft-editor 1.9
 // Project: https://github.com/margox/braft#readme
 // Definitions by: Jonny Yao <https://github.com/petitspois>
+//                 Munif Tanjim <https://github.com/MunifTanjim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from "react";
 import { RawDraftContentState } from 'draft-js';

--- a/types/draft-convert/index.d.ts
+++ b/types/draft-convert/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for draft-convert v2.1.5
 // Project: https://github.com/HubSpot/draft-convert
 // Definitions by: Agustin Valeriani <https://github.com/avaleriani/>
+//                 Munif Tanjim <https://github.com/MunifTanjim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 // Based on: https://github.com/HubSpot/draft-convert/issues/107#issuecomment-488581709 by <https://github.com/sbusch>
 declare module 'draft-convert' {

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -13,7 +13,7 @@
 //                 Kevin Hawkinson <https://github.com/khawkinson>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from 'react';
 import * as Immutable from 'immutable';

--- a/types/draft-js/package.json
+++ b/types/draft-js/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "immutable": "^3.8.1"
+        "immutable": "~3.7.4"
     }
 }

--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -3,8 +3,9 @@
 // Definitions by: imechZhangLY <https://github.com/imechZhangLY>
 //                 brunoMaurice <https://github.com/brunoMaurice>
 //                 ldanet <https://github.com/ldanet>
+//                 Munif Tanjim <https://github.com/MunifTanjim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import * as React from 'react';
 import * as Draft from 'draft-js';
@@ -67,7 +68,12 @@ export interface EditorProps {
     wrapperId?: number;
     customDecorators?: object[];
     editorRef?(ref: object): void;
-    handlePastedText?(text: string, html: string, editorState: EditorState, onChange: (editorState: EditorState) => void): boolean;
+    handlePastedText?(
+        text: string,
+        html: string,
+        editorState: EditorState,
+        onChange: (editorState: EditorState) => void
+    ): boolean;
 }
 
 export class Editor extends React.Component<EditorProps> {

--- a/types/react-rte/index.d.ts
+++ b/types/react-rte/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for react-rte 0.16
 // Project: https://github.com/sstur/react-rte
 // Definitions by: jclyons52 <https://github.com/jclyons52>
+//                 Munif Tanjim <https://github.com/MunifTanjim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import { Component, ReactNode } from "react";
 import { ContentBlock, EditorState } from "draft-js";


### PR DESCRIPTION
| Package | Dependency | Dependency Semver |
| ------------ | ----------------- | --------------------------- |
| `draft-js` | `immutable` | `~3.7.4` |
| `@types/draft-js` | `immutable` | `^3.8.1` |

This causes the following error:

```
The inferred type of '...' cannot be named without a reference to 'draft-js/node_modules/immutable'. This is likely not portable. A type annotation is necessary.ts(2742)
```

Relatated issue details: microsoft/TypeScript#29808

This PR aims to solve that by using the semver `~3.7.4` for `immutable` in `@types/draft-js`.

I also had to bump the `TypeScript Version` to `2.9` for the following packages:
- `@types/draft-js`
- `@types/braft-editor`
- `@types/draft-convert`
- `@types/react-draft-wysiwyg`
- `@types/react-rte`

I don't know if there's any better way to resolve this. I'm open to suggestions.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
