### PR TITLE
feat(chance): add missing string/character options

### DIFF
--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -105,9 +105,28 @@ word = chance.word({length: 10});
 word = chance.word({capitalize: true});
 
 let randomString: string = chance.string();
-randomString = chance.string({pool: 'abcdef', length: 10});
-randomString = chance.string({pool: 'abcdef'});
-randomString = chance.string({length: 10});
+randomString = chance.string({ pool: 'abcdef' });
+randomString = chance.string({ length: 10 });
+randomString = chance.string({ casing: 'upper' });
+randomString = chance.string({ alpha: true });
+randomString = chance.string({ numeric: true });
+randomString = chance.string({ symbols: '!@#$' });
+randomString = chance.string({
+    pool: 'abcdef',
+    length: 10,
+    casing: 'lower',
+    alpha: true,
+    numeric: true,
+    symbols: ')(*&',
+});
+
+let char: string = chance.character();
+char = chance.character({ pool: 'abcdef' });
+char = chance.character({ casing: 'upper' });
+char = chance.character({ alpha: true });
+char = chance.character({ numeric: true });
+char = chance.character({ symbols: '!@#$' });
+char = chance.character({ pool: 'abcdef', casing: 'lower', alpha: true, numeric: true, symbols: ')(*&' });
 
 let url: string = chance.url();
 url = chance.url({protocol: 'http'});

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Chance {
     interface Chance extends Seeded {
         // Basics
         bool(opts?: {likelihood: number}): boolean;
-        character(opts?: Options): string;
+        character(opts?: AtLeastOneKey<CharacterOptions>): string;
         floating(opts?: Options): number;
         integer(opts?: AtLeastOneKey<IntegerOptions>): number;
         letter(opts?: Options): string;
@@ -197,10 +197,15 @@ declare namespace Chance {
         capitalize: boolean;
     }
 
-    interface StringOptions {
-        length: number;
+    interface CharacterOptions {
+        casing: 'upper' | 'lower';
         pool: string;
+        alpha: boolean;
+        numeric: boolean;
+        symbols: string;
     }
+
+    type StringOptions = CharacterOptions & { length: number } ;
 
     interface UrlOptions {
         protocol: string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - the documentation is not thorough on all the parameters that are possible for `chance.string`. so source code was looked at
  - [chance.string](https://github.com/chancejs/chancejs/blob/1.0.18/chance.js#L386)
    - note that the method delegates to `chance.character`, thus every valid option to `chance.character` is a valid option for `chance.string`
  - [chance.character](https://github.com/colbywhite/chancejs/blob/1.0.18/chance.js#L174)
- [x] Increase the version number in the header if appropriate.
  - no major/minor version bump needed
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - not needed