### PR TITLE
Update acquire() and lock() to support multi locks

### DIFF
--- a/types/redlock/index.d.ts
+++ b/types/redlock/index.d.ts
@@ -55,8 +55,8 @@ declare class Redlock extends EventEmitter {
 
     constructor(clients: Redlock.CompatibleRedisClient[], options?: Redlock.Options);
 
-    acquire(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
-    lock(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
+    acquire(resource: string | string[], ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
+    lock(resource: string | string[], ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
 
     disposer(resource: string, ttl: number, errorHandler?: Redlock.Callback<void>): Promise.Disposer<Redlock.Lock>;
 


### PR DESCRIPTION
https://github.com/mike-marcacci/node-redlock#api-docs

Redlock.prototype.lock(resource, ttl, ?callback) => Promise<Lock>

    resource (string or string[]) resource(s) to be locked
    ttl (number) time in ms until the lock expires
    callback (function) callback returning:
        err (Error)
        lock (Lock)
