### PR TITLE
[@types/yup] Fixed array.compact rejector type

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -210,7 +210,13 @@ interface BasicArraySchema<T extends any[] | null | undefined>
     min(limit: number | Ref, message?: TestOptionsMessage): this;
     max(limit: number | Ref, message?: TestOptionsMessage): this;
     ensure(): this;
-    compact(rejector?: (value: T, index: number, array: T[]) => boolean): this;
+    compact(
+        rejector?: (
+            value: InferredArrayType<T>,
+            index: number,
+            array: Array<InferredArrayType<T>>
+        ) => boolean
+    ): this;
 }
 
 export interface NotRequiredNullableArraySchema<T>
@@ -506,3 +512,4 @@ type KeyOfUndefined<T> = {
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> = NotRequiredProps<T> & RequiredProps<T>;
+type InferredArrayType<T> = T extends Array<infer U> ? U : T;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -352,6 +352,15 @@ arrSchema.min(5, 'min');
 arrSchema.min(5, () => 'min');
 arrSchema.compact((value, index, array) => value === array[index]);
 
+const arrOfObjSchema = yup.array().of(
+    yup.object().shape({
+        field: yup.number()
+    })
+);
+arrOfObjSchema.compact((value, index, array) => {
+    return value.field > 10 && array[index].field > 10;
+});
+
 const arr = yup.array();
 const top = (<T>(x?: T): T => x!)();
 const validArr: yup.ArraySchema<typeof top> = arr;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup#arraycompactrejector-value--boolean-schema
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This fixes a bug that appeared in 0.26.17. Since type variable T in `BasicArraySchema` now extends `any[] | null | undefined` (before it was `ArraySchema<T> extends Schema<T[]>`), rejector function in `compact` method always had an array as a first parameter and an array of arrays as the last parameter. This commit fixes this issue. There's a couple of ways to fix this, if you feel like there's a better way to do that, let me know in the review.