### PR TITLE
[node] add dns promise API types

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -242,7 +242,7 @@ declare module "dns" {
     }
 
     function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
-    function setServers(servers: string[]): void;
+    function setServers(servers: ReadonlyArray<string>): void;
     function getServers(): string[];
 
     // Error codes
@@ -288,5 +288,79 @@ declare module "dns" {
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         cancel(): void;
+    }
+
+    namespace promises {
+        function getServers(): string[];
+
+        function lookup(hostname: string, family: number): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupOneOptions): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupAllOptions): Promise<LookupAddress[]>;
+        function lookup(hostname: string, options: LookupOptions): Promise<LookupAddress | LookupAddress[]>;
+        function lookup(hostname: string): Promise<LookupAddress>;
+
+        function lookupService(address: string, port: number): Promise<{ hostname: string, service: string }>;
+
+        function resolve(hostname: string): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
+        function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
+        function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
+        function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
+        function resolve(hostname: string, rrtype: string): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+
+        function resolve4(hostname: string): Promise<string[]>;
+        function resolve4(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve4(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolve6(hostname: string): Promise<string[]>;
+        function resolve6(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve6(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolveAny(hostname: string): Promise<AnyRecord[]>;
+
+        function resolveCname(hostname: string): Promise<string[]>;
+
+        function resolveMx(hostname: string): Promise<MxRecord[]>;
+
+        function resolveNaptr(hostname: string): Promise<NaptrRecord[]>;
+
+        function resolveNs(hostname: string): Promise<string[]>;
+
+        function resolvePtr(hostname: string): Promise<string[]>;
+
+        function resolveSoa(hostname: string): Promise<SoaRecord>;
+
+        function resolveSrv(hostname: string): Promise<SrvRecord[]>;
+
+        function resolveTxt(hostname: string): Promise<string[][]>;
+
+        function reverse(ip: string): Promise<string[]>;
+
+        function setServers(servers: ReadonlyArray<string>): void;
+
+        class Resolver {
+            getServers: typeof getServers;
+            resolve: typeof resolve;
+            resolve4: typeof resolve4;
+            resolve6: typeof resolve6;
+            resolveAny: typeof resolveAny;
+            resolveCname: typeof resolveCname;
+            resolveMx: typeof resolveMx;
+            resolveNaptr: typeof resolveNaptr;
+            resolveNs: typeof resolveNs;
+            resolvePtr: typeof resolvePtr;
+            resolveSoa: typeof resolveSoa;
+            resolveSrv: typeof resolveSrv;
+            resolveTxt: typeof resolveTxt;
+            reverse: typeof reverse;
+            setServers: typeof setServers;
+        }
     }
 }

--- a/types/node/v10/dns.d.ts
+++ b/types/node/v10/dns.d.ts
@@ -242,7 +242,7 @@ declare module "dns" {
     }
 
     function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
-    function setServers(servers: string[]): void;
+    function setServers(servers: ReadonlyArray<string>): void;
     function getServers(): string[];
 
     // Error codes
@@ -288,5 +288,79 @@ declare module "dns" {
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         cancel(): void;
+    }
+
+    namespace promises {
+        function getServers(): string[];
+
+        function lookup(hostname: string, family: number): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupOneOptions): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupAllOptions): Promise<LookupAddress[]>;
+        function lookup(hostname: string, options: LookupOptions): Promise<LookupAddress | LookupAddress[]>;
+        function lookup(hostname: string): Promise<LookupAddress>;
+
+        function lookupService(address: string, port: number): Promise<{ hostname: string, service: string }>;
+
+        function resolve(hostname: string): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
+        function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
+        function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
+        function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
+        function resolve(hostname: string, rrtype: string): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+
+        function resolve4(hostname: string): Promise<string[]>;
+        function resolve4(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve4(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolve6(hostname: string): Promise<string[]>;
+        function resolve6(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve6(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolveAny(hostname: string): Promise<AnyRecord[]>;
+
+        function resolveCname(hostname: string): Promise<string[]>;
+
+        function resolveMx(hostname: string): Promise<MxRecord[]>;
+
+        function resolveNaptr(hostname: string): Promise<NaptrRecord[]>;
+
+        function resolveNs(hostname: string): Promise<string[]>;
+
+        function resolvePtr(hostname: string): Promise<string[]>;
+
+        function resolveSoa(hostname: string): Promise<SoaRecord>;
+
+        function resolveSrv(hostname: string): Promise<SrvRecord[]>;
+
+        function resolveTxt(hostname: string): Promise<string[][]>;
+
+        function reverse(ip: string): Promise<string[]>;
+
+        function setServers(servers: ReadonlyArray<string>): void;
+
+        class Resolver {
+            getServers: typeof getServers;
+            resolve: typeof resolve;
+            resolve4: typeof resolve4;
+            resolve6: typeof resolve6;
+            resolveAny: typeof resolveAny;
+            resolveCname: typeof resolveCname;
+            resolveMx: typeof resolveMx;
+            resolveNaptr: typeof resolveNaptr;
+            resolveNs: typeof resolveNs;
+            resolvePtr: typeof resolvePtr;
+            resolveSoa: typeof resolveSoa;
+            resolveSrv: typeof resolveSrv;
+            resolveTxt: typeof resolveTxt;
+            reverse: typeof reverse;
+            setServers: typeof setServers;
+        }
     }
 }

--- a/types/node/v11/dns.d.ts
+++ b/types/node/v11/dns.d.ts
@@ -242,7 +242,7 @@ declare module "dns" {
     }
 
     function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
-    function setServers(servers: string[]): void;
+    function setServers(servers: ReadonlyArray<string>): void;
     function getServers(): string[];
 
     // Error codes
@@ -293,11 +293,11 @@ declare module "dns" {
     namespace promises {
         function getServers(): string[];
 
-        function lookup(hostname: string, family: number): Promise<{ address: string, family: number }>;
-        function lookup(hostname: string, options: LookupOneOptions): Promise<{ address: string, family: number }>;
-        function lookup(hostname: string, options: LookupAllOptions): Promise<{ addresses: LookupAddress[] }>;
-        function lookup(hostname: string, options: LookupOptions): Promise<{ address: string | LookupAddress[], family: number }>;
-        function lookup(hostname: string): Promise<{ address: string, family: number }>;
+        function lookup(hostname: string, family: number): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupOneOptions): Promise<LookupAddress>;
+        function lookup(hostname: string, options: LookupAllOptions): Promise<LookupAddress[]>;
+        function lookup(hostname: string, options: LookupOptions): Promise<LookupAddress | LookupAddress[]>;
+        function lookup(hostname: string): Promise<LookupAddress>;
 
         function lookupService(address: string, port: number): Promise<{ hostname: string, service: string }>;
 
@@ -343,6 +343,24 @@ declare module "dns" {
 
         function reverse(ip: string): Promise<string[]>;
 
-        function setServers(servers: string[]): void;
+        function setServers(servers: ReadonlyArray<string>): void;
+
+        class Resolver {
+            getServers: typeof getServers;
+            resolve: typeof resolve;
+            resolve4: typeof resolve4;
+            resolve6: typeof resolve6;
+            resolveAny: typeof resolveAny;
+            resolveCname: typeof resolveCname;
+            resolveMx: typeof resolveMx;
+            resolveNaptr: typeof resolveNaptr;
+            resolveNs: typeof resolveNs;
+            resolvePtr: typeof resolvePtr;
+            resolveSoa: typeof resolveSoa;
+            resolveSrv: typeof resolveSrv;
+            resolveTxt: typeof resolveTxt;
+            reverse: typeof reverse;
+            setServers: typeof setServers;
+        }
     }
 }

--- a/types/node/v11/dns.d.ts
+++ b/types/node/v11/dns.d.ts
@@ -289,4 +289,60 @@ declare module "dns" {
         reverse: typeof reverse;
         cancel(): void;
     }
+
+    namespace promises {
+        function getServers(): string[];
+
+        function lookup(hostname: string, family: number): Promise<{ address: string, family: number }>;
+        function lookup(hostname: string, options: LookupOneOptions): Promise<{ address: string, family: number }>;
+        function lookup(hostname: string, options: LookupAllOptions): Promise<{ addresses: LookupAddress[] }>;
+        function lookup(hostname: string, options: LookupOptions): Promise<{ address: string | LookupAddress[], family: number }>;
+        function lookup(hostname: string): Promise<{ address: string, family: number }>;
+
+        function lookupService(address: string, port: number): Promise<{ hostname: string, service: string }>;
+        
+        function resolve(hostname: string): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
+        function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
+        function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
+        function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
+        function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
+        function resolve(hostname: string, rrtype: string): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+
+        function resolve4(hostname: string): Promise<string[]>;
+        function resolve4(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve4(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolve6(hostname: string): Promise<string[]>;
+        function resolve6(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function resolve6(hostname: string, options: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+
+        function resolveAny(hostname: string): Promise<AnyRecord[]>;
+
+        function resolveCname(hostname: string): Promise<string[]>;
+
+        function resolveMx(hostname: string): Promise<MxRecord[]>;
+
+        function resolveNaptr(hostname: string): Promise<NaptrRecord[]>;
+
+        function resolveNs(hostname: string): Promise<string[]>;
+
+        function resolvePtr(hostname: string): Promise<string[]>;
+
+        function resolveSoa(hostname: string): Promise<SoaRecord>;
+
+        function resolveSrv(hostname: string): Promise<SrvRecord[]>;
+
+        function resolveTxt(hostname: string): Promise<string[][]>;
+
+        function reverse(ip: string): Promise<string[]>;
+
+        function setServers(servers: string[]): void;
+    }
 }

--- a/types/node/v11/dns.d.ts
+++ b/types/node/v11/dns.d.ts
@@ -300,7 +300,7 @@ declare module "dns" {
         function lookup(hostname: string): Promise<{ address: string, family: number }>;
 
         function lookupService(address: string, port: number): Promise<{ hostname: string, service: string }>;
-        
+
         function resolve(hostname: string): Promise<string[]>;
         function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
         function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;

--- a/types/node/v11/index.d.ts
+++ b/types/node/v11/index.d.ts
@@ -37,6 +37,7 @@
 //                 Kyle Uehlein <https://github.com/kuehlein>
 //                 Jordi Oliveras Rovira <https://github.com/j-oliveras>
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
+//                 Ivan Sieder <https://github.com/ivansieder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.


### PR DESCRIPTION
Continuation of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35437

----

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) - no tests for dns available
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/dns.html#dns_dns_promises_api
- [ ] Increase the version number in the header if appropriate. - what header? I cannot find one.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - already extended

