### PR TITLE
[kythe] add typings for Kythe node, edge kinds, fact names

### DIFF
--- a/types/kythe/index.d.ts
+++ b/types/kythe/index.d.ts
@@ -23,7 +23,7 @@ export interface VName {
 /**
  * Kythe edge kinds. See
  *   https://kythe.io/docs/schema/#_edge_kinds
- *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L17
+ *   https://github.com/kythe/kythe/tree/master/kythe/data/schema_index.textproto#L17
  */
 export enum EdgeKind {
     ALIASES = '/kythe/edge/aliases',
@@ -84,7 +84,7 @@ export type OrdinalEdge = string & {
 /**
  * Kythe node kinds. See
  *   https://kythe.io/docs/schema/#_node_kinds
- *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L64
+ *   https://github.com/kythe/kythe/tree/master/kythe/data/schema_index.textproto#L64
  */
 export enum NodeKind {
     ABS = 'abs',
@@ -116,7 +116,7 @@ export enum NodeKind {
 
 /**
  * Kythe fact names. See
- *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L92
+ *   https://github.com/kythe/kythe/tree/master/kythe/data/schema_index.textproto#L92
  */
 export enum FactName {
     BUILD_CONFIG = '/kythe/build/config',
@@ -142,7 +142,7 @@ export enum FactName {
 
 /**
  * Kythe fact subkinds. See
- *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L115
+ *   https://github.com/kythe/kythe/tree/master/kythe/data/schema_index.textproto#L115
  */
 export enum Subkind {
     CATEGORY = 'category',

--- a/types/kythe/index.d.ts
+++ b/types/kythe/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/kythe/kythe
 // Definitions by: Ayaz Hafiz <https://github.com/ayazhafiz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /**
  * A VName (Vector Name) for a node in the Kythe schema consists of:
@@ -20,7 +21,152 @@ export interface VName {
 }
 
 /**
- * An Entry in the Kythe schema is either a Fact or an Edge that describes at least one node.
+ * Kythe edge kinds. See
+ *   https://kythe.io/docs/schema/#_edge_kinds
+ *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L17
+ */
+export enum EdgeKind {
+    ALIASES = '/kythe/edge/aliases',
+    ALIASES_ROOT = '/kythe/edge/aliases/root',
+    ANNOTATED_BY = '/kythe/edge/annotatedby',
+    BOUNDED_LOWER = '/kythe/edge/bounded/lower',
+    BOUNDED_UPPER = '/kythe/edge/bounded/upper',
+    CHILD_OF = '/kythe/edge/childof',
+    CHILD_OF_CONTEXT = '/kythe/edge/childof/context',
+    COMPLETES = '/kythe/edge/completes',
+    COMPLETES_UNIQUELY = '/kythe/edge/completes/uniquely',
+    DEFINES = '/kythe/edge/defines',
+    DEFINES_BINDING = '/kythe/edge/defines/binding',
+    DEPENDS = '/kythe/edge/depends',
+    DOCUMENTS = '/kythe/edge/documents',
+    EXPORTS = '/kythe/edge/exports',
+    EXTENDS = '/kythe/edge/extends',
+    GENERATES = '/kythe/edge/generates',
+    INSTANTIATES = '/kythe/edge/instantiates',
+    INSTANTIATES_SPECULATIVE = '/kythe/edge/instantiates/speculative',
+    IMPUTES = '/kythe/edge/imputes',
+    NAMED = '/kythe/edge/named',
+    OVERRIDES = '/kythe/edge/overrides',
+    OVERRIDES_ROOT = '/kythe/edge/overrides/root',
+    OVERRIDES_TRANSITIVE = '/kythe/edge/overrides/transitive',
+    PARAM = '/kythe/edge/param',
+    REF = '/kythe/edge/ref',
+    REF_IMPLICIT = '/kythe/edge/ref/implicit',
+    REF_CALL = '/kythe/edge/ref/call',
+    REF_CALL_IMPLICIT = '/kythe/edge/ref/call/implicit',
+    REF_DOC = '/kythe/edge/ref/doc',
+    REF_EXPANDS = '/kythe/edge/ref/expands',
+    REF_EXPANDS_TRANSITIVE = '/kythe/edge/ref/expands/transitive',
+    REF_FILE = '/kythe/edge/ref/file',
+    REF_IMPORTS = '/kythe/edge/ref/imports',
+    REF_INCLUDES = '/kythe/edge/ref/includes',
+    REF_INIT = '/kythe/edge/ref/init',
+    REF_INIT_IMPLICIT = '/kythe/edge/ref/init/implicit',
+    REF_QUERIES = '/kythe/edge/ref/queries',
+    SATISFIES = '/kythe/edge/satisfies',
+    SPECIALIZES = '/kythe/edge/specializes',
+    SPECIALIZES_SPECULATIVE = '/kythe/edge/specializes/speculative',
+    TAGGED = '/kythe/edge/tagged',
+    TYPED = '/kythe/edge/typed',
+    UNDEFINES = '/kythe/edge/undefines',
+}
+
+/**
+ * A Kythe ordinal edge has the form of
+ *   `${EdgeKind}.${number}`
+ * This is represented as a branded string that is incompatible with a string
+ * but can be compared to a string.
+ */
+export type OrdinalEdge = string & {
+    __ordinalBrand: 'ordinal';
+};
+
+/**
+ * Kythe node kinds. See
+ *   https://kythe.io/docs/schema/#_node_kinds
+ *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L64
+ */
+export enum NodeKind {
+    ABS = 'abs',
+    ABSVAR = 'absvar',
+    ANCHOR = 'anchor',
+    CONSTANT = 'constant',
+    DIAGNOSTIC = 'diagnostic',
+    DOC = 'doc',
+    FILE = 'file',
+    INTERFACE = 'interface',
+    FUNCTION = 'function',
+    LOOKUP = 'lookup',
+    MACRO = 'macro',
+    META = 'meta',
+    NAME = 'name',
+    PACKAGE = 'package',
+    PROCESS = 'process',
+    RECORD = 'record',
+    SUM = 'sum',
+    SYMBOL = 'symbol',
+    TALIAS = 'talias',
+    TAPP = 'tapp',
+    TBUILTIN = 'tbuiltin',
+    TNOMINAL = 'tnominal',
+    TSIGMA = 'tsigma',
+    VARIABLE = 'variable',
+    VCS = 'vcs',
+}
+
+/**
+ * Kythe fact names. See
+ *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L92
+ */
+export enum FactName {
+    BUILD_CONFIG = '/kythe/build/config',
+    CODE = '/kythe/code',
+    COMPLETE = '/kythe/complete',
+    CONTEXT_URL = '/kythe/context/url',
+    DETAILS = '/kythe/details',
+    DOC_URI = '/kythe/doc/uri',
+    LABEL = '/kythe/label',
+    LOC_END = '/kythe/loc/end',
+    LOC_START = '/kythe/loc/start',
+    MESSAGE = '/kythe/message',
+    NODE_KIND = '/kythe/node/kind',
+    PARAM_DEFAULT = '/kythe/param/default',
+    RULE_CLASS = '/kythe/ruleclass',
+    SNIPPET_END = '/kythe/snippet/end',
+    SNIPPET_START = '/kythe/snippet/start',
+    SUBKIND = '/kythe/subkind',
+    TEXT = '/kythe/text',
+    TEXT_ENCODING = '/kythe/text/encoding',
+    VISIBILITY = '/kythe/visibility',
+}
+
+/**
+ * Kythe fact subkinds. See
+ *   https://github.com/kythe/kythe/blob/ba4ff96ee120050bd497ee2c10910bf74e15d32f/kythe/data/schema_index.textproto#L115
+ */
+export enum Subkind {
+    CATEGORY = 'category',
+    CLASS = 'class',
+    CONSTRUCTOR = 'constructor',
+    DESTRUCTOR = 'destructor',
+    ENUM = 'enum',
+    ENUM_CLASS = 'enumClass',
+    FIELD = 'field',
+    IMPLICIT = 'implicit',
+    IMPORT = 'import',
+    INITIALIZER = 'initializer',
+    LOCAL = 'local',
+    LOCAL_PARAMETER = 'local/parameter',
+    METHOD = 'method',
+    NAMESPACE = 'namespace',
+    STRUCT = 'struct',
+    TYPE = 'type',
+    UNION = 'union',
+}
+
+/**
+ * An Entry in the Kythe schema is either a Fact or an Edge that describes at
+ * least one node.
  */
 export interface Entry {
     source: VName;
@@ -40,4 +186,23 @@ export interface Fact extends Entry {
 export interface Edge extends Entry {
     target: VName;
     kind: string;
+}
+
+/**
+ * A Kythe fact expressed in the schema JSON-style encoding.
+ */
+export interface JSONFact {
+    source: VName;
+    fact_name: FactName;
+    fact_value: string;
+}
+
+/**
+ * A Kythe edge expressed in the schema JSON-style encoding.
+ */
+export interface JSONEdge {
+    source: VName;
+    target: VName;
+    edge_kind: EdgeKind | OrdinalEdge;
+    fact_name: '/';
 }

--- a/types/kythe/kythe-tests.ts
+++ b/types/kythe/kythe-tests.ts
@@ -1,40 +1,79 @@
-import { VName, Fact, Edge } from "kythe";
+import { Edge, EdgeKind, Fact, FactName, JSONEdge, JSONFact, OrdinalEdge, VName } from 'kythe';
+
+function makeOrdinal(edgeKind: EdgeKind, ordinal: number): OrdinalEdge {
+    const edge = `${edgeKind}.${ordinal}`;
+    return <OrdinalEdge> edge;
+}
 
 const vname: VName = {
-    signature: "sig#0",
-    corpus: "types",
-    root: "",
-    path: "tests",
-    language: "typescript",
+    signature: 'sig#0',
+    corpus: 'types',
+    root: '',
+    path: 'tests',
+    language: 'typescript',
 };
 
 const fact: Fact = {
     source: vname,
-    label: "fact",
-    value: "complete",
+    label: 'fact',
+    value: 'complete',
 };
 
 const edge: Edge = {
     source: vname,
     target: vname,
-    kind: "edge",
-    label: "fact",
+    kind: 'edge',
+    label: 'fact',
 };
 
-const incompleteVName: VName = { // $ExpectError
-    signature: "sig#0",
-    root: "",
-    language: "typescript"
+const jsonFact: JSONFact = {
+    source: vname,
+    fact_name: FactName.NODE_KIND,
+    fact_value: 'testvalue',
+};
+
+const jsonEdge: JSONEdge = {
+    source: vname,
+    target: vname,
+    edge_kind: EdgeKind.ALIASES,
+    fact_name: '/',
+};
+
+const jsonOrdinalEdge: JSONEdge = {
+    source: vname,
+    target: vname,
+    edge_kind: makeOrdinal(EdgeKind.ALIASES, 0),
+    fact_name: '/',
+};
+
+// $ExpectError
+const incompleteVName: VName = {
+    signature: 'sig#0',
+    root: '',
+    language: 'typescript',
 };
 
 const incompleteFact: Fact = {
     source: vname,
-    label: "incomplete",
-    kind: "notEdge", // $ExpectError
+    label: 'incomplete',
+    kind: 'notEdge', // $ExpectError
 };
 
 const incompleteEdge: Edge = {
     source: vname,
     target: vname,
-    value: "notFact", // $ExpectError
+    value: 'notFact', // $ExpectError
+};
+
+const incompleteJsonFact: JSONFact = {
+    source: vname,
+    fact_name: 'notFact', // $ExpectError
+    fact_value: 'testvalue',
+};
+
+const incompleteJsonEdge: JSONEdge = {
+    source: vname,
+    target: vname,
+    edge_kind: 'asdasd', // $ExpectError
+    fact_name: 'nonEmpty', // $ExpectError
 };


### PR DESCRIPTION
Add typings for Kyhe node kinds, edge kinds, fact names, and for Kythe
JSON schema edge and fact interfaces.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://kythe.io/docs/schema/
- [x] Increase the version number in the header if appropriate.
  - N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.