### PR TITLE
fix(types/next): Add req and res NextContext typedefs used in `next export`

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -49,9 +49,9 @@ declare namespace next {
         /** String of the actual path (including the query) shows in the browser */
         asPath: string;
         /** HTTP request object (server only) */
-        req?: http.IncomingMessage & CustomReq;
+        req?: http.IncomingMessage & CustomReq | { url: string };
         /** HTTP response object (server only) */
-        res?: http.ServerResponse;
+        res?: http.ServerResponse | {};
         /** Fetch Response object (client only) - from https://developer.mozilla.org/en-US/docs/Web/API/Response */
         jsonPageRes?: NodeResponse;
         /** Error object if any error is encountered during the rendering */

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -32,6 +32,34 @@ declare namespace next {
     // End Deprecated
 
     /**
+     * HTTP request object (server only, non-export mode)
+     */
+    type NextReq<CustomReq = {}> = http.IncomingMessage & CustomReq;
+
+    /**
+     * HTTP request object (server only, `next export` mode)
+     *
+     * Note: We're using `Partial` here (instead of `{ url?: string }`)
+     * in order to avoid TS raising typedef errors
+     * when using it like `req && req.getHeaderNames ? req.getHeaderNames() : []`.
+     */
+    type NextExportReq<CustomReq = {}> = Partial<NextReq<CustomReq>>;
+
+    /**
+     * HTTP response object (server only, non-export mode)
+     */
+    type NextResponse = http.ServerResponse;
+
+    /**
+     * HTTP response object (server only, `next export` mode)
+     *
+     * Note: We're using `Partial` here (instead of `{}`)
+     * in order to avoid TS raising typedef errors
+     * when using it like `res && res.getHeaderNames ? res.getHeaderNames() : []`.
+     */
+    type NextExportResponse = Partial<NextResponse>;
+
+    /**
      * Context object used in methods like `getInitialProps()`
      * https://github.com/zeit/next.js/blob/7.0.0/server/render.js#L97
      * https://github.com/zeit/next.js/blob/7.0.0/README.md#fetching-data-and-component-lifecycle
@@ -48,10 +76,16 @@ declare namespace next {
         query: Q;
         /** String of the actual path (including the query) shows in the browser */
         asPath: string;
-        /** HTTP request object (server only) */
-        req?: http.IncomingMessage & CustomReq | { url: string };
-        /** HTTP response object (server only) */
-        res?: http.ServerResponse | {};
+        /**
+         * HTTP request object (server only)
+         * Note: In `next export` mode, this will consist of only `{ url?: string }`.
+         */
+        req?: NextReq<CustomReq> | NextExportReq<CustomReq>;
+        /**
+         * HTTP response object (server only)
+         * Note: In `next export` mode, this will be empty `{}` object.
+         */
+        res?: NextResponse | NextExportResponse;
         /** Fetch Response object (client only) - from https://developer.mozilla.org/en-US/docs/Web/API/Response */
         jsonPageRes?: NodeResponse;
         /** Error object if any error is encountered during the rendering */

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -134,13 +134,12 @@ const explicitTypesRenderResponseTwo = renderPage<PageInitialProps, ProcessedIni
     App => ({ foo, bar }) => <App fooLength={foo.length} bar={!!bar} />
 );
 
-class MyDocumentWithCustomContext extends Document<{ example: string }> {
-    static async getInitialProps(
-        ctx: NextDocumentContext<DefaultQuery, { customField: "custom value" }>
-    ) {
+class MyDocumentWithCustomContext extends Document<{ example: string; url: string }> {
+    static async getInitialProps(ctx: NextDocumentContext<DefaultQuery, { customField: 'custom value' }>) {
         const initialProps = await Document.getInitialProps(ctx);
         const example = ctx.req ? ctx.req.customField : undefined;
-        return { ...initialProps, example };
+        const url = ctx.req ? ctx.req.url : undefined;
+        return { ...initialProps, example, url };
     }
 
     render() {
@@ -151,6 +150,7 @@ class MyDocumentWithCustomContext extends Document<{ example: string }> {
                 </Head>
                 <body className="custom_class">
                     <h1>{this.props.example}</h1>
+                    <h2>{this.props.url}</h2>
                     <Main />
                     <NextScript />
                 </body>


### PR DESCRIPTION
On `next export` command, `req` and `res` objects are hardcoded simple objects: https://github.com/zeit/next.js/blob/master/packages/next/export/worker.js#L42-L43 and thus they have different type definition (i.e. `res.writeHead` is missing which might cause [such code](https://github.com/zeit/next.js/wiki/Redirecting-in-%60getInitialProps%60) to blow up with a `TypeError: res.writeHead is not a function` ).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes