### PR TITLE
Add type definitions for service-worker-mock

### DIFF
--- a/types/service-worker-mock/index.d.ts
+++ b/types/service-worker-mock/index.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export as namespace makeServiceWorkerEnv;
-
 export = makeServiceWorkerEnv;
 declare function makeServiceWorkerEnv(): WorkerGlobalScope;
 

--- a/types/service-worker-mock/index.d.ts
+++ b/types/service-worker-mock/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for service-worker-mock 2.0.3
+// Project: https://github.com/pinterest/service-workers/tree/master/packages/service-worker-mock#readme
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+export as namespace makeServiceWorkerEnv;
+
+export = makeServiceWorkerEnv;
+declare function makeServiceWorkerEnv(): WorkerGlobalScope;
+
+declare namespace makeServiceWorkerEnv{
+    export interface Caches {
+        [key: string]: Cache;
+    }
+
+    export type Listeners = Map<keyof ServiceWorkerGlobalScopeEventMap, EventListener>;
+
+    export interface Snapshot {
+        /**
+         * A key/value map of current cache contents.
+         */
+        caches: Caches;
+
+        /**
+         * A list of active clients.
+         */
+        clients: Client[];
+
+        /**
+         * A list of active notifications.
+         */
+        notifications: Notification[];
+    }
+}
+
+declare global {
+    /**
+     * A key/value map of active listeners (`install`/`activate`/`fetch`/etc).
+     */
+    const listeners: makeServiceWorkerEnv.Listeners;
+
+    /**
+     * Used to trigger active listeners.
+     */
+    function trigger(type: keyof ServiceWorkerGlobalScopeEventMap): Promise<void>;
+
+    /**
+     * Used to generate a snapshot of the service worker internals.
+     */
+    function snapshot(): makeServiceWorkerEnv.Snapshot;
+
+    interface WorkerGlobalScope {
+        listeners: typeof listeners;
+        trigger: typeof trigger;
+        snapshot: typeof snapshot;
+    }
+}

--- a/types/service-worker-mock/index.d.ts
+++ b/types/service-worker-mock/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for service-worker-mock 2.0.3
+// Type definitions for service-worker-mock 2.0
 // Project: https://github.com/pinterest/service-workers/tree/master/packages/service-worker-mock#readme
 // Definitions by: Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -9,14 +9,14 @@ export as namespace makeServiceWorkerEnv;
 export = makeServiceWorkerEnv;
 declare function makeServiceWorkerEnv(): WorkerGlobalScope;
 
-declare namespace makeServiceWorkerEnv{
-    export interface Caches {
+declare namespace makeServiceWorkerEnv {
+    interface Caches {
         [key: string]: Cache;
     }
 
-    export type Listeners = Map<keyof ServiceWorkerGlobalScopeEventMap, EventListener>;
+    type Listeners = Map<keyof ServiceWorkerGlobalScopeEventMap, EventListener>;
 
-    export interface Snapshot {
+    interface Snapshot {
         /**
          * A key/value map of current cache contents.
          */

--- a/types/service-worker-mock/service-worker-mock-tests.ts
+++ b/types/service-worker-mock/service-worker-mock-tests.ts
@@ -1,4 +1,4 @@
-import makeServiceWorkerEnv from 'service-worker-mock';
+import makeServiceWorkerEnv = require('service-worker-mock');
 
 const mock = makeServiceWorkerEnv();
 

--- a/types/service-worker-mock/service-worker-mock-tests.ts
+++ b/types/service-worker-mock/service-worker-mock-tests.ts
@@ -1,0 +1,18 @@
+import makeServiceWorkerEnv from 'service-worker-mock';
+
+const mock = makeServiceWorkerEnv();
+
+Object.assign(self, mock);
+
+trigger('install');
+mock.trigger('install');
+trigger('fetch');
+mock.trigger('fetch');
+
+const emitFetch = listeners.get('fetch') as EventListener;
+emitFetch(new Event('fetch'));
+
+mock.caches.open('OLD_CACHE');
+console.log(snapshot().caches.OLD_CACHE);
+console.log(self.snapshot().clients[0].id);
+console.log(mock.snapshot().notifications[0].body);

--- a/types/service-worker-mock/tsconfig.json
+++ b/types/service-worker-mock/tsconfig.json
@@ -5,7 +5,6 @@
             "es6",
             "webworker"
         ],
-        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/service-worker-mock/tsconfig.json
+++ b/types/service-worker-mock/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "webworker"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "service-worker-mock-tests.ts"
+    ]
+}

--- a/types/service-worker-mock/tslint.json
+++ b/types/service-worker-mock/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Alternative typings are available [here](https://github.com/udacity/cloudflare-typescript-workers/tree/master/packages/%40udacity/types-service-worker-mock), but the readme states they are incomplete.