### PR TITLE
[googlemaps] Remove old map options properties that aren't supported any more

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -170,8 +170,6 @@ declare namespace google.maps {
         minZoom?: number;
         /** If true, do not clear the contents of the Map div. */
         noClear?: boolean;
-        overviewMapControl?: boolean;
-        overviewMapControlOptions?: OverviewMapControlOptions;
         /**
          * The enabled/disabled state of the Pan control.
          * Note: The Pan control is not available in the new set of controls
@@ -207,15 +205,6 @@ declare namespace google.maps {
          * enabled by default.
          */
         scrollwheel?: boolean;
-        /**
-         * The enabled/disabled state of the sign in control. This option only
-         * applies if signed_in=true has been passed as a URL parameter in the
-         * bootstrap request. You may want to use this option to hide the map's sign
-         * in control if you have provided another way for your users to sign in,
-         * such as the Google Sign-In button. This option does not affect the
-         * visibility of the Google avatar shown when the user is already signed in.
-         */
-        signInControl?: boolean;
         /**
          * A StreetViewPanorama to display when the Street View pegman is dropped on
          * the map. If no panorama is specified, a default StreetViewPanorama will
@@ -303,10 +292,6 @@ declare namespace google.maps {
         DEFAULT,
         DROPDOWN_MENU,
         HORIZONTAL_BAR
-    }
-
-    interface OverviewMapControlOptions {
-        opened?: boolean;
     }
 
     type GestureHandlingOptions = 'cooperative' | 'greedy' | 'none' | 'auto';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/maps/documentation/javascript/reference/map?hl=en#MapOptions>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
