### PR TITLE
[phoenix] Fix SocketConnectOptions for phoenix >= 1.4.3

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -36,18 +36,21 @@ export class Channel {
   push(event: string, payload: object, timeout?: number): Push;
 }
 
+export type BinaryType = 'arraybuffer' | 'blob';
 export type ConnectionState = 'connecting' | 'open' | 'closing' | 'closed';
 
 export interface SocketConnectOption {
+  binaryType: BinaryType;
   params: object | (() => object);
   transport: string;
   timeout: number;
   heartbeatIntervalMs: number;
-  reconnectAfterMs: number;
   longpollerTimeout: number;
   encode: (payload: object, callback: (encoded: any) => void) => void;
   decode: (payload: string, callback: (decoded: any) => void) => void;
   logger: (kind: string, message: string, data: any) => void;
+  reconnectAfterMs: (tries: number) => number;
+  rejoinAfterMs: (tries: number) => number;
 }
 
 export class Socket {

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,7 +1,12 @@
 import { Socket, Channel, Presence } from 'phoenix';
 
 function test_socket() {
-  const socket = new Socket('/ws', {params: {userToken: '123'}});
+  const socket = new Socket('/ws', {
+      binaryType: 'arraybuffer',
+      params: { userToken: '123' },
+      reconnectAfterMs: tries => 1000,
+      rejoinAfterMs: tries => 1000,
+  });
   socket.connect();
 }
 


### PR DESCRIPTION
Adds/fixes types of SocketConnectOptions attributes:

- Adds the type of `binaryType`,
- Adds the type of `rejoinAfterMs`,
- Fixes the type of `reconnectAfterMs`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hexdocs.pm/phoenix/js/#socket
- [x] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
