### PR TITLE
Update types/node/v11 & v12

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -241,9 +241,10 @@ interface Buffer extends Uint8Array {
     write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
     toString(encoding?: string, start?: number, end?: number): string;
     toJSON(): { type: 'Buffer', data: number[] };
-    equals(otherBuffer: Uint8Array): boolean;
-    compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
-    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    equals(otherBuffer: Buffer | Uint8Array): boolean;
+    compare(otherBuffer: Buffer | Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
+    concat(list: Buffer[] | Uint8Array[], totalLength?: number): Buffer;
+    copy(targetBuffer: Buffer | Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     /**
      * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
      *
@@ -414,18 +415,17 @@ declare const Buffer: {
      * Returns a buffer which is the result of concatenating all the buffers in the list together.
      *
      * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
-     * If the list has exactly one item, then the first item of the list is returned.
-     * If the list has more than one item, then a new Buffer is created.
+     * If the list has one or more items, then a new Buffer is created.
      *
      * @param list An array of Buffer objects to concatenate
      * @param totalLength Total length of the buffers when concatenated.
      *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
      */
-    concat(list: Uint8Array[], totalLength?: number): Buffer;
+    concat(list: Buffer[] | Uint8Array[], totalLength?: number): Buffer;
     /**
      * The same as buf1.compare(buf2).
      */
-    compare(buf1: Uint8Array, buf2: Uint8Array): number;
+    compare(buf1: Buffer | Uint8Array, buf2: Buffer | Uint8Array): number;
     /**
      * Allocates a new buffer of {size} octets.
      *
@@ -907,7 +907,7 @@ declare namespace NodeJS {
         domain: Domain;
 
         // Worker
-        send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean}, callback?: (error: Error | null) => void): boolean;
+        send?(message: any, sendHandle?: any, options?: { swallowErrors?: boolean }, callback?: (error: Error | null) => void): boolean;
         disconnect(): void;
         connected: boolean;
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -37,6 +37,7 @@
 //                 Kyle Uehlein <https://github.com/kuehlein>
 //                 Jordi Oliveras Rovira <https://github.com/j-oliveras>
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
+//                 Martin Trobäck <https://github.com/lekoaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.
@@ -63,16 +64,16 @@ interface MapConstructor { }
 interface WeakMapConstructor { }
 interface SetConstructor { }
 interface WeakSetConstructor { }
-interface Set<T> {}
-interface Map<K, V> {}
-interface ReadonlySet<T> {}
+interface Set<T> { }
+interface Map<K, V> { }
+interface ReadonlySet<T> { }
 interface IteratorResult<T> { }
 interface Iterable<T> { }
 interface Iterator<T> {
     next(value?: any): IteratorResult<T>;
 }
 interface IterableIterator<T> { }
-interface AsyncIterableIterator<T> {}
+interface AsyncIterableIterator<T> { }
 interface SymbolConstructor {
     readonly iterator: symbol;
     readonly asyncIterator: symbol;

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -241,9 +241,10 @@ interface Buffer extends Uint8Array {
     write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
     toString(encoding?: string, start?: number, end?: number): string;
     toJSON(): { type: 'Buffer', data: number[] };
-    equals(otherBuffer: Uint8Array): boolean;
-    compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
-    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    equals(otherBuffer: Buffer | Uint8Array): boolean;
+    compare(otherBuffer: Buffer | Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
+    concat(list: Buffer[] | Uint8Array[], totalLength?: number): Buffer;
+    copy(targetBuffer: Buffer | Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     slice(start?: number, end?: number): Buffer;
     subarray(begin: number, end?: number): Buffer;
     writeUIntLE(value: number, offset: number, byteLength: number): number;
@@ -398,18 +399,17 @@ declare const Buffer: {
      * Returns a buffer which is the result of concatenating all the buffers in the list together.
      *
      * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
-     * If the list has exactly one item, then the first item of the list is returned.
-     * If the list has more than one item, then a new Buffer is created.
+     * If the list has one or more items, then a new Buffer is created.
      *
      * @param list An array of Buffer objects to concatenate
      * @param totalLength Total length of the buffers when concatenated.
      *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
      */
-    concat(list: Uint8Array[], totalLength?: number): Buffer;
+    concat(list: Buffer[] | Uint8Array[], totalLength?: number): Buffer;
     /**
      * The same as buf1.compare(buf2).
      */
-    compare(buf1: Uint8Array, buf2: Uint8Array): number;
+    compare(buf1: Buffer | Uint8Array, buf2: Buffer | Uint8Array): number;
     /**
      * Allocates a new buffer of {size} octets.
      *


### PR DESCRIPTION
* Fixes documentation for `concat`
* Adds `Buffer | Uint8Array` union to `concat`, `compare`, `equals` and `copy`

Solves #36253.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.