### PR TITLE
node: writableFinished has to be in WriteStream too

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -729,6 +729,7 @@ declare namespace NodeJS {
     }
 
     interface WriteStream extends Socket {
+        readonly writableFinished: boolean;
         readonly writableHighWaterMark: number;
         readonly writableLength: number;
         columns?: number;

--- a/types/node/test/global.ts
+++ b/types/node/test/global.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable, Writable } from 'stream';
 
 {
     const x: NodeModule = {} as any;
@@ -27,4 +27,13 @@ import { Readable } from 'stream';
     const a = Readable.from(['test'], {
         objectMode: true,
     });
+}
+
+{
+    const stdin: Readable = process.stdin;
+    let writableFinished: boolean;
+    const stdout: Writable = process.stdout;
+    writableFinished = process.stdout.writableFinished;
+    const stderr: Writable = process.stderr;
+    writableFinished = process.stderr.writableFinished;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_writable_writablefinished
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Without this patch I'm getting an error for this code:

```ts
import stream from "stream"
const w: stream.Writable = process.stdout
```
