### PR TITLE
Added typing defs for mathjs-6.0

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -306,7 +306,7 @@ declare namespace math {
 
         /**
          * Parse and compile an expression. Returns a an object with a function
-         * eval([scope]) to evaluate the compiled expression.
+         * evaluate([scope]) to evaluate the compiled expression.
          * @param expr The expression to be compiled
          * @returns An object with the compiled expression
          */
@@ -2744,14 +2744,14 @@ declare namespace math {
         cloneDeep(): MathNode;
         /**
          * Compile an expression into optimized JavaScript code. compile returns
-         * an object with a function eval([scope]) to evaluate. Example:
+         * an object with a function evaluate([scope]) to evaluate. Example:
          */
         compile(): EvalFunction;
         /**
          * Compile and eval an expression, this is the equivalent of doing
-         * node.compile().eval(scope). Example:
+         * node.compile().evaluate(scope). Example:
          */
-        eval(expr?: any): any;
+        evaluate(expr?: any): any;
         /**
          * Test whether this node equals an other node. Does a deep comparison
          * of the values of both nodes.
@@ -2896,7 +2896,7 @@ declare namespace math {
     }
 
     interface Parser {
-        eval(expr: string): any;
+        evaluate(expr: string): any;
         get(variable: string): any;
         getAll(): { [key: string]: any; };
         set: (variable: string, value: any) => void;
@@ -3096,7 +3096,7 @@ declare namespace math {
 
         /**
          * Parse and compile an expression. Returns a an object with a function
-         * eval([scope]) to evaluate the compiled expression.
+         * evaluate([scope]) to evaluate the compiled expression.
          */
         compile(): MathJsChain;
 
@@ -3104,7 +3104,7 @@ declare namespace math {
          * Evaluate an expression.
          * @param scope Scope to read/write variables
          */
-        eval(scope?: object): MathJsChain;
+        evaluate(scope?: object): MathJsChain;
 
         /**
          * Retrieve help on a function or data type. Help files are retrieved
@@ -3114,7 +3114,7 @@ declare namespace math {
 
         /**
          * Parse an expression. Returns a node tree, which can be evaluated by
-         * invoking node.eval();
+         * invoking node.evaluate();
          * @param options Available options: nodes - a set of custome nodes
          */
         parse(options?: any): MathJsChain;

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -26,9 +26,22 @@ declare namespace math {
         | Matrix;
     type MathExpression = string | string[] | MathArray | Matrix;
 
+    type FactoryFunction = (scope: any) => any;
+
+    // FactoryFunctionMap can be nested; all nested objects will be flattened
+    type FactoryFunctionMap = {
+        [key: string]: FactoryFunction | FactoryFunctionMap;
+    }
+
     interface MathJsStatic {
-        create: (factories: any, config: ConfigOptions) => MathJsStatic;
-        all: any;
+        create: (factories: FactoryFunctionMap, config: ConfigOptions) => MathJsStatic;
+        factory: (
+            name: string,
+            dependencies: string[],
+            create: (depencencies: { [key: string]: any }) => any,
+            meta?: any,
+        ) => FactoryFunction;
+        all: FactoryFunctionMap;
 
         e: number;
         pi: number;

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for mathjs 5.0
+// Type definitions for mathjs 6.0
 // Project: https://mathjs.org/
 // Definitions by: Ilya Shestakov <https://github.com/siavol>,
 //                  Andy Patterson <https://github.com/andnp>,
 //                  Brad Besserman <https://github.com/bradbesserman>
 //                  Pawel Krol <https://github.com/pawkrol>
+//                  Charlee Li <https://github.com/charlee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -26,6 +27,9 @@ declare namespace math {
     type MathExpression = string | string[] | MathArray | Matrix;
 
     interface MathJsStatic {
+        create: (factories: any, config: ConfigOptions) => MathJsStatic;
+        all: any;
+
         e: number;
         pi: number;
         i: number;
@@ -319,7 +323,7 @@ declare namespace math {
          * @param scope Scope to read/write variables
          * @returns The result of the expression
          */
-        eval(
+        evaluate(
             expr: MathExpression | MathExpression[] | Matrix,
             scope?: object
         ): any;
@@ -334,7 +338,7 @@ declare namespace math {
 
         /**
          * Parse an expression. Returns a node tree, which can be evaluated by
-         * invoking node.eval();
+         * invoking node.evaluate();
          * @param expr Expression to be parsed
          * @param options Available options: nodes - a set of custome nodes
          * @returns A node
@@ -2053,7 +2057,7 @@ declare namespace math {
         /**
          * Compute the standard deviation of a matrix or a list with values. The
          * standard deviations is defined as the square root of the variance:
-         * std(A) = sqrt(var(A)). In case of a (multi dimensional) array or
+         * std(A) = sqrt(variance(A)). In case of a (multi dimensional) array or
          * matrix, the standard deviation over all elements will be calculated.
          * Optionally, the type of normalization can be specified as second
          * parameter. The parameter normalization can be one of the following
@@ -2099,7 +2103,7 @@ declare namespace math {
          * @param args A single matrix or multiple scalar values
          * @returns The variance
          */
-        var(...args: Array<number | BigNumber | Fraction>): any;
+        variance(...args: Array<number | BigNumber | Fraction>): any;
         /**
          * @param array A single matrix
          * @param normalization normalization Determines how to normalize the
@@ -2107,7 +2111,7 @@ declare namespace math {
          * Default value: ‘unbiased’.
          * @returns The variance
          */
-        var(
+        variance(
             array: MathArray | Matrix,
             normalization?: "unbiased" | "uncorrected" | "biased" | "unbiased"
         ): any;
@@ -2571,7 +2575,7 @@ declare namespace math {
          * case, non-primitive types are upper-camel-case. For example ‘number’,
          * ‘string’, ‘Array’, ‘Date’.
          */
-        typeof(x: any): string;
+        typeOf(x: any): string;
 
         /**
          * Import functions from an object or a module
@@ -2700,7 +2704,7 @@ declare namespace math {
     interface Index {} // tslint:disable-line no-empty-interface
 
     interface EvalFunction {
-        eval(scope?: any): any;
+        evaluate(scope?: any): any;
     }
 
     interface MathNode {
@@ -4242,7 +4246,7 @@ declare namespace math {
         /**
          * Compute the standard deviation of a matrix or a list with values. The
          * standard deviations is defined as the square root of the variance:
-         * std(A) = sqrt(var(A)). In case of a (multi dimensional) array or
+         * std(A) = sqrt(variance(A)). In case of a (multi dimensional) array or
          * matrix, the standard deviation over all elements will be calculated.
          * Optionally, the type of normalization can be specified as second
          * parameter. The parameter normalization can be one of the following
@@ -4276,13 +4280,13 @@ declare namespace math {
          * is divided by n 'biased' The sum of squared errors is divided by (n +
          * 1) Note that older browser may not like the variable name var. In
          * that case, the function can be called as math['var'](...) instead of
-         * math.var(...).
+         * math.variance(...).
          * @param normalization normalization Determines how to normalize the
          * variance. Choose ‘unbiased’ (default), ‘uncorrected’, or ‘biased’.
          * Default value: ‘unbiased’.
          * @returns The variance
          */
-        var(
+        variance(
             normalization?: "unbiased" | "uncorrected" | "biased" | "unbiased"
         ): MathJsChain;
 

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -26,21 +26,23 @@ declare namespace math {
         | Matrix;
     type MathExpression = string | string[] | MathArray | Matrix;
 
-    type FactoryFunction = (scope: any) => any;
+    type FactoryFunction<T> = (scope: any) => T;
 
     // FactoryFunctionMap can be nested; all nested objects will be flattened
-    type FactoryFunctionMap = {
-        [key: string]: FactoryFunction | FactoryFunctionMap;
+    interface FactoryFunctionMap {
+        [key: string]: FactoryFunction<any> | FactoryFunctionMap;
     }
+
+    type MathJsFunctionName = keyof MathJsStatic;
 
     interface MathJsStatic {
         create: (factories: FactoryFunctionMap, config: ConfigOptions) => MathJsStatic;
-        factory: (
+        factory: <T>(
             name: string,
-            dependencies: string[],
-            create: (depencencies: { [key: string]: any }) => any,
+            dependencies: MathJsFunctionName[],
+            create: (injected: MathJsStatic) => T,
             meta?: any,
-        ) => FactoryFunction;
+        ) => FactoryFunction<T>;
         all: FactoryFunctionMap;
 
         e: number;

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2099,7 +2099,7 @@ declare namespace math {
          * is divided by n 'biased' The sum of squared errors is divided by (n +
          * 1) Note that older browser may not like the variable name var. In
          * that case, the function can be called as math['var'](...) instead of
-         * math.var(...).
+         * math.variance(...).
          * @param args A single matrix or multiple scalar values
          * @returns The variance
          */
@@ -4562,7 +4562,7 @@ declare namespace math {
         /**
          * Determine the type of a variable.
          */
-        typeof(): MathJsChain;
+        typeOf(): MathJsChain;
     }
 
     interface ImportOptions {

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -1,10 +1,12 @@
 // Import needed for mathjs.import functionality (declaring/extending module)
-import * as math from 'mathjs';
+import { create, all } from 'mathjs';
 
 /*
 Basic usage examples
 */
 {
+	const math = create(all, {});
+
 	// functions and constants
 	math.round(math.e, 3);
 	math.atan2(3, -3) / math.pi;
@@ -15,7 +17,7 @@ Basic usage examples
 	math.add(math.pow(math.sin(angle), 2), math.pow(math.cos(angle), 2));
 
 	// expressions
-	math.eval('1.2 * (2 + 4.5)');
+	math.evaluate('1.2 * (2 + 4.5)');
 
 	// chained operations
 	const a = math.chain(3)
@@ -35,7 +37,7 @@ Bignumbers examples
 */
 {
 	// configure the default type of numbers as BigNumbers
-	math.config({
+	const math = create(all, {
 		number: 'BigNumber',
 		precision: 20,
 	});
@@ -50,6 +52,7 @@ Bignumbers examples
 Chaining examples
 */
 {
+	const math = create(all, {});
 	const a = math.chain(3)
 		.add(4)
 		.multiply(2)
@@ -84,6 +87,7 @@ Chaining examples
 Complex numbers examples
 */
 {
+	const math = create(all, {});
 	const a = math.complex(2, 3);
 	// create a complex number by providing a string with real and complex parts
 	const b = math.complex('3 - 7i');
@@ -125,14 +129,15 @@ Complex numbers examples
 Expressions examples
 */
 {
+	const math = create(all, {});
 	// evaluate expressions
 	{
-		math.eval('sqrt(3^2 + 4^2)');
+		math.evaluate('sqrt(3^2 + 4^2)');
 	}
 
 	// evaluate multiple expressions at once
 	{
-		math.eval([
+		math.evaluate([
 			'f = 3',
 			'g = 4',
 			'f * g'
@@ -142,7 +147,7 @@ Expressions examples
 	// scope can contain both variables and functions
 	{
 		const scope = { hello: (name: string) => `hello, ${name}!` };
-		math.eval('hello("hero")', scope);   // "hello, hero!"
+		math.evaluate('hello("hero")', scope);   // "hello, hero!"
 	}
 
 	// define a function as an expression
@@ -151,7 +156,7 @@ Expressions examples
 			a: 3,
 			b: 4,
 		};
-		const f = math.eval('f(x) = x ^ a', scope);
+		const f = math.evaluate('f(x) = x ^ a', scope);
 		f(2);
 		scope.f(2);
 	}
@@ -168,7 +173,7 @@ Expressions examples
 		// provide a scope for the variable assignment
 		const code2 = math.compile('a = a + 3');
 		const scope = { a: 7 };
-		code2.eval(scope);
+		code2.evaluate(scope);
 	}
 	// 4. using a parser
 	const parser = math.parser();
@@ -198,7 +203,7 @@ Fractions examples
 */
 {
 	// configure the default type of numbers as Fractions
-	math.config({
+	const math = create(all, {
 		number: 'Fraction',
 	});
 
@@ -217,6 +222,8 @@ Fractions examples
 Matrices examples
 */
 {
+	const math = create(all, {});
+
 	// create matrices and arrays. a matrix is just a wrapper around an Array,
 	// providing some handy utilities.
 	const a: math.Matrix = math.matrix([1, 4, 9, 16, 25]);
@@ -293,6 +300,8 @@ Matrices examples
 Sparse matrices examples
 */
 {
+	const math = create(all, {});
+
 	// create a sparse matrix
 	const a = math.identity(1000, 1000, 'sparse');
 
@@ -308,6 +317,8 @@ Sparse matrices examples
 Units examples
 */
 {
+	const math = create(all, {});
+
 	// units can be created by providing a value and unit name, or by providing
 	// a string with a valued unit.
 	const a = math.unit(45, 'cm'); // 450 mm
@@ -355,7 +366,7 @@ Units examples
 	math.number(b, 'cm');
 
 	// the expression parser supports units too
-	math.eval('2 inch to cm');
+	math.evaluate('2 inch to cm');
 
 	// units can be converted to SI
 	math.unit('1 inch').toSI();
@@ -368,6 +379,8 @@ Units examples
 Expression tree examples
 */
 {
+	const math = create(all, {});
+
 	// Filter an expression tree
 	const node: math.MathNode = math.parse('x^2 + x/4 + 3*y');
 	const filtered: math.MathNode[] = node.filter((node: math.MathNode) => node.isSymbolNode && node.name === 'x');
@@ -394,6 +407,8 @@ Expression tree examples
 JSON serialization/deserialization
 */
 {
+	const math = create(all, {});
+
 	const data = {
 		bigNumber: math.bignumber('1.5')
 	};
@@ -414,6 +429,7 @@ declare module 'mathjs' {
 }
 
 {
+	const math = create(all, {});
     const testFun = () => 5;
 
     math.import({

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -437,3 +437,13 @@ declare module 'mathjs' {
 
     const a = math.value * 2;
 }
+
+/*
+Renamed functions from v5 => v6
+ */
+{
+	const math = create(all, {});
+	math.typeOf(1);
+	math.variance([1, 2, 3, 4]);
+	math.evaluate('1 + 2');
+}

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -137,17 +137,13 @@ Expressions examples
 
 	// evaluate multiple expressions at once
 	{
-		math.evaluate([
-			'f = 3',
-			'g = 4',
-			'f * g'
-		]);
+		math.evaluate(['f = 3', 'g = 4', 'f * g']);
 	}
 
 	// scope can contain both variables and functions
 	{
 		const scope = { hello: (name: string) => `hello, ${name}!` };
-		math.evaluate('hello("hero")', scope);   // "hello, hero!"
+		math.evaluate('hello("hero")', scope); // "hello, hero!"
 	}
 
 	// define a function as an expression
@@ -180,10 +176,10 @@ Expressions examples
 
 	// get and set variables and functions
 	{
-        parser.eval('x = 7 / 2');               // 3.5
-     	parser.eval('x + 3');                   // 6.5
-        parser.eval('f(x, y) = x^y');           // f(x, y)
-        parser.eval('f(2, 3)');                 // 8
+		parser.evaluate('x = 7 / 2');               // 3.5
+		parser.evaluate('x + 3');                   // 6.5
+		parser.evaluate('f(x, y) = x^y');           // f(x, y)
+		parser.evaluate('f(2, 3)');                 // 8
 
 		const x = parser.get('x');
 		const f = parser.get('f');

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -1,4 +1,3 @@
-// Import needed for mathjs.import functionality (declaring/extending module)
 import { create, factory, all, MathJsFunctionName } from 'mathjs';
 
 /*

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -446,4 +446,15 @@ Renamed functions from v5 => v6
 	math.typeOf(1);
 	math.variance([1, 2, 3, 4]);
 	math.evaluate('1 + 2');
+
+	// chained operations
+	math.chain(3)
+		.typeOf()
+		.done();
+	math.chain([1, 2, 3])
+		.variance()
+		.done();
+	math.chain('1 + 2')
+		.evaluate()
+		.done();
 }

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -1,5 +1,5 @@
 // Import needed for mathjs.import functionality (declaring/extending module)
-import { create, all } from 'mathjs';
+import { create, factory, all, MathJsFunctionName } from 'mathjs';
 
 /*
 Basic usage examples
@@ -457,4 +457,29 @@ Renamed functions from v5 => v6
 	math.chain('1 + 2')
 		.evaluate()
 		.done();
+}
+
+/*
+Factory Test
+ */
+{
+	// create a factory function
+	const name = 'negativeSquare';
+	const dependencies: MathJsFunctionName[] = ['multiply', 'unaryMinus'];
+	const createNegativeSquare = factory(
+		name,
+		dependencies,
+		(injected) => {
+			const { multiply, unaryMinus } = injected;
+			return function negativeSquare(x: number): number {
+				return unaryMinus(multiply(x, x));
+			};
+		},
+	);
+
+	// create an instance of the function yourself:
+	const multiply = (a: number, b: number) => a * b;
+	const unaryMinus = (a: number) => -a;
+	const negativeSquare = createNegativeSquare({ multiply, unaryMinus });
+	negativeSquare(3);
 }


### PR DESCRIPTION
This PR solved issue #36381, and a related issue in `mathjs` repo: https://github.com/josdejong/mathjs/issues/1539

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/josdejong/mathjs/blob/develop/HISTORY.md#2019-06-08-version-600
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
