### PR TITLE
Move ExpectError in hummus-recipe tests

### DIFF
--- a/types/hummus-recipe/hummus-recipe-tests.ts
+++ b/types/hummus-recipe/hummus-recipe-tests.ts
@@ -18,8 +18,7 @@ newDoc
     .endPDF();
 
 // $ExpectError
-newDoc
-    .createPage("A4")
+newDoc.createPage("A5")
     .text("Memento Mori", 100, 100)
     .endPage()
     .endPDF();


### PR DESCRIPTION
TS3.6 moves the location of 'wrong number of parameters' error for property accesses. This change makes the tests work with all versions of Typescript.
