### PR TITLE
Updated react-stripe-elements CVC definitions

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-stripe-elements 1.1
+// Type definitions for react-stripe-elements 1.2
 // Project: https://github.com/stripe/react-stripe-elements#readme
 // Definitions by: dan-j <https://github.com/dan-j>
 //                 Santiago Doldan <https://github.com/santiagodoldan>
@@ -7,6 +7,7 @@
 //                 Thomas Chia <https://github.com/thchia>
 //                 Piotr Dabrowski <https://github.com/yhnavein>
 //                 Victor Irzak <https://github.com/virzak>
+//                 Alex Price <https://github.com/remotealex>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -85,8 +86,10 @@ export class CardNumberElement extends React.Component<ReactStripeElements.Eleme
 export class CardExpiryElement extends React.Component<ReactStripeElements.ElementProps> {
 }
 
-export class CardCVCElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class CardCvcElement extends React.Component<ReactStripeElements.ElementProps> {}
+
+// Deprecated but aliased until react-stripe-elements v5
+export class CardCVCElement extends CardCvcElement {}
 
 export class PostalCodeElement extends React.Component<ReactStripeElements.ElementProps> {
 }

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -155,7 +155,7 @@ class WrappedComponent extends React.Component<ComponentProps & InjectedStripePr
     isFormValid = () => {
         // use onChange callbacks from *Element components to detect if form is valid for submission
         return false;
-    };
+    }
 
     render() {
         return (

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -6,6 +6,7 @@ import {
     injectStripe,
     CardNumberElement,
     CardExpiryElement,
+    CardCvcElement,
     CardCVCElement,
     PostalCodeElement,
     ReactStripeElements,
@@ -49,25 +50,22 @@ const cardElementProps: ElementsOptions = {
 };
 
 const fontElementsProps: ElementsCreateOptions = {
-  fonts: [
-    {
-      cssSrc: "https://fonts.googleapis.com/css?family=Dosis"
-    },
-    {
-      family: "Dosis, sanz",
-      src: "url(https://somewebsite.com/path/to/font.woff)",
-      style: "normal",
-      weight: "bold",
-      unicodeRange: "U+26"
-    }
-  ],
-  locale: "es"
+    fonts: [
+        {
+            cssSrc: 'https://fonts.googleapis.com/css?family=Dosis',
+        },
+        {
+            family: 'Dosis, sanz',
+            src: 'url(https://somewebsite.com/path/to/font.woff)',
+            style: 'normal',
+            weight: 'bold',
+            unicodeRange: 'U+26',
+        },
+    ],
+    locale: 'es',
 };
 
-<CardElement
-    {...cardElementProps}
-    onReady={(el: HTMLStripeElement) => el.clear()}
-/>;
+<CardElement {...cardElementProps} onReady={(el: HTMLStripeElement) => el.clear()} />;
 
 const ElementsWithPropsTest: React.SFC = () => (
     <div>
@@ -86,6 +84,13 @@ const ElementsWithPropsTest: React.SFC = () => (
             onFocus={(event: ElementChangeResponse) => void 0}
         />
         <CardExpiryElement
+            {...cardElementProps}
+            onChange={(event: ElementChangeResponse) => void 0}
+            onBlur={(event: ElementChangeResponse) => void 0}
+            onReady={(el: HTMLStripeElement) => void 0}
+            onFocus={(event: ElementChangeResponse) => void 0}
+        />
+        <CardCvcElement
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
@@ -113,28 +118,28 @@ interface ComponentProps {
     tokenCallback(token: PatchedTokenResponse): void;
 }
 
-class WrappedComponent extends React.Component<
-    ComponentProps & InjectedStripeProps
-> {
+class WrappedComponent extends React.Component<ComponentProps & InjectedStripeProps> {
     constructor(props: ComponentProps & InjectedStripeProps) {
         super(props);
         // Test for paymentRequest
-        const paymentRequest = props.stripe && props.stripe.paymentRequest({
-            country: 'US',
-            currency: 'usd',
-            total: {
-                label: 'Demo total',
-                amount: 1
-            }
-        });
+        const paymentRequest =
+            props.stripe &&
+            props.stripe.paymentRequest({
+                country: 'US',
+                currency: 'usd',
+                total: {
+                    label: 'Demo total',
+                    amount: 1,
+                },
+            });
         if (paymentRequest) {
-            paymentRequest.on('token', ({complete, token, ...data}) => undefined);
+            paymentRequest.on('token', ({ complete, token, ...data }) => undefined);
             paymentRequest.canMakePayment().then(res => undefined);
         }
     }
     onSubmit = () => {
-        this.props.stripe!
-            .createToken({
+        this.props
+            .stripe!.createToken({
                 name: '',
                 address_line1: '',
                 address_line2: '',
@@ -144,15 +149,13 @@ class WrappedComponent extends React.Component<
                 address_country: '',
                 currency: '',
             })
-            .then((response: PatchedTokenResponse) =>
-                this.props.tokenCallback(response)
-            );
-    }
+            .then((response: PatchedTokenResponse) => this.props.tokenCallback(response));
+    };
 
     isFormValid = () => {
         // use onChange callbacks from *Element components to detect if form is valid for submission
         return false;
-    }
+    };
 
     render() {
         return (
@@ -194,6 +197,7 @@ const ElementsDefaultPropsTest: React.SFC = () => (
         <CardElement />
         <CardNumberElement />
         <CardExpiryElement />
+        <CardCvcElement />
         <CardCVCElement />
         <PostalCodeElement />
     </div>
@@ -222,13 +226,14 @@ const TestStripeProviderProps3: React.SFC<{
  * See: https://github.com/stripe/react-stripe-elements#loading-stripejs-asynchronously
  */
 const TestStripeProviderProps4: React.SFC<{
-    stripe: null | stripe.Stripe
-}> = props =>
+    stripe: null | stripe.Stripe;
+}> = props => (
     <StripeProvider stripe={props.stripe}>
         <Elements>
             <div />
         </Elements>
-    </StripeProvider>;
+    </StripeProvider>
+);
 
 /**
  * StripeProvider should be able to accept options.

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -137,6 +137,7 @@ class WrappedComponent extends React.Component<ComponentProps & InjectedStripePr
             paymentRequest.canMakePayment().then(res => undefined);
         }
     }
+
     onSubmit = () => {
         this.props
             .stripe!.createToken({
@@ -150,7 +151,7 @@ class WrappedComponent extends React.Component<ComponentProps & InjectedStripePr
                 currency: '',
             })
             .then((response: PatchedTokenResponse) => this.props.tokenCallback(response));
-    };
+    }
 
     isFormValid = () => {
         // use onChange callbacks from *Element components to detect if form is valid for submission


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](]).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/stripe/react-stripe-elements/blob/master/CHANGELOG.md#v400---2019-07-05)
- [x] Increase the version number in the header if appropriate.

------ 

In version [4.0](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request) of react-stripe-elements the CardCVCElement was renamed CardCvcElement. The old name will be aliased until v5.

This PR adds this alias.
