### PR TITLE
[@types/http-assert] Fix types for methods ok, strictEqual, notStrictEqual, deepEqual, notDeepEqual

### DIFF
--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -1,9 +1,24 @@
 import httpAssert = require('http-assert');
 import { HttpError } from 'http-errors';
 
+const status = 401;
+const message = 'some error message';
+const options = {};
+
 try {
     httpAssert.equal('hello', 'hello');
-    httpAssert(false, 401, 'authentication failed');
+    httpAssert.notEqual('hello', 'hello', status, message, options);
+    httpAssert.ok(true);
+    httpAssert.ok(true, status, message, options);
+    httpAssert.strictEqual(3, '3');
+    httpAssert.strictEqual(3, '3', status, message, options);
+    httpAssert.notStrictEqual(3, '3');
+    httpAssert.notStrictEqual(3, '3', status, message, options);
+    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' });
+    httpAssert.deepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
+    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' });
+    httpAssert.notDeepEqual({ foo: 'foo' }, { bar: 'bar' }, status, message, options);
+    httpAssert(false, status, message, options);
 } catch (err) {
     console.log((err as HttpError).status);
     console.log((err as HttpError).message);

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jshttp/http-assert
 // Definitions by: jKey Lu <https://github.com/jkeylu>
 //                 Peter Squicciarini <https://github.com/stripedpajamas>
+//                 Alex Bulanov <https://github.com/sapfear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -21,13 +22,27 @@ declare namespace assert {
      */
     type Assert = <T>(a: T, b: T, status?: number, msg?: string, opts?: {}) => void;
 
+    /**
+     * @param status the status code
+     * @param msg the message of the error, defaulting to node's text for that status code
+     * @param opts custom properties to attach to the error object
+     */
+    type AssertOK = (a: any, status?: number, msg?: string, opts?: {}) => void;
+
+    /**
+     * @param status the status code
+     * @param msg the message of the error, defaulting to node's text for that status code
+     * @param opts custom properties to attach to the error object
+     */
+    type AssertEqual = (a: any, b: any, status?: number, msg?: string, opts?: {}) => void;
+
     const equal: Assert;
     const notEqual: Assert;
-    const ok: Assert;
-    const strictEqual: Assert;
-    const notStrictEqual: Assert;
-    const deepEqual: Assert;
-    const notDeepEqual: Assert;
+    const ok: AssertOK;
+    const strictEqual: AssertEqual;
+    const notStrictEqual: AssertEqual;
+    const deepEqual: AssertEqual;
+    const notDeepEqual: AssertEqual;
 }
 
 export = assert;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/http-assert/blob/master/README.md
- [x] Increase the version number in the header if appropriate.
