### PR TITLE
[@types/ws] fix type of `this` in websocket server events

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -199,11 +199,11 @@ declare namespace WebSocket {
         shouldHandle(request: http.IncomingMessage): boolean;
 
         // Events
-        on(event: 'connection', cb: (this: WebSocket, socket: WebSocket, request: http.IncomingMessage) => void): this;
-        on(event: 'error', cb: (this: WebSocket, error: Error) => void): this;
-        on(event: 'headers', cb: (this: WebSocket, headers: string[], request: http.IncomingMessage) => void): this;
-        on(event: 'listening', cb: (this: WebSocket) => void): this;
-        on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+        on(event: 'connection', cb: (this: Server, socket: WebSocket, request: http.IncomingMessage) => void): this;
+        on(event: 'error', cb: (this: Server, error: Error) => void): this;
+        on(event: 'headers', cb: (this: Server, headers: string[], request: http.IncomingMessage) => void): this;
+        on(event: 'listening', cb: (this: Server) => void): this;
+        on(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
 
         addListener(event: 'connection', cb: (client: WebSocket) => void): this;
         addListener(event: 'error', cb: (err: Error) => void): this;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -19,7 +19,7 @@ import * as https from 'https';
 
 {
     const wss = new WebSocket.Server({port: 8081});
-    wss.on('connection', (ws, req) => {
+    wss.on('connection', function(ws, req) {
         console.log('port: %s', this.options.port);
         ws.on('message', (message) => console.log('received: %s', message));
         ws.send('something');

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -20,6 +20,7 @@ import * as https from 'https';
 {
     const wss = new WebSocket.Server({port: 8081});
     wss.on('connection', (ws, req) => {
+        console.log('port: %s', this.options.port);
         ws.on('message', (message) => console.log('received: %s', message));
         ws.send('something');
         ws.send('something', (error?: Error) => {});


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

In `Websocket.Server` event callbacks, `this` is the `Server` instance rather than a `WebSocket`.