### PR TITLE
Yup: Add Id<T> type to make inferred types more readable

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -511,7 +511,8 @@ type KeyOfUndefined<T> = {
     [P in keyof T]-?: undefined extends T[P] ? P : never
 }[keyof T];
 
+type Id<T> = {[K in keyof T]: T[K]};
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
-type InnerInferType<T> = NotRequiredProps<T> & RequiredProps<T>;
+type InnerInferType<T> = Id<NotRequiredProps<T> & RequiredProps<T>>;
 type InferredArrayType<T> = T extends Array<infer U> ? U : T;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below.
- [x] ~~Increase the version number in the header if appropriate.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Added the `Id<T>` type and wrapped the inferred type with this for readability.

Before an inferred type would be displayed like this in VS Code. While correct is hard to read.
```TypeScript
type Person = Partial<Pick<{
    firstName: string;
    gender: Gender;
    email: string | null | undefined;
    birthDate: Date | null | undefined;
    canBeNull: string | null;
    isAlive: boolean | null | undefined;
    mustBeAString: string;
    children: string[] | ... 1 more ... | undefined;
}, "email" | ... 2 more ... | "children">> & Pick<...>
```

With this change the inferred type is much easier to read as VS Code displays it like this:
```TypeScript
type Person = {
    email?: string | null | undefined;
    birthDate?: Date | null | undefined;
    isAlive?: boolean | null | undefined;
    children?: string[] | null | undefined;
    firstName: string;
    gender: Gender;
    canBeNull: string | null;
    mustBeAString: string;
}
```

Note: The `Id<T>` is taken from [here](https://stackoverflow.com/a/49683575/19676)
