### PR TITLE
fix next-server/link children to be ReactNodes instead of ReactElements

### DIFF
--- a/types/next-server/link.d.ts
+++ b/types/next-server/link.d.ts
@@ -11,7 +11,7 @@ export interface LinkProps {
     href?: string | UrlLike;
     as?: string | UrlLike;
     passHref?: boolean;
-    children: React.ReactElement;
+    children: React.ReactNode;
 }
 
 export default class Link extends React.Component<LinkProps> {}


### PR DESCRIPTION
Use `ReactNode` which is aligned with React type definitions, see [link to usage in react definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L146). Using `ReactElement` prevents from using simple strings as children, for example.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L146>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.