### PR TITLE
[styled-system] fix typo in zIndices property name

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -184,7 +184,7 @@ export interface Theme extends BaseTheme {
     shadows?: ObjectOrArray<CSS.BoxShadowProperty>;
     sizes?: ObjectOrArray<CSS.HeightProperty<{}> | CSS.WidthProperty<{}>>;
     textStyles?: ObjectOrArray<CSS.StandardProperties>;
-    zIndeces?: ObjectOrArray<CSS.ZIndexProperty>;
+    zIndices?: ObjectOrArray<CSS.ZIndexProperty>;
 }
 
 /**

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -644,7 +644,7 @@ export const themeA: Theme = {
             letterSpacing: '0.2em'
         }
     },
-    zIndeces: [-1, 0, 1, 9999]
+    zIndices: [-1, 0, 1, 9999]
 };
 
 // Some properties can be formatted differently


### PR DESCRIPTION
This PR updates a typo in the `zIndices` key of the `Theme` interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://styled-system.com/theme-specification#key-reference>>
- [ ] Increase the version number in the header if appropriate. _typo fix only_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _insubstantial changes_


