### PR TITLE
papaparse: Declare parse/unparse overloads all at once

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -18,22 +18,15 @@ export as namespace Papa;
 /**
  * Parse a csv string, a csv file or a readable stream
  */
-export function parse(csvString: string, config?: ParseConfig): ParseResult;
-
-export function parse(file: File, config?: ParseConfig): ParseResult;
-
-export function parse(stream: NodeJS.ReadableStream, config?: ParseConfig): ParseResult;
-
-export function parse(stream: NODE_STREAM_INPUT_TYPE, config?: ParseConfig): NodeJS.ReadWriteStream;
+export const parse: {
+    (input: string | File | NodeJS.ReadableStream, config?: ParseConfig): ParseResult;
+    (stream: NODE_STREAM_INPUT_TYPE, config?: ParseConfig): NodeJS.ReadWriteStream;
+};
 
 /**
  * Unparses javascript data objects and returns a csv string
  */
-export function unparse(data: Array<Object>, config?: UnparseConfig): string;
-
-export function unparse(data: Array<Array<any>>, config?: UnparseConfig): string;
-
-export function unparse(data: UnparseObject, config?: UnparseConfig): string;
+export const unparse: (data: Array<Object> | Array<Array<any>> | UnparseObject, config?: UnparseConfig) => string;
 
 /**
  * Read-Only Properties
@@ -77,7 +70,6 @@ export let DefaultDelimiter: string;
  * I have included the API for this class.
  */
 export class Parser {
-
     constructor(config: ParseConfig);
 
     parse(input: string, baseIndex: number, ignoreLastRow: boolean): any;
@@ -93,37 +85,40 @@ export class Parser {
 }
 
 export interface ParseConfig {
-    delimiter?: string;            // default: ","
-    newline?: string;              // default: "\r\n"
-    quoteChar?: string;            // default: '"'
-    header?: boolean;              // default: false
-    trimHeaders?: boolean;         // default: false
-    dynamicTyping?: boolean | { [headerName: string]: boolean; [columnNumber: number]: boolean;} | ((field: string | number) => boolean); // default: false
-    preview?: number;              // default: 0
-    encoding?: string;             // default: ""
-    worker?: boolean;              // default: false
-    comments?: boolean | string;   // default: false
-    download?: boolean;            // default: false
-    skipEmptyLines?: boolean | 'greedy';      // default: false
-    fastMode?: boolean;            // default: undefined
-    withCredentials?: boolean;     // default: undefined
+    delimiter?: string; // default: ","
+    newline?: string; // default: "\r\n"
+    quoteChar?: string; // default: '"'
+    header?: boolean; // default: false
+    trimHeaders?: boolean; // default: false
+    dynamicTyping?:
+        | boolean
+        | { [headerName: string]: boolean; [columnNumber: number]: boolean }
+        | ((field: string | number) => boolean); // default: false
+    preview?: number; // default: 0
+    encoding?: string; // default: ""
+    worker?: boolean; // default: false
+    comments?: boolean | string; // default: false
+    download?: boolean; // default: false
+    skipEmptyLines?: boolean | 'greedy'; // default: false
+    fastMode?: boolean; // default: undefined
+    withCredentials?: boolean; // default: undefined
 
     // Callbacks
-    step?(results: ParseResult, parser: Parser): void;  // default: undefined
+    step?(results: ParseResult, parser: Parser): void; // default: undefined
     complete?(results: ParseResult, file?: File): void; // default: undefined
-    error?(error: ParseError, file?: File): void;       // default: undefined
+    error?(error: ParseError, file?: File): void; // default: undefined
     chunk?(results: ParseResult, parser: Parser): void; // default: undefined
-    beforeFirstChunk?(chunk: string): string | void;    // default: undefined
+    beforeFirstChunk?(chunk: string): string | void; // default: undefined
     transform?(value: string, field: string | number): any; // default: undefined
 }
 
 export interface UnparseConfig {
-    quotes?: boolean | boolean[];   // default: false
-	quoteChar?: string;             // default: '"'
-	escapeChar?: string;            // default: '"'
-	delimiter?: string;             // default: ","
-	header?: boolean;               // default: true
-	newline?: string;               // default: "\r\n"
+    quotes?: boolean | boolean[]; // default: false
+    quoteChar?: string; // default: '"'
+    escapeChar?: string; // default: '"'
+    delimiter?: string; // default: ","
+    header?: boolean; // default: true
+    newline?: string; // default: "\r\n"
 }
 
 export interface UnparseObject {
@@ -132,18 +127,18 @@ export interface UnparseObject {
 }
 
 export interface ParseError {
-    type: string;     // A generalization of the error
-    code: string;     // Standardized error code
-    message: string;  // Human-readable details
-    row: number;      // Row index of parsed data where error is
+    type: string; // A generalization of the error
+    code: string; // Standardized error code
+    message: string; // Human-readable details
+    row: number; // Row index of parsed data where error is
 }
 
 export interface ParseMeta {
-    delimiter: string;     // Delimiter used
-    linebreak: string;     // Line break sequence used
-    aborted: boolean;      // Whether process was aborted
+    delimiter: string; // Delimiter used
+    linebreak: string; // Line break sequence used
+    aborted: boolean; // Whether process was aborted
     fields: Array<string>; // Array of field names
-    truncated: boolean;    // Whether preview consumed all input
+    truncated: boolean; // Whether preview consumed all input
     cursor: number;
 }
 


### PR DESCRIPTION
There was a problem in TS@next with the TS checker choosing the wrong overload.  Combining all the variants into one declaration seems to fix it.