### PR TITLE
[@types/mongoose] Accept deep partial in model interface

### DIFF
--- a/types/connect-mongo/index.d.ts
+++ b/types/connect-mongo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kcbanner/connect-mongo
 // Definitions by: Mizuki Yamamoto <https://github.com/Syati>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="express-session" />
 

--- a/types/joigoose/index.d.ts
+++ b/types/joigoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yoitsro/joigoose
 // Definitions by: Karoline <https://github.com/boothwhack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import * as Mongoose from "mongoose";
 import * as Joi from "joi";

--- a/types/mongoose-auto-increment/index.d.ts
+++ b/types/mongoose-auto-increment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/codetunnel/mongoose-auto-increment
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Connection, Schema, Mongoose } from 'mongoose';
 

--- a/types/mongoose-deep-populate/index.d.ts
+++ b/types/mongoose-deep-populate/index.d.ts
@@ -2,8 +2,8 @@
 // Project: https://github.com/buunguyen/mongoose-deep-populate
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Mongoose, Schema } from 'mongoose';
 
-export default function(mognoose: Mongoose): (schema: Schema, options: Object) => void;
+export default function (mognoose: Mongoose): (schema: Schema, options: Object) => void;

--- a/types/mongoose-geojson-schema/index.d.ts
+++ b/types/mongoose-geojson-schema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rideamigoscorp/mongoose-geojson-schema#readme
 // Definitions by: Bond <https://github.com/bondz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-mock/index.d.ts
+++ b/types/mongoose-mock/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JohanObrink/mongoose-mock
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -4,7 +4,7 @@
 //                 simonxca <https://github.com/simonxca>
 //                 woutgg <https://github.com/woutgg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 //
 // Based on type declarations for mongoose-paginate 5.0.0.
 

--- a/types/mongoose-promise/index.d.ts
+++ b/types/mongoose-promise/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="mongoose" />
 /// <reference types="mpromise" />
