### PR TITLE
Yup: Allow specific type with oneOf and mixed schema

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -73,7 +73,7 @@ export interface Schema<T> {
     default(value: any): this;
     default(): T;
     typeError(message?: TestOptionsMessage): this;
-    oneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
+    oneOf(arrayOfValues: T[], message?: TestOptionsMessage): this;
     notOneOf(arrayOfValues: any[], message?: TestOptionsMessage): this;
     when(keys: string | any[], builder: WhenOptions<this>): this;
     test(
@@ -92,8 +92,10 @@ export interface Schema<T> {
 }
 
 export interface MixedSchemaConstructor {
-    (): MixedSchema;
-    new (options?: { type?: string; [key: string]: any }): MixedSchema;
+    // tslint:disable-next-line:no-unnecessary-generics
+    <T = any>(): MixedSchema<T>;
+    // tslint:disable-next-line:no-unnecessary-generics
+    new <T = any>(options?: { type?: string; [key: string]: any }): MixedSchema<T>;
 }
 
 export interface MixedSchema<T = any> extends Schema<T> {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -572,8 +572,16 @@ yup.object<MyInterface>({
     arrayField: yup.array(yup.string()).required(),
 });
 
+enum Gender {
+    Male = 'Male',
+    Female = 'Female',
+}
+
 const personSchema = yup.object({
     firstName: yup.string(), // $ExpectType StringSchema<string>
+    gender: yup
+        .mixed<Gender>()
+        .oneOf([Gender.Male, Gender.Female]),
     email: yup
         .string()
         .nullable()
@@ -606,6 +614,7 @@ type Person = yup.InferType<typeof personSchema>;
 // Equivalent to:
 // type Person = {
 //     firstName: string;
+//     gender: Gender;
 //     email?: string | null | undefined;
 //     birthDate?: Date | null | undefined;
 //     canBeNull: string | null;
@@ -616,12 +625,14 @@ type Person = yup.InferType<typeof personSchema>;
 
 const minimalPerson: Person = {
     firstName: '',
+    gender: Gender.Female,
     canBeNull: null,
     mustBeAString: '',
 };
 
 const person: Person = {
     firstName: '',
+    gender: Gender.Male,
     email: null,
     birthDate: null,
     canBeNull: null,
@@ -638,6 +649,8 @@ person.isAlive = undefined;
 person.children = ['1', '2', '3'];
 person.children = undefined;
 
+// $ExpectError
+person.gender = 1;
 // $ExpectError
 person.firstName = null;
 // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] ~~Increase the version number in the header if appropriate.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~


Previously the following Yup schema definition would result in a gender property that was of type `any` effectively disabling all type checking.

```TypeScript
enum Gender {
    Male = 'Male',
    Female = 'Female',
}

const personSchema = yup.object({
    firstName: yup.string(), // $ExpectType StringSchema<string>
    gender: yup
        .mixed()
        .oneOf([Gender.Male, Gender.Female])
});
```

With this change the Yup schema can, optionally, be written as follows and the `gender` property will be typed as `Gender`.

```TypeScript
enum Gender {
    Male = 'Male',
    Female = 'Female',
}

const personSchema = yup.object({
    firstName: yup.string(),
    gender: yup
        .mixed<Gender>()
        .oneOf([Gender.Male, Gender.Female])
});
```

Resulting TypeScript type alias:
```TypeScript
type Person = {
    firstName: string;
    gender: Gender;
}
```

A second benefit is that the values passed into the `oneOf()` function are also type checked.

To preserve backwards compatibility the type for `mixed()` is optional and default to `any`.
