### PR TITLE
[react-html-parser] fix wrong `transform` type definition

### DIFF
--- a/types/react-html-parser/index.d.ts
+++ b/types/react-html-parser/index.d.ts
@@ -1,27 +1,29 @@
 // Type definitions for react-html-parser 2.0
 // Project: https://github.com/wrakky/react-html-parser#readme
 // Definitions by: Spencer Elliott <https://github.com/elliottsj>
+//                 Wooram Jun <https://github.com/chatoo2412>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import { ReactElement } from "react";
+import { DomElement } from "htmlparser2";
 
 export interface Transform {
-    (node: object, index: number, transform?: Transform): ReactElement | void | null;
+    (node: DomElement, index: number, transform?: Transform): ReactElement | void | null;
 }
 
 export interface Options {
     decodeEntities?: boolean;
     transform?: Transform;
-    preprocessNodes?(nodes: object[]): any;
+    preprocessNodes?(nodes: DomElement[]): any;
 }
 
 export function convertNodeToElement(
-    node: object,
+    node: DomElement,
     index: number,
     transform: Transform,
 ): ReactElement;
 
-export function processNodes(nodes: object[], transform: Transform): ReactElement[];
+export function processNodes(nodes: DomElement[], transform: Transform): ReactElement[];
 
 export default function HtmlParser(html: string, options?: Options): ReactElement[];

--- a/types/react-html-parser/react-html-parser-tests.tsx
+++ b/types/react-html-parser/react-html-parser-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactHtmlParser, { processNodes, convertNodeToElement } from 'react-html-parser';
+import ReactHtmlParser, { processNodes, convertNodeToElement, Transform } from 'react-html-parser';
 
 class HtmlComponent extends React.Component {
     render() {
@@ -8,7 +8,7 @@ class HtmlComponent extends React.Component {
     }
 }
 
-const transform = (node: any, index: number): React.ReactElement | void => {
+const transform: Transform = (node, index) => {
     // convert <ul> to <ol>
     if (node.type === 'tag' && node.name === 'ul') {
         node.name = 'ol';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wrakky/react-html-parser#transform-function
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.