### PR TITLE
fix(chart.js): add missing ChartTooltipItem fields

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -46,7 +46,14 @@ const chart: Chart = new Chart(ctx, {
             caretPadding: 2,
             displayColors: true,
             borderColor: "rgba(0,0,0,0)",
-            borderWidth: 1
+            borderWidth: 1,
+            callbacks: {
+                title: ([point]) => point.label ? point.label.substring(0, 2) : 'title',
+                label(tooltipItem) {
+                    const { value, x, y, label } = tooltipItem;
+                    return `${label}(${x}, ${y}) = ${value}`;
+                },
+            },
         },
         scales: {
             xAxes: [

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -154,10 +154,14 @@ declare namespace Chart {
     }
 
     interface ChartTooltipItem {
+        label?: string;
+        value?: string;
         xLabel?: string | number;
         yLabel?: string | number;
         datasetIndex?: number;
         index?: number;
+        x?: number;
+        y?: number;
     }
 
     interface ChartTooltipLabelColor {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

[Tooltip Item Interface](https://www.chartjs.org/docs/latest/configuration/tooltip.html#tooltip-item-interface).
Sadly it doesn't specify if fields can be undefined. I've kept the new field type definition similar to the previous `ChartTooltipItem` definitions because I'm not sure which can and cannot be undefined.

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

