### PR TITLE
[haversine] Make types more precise and add dtslint tests

### DIFF
--- a/types/haversine/haversine-tests.ts
+++ b/types/haversine/haversine-tests.ts
@@ -5,9 +5,9 @@ const start: haversine.CoordinateLongitudeLatitude = {
   latitude: 11.4017529
 };
 
-const end: haversine.CoordinateLongitudeLatitude = {
-  longitude: 52.5065133,
-  latitude: 13.1445551
+const end = {
+    longitude: 52.5065133,
+    latitude: 13.1445551,
 };
 
 const options: haversine.Options = {
@@ -15,7 +15,12 @@ const options: haversine.Options = {
   threshold: 1
 };
 
-haversine(start, end, options);
+haversine(start, end, options);  // $ExpectType number
+haversine(start, end, { unit: 'km', threshold: 1 });  // $ExpectType boolean
+
+haversine(start, end, {format: '[lat,lon]'});  // $ExpectError
+haversine(start, end, {format: '[lon,lat]'});  // $ExpectError
+haversine(start, end, {format: '{lat,lng}'});  // $ExpectError
 
 const startShort: haversine.CoordinateLonLat = {
   lon: 48.1548256,
@@ -27,56 +32,63 @@ const endShort: haversine.CoordinateLonLat = {
   lat: 13.1445551
 };
 
-const optionsShort: haversine.Options = {
-  format: '{lon,lat}'
+haversine(startShort, endShort);  // $ExpectError
+
+haversine(startShort, endShort, { format: '{lon,lat}' });  // $ExpectType number
+haversine(startShort, endShort, { format: '{lon,lat}', threshold: 1 });  // $ExpectType boolean
+
+const startLatLng = {
+    lat: 11.4017529,
+    lng: 48.1548256,
 };
 
-haversine(startShort, endShort, optionsShort);
-
-const startLatLng: haversine.CoordinateLatLng = {
-  lat: 11.4017529,
-  lng: 48.1548256,
-};
-
-const endLatLng: haversine.CoordinateLatLng = {
-  lat: 13.1445551,
-  lng: 52.5065133,
+const endLatLng = {
+    lat: 13.1445551,
+    lng: 52.5065133,
 };
 
 const optionsLatLng: haversine.Options = {
-  format: '{lat,lng}'
+    format: '{lat,lng}',
 };
 
-haversine(startLatLng, endLatLng, optionsLatLng);
+haversine(startLatLng, endLatLng, optionsLatLng);  // $ExpectType number
+
+// not actually valid, but the type of optionsLatLng.format is widened to string
+haversine(start, end, optionsLatLng);  // $ExpectType number
+haversine(start, end, { format: '{lat,lng}' });  // $ExpectError
 
 const startLatLon: haversine.LatLonTuple = [11.4017529, 48.1548256];
 
 const endLatLon: haversine.LatLonTuple = [13.1445551, 52.5065133];
 
 const optionsLatLon: haversine.Options = {
-  format: '[lat,lon]'
+    format: '[lat,lon]',
 };
 
 haversine(startLatLon, endLatLon, optionsLatLon);
 
 const startGeoJSON = {
-  type: "Feature",
-  geometry: {
-    type: "LineString",
-    coordinates: startLatLon
-  }
+    type: 'Feature',
+    geometry: {
+        type: 'Point',
+        coordinates: startLatLon,
+    },
 };
 
 const endGeoJSON = {
-  type: "Feature",
-  geometry: {
-    type: "LineString",
-    coordinates: endLatLon
-  }
+    type: 'Feature',
+    geometry: {
+        type: 'Point',
+        coordinates: endLatLon,
+    },
 };
 
 const optionsGeoJSON: haversine.Options = {
-  format: 'geojson'
+    format: 'geojson',
 };
 
-haversine(startGeoJSON, endGeoJSON, optionsGeoJSON);
+haversine(startGeoJSON, endGeoJSON, optionsGeoJSON);  // $ExpectType number
+haversine(startGeoJSON, endGeoJSON, { format: 'geojson', unit: 'nmi'});  // $ExpectType number
+haversine(startGeoJSON, endGeoJSON, { format: 'geojson', unit: 'nmi', threshold: 2});  // $ExpectType boolean
+
+haversine(start, end, { format: 'geojson' });  // $ExpectError

--- a/types/haversine/index.d.ts
+++ b/types/haversine/index.d.ts
@@ -37,7 +37,7 @@ declare namespace haversine {
         /**
          * If passed, will result in library returning boolean value of whether or not the start and end points are within that supplied threshold.
          */
-        threshold?: number;
+        threshold?: number | null;
         /** Format of coordinate arguments. */
         format?: '[lat,lon]' | '[lon,lat]' | '{lon,lat}' | '{lat,lng}' | 'geojson';
     }

--- a/types/haversine/index.d.ts
+++ b/types/haversine/index.d.ts
@@ -1,7 +1,9 @@
 // Type definitions for haversine 1.1
 // Project: https://github.com/njj/haversine, https://github.com/niix/haversine
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
+//                 Dan Vanderkam <https://github.com/danvk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 declare namespace haversine {
     interface CoordinateLongitudeLatitude {
@@ -30,28 +32,39 @@ declare namespace haversine {
     type Coordinate = (CoordinateLongitudeLatitude | CoordinateLonLat | CoordinateLatLng | LatLonTuple | GeoJSON);
 
     interface Options {
-        /**
-         * Unit of measurement applied to result. Default: "km".
-         */
+        /** Unit of measurement applied to result. Default: "km". */
         unit?: 'km' | 'mile' | 'meter' | 'nmi';
         /**
-         * If passed, will result in library returning boolean value of whether or not the start and end points are within that supplied threshold. Default: null.
+         * If passed, will result in library returning boolean value of whether or not the start and end points are within that supplied threshold.
          */
         threshold?: number;
-        /**
-         * Format of coordinate arguments.
-         */
+        /** Format of coordinate arguments. */
         format?: '[lat,lon]' | '[lon,lat]' | '{lon,lat}' | '{lat,lng}' | 'geojson';
     }
+
+    // The input & output types of haversine() both depend on the Options object.
+    type ParamType<T extends Options|undefined> = T extends undefined
+        ? CoordinateLongitudeLatitude
+        : T extends {format: '[lat,lon]' | '[lon,lat]'}
+        ? [number, number]
+        : T extends {format: '{lat,lon}'}
+        ? CoordinateLonLat
+        : T extends {format: '{lat,lng}'}
+        ? CoordinateLatLng
+        : T extends {format: 'geojson'}
+        ? GeoJSON
+        : Coordinate;
+
+    type Return<T extends Options|undefined> = T extends {threshold: number} ? boolean : number;
 }
 
 /**
  * Determines the great-circle distance between two points on a sphere given their longitudes and latitudes
  */
-declare function haversine(
-    start: haversine.Coordinate,
-    end: haversine.Coordinate,
-    options?: haversine.Options
-): number;
+declare function haversine<OptionsT extends haversine.Options|undefined = undefined>(
+    start: haversine.ParamType<OptionsT>,
+    end: haversine.ParamType<OptionsT>,
+    options?: OptionsT,
+  ): haversine.Return<OptionsT>;
 
 export = haversine;


### PR DESCRIPTION
The parameter and return type of `haversine` both depend on the options parameter. If you pass in a literal or other sufficiently precise options object, this will get you better type safety. If not, this should be a no-op.

This uses conditional types, so the TypeScript version requirement goes up to 2.8.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/njj/haversine
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
