### PR TITLE
[@types/mongoose] Property 'disconnected' does not exist on type 'ConnectionStates'.

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -403,7 +403,7 @@ declare module "mongoose" {
     static STATES: ConnectionStates;
   }
 
-  enum ConnectionStates {
+  export enum ConnectionStates {
     disconnected = 0,
     connected = 1,
     connecting = 2,


### PR DESCRIPTION
When attempting to use `STATES` in user-land, the user will receive an error like `Property 'disconnected' does not exist on type 'ConnectionStates'.`

For example:
```
import mongoose from 'mongoose';
console.log(mongoose.STATES.disconnected);
                            ^^^^^^^^^^^^^
                            Property 'disconnected' does not exist on type 'ConnectionStates'.
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
