### PR TITLE
[ghost-storage-base] add module types

### DIFF
--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -6,11 +6,11 @@ class MyCustomAdapter extends StorageBase {
         super();
     }
 
-    async exists(fileName: string, targetDir: string) {
+    async exists(fileName: string, targetDir?: string) {
         return true;
     }
 
-    async save(image: Image, targetDir: string) {
+    async save(image: Image, targetDir?: string) {
         return 'string';
     }
 
@@ -18,7 +18,7 @@ class MyCustomAdapter extends StorageBase {
         return (req: Request, res: Response, next: NextFunction) => next();
     }
 
-    async delete(fileName: string, targetDir: string) {
+    async delete(fileName: string, targetDir?: string) {
         return true;
     }
 

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -1,4 +1,4 @@
-import StorageBase, { Image, ReadOptions } from 'ghost-storage-base';
+import { StorageBase, Image, ReadOptions } from 'ghost-storage-base';
 import { Request, Response, NextFunction } from 'express';
 
 class MyCustomAdapter extends StorageBase {

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -1,0 +1,45 @@
+import StorageBase, { Image, ReadOptions } from 'ghost-storage-base';
+import { Request, Response, NextFunction } from 'express';
+
+class MyCustomAdapter extends StorageBase {
+    constructor() {
+        super();
+    }
+
+    async exists(fileName: string, targetDir: string) {
+        return true;
+    }
+
+    async save(image: Image, targetDir: string) {
+        return 'string';
+    }
+
+    serve() {
+        return (req: Request, res: Response, next: NextFunction) => next();
+    }
+
+    async delete(fileName: string, targetDir: string) {
+        return true;
+    }
+
+    async read(options: ReadOptions) {
+        return Buffer.from([]);
+    }
+}
+
+const image: Image = {
+    path: 'tmp/123456.jpg',
+    name: 'IMAGE.jpg',
+    type: 'image/jpeg',
+};
+
+const storage = new MyCustomAdapter();
+
+storage.getTargetDir('/'); // $ExpectType string
+storage.getUniqueFileName(image, '/target'); // $ExpectType string
+storage.getSanitizedFileName('IMAGE.jpg'); // $ExpectType string
+
+storage.exists('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>
+storage.save(image, '/'); // $ExpectType Promise<string>
+storage.serve(); // $ExpectType (req: Request, res: Response, next: NextFunction) => void
+storage.delete('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -16,7 +16,7 @@ export interface ReadOptions {
     path: string;
 }
 
-export default abstract class StorageBase {
+export abstract class StorageBase {
     constructor();
 
     abstract exists(fileName: string, targetDir: string): Promise<boolean>;

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/TryGhost/Ghost-Storage-Base
 // Definitions by: Demian <https://github.com/thde>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 import { Handler }  from 'express';
 

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -25,7 +25,7 @@ export abstract class StorageBase {
     abstract delete(fileName: string, targetDir?: string): Promise<boolean>;
     abstract read(options?: ReadOptions): Promise<Buffer>;
 
-    getTargetDir(baseDir: string): string;
+    getTargetDir(baseDir?: string): string;
     getUniqueFileName(image: Image, targetDir: string): string;
     getSanitizedFileName(fileName: string): string;
 }

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -16,7 +16,7 @@ export interface ReadOptions {
     path: string;
 }
 
-export abstract class StorageBase {
+export default abstract class StorageBase {
     constructor();
 
     abstract exists(fileName: string, targetDir: string): Promise<boolean>;

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for ghost-storage-base 0.0.3
+// Project: https://github.com/TryGhost/Ghost-Storage-Base
+// Definitions by: Demian <https://github.com/thde>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Handler }  from 'express';
+
+export interface Image {
+    path: string;
+    name: string;
+    type: string;
+}
+
+export interface ReadOptions {
+    path: string
+}
+
+export declare abstract class StorageBase { 
+    constructor();
+
+    abstract exists(fileName: string, targetDir: string): Promise<boolean>;
+    abstract save(image: Image, targetDir: string): Promise<string>;
+    abstract serve(): Handler;
+    abstract delete(fileName: string, targetDir: string): Promise<boolean>;
+    abstract read(options: ReadOptions): Promise<Buffer>;
+
+    getTargetDir(baseDir: string): string;
+    getUniqueFileName(image: Image, targetDir: string): string;
+    getSanitizedFileName(fileName: string): string;
+}
+
+export default StorageBase;

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -19,11 +19,11 @@ export interface ReadOptions {
 export abstract class StorageBase {
     constructor();
 
-    abstract exists(fileName: string, targetDir: string): Promise<boolean>;
-    abstract save(image: Image, targetDir: string): Promise<string>;
+    abstract exists(fileName: string, targetDir?: string): Promise<boolean>;
+    abstract save(image: Image, targetDir?: string): Promise<string>;
     abstract serve(): Handler;
-    abstract delete(fileName: string, targetDir: string): Promise<boolean>;
-    abstract read(options: ReadOptions): Promise<Buffer>;
+    abstract delete(fileName: string, targetDir?: string): Promise<boolean>;
+    abstract read(options?: ReadOptions): Promise<Buffer>;
 
     getTargetDir(baseDir: string): string;
     getUniqueFileName(image: Image, targetDir: string): string;

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/TryGhost/Ghost-Storage-Base
 // Definitions by: Demian <https://github.com/thde>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Handler } from 'express';
 

--- a/types/ghost-storage-base/index.d.ts
+++ b/types/ghost-storage-base/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for ghost-storage-base 0.0.3
+// Type definitions for ghost-storage-base 0.0
 // Project: https://github.com/TryGhost/Ghost-Storage-Base
 // Definitions by: Demian <https://github.com/thde>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import { Handler }  from 'express';
+import { Handler } from 'express';
 
 export interface Image {
     path: string;
@@ -13,10 +13,10 @@ export interface Image {
 }
 
 export interface ReadOptions {
-    path: string
+    path: string;
 }
 
-export declare abstract class StorageBase { 
+export abstract class StorageBase {
     constructor();
 
     abstract exists(fileName: string, targetDir: string): Promise<boolean>;
@@ -29,5 +29,3 @@ export declare abstract class StorageBase {
     getUniqueFileName(image: Image, targetDir: string): string;
     getSanitizedFileName(fileName: string): string;
 }
-
-export default StorageBase;

--- a/types/ghost-storage-base/tsconfig.json
+++ b/types/ghost-storage-base/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ghost-storage-base-tests.ts"
+    ]
+}

--- a/types/ghost-storage-base/tslint.json
+++ b/types/ghost-storage-base/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
## Description

Based on the following:

- https://github.com/TryGhost/Ghost-Storage-Base ([NPM](https://www.npmjs.com/package/ghost-storage-base))
- https://docs.ghost.org/concepts/storage-adapters/
- https://github.com/TryGhost/Ghost/blob/master/core/server/adapters/storage/LocalFileStorage.js
- https://github.com/colinmeinke/ghost-storage-adapter-s3/blob/master/src/index.js

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
