### PR TITLE
Fix linting types which should be optional

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1456,7 +1456,7 @@ declare namespace CodeMirror {
      * linter.
      */
     interface LintOptions extends LintStateOptions {
-        getAnnotations: Linter | AsyncLinter;
+        getAnnotations?: Linter | AsyncLinter;
     }
 
     /**

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1447,7 +1447,7 @@ declare namespace CodeMirror {
      */
     interface LintStateOptions {
         async?: boolean;
-        hasGutters: boolean;
+        hasGutters?: boolean;
         onUpdateLinting?: (annotationsNotSorted: Annotation[], annotations: Annotation[], codeMirror: Editor) => void;
     }
 

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1446,7 +1446,7 @@ declare namespace CodeMirror {
      * initialization of the CodeMirror instance.
      */
     interface LintStateOptions {
-        async: boolean;
+        async?: boolean;
         hasGutters: boolean;
         onUpdateLinting?: (annotationsNotSorted: Annotation[], annotations: Annotation[], codeMirror: Editor) => void;
     }


### PR DESCRIPTION
This PR fixes some of the linting types which are incorrectly typed as being required.

CC: @mihailik, @nrbernard

## Template
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Sources to the code are in each individual commit
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
