### PR TITLE
Support for UMD module definitions

### DIFF
--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -685,3 +685,4 @@ declare namespace i18next {
 
 declare const i18next: i18next.i18n;
 export = i18next;
+export as namespace i18next;


### PR DESCRIPTION
Adding support for UMD module definitions, so types can be used in a project with no module loading.
[UMD](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#support-for-umd-module-definitions)

In a TS project where module code generation is set to 'none', types cannot be resolved without using an "import".

If "import" is used compiler complains **"Cannot use imports, exports or module augmentations when '--module' is 'none"**

Credit to [Aluan Haddad](https://stackoverflow.com/users/1915893/aluan-haddad) and [Mu-Tsun Tsai](https://stackoverflow.com/users/9953396/mu-tsun-tsai)

[Original stackoverflow issue](https://stackoverflow.com/questions/56774764/reference-declaration-file-d-ts-in-a-ts-file-with-compiler-module-option/)