### PR TITLE
Add type definition for node-timecodes

### DIFF
--- a/types/node-timecodes/index.d.ts
+++ b/types/node-timecodes/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for node-timecodes 2.5
+// Project: https://github.com/Synchronized-TV/node-timecodes
+// Definitions by: Mitsuka Hanakura a.k.a. ragg <https://github.com/ra-gg>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface TimecodeOptions {
+    frameRate?: number;
+    ms?: boolean;
+}
+
+export function toSeconds(timecode: string, frameRate?: number): number;
+export function fromSeconds(seconds: number, option?: TimecodeOptions): string;
+export const constants: { framerate: number };
+
+declare const _: {
+    toSeconds: typeof toSeconds;
+    fromSeconds: typeof fromSeconds;
+    constants: typeof constants;
+};
+
+export default _;

--- a/types/node-timecodes/node-timecodes-tests.ts
+++ b/types/node-timecodes/node-timecodes-tests.ts
@@ -1,0 +1,11 @@
+import timecode, { fromSeconds, toSeconds, TimecodeOptions } from 'node-timecodes';
+
+type Option = TimecodeOptions;
+
+timecode.fromSeconds(1);
+timecode.fromSeconds(1, { frameRate: 30, ms: true });
+fromSeconds(1);
+timecode.toSeconds('00:01:00:00');
+timecode.toSeconds('00:01:00:00', 30);
+toSeconds('00:01:00:00', 30);
+timecode.constants.framerate;

--- a/types/node-timecodes/tsconfig.json
+++ b/types/node-timecodes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-timecodes-tests.ts"
+    ]
+}

--- a/types/node-timecodes/tslint.json
+++ b/types/node-timecodes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
