### PR TITLE
parse5: Fix default parent node inheritance

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -131,7 +131,7 @@ export interface DefaultTreeNode {
 /**
  * Default tree adapter ParentNode interface.
  */
-export interface DefaultTreeParentNode {
+export interface DefaultTreeParentNode extends DefaultTreeNode {
     /**
      * Child nodes.
      */

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -127,6 +127,7 @@ defaultElement.namespaceURI; // $ExpectType string
 defaultElement.nodeName; // $ExpectType string
 defaultElement.tagName; // $ExpectType string
 defaultElement.parentNode; // $ExpectType DefaultTreeParentNode
+defaultElement.parentNode.nodeName; // $ExpectType string
 
 const defaultAttr = defaultElement.attrs[0];
 
@@ -142,6 +143,7 @@ defaultTextNode.sourceCodeLocation!; // $ExpectType Location
 defaultTextNode.nodeName; // $ExpectType "#text"
 defaultTextNode.value; // $ExpectType string
 defaultTextNode.parentNode; // $ExpectType DefaultTreeParentNode
+defaultTextNode.parentNode.nodeName; // $ExpectType string
 
 const defaultCommentNode = defaultDocumentFragment
     .childNodes[0] as parse5.DefaultTreeCommentNode;
@@ -150,6 +152,7 @@ defaultCommentNode.sourceCodeLocation!; // $ExpectType Location
 defaultCommentNode.nodeName; // $ExpectType "#comment"
 defaultCommentNode.data; // $ExpectType string
 defaultCommentNode.parentNode; // $ExpectType DefaultTreeParentNode
+defaultCommentNode.parentNode.nodeName; // $ExpectType string
 
 const adapter = defaultAdapter;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js#L6
  All kinds of elements, that can have children, in fact have `nodeName`. Actually every node provided by parse5 has `nodeName`.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

