### PR TITLE
workbox-window: Fix messageSW function signature

### DIFF
--- a/types/workbox-window/Workbox.d.ts
+++ b/types/workbox-window/Workbox.d.ts
@@ -37,7 +37,7 @@ interface WokerboxEventMap {
     installed: WorkboxEvent;
     waiting: WorkboxWaitingEvent;
     controlling: WorkboxEvent;
-    activated: WorkboxEvent;
+    activated: WorkboxUpdatableEvent;
     redundant: WorkboxEvent;
     externalinstalled: WorkboxExtendableEvent;
     externalwaiting: WorkboxExtendableEvent;
@@ -106,7 +106,7 @@ declare class Workbox extends EventTargetShim {
      * returned by `messageSW()`. If no response is set, the promise will never
      * resolve.
      */
-    messageSW(): Promise<object>;
+    messageSW(data: any): Promise<object>;
 
     addEventListener<K extends keyof WokerboxEventMap>(type: K, listener: (this: Workbox, ev: WokerboxEventMap[K]) => void): void;
     removeEventListener<K extends keyof WokerboxEventMap>(type: K, listener: (this: Workbox, ev: WokerboxEventMap[K]) => void): void;


### PR DESCRIPTION
Fix `messageSW` function signature to have data being sent as a parameter
Also updated the `activated` event to use the `WorkboxUpdatableEvent` as it's event type as it includes a `isUpdate` boolean as well

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-window.Workbox