### PR TITLE
updated definition for friendly-errors-webpack-plugin to match interface for Webpack plugin

### DIFF
--- a/types/friendly-errors-webpack-plugin/index.d.ts
+++ b/types/friendly-errors-webpack-plugin/index.d.ts
@@ -4,37 +4,39 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import { Plugin } from 'webpack';
+import { Plugin, Compiler } from 'webpack';
 
 export = FriendlyErrorsWebpackPlugin;
 
 declare class FriendlyErrorsWebpackPlugin extends Plugin {
-	constructor(options?: FriendlyErrorsWebpackPlugin.Options);
+    constructor(options?: FriendlyErrorsWebpackPlugin.Options);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace FriendlyErrorsWebpackPlugin {
-	enum Severity {
-		Error = "error",
-		Warning = "warning",
-	}
+    enum Severity {
+        Error = "error",
+        Warning = "warning",
+    }
 
-	interface Options {
-		compilationSuccessInfo?: {
-			messages: string[],
-			notes: string[],
-		};
-		onErrors?(severity: Severity, errors: string): void;
-		clearConsole?: boolean;
-		additionalFormatters?: Array<(errors: WebpackError[], type: Severity) => string[]>;
-		additionalTransformers?: Array<(error: any) => any>;
-	}
+    interface Options {
+        compilationSuccessInfo?: {
+            messages: string[],
+            notes: string[],
+        };
+        onErrors?(severity: Severity, errors: string): void;
+        clearConsole?: boolean;
+        additionalFormatters?: Array<(errors: WebpackError[], type: Severity) => string[]>;
+        additionalTransformers?: Array<(error: any) => any>;
+    }
 
-	interface WebpackError {
-		message: string;
-		file: string;
-		origin: string;
-		name: string;
-		severity: Severity;
-		webpackError: any;
-	}
+    interface WebpackError {
+        message: string;
+        file: string;
+        origin: string;
+        name: string;
+        severity: Severity;
+        webpackError: any;
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
