### PR TITLE
[@types/node] added missing 'highWaterMark' option for fs.createWriteStream

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1724,6 +1724,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
 
     /**

--- a/types/node/v10/fs.d.ts
+++ b/types/node/v10/fs.d.ts
@@ -1724,6 +1724,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
 
     /**

--- a/types/node/v11/fs.d.ts
+++ b/types/node/v11/fs.d.ts
@@ -1724,6 +1724,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
 
     /**

--- a/types/node/v6/base.d.ts
+++ b/types/node/v6/base.d.ts
@@ -2934,6 +2934,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
     export function fdatasync(fd: number, callback: Function): void;
     export function fdatasyncSync(fd: number): void;

--- a/types/node/v7/base.d.ts
+++ b/types/node/v7/base.d.ts
@@ -2965,6 +2965,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
     export function fdatasync(fd: number, callback: Function): void;
     export function fdatasyncSync(fd: number): void;

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -4607,6 +4607,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
 
     /**

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -5025,6 +5025,7 @@ declare module "fs" {
         mode?: number;
         autoClose?: boolean;
         start?: number;
+        highWaterMark?: number;
     }): WriteStream;
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * Even though it's [not documented on fs.createWriteStream](https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_createwritestream_path_options), a [stream.Writable can take highWaterMark as an option](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_constructor_new_stream_writable_options). Checking the [source code](https://github.com/nodejs/node/blob/master/lib/internal/fs/streams.js#L231), you can see that the options you pass to createWriteStream are passed to stream.Writable. I've been using it from node 6+ and it's included in [their tests](https://github.com/nodejs/node/blob/39141426d46a7e55d93ad2e8efa12ed86d223522/test/parallel/test-file-write-stream2.js#L67)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

