### PR TITLE
@types/highcharts AxisOptions.autoRotation add missing boolean type as union

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -8,6 +8,7 @@
 //                 ArunkeshavaReddy Sankaramaddi <https://github.com/Arunkeshavareddy>
 //                 Dolan Miu <https://github.com/dolanmiu>
 //                 Jack Siman <https://github.com/jjsiman>
+//                 Matthew Wills <https://github.com/mdotwills>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -82,7 +83,7 @@ declare namespace Highcharts {
          * @default [-45]
          * @since 4.1.0
          */
-        autoRotation?: number[];
+        autoRotation?: number[] | boolean;
         /**
          * When each category width is more than this many pixels, we don't apply auto rotation. Instead, we lay out the
          * axis label with word wrap. A lower limit makes sense when the label contains multiple short words that don't

--- a/types/highcharts/test/index.ts
+++ b/types/highcharts/test/index.ts
@@ -2397,6 +2397,12 @@ function test_AxisOptions() {
             ['minute', [1, 2, 5, 10, 15, 30]]],
         visible: true
     };
+
+    const labelsOptionUnions: Highcharts.AxisOptions = {
+        labels: {
+            autoRotation: false
+        }
+    };
 }
 
 function test_AxisObject() {


### PR DESCRIPTION
Reference: https://api.highcharts.com/highcharts/xAxis.labels.autoRotation

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Changing** an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.highcharts.com/highcharts/xAxis.labels.autoRotation
- [ ] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ Not required.