### PR TITLE
papaparse: add transformHeader option

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for PapaParse v4.5
+// Type definitions for PapaParse v5.0
 // Project: https://github.com/mholt/PapaParse
 // Definitions by: Pedro Flemming <https://github.com/torpedro>
 //                 Rain Shen <https://github.com/rainshen49>
@@ -110,6 +110,7 @@ export interface ParseConfig {
     chunk?(results: ParseResult, parser: Parser): void; // default: undefined
     beforeFirstChunk?(chunk: string): string | void; // default: undefined
     transform?(value: string, field: string | number): any; // default: undefined
+    transformHeader?(header: string): string; // default: undefined
 }
 
 export interface UnparseConfig {

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -45,7 +45,10 @@ var file = new File(null, null, null);
 
 Papa.parse(file, {
     transform: function(value, field) {},
-    complete: function(a, b) {
+    transformHeader: function(header) {
+        return header;
+    },
+    complete: function (a, b) {
         a.meta.fields;
         b.name;
     },


### PR DESCRIPTION
Version 5 introduces a new option `transformHeader`.

See https://www.papaparse.com/docs#config

This PR also includes a fix for TS@next from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36470

