### PR TITLE
[aws-lambda] Add missing fields on CognitoUserPoolTriggerEvent

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -444,6 +444,7 @@ str = cognitoUserPoolEvent.callerContext.clientId;
 str = cognitoUserPoolEvent.request.userAttributes["email"];
 str = cognitoUserPoolEvent.request.validationData!["k1"];
 strOrUndefined = cognitoUserPoolEvent.request.codeParameter;
+strOrUndefined = cognitoUserPoolEvent.request.linkParameter;
 strOrUndefined = cognitoUserPoolEvent.request.usernameParameter;
 boolOrUndefined = cognitoUserPoolEvent.request.newDeviceUsed;
 cognitoUserPoolEvent.request.session![0].challengeName === "CUSTOM_CHALLENGE";
@@ -477,6 +478,31 @@ cognitoUserPoolEvent.response.desiredDeliveryMediums === ["EMAIL"];
 cognitoUserPoolEvent.response.desiredDeliveryMediums === ["SMS"];
 cognitoUserPoolEvent.response.desiredDeliveryMediums === ["SMS", "EMAIL"];
 boolOrUndefined = cognitoUserPoolEvent.response.forceAliasCreation;
+// From AWS examples
+cognitoUserPoolEvent.response = {
+    claimsOverrideDetails: {
+        claimsToAddOrOverride: {
+            attribute_key2: "attribute_value2",
+            attribute_key: "attribute_value"
+        },
+        claimsToSuppress: ["email"]
+    }
+};
+cognitoUserPoolEvent.response = {
+    claimsOverrideDetails: {
+        claimsToAddOrOverride: {
+            attribute_key2: "attribute_value2",
+            attribute_key: "attribute_value"
+        },
+        claimsToSuppress: ["email"],
+        groupOverrideDetails: {
+            groupsToOverride: ["group-A", "group-B", "group-C"],
+            iamRolesToOverride: ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
+            preferredRole: "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+        }
+    }
+};
+cognitoUserPoolEvent.response.claimsOverrideDetails!.groupOverrideDetails = null;
 
 // CloudFormation Custom Resource
 switch (cloudformationCustomResourceEvent.RequestType) {

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -293,6 +293,7 @@ export interface CognitoUserPoolTriggerEvent {
         userAttributes: { [key: string]: string };
         validationData?: { [key: string]: string };
         codeParameter?: string;
+        linkParameter?: string;
         usernameParameter?: string;
         newDeviceUsed?: boolean;
         session?: Array<{
@@ -322,6 +323,15 @@ export interface CognitoUserPoolTriggerEvent {
         messageAction?: "SUPPRESS";
         desiredDeliveryMediums?: Array<"EMAIL" | "SMS">;
         forceAliasCreation?: boolean;
+        claimsOverrideDetails?: {
+            claimsToAddOrOverride?: { [key: string]: string };
+            claimsToSuppress?: string[];
+            groupOverrideDetails?: null | {
+                groupsToOverride?: string[];
+                iamRolesToOverride?: string[];
+                preferredRole?: string;
+            };
+        };
     };
 }
 export type CognitoUserPoolEvent = CognitoUserPoolTriggerEvent;


### PR DESCRIPTION
See:
https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html#cognito-user-pools-lambda-trigger-syntax-pre-token-generation

The linkParameter doesn't seem to be in the documentation, but it is there on the events.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
