### PR TITLE
[ol] Mark TransformFunction parameters optional

### DIFF
--- a/types/ol/proj.d.ts
+++ b/types/ol/proj.d.ts
@@ -25,4 +25,4 @@ export function transform(coordinate: Coordinate, source: ProjectionLike, destin
 export function transformExtent(extent: Extent, source: ProjectionLike, destination: ProjectionLike): Extent;
 export function transformWithProjections(point: Coordinate, sourceProjection: Projection, destinationProjection: Projection): Coordinate;
 export type ProjectionLike = Projection | string;
-export type TransformFunction = ((param0: number[], param1: number[], param2: number) => number[]);
+export type TransformFunction = ((input: number[], opt_output?: number[], opt_dimension?: number) => number[]);


### PR DESCRIPTION
The `output` and `dimension` parameters are optionals in the TransformFunction definition.
See https://github.com/openlayers/openlayers/blob/v5.3.1/src/ol/proj.js#L75-L83

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
