### PR TITLE
slate-react: Separated type for onChange function

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -114,12 +114,18 @@ export interface Plugin extends CorePlugin {
 export type PluginOrPlugins = Plugin | Plugins;
 export interface Plugins extends Array<PluginOrPlugins> {}
 
+export interface OnChangeParam {
+    operations: Immutable.List<Operation>;
+    value: Value
+}
+export type OnChangeFn = (change: OnChangeParam) => any;
+
 export interface BasicEditorProps {
     value: Value;
     autoCorrect?: boolean;
     autoFocus?: boolean;
     className?: string;
-    onChange?: (change: { operations: Immutable.List<Operation>; value: Value }) => any;
+    onChange?: OnChangeFn;
     placeholder?: any;
     plugins?: Plugins;
     readOnly?: boolean;

--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -116,7 +116,7 @@ export interface Plugins extends Array<PluginOrPlugins> {}
 
 export interface OnChangeParam {
     operations: Immutable.List<Operation>;
-    value: Value
+    value: Value;
 }
 export type OnChangeFn = (change: OnChangeParam) => any;
 

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -2,6 +2,7 @@ import { Editor, Plugin, EditorProps, RenderBlockProps, RenderInlineProps } from
 import { Value, Editor as Controller, Operation, Point, Range, Inline, Mark, Document, Decoration } from "slate";
 import * as React from "react";
 import * as Immutable from "immutable";
+import { OnChangeFn } from "slate-react";
 
 class MyPlugin implements Plugin {
     renderBlock(props: RenderBlockProps, editor: Controller, next: () => void) {
@@ -26,8 +27,8 @@ class MyPlugin implements Plugin {
             }
         }
     }
-    onChange = (change: {operations: Immutable.List<Operation>, value: Value}) => {
-        console.log(change.value);
+    onChange: OnChangeFn = ({ operations, value }) => {
+        console.log(operations, value);
     }
 }
 

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -2,15 +2,15 @@ import { Editor, Plugin, EditorProps, RenderBlockProps, RenderInlineProps } from
 import { Value, Editor as Controller, Operation, Point, Range, Inline, Mark, Document, Decoration } from "slate";
 import * as React from "react";
 import * as Immutable from "immutable";
-import { OnChangeFn } from "slate-react";
+import { OnChangeFn } from 'slate-react';
 
 class MyPlugin implements Plugin {
     renderBlock(props: RenderBlockProps, editor: Controller, next: () => void) {
         const { node } = props;
         if (node) {
             switch (node.object) {
-                case "block":
-                    return <div id="slate-block-test"/>;
+                case 'block':
+                    return <div id="slate-block-test" />;
                 default:
                     return undefined;
             }
@@ -20,7 +20,7 @@ class MyPlugin implements Plugin {
         const { node } = props;
         if (node) {
             switch (node.object) {
-                case "inline":
+                case 'inline':
                     return <span id="slate-inline-test">Hello world</span>;
                 default:
                     return undefined;
@@ -29,7 +29,7 @@ class MyPlugin implements Plugin {
     }
     onChange: OnChangeFn = ({ operations, value }) => {
         console.log(operations, value);
-    }
+    };
 }
 
 const myPlugin = new MyPlugin();

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -1,8 +1,6 @@
-import { Editor, Plugin, EditorProps, RenderBlockProps, RenderInlineProps } from "slate-react";
-import { Value, Editor as Controller, Operation, Point, Range, Inline, Mark, Document, Decoration } from "slate";
+import { Editor, Plugin, EditorProps, OnChangeFn, RenderBlockProps, RenderInlineProps } from "slate-react";
+import { Value, Editor as Controller, Point, Range, Inline, Mark, Document, Decoration } from "slate";
 import * as React from "react";
-import * as Immutable from "immutable";
-import { OnChangeFn } from 'slate-react';
 
 class MyPlugin implements Plugin {
     renderBlock(props: RenderBlockProps, editor: Controller, next: () => void) {

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -1,5 +1,5 @@
-import { Editor, Plugin, EditorProps, OnChangeFn, RenderBlockProps, RenderInlineProps } from "slate-react";
-import { Value, Editor as Controller, Point, Range, Inline, Mark, Document, Decoration } from "slate";
+import { Editor, Plugin, EditorProps, OnChangeFn, RenderBlockProps, RenderInlineProps } from 'slate-react';
+import { Value, Editor as Controller, Point, Range, Inline, Mark, Document, Decoration } from 'slate';
 import * as React from "react";
 
 class MyPlugin implements Plugin {
@@ -27,7 +27,7 @@ class MyPlugin implements Plugin {
     }
     onChange: OnChangeFn = ({ operations, value }) => {
         console.log(operations, value);
-    };
+    }
 }
 
 const myPlugin = new MyPlugin();


### PR DESCRIPTION
A small change in order to be able to import and re-use types of `onChange` function and its parameter.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
