### PR TITLE
[Crossfilter] Change return type of group.all() to a readonly array

### DIFF
--- a/types/crossfilter/crossfilter-tests.ts
+++ b/types/crossfilter/crossfilter-tests.ts
@@ -116,6 +116,9 @@ var types = paymentCountByType.all();
 // $ExpectError
 types.sort();
 
+types[0].key;
+types[0].value;
+
 paymentsByTotal.dispose();
 
 crossfilter.bisect([], null, 0, 0);

--- a/types/crossfilter/crossfilter-tests.ts
+++ b/types/crossfilter/crossfilter-tests.ts
@@ -62,9 +62,7 @@ var paymentGroupsByTotal = paymentsByTotal.group(total => Math.floor(total / 100
 
 paymentGroupsByTotal.size();
 
-// bug of TS 0.9.5 https://typescript.codeplex.com/discussions/471751
-//paymentGroupsByTotal.reduce((p, v) => p + 1, (p, v) => p - 1, () => 0);
-paymentGroupsByTotal.reduce<number>((p, v) => p + 1, (p, v) => p - 1, () => 0);
+paymentGroupsByTotal.reduce((p, v) => p + 1, (p, v) => p - 1, () => 0);
 
 paymentGroupsByTotal.reduceCount();
 
@@ -114,6 +112,9 @@ topTypes[0].key;   // the top payment type (e.g., "tab")
 topTypes[0].value; // the count of payments of that type (e.g., 8)
 
 var types = paymentCountByType.all();
+
+// $ExpectError
+types.sort();
 
 paymentsByTotal.dispose();
 

--- a/types/crossfilter/index.d.ts
+++ b/types/crossfilter/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CrossFilter
 // Project: https://github.com/square/crossfilter
-// Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>, Einar Norðfjörð <https://github.com/nordfjord>
+// Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>, Einar Norðfjörð <https://github.com/nordfjord>, Tijmen Wildervanck <https://github.com/TijmenW>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace CrossFilter {
@@ -73,7 +73,7 @@ declare namespace CrossFilter {
 
     export interface Group<T, TKey, TValue> {
         top(k: number): Grouping<TKey, TValue>[];
-        all(): Grouping<TKey, TValue>[];
+        all(): readonly Grouping<TKey, TValue>[];
         reduce<TGroup>(add: (p: TGroup, v: T) => TGroup, remove: (p: TGroup, v: T) => TGroup, initial: () => TGroup): Group<T, TKey, TGroup>;
         reduceCount(): Group<T, TKey, number>;
         reduceSum<TGroup>(value: (data: T) => TGroup): Group<T, TKey, TGroup>;

--- a/types/crossfilter/index.d.ts
+++ b/types/crossfilter/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/square/crossfilter
 // Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>, Einar Norðfjörð <https://github.com/nordfjord>, Tijmen Wildervanck <https://github.com/TijmenW>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
 
 declare namespace CrossFilter {
 
@@ -74,7 +73,7 @@ declare namespace CrossFilter {
 
     export interface Group<T, TKey, TValue> {
         top(k: number): Grouping<TKey, TValue>[];
-        all(): readonly Grouping<TKey, TValue>[];
+        all(): ReadonlyArray<Grouping<TKey, TValue>>;
         reduce<TGroup>(add: (p: TGroup, v: T) => TGroup, remove: (p: TGroup, v: T) => TGroup, initial: () => TGroup): Group<T, TKey, TGroup>;
         reduceCount(): Group<T, TKey, number>;
         reduceSum<TGroup>(value: (data: T) => TGroup): Group<T, TKey, TGroup>;

--- a/types/crossfilter/index.d.ts
+++ b/types/crossfilter/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/square/crossfilter
 // Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>, Einar Norðfjörð <https://github.com/nordfjord>, Tijmen Wildervanck <https://github.com/TijmenW>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
 
 declare namespace CrossFilter {
 


### PR DESCRIPTION
There was a mistake in the return type of crossfilter `group.all()`, it returned a writeable array, while the documentation said that it's forbidden to modify it. 

I don't know if have to increase the version number, it's a breaking change, but crossfilter itself didn't update.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) 
 - Added test, but when running, they complained about `logrocket` not being in the whitelist. I think this is unrelated. `npm run lint crossfilter` runs. 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/square/crossfilter/wiki/API-Reference#group_all: “do not change the returned array”.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
