### PR TITLE
[classnames] improve types for `classnames/bind` and add types for `classnames/dedupe`

### DIFF
--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -3,6 +3,9 @@ import { ClassNamesFn } from './types';
 interface ClassNamesBind extends ClassNamesFn {
     bind(styles: Record<string, string>): ClassNamesFn;
 }
-declare const classNamesBind: ClassNamesBind;
+type ClassNamesBindExport = ClassNamesBind & {
+    default: ClassNamesBind;
+};
+declare const classNamesBind: ClassNamesBindExport;
 
 export = classNamesBind;

--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -1,3 +1,8 @@
-import classNames = require('./index');
+import { ClassNamesFn } from './types';
 
-export function bind(styles: Record<string, string>): typeof classNames;
+interface ClassNamesBind extends ClassNamesFn {
+    bind(styles: Record<string, string>): ClassNamesFn;
+}
+declare const classNamesBind: ClassNamesBind;
+
+export = classNamesBind;

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -17,7 +17,7 @@ classNames(['foo', 'bar', 'baz']); // => 'foo bar baz'
 classNames([1, 2, 3]); // => '1 2 3'
 classNames([{ foo: true, bar: false }, { baz: true }]); // => 'foo baz'
 
-classNames(["foo", ["bar", {baz: true}]]); // => 'foo bar baz'
+classNames(['foo', ['bar', { baz: true }]]); // => 'foo bar baz'
 
 // falsey values are just ignored
 classNames(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
@@ -28,9 +28,9 @@ classNames(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
 // Support for CSS-Modules. Example from README:
 // https://github.com/JedWatson/classnames/blob/master/README.md#alternate-bind-version-for-css-modules
 const styles = {
-  foo: 'abc',
-  bar: 'def',
-  baz: 'xyz'
+    foo: 'abc',
+    bar: 'def',
+    baz: 'xyz',
 };
 
 const cx = cn.bind(styles);
@@ -40,4 +40,7 @@ const className = cx('foo', ['bar'], { baz: true }); // => "abc def xyz"
 cx(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
 
 // true is just ignored
-cx(true || "foo");
+cx(true || 'foo');
+
+// export of classnames/bind can be used the same as normal classnames
+cn(null, 'bar', undefined, 1, ['foo', 'bar', { baz: true }], '');

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -1,6 +1,8 @@
 import classNames = require('classnames');
 import * as classNames2 from 'classnames';
 import * as cn from 'classnames/bind';
+import classNamesDedupe = require('classnames/dedupe');
+import * as classNamesDedupe2 from 'classnames/dedupe';
 
 classNames2('foo', 'bar'); // => 'foo bar'
 
@@ -44,3 +46,7 @@ cx(true || 'foo');
 
 // export of classnames/bind can be used the same as normal classnames
 cn(null, 'bar', undefined, 1, ['foo', 'bar', { baz: true }], '');
+
+// classnames/dedupe has same usage as normal classnames
+classNamesDedupe('foo', { bar: true, duck: false }, 'baz', { quux: true }); // => 'foo bar baz quux'
+classNamesDedupe2('foo', { bar: true, duck: false }, 'baz', { quux: true }); // => 'foo bar baz quux'

--- a/types/classnames/dedupe.d.ts
+++ b/types/classnames/dedupe.d.ts
@@ -1,0 +1,5 @@
+import { ClassNamesExport } from './types';
+
+declare const classNamesDedupe: ClassNamesExport;
+
+export = classNamesDedupe;

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -7,6 +7,7 @@
 //                 Michal Adamczyk <https://github.com/mradamczyk>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Josh McCullough <https://github.com/joshmccullough>
+//                 uhyo <https://github.com/uhyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -10,9 +10,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { ClassValue, ClassNamesFn } from './types';
-
-type ClassNamesExport = ClassNamesFn & { default: ClassNamesFn };
+import { ClassValue, ClassNamesExport } from './types';
 
 declare const classNames: ClassNamesExport;
 

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -10,9 +10,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { ClassValue } from './types';
-
-type ClassNamesFn = (...classes: ClassValue[]) => string;
+import { ClassValue, ClassNamesFn } from './types';
 
 type ClassNamesExport = ClassNamesFn & { default: ClassNamesFn };
 

--- a/types/classnames/tsconfig.json
+++ b/types/classnames/tsconfig.json
@@ -19,6 +19,7 @@
     "files": [
         "index.d.ts",
         "bind.d.ts",
+        "dedupe.d.ts",
         "types.d.ts",
         "classnames-tests.ts"
     ]

--- a/types/classnames/types.d.ts
+++ b/types/classnames/types.d.ts
@@ -1,9 +1,11 @@
 // This is the only way I found to break circular references between ClassArray and ClassValue
 // https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
-export interface ClassArray extends Array<ClassValue> { } // tslint:disable-line no-empty-interface
+export interface ClassArray extends Array<ClassValue> {} // tslint:disable-line no-empty-interface
 
 export interface ClassDictionary {
-	[id: string]: any;
+    [id: string]: any;
 }
 
 export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | boolean;
+
+export type ClassNamesFn = (...classes: ClassValue[]) => string;

--- a/types/classnames/types.d.ts
+++ b/types/classnames/types.d.ts
@@ -9,3 +9,5 @@ export interface ClassDictionary {
 export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | boolean;
 
 export type ClassNamesFn = (...classes: ClassValue[]) => string;
+
+export type ClassNamesExport = ClassNamesFn & { default: ClassNamesFn };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [bind](https://github.com/JedWatson/classnames/blob/master/tests/bind.js) [dedupe](https://github.com/JedWatson/classnames/blob/master/tests/dedupe.js)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## description

This PR improves the definition of `classnames/bind` so that the export of `classnames/bind` can be used in the same way as normal `classnames` without calling `bind()`.

Also this PR adds `classnames/dedupe` definiton which has been missing.

Some types defined in `index.d.ts` are moved to `types.d.ts` so that they can be reused by `bind.d.ts` and `dedupe.d.ts`.