### PR TITLE
[graphql] AsyncIterator to AsyncIterableIterator

### DIFF
--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -33,7 +33,7 @@ export function subscribe<TData = ExecutionResultDataDefault>(args: {
     operationName?: Maybe<string>;
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
     subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-}): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
+}): Promise<AsyncIterableIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
 export function subscribe<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
@@ -44,7 +44,7 @@ export function subscribe<TData = ExecutionResultDataDefault>(
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
     subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
+): Promise<AsyncIterableIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
 /**
  * Implements the "CreateSourceEventStream" algorithm described in the


### PR DESCRIPTION
if the iterator is not iterable, you can't use it with a native `for await`.
 
per lib.es2018:
```
interface AsyncIterableIterator<T> extends AsyncIterator<T> {
    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
