### PR TITLE
[@types/stripe] Correct types for invoice.charge and invoiceItem.invoice

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -2643,7 +2643,7 @@ declare namespace Stripe {
             /**
              * ID of the latest charge generated for this invoice, if any. [Expandable]
              */
-            charge: string | charges.ICharge;
+            charge: string | charges.ICharge | null;
 
             /**
              * Whether or not the invoice is still trying to collect payment. An invoice is closed if it's either paid or
@@ -3339,9 +3339,9 @@ declare namespace Stripe {
             discountable: boolean;
 
             /**
-             * If null, the invoice item is pending and will be included in the upcoming invoice.
+             * If null, the invoice item is pending and will be included in the upcoming invoice. [Expandable]
              */
-            invoice: string | null;
+            invoice: string | invoices.IInvoice | null;
             livemode: boolean;
             metadata: IMetadata;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/api/invoices/object#invoice_object-charge> and <https://stripe.com/docs/api/invoiceitems/object#invoiceitem_object-invoice>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Details
I'm working with invoices and invoiceItems and ran into the following two items:

1. The invoice object does not always have an associated charge so the `invoice.charge` typing should include an `| null`.

2. Relatedly, the `invoice` field on the invoice item object is expandable, so `invoiceItem.invoice` typing should include an `| invoices.Invoice`.