### PR TITLE
(office.js and office.preview.js) reverse mistaken change

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -458,10 +458,6 @@ declare namespace Office {
         */
         error: Office.Error;
         /**
-        * Gets the the GUID of the CustomXmlPart, when T (the type of the value property) is {@link Office.CustomXmlPart}.
-        */
-        id?: string;
-        /**
         * Gets the {@link Office.AsyncResultStatus} of the asynchronous operation.
         */
         status: AsyncResultStatus;

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -458,10 +458,6 @@ declare namespace Office {
         */
         error: Office.Error;
         /**
-        * Gets the the GUID of the CustomXmlPart, when T (the type of the value property) is {@link Office.CustomXmlPart}.
-        */
-        id?: string;
-        /**
         * Gets the {@link Office.AsyncResultStatus} of the asynchronous operation.
         */
         status: AsyncResultStatus;


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/56837015/how-to-add-and-get-a-customxmlpart-programmatically/56839862?noredirect=1#comment100342189_56839862


This reverses a change made by mistake earlier in the week. It was based on a misunderstanding.
