### PR TITLE
[@types/react-rangeslider] handleLabel type fix

### DIFF
--- a/types/react-rangeslider/index.d.ts
+++ b/types/react-rangeslider/index.d.ts
@@ -9,7 +9,7 @@ import * as React from 'react';
 export interface SliderProps {
 	disabled?: boolean;
 	format?: (value: number) => string | number | undefined;
-	handleLabel?: boolean;
+	handleLabel?: string;
 	labels?: { [value: number]: string };
 	max?: number;
 	min?: number;


### PR DESCRIPTION
Based on the component definition, the handleLabel as a string. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/whoisandy/react-rangeslider/blob/master/src/Rangeslider.js#L39
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
