### PR TITLE
[electron-packager] Add all electron-osx-sign options

### DIFF
--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -5,6 +5,7 @@
 //                 John Kleinschmidt <https://github.com/jkleinsc>
 //                 Brendan Forster <https://github.com/shiftkey>
 //                 Mark Lee <https://github.com/malept>
+//                 Florian Keller <https://github.com/ffflorian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -57,9 +58,19 @@ declare namespace electronPackager {
     }
 
     interface ElectronOsXSignOptions {
-        identity?: string;
         entitlements?: string;
         "entitlements-inherit"?: string;
+        "gatekeeper-assess"?: boolean;
+        // see https://github.com/electron-userland/electron-packager/blob/92d09bba34599283a794fd6f24b88470f0cb1074/src/mac.js#L359
+        identity?: string | true;
+        "identity-validation"?: boolean;
+        ignore?: string;
+        keychain?: string;
+        "pre-auto-entitlements"?: boolean;
+        "pre-embed-provisioning-profile"?: boolean;
+        "provisioning-profile"?: string;
+        requirements?: string;
+        type?: string;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/electron-userland/electron-osx-sign/blob/master/index.d.ts#L26
  - https://github.com/electron-userland/electron-packager/blob/master/src/mac.js#L10
  - https://github.com/electron-userland/electron-packager/blob/master/src/mac.js#L293
  - https://github.com/electron-userland/electron-packager/blob/master/src/mac.js#L346
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
