### PR TITLE
[@types/mongoose] Enhance aggregate function with proper signature

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -25,6 +25,7 @@
 //                 Vlad Melnik <https://github.com/vladmel1234>
 //                 Jarom Loveridge <https://github.com/jloveridge>
 //                 Grimmer Kang <https://github.com/grimmer0125>
+//                 Fabian Hilz <https://github.com/locke21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2867,7 +2867,7 @@ declare module "mongoose" {
      * @param aggregations pipeline operator(s) or operator array
      */
     aggregate(aggregations?: any[]): Aggregate<any[]>;
-    aggregate(aggregations: any[], cb: Function): Promise<any[]>;
+    aggregate(aggregations: any[], cb: (err:any, result: T[]) => void): Promise<T[]>;
 
     /** Counts number of matching documents in a database collection. */
     count(conditions: any, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;


### PR DESCRIPTION
This change is needed to give a proper information about type of the aggregate result in the callback function. I use this coding in my own application already and everything is working. I use the `aggregate` function with the following syntax:

```typescript
Question.aggregate([{ $sample: { size: 5 } }], (err, questions) => {
        // use questions fully typed with Array<IQuestion>
});
```

Without my changes `questions` is typed as `any` and i have to explicitly type `questions` like 

```typescript
Question.aggregate([{ $sample: { size: 5 } }], (err:any, questions:IQuestion[]) => {
        
});
```

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: It's just a stronger typed function
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
