### PR TITLE
[stripe-v3] Update Stripe checkout types to include server implementation

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -28,7 +28,10 @@ declare namespace stripe {
         createSource(element: elements.Element, options?: { owner?: OwnerInfo }): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
+        // We use function overloading instead of a union here to ensure that redirectToCheckout can only be
+        // called with either the server options or the client options - not a mix of both.
         redirectToCheckout(options: StripeClientCheckoutOptions): Promise<StripeRedirectResponse>;
+        // tslint:disable-next-line unified-signatures
         redirectToCheckout(options: StripeServerCheckoutOptions): Promise<StripeRedirectResponse>;
         paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;
         createPaymentMethod(

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -28,7 +28,8 @@ declare namespace stripe {
         createSource(element: elements.Element, options?: { owner?: OwnerInfo }): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
         retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
-        redirectToCheckout(options: StripeCheckoutOptions): Promise<StripeRedirectResponse>;
+        redirectToCheckout(options: StripeClientCheckoutOptions): Promise<StripeRedirectResponse>;
+        redirectToCheckout(options: StripeServerCheckoutOptions): Promise<StripeRedirectResponse>;
         paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;
         createPaymentMethod(
             type: paymentMethod.paymentMethodType,
@@ -75,15 +76,19 @@ declare namespace stripe {
     };
 
     type billingAddressCollectionType = 'required' | 'auto' | '';
-    interface StripeCheckoutOptions {
+
+    interface StripeClientCheckoutOptions {
         items: StripeCheckoutItem[];
         successUrl: string;
         cancelUrl: string;
         clientReferenceId?: string;
         customerEmail?: string;
         billingAddressCollection?: billingAddressCollectionType;
-        sessionId?: string;
         locale?: string;
+    }
+
+    interface StripeServerCheckoutOptions {
+        sessionId: string;
     }
 
     interface StripeCheckoutItem {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -196,13 +196,21 @@ describe("Stripe elements", () => {
         });
     });
 
-    it("should use checkout API", () => {
+    it("should use checkout API for client implementations", () => {
         stripe.redirectToCheckout({
             items: [
                 { sku: 'sku_123', quantity: 1 }
             ],
             successUrl: 'https://example.com/success',
             cancelUrl: 'https://example.com/canceled',
+        }).then(errorResult => {
+            console.log(errorResult.error.param);
+        });
+    });
+
+    it("should use the checkout API for server implementations", () => {
+        stripe.redirectToCheckout({
+            sessionId: 'sess_test_123',
         }).then(errorResult => {
             console.log(errorResult.error.param);
         });

--- a/types/stripe-v3/tslint.json
+++ b/types/stripe-v3/tslint.json
@@ -5,6 +5,7 @@
 		"dt-header": false,
         "npm-naming": false,
         "no-angle-bracket-type-assertion": false,
-		"no-any-union": false
+		"no-any-union": false,
+		"unified-signatures": false
 	}
 }

--- a/types/stripe-v3/tslint.json
+++ b/types/stripe-v3/tslint.json
@@ -5,7 +5,6 @@
 		"dt-header": false,
         "npm-naming": false,
         "no-angle-bracket-type-assertion": false,
-		"no-any-union": false,
-		"unified-signatures": false
+		"no-any-union": false
 	}
 }


### PR DESCRIPTION
There are 2 ways to use Stripe Checkout: the client implementation and
the server implementation. The former requires more parameters, such as
redirect URLs and the products for the checkout session. In the server
implementation the session is created server-side so the only parameter
required for `redirectToCheckout` is the session ID.

Function overloading has been used in favour of a union type for the options parameter as this enforces exclusivity between the two implementations. See https://github.com/Microsoft/TypeScript/issues/14094 (hence the tslint rule being disabled).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

---

- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/payments/checkout/client
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

