### PR TITLE
Added Type for showTimeInput

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -133,6 +133,7 @@ export interface ReactDatePickerProps {
 	withPortal?: boolean;
 	yearDropdownItemNumber?: number;
 	timeInputLabel?: string;
+    showTimeInput?: boolean;
 	inlineFocusSelectedMonth?: boolean;
 	onDayMouseEnter?: (date: Date) => void;
 	onMonthMouseLeave?: () => void;


### PR DESCRIPTION
Added type for showTimeInput for the latest release Datepicker v2.8.0
 
Reference: 
showTimeInput: PropTypes.bool
https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L150

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L150>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (already upto date)
// Type definitions for react-datepicker 2.8
