### PR TITLE
Add payment method info to Stripe charge details

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1662,201 +1662,201 @@ declare namespace Stripe {
         }
 
         interface IAlipayPaymentMethodDetails {
-          type: "alipay";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          alipay: {};
+            type: "alipay";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            alipay: {};
         }
 
         interface IBancontactPaymentMethodDetails {
-          type: "bancontact";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          bancontact: {};
+            type: "bancontact";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            bancontact: {};
         }
 
         interface ICardPaymentMethodDetails {
-          type: "card";
-          card: {
-            /**
-             * Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
-             */
-            brand: "amex" | "diner" | "discover" | "jcb" | "mastercard" | "unionpay" | "visa" | "unknown";
+            type: "card";
+            card: {
+                /**
+                 * Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+                 */
+                brand: "amex" | "diner" | "discover" | "jcb" | "mastercard" | "unionpay" | "visa" | "unknown";
 
-            /**
-             * Check results by Card networks on Card address and CVC at time of payment.
-             */
-            checks: {
-              /**
-               * If a address line1 was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
-               */
-              address_line1_check: "pass" | "failed" | "unavailable" | "unchecked";
+                /**
+                 * Check results by Card networks on Card address and CVC at time of payment.
+                 */
+                checks: {
+                    /**
+                     * If a address line1 was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+                     */
+                    address_line1_check: "pass" | "failed" | "unavailable" | "unchecked";
 
-              /**
-               * If a address postal code was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
-               */
-              address_postal_code_check: "pass" | "failed" | "unavailable" | "unchecked";
+                    /**
+                     * If a address postal code was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+                     */
+                    address_postal_code_check: "pass" | "failed" | "unavailable" | "unchecked";
 
-              /**
-               * If a CVC was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
-               */
-              cvc_check: "pass" | "failed" | "unavailable" | "unchecked";
-            }
+                    /**
+                     * If a CVC was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+                     */
+                    cvc_check: "pass" | "failed" | "unavailable" | "unchecked";
+                }
 
-            /**
-             * Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of
-             * the international breakdown of cards you’ve collected.
-             */
-            country: string;
+                /**
+                 * Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of
+                 * the international breakdown of cards you’ve collected.
+                 */
+                country: string;
 
-            /**
-             * Two-digit number representing the card’s expiration month.
-             */
-            exp_month: number;
+                /**
+                 * Two-digit number representing the card’s expiration month.
+                 */
+                exp_month: number;
 
-            /**
-             * Four-digit number representing the card’s expiration year.
-             */
-            exp_year: number;
+                /**
+                 * Four-digit number representing the card’s expiration year.
+                 */
+                exp_year: number;
 
-            /**
-             * Uniquely identifies this particular card number. You can use this attribute to check whether two
-             * customers who’ve signed up with you are using the same card number, for example.
-             */
-            fingerprint: string;
+                /**
+                 * Uniquely identifies this particular card number. You can use this attribute to check whether two
+                 * customers who’ve signed up with you are using the same card number, for example.
+                 */
+                fingerprint: string;
 
-            /**
-             * Card funding type. Can be credit, debit, prepaid, or unknown.
-             */
-            funding: "credit" | "debit" | "prepaid" | "unknown";
+                /**
+                 * Card funding type. Can be credit, debit, prepaid, or unknown.
+                 */
+                funding: "credit" | "debit" | "prepaid" | "unknown";
 
-            /**
-             * The last four digits of the card.
-             */
-            last4: number;
+                /**
+                 * The last four digits of the card.
+                 */
+                last4: number;
 
-            /**
-             * Populated if this transaction used 3D Secure authentication.
-             */
-            three_d_secure?: {
-              /**
-               * Whether or not authentication was performed. 3D Secure will succeed without authentication when the
-               * card is not enrolled.
-               */
-              authenticated: boolean;
+                /**
+                 * Populated if this transaction used 3D Secure authentication.
+                 */
+                three_d_secure?: {
+                    /**
+                     * Whether or not authentication was performed. 3D Secure will succeed without authentication when the
+                     * card is not enrolled.
+                     */
+                    authenticated: boolean;
 
-              /**
-               * Whether or not 3D Secure succeeded.
-               */
-              succeeded: boolean;
+                    /**
+                     * Whether or not 3D Secure succeeded.
+                     */
+                    succeeded: boolean;
 
-              /**
-               * The version of 3D Secure that was used for this payment.
-               */
-              version: string;
+                    /**
+                     * The version of 3D Secure that was used for this payment.
+                     */
+                    version: string;
+                };
+
+                /**
+                 * If this Card is part of a card wallet, this contains the details of the card wallet.
+                 */
+                wallet?: {
+                    /**
+                     * The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`,
+                     * `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name
+                     * matching this value. It contains additional information specific to the card wallet type.
+                     */
+                    type: "amex_express_checkout" | "apple_pay" | "google_pay" | "masterpass" | "samsung_pay" | "visa_checkout";
+
+                    /**
+                     * If this is an `amex_express_checkout` card wallet, this hash contains details about the wallet.
+                     */
+                    amex_express_checkout: {};
+
+                    /**
+                     * If this is an `apple_pay` card wallet, this hash contains details about the wallet.
+                     */
+                    apple_pay: {};
+
+                    /**
+                     * (For tokenized numbers only.) The last four digits of the device account number.
+                     */
+                    dynamic_last4?: string;
+
+                    /**
+                     * If this is a `google_pay` card wallet, this hash contains details about the wallet.
+                     */
+                    google_pay?: string;
+
+                    /**
+                     * If this is a `masterpass` card wallet, this hash contains details about the wallet.
+                     */
+                    masterpass?: {
+                        // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-masterpass
+                    };
+
+                    /**
+                     * If this is a `visa_checkout` card wallet, this hash contains details about the wallet.
+                     */
+                    visa_checkout: {
+                        // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-visa_checkout
+                    };
+                };
             };
-
-            /**
-             * If this Card is part of a card wallet, this contains the details of the card wallet.
-             */
-            wallet?: {
-              /**
-               * The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`,
-               * `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name
-               * matching this value. It contains additional information specific to the card wallet type.
-               */
-              type: "amex_express_checkout" | "apple_pay" | "google_pay" | "masterpass" | "samsung_pay" | "visa_checkout";
-
-              /**
-               * If this is an `amex_express_checkout` card wallet, this hash contains details about the wallet.
-               */
-              amex_express_checkout: {};
-
-              /**
-               * If this is an `apple_pay` card wallet, this hash contains details about the wallet.
-               */
-              apple_pay: {};
-
-              /**
-               * (For tokenized numbers only.) The last four digits of the device account number.
-               */
-              dynamic_last4?: string;
-
-              /**
-               * If this is a `google_pay` card wallet, this hash contains details about the wallet.
-               */
-              google_pay?: string;
-
-              /**
-               * If this is a `masterpass` card wallet, this hash contains details about the wallet.
-               */
-              masterpass?: {
-                // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-masterpass
-              };
-
-              /**
-               * If this is a `visa_checkout` card wallet, this hash contains details about the wallet.
-               */
-              visa_checkout: {
-                // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-visa_checkout
-              };
-            };
-          };
         }
 
         interface ICardPresentPaymentMethodDetails {
-          type: "card_present";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          card_present: {};
+            type: "card_present";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            card_present: {};
         }
 
         interface IEpsPaymentMethodDetails {
-          type: "eps";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          eps: {};
+            type: "eps";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            eps: {};
         }
 
         interface IGiropayPaymentMethodDetails {
-          type: "giropay";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          giropay: {};
+            type: "giropay";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            giropay: {};
         }
 
         interface IIdealPaymentMethodDetails {
-          type: "ideal";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          ideal: {};
+            type: "ideal";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            ideal: {};
         }
 
         interface IKlarnaPaymentMethodDetails {
-          type: "klarna";
-          klarna: {};
+            type: "klarna";
+            klarna: {};
         }
 
         interface IMultibancoPaymentMethodDetails {
-          type: "multibanco";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          multibanco: {};
+            type: "multibanco";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            multibanco: {};
         }
 
         interface IP24PaymentMethodDetails {
-          type: "p24";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          p24: {};
+            type: "p24";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            p24: {};
         }
 
         interface ISofortPaymentMethodDetails {
-          type: "sofort";
-          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
-          sofort: {};
+            type: "sofort";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            sofort: {};
         }
 
         interface IStripeAccountPaymentMethodDetails {
-          type: "stripe_account";
-          stripe_account: {};
+            type: "stripe_account";
+            stripe_account: {};
         }
 
         interface IWechatPaymentMethodDetails {
-          type: "wechat";
-          wechat: {};
+            type: "wechat";
+            wechat: {};
         }
     }
 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1297,6 +1297,21 @@ declare namespace Stripe {
             paid: boolean;
 
             /**
+             * ID of the PaymentIntent associated with this charge, if one exists.
+             */
+            payment_intent?: string;
+
+            /**
+             * ID of the payment method used in this charge.
+             */
+            payment_method: string;
+
+            /**
+             * Details about the payment method at the time of the transaction.
+             */
+            payment_method_details: IPaymentMethodDetails;
+
+            /**
              * This is the email address that the receipt for this charge was sent to.
              */
             receipt_email: string | null;
@@ -1598,6 +1613,251 @@ declare namespace Stripe {
         }
 
         interface IChargeRefunds extends IList<refunds.IRefund>, resources.ChargeRefunds { }
+
+        type IPaymentMethodDetails =
+            | IAchCreditTransferPaymentMethodDetails
+            | IAchDebitPaymentMethodDetails
+            | IAlipayPaymentMethodDetails
+            | IBancontactPaymentMethodDetails
+            | ICardPaymentMethodDetails
+            | ICardPresentPaymentMethodDetails
+            | IEpsPaymentMethodDetails
+            | IGiropayPaymentMethodDetails
+            | IIdealPaymentMethodDetails
+            | IKlarnaPaymentMethodDetails
+            | IP24PaymentMethodDetails
+            | ISofortPaymentMethodDetails
+            | IStripeAccountPaymentMethodDetails
+            | IWechatPaymentMethodDetails;
+
+        interface IAchCreditTransferPaymentMethodDetails {
+            type: "ach_credit_transfer";
+            ach_credit_transfer: {
+                /**
+                 * Account number to transfer funds to.
+                 */
+                account_number: string;
+
+                /**
+                 * Name of the bank associated with the routing number.
+                 */
+                bank_name: string;
+
+                /**
+                 * Routing transit number for the bank account to transfer funds to.
+                 */
+                routing_number: string;
+
+                /**
+                 * SWIFT code of the bank associated with the routing number.
+                 */
+                swift_code: string;
+            };
+        }
+
+        interface IAchDebitPaymentMethodDetails {
+            type: "ach_debit";
+            // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+            ach_debit: {};
+        }
+
+        interface IAlipayPaymentMethodDetails {
+          type: "alipay";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          alipay: {};
+        }
+
+        interface IBancontactPaymentMethodDetails {
+          type: "bancontact";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          bancontact: {};
+        }
+
+        interface ICardPaymentMethodDetails {
+          type: "card";
+          card: {
+            /**
+             * Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+             */
+            brand: "amex" | "diner" | "discover" | "jcb" | "mastercard" | "unionpay" | "visa" | "unknown";
+
+            /**
+             * Check results by Card networks on Card address and CVC at time of payment.
+             */
+            checks: {
+              /**
+               * If a address line1 was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+               */
+              address_line1_check: "pass" | "failed" | "unavailable" | "unchecked";
+
+              /**
+               * If a address postal code was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+               */
+              address_postal_code_check: "pass" | "failed" | "unavailable" | "unchecked";
+
+              /**
+               * If a CVC was provided, results of the check, one of `pass`, `failed`, `unavailable` or `unchecked`.
+               */
+              cvc_check: "pass" | "failed" | "unavailable" | "unchecked";
+            }
+
+            /**
+             * Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of
+             * the international breakdown of cards you’ve collected.
+             */
+            country: string;
+
+            /**
+             * Two-digit number representing the card’s expiration month.
+             */
+            exp_month: number;
+
+            /**
+             * Four-digit number representing the card’s expiration year.
+             */
+            exp_year: number;
+
+            /**
+             * Uniquely identifies this particular card number. You can use this attribute to check whether two
+             * customers who’ve signed up with you are using the same card number, for example.
+             */
+            fingerprint: string;
+
+            /**
+             * Card funding type. Can be credit, debit, prepaid, or unknown.
+             */
+            funding: "credit" | "debit" | "prepaid" | "unknown";
+
+            /**
+             * The last four digits of the card.
+             */
+            last4: number;
+
+            /**
+             * Populated if this transaction used 3D Secure authentication.
+             */
+            three_d_secure?: {
+              /**
+               * Whether or not authentication was performed. 3D Secure will succeed without authentication when the
+               * card is not enrolled.
+               */
+              authenticated: boolean;
+
+              /**
+               * Whether or not 3D Secure succeeded.
+               */
+              succeeded: boolean;
+
+              /**
+               * The version of 3D Secure that was used for this payment.
+               */
+              version: string;
+            };
+
+            /**
+             * If this Card is part of a card wallet, this contains the details of the card wallet.
+             */
+            wallet?: {
+              /**
+               * The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`,
+               * `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name
+               * matching this value. It contains additional information specific to the card wallet type.
+               */
+              type: "amex_express_checkout" | "apple_pay" | "google_pay" | "masterpass" | "samsung_pay" | "visa_checkout";
+
+              /**
+               * If this is an `amex_express_checkout` card wallet, this hash contains details about the wallet.
+               */
+              amex_express_checkout: {};
+
+              /**
+               * If this is an `apple_pay` card wallet, this hash contains details about the wallet.
+               */
+              apple_pay: {};
+
+              /**
+               * (For tokenized numbers only.) The last four digits of the device account number.
+               */
+              dynamic_last4?: string;
+
+              /**
+               * If this is a `google_pay` card wallet, this hash contains details about the wallet.
+               */
+              google_pay?: string;
+
+              /**
+               * If this is a `masterpass` card wallet, this hash contains details about the wallet.
+               */
+              masterpass?: {
+                // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-masterpass
+              };
+
+              /**
+               * If this is a `visa_checkout` card wallet, this hash contains details about the wallet.
+               */
+              visa_checkout: {
+                // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-wallet-visa_checkout
+              };
+            };
+          };
+        }
+
+        interface ICardPresentPaymentMethodDetails {
+          type: "card_present";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          card_present: {};
+        }
+
+        interface IEpsPaymentMethodDetails {
+          type: "eps";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          eps: {};
+        }
+
+        interface IGiropayPaymentMethodDetails {
+          type: "giropay";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          giropay: {};
+        }
+
+        interface IIdealPaymentMethodDetails {
+          type: "ideal";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          ideal: {};
+        }
+
+        interface IKlarnaPaymentMethodDetails {
+          type: "klarna";
+          klarna: {};
+        }
+
+        interface IMultibancoPaymentMethodDetails {
+          type: "multibanco";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          multibanco: {};
+        }
+
+        interface IP24PaymentMethodDetails {
+          type: "p24";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          p24: {};
+        }
+
+        interface ISofortPaymentMethodDetails {
+          type: "sofort";
+          // TODO: fill in from https://stripe.com/docs/api/charges/object#charge_object-payment_method_details.
+          sofort: {};
+        }
+
+        interface IStripeAccountPaymentMethodDetails {
+          type: "stripe_account";
+          stripe_account: {};
+        }
+
+        interface IWechatPaymentMethodDetails {
+          type: "wechat";
+          wechat: {};
+        }
     }
 
     namespace coupons {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -85,6 +85,10 @@ stripe.charges.create({
 }).then((charge) => {
     // asynchronously called
 
+    charge.payment_intent; // $ExpectType string
+    charge.payment_method; // $ExpectType string
+    charge.payment_method_details; // $ExpectType IPaymentMethodDetails
+
     charge.refunds.create().then((refund) => {
         const reason = refund.failure_reason;
         // asynchronously called


### PR DESCRIPTION
The `ICharge` interface was missing a number of fields. I defined a good chunk of the `payment_method_details` but got bored after a while and left some TODOs for the community to finish.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/api/charges/object>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.