### PR TITLE
[hapi-pino] Support scoped Hapi package, update for 6.x

### DIFF
--- a/types/hapi-pino/hapi-pino-tests.ts
+++ b/types/hapi-pino/hapi-pino-tests.ts
@@ -1,4 +1,4 @@
-import { Server } from 'hapi';
+import { Server } from '@hapi/hapi';
 import * as pino from 'pino';
 import * as HapiPino from 'hapi-pino';
 

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,24 +1,24 @@
-// Type definitions for hapi-pino 5.2
+// Type definitions for hapi-pino 6.0
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
+//                 Todd Bealmear <https://github.com/todd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 /// <reference types='node' />
 
-import {
-    Plugin,
-} from 'hapi';
 import * as pino from 'pino';
 
-declare module 'hapi' {
-interface Server {
-    logger: () => pino.Logger;
-}
+import { Plugin } from '@hapi/hapi';
 
-interface Request {
-    logger: pino.Logger;
-}
+declare module '@hapi/hapi' {
+    interface Server {
+        logger: () => pino.Logger;
+    }
+
+    interface Request {
+        logger: pino.Logger;
+    }
 }
 
 declare namespace HapiPino {

--- a/types/hapi-pino/tsconfig.json
+++ b/types/hapi-pino/tsconfig.json
@@ -14,7 +14,33 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@hapi/hapi": [
+                "hapi__hapi"
+            ],
+            "@hapi/boom": [
+                "hapi__boom"
+            ],
+            "@hapi/shot": [
+                "hapi__shot"
+            ],
+            "@hapi/mimos": [
+                "hapi__mimos"
+            ],
+            "@hapi/iron": [
+                "hapi__iron"
+            ],
+            "@hapi/joi": [
+                "hapi__joi"
+            ],
+            "@hapi/podium": [
+                "hapi__podium"
+            ],
+            "@hapi/catbox": [
+                "hapi__catbox"
+            ]
+        }
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Hapi-pino 6.x only supports 17.x and 18.x, which are supported under the new scoped `@hapi/hapi` package. This PR drops support for the legacy package and adds support for the new scoped package.