### PR TITLE
add typings for node-gzip

### DIFF
--- a/types/node-gzip/index.d.ts
+++ b/types/node-gzip/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for node-gzip 1.1
+// Project: https://github.com/Rebsos/node-gzip#readme
+// Definitions by: mike castleman <https://github.com/mlc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+
+import { InputType, ZlibOptions } from 'zlib';
+
+export function gzip(input: InputType, options?: ZlibOptions): Promise<Buffer>;
+export function ungzip(input: InputType, options?: ZlibOptions): Promise<Buffer>;

--- a/types/node-gzip/node-gzip-tests.ts
+++ b/types/node-gzip/node-gzip-tests.ts
@@ -1,0 +1,16 @@
+import { gzip, ungzip } from 'node-gzip';
+
+const testGzip = async () => {
+    const someBuffer = Buffer.from('hello');
+    const zipped1 = await gzip(someBuffer);
+
+    const zipped2 = await gzip('gzipping a string directly');
+
+    return [zipped1.byteLength, zipped2[0]];
+};
+
+const testUngzip = async () => {
+    const data = Buffer.from('H4sICHeEGV0AA2EA4wIAkwbXMgEAAAA=', 'base64');
+    const ungzipped = await ungzip(data);
+    return ungzipped.toString('utf-8');
+};

--- a/types/node-gzip/tsconfig.json
+++ b/types/node-gzip/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-gzip-tests.ts"
+    ]
+}

--- a/types/node-gzip/tslint.json
+++ b/types/node-gzip/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds types for [node-gzip](https://github.com/Rebsos/node-gzip), a small package which provides a Promise-based API for the `gzip` and `ungzip` functions in node `zlib`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
