### PR TITLE
Update README to require spaces

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -134,7 +134,7 @@ Para un buen paquete de ejemplo, vea [base64-js](https://github.com/DefinitelyTy
 #### Errores comunes
 
 * Primero, sigue el consejo del [manual](http://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatear: Ya sea utilizar todo en tabs, o siempre utiliza 4 espacios.
+* Formatear: Utiliza 4 espacios.
 * `function sum(nums: number[]): number`: Utiliza `ReadonlyArray` si una función no escribe a sus parámetros.
 * `interface Foo { new(): Foo; }`:
     Este define el tipo de objeto que esten nuevos. Probablemente quieras `declare class Foo { constructor(); }`.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For a good example package, see [base64-js](https://github.com/DefinitelyTyped/D
 #### Common mistakes
 
 * First, follow advice from the [handbook](http://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatting: Either use all tabs, or always use 4 spaces.
+* Formatting: Use 4 spaces. For new code, this is enforced by Prettier.
 * `function sum(nums: number[]): number`: Use `ReadonlyArray` if a function does not write to its parameters.
 * `interface Foo { new(): Foo; }`:
     This defines a type of objects that are new-able. You probably want `declare class Foo { constructor(); }`.


### PR DESCRIPTION
I'm not sure how to fill out the spanish sentence to match the english one, but I deleted the misleading part about tabs.

For Korean/Russian/Chinese, I don't trust myself to even find the sentence to simplify.