### PR TITLE
More-correct typings for chaining in underscore

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5357,7 +5357,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sample
         **/
-        sample<T>(n: number): _ChainSingle<T>;
+        sample<T>(n: number): _Chain<T, T[]>;
 
         /**
         * @see _.sample

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5255,7 +5255,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.invoke
         **/
-        invoke(methodName: string, ...args: any[]): _Chain<any>;
+        invoke(methodName: string, ...args: any[]): _Chain<any, any[]>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -4622,7 +4622,7 @@ declare module _ {
          * Wrapped type any[][].
          * @see _.chunk
          **/
-        chunk(): any[][];
+        chunk(count: number): any[][];
 
         /* ***********
         * Functions *
@@ -5570,7 +5570,7 @@ declare module _ {
         * Wrapped type `number`.
         * @see _.range
         **/
-        range(stop: number, step?: number): _Chain<T>;
+        range(stop: number, step?: number): _Chain<number, number[]>;
 
         /**
         * Wrapped type `number`.
@@ -5582,7 +5582,7 @@ declare module _ {
          * Wrapped type `any[][]`.
          * @see _.chunk
          **/
-        chunk(): _Chain<T[], T[][]>;
+        chunk(count: number): _Chain<T[], T[][]>;
 
         /* ***********
         * Functions *
@@ -5592,7 +5592,7 @@ declare module _ {
         * Wrapped type `Function`.
         * @see _.bind
         **/
-        bind(object: any, ...args: any[]): _Chain<T, V>;
+        bind(object: any, ...args: any[]): _ChainSingle<T>;
 
         /**
         * Wrapped type `object`.
@@ -5604,7 +5604,7 @@ declare module _ {
         * Wrapped type `Function`.
         * @see _.partial
         **/
-        partial(...args: any[]): _Chain<T, V>;
+        partial(...args: any[]): _ChainSingle<Function>;
 
         /**
         * Wrapped type `Function`.
@@ -5616,18 +5616,18 @@ declare module _ {
         * Wrapped type `Function`.
         * @see _.defer
         **/
-        defer(...args: any[]): _Chain<T, V>;
+        defer(...args: any[]): _ChainSingle<void>;
 
         /**
         * Wrapped type `Function`.
         * @see _.delay
         **/
-        delay(wait: number, ...args: any[]): _Chain<T, V>;
+        delay(wait: number, ...args: any[]): _ChainSingle<void>;
 
         /**
         * @see _.delay
         **/
-        delay(...args: any[]): _Chain<T, V>;
+        delay(...args: any[]): _ChainSingle<void>;
 
         /**
         * Wrapped type `Function`.
@@ -5651,31 +5651,31 @@ declare module _ {
          * Wrapped type `Function`.
          * @see _.once
          **/
-        restArgs(startIndex?: number): _Chain<T, V>;
+        restArgs(starIndex?: number): _ChainSingle<Function>;
 
         /**
         * Wrapped type `number`.
         * @see _.after
         **/
-        after(func: Function): _Chain<T, V>;
+        after(times: number): _Chain<T, V>;
 
         /**
         * Wrapped type `number`.
         * @see _.before
         **/
-        before(fn: Function): _Chain<T, V>;
+        before(times: number): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.wrap
         **/
-        wrap(wrapper: Function): () => _Chain<T, V>;
+        wrap(wrapper: Function): _ChainSingle<Function>;
 
         /**
         * Wrapped type `Function`.
         * @see _.negate
         **/
-        negate(): _Chain<T, V>;
+        negate(): _ChainSingle<Function>;
 
         /**
         * Wrapped type `Function[]`.
@@ -5772,7 +5772,7 @@ declare module _ {
          * Wrapped type `any`.
          * @see _.create
          **/
-        create(props?: object): _Chain<T, V>;
+        create(props?: object): _Chain<any>;
 
         /**
         * Wrapped type `any[]`.
@@ -5973,7 +5973,7 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.mixin
         **/
-        mixin(): _Chain<T, V>;
+        mixin(obj: any): _ChainSingle<undefined>;
 
         /**
         * Wrapped type `string|Function|Object`.
@@ -6009,7 +6009,7 @@ declare module _ {
         * Wrapped type `string`.
         * @see _.template
         **/
-        template(settings?: _.TemplateSettings): (...data: any[]) => _ChainSingle<(kv: any) => string>;
+        template(settings?: _.TemplateSettings): _ChainSingle<(...data: any[]) => string>;
 
         /************* *
         * Array proxy *
@@ -6068,7 +6068,7 @@ declare module _ {
         * @param compareFn Optional. Specifies a function that defines the sort order. If omitted, the array is sorted according to each character's Unicode code point value, according to the string conversion of each element.
         * @return The sorted array.
         **/
-        sort(compareFn?: (a: T, b: T) => boolean): _Chain<T, T[]>;
+        sort(compareFn?: (a: T, b: T) => number): _Chain<T, T[]>;
 
         /**
         * Changes the content of an array by removing existing elements and/or adding new elements.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5189,7 +5189,7 @@ declare module _ {
         filter(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T, T[]>;
 
         /**
-        * @see _.select
+        * @see _.filter
         **/
         select(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T, T[]>;
 
@@ -5255,7 +5255,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.invoke
         **/
-        invoke(methodName: string, ...args: any[]): _Chain<T, V>;
+        invoke(methodName: string, ...args: any[]): _Chain<any>;
 
         /**
         * Wrapped type `any[]`.
@@ -5357,12 +5357,12 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sample
         **/
-        sample<T>(n: number): _Chain<T, T[]>;
+        sample<T>(n: number): _ChainSingle<T>;
 
         /**
         * @see _.sample
         **/
-        sample<T>(): _Chain<T, T[]>;
+        sample<T>(): _ChainSingle<T>;
 
         /**
         * Wrapped type `any`.
@@ -5703,19 +5703,19 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.values
         **/
-        values(): _Chain<any, any[]>;
+        values(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `object`.
         * @see _.mapObject
         **/
-        mapObject<TResult>(fn: _.ListIterator<T, TResult>): _Chain<TResult, any>;
+        mapObject<TResult>(fn: _.ListIterator<T, TResult>): _Chain<TResult, Dictionary<TResult>>;
 
         /**
         * Wrapped type `object`.
         * @see _.pairs
         **/
-        pairs(): _Chain<[string, any], [string, any][]>;
+        pairs(): _Chain<[string, T], [string, T][]>;
 
         /**
         * Wrapped type `object`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5709,7 +5709,7 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.mapObject
         **/
-        mapObject<TResult>(fn: _.ListIterator<T, TResult>): _Chain<TResult, Dictionary<TResult>>;
+        mapObject<TResult>(fn: _.ObjectIterator<T, TResult>): _Chain<TResult, Dictionary<TResult>>;
 
         /**
         * Wrapped type `object`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5357,12 +5357,12 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sample
         **/
-        sample<T>(n: number): _Chain<T, T[]>;
+        sample(n: number): _Chain<T, T[]>;
 
         /**
         * @see _.sample
         **/
-        sample<T>(): _ChainSingle<T>;
+        sample(): _ChainSingle<T>;
 
         /**
         * Wrapped type `any`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5766,13 +5766,14 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.defaults
         **/
-        defaults(...defaults: any[]): _Chain<T, V>;
+        defaults(...defaults: any[]): _Chain<any, Dictionary<any>>;
 
         /**
          * Wrapped type `any`.
          * @see _.create
          **/
-        create(props?: object): _Chain<any>;
+        create<U>(props?: U): _Chain<U[keyof U] | T, U & V>;
+        create(): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.
@@ -5979,7 +5980,7 @@ declare module _ {
         * Wrapped type `string|Function|Object`.
         * @see _.iteratee
         **/
-        iteratee(context?: any): _ChainSingle<any>;
+        iteratee(context?: any): _ChainSingle<Predicate<any>>;
 
         /**
         * Wrapped type `string`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5977,7 +5977,7 @@ declare module _ {
         mixin(obj: any): _ChainSingle<undefined>;
 
         /**
-        * Wrapped type `string|Function|Object`.
+         * Wrapped type `IterateePropertyShorthand|Function|IterateeMatcherShorthand<T>`.
         * @see _.iteratee
         **/
         iteratee(context?: any): _ChainSingle<Predicate<any>>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5073,22 +5073,22 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.each
         **/
-        each(iterator: _.ListIterator<T, void>, context?: any): _Chain<T>;
+        each(iterator: _.ListIterator<T, void>, context?: any): _Chain<T, V>;
 
         /**
         * @see _.each
         **/
-        each(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T>;
+        each(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T, V>;
 
         /**
         * @see _.each
         **/
-        forEach(iterator: _.ListIterator<T, void>, context?: any): _Chain<T>;
+        forEach(iterator: _.ListIterator<T, void>, context?: any): _Chain<T, V>;
 
         /**
         * @see _.each
         **/
-        forEach(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T>;
+        forEach(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.
@@ -5186,18 +5186,18 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.filter
         **/
-        filter(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T>;
+        filter(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T, T[]>;
 
         /**
-        * @see _.filter
+        * @see _.select
         **/
-        select(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T>;
+        select(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.where
         **/
-        where<U extends {}>(properties: U): _Chain<T>;
+        where<U extends {}>(properties: U): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
@@ -5209,7 +5209,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.reject
         **/
-        reject(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T>;
+        reject(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
@@ -5255,7 +5255,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.invoke
         **/
-        invoke(methodName: string, ...args: any[]): _Chain<T>;
+        invoke(methodName: string, ...args: any[]): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.
@@ -5303,13 +5303,13 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
+        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator: string, context?: any): _Chain<T>;
+        sortBy(iterator: string, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
@@ -5327,48 +5327,48 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.indexBy
         **/
-        indexBy(iterator: _.ListIterator<T, any>, context?: any): _Chain<T>;
+        indexBy(iterator: _.ListIterator<T, any>, context?: any): _Chain<T, Dictionary<T>>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.indexBy
         **/
-        indexBy(iterator: string, context?: any): _Chain<T>;
+        indexBy(iterator: string, context?: any): _Chain<T, Dictionary<T>>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.countBy
         **/
-        countBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
+        countBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<number, Dictionary<number>>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.countBy
         **/
-        countBy(iterator: string, context?: any): _Chain<T>;
+        countBy(iterator: string, context?: any): _Chain<number, Dictionary<number>>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.shuffle
         **/
-        shuffle(): _Chain<T>;
+        shuffle(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.sample
         **/
-        sample<T>(n: number): _Chain<T>;
+        sample<T>(n: number): _Chain<T, T[]>;
 
         /**
         * @see _.sample
         **/
-        sample<T>(): _Chain<T>;
+        sample<T>(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any`.
         * @see _.toArray
         **/
-        toArray(): _Chain<T>;
+        toArray(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any`.
@@ -5390,33 +5390,33 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.first
         **/
-        first(n: number): _Chain<T>;
+        first(n: number): _Chain<T, T[]>;
 
         /**
         * @see _.first
         **/
-        head(): _Chain<T>;
+        head(): _ChainSingle<T | undefined>;
 
         /**
         * @see _.first
         **/
-        head(n: number): _Chain<T>;
+        head(n: number): _Chain<T, T[]>;
 
         /**
         * @see _.first
         **/
-        take(): _Chain<T>;
+        take(): _ChainSingle<T | undefined>;
 
         /**
         * @see _.first
         **/
-        take(n: number): _Chain<T>;
+        take(n: number): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.initial
         **/
-        initial(n?: number): _Chain<T>;
+        initial(n?: number): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
@@ -5428,29 +5428,29 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.last
         **/
-        last(n: number): _Chain<T>;
+        last(n: number): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.rest
         **/
-        rest(n?: number): _Chain<T>;
+        rest(n?: number): _Chain<T, T[]>;
 
         /**
         * @see _.rest
         **/
-        tail(n?: number): _Chain<T>;
+        tail(n?: number): _Chain<T, T[]>;
 
         /**
         * @see _.rest
         **/
-        drop(n?: number): _Chain<T>;
+        drop(n?: number): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.compact
         **/
-        compact(): _Chain<T>;
+        compact(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any`.
@@ -5468,7 +5468,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.partition
         **/
-        partition(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T[]>;
+        partition(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T[], T[][]>;
 
         /**
         * Wrapped type `any[][]`.
@@ -5480,58 +5480,58 @@ declare module _ {
         * Wrapped type `any[][]`.
         * @see _.intersection
         **/
-        intersection(...arrays: _.List<T>[]): _Chain<T>;
+        intersection(...arrays: _.List<T>[]): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.difference
         **/
-        difference(...others: _.List<T>[]): _Chain<T>;
+        difference(...others: _.List<T>[]): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.uniq
         **/
-        uniq(isSorted?: boolean, iterator?: _.ListIterator<T, any> | _.IterateePropertyShorthand): _Chain<T>;
+        uniq(isSorted?: boolean, iterator?: _.ListIterator<T, any> | _.IterateePropertyShorthand): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.uniq
         **/
-        uniq<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T>;
+        uniq<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T, T[]>;
 
         /**
         * @see _.uniq
         **/
-        unique<TSort>(isSorted?: boolean, iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand): _Chain<T>;
+        unique<TSort>(isSorted?: boolean, iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand): _Chain<T, T[]>;
 
         /**
         * @see _.uniq
         **/
-        unique<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T>;
+        unique<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[][]`.
         * @see _.zip
         **/
-        zip(...arrays: any[][]): _Chain<T>;
+        zip(...arrays: any[][]): _Chain<any[], any[][]>;
 
         /**
         * Wrapped type `any[][]`.
         * @see _.unzip
         **/
-        unzip(...arrays: any[][]): _Chain<T>;
+        unzip(...arrays: any[][]): _Chain<any[], any[][]>;
 
         /**
         * Wrapped type `any[][]`.
         * @see _.object
         **/
-        object(...keyValuePairs: any[][]): _Chain<T>;
+        object(...keyValuePairs: any[][]): _Chain<any, Dictionary<any>>;
 
         /**
         * @see _.object
         **/
-        object(values?: any): _Chain<T>;
+        object(values?: any): _Chain<any, Dictionary<any>>;
 
         /**
         * Wrapped type `any[]`.
@@ -5576,13 +5576,13 @@ declare module _ {
         * Wrapped type `number`.
         * @see _.range
         **/
-        range(): _Chain<T>;
+        range(): _Chain<number, number[]>;
 
         /**
          * Wrapped type `any[][]`.
          * @see _.chunk
          **/
-        chunk(): _Chain<T>;
+        chunk(): _Chain<T[], T[][]>;
 
         /* ***********
         * Functions *
@@ -5592,96 +5592,96 @@ declare module _ {
         * Wrapped type `Function`.
         * @see _.bind
         **/
-        bind(object: any, ...args: any[]): _Chain<T>;
+        bind(object: any, ...args: any[]): _Chain<T, V>;
 
         /**
         * Wrapped type `object`.
         * @see _.bindAll
         **/
-        bindAll(...methodNames: string[]): _Chain<T>;
+        bindAll(...methodNames: string[]): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.partial
         **/
-        partial(...args: any[]): _Chain<T>;
+        partial(...args: any[]): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.memoize
         **/
-        memoize(hashFn?: (n: any) => string): _Chain<T>;
+        memoize(hashFn?: (n: any) => string): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.defer
         **/
-        defer(...args: any[]): _Chain<T>;
+        defer(...args: any[]): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.delay
         **/
-        delay(wait: number, ...args: any[]): _Chain<T>;
+        delay(wait: number, ...args: any[]): _Chain<T, V>;
 
         /**
         * @see _.delay
         **/
-        delay(...args: any[]): _Chain<T>;
+        delay(...args: any[]): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.throttle
         **/
-        throttle(wait: number, options?: _.ThrottleSettings): _Chain<T>;
+        throttle(wait: number, options?: _.ThrottleSettings): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.debounce
         **/
-        debounce(wait: number, immediate?: boolean): _Chain<T>;
+        debounce(wait: number, immediate?: boolean): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.once
         **/
-        once(): _Chain<T>;
+        once(): _Chain<T, V>;
 
         /**
          * Wrapped type `Function`.
          * @see _.once
          **/
-        restArgs(startIndex?: number): _Chain<T>;
+        restArgs(startIndex?: number): _Chain<T, V>;
 
         /**
         * Wrapped type `number`.
         * @see _.after
         **/
-        after(func: Function): _Chain<T>;
+        after(func: Function): _Chain<T, V>;
 
         /**
         * Wrapped type `number`.
         * @see _.before
         **/
-        before(fn: Function): _Chain<T>;
+        before(fn: Function): _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.wrap
         **/
-        wrap(wrapper: Function): () => _Chain<T>;
+        wrap(wrapper: Function): () => _Chain<T, V>;
 
         /**
         * Wrapped type `Function`.
         * @see _.negate
         **/
-        negate(): _Chain<T>;
+        negate(): _Chain<T, V>;
 
         /**
         * Wrapped type `Function[]`.
         * @see _.compose
         **/
-        compose(...functions: Function[]): _Chain<T>;
+        compose(...functions: Function[]): _Chain<T, V>;
 
         /********* *
          * Objects *
@@ -5691,60 +5691,60 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.keys
         **/
-        keys(): _Chain<string>;
+        keys(): _Chain<string, string[]>;
 
         /**
         * Wrapped type `object`.
         * @see _.allKeys
         **/
-        allKeys(): _Chain<string>;
+        allKeys(): _Chain<string, string[]>;
 
         /**
         * Wrapped type `object`.
         * @see _.values
         **/
-        values(): _Chain<any>;
+        values(): _Chain<any, any[]>;
 
         /**
         * Wrapped type `object`.
         * @see _.mapObject
         **/
-        mapObject(fn: _.ListIterator<T, any>): _Chain<T>;
+        mapObject<TResult>(fn: _.ListIterator<T, TResult>): _Chain<TResult, any>;
 
         /**
         * Wrapped type `object`.
         * @see _.pairs
         **/
-        pairs(): _Chain<[string, any]>;
+        pairs(): _Chain<[string, any], [string, any][]>;
 
         /**
         * Wrapped type `object`.
         * @see _.invert
         **/
-        invert(): _Chain<T>;
+        invert(): _Chain<string, Dictionary<string>>;
 
         /**
         * Wrapped type `object`.
         * @see _.functions
         **/
-        functions(): _Chain<T>;
+        functions(): _Chain<string, string[]>;
 
         /**
         * @see _.functions
         **/
-        methods(): _Chain<T>;
+        methods(): _Chain<string, string[]>;
 
         /**
         * Wrapped type `object`.
         * @see _.extend
         **/
-        extend(...sources: any[]): _Chain<T>;
+        extend(...sources: any[]): _Chain<any, Dictionary<any>>;
 
         /**
         * Wrapped type `object`.
         * @see _.extend
         **/
-        findKey(predicate: _.ObjectIterator<any, boolean>, context?: any): _Chain<T>
+        findKey(predicate: _.ObjectIterator<any, boolean>, context?: any): _ChainSingle<string>
 
         /**
         * Wrapped type `object`.
@@ -5758,177 +5758,177 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.omit
         **/
-        omit(...keys: string[]): _Chain<T>;
-        omit(keys: string[]): _Chain<T>;
-        omit(iteratee: Function): _Chain<T>;
+        omit(...keys: string[]): _Chain<T, V>;
+        omit(keys: string[]): _Chain<T, V>;
+        omit(iteratee: Function): _Chain<T, V>;
 
         /**
         * Wrapped type `object`.
         * @see _.defaults
         **/
-        defaults(...defaults: any[]): _Chain<T>;
+        defaults(...defaults: any[]): _Chain<T, V>;
 
         /**
          * Wrapped type `any`.
          * @see _.create
          **/
-        create(props?: object): _Chain<T>;
+        create(props?: object): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.clone
         **/
-        clone(): _Chain<T>;
+        clone(): _Chain<T, V>;
 
         /**
         * Wrapped type `object`.
         * @see _.tap
         **/
-        tap(interceptor: (...as: any[]) => any): _Chain<T>;
+        tap(interceptor: (...as: any[]) => any): _Chain<T, V>;
 
         /**
         * Wrapped type `object`.
         * @see _.has
         **/
-        has(key: string): _Chain<T>;
+        has(key: string): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.matches
         **/
-        matches(): _Chain<T>;
+        matches(): _ChainSingle<boolean>;
 
         /**
          * Wrapped type `any[]`.
          * @see _.matcher
          **/
-        matcher(): _Chain<T>;
+        matcher(): _ChainSingle<(obj: any) => boolean>;
 
         /**
         * Wrapped type `string`.
         * @see _.property
         **/
-        property(): _Chain<T>;
+        property(): _ChainSingle<(obj: any) => any>;
 
         /**
         * Wrapped type `object`.
         * @see _.propertyOf
         **/
-        propertyOf(): _Chain<T>;
+        propertyOf(): _ChainSingle<(property: string) => T>;
 
         /**
         * Wrapped type `object`.
         * @see _.isEqual
         **/
-        isEqual(other: any): _Chain<T>;
+        isEqual(other: any): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isEmpty
         **/
-        isEmpty(): _Chain<T>;
+        isEmpty(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isMatch
         **/
-        isMatch(): _Chain<T>;
+        isMatch(properties: Partial<V>): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isElement
         **/
-        isElement(): _Chain<T>;
+        isElement(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isArray
         **/
-        isArray(): _Chain<T>;
+        isArray(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isSymbol
         **/
-        isSymbol(): _Chain<T>;
+        isSymbol(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isObject
         **/
-        isObject(): _Chain<T>;
+        isObject(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isArguments
         **/
-        isArguments(): _Chain<T>;
+        isArguments(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isFunction
         **/
-        isFunction(): _Chain<T>;
+        isFunction(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isError
         **/
-        isError(): _Chain<T>;
+        isError(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isString
         **/
-        isString(): _Chain<T>;
+        isString(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isNumber
         **/
-        isNumber(): _Chain<T>;
+        isNumber(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isFinite
         **/
-        isFinite(): _Chain<T>;
+        isFinite(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isBoolean
         **/
-        isBoolean(): _Chain<T>;
+        isBoolean(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isDate
         **/
-        isDate(): _Chain<T>;
+        isDate(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isRegExp
         **/
-        isRegExp(): _Chain<T>;
+        isRegExp(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isNaN
         **/
-        isNaN(): _Chain<T>;
+        isNaN(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isNull
         **/
-        isNull(): _Chain<T>;
+        isNull(): _ChainSingle<boolean>;
 
         /**
         * Wrapped type `object`.
         * @see _.isUndefined
         **/
-        isUndefined(): _Chain<T>;
+        isUndefined(): _ChainSingle<boolean>;
 
         /********* *
          * Utility *
@@ -5938,78 +5938,78 @@ declare module _ {
         * Wrapped type `any`.
         * @see _.identity
         **/
-        identity(): _Chain<T>;
+        identity(): _Chain<T, V>;
 
         /**
         * Wrapped type `any`.
         * @see _.constant
         **/
-        constant(): _Chain<T>;
+        constant(): _ChainSingle<() => V>;
 
         /**
         * Wrapped type `any`.
         * @see _.noop
         **/
-        noop(): _Chain<T>;
+        noop(): _ChainSingle<undefined>;
 
         /**
         * Wrapped type `number`.
         * @see _.times
         **/
-        times<TResult>(iterator: (n: number) => TResult, context?: any): _Chain<T>;
+        times<TResult>(iterator: (n: number) => TResult, context?: any): _Chain<TResult, TResult[]>;
 
         /**
         * Wrapped type `number`.
         * @see _.random
         **/
-        random(): _Chain<T>;
+        random(): _ChainSingle<number>;
         /**
         * Wrapped type `number`.
         * @see _.random
         **/
-        random(max: number): _Chain<T>;
+        random(max: number): _ChainSingle<number>;
 
         /**
         * Wrapped type `object`.
         * @see _.mixin
         **/
-        mixin(): _Chain<T>;
+        mixin(): _Chain<T, V>;
 
         /**
         * Wrapped type `string|Function|Object`.
         * @see _.iteratee
         **/
-        iteratee(context?: any): _Chain<T>;
+        iteratee(context?: any): _ChainSingle<any>;
 
         /**
         * Wrapped type `string`.
         * @see _.uniqueId
         **/
-        uniqueId(): _Chain<T>;
+        uniqueId(): _ChainSingle<string>;
 
         /**
         * Wrapped type `string`.
         * @see _.escape
         **/
-        escape(): _Chain<T>;
+        escape(): _ChainSingle<string>;
 
         /**
         * Wrapped type `string`.
         * @see _.unescape
         **/
-        unescape(): _Chain<T>;
+        unescape(): _ChainSingle<string>;
 
         /**
         * Wrapped type `object`.
         * @see _.result
         **/
-        result(property: string, defaultValue?: any): _Chain<T>;
+        result(property: string, defaultValue?: any): _ChainSingle<any>;
 
         /**
         * Wrapped type `string`.
         * @see _.template
         **/
-        template(settings?: _.TemplateSettings): (...data: any[]) => _Chain<T>;
+        template(settings?: _.TemplateSettings): (...data: any[]) => _ChainSingle<(kv: any) => string>;
 
         /************* *
         * Array proxy *
@@ -6021,14 +6021,14 @@ declare module _ {
         * @param arr Arrays and/or values to concatenate into a new array. See the discussion below for details.
         * @return A new array comprised of the array on which it is called
         **/
-        concat(...arr: Array<T[]>): _Chain<T>;
+        concat(...arr: Array<T[]>): _Chain<T, T[]>;
 
         /**
         * Join all elements of an array into a string.
         * @param separator Optional. Specifies a string to separate each element of the array. The separator is converted to a string if necessary. If omitted, the array elements are separated with a comma.
         * @return The string conversions of all array elements joined into one string.
         **/
-        join(separator?: any): _ChainSingle<T>;
+        join(separator?: any): _ChainSingle<string>;
 
         /**
         * Removes the last element from an array and returns that element.
@@ -6041,13 +6041,13 @@ declare module _ {
         * @param item The elements to add to the end of the array.
         * @return The array with the element added to the end.
         **/
-        push(...item: Array<T>): _Chain<T>;
+        push(...item: Array<T>): _Chain<T, T[]>;
 
         /**
         * Reverses an array in place. The first array element becomes the last and the last becomes the first.
         * @return The reversed array.
         **/
-        reverse(): _Chain<T>;
+        reverse(): _Chain<T, T[]>;
 
         /**
         * Removes the first element from an array and returns that element. This method changes the length of the array.
@@ -6061,14 +6061,14 @@ declare module _ {
         * @param end Optional. Zero-based index at which to end extraction. slice extracts up to but not including end.
         * @return A shallow copy of a portion of an array into a new array object.
         **/
-        slice(start: number, end?: number): _Chain<T>;
+        slice(start: number, end?: number): _Chain<T, T[]>;
 
         /**
         * Sorts the elements of an array in place and returns the array. The sort is not necessarily stable. The default sort order is according to string Unicode code points.
         * @param compareFn Optional. Specifies a function that defines the sort order. If omitted, the array is sorted according to each character's Unicode code point value, according to the string conversion of each element.
         * @return The sorted array.
         **/
-        sort(compareFn?: (a: T, b: T) => boolean): _Chain<T>;
+        sort(compareFn?: (a: T, b: T) => boolean): _Chain<T, T[]>;
 
         /**
         * Changes the content of an array by removing existing elements and/or adding new elements.
@@ -6077,20 +6077,20 @@ declare module _ {
         * @param items The element to add to the array. If you don't specify any elements, splice will only remove elements from the array.
         * @return An array containing the deleted elements. If only one element is removed, an array of one element is returned. If no elements are removed, an empty array is returned.
         **/
-        splice(index: number, quantity: number, ...items: Array<T>): _Chain<T>;
+        splice(index: number, quantity: number, ...items: Array<T>): _Chain<T, T[]>;
 
         /**
         * A string representing the specified array and its elements.
         * @return A string representing the specified array and its elements.
         **/
-        toString(): _ChainSingle<T>;
+        toString(): _ChainSingle<string>;
 
         /**
         * Adds one or more elements to the beginning of an array and returns the new length of the array.
         * @param items The elements to add to the front of the array.
         * @return The array with the element added to the beginning.
         **/
-        unshift(...items: Array<T>): _Chain<T>;
+        unshift(...items: Array<T>): _Chain<T, T[]>;
 
         /********** *
          * Chaining *
@@ -6100,7 +6100,7 @@ declare module _ {
         * Wrapped type `any`.
         * @see _.chain
         **/
-        chain(): _Chain<T>;
+        chain(): _Chain<T, V>;
 
         /**
         * Wrapped type `any`.
@@ -6111,7 +6111,7 @@ declare module _ {
     interface _ChainSingle<T> {
         value(): T;
     }
-    interface _ChainOfArrays<T> extends _Chain<T[]> {
+    interface _ChainOfArrays<T> extends _Chain<T[], T[][]> {
         flatten(shallow?: boolean): _Chain<T>;
     }
 }

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5657,13 +5657,13 @@ declare module _ {
         * Wrapped type `number`.
         * @see _.after
         **/
-        after(times: number): _Chain<T, V>;
+        after<F extends Function>(fn: F): _ChainSingle<F>;
 
         /**
         * Wrapped type `number`.
         * @see _.before
         **/
-        before(times: number): _Chain<T, V>;
+        before<F extends Function>(fn: F): _ChainSingle<F>;
 
         /**
         * Wrapped type `Function`.
@@ -5721,7 +5721,7 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.invert
         **/
-        invert(): _Chain<string, Dictionary<string>>;
+        invert(): _Chain<any, Dictionary<any>>;
 
         /**
         * Wrapped type `object`.
@@ -5977,7 +5977,7 @@ declare module _ {
         mixin(obj: any): _ChainSingle<undefined>;
 
         /**
-         * Wrapped type `IterateePropertyShorthand|Function|IterateeMatcherShorthand<T>`.
+        * Wrapped type `IterateePropertyShorthand|Function|IterateeMatcherShorthand<T>`.
         * @see _.iteratee
         **/
         iteratee(context?: any): _ChainSingle<Predicate<any>>;

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -628,7 +628,7 @@ function chain_tests() {
   }
 
   var lastN = _.chain([1, 2, 3, 4]).last(3).value().length;
-  var fisrtN = _.chain([1, 2, 3, 4]).first(3).value().length;
+  var firstN = _.chain([1, 2, 3, 4]).first(3).value().length;
   var drop = _.chain([1, 2, 3, 4]).drop().value().length;
 
   var part: number[][] = _.chain([0, 1, 2, 3, 4, 5]).partition(n => n % 2 == 0).value();
@@ -663,8 +663,9 @@ function chain_tests() {
   var throttle: (s: string) => void = _.chain(alert).throttle(5).value();
   var debounce: (s: string) => void = _.chain(alert).debounce(5).value();
   var once: (s: string) => void = _.chain((s: string) => console.log(s, s)).once().value();
-  var after: (s: string) => void = _.chain((s: string) => console.log(s, s)).after(1).value();
-  var before: (s: string) => void = _.chain((s: string) => console.log(s, s)).before(2).value();
+
+  var after: (s: string) => void = _.chain(1).after((s: string) => console.log(s, s)).value();
+  var before: (s: string) => void = _.chain(2).before((s: string) => console.log(s, s)).value();
   var restArgs: Function = _.chain((a: number, b: string[]) => console.log(a, b))
     .restArgs(1)
     .value();
@@ -685,6 +686,7 @@ function chain_tests() {
     .value();
   var paired: Array<[string, number]> = _.chain({a: 1, b: 2}).pairs().value();
   var inverted: {[key: string]: string} = _.chain({a: 'b', b: 'a'}).invert().value();
+  var invertedArray: {[key: string]: number} = _.chain(['a', 'b', 'c']).invert().value();
   var functions: string[] = _.chain(_).functions().value();
   var methods: string[] = _.chain(_).methods().value();
   var extend: {[key: string]: number} = _.chain({a: 1, b: 2}).extend({c: 3}, {d: 4}).value();

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -593,6 +593,9 @@ function chain_tests() {
     .groupBy(v => v[0])
     .value()[0].length;
 
+  var sampleOne = _.chain([1, 2, 3]).sample().value() * 2;
+  var sampleMore = _.chain([1, 2, 3]).sample(2).value().length;
+
 	var n = _.chain([1, 2, 3, 200])
 		.filter(num => num % 2 == 0)
 		.tap(alert)

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -586,8 +586,32 @@ function chain_tests() {
   var each = _.chain([4, 3, 2, 1])
     .map(v => v * 5)
     .each(v => console.log(v))
+    .forEach(v => console.log(v))
     .value()
     .length;
+
+  var objectEach: {[key: string]: number} = _.chain({a: 4, b: 3, c: 2, d: 1})
+    .each(v => console.log(v))
+    .forEach(v => console.log(v))
+    .value();
+
+  var whereAndReject = _.chain({a: 4, b: 3, c: 2, d: 1})
+    .where(v => v < 2)
+    .reject(v => v > 3)
+    .value()
+    .length;
+
+  var invoke = _.chain(
+    [[5, 1, 7], [3, 2, 1]]
+  ).invoke('sort').value().length;
+
+  var indexBy: {[key: string]: string} = _.chain(['a', 'bb', 'c', 'dd'])
+    .indexBy(v => v[0])
+    .value()
+
+  var countBy: {[key: string]: number} = _.chain(['a', 'aa', 'b', 'bb'])
+    .countBy(v => v[0])
+    .value();
 
   var groupBy = _.chain(['a', 'aa', 'b', 'bb'])
     .groupBy(v => v[0])
@@ -595,6 +619,125 @@ function chain_tests() {
 
   var sampleOne = _.chain([1, 2, 3]).sample().value() * 2;
   var sampleMore = _.chain([1, 2, 3]).sample(2).value().length;
+
+  function testChainToArray() {
+    var f: string[] = _.chain(arguments)
+      .toArray()
+      .value()
+      .slice();
+  }
+
+  var lastN = _.chain([1, 2, 3, 4]).last(3).value().length;
+  var fisrtN = _.chain([1, 2, 3, 4]).first(3).value().length;
+  var drop = _.chain([1, 2, 3, 4]).drop().value().length;
+
+  var part: number[][] = _.chain([0, 1, 2, 3, 4, 5]).partition(n => n % 2 == 0).value();
+  var compact: string[] = _.chain(['a', null, 'b'] as string[]).compact().value();
+  var intersection: string[] = _.chain(['a', 'b']).intersection(['b', 'c']).value();
+  var difference: string[] = _.chain(['a', 'b']).difference(['b', 'c']).value();
+  var uniq: string[] = _.chain(['a', 'b', 'c', 'b', 'a']).uniq().value();
+  var zip: Array<string | number>[] = _.chain(['a', 'b', 'c']).zip([1, 2, 3]).value();
+  var unzip: string[][] = _.chain([['a', 'b', 'c'], ['d', 'e', 'f']]).unzip().value();
+  var obj: {[key: string]: number} = _.chain([['a', 1], ['b', 2]]).object().value();
+  var range: number[] = _.chain(10).range().value();
+  var range2: number[] = _.chain(1).range(10, 2).value();
+  var shuffleChunk: number[][] = _.chain([1, 2, 3, 4, 5, 6]).shuffle().chunk(2).value();
+
+  interface bindAll {
+    a: () => number;
+    b: (a: number) => string;
+  }
+
+  var didBindAll: bindAll = _.chain({a: () => 5, b: (a: number) => a.toString()})
+    .bindAll('a', 'b')
+    .value();
+
+  var partial: Function = _.chain((a: number, b: number) => b - a)
+    .partial(5)
+    .value();
+
+  var bind: (a: number) => number = _.chain((a: number) => a * 2).bind({}).value();
+
+  _.chain(alert).defer('hello');
+  _.chain(alert).delay(5, 'hello');
+  var throttle: (s: string) => void = _.chain(alert).throttle(5).value();
+  var debounce: (s: string) => void = _.chain(alert).debounce(5).value();
+  var once: (s: string) => void = _.chain((s: string) => console.log(s, s)).once().value();
+  var after: (s: string) => void = _.chain((s: string) => console.log(s, s)).after(1).value();
+  var before: (s: string) => void = _.chain((s: string) => console.log(s, s)).before(2).value();
+  var restArgs: Function = _.chain((a: number, b: string[]) => console.log(a, b))
+    .restArgs(1)
+    .value();
+
+  var hello = name => 'hello: ' + name;
+  var hello2: Function = _.chain(hello)
+    .wrap((func) => 'before, ' + func('moe') + ', after')
+    .value();
+
+  var negated: boolean = _.chain((a: boolean, b: boolean) => (a || b))
+    .negate()
+    .value()(true, false);
+  var compose: (v: string) => string = _.chain(hello).compose(h => h + '!').value()
+  var keys: string[] = _.chain({a: 1, b: 2}).keys().value();
+  var values: number[] = _.chain({a: 1, b: 2}).values().value();
+  var mappedObj: {[key: string]: string} = _.chain({a: 1, b: 2})
+    .mapObject(v => v.toString())
+    .value();
+  var paired: Array<[string, number]> = _.chain({a: 1, b: 2}).pairs().value();
+  var inverted: {[key: string]: string} = _.chain({a: 'b', b: 'a'}).invert().value();
+  var functions: string[] = _.chain(_).functions().value();
+  var methods: string[] = _.chain(_).methods().value();
+  var extend: {[key: string]: number} = _.chain({a: 1, b: 2}).extend({c: 3}, {d: 4}).value();
+  var findKey: string = _.chain({a: 1, b: 2}).findKey(v => v % 2 === 0).value();
+  var omit: {[key: string]: number} = _.chain({a: 1, b: 2}).omit('a').value();
+  var clone: {[key: string]: number} = _.chain({a: 1, b: 2}).clone().value();
+  var has: boolean = _.chain({a: 1, b: 2}).has('b').value();
+  var defaults: {[key: string]: number} = _.chain({a: 1}).defaults({b: 2}).value();
+  var create: {[key: string]: number} = _.chain(Object.prototype).create({a: 1, b: 2}).value();
+  var matches: (obj: any) => boolean = _.chain({a: 1, b: 2}).matcher().value();
+  var property: (obj: any) => string = _.chain('hello').property().value();
+  var propertyOf: (key: string) => any = _.chain({a: 1, b: 2}).propertyOf().value();
+  var isEqual: boolean = _.chain({a: 1, b: 2}).isEqual({c: 3}).value();
+  var isEmpty: boolean = _.chain({a: 1, b: 2}).isEmpty().value();
+  var isMatch: boolean = _.chain({a: 1, b: 2}).isMatch({b: 3}).value();
+  var isElement: boolean = _.chain('hello').isElement().value();
+  var isArray: boolean = _.chain('hello').isArray().value();
+  var isSymbol: boolean = _.chain('hello').isSymbol().value();
+  var isArguments: boolean = _.chain('hello').isArguments().value();
+  var isFunction: boolean = _.chain('hello').isFunction().value();
+  var isError: boolean = _.chain('hello').isError().value();
+  var isString: boolean = _.chain('hello').isString().value();
+  var isNumber: boolean = _.chain('hello').isNumber().value();
+  var isFinite: boolean = _.chain('hello').isFinite().value();
+  var isBoolean: boolean = _.chain('hello').isBoolean().value();
+  var isDate: boolean = _.chain('hello').isDate().value();
+  var isRegExp: boolean = _.chain('hello').isRegExp().value();
+  var isNaN: boolean = _.chain('hello').isNaN().value();
+  var isNull: boolean = _.chain('hello').isNull().value();
+  var isUndefined: boolean = _.chain('hello').isUndefined().value();
+  var identity: number[] = _.chain([1, 2, 3]).identity().value();
+  var constant: () => string = _.chain('hello').constant().value();
+  _.chain('hello').noop();
+  var times: number[] = _.chain(5).times(n => n*2).value();
+  var random: number = _.chain(10).random().value();
+  _.chain([1, 2, 3]).mixin({a: () => 'hello'});
+  var uniqueId: string = _.chain('prefix').uniqueId().value();
+  var esc: string = _.chain('hello').escape().value();
+  var unesc: string = _.chain('hello').unescape().value();
+  var result: string = _.chain({a: () => 'hello'}).result('a').value();
+  var template: (kv: any) => string = _.chain('templatey').template().value();
+  var proxies: number[] = _.chain([1, 2, 3])
+    .concat([4, 5, 6])
+    .push(7)
+    .reverse()
+    .slice(0)
+    .sort((a: number, b: number) => b - a)
+    .unshift(0)
+    .splice(5, 1, 2, 3, 4, 5)
+    .value();
+  var joined: string = _.chain(['a', 'b', 'c']).join(', ').value();
+  var toString: string = _.chain([1, 2, 3]).toString().value();
+  var chainchain: string[] = _.chain(['a', 'b', 'c']).chain().value();
 
 	var n = _.chain([1, 2, 3, 200])
 		.filter(num => num % 2 == 0)

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -571,6 +571,28 @@ function chain_tests() {
 		.map(num => "string" + num)
 		.value();
 
+  var numEvens = _.chain(['a', 'bb', 'ccc', 'dddd'])
+    .map(n => n.length)
+    .filter(s => s % 2 == 0)
+    .value()
+    .length;
+
+  var sortBy = _.chain([4, 3, 2, 1])
+    .map(v => v * 5)
+    .sortBy(v => v)
+    .value()
+    .length;
+
+  var each = _.chain([4, 3, 2, 1])
+    .map(v => v * 5)
+    .each(v => console.log(v))
+    .value()
+    .length;
+
+  var groupBy = _.chain(['a', 'aa', 'b', 'bb'])
+    .groupBy(v => v[0])
+    .value()[0].length;
+
 	var n = _.chain([1, 2, 3, 200])
 		.filter(num => num % 2 == 0)
 		.tap(alert)


### PR DESCRIPTION
In particular, the wrapped collection type in `_Chain` was often lost, which didn't cause problems until returning a value. Anything of type `_Chain<T>` is typed to return a single `T` from its `.value()` when generally what is actually returned is a `T[]` or `Dictionary<T>`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [see main underscore docs](http://underscorejs.org) for context 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/36838)
<!-- Reviewable:end -->
