### PR TITLE
[jquery.fancytree] Add dynamic callback type for certain option properties

### DIFF
--- a/types/jquery.fancytree/index.d.ts
+++ b/types/jquery.fancytree/index.d.ts
@@ -4,6 +4,7 @@
 //                 Mahdi Abedi <https://github.com/abedi-ir>
 //                 Nikolai Ommundsen <https://github.com/niikoo>
 //                 Nitecube <https://github.com/Nitecube>
+//                 Greg Fulllman <https://github.com/gregfullman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -803,7 +804,9 @@ declare namespace Fancytree {
         /** Add `id="..."` to node markup (default: true). */
         generateIds?: boolean;
         /** Node icon url, if only filename, please use imagePath to set the path */
-        icon?: boolean | string;
+        icon?: boolean | string | ((event: JQueryEventObject, data: EventData) => string|boolean);
+        /** Add a title attribute to the node's icon span markup, thus enabling a tooltip (default: false). */
+        iconTooltip?: boolean | string | ((event: JQueryEventObject, data: EventData) => string|boolean);
         /** Prefix (default: "ft_") */
         idPrefix?: string;
         /** Path to a folder containing icons (default: null, using 'skin/' subdirectory). */
@@ -835,7 +838,7 @@ declare namespace Fancytree {
         /** Animation options, false:off (default: { effect: "blind", options: {direction: "vertical", scale: "box"}, duration: 200 }) */
         toggleEffect?: JQueryUI.EffectOptions;
         /** Tooltips */
-        tooltip?: boolean;
+        tooltip?: boolean | string | ((event: JQueryEventObject, data: EventData) => string|boolean);
 
         /** (dynamic Option)Prevent (de-)selection using mouse or keyboard. */
         unselectable?: boolean | ((event: JQueryEventObject, data: Fancytree.EventData) => boolean | undefined);

--- a/types/jquery.fancytree/jquery.fancytree-tests.ts
+++ b/types/jquery.fancytree/jquery.fancytree-tests.ts
@@ -44,6 +44,24 @@ $("#tree").fancytree(<Fancytree.FancytreeOptions>{
 			return false;
 		}
 	},
+	icon: (event: JQueryEventObject, data: Fancytree.EventData): string|boolean => {
+		if((data.node as any).icon) {
+			return (data.node as any).icon as string;
+		}
+		return false;
+	},
+	iconTooltip: (event: JQueryEventObject, data: Fancytree.EventData): string|boolean => {
+		if((data.node as any).icon) {
+			return data.node.tooltip;
+		}
+		return false;
+	},
+	tooltip: (event: JQueryEventObject, data: Fancytree.EventData): string|boolean => {
+		if(data.node.tooltip) {
+			return data.node.tooltip;
+		}
+		return false;
+	},
 	unselectable: function (event, data) {
 		return true;
 	},


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://wwwendt.de/tech/fancytree/doc/jsdoc/global.html#FancytreeOptions
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