@@ -37,11 +37,11 @@ declare module 'mongoose' {
      */
     constructor(fn?: (err: any, ...args: T[]) => void);
 
-      /**
-     * Adds a single function as a listener to both err and complete.
-     * It will be executed with traditional node.js argument position when the promise is resolved.
-     * @deprecated Use onResolve instead.
-     */
+    /**
+   * Adds a single function as a listener to both err and complete.
+   * It will be executed with traditional node.js argument position when the promise is resolved.
+   * @deprecated Use onResolve instead.
+   */
     addBack(listener: (err: any, ...args: T[]) => void): this;
 
     /**

--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -2,11 +2,11 @@
 // Project: https://github.com/larryprice/mongoose-simple-random
 // Definitions by: Roberts Slisans <https://github.com/rsxdalv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import mongoose = require('mongoose');
 declare function pluginFunc(schema: mongoose.Schema): void;
-declare namespace pluginFunc {}
+declare namespace pluginFunc { }
 export = pluginFunc;
 
 declare module "mongoose" {

--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/blakehaswell/mongoose-unique-validator#readme
 // Definitions by: Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Schema } from "mongoose";
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -227,13 +227,13 @@ declare module "mongoose" {
     openUri(uri: string, options?: ConnectionOptions): Promise<Connection>;
     openUri(uri: string, callback: (err: any, conn?: Connection) => void): Connection;
     openUri(
-      uri: string,
-      options: ConnectionOptions,
-      callback?: (err: any, conn?: Connection) => void
+        uri: string,
+        options: ConnectionOptions,
+        callback?: (err: any, conn?: Connection) => void
     ): Connection & {
-      then: Promise<Connection>["then"];
-      catch: Promise<Connection>["catch"];
-    };
+        then: Promise<Connection>["then"];
+        catch: Promise<Connection>["catch"];
+      };
 
     /** Helper for dropDatabase() */
     dropDatabase(callback?: (err: any) => void): Promise<any>;
@@ -506,7 +506,7 @@ declare module "mongoose" {
     export class ValidationError extends Error {
       name: 'ValidationError';
 
-      errors: { [path: string]: ValidatorError | CastError };
+      errors: {[path: string]: ValidatorError | CastError};
 
       constructor(instance?: MongooseDocument);
 
@@ -528,13 +528,13 @@ declare module "mongoose" {
      */
     export class ValidatorError extends Error {
       name: 'ValidatorError';
-      properties: { message: string, type?: string, path?: string, value?: any, reason?: any };
+      properties: {message: string, type?: string, path?: string, value?: any, reason?: any};
       kind: string;
       path: string;
       value: any;
       reason: any;
 
-      constructor(properties: { message?: string, type?: string, path?: string, value?: any, reason?: any });
+      constructor(properties: {message?: string, type?: string, path?: string, value?: any, reason?: any});
 
       formatMessage(msg: string | Function, properties: any): string;
 
@@ -1859,7 +1859,7 @@ declare module "mongoose" {
       callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
     findOneAndRemove(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (error: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, result: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
     findOneAndRemove(conditions: any, options: QueryFindOneAndRemoveOptions,
       callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
 
@@ -1879,13 +1879,13 @@ declare module "mongoose" {
     findOneAndUpdate(query: any, update: any,
       options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
     findOneAndUpdate(query: any, update: any,
       options: { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: DocType, res: any) => void): DocumentQuery<DocType, DocType> & QueryHelpers;
     findOneAndUpdate(query: any, update: any, options: { rawResult: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
     findOneAndUpdate(query: any, update: any, options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
 
@@ -2226,7 +2226,7 @@ declare module "mongoose" {
     /** if true, returns the raw result from the MongoDB driver */
     rawResult?: boolean;
     /** overwrites the schema's strict mode option for this update */
-    strict?: boolean | string;
+    strict?: boolean|string;
   }
 
   interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
@@ -2250,7 +2250,7 @@ declare module "mongoose" {
      *  by default, mongoose only returns the first error that occurred in casting the query.
      *  Turn on this option to aggregate all the cast errors.
      */
-    multipleCastError?: boolean;
+      multipleCastError?: boolean;
     /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
     fields?: any | string;
   }
@@ -3014,26 +3014,26 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
 
-    /**
-    * Issue a mongodb findOneAndDelete command by a document's _id field.
-    * findByIdAndDelete(id, ...) is equivalent to findByIdAndDelete({ _id: id }, ...).
-    * Finds a matching document, removes it, passing the found document (if any) to the callback.
-    * Executes immediately if callback is passed, else a Query object is returned.
-    *
-    * Note: same signatures as findByIdAndRemove
-    *
-    * @param id value of _id to query by
-    */
+     /**
+     * Issue a mongodb findOneAndDelete command by a document's _id field.
+     * findByIdAndDelete(id, ...) is equivalent to findByIdAndDelete({ _id: id }, ...).
+     * Finds a matching document, removes it, passing the found document (if any) to the callback.
+     * Executes immediately if callback is passed, else a Query object is returned.
+     *
+     * Note: same signatures as findByIdAndRemove
+     *
+     * @param id value of _id to query by
+     */
     findByIdAndDelete(): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndDelete(id: any | number | string,
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3054,11 +3054,11 @@ declare module "mongoose" {
     findByIdAndUpdate(id: any | number | string, update: any,
       options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T>) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
     findByIdAndUpdate(id: any | number | string, update: any,
-      options: { rawResult: true } & QueryFindOneAndUpdateOptions,
+      options: { rawResult : true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndUpdate(id: any | number | string, update: any,
       options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
@@ -3091,7 +3091,7 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndRemove(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndRemove(conditions: any, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3107,7 +3107,7 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndDelete(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndDelete(conditions: any, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3123,16 +3123,16 @@ declare module "mongoose" {
     findOneAndUpdate(conditions: any, update: any,
       callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
-      options: { rawResult: true } & { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
+      options: { rawResult : true } & { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: T, res: any) => void): DocumentQuery<T, T> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: { rawResult: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T> & QueryHelpers;
@@ -3376,7 +3376,7 @@ declare module "mongoose" {
      *  by default, mongoose only returns the first error that occurred in casting the query.
      *  Turn on this option to aggregate all the cast errors.
      */
-    multipleCastError?: boolean;
+      multipleCastError?: boolean;
   }
 
   interface ModelMapReduceOption<T, Key, Val> {

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -27,7 +27,7 @@
 //                 Grimmer Kang <https://github.com/grimmer0125>
 //                 Richard Davison <https://github.com/richarddd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="mongodb" />
 /// <reference types="node" />

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -25,6 +25,7 @@
 //                 Vlad Melnik <https://github.com/vladmel1234>
 //                 Jarom Loveridge <https://github.com/jloveridge>
 //                 Grimmer Kang <https://github.com/grimmer0125>
+//                 Richard Davison <https://github.com/richarddd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -64,6 +65,16 @@ declare module "mongoose" {
   import mongodb = require('mongodb');
   import stream = require('stream');
   import mongoose = require('mongoose');
+
+  /**
+   * Allows for nested objects and arrays to be partial
+   */
+  export type DeepPartial<T> = {
+    [P in keyof T]?:
+    T[P] extends (infer U)[] ? DeepPartial<U>[] :
+    T[P] extends object ? DeepPartial<T[P]> :
+    T[P];
+  };
 
   /**
    * Gets and optionally overwrites the function used to pluralize collection names
@@ -216,13 +227,13 @@ declare module "mongoose" {
     openUri(uri: string, options?: ConnectionOptions): Promise<Connection>;
     openUri(uri: string, callback: (err: any, conn?: Connection) => void): Connection;
     openUri(
-        uri: string,
-        options: ConnectionOptions,
-        callback?: (err: any, conn?: Connection) => void
+      uri: string,
+      options: ConnectionOptions,
+      callback?: (err: any, conn?: Connection) => void
     ): Connection & {
-        then: Promise<Connection>["then"];
-        catch: Promise<Connection>["catch"];
-      };
+      then: Promise<Connection>["then"];
+      catch: Promise<Connection>["catch"];
+    };
 
     /** Helper for dropDatabase() */
     dropDatabase(callback?: (err: any) => void): Promise<any>;
@@ -495,7 +506,7 @@ declare module "mongoose" {
     export class ValidationError extends Error {
       name: 'ValidationError';
 
-      errors: {[path: string]: ValidatorError | CastError};
+      errors: { [path: string]: ValidatorError | CastError };
 
       constructor(instance?: MongooseDocument);
 
@@ -517,13 +528,13 @@ declare module "mongoose" {
      */
     export class ValidatorError extends Error {
       name: 'ValidatorError';
-      properties: {message: string, type?: string, path?: string, value?: any, reason?: any};
+      properties: { message: string, type?: string, path?: string, value?: any, reason?: any };
       kind: string;
       path: string;
       value: any;
       reason: any;
 
-      constructor(properties: {message?: string, type?: string, path?: string, value?: any, reason?: any});
+      constructor(properties: { message?: string, type?: string, path?: string, value?: any, reason?: any });
 
       formatMessage(msg: string | Function, properties: any): string;
 
@@ -1848,7 +1859,7 @@ declare module "mongoose" {
       callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
     findOneAndRemove(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (error: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, result: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
     findOneAndRemove(conditions: any, options: QueryFindOneAndRemoveOptions,
       callback?: (error: any, doc: DocType | null, result: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
 
@@ -1868,13 +1879,13 @@ declare module "mongoose" {
     findOneAndUpdate(query: any, update: any,
       options: { rawResult: true } & { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType>> & QueryHelpers;
     findOneAndUpdate(query: any, update: any,
       options: { upsert: true } & { new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: DocType, res: any) => void): DocumentQuery<DocType, DocType> & QueryHelpers;
     findOneAndUpdate(query: any, update: any, options: { rawResult: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<DocType | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<DocType | null>> & QueryHelpers;
     findOneAndUpdate(query: any, update: any, options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: DocType | null, res: any) => void): DocumentQuery<DocType | null, DocType> & QueryHelpers;
 
@@ -2215,7 +2226,7 @@ declare module "mongoose" {
     /** if true, returns the raw result from the MongoDB driver */
     rawResult?: boolean;
     /** overwrites the schema's strict mode option for this update */
-    strict?: boolean|string;
+    strict?: boolean | string;
   }
 
   interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
@@ -2239,7 +2250,7 @@ declare module "mongoose" {
      *  by default, mongoose only returns the first error that occurred in casting the query.
      *  Turn on this option to aggregate all the cast errors.
      */
-      multipleCastError?: boolean;
+    multipleCastError?: boolean;
     /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
     fields?: any | string;
   }
@@ -2813,7 +2824,7 @@ declare module "mongoose" {
      *   Model#ensureIndexes. If an error occurred it is passed with the event.
      *   The fields, options, and index name are also passed.
      */
-    new(doc?: Partial<T>): T;
+    new(doc?: DeepPartial<T>): T;
 
     /**
      * Requires a replica set running MongoDB >= 3.6.0. Watches the underlying collection for changes using MongoDB change streams.
@@ -3003,26 +3014,26 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndRemove(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
 
-     /**
-     * Issue a mongodb findOneAndDelete command by a document's _id field.
-     * findByIdAndDelete(id, ...) is equivalent to findByIdAndDelete({ _id: id }, ...).
-     * Finds a matching document, removes it, passing the found document (if any) to the callback.
-     * Executes immediately if callback is passed, else a Query object is returned.
-     *
-     * Note: same signatures as findByIdAndRemove
-     *
-     * @param id value of _id to query by
-     */
+    /**
+    * Issue a mongodb findOneAndDelete command by a document's _id field.
+    * findByIdAndDelete(id, ...) is equivalent to findByIdAndDelete({ _id: id }, ...).
+    * Finds a matching document, removes it, passing the found document (if any) to the callback.
+    * Executes immediately if callback is passed, else a Query object is returned.
+    *
+    * Note: same signatures as findByIdAndRemove
+    *
+    * @param id value of _id to query by
+    */
     findByIdAndDelete(): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndDelete(id: any | number | string,
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndDelete(id: any | number | string, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3043,11 +3054,11 @@ declare module "mongoose" {
     findByIdAndUpdate(id: any | number | string, update: any,
       options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
     findByIdAndUpdate(id: any | number | string, update: any,
-      options: { rawResult : true } & QueryFindOneAndUpdateOptions,
+      options: { rawResult: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: mongodb.FindAndModifyWriteOpResultObject<T | null>) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findByIdAndUpdate(id: any | number | string, update: any,
       options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
@@ -3080,7 +3091,7 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndRemove(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndRemove(conditions: any, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3096,7 +3107,7 @@ declare module "mongoose" {
       callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndDelete(conditions: any, options: { rawResult: true } & QueryFindOneAndRemoveOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndDelete(conditions: any, options: QueryFindOneAndRemoveOptions, callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
 
     /**
@@ -3112,16 +3123,16 @@ declare module "mongoose" {
     findOneAndUpdate(conditions: any, update: any,
       callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
-      options: { rawResult : true } & { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
+      options: { rawResult: true } & { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T>> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: { upsert: true, new: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: T, res: any) => void): DocumentQuery<T, T> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: { rawResult: true } & QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: mongodb.FindAndModifyWriteOpResultObject<T | null>, res: any) => void)
-        : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
+      : Query<mongodb.FindAndModifyWriteOpResultObject<T | null>> & QueryHelpers;
     findOneAndUpdate(conditions: any, update: any,
       options: QueryFindOneAndUpdateOptions,
       callback?: (err: any, doc: T | null, res: any) => void): DocumentQuery<T | null, T> & QueryHelpers;
@@ -3365,7 +3376,7 @@ declare module "mongoose" {
      *  by default, mongoose only returns the first error that occurred in casting the query.
      *  Turn on this option to aggregate all the cast errors.
      */
-      multipleCastError?: boolean;
+    multipleCastError?: boolean;
   }
 
   interface ModelMapReduceOption<T, Key, Val> {

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -801,6 +801,24 @@ ImageModel.findOne({}, function(err, doc) {
     doc.id;
   }
 });
+
+/* Testing deep partials */
+interface NestedDoc extends mongoose.Document {
+  name: string;
+  image: ImageDoc;
+}
+var NestedDocSchema = new mongoose.Schema({
+  name: String,
+  image: ImageModel
+});
+const NestedModel = mongoose.model<NestedDoc>('Nested', NestedDocSchema);
+const nested = new NestedModel({
+  name: "name",
+  image: {
+    name: "name"
+  }
+})
+
 /* Using flatten maps example */
 interface Submission extends mongoose.Document {
   name: string;

--- a/types/multer-gridfs-storage/index.d.ts
+++ b/types/multer-gridfs-storage/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devconcept/multer-gridfs-storage
 // Definitions by: devconcept <https://github.com/devconcept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { EventEmitter } from 'events';
 import { Express } from 'express';

--- a/types/resourcejs/index.d.ts
+++ b/types/resourcejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/travist/resourcejs
 // Definitions by: Shaun Luttin <https://github.com/shaunluttin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import express = require("express");
 import mongoose = require("mongoose");


### PR DESCRIPTION
The problem with my previous pr (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36517) was when you were using nested objects, they have to be specified as full objects with all props.

This PR fixes that.

However, this requires TypeScript 2.8 which adds support for mapped types. I had to update all other definitions depending on mongoose.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).