### PR TITLE
[angular] Add typings for jQuery custom event into jqLite

### DIFF
--- a/types/angular/jqlite.d.ts
+++ b/types/angular/jqlite.d.ts
@@ -785,6 +785,14 @@ interface BaseJQueryEventObject extends Event {
     metaKey: boolean;
 }
 
+interface JQueryCustomEventObject extends BaseJQueryEventObject {
+    /**
+     * @see {@link https://api.jquery.com/category/events/event-object/}
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent}
+     */
+    detail?: any;
+}
+
 interface JQueryInputEventObject extends BaseJQueryEventObject {
     altKey: boolean;
     ctrlKey: boolean;
@@ -814,7 +822,7 @@ interface JQueryKeyEventObject extends JQueryInputEventObject {
     keyCode: number;
 }
 
-interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject {
+interface JQueryEventObject extends BaseJQueryEventObject, JQueryCustomEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject {
 }
 
 /**


### PR DESCRIPTION
This pull request ports #31952 into AngularJS jqLite.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/category/events/event-object/ https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent Also, to verify this works in AngularJS jqLite (which does not include full jQuery), see https://plnkr.co/edit/FRIbAeoHnODJDP7DMEKZ?p=preview. Open your JS console, click the run button, then click "Edit", and you will see some debug info in your console which comes from `editableField.js`. AngularJS `$element.on()` does exist in jqLite, see https://docs.angularjs.org/api/ng/function/angular.element and https://api.jquery.com/on/.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.