### PR TITLE
fix(chart.js): add missing Chart instance fields

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -169,3 +169,11 @@ Chart.Tooltip.positioners.custom = (elements: any[], eventPosition: Point) => {
         y: eventPosition.y + 10
     };
 };
+
+if (radialChart.width !== null && radialChart.height !== null) {
+    console.log('area', radialChart.width * radialChart.height);
+}
+if (radialChart.aspectRatio !== null) {
+    console.log(radialChart.aspectRatio * 2);
+}
+console.log(radialChart.options === radialChart.config.options);

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -42,6 +42,10 @@ declare class Chart {
     getDatasetMeta: (index: number) => Meta;
     ctx: CanvasRenderingContext2D | null;
     canvas: HTMLCanvasElement | null;
+    width: number | null;
+    height: number | null;
+    aspectRatio: number | null;
+    options: Chart.ChartOptions;
     chartArea: Chart.ChartArea;
     static pluginService: PluginServiceStatic;
     static plugins: PluginServiceStatic;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

* https://github.com/chartjs/Chart.js/blob/master/src/core/core.controller.js#L180-L183

The `Chart` instance has some fields which weren't specified yet.
I've used `null` as the unset option because it's the same unset type that `canvas` uses which is used to decide whether to set them or not.

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
