### PR TITLE
[@types/slate-react] fixed the typings of RenderNodeProps.editor

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -44,7 +44,7 @@ export interface RenderAttributes {
 export interface RenderMarkProps {
     attributes: RenderAttributes;
     children: React.ReactNode;
-    editor: CoreEditor;
+    editor: Editor;
     mark: Mark;
     marks: Immutable.Set<Mark>;
     node: Node;
@@ -53,14 +53,14 @@ export interface RenderMarkProps {
 }
 
 export interface RenderNodeProps {
-  attributes: RenderAttributes;
-  children: React.ReactNode;
-  editor: CoreEditor;
-  isFocused: boolean;
-  isSelected: boolean;
-  key: string;
-  parent: Node;
-  readOnly: boolean;
+    attributes: RenderAttributes;
+    children: React.ReactNode;
+    editor: Editor;
+    isFocused: boolean;
+    isSelected: boolean;
+    key: string;
+    parent: Node;
+    readOnly: boolean;
 }
 
 export interface RenderBlockProps extends RenderNodeProps {


### PR DESCRIPTION
according to https://github.com/ianstormtaylor/slate/blob/4eff9b5a06/packages/slate-react/src/components/editor.js#L175
it should be Editor, NOT Slate.Editor

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/slate/blob/9e2e2a1cc5/packages/slate-react/src/components/editor.js#L183
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
