### PR TITLE
express-rate-limit: Added support for resetKey on the RateLimit object

### DIFF
--- a/types/express-rate-limit/express-rate-limit-tests.ts
+++ b/types/express-rate-limit/express-rate-limit-tests.ts
@@ -7,7 +7,7 @@ const apiLimiter = new RateLimit({
   skipFailedRequests: false,
   skipSuccessfulRequests: true,
 });
-apiLimiter.resetKey("testKey");
+apiLimiter.resetKey('testKey');
 
 const apiLimiterWithMaxFn = new RateLimit({
     windowMs: 15 * 60 * 1000,

--- a/types/express-rate-limit/express-rate-limit-tests.ts
+++ b/types/express-rate-limit/express-rate-limit-tests.ts
@@ -7,6 +7,7 @@ const apiLimiter = new RateLimit({
   skipFailedRequests: false,
   skipSuccessfulRequests: true,
 });
+apiLimiter.resetKey("testKey");
 
 const apiLimiterWithMaxFn = new RateLimit({
     windowMs: 15 * 60 * 1000,

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -99,7 +99,10 @@ declare namespace RateLimit {
          */
         windowMs?: number;
     }
+    interface Instance extends express.RequestHandler {
+        resetKey(key: string): void;
+    }
 }
 
-declare var RateLimit: new (options: RateLimit.Options) => express.RequestHandler;
+declare var RateLimit: new (options: RateLimit.Options) => RateLimit.Instance;
 export = RateLimit;

--- a/types/express-rate-limit/v2/express-rate-limit-tests.ts
+++ b/types/express-rate-limit/v2/express-rate-limit-tests.ts
@@ -5,7 +5,7 @@ const apiLimiter = new RateLimit({
   max: 100,
   delayMs: 0 // disabled
 });
-apiLimiter.resetKey("testKey");
+apiLimiter.resetKey('testKey');
 
 const apiLimiterWithMessageObject = new RateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes

--- a/types/express-rate-limit/v2/express-rate-limit-tests.ts
+++ b/types/express-rate-limit/v2/express-rate-limit-tests.ts
@@ -5,6 +5,7 @@ const apiLimiter = new RateLimit({
   max: 100,
   delayMs: 0 // disabled
 });
+apiLimiter.resetKey("testKey");
 
 const apiLimiterWithMessageObject = new RateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes

--- a/types/express-rate-limit/v2/index.d.ts
+++ b/types/express-rate-limit/v2/index.d.ts
@@ -36,7 +36,11 @@ declare namespace RateLimit {
         onLimitReached?(req: express.Request, res: express.Response, optionsUsed: Options): void;
         windowMs?: number;
     }
+
+    interface Instance extends express.RequestHandler {
+        resetKey(key: string): void;
+    }
 }
 
-declare var RateLimit: new (options: RateLimit.Options) => express.RequestHandler;
+declare var RateLimit: new (options: RateLimit.Options) => RateLimit.Instance;
 export = RateLimit;


### PR DESCRIPTION
Per https://github.com/nfriedly/express-rate-limit/blob/master/lib/express-rate-limit.js#L139, `resetKey` should be callable on the returned middleware itself.

Also https://github.com/nfriedly/express-rate-limit#instanceresetkeykey for the explanation in the documentation.

~~~

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfriedly/express-rate-limit/blob/master/lib/express-rate-limit.js#L139 and https://github.com/nfriedly/express-rate-limit#instanceresetkeykey
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
