### PR TITLE
[restify] Remove old property from Next interface

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -877,8 +877,6 @@ export interface RedirectOptions {
 
 export interface Next {
     (err?: any): void;
-
-    ifError(err?: any): void;
 }
 
 export interface RouteSpec {


### PR DESCRIPTION
`next.ifError` was deprecated in version 5.x - https://github.com/restify/node-restify/blob/5.x/lib/deprecationWarnings.js#L4-L17 - and removed completely in version 7.x - https://github.com/restify/node-restify/blob/master/CHANGELOG.md#700-2018-03-20

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  `next.ifError` was deprecated in version 5.x - https://github.com/restify/node-restify/blob/5.x/lib/deprecationWarnings.js#L4-L17 - and removed completely in version 7.x - https://github.com/restify/node-restify/blob/master/CHANGELOG.md#700-2018-03-20
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
