### PR TITLE
[@types/stripe] Add support for Credit Notes

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7721,7 +7721,7 @@ declare namespace Stripe {
             ): Promise<creditNotes.ICreditNote>;
 
             /**
-             * Returns a list of your credit notes. Credit notes are returned sorted by creation date, with the most recently created invoice
+             * Returns a list of your credit notes. Credit notes are returned sorted by creation date, with the most recently created credit note
              * items appearing first.
              */
             list(

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1928,18 +1928,55 @@ declare namespace Stripe {
              */
             object: "credit_note";
 
+            /**
+             * The integer amount in cents representing the total amount of the credit note.
+             */
             amount: number;
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
             created: string;
+
+            /**
+             * Three-letter ISO currency code, in lowercase. Must be a supported currency.
+             */
             currency: string;
+
+            /**
+             * ID of the customer. [Expandable]
+             */
             customer: string | customers.ICustomer;
-            customer_balance_transaction: string;
+
+            /**
+             * Customer balance transaction related to this credit note. [Expandable]
+             */
+            customer_balance_transaction: string | balance.IBalanceTransaction;
+
+            /**
+             * ID of the invoice. [Expandable]
+             */
             invoice: string | invoices.IInvoice;
+
+            /**
+             * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+             */
             livemode: boolean;
+
+            /**
+             * Customer-facing text that appears on the credit note PDF.
+             */
             memo: string | null;
+
+            /**
+             * Set of key-value pairs that you can attach to an object.
+             * This can be useful for storing additional information about the object in a structured format.
+             */
             metadata: IMetadata;
 
             /**
-             * A unique number that identifies this particular credit note and appears on the PDF of the credit note and its associated invoice.
+             * A unique number that identifies this particular credit note.
+             * It appears on the PDF of the credit note and its associated invoice.
              */
             number: string;
 
@@ -1954,7 +1991,7 @@ declare namespace Stripe {
             reason: CreditNoteReason | null;
 
             /**
-             * Refund related to this credit note.
+             * Refund related to this credit note. [Expandable]
              */
             refund: string | null | refunds.IRefund;
 
@@ -1980,7 +2017,15 @@ declare namespace Stripe {
          * It will be automatically applied to their next invoice.
          */
         credit_amount?: number;
+
+        /**
+         * The credit note’s memo appears on the credit note PDF. This can be unset by updating the value to nil and then saving.
+         */
         memo?: string;
+
+        /**
+         * Reason for issuing this credit note, one of duplicate, fraudulent, order_change, or product_unsatisfactory.
+         */
         reason?: CreditNoteReason;
 
         /**
@@ -1995,10 +2040,16 @@ declare namespace Stripe {
       }
 
       interface ICreditNoteUpdateOptions extends IDataOptionsWithMetadata {
+        /**
+         * Credit note memo. This can be unset by updating the value to nil and then saving.
+         */
         memo?: string;
       }
 
       interface ICreditNoteListOptions extends IListOptions {
+        /**
+         * ID of the invoice.
+         */
         invoice?: string;
       }
 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1951,7 +1951,7 @@ declare namespace Stripe {
             /**
              * Reason for issuing this credit note, one of duplicate, fraudulent, order_change, or product_unsatisfactory
              */
-            reason: string | null;
+            reason: CreditNoteReason | null;
 
             /**
              * Refund related to this credit note.
@@ -1961,14 +1961,14 @@ declare namespace Stripe {
             /**
              * Status of this credit note, one of issued or void.
              */
-            status: string;
+            status: "issued" | "void";
 
             /**
              * Type of this credit note, one of post_payment or pre_payment.
              * A pre_payment credit note means it was issued when the invoice was open.
              * A post_payment credit note means it was issued when the invoice was paid.
              */
-            type: string;
+            type: "post_payment" | "pre_payment";
       }
 
       interface ICreditNoteCreationOptions extends IDataOptionsWithMetadata {
@@ -1981,7 +1981,7 @@ declare namespace Stripe {
          */
         credit_amount?: number;
         memo?: string;
-        reason?: string;
+        reason?: CreditNoteReason;
 
         /**
          * ID of an existing refund to link this credit note to.
@@ -2001,6 +2001,11 @@ declare namespace Stripe {
       interface ICreditNoteListOptions extends IListOptions {
         invoice?: string;
       }
+
+      /**
+       * Reason for issuing a credit note, one of duplicate, fraudulent, order_change, or product_unsatisfactory
+       */
+      type CreditNoteReason = "duplicate" | "fraudulent" | "order_change" | "product_unsatisfactory";
     }
 
     namespace customers {

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -57,6 +57,7 @@ declare class Stripe {
     charges: Stripe.resources.Charges;
     checkout: Stripe.resources.Checkout;
     coupons: Stripe.resources.Coupons;
+    creditNotes: Stripe.resources.CreditNotes;
     customers: Stripe.resources.Customers;
     disputes: Stripe.resources.Disputes;
     events: Stripe.resources.Events;
@@ -92,11 +93,11 @@ declare class Stripe {
     sources: Stripe.resources.Sources;
 
     setHost(host: string): void;
-    setHost(host: string, port: string|number): void;
-    setHost(host: string, port: string|number, protocol: string): void;
+    setHost(host: string, port: string | number): void;
+    setHost(host: string, port: string | number, protocol: string): void;
 
     setProtocol(protocol: string): void;
-    setPort(port: string|number): void;
+    setPort(port: string | number): void;
     setApiVersion(version?: string): void;
     setApiKey(key?: string): void;
     setTimeout(timeout?: number): void;
@@ -1915,6 +1916,93 @@ declare namespace Stripe {
         }
     }
 
+    namespace creditNotes {
+      /**
+       * Credit notes are documents that decrease the amount owed on a specified invoice.
+       * Credit notes are the only way to adjust the amount of an invoice once it's been finalized
+       * (other than voiding and recreating the invoice from scratch).
+       */
+      interface ICreditNote extends IResourceObject {
+            /**
+             * Value is "credit_note"
+             */
+            object: "credit_note";
+
+            amount: number;
+            created: string;
+            currency: string;
+            customer: string | customers.ICustomer;
+            customer_balance_transaction: string;
+            invoice: string | invoices.IInvoice;
+            livemode: boolean;
+            memo: string | null;
+            metadata: IMetadata;
+
+            /**
+             * A unique number that identifies this particular credit note and appears on the PDF of the credit note and its associated invoice.
+             */
+            number: string;
+
+            /**
+             * The link to download the PDF of the credit note.
+             */
+            pdf: string;
+
+            /**
+             * Reason for issuing this credit note, one of duplicate, fraudulent, order_change, or product_unsatisfactory
+             */
+            reason: string | null;
+
+            /**
+             * Refund related to this credit note.
+             */
+            refund: string | null | refunds.IRefund;
+
+            /**
+             * Status of this credit note, one of issued or void.
+             */
+            status: string;
+
+            /**
+             * Type of this credit note, one of post_payment or pre_payment.
+             * A pre_payment credit note means it was issued when the invoice was open.
+             * A post_payment credit note means it was issued when the invoice was paid.
+             */
+            type: string;
+      }
+
+      interface ICreditNoteCreationOptions extends IDataOptionsWithMetadata {
+        amount: number;
+        invoice: string;
+
+        /**
+         * The amount to credit the customer’s balance.
+         * It will be automatically applied to their next invoice.
+         */
+        credit_amount?: number;
+        memo?: string;
+        reason?: string;
+
+        /**
+         * ID of an existing refund to link this credit note to.
+         */
+        refund?: string;
+
+        /**
+         * The amount to refund. If set, a refund will be created for the charge associated with the invoice.
+         */
+        refund_amount?: number;
+      }
+
+      interface ICreditNoteUpdateOptions extends IDataOptionsWithMetadata {
+        memo?: string;
+      }
+
+      interface ICreditNoteListOptions extends IListOptions {
+        invoice?: string;
+      }
+    }
+
     namespace customers {
         /**
          * Customer objects allow you to perform recurring charges and track multiple charges that are associated
@@ -2791,6 +2879,16 @@ declare namespace Stripe {
              * Start of the usage period during which invoice items were added to this invoice
              */
             period_start: number;
+
+            /**
+             * Total amount of all post-payment credit notes issued for this invoice.
+             */
+            post_payment_credit_notes_amount: number;
+
+            /**
+             * Total amount of all pre-payment credit notes issued for this invoice.
+             */
+            pre_payment_credit_notes_amount: number;
 
             /**
              * This is the transaction number that appears on email receipts sent for this invoice.
@@ -7576,6 +7674,83 @@ declare namespace Stripe {
             list(data: IListOptionsCreated, response?: IResponseFn<IList<coupons.ICoupon>>): IListPromise<coupons.ICoupon>;
             list(options: HeaderOptions, response?: IResponseFn<IList<coupons.ICoupon>>): IListPromise<coupons.ICoupon>;
             list(response?: IResponseFn<IList<coupons.ICoupon>>): IListPromise<coupons.ICoupon>;
+        }
+
+        class CreditNotes extends StripeResource {
+            /**
+             * A credit note can be issued for open and paid invoices.
+             * When issued for an open invoice, a credit note decreases the invoice’s amount due.
+             * When issued for a paid invoice, it is commonly used to refund or credit a specified amount to the customer.
+             */
+            create(
+                data: creditNotes.ICreditNoteCreationOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+            create(
+                data: creditNotes.ICreditNoteCreationOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+
+            /**
+             * Retrieves the credit note with the given ID.
+             */
+            retrieve(
+                creditNoteId: string,
+                options: HeaderOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+            retrieve(
+                creditNoteId: string,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+
+            /**
+             * Updates the memo or metadata on the credit note.
+             */
+            update(
+                creditNoteId: string,
+                data: creditNotes.ICreditNoteUpdateOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+            update(
+                creditNoteId: string,
+                data: creditNotes.ICreditNoteUpdateOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+
+            /**
+             * Returns a list of your credit notes. Credit notes are returned sorted by creation date, with the most recently created invoice
+             * items appearing first.
+             */
+            list(
+                data: creditNotes.ICreditNoteListOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<IList<creditNotes.ICreditNote>>
+            ): Promise<IList<creditNotes.ICreditNote>>;
+            list(
+                data: creditNotes.ICreditNoteListOptions,
+                response?: IResponseFn<IList<creditNotes.ICreditNote>>
+            ): Promise<IList<creditNotes.ICreditNote>>;
+            list(
+                options: HeaderOptions,
+                response?: IResponseFn<IList<creditNotes.ICreditNote>>
+            ): Promise<IList<creditNotes.ICreditNote>>;
+            list(response?: IResponseFn<IList<creditNotes.ICreditNote>>): Promise<IList<creditNotes.ICreditNote>>;
+
+            /**
+             * Marks a credit note as void. Voiding a credit note reverses its adjustment. Voiding is only possible on open invoices.
+             */
+            voidCreditNote(
+                creditNoteId: string,
+                options: HeaderOptions,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
+            voidCreditNote(
+                creditNoteId: string,
+                response?: IResponseFn<creditNotes.ICreditNote>
+            ): Promise<creditNotes.ICreditNote>;
         }
 
         class CustomerCards extends StripeResource {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -271,6 +271,76 @@ stripe.checkout.sessions.create({
 
 //#endregion
 
+//#region CreditNotes tests
+// ##################################################################################
+stripe.creditNotes.create({
+  amount: 100,
+  invoice: "in_15fvyXEe31JkLCeQH7QbgZZb",
+}, (err, creditNote) => {
+  creditNote; // $ExpectType ICreditNote
+});
+stripe.creditNotes.create({
+  amount: 100,
+  invoice: "in_15fvyXEe31JkLCeQH7QbgZZb",
+}).then((creditNote) => {
+  creditNote; // $ExpectType ICreditNote
+});
+
+stripe.creditNotes.retrieve(
+  "cn_1FsAjKFpRTWZADwSy2clIZum",
+  (err, creditNote) => {
+    creditNote; // $ExpectType ICreditNote
+  }
+);
+stripe.creditNotes.retrieve("cn_1FsAjKFpRTWZADwSy2clIZum").then((creditNote) => {
+  creditNote; // $ExpectType ICreditNote
+});
+
+stripe.creditNotes.retrieve("cn_1FsAjKFpRTWZADwSy2clIZum", { expand: ["refund"] }).then((creditNote) => {
+  creditNote.refund;
+});
+
+stripe.creditNotes.update(
+  "cn_1FsAjKFpRTWZADwSy2clIZum",
+  {
+    memo: 'foobar',
+  },
+  (err, creditNote) => {
+    creditNote; // $ExpectType ICreditNote
+  }
+);
+stripe.creditNotes.update(
+  "cn_1FsAjKFpRTWZADwSy2clIZum",
+  {
+    memo: 'foobar',
+  }).then((creditNote) => {
+    creditNote; // $ExpectType ICreditNote
+  }
+);
+
+stripe.creditNotes.list(
+  { invoice: "in_15fvyXEe31JkLCeQH7QbgZZb", limit: 3 },
+  (err, creditNotes) => {
+    creditNotes; // $ExpectType IList<ICreditNote>
+  }
+);
+stripe.creditNotes.list({ invoice: "in_15fvyXEe31JkLCeQH7QbgZZb", limit: 3 }).then((creditNotes) => {
+  creditNotes; // $ExpectType IList<ICreditNote>
+});
+
+stripe.creditNotes.voidCreditNote(
+  "cn_1FsAjKFpRTWZADwSy2clIZum",
+  (err, creditNote) => {
+    creditNote; // $ExpectType ICreditNote
+  }
+);
+
+stripe.creditNotes.voidCreditNote("cn_1FsAjKFpRTWZADwSy2clIZum").then(creditNote => {
+  creditNote; // $ExpectType ICreditNote
+});
+
+//#endregion
+
 //#region Customer tests
 // ##################################################################################
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/api/credit_notes>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Extended Explanation

Credit notes are supported as of stripe-node v6.29.0. See https://github.com/stripe/stripe-node/blob/master/CHANGELOG.md#6290---2019-04-18. This adds support for the credit notes API.

This includes two credit note-related fields currently missing from the `invoices` types: `post_payment_credit_notes_amount` and `pre_payment_credit_notes_amount`
See: https://stripe.com/docs/api/invoices/object#invoice_object-post_payment_credit_notes_amount 