### PR TITLE
Dom fixes 2019 07 11

### DIFF
--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -190,9 +190,6 @@ function JQueryStatic() {
                 target;
             });
             const myDocForced: JQuery<Document> = $(document);
-            const myWindow = $(window);
-            // $ExpectType JQuery<Window>
-            myWindow;
             const myWindowForced: JQuery<Window> = $(window);
             // $ExpectType JQuery<Window>
             myWindowForced;

--- a/types/jquery/test/jquery-slim-window-module-tests.ts
+++ b/types/jquery/test/jquery-slim-window-module-tests.ts
@@ -1,5 +1,4 @@
 import jq = require('jquery/dist/jquery.slim');
 
 const $window = jq(window);
-// $ExpectType JQuery<Window>
-$window;
+const forced: JQuery<Window> = $window;

--- a/types/jquery/test/jquery-window-module-tests.ts
+++ b/types/jquery/test/jquery-window-module-tests.ts
@@ -1,5 +1,4 @@
 import jq = require('jquery');
 
 const $window = jq(window);
-// $ExpectType JQuery<Window>
-$window;
+const forced: JQuery<Window> = $window;

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -119,7 +119,7 @@ interface CredentialsContainer {
 /**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-credentialdata}
  */
-interface Credential {
+interface CredentialData {
     /**
      * The credential’s identifier. This might be a GUID, username, or email
      * address, for instance.
@@ -134,13 +134,12 @@ type CredentialType = PasswordCredential|FederatedCredential|PublicKeyCredential
  * will inherit.
  * @see {@link https://www.w3.org/TR/credential-management-1/#credential}
  */
-declare abstract class CredentialBase {
+interface Credential {
     /**
      * The credential’s identifier. This might be a GUID, username, or email
      * address, for instance.
      */
     readonly id: string;
-
     /**
      * The credential’s type.
      */
@@ -150,7 +149,7 @@ declare abstract class CredentialBase {
 /**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-siteboundcredentialdata}
  */
-interface SiteBoundCredentialData extends Credential {
+interface SiteBoundCredentialData extends CredentialData {
     /**
      * A name associated with the credential, intended as a human-understandable
      * public name.
@@ -170,7 +169,9 @@ interface SiteBoundCredentialData extends Credential {
  * agent’s credential
  * store.
  */
-declare abstract class SiteBoundCredential extends CredentialBase {
+// tslint:disable-next-line no-empty-interface
+interface SiteBoundCredential extends Credential { }
+declare abstract class SiteBoundCredential {
     /**
      * A name associated with the credential, intended as a human-understandable
      * public name.
@@ -481,14 +482,6 @@ interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
     readonly authenticatorData: ArrayBuffer;
     readonly signature: ArrayBuffer;
     readonly userHandle: ArrayBuffer | null;
-}
-
-interface Credential {
-    /**
-     * The credential’s identifier. This might be a GUID, username, or email
-     * address, for instance.
-     */
-    readonly id: string;
 }
 
 /**

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -116,6 +116,17 @@ interface CredentialsContainer {
     preventSilentAccess(): Promise<void>;
 }
 
+/**
+ * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-credentialdata}
+ */
+interface Credential {
+    /**
+     * The credential’s identifier. This might be a GUID, username, or email
+     * address, for instance.
+     */
+    readonly id: string;
+}
+
 type CredentialType = PasswordCredential|FederatedCredential|PublicKeyCredential;
 
 /**
@@ -139,12 +150,7 @@ declare abstract class CredentialBase {
 /**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-siteboundcredentialdata}
  */
-interface SiteBoundCredentialData {
-    /**
-     * The credential’s identifier. This might be a GUID, username, or email
-     * address, for instance.
-     */
-    id: string;
+interface SiteBoundCredentialData extends Credential {
     /**
      * A name associated with the credential, intended as a human-understandable
      * public name.
@@ -477,16 +483,18 @@ interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
     readonly userHandle: ArrayBuffer | null;
 }
 
-/**
- * @see {@link https://w3c.github.io/webauthn/#publickeycredential}
- */
-interface PublicKeyCredential {
+interface Credential {
     /**
      * The credential’s identifier. This might be a GUID, username, or email
      * address, for instance.
      */
-    id: string;
+    readonly id: string;
+}
 
+/**
+ * @see {@link https://w3c.github.io/webauthn/#publickeycredential}
+ */
+interface PublicKeyCredential extends Credential {
     readonly type: "public-key";
     readonly rawId: ArrayBuffer;
     readonly response: AuthenticatorResponse;

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package W3C (WebAppSec) Credential Management API Level 1, 0.4
+// Type definitions for non-npm package W3C (WebAppSec) Credential Management API Level 1, 0.5
 // Project: https://github.com/w3c/webappsec-credential-management
 // Definitions by: Iain McGinniss <https://github.com/iainmcgin>
 //                 Joao Peixoto <https://github.com/Hartimer>

--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -116,17 +116,6 @@ interface CredentialsContainer {
     preventSilentAccess(): Promise<void>;
 }
 
-/**
- * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-credentialdata}
- */
-interface CredentialData {
-    /**
-     * The credential’s identifier. This might be a GUID, username, or email
-     * address, for instance.
-     */
-    id: string;
-}
-
 type CredentialType = PasswordCredential|FederatedCredential|PublicKeyCredential;
 
 /**
@@ -150,7 +139,12 @@ declare abstract class CredentialBase {
 /**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-siteboundcredentialdata}
  */
-interface SiteBoundCredentialData extends CredentialData {
+interface SiteBoundCredentialData {
+    /**
+     * The credential’s identifier. This might be a GUID, username, or email
+     * address, for instance.
+     */
+    id: string;
     /**
      * A name associated with the credential, intended as a human-understandable
      * public name.
@@ -372,16 +366,21 @@ interface FederatedCredentialRequestOptions {
 
 // Type definitions for webauthn
 // Spec: https://w3c.github.io/webauthn/
+interface txAuthGenericArg {
+    content: ArrayBuffer;
+    contentType: string;
+}
 
-/**
- * @see {@link https://w3c.github.io/webauthn/#enumdef-publickeycredentialtype}
- */
-type PublicKeyCredentialType = "public-key";
-
-/**
- * @see {@link https://w3c.github.io/webauthn/#enumdef-userverificationrequirement}
- */
-type UserVerificationRequirement = "required" | "preferred" | "discouraged";
+interface AuthenticationExtensionsClientInputs {
+    appid?: string;
+    authnSel?: Array<ArrayBufferView | ArrayBuffer>;
+    exts?: boolean;
+    loc?: boolean;
+    txAuthGeneric?: txAuthGenericArg;
+    txAuthSimple?: string;
+    uvi?: boolean;
+    uvm?: boolean;
+}
 
 /**
  * @see {@link https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions}
@@ -391,8 +390,8 @@ interface PublicKeyCredentialRequestOptions {
     timeout?: number;
     rpId?: string;
     allowCredentials?: PublicKeyCredentialDescriptor[];
-    userVerification?: UserVerificationRequirement;
-    extensions?: any;
+    userVerification?: "required" | "preferred" | "discouraged";
+    extensions?: AuthenticationExtensionsClientInputs;
 }
 
 /**
@@ -416,42 +415,27 @@ interface PublicKeyCredentialUserEntity {
  * @see {@link https://w3c.github.io/webauthn/#dictdef-publickeycredentialparameters}
  */
 interface PublicKeyCredentialParameters {
-    type: PublicKeyCredentialType;
+    type: "public-key";
     alg: number;
 }
-
-/**
- * @see {@link https://w3c.github.io/webauthn/#transport}
- */
-type AuthenticatorTransport = "usb" | "nfc" | "ble" | "internal";
 
 /**
  * @see {@link https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptor}
  */
 interface PublicKeyCredentialDescriptor {
-    type: PublicKeyCredentialType;
+    type: "public-key";
     id: BufferSource;
-    transports?: AuthenticatorTransport[];
+    transports?: Array<"usb" | "nfc" | "ble" | "internal">;
 }
-
-/**
- * @see {@link https://w3c.github.io/webauthn/#attachment}
- */
-type AuthenticatorAttachment = "platform" | "cross-platform";
 
 /**
  * @see {@link https://w3c.github.io/webauthn/#dictdef-authenticatorselectioncriteria}
  */
 interface AuthenticatorSelectionCriteria {
-    authenticatorAttachment?: AuthenticatorAttachment;
+    authenticatorAttachment?: "platform" | "cross-platform";
     requireResidentKey?: boolean;
-    userVerification?: UserVerificationRequirement;
+    userVerification?: "required" | "preferred" | "discouraged";
 }
-
-/**
- * @see {@link https://w3c.github.io/webauthn/#attestation-convey}
- */
-type AttestationConveyancePreference = "none" | "indirect" | "direct";
 
 /**
  * @see {@link https://w3c.github.io/webauthn/#dictdef-makepublickeycredentialoptions}
@@ -466,8 +450,8 @@ interface PublicKeyCredentialCreationOptions {
     timeout?: number;
     excludeCredentials?: PublicKeyCredentialDescriptor[];
     authenticatorSelection?: AuthenticatorSelectionCriteria;
-    attestation?: AttestationConveyancePreference;
-    extensions?: any;
+    attestation?: "none" | "indirect" | "direct";
+    extensions?: AuthenticationExtensionsClientInputs;
 }
 
 /**
@@ -496,8 +480,14 @@ interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
 /**
  * @see {@link https://w3c.github.io/webauthn/#publickeycredential}
  */
-interface PublicKeyCredential extends CredentialData {
-    readonly type: PublicKeyCredentialType;
+interface PublicKeyCredential {
+    /**
+     * The credential’s identifier. This might be a GUID, username, or email
+     * address, for instance.
+     */
+    id: string;
+
+    readonly type: "public-key";
     readonly rawId: ArrayBuffer;
-    readonly response: AuthenticatorAttestationResponse|AuthenticatorAssertionResponse;
+    readonly response: AuthenticatorResponse;
 }

--- a/types/webgl2/index.d.ts
+++ b/types/webgl2/index.d.ts
@@ -798,7 +798,6 @@ declare var WebGL2RenderingContext: {
     readonly STENCIL_CLEAR_VALUE: number;
     readonly STENCIL_FAIL: number;
     readonly STENCIL_FUNC: number;
-    readonly STENCIL_INDEX: number;
     readonly STENCIL_INDEX8: number;
     readonly STENCIL_PASS_DEPTH_FAIL: number;
     readonly STENCIL_PASS_DEPTH_PASS: number;


### PR DESCRIPTION
1. `$(window)` will have a different type in TS 3.6, `JQuery<Window & typeof globalThis>`, so `ExpectType JQuery<Window>` assertions won't work anymore. I weakened the test to test assignability:

```ts
const jqw: JQuery<Window> = $(window);
```

2. webappsec-credential-management needs to avoid conflicts with the DOM version that 3.6 will include in order to keep compiling. I copied interfaces and inlined type aliases where needed.

Inlining type aliases is not the ideal solution, but they don't merge, so I couldn't copy them like interfaces. And they are (1) used only once or twice (2) self-explanatory literal unions, so I think it's fine for a package that will see reduced use once 3.6 is released.

I also renamed CredentialBase to Credential and changed it to an interface, also to match the DOM code in 3.6.

3. webgl2 is also now in the DOM, so the types need to match exactly. I deleted an extra property. Again, I expect this package to stop being used as much once 3.6 is released.
