### PR TITLE
Backport signature merging for JQuery.find to v2

### DIFF
--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -3518,24 +3518,11 @@ interface JQuery {
     /**
      * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
      *
-     * @param selector A string containing a selector expression to match elements against.
+     * @param selector_element A string containing a selector expression, an element or a jQuery object to match elements against.
      * @see {@link https://api.jquery.com/find/#find-selector}
-     */
-    find(selector: string): JQuery;
-    /**
-     * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
-     *
-     * @param element An element to match elements against.
      * @see {@link https://api.jquery.com/find/#find-element}
      */
-    find(element: Element): JQuery;
-    /**
-     * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
-     *
-     * @param obj A jQuery object to match elements against.
-     * @see {@link https://api.jquery.com/find/#find-element}
-     */
-    find(obj: JQuery): JQuery;
+    find(selector_element: string | Element | JQuery): JQuery;
 
     /**
      * Reduce the set of matched elements to the first in the set.

--- a/types/jquery/v2/jquery-tests.ts
+++ b/types/jquery/v2/jquery-tests.ts
@@ -1753,6 +1753,8 @@ function test_find() {
     .end()
         .find(":contains('t')")
         .css({ "font-style": "italic", "font-weight": "bolder" });
+    var input_selector = '.input' as string | JQuery | Element;
+    $("body").find(input_selector).prop("disabled", true);
 }
 
 function test_finish() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/find/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Type for v3 `find` is already using merged type definition
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/JQuery.d.ts#L4136
but we are stuck in jquery v2 (due to backward incompatibility) for now
And we use `find` quite often and needed to use pointless conditional like this:
```typescript
interface Selector {
  scope:                string | JQuery
  carousel:             string | JQuery
  slide_to_prev_button: string | JQuery
  slide_to_next_button: string | JQuery
}

function(selector: Selector) {
const $container_el: JQuery = $(selector.scope)
// Can't assign directly since type incompatible to any of the method signature
// const $carousel = this.$container_el.find(selector.carousel)
const $carousel = typeof selector.carousel === "string" ?
      this.$container_el.find(selector.carousel) :
      this.$container_el.find(selector.carousel)
}
```