### PR TITLE
Improve cast.framework.messages.PlayerState in chromecast-caf-receiver

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -142,7 +142,12 @@ export type MessageType =
     | 'FOCUS_STATE'
     | 'CUSTOM_COMMAND';
 
-export type PlayerState = 'IDLE' | 'PLAYING' | 'PAUSED' | 'BUFFERING';
+export enum PlayerState {
+    BUFFERING = 'BUFFERING',
+    IDLE = 'IDLE',
+    PAUSED = 'PAUSED',
+    PLAYING = 'PLAYING',
+}
 
 export type QueueChangeType = 'INSERT' | 'REMOVE' | 'ITEMS_CHANGE' | 'UPDATE' | 'NO_CHANGE';
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.PlayerState

As everything else, this is an enum.