### PR TITLE
Yup: Support concat() method with better typings

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -12,7 +12,7 @@
 //                 Desmond Koh <https://github.com/deskoh>
 //                 Maurice de Beijer <https://github.com/mauricedb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 export function reach<T>(
     schema: Schema<T>,
@@ -296,6 +296,8 @@ export interface ObjectSchema<T extends object | null | undefined = object>
     nullable(isNullable?: boolean): ObjectSchema<T>;
     required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
+    concat(schema: this): this;
+    concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;
 }
 
 export type TransformFunction<T> = (

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -12,7 +12,7 @@
 //                 Desmond Koh <https://github.com/deskoh>
 //                 Maurice de Beijer <https://github.com/mauricedb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.8
 
 export function reach<T>(
     schema: Schema<T>,

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -104,6 +104,8 @@ export interface MixedSchema<T = any> extends Schema<T> {
     nullable(isNullable?: boolean): MixedSchema<T>;
     required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
+    concat(schema: this): this;
+    concat<U >(schema: MixedSchema<U>): MixedSchema<T | U>;
 }
 
 export interface StringSchemaConstructor {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -199,6 +199,10 @@ mixed.test({
     test: testContext,
 });
 
+// mixed with concat
+yup.object({ name: yup.string() }).concat(yup.object({ when: yup.date() })); // $ExpectType ObjectSchema<{ name: string; } & { when: Date; }>
+yup.mixed<string>().concat(yup.date()); // $ExpectType MixedSchema<string | Date>
+
 // Async ValidationError
 const asyncValidationErrorTest = function(this: TestContext): Promise<ValidationError> {
     return new Promise(resolve => resolve(this.createError({ path: 'testPath', message: 'testMessage' })));
@@ -693,13 +697,3 @@ function wrapper<T>(b: boolean, msx: MixedSchema<T>): MixedSchema<T> {
 
 const resultingSchema1 = wrapper<string | number>(false, yup.mixed().oneOf(['1', 2])); // $ExpectType MixedSchema<string | number>
 const resultingSchema2 = wrapper<string | number>(true, yup.mixed().oneOf(['1', 2])); // $ExpectType MixedSchema<string | number | null>
-
-const partAShema = yup.object({
-    a: yup.string()
-});
-
-const partBSchema = yup.object({
-    b: yup.string()
-});
-
-const bothPartsSchema = partAShema.concat(partBSchema); // $ExpectType ObjectSchema<{ a: string; } & { b: string; }>

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -693,3 +693,13 @@ function wrapper<T>(b: boolean, msx: MixedSchema<T>): MixedSchema<T> {
 
 const resultingSchema1 = wrapper<string | number>(false, yup.mixed().oneOf(['1', 2])); // $ExpectType MixedSchema<string | number>
 const resultingSchema2 = wrapper<string | number>(true, yup.mixed().oneOf(['1', 2])); // $ExpectType MixedSchema<string | number | null>
+
+const partAShema = yup.object({
+    a: yup.string()
+});
+
+const partBSchema = yup.object({
+    b: yup.string()
+});
+
+const bothPartsSchema = partAShema.concat(partBSchema); // $ExpectType ObjectSchema<{ a: string; } & { b: string; }>


### PR DESCRIPTION
Fixes #36555

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See issue and below
- [x] ~~Increase the version number in the header if appropriate.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Fixes the following which is valid for Yup:
```TypeScript
const schemaA = yup.object({ a: yup.string() });
const schemaB = yup.object({ b: yup.date() });
const mixedSchema = schemaA.concat(schemaB);
type MixedType = yup.InferType<typeof mixedSchema>;
```
This resolves `MixedType` to `{ a: string; b: Date; }`

In the case of conflicting property types it resolves them to `never`
```
const schemaA = yup.object({ a: yup.string() });
const schemaB = yup.object({ a: yup.bool() });
const mixedSchema = schemaA.concat(schemaB);
type MixedType = yup.InferType<typeof mixedSchema>;
```
This resolves `MixedType` to `{ a: never; }` which makes sense as the `schemaA.concat(schemaB);` statement would result in a Yup _TypeError: You cannot `concat()` schema's of different types: string and boolean_ at run-time. Note: With some type combinations TypeScript resolves to the likes of `string & Date` with is less clear but also means you can't assign anything the the property unless it is if type `any`. Not perfect and it would still produce the same run-time error.

Also fixed the `concat()` on the `MixedSchema`
```TypeScript
const mixedStringOrDateSchema = yup.mixed<string>().concat(yup.date())
```
This will now resolve to `yup.MixedSchema<string | Date>`

Note: Doesn't fix the following case which is valid for Yup:
```TypeScript
const schemaA = yup.object({ a: yup.mixed<string>() });
const schemaB = yup.object({ a: yup.date() });
const mixedSchema = schemaA.concat(schemaB);
type MixedType = yup.InferType<typeof mixedSchema>;
```

Where `MixedType` is inferred as `{ a: string & Date; }` where it should be: `{ a: string | Date; }` as both a `string` and `Date` are valid according to Yup