### PR TITLE
Update tests in preparation for TS #32260

### DIFF
--- a/types/storage-helper/storage-helper-tests.ts
+++ b/types/storage-helper/storage-helper-tests.ts
@@ -7,8 +7,8 @@ storageHelper.setItem('foo', 'bas', false);
 storageHelper.getItem('foo'); // $ExpectType string | null
 storageHelper.getItem('foo', false); // $ExpectType string | null
 storageHelper.getItem('foo', undefined); // $ExpectType string | null
-storageHelper.getItem('foo', false, Boolean() ? 1 : undefined); // $ExpectType string | number | null
-storageHelper.getItem('foo', false, 1); // $ExpectType string | number | null
+storageHelper.getItem('foo', false, Boolean() ? 1 + 1 : undefined); // $ExpectType string | number | null
+storageHelper.getItem('foo', false, 1 + 1); // $ExpectType string | number | null
 storageHelper.getItem('foo', false, undefined); // $ExpectType string | null
 storageHelper.getItem('foo', true); // $ExpectType any
 storageHelper.getItem('foo', true, 1); // $ExpectType any

--- a/types/wordpress__hooks/wordpress__hooks-tests.ts
+++ b/types/wordpress__hooks/wordpress__hooks-tests.ts
@@ -89,7 +89,7 @@ hooks.filters;
         firstFilter('foo', 'other', 'args', 34, 'blah', true);
 
         // $ExpectType boolean
-        firstFilter(true);
+        firstFilter(1 < 2);
 
         // $ExpectType number
         firstFilter(123);


### PR DESCRIPTION
Update tests in `storage-helper` and `wordpress__hooks` in preparation for https://github.com/microsoft/TypeScript/pull/32260.
