### PR TITLE
[@wordpress/blocks] miscellaneous fixes for compatibility with wordpress core

### DIFF
--- a/types/wordpress__blocks/api/categories.d.ts
+++ b/types/wordpress__blocks/api/categories.d.ts
@@ -1,7 +1,9 @@
+import { Dashicon } from '@wordpress/components';
+
 export interface Category {
     slug: string;
     title: string;
-    icon: JSX.Element | null;
+    icon?: JSX.Element | Dashicon.Icon | null;
 }
 
 /**

--- a/types/wordpress__blocks/api/factory.d.ts
+++ b/types/wordpress__blocks/api/factory.d.ts
@@ -74,7 +74,4 @@ export function getPossibleBlockTransformations(blocks: BlockInstance[]): Array<
  * @param blocks - One or more `BlockInstance`.
  * @param name - Block name of block to be switched to.
  */
-export function switchToBlockType(
-    blocks: BlockInstance | BlockInstance[],
-    name: string
-): BlockInstance[] | null;
+export function switchToBlockType(blocks: BlockInstance | BlockInstance[], name: string): BlockInstance[] | null;

--- a/types/wordpress__blocks/api/factory.d.ts
+++ b/types/wordpress__blocks/api/factory.d.ts
@@ -11,7 +11,7 @@ import { Block, BlockInstance, Transform } from '../';
 export function cloneBlock<T extends Record<string, any>>(
     block: BlockInstance<T>,
     mergeAttributes?: Partial<T>,
-    newInnerBlocks?: readonly BlockInstance[]
+    newInnerBlocks?: BlockInstance[]
 ): BlockInstance<T>;
 
 /**
@@ -24,7 +24,7 @@ export function cloneBlock<T extends Record<string, any>>(
 export function createBlock<T extends Record<string, any>>(
     name: string,
     attributes?: Partial<T>,
-    innerBlocks?: readonly BlockInstance[]
+    innerBlocks?: BlockInstance[]
 ): BlockInstance<T>;
 
 /**
@@ -66,7 +66,7 @@ export function getBlockTransforms<T extends Record<string, any> = Record<string
  *
  * @returns Block types that ALL blocks in `blocks` can be transformed to.
  */
-export function getPossibleBlockTransformations(blocks: readonly BlockInstance[]): Array<Block<Record<string, any>>>;
+export function getPossibleBlockTransformations(blocks: BlockInstance[]): Array<Block<Record<string, any>>>;
 
 /**
  * Switch one or more blocks into one or more blocks of the new block type.
@@ -75,6 +75,6 @@ export function getPossibleBlockTransformations(blocks: readonly BlockInstance[]
  * @param name - Block name of block to be switched to.
  */
 export function switchToBlockType(
-    blocks: BlockInstance | readonly BlockInstance[],
+    blocks: BlockInstance | BlockInstance[],
     name: string
 ): BlockInstance[] | null;

--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -25,7 +25,7 @@ export function getBlockType<T = any>(name: string | undefined): Block<T> | unde
 /**
  * Returns all registered blocks.
  */
-export function getBlockTypes(): ReadonlyArray<Block<any>>;
+export function getBlockTypes(): Array<Block<any>>;
 
 /**
  * Returns an array with the child blocks of a given block.

--- a/types/wordpress__blocks/api/serializer.d.ts
+++ b/types/wordpress__blocks/api/serializer.d.ts
@@ -28,7 +28,7 @@ export function getBlockMenuDefaultClassName(blockName: string): string;
 export function getSaveContent<T>(
     blockTypeOrName: Block<T> | string,
     attributes: T,
-    innerBlocks?: readonly BlockInstance[]
+    innerBlocks?: BlockInstance[]
 ): string;
 
 /**
@@ -42,7 +42,7 @@ export function getSaveContent<T>(
 export function getSaveElement<T>(
     blockTypeOrName: Block<T> | string,
     attributes: T,
-    innerBlocks?: readonly BlockInstance[]
+    innerBlocks?: BlockInstance[]
 ): ReactChild;
 
 /**
@@ -50,4 +50,4 @@ export function getSaveElement<T>(
  *
  * @param blocks - Block(s) to serialize.
  */
