### PR TITLE
parse5: more strict typings for getParentNode

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -139,6 +139,16 @@ export interface DefaultTreeParentNode extends DefaultTreeNode {
 }
 
 /**
+ * Default tree adapter ChildNode interface.
+ */
+export interface DefaultTreeChildNode extends DefaultTreeNode {
+    /**
+     * Parent node.
+     */
+    parentNode: DefaultTreeParentNode;
+}
+
+/**
  * Default tree adapter DocumentType interface.
  */
 export interface DefaultTreeDocumentType extends DefaultTreeNode {
@@ -187,7 +197,7 @@ export interface DefaultTreeDocumentFragment extends DefaultTreeParentNode {
 /**
  * Default tree adapter Element interface.
  */
-export interface DefaultTreeElement extends DefaultTreeParentNode {
+export interface DefaultTreeElement extends DefaultTreeChildNode, DefaultTreeParentNode {
     /**
      * The name of the node. Equals to element {@link tagName}.
      */
@@ -205,10 +215,6 @@ export interface DefaultTreeElement extends DefaultTreeParentNode {
      */
     attrs: Attribute[];
     /**
-     * Parent node.
-     */
-    parentNode: DefaultTreeParentNode;
-    /**
      * Element source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
     sourceCodeLocation?: ElementLocation;
@@ -217,7 +223,7 @@ export interface DefaultTreeElement extends DefaultTreeParentNode {
 /**
  * Default tree adapter CommentNode interface.
  */
-export interface DefaultTreeCommentNode extends DefaultTreeNode {
+export interface DefaultTreeCommentNode extends DefaultTreeChildNode {
     /**
      * The name of the node.
      */
@@ -227,10 +233,6 @@ export interface DefaultTreeCommentNode extends DefaultTreeNode {
      */
     data: string;
     /**
-     * Parent node.
-     */
-    parentNode: DefaultTreeParentNode;
-    /**
      * Comment source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
     sourceCodeLocation?: Location;
@@ -239,7 +241,7 @@ export interface DefaultTreeCommentNode extends DefaultTreeNode {
 /**
  * Default tree adapter TextNode interface.
  */
-export interface DefaultTreeTextNode extends DefaultTreeNode {
+export interface DefaultTreeTextNode extends DefaultTreeChildNode {
     /**
      * The name of the node.
      */
@@ -248,10 +250,6 @@ export interface DefaultTreeTextNode extends DefaultTreeNode {
      * Text content.
      */
     value: string;
-    /**
-     * Parent node.
-     */
-    parentNode: DefaultTreeParentNode;
     /**
      * Text node source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
@@ -264,6 +262,11 @@ export interface DefaultTreeTextNode extends DefaultTreeNode {
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeNode}) to get access to the properties.
  */
 export type Node = DefaultTreeNode | object;
+/**
+ * Generic ChildNode interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeChildNode}) to get access to the properties.
+ */
+export type ChildNode = DefaultTreeChildNode | object;
 /**
  * Generic ParentNode interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeParentNode}) to get access to the properties.
@@ -450,7 +453,7 @@ export interface TreeAdapter {
      *
      * @param node - Node.
      */
-    getParentNode(node: Node): ParentNode;
+    getParentNode(node: ChildNode): ParentNode;
     /**
      * Returns the given element's attributes in an array, in the form of name-value pairs.
      * Foreign attributes may contain `namespace` and `prefix` fields as well.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As `DefaultTreeParentNode` was extracted, it's great idea to have `DefaultTreeChildNode`. It makes possible add more strict typings for `getParentNode`.