### PR TITLE
Add type definitions for aws-regions

### DIFF
--- a/types/aws-regions/aws-regions-tests.ts
+++ b/types/aws-regions/aws-regions-tests.ts
@@ -1,0 +1,30 @@
+import awsRegions from 'aws-regions';
+
+awsRegions.list() ===
+    [
+        {
+            name: 'N. Virginia',
+            full_name: 'US East (N. Virginia)',
+            code: 'us-east-1',
+            public: true,
+            zones: ['us-east-1a'],
+        },
+    ];
+
+awsRegions.lookup({ code: 'us-east-1' }) ===
+    {
+        name: 'N. Virginia',
+        full_name: 'US East (N. Virginia)',
+        code: 'us-east-1',
+        public: true,
+        zones: ['us-east-1a'],
+    };
+
+awsRegions.lookup({ name: 'N. Virginia' }) ===
+    {
+        name: 'N. Virginia',
+        full_name: 'US East (N. Virginia)',
+        code: 'us-east-1',
+        public: true,
+        zones: ['us-east-1a'],
+    };

--- a/types/aws-regions/index.d.ts
+++ b/types/aws-regions/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for aws-regions 2.1
+// Project: https://github.com/jsonmaur/aws-regions/tree/master/javascript#readme
+// Definitions by: Alex Lapa <https://github.com/Deadarius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+interface AwsRegionInfo {
+    name: string;
+    full_name: string;
+    code: string;
+    public: boolean;
+    zones: ReadonlyArray<string>;
+}
+
+interface ListOptions {
+    public?: boolean;
+}
+
+interface LookupOptionsCode {
+    code: string;
+}
+
+interface LookupOptionsName {
+    name: string;
+}
+
+type LookupOptions = LookupOptionsCode | LookupOptionsName;
+
+interface AwsRegions {
+    list: (options?: ListOptions) => AwsRegionInfo[];
+    lookup: (options: LookupOptions) => AwsRegionInfo;
+}
+
+declare const awsRegions: AwsRegions;
+
+export = awsRegions;

--- a/types/aws-regions/tsconfig.json
+++ b/types/aws-regions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "aws-regions-tests.ts"
+    ]
+}

--- a/types/aws-regions/tslint.json
+++ b/types/aws-regions/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
