### PR TITLE
[@types/country-data] Add missing keys to countries export

### DIFF
--- a/types/country-data/country-data-tests.ts
+++ b/types/country-data/country-data-tests.ts
@@ -5,10 +5,11 @@ lib.callingCountries.all; // $ExpectType ReadonlyArray<Country>
 lib.continents.africa; // $ExpectType Continent
 lib.continents.africa.countries; // $ExpectType ReadonlyArray<Country>
 lib.countries.all; // $ExpectType ReadonlyArray<Country>
+lib.countries.BY; // $ExpectType Country
 lib.currencies.all; // $ExpectType ReadonlyArray<Currency>
 lib.languages.all; // $ExpectType ReadonlyArray<Language>
 lib.regions.antarctica; // $ExpectType Region
 lib.regions.antarctica.countries; // $ExpectType ReadonlyArray<string>
-lib.lookup.countries(""); // $ExpectType ReadonlyArray<Country>
-lib.lookup.currencies(""); // $ExpectType ReadonlyArray<Currency>
-lib.lookup.languages(""); // $ExpectType ReadonlyArray<Language>
+lib.lookup.countries(''); // $ExpectType ReadonlyArray<Country>
+lib.lookup.currencies(''); // $ExpectType ReadonlyArray<Currency>
+lib.lookup.languages(''); // $ExpectType ReadonlyArray<Language>

--- a/types/country-data/index.d.ts
+++ b/types/country-data/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/OpenBookPrices/country-data
 // Definitions by: Logan Dam <https://github.com/biltongza>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
 
 export interface Country {
     readonly alpha2: string;
@@ -41,6 +42,8 @@ export interface Region {
 }
 
 export const countries: {
+    readonly [key: string]: Country;
+} & {
     readonly all: ReadonlyArray<Country>;
 };
 


### PR DESCRIPTION
`country-data` library exports `countries` object and regarding documentation it contains `all` property with an array of countries data as well as properties for each country itself (with a short code as a key). The current version of typings is only aware of the `all` exports.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source Code](https://github.com/OpenBookPrices/country-data/blob/master/index.js#L24),  [Readme Reference](https://github.com/OpenBookPrices/country-data#example-usage)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