-export function serialize(blocks: readonly BlockInstance[]): string;
+export function serialize(blocks: BlockInstance[]): string;

--- a/types/wordpress__blocks/api/templates.d.ts
+++ b/types/wordpress__blocks/api/templates.d.ts
@@ -9,7 +9,7 @@ export interface TemplateArray extends ReadonlyArray<Template> {}
  * @param blocks - Block list.
  * @param template - Block template.
  */
-export function doBlocksMatchTemplate(blocks?: readonly BlockInstance[], template?: TemplateArray): boolean;
+export function doBlocksMatchTemplate(blocks?: BlockInstance[], template?: TemplateArray): boolean;
 
 /**
  * Synchronize a block list with a block template.

--- a/types/wordpress__blocks/block-content-provider.d.ts
+++ b/types/wordpress__blocks/block-content-provider.d.ts
@@ -1,9 +1,32 @@
+import { BlockInstance } from './';
 import { ComponentType, ReactNode } from '@wordpress/element';
 
 /**
- * A Higher Order Component used to inject BlockContent using context to the
- * wrapped component.
+ * A Higher Order Component used to inject BlockContent using context to the wrapped component.
  */
 export function withBlockContentContext<T extends ComponentType<any>>(
     wrapped: T
 ): T extends ComponentType<infer U> ? ComponentType<Omit<U, 'BlockContent'>> : never;
+
+declare namespace BlockContentProvider {
+    interface Props {
+        children: ReactNode;
+        innerBlocks: BlockInstance[];
+    }
+}
+/**
+ * An internal block component used in block content serialization to inject nested block content
+ * within the `save` implementation of the ancestor component in which it is nested. The component
+ * provides a pre-bound `BlockContent` component via context, which is used by the developer-facing
+ * `InnerBlocks.Content` component to render block content.
+ *
+ * @example
+ * ```jsx
+ * <BlockContentProvider innerBlocks={ innerBlocks }>
+ * 	{ blockSaveElement }
+ * </BlockContentProvider>
+ * ```
+ */
+declare const BlockContentProvider: ComponentType<BlockContentProvider.Props>;
+
+export default BlockContentProvider;

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -169,14 +169,14 @@ export interface BlockDeprecation<T extends Record<string, any>>
      * technically valid even once deprecated, and requires updates to its
      * attributes or inner blocks.
      */
-    isEligible?(attributes: Record<string, any>, innerBlocks: readonly BlockInstance[]): boolean;
+    isEligible?(attributes: Record<string, any>, innerBlocks: BlockInstance[]): boolean;
     /**
      * A function which, given the old attributes and inner blocks is
      * expected to return either the new attributes or a tuple array of
      * [attributes, innerBlocks] compatible with the block.
      */
     migrate?(attributes: Record<string, any>): T;
-    migrate?(attributes: Record<string, any>, innerBlocks: readonly BlockInstance[]): [T, BlockInstance[]];
+    migrate?(attributes: Record<string, any>, innerBlocks: BlockInstance[]): [T, BlockInstance[]];
 }
 
 //

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -264,7 +264,7 @@ blocks.getBlockSupport('core/paragraph', 'inserter', { foo: 'bar' });
 // $ExpectType Block<any> | undefined
 blocks.getBlockType('core/paragraph');
 
-// $ExpectType ReadonlyArray<Block<any>>
+// $ExpectType Block<any>[]
 blocks.getBlockTypes();
 
 // $ExpectType string[]


### PR DESCRIPTION
**Note to reviewer:** These fixes are for compatibility reasons. They were found while attempting to add type checking support to the package itself. Specifically, the package mutates a lot of things internally that aren't meant to be mutated externally, and to avoid the conflict while referencing these types, the readonly attribute in these cases were removed. Also misc other small fixes were added.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.