### PR TITLE
[stripe] add missed parameter into PaymentIntent API `setup_future_usage`

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -27,6 +27,7 @@
 //                 Oleg Vaskevich <https://github.com/vaskevich>
 //                 Dylan Aspden <https://github.com/dhaspden>
 //                 Ethan Setnik <https://github.com/esetnik>
+//                 Pavel Ivanov <https://github.com/schfkt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -4377,6 +4378,10 @@ declare namespace Stripe {
     }
 
     namespace paymentIntents {
+        type PaymentIntentCancelationReason = 'duplicate' | 'fraudulent' | 'requested_by_customer' | 'failed_invoice';
+
+        type PaymentIntentFutureUsageType = 'on_session' | 'off_session';
+
         interface IPaymentIntent extends IResourceObject {
             /**
              * Value is "payment_intent".
@@ -4495,6 +4500,11 @@ declare namespace Stripe {
              */
             review?: string | reviews.IReview | null;
 
+            /*
+             * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
+             */
+            setup_future_usage: paymentIntents.PaymentIntentFutureUsageType | null;
+
             /**
              * Shipping information for this PaymentIntent.
              */
@@ -4561,8 +4571,6 @@ declare namespace Stripe {
              */
             use_stripe_sdk: any;
         }
-
-        type PaymentIntentCancelationReason = 'duplicate' | 'fraudulent' | 'requested_by_customer' | 'failed_invoice';
 
         interface IPaymentIntentCreationOptions {
             /**
@@ -4643,6 +4651,11 @@ declare namespace Stripe {
              */
             save_payment_method?: boolean;
 
+            /*
+             * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
+             */
+            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
+
             /**
              * Shipping information for this PaymentIntent.
              */
@@ -4708,6 +4721,11 @@ declare namespace Stripe {
              */
             save_payment_method?: boolean;
 
+            /*
+             * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
+             */
+            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
+
             /**
              * Shipping information for this PaymentIntent.
              */
@@ -4749,6 +4767,11 @@ declare namespace Stripe {
              * Set to `true` to save this PaymentIntent’s payment method to the associated Customer, if the payment method is not already attached. This parameter only applies to the payment method passed in the same request or the current payment method attached to the PaymentIntent and must be specified again if a new payment method is added.
              */
             save_payment_method?: boolean;
+
+            /*
+             * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
+             */
+            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
 
             /**
              * Shipping information for this PaymentIntent.

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4503,7 +4503,7 @@ declare namespace Stripe {
             /*
              * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
              */
-            setup_future_usage: paymentIntents.PaymentIntentFutureUsageType | null;
+            setup_future_usage: PaymentIntentFutureUsageType | null;
 
             /**
              * Shipping information for this PaymentIntent.
@@ -4654,7 +4654,7 @@ declare namespace Stripe {
             /*
              * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
              */
-            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
+            setup_future_usage?: PaymentIntentFutureUsageType;
 
             /**
              * Shipping information for this PaymentIntent.
@@ -4724,7 +4724,7 @@ declare namespace Stripe {
             /*
              * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
              */
-            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
+            setup_future_usage?: PaymentIntentFutureUsageType;
 
             /**
              * Shipping information for this PaymentIntent.
@@ -4771,7 +4771,7 @@ declare namespace Stripe {
             /*
              * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
              */
-            setup_future_usage?: paymentIntents.PaymentIntentFutureUsageType;
+            setup_future_usage?: PaymentIntentFutureUsageType;
 
             /**
              * Shipping information for this PaymentIntent.


### PR DESCRIPTION
As per https://stripe.com/docs/api/payment_intents/object#payment_intent_object-setup_future_usage
PaymentIntents have `setup_future_usage` parameter which indicates that you intend to make future payments with this PaymentIntent’s payment method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-setup_future_usage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
