### PR TITLE
styled-components: Add CSSPseudos and simplify CSSObject

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -7,6 +7,7 @@
 //                 Jason Killian <https://github.com/jkillian>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 David Ruisinger <https://github.com/flavordaaave>
+//                 Matthew Wagerfield <https://github.com/wagerfield>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -21,17 +22,14 @@ declare global {
 import * as CSS from "csstype";
 import * as React from "react";
 
-export type CSSObject = CSS.Properties<string | number> &
-    // Index type to allow selector nesting
-    // This is "[key in string]" and not "[key: string]" to allow CSSObject to be self-referential
-    {
-        // we need the CSS.Properties in here too to ensure the index signature doesn't create impossible values
-        [key in string]:
-            | CSS.Properties<string | number>[keyof CSS.Properties<
-                  string | number
-              >]
-            | CSSObject
-    };
+export type CSSProperties = CSS.Properties<string | number>
+
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
+
+export interface CSSObject extends CSSProperties, CSSPseudos {
+    [key: string]: CSSObject | string | number | undefined
+}
+
 export type CSSKeyframes = object & { [key: string]: CSSObject };
 
 export interface ThemeProps<T> {
@@ -219,6 +217,7 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
+            | CSSObject[]
             | InterpolationFunction<
                   ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
               >,
@@ -232,6 +231,7 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
+            | CSSObject[]
             | InterpolationFunction<
                   ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
               >,
@@ -324,13 +324,14 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 
 export interface BaseThemedCssFunction<T extends object> {
     (
-        first: TemplateStringsArray | CSSObject,
+        first: TemplateStringsArray | CSSObject | CSSObject[],
         ...interpolations: SimpleInterpolation[]
     ): FlattenSimpleInterpolation;
     (
         first:
             | TemplateStringsArray
             | CSSObject
+            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<{}, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
     ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
@@ -338,6 +339,7 @@ export interface BaseThemedCssFunction<T extends object> {
         first:
             | TemplateStringsArray
             | CSSObject
+            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): FlattenInterpolation<ThemedStyledProps<P, T>>;
@@ -372,6 +374,7 @@ export interface ThemedStyledComponentsModule<
         first:
             | TemplateStringsArray
             | CSSObject
+            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): GlobalStyleComponent<P, T>;
@@ -445,6 +448,7 @@ export function createGlobalStyle<P extends object = {}>(
     first:
         | TemplateStringsArray
         | CSSObject
+        | CSSObject[]
         | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
     ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
 ): GlobalStyleComponent<P, DefaultTheme>;
@@ -511,6 +515,7 @@ export class StyleSheetManager extends React.Component<
 export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
     | string
     | CSSObject
+    | CSSObject[]
     | FlattenInterpolation<ThemeProps<T>>;
 
 export default styled;

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -217,7 +217,6 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
-            | CSSObject[]
             | InterpolationFunction<
                   ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
               >,
@@ -231,7 +230,6 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
-            | CSSObject[]
             | InterpolationFunction<
                   ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
               >,
@@ -324,14 +322,13 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 
 export interface BaseThemedCssFunction<T extends object> {
     (
-        first: TemplateStringsArray | CSSObject | CSSObject[],
+        first: TemplateStringsArray | CSSObject,
         ...interpolations: SimpleInterpolation[]
     ): FlattenSimpleInterpolation;
     (
         first:
             | TemplateStringsArray
             | CSSObject
-            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<{}, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
     ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
@@ -339,7 +336,6 @@ export interface BaseThemedCssFunction<T extends object> {
         first:
             | TemplateStringsArray
             | CSSObject
-            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): FlattenInterpolation<ThemedStyledProps<P, T>>;
@@ -374,7 +370,6 @@ export interface ThemedStyledComponentsModule<
         first:
             | TemplateStringsArray
             | CSSObject
-            | CSSObject[]
             | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): GlobalStyleComponent<P, T>;
@@ -448,7 +443,6 @@ export function createGlobalStyle<P extends object = {}>(
     first:
         | TemplateStringsArray
         | CSSObject
-        | CSSObject[]
         | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
     ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
 ): GlobalStyleComponent<P, DefaultTheme>;
@@ -515,7 +509,6 @@ export class StyleSheetManager extends React.Component<
 export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
     | string
     | CSSObject
-    | CSSObject[]
     | FlattenInterpolation<ThemeProps<T>>;
 
 export default styled;

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -22,12 +22,12 @@ declare global {
 import * as CSS from "csstype";
 import * as React from "react";
 
-export type CSSProperties = CSS.Properties<string | number>
+export type CSSProperties = CSS.Properties<string | number>;
 
-export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
 
 export interface CSSObject extends CSSProperties, CSSPseudos {
-    [key: string]: CSSObject | string | number | undefined
+    [key: string]: CSSObject | string | number | undefined;
 }
 
 export type CSSKeyframes = object & { [key: string]: CSSObject };

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -900,6 +900,8 @@ function validateArgumentsAndReturns() {
             ${{ color: "blue" }}
         `
     );
+    // _technically_ valid as styled-components doesn't look at .raw but best not to support it
+    // $ExpectError
     css([]);
 
     styled.div({ color: "blue" });
@@ -914,6 +916,7 @@ function validateArgumentsAndReturns() {
             ${{ color: "blue" }}
         `
     );
+    // $ExpectError
     styled.div([]);
 
     createGlobalStyle({
@@ -938,6 +941,7 @@ function validateArgumentsAndReturns() {
             color: ${() => "blue"};
         }
     `);
+    // $ExpectError
     createGlobalStyle([]);
 }
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -900,8 +900,6 @@ function validateArgumentsAndReturns() {
             ${{ color: "blue" }}
         `
     );
-    // _technically_ valid as styled-components doesn't look at .raw but best not to support it
-    // $ExpectError
     css([]);
 
     styled.div({ color: "blue" });
@@ -916,7 +914,6 @@ function validateArgumentsAndReturns() {
             ${{ color: "blue" }}
         `
     );
-    // $ExpectError
     styled.div([]);
 
     createGlobalStyle({
@@ -941,7 +938,6 @@ function validateArgumentsAndReturns() {
             color: ${() => "blue"};
         }
     `);
-    // $ExpectError
     createGlobalStyle([]);
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

The current `CSSObject` definition uses a bit of a convoluted `type` definition and doesn't include any pseudo selectors. The changes I have made add pseudo selector keys to the `CSSObject` while simplifying its definition.

In addition to this, I have added `CSSObject[]` to the `css` and `styled` function definitions. This is something that Styled Components supports, but the definitions previously threw an error for.

I have removed the `$ExpectError` comments from the 3 tests where an array was being passed to `css`, `styled.div` and `createGlobalStyle`.