### PR TITLE
fix the type of ShallowRenderer.render's return

### DIFF
--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -14,9 +14,10 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
+     * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): void;
+    render(element: ReactElement, context?: any): ReactElement;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -17,7 +17,7 @@ export interface ShallowRenderer {
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
      * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): ReactElement;
+    render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -17,7 +17,7 @@ export interface ShallowRenderer {
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
      * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): void | ReactElement;
+    render(element: ReactElement, context?: any): ReactElement;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -14,8 +14,8 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
-     * and returns shallowly rendered output.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
+     * It usually returns shallowly rendered output and return void when rendering.
      */
     render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -14,8 +14,8 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
-     * It usually returns shallowly rendered output and return void when rendering.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
+     * and returns shallowly rendered output.
      */
     render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -10,8 +10,8 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
-     * and returns shallowly rendered output.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
+     * It usually returns shallowly rendered output and return void when rendering.
      */
     render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -10,8 +10,8 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
-     * It usually returns shallowly rendered output and return void when rendering.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
+     * and returns shallowly rendered output.
      */
     render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -13,7 +13,7 @@ export interface ShallowRenderer {
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
      * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): ReactElement;
+    render(element: ReactElement, context?: any): void | ReactElement;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -10,9 +10,10 @@ export interface ShallowRenderer {
      */
     getRenderOutput(): ReactElement;
     /**
-     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
+     * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
+     * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): void;
+    render(element: ReactElement, context?: any): ReactElement;
     unmount(): void;
 }
 

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -13,7 +13,7 @@ export interface ShallowRenderer {
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep,
      * and returns shallowly rendered output.
      */
-    render(element: ReactElement, context?: any): void | ReactElement;
+    render(element: ReactElement, context?: any): ReactElement;
     unmount(): void;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
v15:<https://github.com/facebook/react/blob/v15.6.2/src/renderers/testing/ReactShallowRenderer.js>; v16:<https://github.com/facebook/react/blob/master/packages/react-test-renderer/src/ReactShallowRenderer.js>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

```javascript
// source code for v16
render(element: ReactElement | null, context: null | Object = emptyObject) {
  ...
  return this.getRenderOutput();
}
```
