### PR TITLE
[k6] Expose to autoimport

### DIFF
--- a/types/k6/index.d.ts
+++ b/types/k6/index.d.ts
@@ -20,6 +20,15 @@
 
 import './global'; // Type global environment
 
+// Expose everything to autoimport
+import './crypto';
+import './encoding';
+import './html';
+import './http';
+import './metrics';
+import './options';
+import './ws';
+
 export function check<T>(val: T, sets: Checkers<T>, tags?: object): boolean;
 export function fail(err?: string): never;
 export function group<T>(name: string, fn: () => T): T;


### PR DESCRIPTION
Exposes submodules to autoimport.

The Visual Studio Code [autoimport feature](https://code.visualstudio.com/Docs/languages/typescript#_auto-imports) lists all types in a package and offers to automatically add an import for the selected export. This is currently not working for the `k6/*` submodules.

Autoimport seems to only pick up things that are loaded by `index`. Adds imports for all submodules to `index`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://code.visualstudio.com/Docs/languages/typescript#_auto-imports
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.