### PR TITLE
styletron-react: add missing injected component props

### DIFF
--- a/types/styletron-react/index.d.ts
+++ b/types/styletron-react/index.d.ts
@@ -57,7 +57,16 @@ export interface Styletron {
     };
 }
 
-export type StyletronComponent<Props> = React.FC<Props> & {
+export type StyleObjectFn<P extends object> = (props: P) => StyleObject;
+
+export type $StyleProp<P extends object> = StyleObject | StyleObjectFn<P>;
+
+export interface StyletronComponentInjectedProps<P extends object> {
+    $as?: StyletronBase;
+    $style?: $StyleProp<P>;
+}
+
+export type StyletronComponent<P extends object> = React.FC<P & StyletronComponentInjectedProps<P>> & {
     __STYLETRON__: Styletron;
 };
 
@@ -173,6 +182,10 @@ export const withTransform: WithTransformFn;
 
 export const withStyleDeep: WithStyleFn;
 
+/**
+ * Aliases to withStyleDeep()
+ * @deprecated use withStyleDeep()
+ */
 export const withStyle: typeof withStyleDeep;
 
 export const withWrapper: WithWrapperFn;

--- a/types/styletron-react/styletron-react-tests.tsx
+++ b/types/styletron-react/styletron-react-tests.tsx
@@ -56,6 +56,16 @@ const DynamicStyledComplexButton = styled(
 
 <DynamicStyledComplexButton $fraction={Math.random()} isDisabled />;
 
+// Allows $as prop
+<BasicStyled $as="button" />;
+
+// Allows $style prop
+<BasicStyled $style={{ color: 'blue' }} />;
+
+const $styleFn = (props: DynamicStyledProps) => ({ color: props.$fraction < 0.2 ? 'red' : 'green' });
+
+<DynamicStyled $style={$styleFn} $fraction={Math.random()} />;
+
 // withStyle()
 // --------------------------
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/styletron/styletron/releases/tag/styletron-react%405.0.0
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Added note to `withStyle` definition being deprecated in favor of `withStyleDeep`.
Added `$as` and `$style` injected props to `StyletronComponent` definition.
