### PR TITLE
Add wrappedComponentRef prop to react-router withRouter()

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -132,10 +132,20 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(pathn
 
 export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean | undefined }): string;
 
+export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass
+  ? { wrappedComponentRef?: (ref: InstanceType<C> | null) => any }
+  : {};
+
+export interface WithRouterStatics<C extends React.ComponentType<any>> {
+  WrappedComponent: C;
+}
+
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;
+export function withRouter<P extends RouteComponentProps<any>, C extends React.ComponentType<P>>(
+  component: C & React.ComponentType<P>,
+): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
 
 export const __RouterContext: React.Context<RouteComponentProps>;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -133,7 +133,7 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(pathn
 export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean | undefined }): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass
-  ? { wrappedComponentRef?: (ref: InstanceType<C> | null) => any }
+  ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }
   : {};
 
 export interface WithRouterStatics<C extends React.ComponentType<any>> {

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -17,11 +17,13 @@ class ComponentClass extends React.Component<TOwnProps> {
 
 const WithRouterComponentFunction = withRouter(ComponentFunction);
 const WithRouterComponentClass = withRouter(ComponentClass);
+WithRouterComponentClass.WrappedComponent; // $ExpectType typeof ComponentClass
 
 const WithRouterTestFunction = () => (
     <WithRouterComponentFunction username="John" />
 );
-const WithRouterTestClass = () => <WithRouterComponentClass username="John" />;
+const OnWrappedRef = (ref: ComponentClass | null) => {};
+const WithRouterTestClass = () => <WithRouterComponentClass username="John" wrappedComponentRef={OnWrappedRef} />;
 
 // union props
 {

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -22,8 +22,11 @@ WithRouterComponentClass.WrappedComponent; // $ExpectType typeof ComponentClass
 const WithRouterTestFunction = () => (
     <WithRouterComponentFunction username="John" />
 );
-const OnWrappedRef = (ref: ComponentClass | null) => {};
-const WithRouterTestClass = () => <WithRouterComponentClass username="John" wrappedComponentRef={OnWrappedRef} />;
+const OnWrappedRefFn = (ref: ComponentClass | null) => {};
+const WithRouterTestClass = () => <WithRouterComponentClass username="John" wrappedComponentRef={OnWrappedRefFn} />;
+
+const OnWrappedRef = React.createRef<ComponentClass>();
+const WithRouterTestClass2 = () => <WithRouterComponentClass username="John" wrappedComponentRef={OnWrappedRef} />;
 
 // union props
 {


### PR DESCRIPTION
Components wrapped using `withRouter()` cannot use `ref` as that leads to an error like this:

> Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Updating types to expose the `wrappedComponentRef` prop and the `WrappedComponent` static on the generated HOC.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ReactTraining/react-router/pull/4838>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.