### PR TITLE
[webpack-dev-server] fix constructor argument types

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -29,7 +29,7 @@ declare namespace WebpackDevServer {
 
     type ProxyConfigArrayItem = {
         path?: string | string[];
-        context?: string | string[] | httpProxyMiddleware.Filter
+        context?: string | string[] | httpProxyMiddleware.Filter;
     } & httpProxyMiddleware.Config;
 
     type ProxyConfigArray = ProxyConfigArrayItem[];
@@ -105,10 +105,12 @@ declare namespace WebpackDevServer {
         /** Specify a page to navigate to when opening the browser. */
         openPage?: string;
         /** Shows a full-screen overlay in the browser when there are compiler errors or warnings. Disabled by default. */
-        overlay?: boolean | {
-            warnings?: boolean;
-            errors?: boolean;
-        };
+        overlay?:
+            | boolean
+            | {
+                  warnings?: boolean;
+                  errors?: boolean;
+              };
         /** When used via the CLI, a path to an SSL .pfx file. If used in options, it should be the bytestream of the .pfx file. */
         pfx?: string;
         /** The passphrase to a SSL PFX file. */
@@ -165,10 +167,7 @@ declare module 'webpack' {
 }
 
 declare class WebpackDevServer {
-    constructor(
-        webpack: webpack.Compiler | webpack.MultiCompiler,
-        config: WebpackDevServer.Configuration
-    );
+    constructor(webpack: webpack.Compiler | webpack.MultiCompiler, config?: WebpackDevServer.Configuration);
 
     static addDevServerEntrypoints(
         webpackOptions: webpack.Configuration | webpack.Configuration[],


### PR DESCRIPTION
The `config` argument to the `WebpackDevServer` constructor is optional.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-server/blob/99192c8261fca1169fe9a51990a0c6013946bbeb/lib/Server.js#L51
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
