### PR TITLE
@postlight/mercury-parser: `html` param can be a `Buffer` as well

### DIFF
--- a/types/postlight__mercury-parser/index.d.ts
+++ b/types/postlight__mercury-parser/index.d.ts
@@ -24,7 +24,7 @@ export interface ParseResult {
 export interface ParseOptions {
     contentType?: 'html' | 'markdown' | 'text';
     headers?: object;
-    html?: string;
+    html?: string | Buffer;
 }
 
 export function parse(url: string, options?: ParseOptions): Promise<ParseResult>;

--- a/types/postlight__mercury-parser/index.d.ts
+++ b/types/postlight__mercury-parser/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
+/// <reference types="node" />
+
 export interface ParseResult {
     title: string | null;
     content: string | null;

--- a/types/postlight__mercury-parser/tsconfig.json
+++ b/types/postlight__mercury-parser/tsconfig.json
@@ -13,7 +13,9 @@
         "typeRoots": [
             "../"
         ],
-        "types": [],
+        "types": [
+            "node"
+        ],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/postlight__mercury-parser/tsconfig.json
+++ b/types/postlight__mercury-parser/tsconfig.json
@@ -13,9 +13,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": [
-            "node"
-        ],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
See here for reference:
https://github.com/postlight/mercury-parser/issues/362