### PR TITLE
 [@types/sdp-transform] fix incorrect types

### DIFF
--- a/types/sdp-transform/index.d.ts
+++ b/types/sdp-transform/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for sdp-transform 2.4
 // Project: https://github.com/clux/sdp-transform#readme
-// Definitions by: @loc <https://github.com/loc>
-// Definitions by: @muenchow <https://github.com/muenchow>
+// Definitions by: @loc <https://github.com/loc>, @muenchow <https://github.com/muenchow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // https://tools.ietf.org/html/rfc4566

--- a/types/sdp-transform/index.d.ts
+++ b/types/sdp-transform/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for sdp-transform 2.4
 // Project: https://github.com/clux/sdp-transform#readme
 // Definitions by: @loc <https://github.com/loc>
+// Definitions by: @muenchow <https://github.com/muenchow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // https://tools.ietf.org/html/rfc4566
@@ -81,12 +82,12 @@ export interface SharedAttributes {
     // a=control
     control?: string;
     // a=extmap
-    ext?: {
+    ext?: Array<{
         value: number;
         direction?: string;
         uri: string;
         config?: string;
-    };
+    }>;
     // a=setup
     setup?: string;
 
@@ -134,12 +135,12 @@ export interface SessionAttributes extends SharedAttributes {
  * https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-9
  */
 export interface MediaAttributes extends SharedAttributes {
-    rtp?: {
+    rtp: Array<{
         payload: number;
         codec: string;
         rate?: number;
         encoding?: number;
-    };
+    }>;
     rtcp?: {
         port: number;
         netType?: string;
@@ -158,10 +159,10 @@ export interface MediaAttributes extends SharedAttributes {
         value: number;
     };
     // a=fmtp
-    fmtp?: {
+    fmtp: Array<{
         payload: number;
         config: string;
-    };
+    }>;
     // a=mid
     mid?: string;
     // a=msid
@@ -185,10 +186,10 @@ export interface MediaAttributes extends SharedAttributes {
         ip: string;
         port: number;
         type: string;
-        raddr: string;
-        rport: number;
-        tcptype: string;
-        generation: number;
+        raddr?: string;
+        rport?: number;
+        tcptype?: string;
+        generation?: number;
         'network-id'?: number;
         'network-cost'?: number;
     }>;

--- a/types/sdp-transform/sdp-transform-tests.ts
+++ b/types/sdp-transform/sdp-transform-tests.ts
@@ -7,4 +7,10 @@ import {
 const session: SessionDescription = parse('');
 const mediaType: string = session.media[0].type;
 session.media[0].type = 'video';
+const extension: string = session.media[0].ext![0].uri;
+session.media[0].ext![0].uri = 'urn:ietf:params:rtp-hdrext:ssrc-audio-level';
+const codec: string = session.media[0].rtp[0].codec;
+session.media[0].rtp[0].codec = 'opus';
+const config: string = session.media[0].fmtp[0].config;
+session.media[0].fmtp[0].config = 'maxplaybackrate=48000;stereo=1;useinbandfec=1';
 const sdp: string = write(session);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tools.ietf.org/html/rfc4566
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

------------------

I made `ext`, `ftmp` and `rtp` arrays, becase every media line defines multiple possible formats to be used. The sdp-transform library correctly parses them as a array, but the type definitions did not.
Additionally i removed the optional from `ftmp` and `rtp`, because after some testing i noticed that sdp-transform uses empty arrays if the information is missing.

I also made `raddr`, `rport`, `tcptype` and `generation` in `candidates` optional, because `raddr`, `rport` and `tcptype` are either optional, required or forbidden depending on the `type`. `generation` has been made optional because it is an optional ice-extension.
