### PR TITLE
[serialport] Add error nullability

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -21,12 +21,12 @@ declare class SerialPort extends Stream.Duplex {
 	open(callback?: SerialPort.ErrorCallback): void;
 	update(options: SerialPort.UpdateOptions, callback?: SerialPort.ErrorCallback): void;
 
-	write(data: string| number[] | Buffer, callback?: (error: any, bytesWritten: number) => void): boolean;
-	write(buffer: string| number[] | Buffer, encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex', callback?: (error: any, bytesWritten: number) => void): boolean;
+	write(data: string| number[] | Buffer, callback?: (error: Error | null | undefined, bytesWritten: number) => void): boolean;
+	write(buffer: string| number[] | Buffer, encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex', callback?: (error: Error | null | undefined, bytesWritten: number) => void): boolean;
 
 	read(size?: number): string | Buffer | null;
 
-	close(callback?: (error: Error) => void): void;
+	close(callback?: (error?: Error | null) => void): void;
 
 	set(options: SerialPort.SetOptions, callback?: SerialPort.ErrorCallback): void;
 	get(callback?: SerialPort.ModemBitsCallback): void;
@@ -46,9 +46,9 @@ declare class SerialPort extends Stream.Duplex {
 
 declare namespace SerialPort {
 	// Callbacks Type Defs
-	type ErrorCallback = (error: Error) => void;
-	type ModemBitsCallback = (error: Error, status: {cts: boolean, dsr: boolean, dcd: boolean }) => void;
-	type ListCallback = (error: Error, port: any[]) => void;
+	type ErrorCallback = (error?: Error | null) => void;
+	type ModemBitsCallback = (error: Error | null | undefined, status: {cts: boolean, dsr: boolean, dcd: boolean }) => void;
+	type ListCallback = (error: Error | null | undefined, ports: any[]) => void;
 
 	// Options Type Defs
 	interface OpenOptions {

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -136,7 +136,7 @@ function test_properties() {
 function test_list_ports_promise() {
     const ports = SerialPort
         .list()
-        .then((ports: any) => {})
+        .then((ports: SerialPort.PortInfo[]) => {})
         .catch((err: Error) => {});
 }
 

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -8,7 +8,7 @@ function test_basic_connect() {
 
 function test_connect_config() {
     const port1 = new SerialPort('', {
-        }, (error: Error) => {});
+        }, error => {});
 
     const port4 = new SerialPort('', {
             autoOpen: false,
@@ -25,7 +25,13 @@ function test_connect_config() {
                 vmin: 1,
                 vtime: 1
             }
-        }, (error: Error) => {});
+        },
+        error => {
+            if (error !== null) {
+                console.error(error);
+            }
+        }
+    );
 }
 
 function test_open() {
@@ -41,8 +47,8 @@ function test_update() {
 function test_write() {
     const port = new SerialPort('');
 
-    port.write('test', (error: Error) => {});
-    port.write('test', 'utf8', (error: Error) => {});
+    port.write('test', (error?: Error | null) => {});
+    port.write('test', 'utf8', (error?: Error | null) => {});
 }
 
 function test_read() {
@@ -54,13 +60,13 @@ function test_read() {
 function test_close() {
     const port = new SerialPort('');
 
-    port.close((error: Error) => {});
+    port.close((error?: Error | null) => {});
 }
 
 function test_set() {
     const port = new SerialPort('');
 
-    port.set({}, (error: Error) => {});
+    port.set({}, (error?: Error | null) => {});
 }
 
 function test_get() {
@@ -72,13 +78,13 @@ function test_get() {
 function test_flush() {
     const port = new SerialPort('');
 
-    port.flush((error: Error) => {});
+    port.flush((error?: Error | null) => {});
 }
 
 function test_drain() {
     const port = new SerialPort('');
 
-    port.drain((error: Error) => {});
+    port.drain((error?: Error | null) => {});
 }
 
 function test_pause_resume() {
@@ -135,5 +141,5 @@ function test_list_ports_promise() {
 }
 
 function test_list_ports_callback() {
-    const ports = SerialPort.list((error: Error, port: any[]) => {});
+    const ports = SerialPort.list((error: Error | null | undefined, ports: any[]) => {});
 }

--- a/types/serialport/tslint.json
+++ b/types/serialport/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-type-predicates": true
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://serialport.io/docs/guide-usage (see `function(err)`)
  - https://github.com/serialport/node-serialport/blob/ef80d830804b0bf22d37c13d19eaa674800f9691/packages/serialport/test/integration.js#L55
  - Most methods are inherited from Node stream and according to types that means that the err parameter can be null or undefined.