### PR TITLE
react-tagsinput: correct naming and types: component to element

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -43,7 +43,7 @@ declare namespace TagsInput {
         readonly tag: Tag;
     }
 
-    type RenderLayout = (tagComponent: React.Component[], inputComponent: React.Component) => React.ReactChild;
+    type RenderLayout = (tagComponents: React.Component[], inputComponent: React.Component) => React.ReactChild;
 
     interface ReactTagsInputProps extends React.Props<TagsInput> {
         value: Tag[];

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -43,7 +43,7 @@ declare namespace TagsInput {
         readonly tag: Tag;
     }
 
-    type RenderLayout = (tagComponents: React.Component[], inputComponent: React.Component) => React.ReactChild;
+    type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactChild;
 
     interface ReactTagsInputProps extends React.Props<TagsInput> {
         value: Tag[];


### PR DESCRIPTION
A component is a function/class that is yet to be called. In this case, the component has already been called, so we're dealing with the resulting value—the element.

https://github.com/olahol/react-tagsinput/pull/193

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/olahol/react-tagsinput/pull/193
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.