### PR TITLE
Add description prop to @types/lingui__react Trans component

### DIFF
--- a/types/lingui__react/Trans.d.ts
+++ b/types/lingui__react/Trans.d.ts
@@ -3,6 +3,7 @@ import { RenderProps } from './Render';
 
 export interface TransPropsWithoutI18n extends RenderProps {
     id?: string;
+    description?: string;
     defaults?: string;
     values?: object;
     formats?: object;

--- a/types/lingui__react/lingui__react-tests.tsx
+++ b/types/lingui__react/lingui__react-tests.tsx
@@ -53,7 +53,7 @@ const App = () => {
                     <span aria-label={i18n.t('ageId')`${age} years old`}>Attributes</span>
                 )}
             </I18nComponent>
-            <Trans>Name {name} in <code>Trans</code>.</Trans>
+            <Trans description="Comment for translators">Name {name} in <code>Trans</code>.</Trans>
             <Trans id="transId">Name {name} in <code>Trans</code> with <code>id</code>.</Trans>
             <Plural id="msg.plural"
                     value={numBooks}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lingui.js.org/releases/migration-3.html (In the migrating to 3.x docs it mentions that 2.x has a `description` prop -- I have tested and verified that the `description` prop is extracted to po files, see the screenshot below).
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

![image](https://user-images.githubusercontent.com/49649953/60297010-514e3480-98f5-11e9-8581-d8e8fac1620c.png)
