### PR TITLE
fixed incorrect depcheck Results interface

### DIFF
--- a/types/depcheck/depcheck-tests.ts
+++ b/types/depcheck/depcheck-tests.ts
@@ -9,10 +9,7 @@ const options: depcheck.Options = {
         '*.js': depcheck.parser.es6,
         '*.jsx': depcheck.parser.jsx,
     },
-    detectors: [
-        depcheck.detector.requireCallExpression,
-        depcheck.detector.importDeclaration,
-    ],
+    detectors: [depcheck.detector.requireCallExpression, depcheck.detector.importDeclaration],
     specials: [depcheck.special.eslint, depcheck.special.webpack],
 };
 
@@ -22,8 +19,26 @@ depcheck('/', options);
 depcheck('/', options, unused => {
     const dependencies: string[] = unused.dependencies;
     const devDependencies: string[] = unused.devDependencies;
-    const missing: string[] = unused.missing;
-    const using: string[] = unused.using;
-    const invalidFiles: string[] = unused.invalidFiles;
-    const invalidDirs: string[] = unused.invalidDirs;
+    const missing: { [dependencyName: string]: string[] } = unused.missing;
+    const using: { [dependencyName: string]: string[] } = unused.using;
+    const invalidFiles: { [filePath: string]: any } = unused.invalidFiles;
+    const invalidDirs: { [filePath: string]: any } = unused.invalidDirs;
 });
+
+const exampleResult: depcheck.Results = {
+    dependencies: ['underscore'],
+    devDependencies: ['jasmine'],
+    missing: {
+        lodash: ['/path/to/my/project/file.using.lodash.js'],
+    },
+    using: {
+        react: ['/path/to/my/project/file.using.react.jsx', '/path/to/my/project/another.file.using.react.jsx'],
+        lodash: ['/path/to/my/project/file.using.lodash.js'],
+    },
+    invalidFiles: {
+        '/path/to/my/project/file.having.syntax.error.js': 'SyntaxError: <call stack here>',
+    },
+    invalidDirs: {
+        '/path/to/my/project/folder/without/permission': 'Error: EACCES, <call stack here>',
+    },
+};

--- a/types/depcheck/index.d.ts
+++ b/types/depcheck/index.d.ts
@@ -1,17 +1,15 @@
-// Type definitions for depcheck 0.6
+// Type definitions for depcheck 0.8
 // Project: https://github.com/depcheck/depcheck
 // Definitions by: ark120202 <https://github.com/ark120202>
+//                 jrnail23 <https://github.com/jrnail23>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function depcheck(
-    rootDir: string,
-    options: depcheck.Options,
-): Promise<depcheck.Results>;
+declare function depcheck(rootDir: string, options: depcheck.Options): Promise<depcheck.Results>;
 
 declare function depcheck<T>(
     rootDir: string,
     options: depcheck.Options,
-    callback: (results: depcheck.Results) => T,
+    callback: (results: depcheck.Results) => T
 ): Promise<T>;
 
 declare namespace depcheck {
@@ -19,12 +17,7 @@ declare namespace depcheck {
         [key: string]: any;
     }
 
-    type Parser = (
-        content: string,
-        filePath: string,
-        deps: ReadonlyArray<string>,
-        rootDir: string,
-    ) => Node;
+    type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node;
 
     type Detector = (node: Node) => ReadonlyArray<string> | string;
 
@@ -43,10 +36,18 @@ declare namespace depcheck {
     interface Results {
         dependencies: string[];
         devDependencies: string[];
-        missing: string[];
-        using: string[];
-        invalidFiles: string[];
-        invalidDirs: string[];
+        using: {
+            [dependencyName: string]: string[];
+        };
+        missing: {
+            [dependencyName: string]: string[];
+        };
+        invalidFiles: {
+            [filePath: string]: any;
+        };
+        invalidDirs: {
+            [filePath: string]: any;
+        };
     }
 
     const parser: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [depcheck docs example](https://github.com/depcheck/depcheck#example)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Also, here is a cleaned up example of a result I've gotten through my own usage of `depcheck`, showing that the type of  the values in the `invalidFiles` map isn't always a string:
```json
{
  "dependencies": [
    "classnames"
  ],
  "devDependencies": [
    "@babel/plugin-proposal-class-properties",
    "@babel/plugin-proposal-decorators"
  ],
  "missing": {
    "isomorphic-fetch": [
      "/Users/username/code/my-project/src/actions/user-settings.js"
    ]
  },
  "using": {
    "eslint-plugin-node": [
      "/Users/username/code/my-project/.eslintrc.js"
    ],
    "eslint": [
      "/Users/username/code/my-project/.eslintrc.js",
      "/Users/username/code/my-project/package.json",
      "/Users/username/code/my-project/src/.eslintrc.js"
    ]
  },
  "invalidFiles": {
    "/Users/username/code/my-project/src/components/app/modals/checkbox.js": {
      "pos": 281,
      "loc": {
        "line": 10,
        "column": 5
      }
    },
    "/Users/username/code/my-project/src/components/app/modals/dropdown.js": {
      "pos": 278,
      "loc": {
        "line": 9,
        "column": 5
      }
    }
  },
  "invalidDirs": {}
}
```