### PR TITLE
[@types/stripe] Add missing "card" field to ISource

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5792,7 +5792,7 @@ declare namespace Stripe {
         /**
          * Hash describing the card used to make the charge
          */
-        interface ICardHash extends IResourceObject {
+        interface ICardHash extends IResourceObject, ICardHashInfo {
             /**
              * ID of card (used in conjunction with a customer or recipient ID)
              */
@@ -5802,79 +5802,6 @@ declare namespace Stripe {
              * Value is 'card'
              */
             object: "card";
-
-            /**
-             * The card number
-             */
-            number?: string;
-
-            /**
-             * Card brand. Can be Visa, American Express, MasterCard, Discover, JCB, Diners Club, or Unknown.
-             */
-            brand: "Visa" | "American Express" | "MasterCard" | "Discover" | "JCB" | "Diners Club" | "Unknown" ;
-            exp_month: number;
-            exp_year: number;
-
-            /**
-             * Card funding type. Can be credit, debit, prepaid, or unknown
-             */
-            funding: "credit" | "debit" | "prepaid" | "unknown";
-            last4: string;
-            address_city: string | null;
-
-            /**
-             * Billing address country, if provided when creating card
-             */
-            address_country: string | null;
-            address_line1: string | null;
-
-            /**
-             * If address_line1 was provided, results of the check: pass, fail, unavailable, or unchecked.
-             */
-            address_line1_check: "pass" | "fail" | "unavailable" | "unchecked" | null;
-            address_line2: string | null;
-            address_state: string | null;
-            address_zip: string | null;
-
-            /**
-             * If address_zip was provided, results of the check: pass, fail, unavailable, or unchecked.
-             */
-            address_zip_check: "pass" | "fail" | "unavailable" | "unchecked" | null;
-
-            /**
-             * Two-letter ISO code representing the country of the card. You could use this
-             * attribute to get a sense of the international breakdown of cards you've collected.
-             */
-            country: string;
-
-            /**
-             * If a CVC was provided, results of the check: pass, fail, unavailable, or unchecked
-             */
-            cvc_check: "pass" | "fail" | "unavailable" | "unchecked";
-
-            /**
-             * (For Apple Pay integrations only.) The last four digits of the device account number.
-             */
-            dynamic_last4: string | null;
-
-            /**
-             * Cardholder name
-             */
-            name: string | null;
-
-            /**
-             * Uniquely identifies this particular card number. You can use this attribute to check
-             * whether two customers who've signed up with you are using the same card number, for example.
-             */
-            fingerprint: string;
-
-            metadata?: IMetadata;
-
-            /**
-             * If the card number is tokenized, this is the method that was
-             * used. Can be "apple_pay" or "android_pay".
-             */
-            tokenization_method: "apple_pay" | "android_pay" | null;
         }
 
         interface ICardUpdateOptions extends IDataOptionsWithMetadata {
@@ -6716,6 +6643,7 @@ declare namespace Stripe {
                 refund_account_holder_name?: string | null;
             };
             amount?: number | null;
+            card?: ICardHashInfo;
             client_secret: string;
             code_verification?: {
                 attempts_remaining: number
@@ -9174,6 +9102,69 @@ declare namespace Stripe {
 
     interface IResourceObject extends IObject {
         id: string;
+    }
+
+    interface ICardHashInfo {
+        /**
+         * The card number
+         */
+        number?: string;
+        /**
+         * Card brand. Can be Visa, American Express, MasterCard, Discover, JCB, Diners Club, or Unknown.
+         */
+        brand: "Visa" | "American Express" | "MasterCard" | "Discover" | "JCB" | "Diners Club" | "Unknown" ;
+        exp_month: number;
+        exp_year: number;
+        /**
+         * Card funding type. Can be credit, debit, prepaid, or unknown
+         */
+        funding: "credit" | "debit" | "prepaid" | "unknown";
+        last4: string;
+        address_city: string | null;
+        /**
+         * Billing address country, if provided when creating card
+         */
+        address_country: string | null;
+        address_line1: string | null;
+        /**
+         * If address_line1 was provided, results of the check: pass, fail, unavailable, or unchecked.
+         */
+        address_line1_check: "pass" | "fail" | "unavailable" | "unchecked" | null;
+        address_line2: string | null;
+        address_state: string | null;
+        address_zip: string | null;
+        /**
+         * If address_zip was provided, results of the check: pass, fail, unavailable, or unchecked.
+         */
+        address_zip_check: "pass" | "fail" | "unavailable" | "unchecked" | null;
+        /**
+         * Two-letter ISO code representing the country of the card. You could use this
+         * attribute to get a sense of the international breakdown of cards you've collected.
+         */
+        country: string;
+        /**
+         * If a CVC was provided, results of the check: pass, fail, unavailable, or unchecked
+         */
+        cvc_check: "pass" | "fail" | "unavailable" | "unchecked";
+        /**
+         * (For Apple Pay integrations only.) The last four digits of the device account number.
+         */
+        dynamic_last4: string | null;
+        /**
+         * Cardholder name
+         */
+        name: string | null;
+        /**
+         * Uniquely identifies this particular card number. You can use this attribute to check
+         * whether two customers who've signed up with you are using the same card number, for example.
+         */
+        fingerprint: string;
+        metadata?: IMetadata;
+        /**
+         * If the card number is tokenized, this is the method that was
+         * used. Can be "apple_pay" or "android_pay".
+         */
+        tokenization_method: "apple_pay" | "android_pay" | null;
     }
 
     type IResponseFn<R> = (err: IStripeError, value: R) => void;

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -9109,23 +9109,27 @@ declare namespace Stripe {
          * The card number
          */
         number?: string;
+
         /**
          * Card brand. Can be Visa, American Express, MasterCard, Discover, JCB, Diners Club, or Unknown.
          */
         brand: "Visa" | "American Express" | "MasterCard" | "Discover" | "JCB" | "Diners Club" | "Unknown" ;
         exp_month: number;
         exp_year: number;
+
         /**
          * Card funding type. Can be credit, debit, prepaid, or unknown
          */
         funding: "credit" | "debit" | "prepaid" | "unknown";
         last4: string;
         address_city: string | null;
+
         /**
          * Billing address country, if provided when creating card
          */
         address_country: string | null;
         address_line1: string | null;
+
         /**
          * If address_line1 was provided, results of the check: pass, fail, unavailable, or unchecked.
          */
@@ -9133,33 +9137,40 @@ declare namespace Stripe {
         address_line2: string | null;
         address_state: string | null;
         address_zip: string | null;
+
         /**
          * If address_zip was provided, results of the check: pass, fail, unavailable, or unchecked.
          */
         address_zip_check: "pass" | "fail" | "unavailable" | "unchecked" | null;
+
         /**
          * Two-letter ISO code representing the country of the card. You could use this
          * attribute to get a sense of the international breakdown of cards you've collected.
          */
         country: string;
+
         /**
          * If a CVC was provided, results of the check: pass, fail, unavailable, or unchecked
          */
         cvc_check: "pass" | "fail" | "unavailable" | "unchecked";
+
         /**
          * (For Apple Pay integrations only.) The last four digits of the device account number.
          */
         dynamic_last4: string | null;
+
         /**
          * Cardholder name
          */
         name: string | null;
+
         /**
          * Uniquely identifies this particular card number. You can use this attribute to check
          * whether two customers who've signed up with you are using the same card number, for example.
          */
         fingerprint: string;
         metadata?: IMetadata;
+
         /**
          * If the card number is tokenized, this is the method that was
          * used. Can be "apple_pay" or "android_pay".

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1556,6 +1556,16 @@ stripe.subscriptions.list({ customer: "cus_5rfJKDJkuxzh5Q", plan: "platypi-dev" 
 
 //#endregion
 
+//#region Sources tests
+// ##################################################################################
+
+stripe.sources.retrieve("tok_15V2YhEe31JkLCeQy9iUgsJX").then((source) => {
+    // asynchronously called
+    const obj: Stripe.ICardHashInfo = source.card;
+});
+
+//#endregion
+
 //#region Subscription Items tests
 // ##################################################################################
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1561,7 +1561,7 @@ stripe.subscriptions.list({ customer: "cus_5rfJKDJkuxzh5Q", plan: "platypi-dev" 
 
 stripe.sources.retrieve("tok_15V2YhEe31JkLCeQy9iUgsJX").then((source) => {
     // asynchronously called
-    const obj: Stripe.ICardHashInfo = source.card;
+    const obj: Stripe.ICardHashInfo = source.card; // $ExpectType ICardHashInfo
 });
 
 //#endregion

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1561,7 +1561,7 @@ stripe.subscriptions.list({ customer: "cus_5rfJKDJkuxzh5Q", plan: "platypi-dev" 
 
 stripe.sources.retrieve("tok_15V2YhEe31JkLCeQy9iUgsJX").then((source) => {
     // asynchronously called
-    const obj: Stripe.ICardHashInfo = source.card; // $ExpectType ICardHashInfo
+    source.card; // $ExpectType ICardHashInfo
 });
 
 //#endregion


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/sources/object#source_object-type
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

**Extended Explanation**:
The current return type of the Sources API doesn't include the hash of the object other than for "ach_credit_transfer".

The Source object contains the hash as stated here:
https://stripe.com/docs/api/sources/object#source_object-type
"An additional hash is included on the source with a name matching this value. It contains additional information specific to the payment method used."

I only edited for the card object since that's the only one I'm using at the moment. Here is a sample response from `stripe.sources.retrieve`, with the `client_secret` and `customer` fields removed, using a Stripe test card:

```
{
  id: 'src_1ErXDALiwAROT4Ut92v567R5',
  object: 'source',
  amount: null,
  card: {
    exp_month: 4,
    exp_year: 2044,
    last4: '4444',
    country: 'US',
    brand: 'MasterCard',
    address_zip_check: 'pass',
    cvc_check: 'pass',
    funding: 'credit',
    fingerprint: 'MNBgjfj3540R8jlu',
    three_d_secure: 'optional',
    name: null,
    address_line1_check: null,
    tokenization_method: null,
    dynamic_last4: null
  },
  created: 1562017136,
  currency: null,
  flow: 'none',
  livemode: false,
  metadata: {},
  owner: {
    address: {
      city: null,
      country: null,
      line1: null,
      line2: null,
      postal_code: '44444',
      state: null
    },
    email: null,
    name: null,
    phone: null,
    verified_address: null,
    verified_email: null,
    verified_name: null,
    verified_phone: null
  },
  statement_descriptor: null,
  status: 'chargeable',
  type: 'card',
  usage: 'reusable'
}
```

In adding "card" field to `ISource`, I wanted to retain the comments and fields of `ICardHash` without the `object` and `id` fields, since those are omitted from the Sources API. So I created a new interface and shared that among `ICardHash` and `ISource`. Open to suggestions on how to do this better. 