### PR TITLE
[react-select] Export component props.

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Claas Ahlrichs <https://github.com/claasahl>
 //                 Jon Freedman <https://github.com/jonfreedman>
 //                 Nathan Bierema <https://github.com/Methuselah96>
+//                 Thomas Chia <https://github.com/thchia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/react-select/src/AsyncCreatable.d.ts
+++ b/types/react-select/src/AsyncCreatable.d.ts
@@ -6,7 +6,7 @@ import { cleanValue } from './utils';
 
 export type Props<OptionType> = AsyncProps<OptionType> & CreatableProps<OptionType>;
 
-type State<OptionType> = AsyncState<OptionType> & CreatableState<OptionType>;
+export type State<OptionType> = AsyncState<OptionType> & CreatableState<OptionType>;
 
 export class AsyncCreatable<OptionType> extends Component<Props<OptionType>, State<OptionType>> {
     static defaultProps: Props<any>;

--- a/types/react-select/src/AsyncCreatable.d.ts
+++ b/types/react-select/src/AsyncCreatable.d.ts
@@ -4,7 +4,7 @@ import { Props as CreatableProps, State as CreatableState } from './Creatable';
 import { OptionsType, ValueType, ActionMeta, InputActionMeta } from './types';
 import { cleanValue } from './utils';
 
-type Props<OptionType> = AsyncProps<OptionType> & CreatableProps<OptionType>;
+export type Props<OptionType> = AsyncProps<OptionType> & CreatableProps<OptionType>;
 
 type State<OptionType> = AsyncState<OptionType> & CreatableState<OptionType>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### Motivation

I'm facing an issue best illustrated with a code sample:

```tsx
import Select from 'react-select'

type SelectProps = React.ComponentProps<typeof Select>

const MySelect = () => {
  const props: SelectProps = {
    onChange: (v, actionMeta) => { ... } <----- v and actionMeta are any
  }
  return <Select {...props} />
}
```
Somehow the arguments to onChange are not getting through. This can be fixed by exporting the prop declarations directly and using those instead of the `ComponentProps` util.