### PR TITLE
[@types/gapi] Update Docs with updated Google API Client webpage/owner

### DIFF
--- a/types/gapi/index.d.ts
+++ b/types/gapi/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Google API Client 0.0
-// Project: https://code.google.com/p/google-api-javascript-client/
-// Definitions by: Frank M <https://github.com/sgtfrankieboy>
+// Type definitions for Google API Client
+// Project: https://github.com/google/google-api-javascript-client
+// Definitions by: Frank M <https://github.com/sgtfrankieboy>, grant <https://github.com/grant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
# [@types/gapi] Update Docs with updated Google API Client webpage/owner

This change removes the link Google Code (a deprecated project) and adds `grant` as a maintainer of the types (currently maintainer of the client).

https://github.com/google/google-api-javascript-client

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google/google-api-javascript-client
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.