### PR TITLE
R.zip compatible with a tuple array

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -556,13 +556,10 @@ declare namespace R {
 
     type Path = ReadonlyArray<(number | string)>;
 
+    type KeyValueTuple<K, V> = [K, V];
+
     interface Functor<T> {
         map<U>(fn: (t: T) => U): Functor<U>;
-    }
-
-    interface KeyValuePair<K, V> extends Array<K | V> {
-        0: K;
-        1: V;
     }
 
     interface ArrayLike {
@@ -1428,8 +1425,8 @@ declare namespace R {
         /**
          * Creates a new object out of a list key-value pairs.
          */
-        fromPairs<V>(pairs: Array<KeyValuePair<string, V>>): { [index: string]: V };
-        fromPairs<V>(pairs: Array<KeyValuePair<number, V>>): { [index: number]: V };
+        fromPairs<V>(pairs: Array<KeyValueTuple<string, V>>): { [index: string]: V };
+        fromPairs<V>(pairs: Array<KeyValueTuple<number, V>>): { [index: number]: V };
 
         /**
          * Splits a list into sublists stored in an object, based on the result of
@@ -3126,17 +3123,15 @@ declare namespace R {
         /**
          * Creates a new list out of the two supplied by creating each possible pair from the lists.
          */
-        xprod<K, V>(as: ReadonlyArray<K>, bs: ReadonlyArray<V>): Array<KeyValuePair<K, V>>;
-        xprod<K>(as: ReadonlyArray<K>): <V>(bs: ReadonlyArray<V>) => Array<KeyValuePair<K, V>>;
+        xprod<K, V>(as: ReadonlyArray<K>, bs: ReadonlyArray<V>): Array<KeyValueTuple<K, V>>;
+        xprod<K>(as: ReadonlyArray<K>): <V>(bs: ReadonlyArray<V>) => Array<KeyValueTuple<K, V>>;
 
         /**
          * Creates a new list out of the two supplied by pairing up equally-positioned items from
          * both lists. Note: `zip` is equivalent to `zipWith(function(a, b) { return [a, b] })`.
          */
-        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<[K, V]>;
-        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<[K, V]>;
-        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<KeyValuePair<K, V>>;
-        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<KeyValuePair<K, V>>;
+        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<KeyValueTuple<K, V>>;
+        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<KeyValueTuple<K, V>>;
 
         /**
          * Creates a new object out of a list of keys and a list of values.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -556,7 +556,7 @@ declare namespace R {
 
     type Path = ReadonlyArray<(number | string)>;
 
-    type KeyValueTuple<K, V> = [K, V];
+    type KeyValuePair<K, V> = [K, V];
 
     interface Functor<T> {
         map<U>(fn: (t: T) => U): Functor<U>;
@@ -1425,8 +1425,8 @@ declare namespace R {
         /**
          * Creates a new object out of a list key-value pairs.
          */
-        fromPairs<V>(pairs: Array<KeyValueTuple<string, V>>): { [index: string]: V };
-        fromPairs<V>(pairs: Array<KeyValueTuple<number, V>>): { [index: number]: V };
+        fromPairs<V>(pairs: Array<KeyValuePair<string, V>>): { [index: string]: V };
+        fromPairs<V>(pairs: Array<KeyValuePair<number, V>>): { [index: number]: V };
 
         /**
          * Splits a list into sublists stored in an object, based on the result of
@@ -3123,15 +3123,15 @@ declare namespace R {
         /**
          * Creates a new list out of the two supplied by creating each possible pair from the lists.
          */
-        xprod<K, V>(as: ReadonlyArray<K>, bs: ReadonlyArray<V>): Array<KeyValueTuple<K, V>>;
-        xprod<K>(as: ReadonlyArray<K>): <V>(bs: ReadonlyArray<V>) => Array<KeyValueTuple<K, V>>;
+        xprod<K, V>(as: ReadonlyArray<K>, bs: ReadonlyArray<V>): Array<KeyValuePair<K, V>>;
+        xprod<K>(as: ReadonlyArray<K>): <V>(bs: ReadonlyArray<V>) => Array<KeyValuePair<K, V>>;
 
         /**
          * Creates a new list out of the two supplied by pairing up equally-positioned items from
          * both lists. Note: `zip` is equivalent to `zipWith(function(a, b) { return [a, b] })`.
          */
-        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<KeyValueTuple<K, V>>;
-        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<KeyValueTuple<K, V>>;
+        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<KeyValuePair<K, V>>;
+        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<KeyValuePair<K, V>>;
 
         /**
          * Creates a new object out of a list of keys and a list of values.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3133,6 +3133,8 @@ declare namespace R {
          * Creates a new list out of the two supplied by pairing up equally-positioned items from
          * both lists. Note: `zip` is equivalent to `zipWith(function(a, b) { return [a, b] })`.
          */
+        zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<[K, V]>;
+        zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<[K, V]>;
         zip<K, V>(list1: ReadonlyArray<K>, list2: ReadonlyArray<V>): Array<KeyValuePair<K, V>>;
         zip<K>(list1: ReadonlyArray<K>): <V>(list2: ReadonlyArray<V>) => Array<KeyValuePair<K, V>>;
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1582,6 +1582,14 @@ type Pair = KeyValuePair<string, number>;
 () => {
     R.zip([1, 2, 3], ["a", "b", "c"]); // => [[1, 'a'], [2, 'b'], [3, 'c']]
     R.zip([1, 2, 3])(["a", "b", "c"]); // => [[1, 'a'], [2, 'b'], [3, 'c']]
+
+    type TNames = string[];
+    const fullNames: TNames[] = R.zip<string, string>(["John", "Juliet", "Melanie"], ["Titor", "Burke", "Cross"]);
+    const fullNames2: TNames[] = R.zip(["John", "Juliet", "Melanie"])(["Titor", "Burke", "Cross"]);
+
+    type TNameAge = [string, number];
+    const namesAndAges: TNameAge[] = R.zip<string, number>(["John", "Juliet", "Melanie"], [21, 22, 23]);
+    const namesAndAges2: TNameAge[] = R.zip(["John", "Juliet", "Melanie"])([21, 22, 23]);
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### The problem

Currently this is not posible:
```typescript
type TNameAge = [string, number]; // this is a tuple (not an array) to typescript

const namesAndAges: TNameAge[] = R.zip<string, number>(["John", "Juliet", "Melanie"], [21, 22, 23]);
const namesAndAges2: TNameAge[] = R.zip(["John", "Juliet", "Melanie"])([21, 22, 23]);
```

**TNameAge** is a [typescript tuple](https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple), so you can't assign it the result of **R.zip** to a typed tuple, because they aren't compatible. But they should be, because once compiled to javascript there's no difference.

I added some tests to make sure is compatible with both of them, a tuple array (`Array<TNameAge>`), and a common array (`Array<TNames>`), to make sure I'm not breaking the current behavior:
```typescript
type TNameAge = [string, number]; // this is a tuple (not an array) to typescript
const namesAndAges: TNameAge[] = R.zip<string, number>(["John", "Juliet", "Melanie"], [21, 22, 23]);
const namesAndAges2: TNameAge[] = R.zip(["John", "Juliet", "Melanie"])([21, 22, 23]);

type TNames = string[]; // this is an array
const fullNames: TNames[] = R.zip<string, string>(["John", "Juliet", "Melanie"], ["Titor", "Burke", "Cross"]);
const fullNames2: TNames[] = R.zip(["John", "Juliet", "Melanie"])(["Titor", "Burke", "Cross"]);
```
