### PR TITLE
Updated definition of type for case-sensitive-paths-webpack-plugin 

### DIFF
--- a/types/case-sensitive-paths-webpack-plugin/case-sensitive-paths-webpack-plugin-tests.ts
+++ b/types/case-sensitive-paths-webpack-plugin/case-sensitive-paths-webpack-plugin-tests.ts
@@ -1,9 +1,10 @@
-import { Configuration } from 'webpack';
+import { Compiler, Configuration } from 'webpack';
 import CaseSensitivePathsWebpackPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const options: CaseSensitivePathsWebpackPlugin.Options = {
     debug: true,
 };
+const compiler: Compiler = new Compiler();
 
 const c: Configuration = {
     plugins: [
@@ -11,5 +12,6 @@ const c: Configuration = {
         new CaseSensitivePathsWebpackPlugin({
             debug: true
         }),
+        new CaseSensitivePathsWebpackPlugin().apply(compiler),
     ],
 };

--- a/types/case-sensitive-paths-webpack-plugin/case-sensitive-paths-webpack-plugin-tests.ts
+++ b/types/case-sensitive-paths-webpack-plugin/case-sensitive-paths-webpack-plugin-tests.ts
@@ -1,17 +1,20 @@
-import { Compiler, Configuration } from 'webpack';
+import { Compiler, Configuration, Plugin } from 'webpack';
 import CaseSensitivePathsWebpackPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const options: CaseSensitivePathsWebpackPlugin.Options = {
     debug: true,
 };
 const compiler: Compiler = new Compiler();
+const plugin: Plugin = new CaseSensitivePathsWebpackPlugin();
+
+plugin.apply(compiler);
 
 const c: Configuration = {
     plugins: [
         new CaseSensitivePathsWebpackPlugin(),
         new CaseSensitivePathsWebpackPlugin({
-            debug: true
+            debug: true,
         }),
-        new CaseSensitivePathsWebpackPlugin().apply(compiler),
+        plugin,
     ],
 };

--- a/types/case-sensitive-paths-webpack-plugin/index.d.ts
+++ b/types/case-sensitive-paths-webpack-plugin/index.d.ts
@@ -4,12 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Plugin } from 'webpack';
+import { Plugin, Compiler } from 'webpack';
 
 export = CaseSensitivePathsWebpackPlugin;
 
 declare class CaseSensitivePathsWebpackPlugin extends Plugin {
     constructor(options?: CaseSensitivePathsWebpackPlugin.Options);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace CaseSensitivePathsWebpackPlugin {

--- a/types/html-webpack-plugin/index.d.ts
+++ b/types/html-webpack-plugin/index.d.ts
@@ -6,14 +6,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Plugin, compilation } from 'webpack';
+import { Plugin, compilation, Compiler } from 'webpack';
 import { AsyncSeriesWaterfallHook } from 'tapable';
 import { Options as HtmlMinifierOptions } from 'html-minifier';
 
 export = HtmlWebpackPlugin;
 
 declare class HtmlWebpackPlugin extends Plugin {
-	constructor(options?: HtmlWebpackPlugin.Options);
+    constructor(options?: HtmlWebpackPlugin.Options);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace HtmlWebpackPlugin {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
