### PR TITLE
Elasticsearch: Changed type to optional field in IndicesPutMappingParams interface to bring it in line with the optional nature of the 7.x api version and it's future deprecation

### DIFF
--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1290,7 +1290,7 @@ export interface IndicesPutMappingParams extends GenericParams {
     expandWildcards?: ExpandWildcards;
     updateAllTypes?: boolean;
     index: NameList;
-    type: string;
+    type?: string;
     body: any;
 }
 


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html