### PR TITLE
[@types/enzyme] Add missing Wrapper debug options parameter

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -456,6 +456,9 @@ function ShallowWrapperTest() {
 
     function test_debug() {
         stringVal = shallowWrapper.debug();
+        stringVal = shallowWrapper.debug({verbose: false});
+        stringVal = shallowWrapper.debug({ignoreProps: true});
+        stringVal = shallowWrapper.debug({ignoreProps: true, verbose: true});
     }
 
     function test_type() {
@@ -885,6 +888,9 @@ function ReactWrapperTest() {
 
     function test_debug() {
         stringVal = reactWrapper.debug();
+        stringVal = reactWrapper.debug({verbose: false});
+        stringVal = reactWrapper.debug({ignoreProps: true});
+        stringVal = reactWrapper.debug({ignoreProps: true, verbose: true});
     }
 
     function test_type() {

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -456,9 +456,9 @@ function ShallowWrapperTest() {
 
     function test_debug() {
         stringVal = shallowWrapper.debug();
-        stringVal = shallowWrapper.debug({verbose: false});
-        stringVal = shallowWrapper.debug({ignoreProps: true});
-        stringVal = shallowWrapper.debug({ignoreProps: true, verbose: true});
+        stringVal = shallowWrapper.debug({ verbose: false });
+        stringVal = shallowWrapper.debug({ ignoreProps: true });
+        stringVal = shallowWrapper.debug({ ignoreProps: true, verbose: true });
     }
 
     function test_type() {
@@ -888,9 +888,9 @@ function ReactWrapperTest() {
 
     function test_debug() {
         stringVal = reactWrapper.debug();
-        stringVal = reactWrapper.debug({verbose: false});
-        stringVal = reactWrapper.debug({ignoreProps: true});
-        stringVal = reactWrapper.debug({ignoreProps: true, verbose: true});
+        stringVal = reactWrapper.debug({ verbose: false });
+        stringVal = reactWrapper.debug({ ignoreProps: true });
+        stringVal = reactWrapper.debug({ ignoreProps: true, verbose: true });
     }
 
     function test_type() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -102,9 +102,15 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      * @param ...args The argments to the invokePropName function
      * @returns The value of the function.
      */
-    invoke<K extends NonNullable<{
-        [K in keyof P]: P[K] extends ((...arg: any[]) => void) | undefined ? K : never
-    }[keyof P]>>(invokePropName: K): P[K];
+    invoke<
+        K extends NonNullable<
+            {
+                [K in keyof P]: P[K] extends ((...arg: any[]) => void) | undefined ? K : never;
+            }[keyof P]
+        >
+    >(
+        invokePropName: K
+    ): P[K];
 
     /**
      * Returns whether or not the current node matches a provided selector.
@@ -301,8 +307,8 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      * tests are not passing when you expect them to.
      */
     debug(options?: {
-        ignoreProps?: boolean, // Whether props should be omitted in the resulting string. Props are included by default.
-        verbose?: boolean // Whether arrays and objects passed as props should be verbosely printed.
+        ignoreProps?: boolean; // Whether props should be omitted in the resulting string. Props are included by default.
+        verbose?: boolean; // Whether arrays and objects passed as props should be verbosely printed.
     }): string;
 
     /**

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -11,6 +11,7 @@
 //                 Christian Rackerseder <https://github.com/screendriver>
 //                 Mateusz Sokoła <https://github.com/mateuszsokola>
 //                 Braiden Cutforth <https://github.com/braidencutforth>
+//                 Erick Zhao <https://github.com/erickzhao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -308,7 +308,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      * tests are not passing when you expect them to.
      */
     debug(options?: {
-        /** Whether props should be omitted in the resulting string. Props are included by default. */ 
+        /** Whether props should be omitted in the resulting string. Props are included by default. */
         ignoreProps?: boolean;
         /** Whether arrays and objects passed as props should be verbosely printed. */
         verbose?: boolean;

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -300,7 +300,10 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      * Returns an html-like string of the wrapper for debugging purposes. Useful to print out to the console when
      * tests are not passing when you expect them to.
      */
-    debug(): string;
+    debug(options?: {
+        ignoreProps?: boolean, // Whether props should be omitted in the resulting string. Props are included by default.
+        verbose?: boolean // Whether arrays and objects passed as props should be verbosely printed.
+    }): string;
 
     /**
      * Returns the name of the current node of the wrapper.

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -308,8 +308,10 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
      * tests are not passing when you expect them to.
      */
     debug(options?: {
-        ignoreProps?: boolean; // Whether props should be omitted in the resulting string. Props are included by default.
-        verbose?: boolean; // Whether arrays and objects passed as props should be verbosely printed.
+        /** Whether props should be omitted in the resulting string. Props are included by default. */ 
+        ignoreProps?: boolean;
+        /** Whether arrays and objects passed as props should be verbosely printed. */
+        verbose?: boolean;
     }): string;
 
     /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* `ShallowWrapper`: https://airbnb.io/enzyme/docs/api/ShallowWrapper/debug.html
* `ReactWrapper`: https://airbnb.io/enzyme/docs/api/ReactWrapper/debug.html
**N.B. although the `ReactWrapper` docs are missing the `verbose` option, it's implemented in the code. I've opened a PR here to fix the docs: https://github.com/airbnb/enzyme/pull/2184. See PR for more context.**
- [x] ~Increase the version number in the header if appropriate.~ **(N/A)**
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ **(N/A)**
