### PR TITLE
Add WindowOrWorkerGlobalScope.fetch

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -31,6 +31,10 @@ declare interface GlobalFetch {
 
 declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 
+declare interface WindowOrWorkerGlobalScope {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
 interface Blob {}
 
 declare class FormData {

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -1,4 +1,4 @@
-const fetchCopy: GlobalFetch["fetch"] = fetch;
+const fetchCopy: WindowOrWorkerGlobalScope["fetch"] = fetch;
 
 const myHeaders = new Headers();
 myHeaders.append("Content-Type", "image/jpeg");


### PR DESCRIPTION
This is compatible with TS3.6 and above, which remove GlobalFetch.

I didn't remove GlobalFetch from react-native, though, since I want it to be compatible with lower versions of typescript.