### PR TITLE
[fluent] Add 'undefined' to return type of FluentBundle.getMessage()

### DIFF
--- a/types/fluent/fluent-tests.ts
+++ b/types/fluent/fluent-tests.ts
@@ -13,7 +13,7 @@ if (errors1.length) {
 
 const welcome = bundle1.getMessage('welcome');
 
-bundle1.format(welcome, { name: 'Anna' });
+bundle1.format(welcome || [], { name: 'Anna' });
 
 // FluentBundle constructor examples:
 const bundle2 = new FluentBundle(['en-US']);
@@ -41,8 +41,8 @@ bundle2.getMessage('foo');
 const errors2: Array<string | Error> = [];
 bundle1.addMessages('hello = Hello, { $name }!');
 const hello = bundle2.getMessage('hello');
-bundle3.format(hello, { name: 'Jane' }, errors2);
-bundle3.format(hello, undefined, errors2);
+bundle3.format(hello || [], { name: 'Jane' }, errors2);
+bundle3.format(hello || [], undefined, errors2);
 
 for (const [id, message] of bundle1.messages) {
   bundle1.getMessage(id);

--- a/types/fluent/index.d.ts
+++ b/types/fluent/index.d.ts
@@ -30,7 +30,7 @@ export class FluentBundle {
     constructor(locales: string | string[], options?: FluentBundleContructorOptions);
     locales: string[];
     messages: IterableIterator<[string, FluentNode[]]>;
-    hasMessage(source: string): boolean;
+    hasMessage(id: string): boolean;
     addMessages(source: string): string[];
     getMessage(id: string): FluentNode[] | undefined;
     format(message: FluentNode[], args?: object, errors?: Array<string | Error>): string;

--- a/types/fluent/index.d.ts
+++ b/types/fluent/index.d.ts
@@ -32,7 +32,7 @@ export class FluentBundle {
     messages: IterableIterator<[string, FluentNode[]]>;
     hasMessage(source: string): boolean;
     addMessages(source: string): string[];
-    getMessage(id: string): FluentNode[];
+    getMessage(id: string): FluentNode[] | undefined;
     format(message: FluentNode[], args?: object, errors?: Array<string | Error>): string;
     addResource(res: FluentResource): string[];
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://projectfluent.org/fluent.js/fluent/class/src/bundle.js~FluentBundle.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

My tests indicate that when `id` is not found in the `FluentBundle` when calling `getMessage(id)`, it will return `undefined`. This makes it a little awkward since the type definition suggests otherwise. This will be a breaking change for existing code if it doesn't test for this already though (should I do something about the version number??).

I've also tweaked `FluentBundle.hasMessage()`'s signature since the [API docs](http://projectfluent.org/fluent.js/fluent/class/src/bundle.js~FluentBundle.html) call the parameter `id`, not `source`. My current understanding of TypeScript is that this shouldn't break anything, but not 100% sure on that.