### PR TITLE
add onEscapeKeyDown type to Modal

### DIFF
--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -28,7 +28,8 @@ declare namespace Modal {
         enforceFocus?: boolean;
         keyboard?: boolean;
         onBackdropClick?: (node: HTMLElement) => any;
-        onEscapeKeyUp?: (node: HTMLElement) => any;
+        onEscapeKeyDown?: (node: HTMLElement) => any;
+        onEscapeKeyUp?: (node: HTMLElement) => any; // deprecated, use onEscapeKeyDown
         onShow?: (node: HTMLElement) => any;
         show?: boolean;
         transition?: React.ReactElement;

--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -29,7 +29,10 @@ declare namespace Modal {
         keyboard?: boolean;
         onBackdropClick?: (node: HTMLElement) => any;
         onEscapeKeyDown?: (node: HTMLElement) => any;
-        onEscapeKeyUp?: (node: HTMLElement) => any; // deprecated, use onEscapeKeyDown
+        /**
+         * @deprecated since Sept 25, 2017, use onEscapeKeyDown instead
+         **/
+        onEscapeKeyUp?: (node: HTMLElement) => any;
         onShow?: (node: HTMLElement) => any;
         show?: boolean;
         transition?: React.ReactElement;


### PR DESCRIPTION
onEscapeKeyUp is deprecated in favor of onEscapeKeyDown.  React-bootstrap provides a console warning about this, yet there is no onEscapeKeyDown in @types/react-bootstrap so I'm adding it here.