### PR TITLE
Update sinon-test definitions

### DIFF
--- a/types/sinon-test/index.d.ts
+++ b/types/sinon-test/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sinon-test 1.0
+// Type definitions for sinon-test 2.4
 // Project: https://github.com/sinonjs/sinon-test
 // Definitions by: Francis Saul <https://github.com/mummybot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -9,16 +9,14 @@ import * as Sinon from 'sinon';
 interface Configuration {
     injectIntoThis?: boolean;
     injectInto?: any;
-    properties?: Array<"spy"| "stub"| "mock"| "clock"| "server"| "requests">;
+    properties?: Array<"spy" | "stub" | "mock" | "clock" | "server" | "requests">;
     useFakeTimers?: boolean;
     useFakeServer?: boolean;
 }
 
-interface sinonTest {
-    configureTest(sinon: Sinon.SinonStatic, config?: Configuration): any;
-    configureTestCase(sinon: Sinon.SinonStatic, config?: Configuration): any;
+declare function sinonTest(sinon: Sinon.SinonStatic, config?: Configuration): any;
+declare namespace sinonTest {
+    function configureTest(sinon: Sinon.SinonStatic, config?: Configuration): any;
 }
-
-declare var sinonTest: sinonTest;
 
 export = sinonTest;

--- a/types/sinon-test/sinon-test-tests.ts
+++ b/types/sinon-test/sinon-test-tests.ts
@@ -11,15 +11,4 @@ function testConfigure() {
     });
 }
 
-function testConfigureTestCase() {
-    const test = sinonTest.configureTestCase(sinon, {
-    injectIntoThis: true,
-    injectInto: true,
-    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
-    useFakeTimers: true,
-    useFakeServer: true
-    });
-}
-
 testConfigure();
-testConfigureTestCase();

--- a/types/sinon-test/tsconfig.json
+++ b/types/sinon-test/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon-test/commit/279883b3b6812063e5cafcdf66e2f40f02b6f80a https://github.com/sinonjs/sinon-test/commit/81ab7d59c4abee846cfd4f6b08f85f28ab322ffd
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I believe that `configureWithTestCase` has been removed from `sinon-test`. The first link that I have provided above shows this change. This PR will remove the type definition for this deleted function as well as its corresponding test. 

The interface for `sinon-test` has also changed, with `configureTest` now deprecated. The PR will update these definitions as well.

cc @peterjwest 