### PR TITLE
@types/bootstrap dropdown added missing parameter options

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -513,10 +513,12 @@ declare global {
         /**
          * Call a method on the dropdown element:
          * * `toggle` – Toggles the dropdown menu of a given navbar or tabbed navigation.
+         * * `show` - Shows the dropdown menu of a given navbar or tabbed navigation.
+         * * `hide` - Hides the dropdown menu of a given navbar or tabbed navigation.
          * * `update` – Updates the position of an element's dropdown.
          * * `dispose` – Destroys an element's dropdown.
          */
-        dropdown(action: "toggle" | "update" | "dispose"): this;
+        dropdown(action: "toggle" | "show" | "hide" | "update" | "dispose"): this;
         /**
          * Toggle contextual overlays for displaying lists of links.
          *

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -513,8 +513,8 @@ declare global {
         /**
          * Call a method on the dropdown element:
          * * `toggle` – Toggles the dropdown menu of a given navbar or tabbed navigation.
-         * * `show` - Shows the dropdown menu of a given navbar or tabbed navigation.
-         * * `hide` - Hides the dropdown menu of a given navbar or tabbed navigation.
+         * * `show` – Shows the dropdown menu of a given navbar or tabbed navigation.
+         * * `hide` – Hides the dropdown menu of a given navbar or tabbed navigation.
          * * `update` – Updates the position of an element's dropdown.
          * * `dispose` – Destroys an element's dropdown.
          */


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://getbootstrap.com/docs/4.2/components/dropdowns/#methods>>
