### PR TITLE
Node-Fetch: Generic for "body".json() method

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -141,7 +141,8 @@ export class Body {
     body: NodeJS.ReadableStream;
     bodyUsed: boolean;
     buffer(): Promise<Buffer>;
-    json(): Promise<any>;
+    // tslint:disable-next-line:no-unnecessary-generics
+    json<T extends any>(): Promise<T>;
     size: number;
     text(): Promise<string>;
     textConverted(): Promise<string>;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -8,6 +8,7 @@
 //                 Jason Li <https://github.com/JasonLi914>
 //                 Brandon Wilson <https://github.com/wilsonianb>
 //                 Steve Faulkner <https://github.com/southpolesteve>
+//                 Jeroen Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -144,3 +144,21 @@ function test_ResponseInit() {
         });
     });
 }
+
+interface test_JsonPlaceholderBody {
+    userId: number;
+    id: number;
+    title: string;
+    completed: boolean;
+}
+
+function test_ResponseJsonBody() {
+    fetch('https://jsonplaceholder.typicode.com/todos/1', {}).then(response => {
+        response.json().then(dataWithoutGeneric => {
+            // no type information available => Attempting to access 'id' throws "Property 'id' does not exist on type '{}'" in tests
+        });
+        response.json<test_JsonPlaceholderBody>().then(dataWithGeneric => {
+            const id = dataWithGeneric.id; // type information available
+        });
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: **N.A. This is coming from a frustration I had in my own code where I would have to cast my data in some way or another when it's much cleaner when the function would just support generics.**
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

I've had to add a `// tslint:disable-next-line:no-unnecessary-generics` to add this to avoid [this linting rule](https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md). I opted for this because the suggested adjustments from the dtslint documentation are not applicable to this specific case and I believe that adding type information in the way this PR does is worth having a single line disable a single dtslint rule.

The key benefit for this can be seen in the added test cases where type information is *not* available in the code where `.json()` resolves to `Promise<any>`, but  *does* have type information when passing in the generic.

---

Example using actual code of before and after.

**Before**:
```ts
(async function() {
    try {
      // Fetch Reddit comments for a user
      const response = await fetch(`https://www.reddit.com/user/favna/comments.json?after=''&limit=100`);
      const json: RedditResponse<'comments'> = await response.json();
      // or
      const json2 = await response.json() as RedditResponse<'comments'>;
      //  Do something with the JSON
    } catch (err) {
        msg.reply(err);
    }
})();
```

**After**:
```ts
(async function() {
    try {
      // Fetch Reddit comments for a user
      const response = await fetch(`https://www.reddit.com/user/favna/comments.json?after=''&limit=100`);
      const json = await response.json<RedditResponse<'comments'>>();
      //  Do something with the JSON
    } catch (err) {
        msg.reply(err);
    }
})();
```

---

p.s. I also tried to pull the generic all the way up to the `fetch` function and while in terms of typing I managed, it made many tests crash and basically requiring a higher typescript version, which in turn caused a lot of dependency issues as other packages depend on node-fetch. Figured that was not the best way going forward, but maybe it'll be something to keep in mind if the node-fetch library itself does a major version upgrade.