### PR TITLE
[gapi] Don't require session_state in gapi.auth.setToken(), it's not required

### DIFF
--- a/types/gapi/gapi-tests.ts
+++ b/types/gapi/gapi-tests.ts
@@ -119,3 +119,10 @@ gapi.client.request({
 function processResponse(response: any) {
   // Stub
 }
+
+gapi.auth.setToken({
+  access_token: 'dummy-value',
+  error: '',
+  expires_in: '',
+  state: '',
+});

--- a/types/gapi/index.d.ts
+++ b/types/gapi/index.d.ts
@@ -20,7 +20,7 @@ interface GoogleApiOAuth2TokenObject {
      * The duration, in seconds, the token is valid for. Only present in successful responses
      */
     expires_in: string;
-    session_state: GoogleApiOAuth2TokenSessionState;
+    session_state?: GoogleApiOAuth2TokenSessionState;
     /**
      * The Google API scopes related to this token
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A, but extra session state isn't needed when setting the token
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
