### PR TITLE
[pdfkit] Add missing definitions for interface ImageOption

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -7,27 +7,26 @@
 
 declare namespace PDFKit {
     interface PDFGradient {
-        new(document: any): PDFGradient ;
-        stop(pos: number, color?: string|PDFKit.PDFGradient, opacity?: number): PDFGradient;
+        new (document: any): PDFGradient;
+        stop(pos: number, color?: string | PDFKit.PDFGradient, opacity?: number): PDFGradient;
         embed(): void;
         apply(): void;
     }
 
     interface PDFLinearGradient extends PDFGradient {
-        new(document: any, x1: number, y1: number, x2: number, y2: number): PDFLinearGradient;
+        new (document: any, x1: number, y1: number, x2: number, y2: number): PDFLinearGradient;
         shader(fn: () => any): any;
         opacityGradient(): PDFLinearGradient;
     }
 
     interface PDFRadialGradient extends PDFGradient {
-        new(document: any, x1: number, y1: number, x2: number, y2: number): PDFRadialGradient;
+        new (document: any, x1: number, y1: number, x2: number, y2: number): PDFRadialGradient;
         shader(fn: () => any): any;
         opacityGradient(): PDFRadialGradient;
     }
 }
 
 declare namespace PDFKit.Mixins {
-
     interface AnnotationOption {
         Type?: string;
         Rect?: any;
@@ -63,7 +62,7 @@ declare namespace PDFKit.Mixins {
     type ColorValue = string | PDFGradient | [number, number, number] | [number, number, number, number];
 
     // The winding / filling rule accepted by PDFKit:
-    type RuleValue = "even-odd" | "evenodd" | "non-zero" | "nonzero";
+    type RuleValue = 'even-odd' | 'evenodd' | 'non-zero' | 'nonzero';
 
     interface PDFColor<TDocument> {
         fillColor(color: ColorValue, opacity?: number): TDocument;
@@ -108,7 +107,7 @@ declare namespace PDFKit.Mixins {
         /**  The maximum height that text should be clipped to */
         height?: number;
         /** The character to display at the end of the text when it is too long. Set to true to use the default character. */
-        ellipsis?: boolean|string;
+        ellipsis?: boolean | string;
         /**  the number of columns to flow the text into */
         columns?: number;
         /** the amount of space between each column (1/4 inch by default) */
@@ -148,12 +147,11 @@ declare namespace PDFKit.Mixins {
         text(text: string, options?: TextOptions): TDocument;
         widthOfString(text: string, options?: TextOptions): number;
         heightOfString(text: string, options?: TextOptions): number;
-        list(list: Array<string|any>, x?: number, y?: number, options?: TextOptions): TDocument;
-        list(list: Array<string|any>, options?: TextOptions): TDocument;
+        list(list: Array<string | any>, x?: number, y?: number, options?: TextOptions): TDocument;
+        list(list: Array<string | any>, options?: TextOptions): TDocument;
     }
 
     interface PDFVector<TDocument> {
-
         save(): TDocument;
         restore(): TDocument;
         closePath(): TDocument;
@@ -189,8 +187,8 @@ declare namespace PDFKit.Mixins {
 
 declare namespace PDFKit {
     /**
-    * PDFKit data
-    */
+     * PDFKit data
+     */
     interface PDFData {
         new (data: any[]): PDFData;
         readByte(): any;
@@ -221,7 +219,7 @@ declare namespace PDFKit {
     }
 }
 
-declare module "pdfkit/js/data" {
+declare module 'pdfkit/js/data' {
     var PDFKitData: PDFKit.PDFData;
     export = PDFKitData;
 }
@@ -241,36 +239,41 @@ declare namespace PDFKit {
         compress?: boolean;
         info?: DocumentInfo;
         autoFirstPage?: boolean;
-        size?: number[]|string;
+        size?: number[] | string;
         margin?: number;
         margins?: { top: number; left: number; bottom: number; right: number };
-        layout?: "portrait" | "landscape";
+        layout?: 'portrait' | 'landscape';
 
         bufferPages?: boolean;
     }
 
-    interface PDFDocument extends NodeJS.ReadableStream,
-        Mixins.PDFAnnotation<PDFDocument>, Mixins.PDFColor<PDFDocument>, Mixins.PDFImage<PDFDocument>,
-        Mixins.PDFText<PDFDocument>, Mixins.PDFVector<PDFDocument>, Mixins.PDFFont<PDFDocument> {
+    interface PDFDocument
+        extends NodeJS.ReadableStream,
+            Mixins.PDFAnnotation<PDFDocument>,
+            Mixins.PDFColor<PDFDocument>,
+            Mixins.PDFImage<PDFDocument>,
+            Mixins.PDFText<PDFDocument>,
+            Mixins.PDFVector<PDFDocument>,
+            Mixins.PDFFont<PDFDocument> {
         /**
-        * PDF Version
-        */
+         * PDF Version
+         */
         version: number;
         /**
-        * Wheter streams should be compressed
-        */
+         * Wheter streams should be compressed
+         */
         compress: boolean;
         /**
-        * PDF document Metadata
-        */
+         * PDF document Metadata
+         */
         info: DocumentInfo;
         /**
-        * Options for the document
-        */
+         * Options for the document
+         */
         options: PDFDocumentOptions;
         /**
-        * Represent the current page.
-        */
+         * Represent the current page.
+         */
         page: PDFPage;
 
         x: number;
@@ -283,39 +286,39 @@ declare namespace PDFKit {
         switchToPage(n?: number): PDFPage;
         flushPages(): void;
         ref(data: {}): PDFKitReference;
-        addContent(data: any): PDFDocument
+        addContent(data: any): PDFDocument;
         /**
-        * Deprecated
-        */
+         * Deprecated
+         */
         write(fileName: string, fn: any): void;
         /**
-        * Deprecated. Throws exception
-        */
+         * Deprecated. Throws exception
+         */
         output(fn: any): void;
         end(): void;
         toString(): string;
     }
 }
 
-declare module "pdfkit" {
+declare module 'pdfkit' {
     var doc: PDFKit.PDFDocument;
     export = doc;
 }
 
-declare module "pdfkit/js/gradient" {
-    var gradient : {
+declare module 'pdfkit/js/gradient' {
+    var gradient: {
         PDFGradient: PDFKit.PDFGradient;
         PDFLinearGradient: PDFKit.PDFLinearGradient;
         PDFRadialGradiant: PDFKit.PDFRadialGradient;
-    }
+    };
 
     export = gradient;
 }
 
 declare namespace PDFKit {
     /**
-   * Represent a single page in the PDF document
-   */
+     * Represent a single page in the PDF document
+     */
     interface PDFPage {
         size: string;
         layout: string;
@@ -325,9 +328,9 @@ declare namespace PDFKit {
         document: PDFDocument;
         content: PDFKitReference;
 
-    /**
-     * The page dictionnary
-     */
+        /**
+         * The page dictionnary
+         */
         dictionary: PDFKitReference;
 
         fonts: any;
@@ -342,10 +345,10 @@ declare namespace PDFKit {
     }
 }
 
-declare module "pdfkit/js/page" {
-  var PDFKitPage: PDFKit.PDFPage
+declare module 'pdfkit/js/page' {
+    var PDFKitPage: PDFKit.PDFPage;
 
-    export = PDFKitPage
+    export = PDFKitPage;
 }
 
 declare namespace PDFKit {
@@ -353,7 +356,7 @@ declare namespace PDFKit {
     class PDFKitReference {
         id: number;
         gen: number;
-        deflate:any;
+        deflate: any;
         compress: boolean;
         uncompressedLength: number;
         chunks: any[];
@@ -369,38 +372,38 @@ declare namespace PDFKit {
     }
 }
 
-declare module "pdfkit/js/reference" {
+declare module 'pdfkit/js/reference' {
     var PDFKitReference: PDFKit.PDFKitReference;
 
     export = PDFKitReference;
 }
 
-declare module "pdfkit/js/mixins/annotations" {
+declare module 'pdfkit/js/mixins/annotations' {
     var PDFKitAnnotation: PDFKit.Mixins.PDFAnnotation<void>;
     export = PDFKitAnnotation;
 }
 
-declare module "pdfkit/js/mixins/color" {
+declare module 'pdfkit/js/mixins/color' {
     var PDFKitColor: PDFKit.Mixins.PDFColor<void>;
     export = PDFKitColor;
 }
 
-declare module "pdfkit/js/mixins/fonts" {
+declare module 'pdfkit/js/mixins/fonts' {
     var PDFKitFont: PDFKit.Mixins.PDFFont<void>;
     export = PDFKitFont;
 }
 
-declare module "pdfkit/js/mixins/images" {
+declare module 'pdfkit/js/mixins/images' {
     var PDFKitImage: PDFKit.Mixins.PDFImage<void>;
     export = PDFKitImage;
 }
 
-declare module "pdfkit/js/mixins/text" {
+declare module 'pdfkit/js/mixins/text' {
     var PDFKitText: PDFKit.Mixins.PDFText<void>;
     export = PDFKitText;
 }
 
-declare module "pdfkit/js/mixins/vector" {
+declare module 'pdfkit/js/mixins/vector' {
     var PDFKitVector: PDFKit.Mixins.PDFVector<void>;
     export = PDFKitVector;
 }

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Pdfkit v0.10.0
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
+//                 Erik Berreßem <https://github.com/she11sh0cked>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -89,8 +89,8 @@ declare namespace PDFKit.Mixins {
         /** Scale percentage */
         scale?: number;
         /** Two elements array specifying dimensions(w,h)  */
-        fit?: number[];
-        cover?: boolean;
+        fit?: [number, number];
+        cover?: [number, number];
         align?: 'center' | 'right';
         valign?: 'center' | 'bottom';
         link?: AnnotationOption;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -47,6 +47,7 @@ declare namespace PDFKit.Mixins {
     interface PDFAnnotation<TDocument> {
         annotate(x: number, y: number, w: number, h: number, option: AnnotationOption): TDocument;
         note(x: number, y: number, w: number, h: number, content: string, option?: AnnotationOption): TDocument;
+        goTo(x: number, y: number, w: number, h: number, name: string, options?: AnnotationOption): TDocument;
         link(x: number, y: number, w: number, h: number, url: string, option?: AnnotationOption): TDocument;
         highlight(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
         underline(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
@@ -89,6 +90,12 @@ declare namespace PDFKit.Mixins {
         scale?: number;
         /** Two elements array specifying dimensions(w,h)  */
         fit?: number[];
+        cover?: boolean;
+        align?: 'center' | 'right';
+        valign?: 'center' | 'bottom';
+        link?: AnnotationOption;
+        goTo?: AnnotationOption;
+        destination?: string;
     }
 
     interface PDFImage<TDocument> {
@@ -136,7 +143,8 @@ declare namespace PDFKit.Mixins {
         continued?: boolean;
 
         /** the alignment of the text (center, justify, left, right) */
-        align?: string;
+        //TODO check this
+        align?: 'center' | 'justify' | 'left' | 'right' | string;
     }
 
     interface PDFText<TDocument> {

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Pdfkit v0.7.2
+// Type definitions for Pdfkit v0.10.0
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -1,153 +1,168 @@
-
-
-import PDFGradient = require("pdfkit/js/gradient");
+import PDFGradient = require('pdfkit/js/gradient');
 
 var PDFRadialGradiant = PDFGradient.PDFRadialGradiant;
 var PDFLinearGradient = PDFGradient.PDFLinearGradient;
 
-import mtext = require("pdfkit/js/mixins/text");
+import mtext = require('pdfkit/js/mixins/text');
 
-import PDFDocument = require("pdfkit");
+import PDFDocument = require('pdfkit');
 
-import font = require("pdfkit/js/mixins/fonts");
-import pdfData = require("pdfkit/js/data");
-import text = require("pdfkit/js/mixins/text");
+import font = require('pdfkit/js/mixins/fonts');
+import pdfData = require('pdfkit/js/data');
+import text = require('pdfkit/js/mixins/text');
 
-font.registerFont("Arial");
-text.widthOfString("Kila",{ellipsis:true});
+font.registerFont('Arial');
+text.widthOfString('Kila', { ellipsis: true });
 
-var doc = new PDFDocument({compress:false, size:[526,525],autoFirstPage:true});
-
+var doc = new PDFDocument({ compress: false, size: [526, 525], autoFirstPage: true });
 
 doc.addPage({
-  margin: 50
+    margin: 50,
 });
 
 doc.addPage({
-  margins: {
-    top: 50,
-    bottom: 50,
-    left: 72,
-    right: 72
-  }
+    margins: {
+        top: 50,
+        bottom: 50,
+        left: 72,
+        right: 72,
+    },
 });
 
 doc.addPage({
-  layout: "landscape"
+    layout: 'landscape',
 });
 
-doc.info.Title = "Sample";
-doc.info.Author = "kila Mogrosso";
+doc.info.Title = 'Sample';
+doc.info.Author = 'kila Mogrosso';
 
 // Create basic shapes
-doc.moveTo(0,20)
-  .lineTo(100,160)
-  .quadraticCurveTo(130,200,150,120)
-  .lineTo(400,90)
-  .strokeColor([255, 0, 0], 1)
-  .strokeColor([255, 0, 0])
-  .stroke();
+doc.moveTo(0, 20)
+    .lineTo(100, 160)
+    .quadraticCurveTo(130, 200, 150, 120)
+    .lineTo(400, 90)
+    .strokeColor([255, 0, 0], 1)
+    .strokeColor([255, 0, 0])
+    .stroke();
 
 //SVG Paths
-doc.path("M 0,20 L 100,160 Q 130,200 150,120 C 190,-40 200,200 300,150 L 400,90")
-  .stroke();
+doc.path('M 0,20 L 100,160 Q 130,200 150,120 C 190,-40 200,200 300,150 L 400,90').stroke();
 
 //Rectangle shape helper sample
-doc.rect(100,200,100,100);
+doc.rect(100, 200, 100, 100);
 // Rounded rectangle
-doc.roundedRect(150,250,150,150,10);
+doc.roundedRect(150, 250, 150, 150, 10);
 
 //polygon
-doc.polygon([100,0],[50,100],[50,100]);
-
+doc.polygon([100, 0], [50, 100], [50, 100]);
 
 doc.lineWidth(25);
-doc.lineCap('butt').moveTo(50, 20).lineTo(100, 20).stroke();
-doc.lineCap('round').moveTo(150, 20).lineTo(200, 20).stroke();
-doc.lineCap('square').moveTo(250, 20).circle(275, 30, 15).stroke();
-doc.lineJoin('miter').rect(50, 100, 50, 50).stroke();
-doc.lineJoin('round').rect(150, 100, 50, 50).stroke();
-doc.lineJoin('bevel').rect(250, 100, 50, 50).stroke();
-
+doc.lineCap('butt')
+    .moveTo(50, 20)
+    .lineTo(100, 20)
+    .stroke();
+doc.lineCap('round')
+    .moveTo(150, 20)
+    .lineTo(200, 20)
+    .stroke();
+doc.lineCap('square')
+    .moveTo(250, 20)
+    .circle(275, 30, 15)
+    .stroke();
+doc.lineJoin('miter')
+    .rect(50, 100, 50, 50)
+    .stroke();
+doc.lineJoin('round')
+    .rect(150, 100, 50, 50)
+    .stroke();
+doc.lineJoin('bevel')
+    .rect(250, 100, 50, 50)
+    .stroke();
 
 doc.circle(100, 50, 50)
-  .lineWidth(3)
-  .fillOpacity(0.8)
-  .fillAndStroke("red", "#900");
+    .lineWidth(3)
+    .fillOpacity(0.8)
+    .fillAndStroke('red', '#900');
 
-var grad = doc.linearGradient(50, 0, 150, 100)
-  .stop(0, 'green')
-  .stop(1, 'red');
+var grad = doc
+    .linearGradient(50, 0, 150, 100)
+    .stop(0, 'green')
+    .stop(1, 'red');
 
-doc.rect(50, 0, 100, 100)
-.fill(grad);
+doc.rect(50, 0, 100, 100).fill(grad);
 
-doc.rect(150, 0, 25, 25)
-.fill();
+doc.rect(150, 0, 25, 25).fill();
 
-doc.circle(100, 50, 50).dash(5, {
-  space: 10
-}).stroke();
+doc.circle(100, 50, 50)
+    .dash(5, {
+        space: 10,
+    })
+    .stroke();
 
 var rgrad = doc.radialGradient(300, 50, 0, 300, 50, 50);
 rgrad.stop(0, 'orange', 0).stop(1, 'orange', 1);
-doc.circle(300, 50, 50)
-  .fill(rgrad);
+doc.circle(300, 50, 50).fill(rgrad);
 
 doc.fillColor('red')
-  .translate(-100, -50)
-  .scale(0.8);
+    .translate(-100, -50)
+    .scale(0.8);
 
-doc.path('M 250,75 L 323,301 131,161 369,161 177,301 z')
-  .fill('non-zero');
+doc.path('M 250,75 L 323,301 131,161 369,161 177,301 z').fill('non-zero');
 
 doc.translate(280, 0)
-  .path('M 250,75 L 323,301 131,161 369,161 177,301 z')
-  .fill('even-odd');
+    .path('M 250,75 L 323,301 131,161 369,161 177,301 z')
+    .fill('even-odd');
 
-doc.circle(100,100,100)
-  .clip();
+doc.circle(100, 100, 100).clip();
 
 doc.fontSize(25)
-  .fillColor('blue')
-  .text('This is a link!', 20, 0);
+    .fillColor('blue')
+    .text('This is a link!', 20, 0);
 
 var width = doc.widthOfString('This is a link!');
 
 var height = doc.currentLineHeight();
 
 doc.underline(20, 0, width, height, {
-  color: 'blue'
+    color: 'blue',
 }).link(20, 0, width, height, 'http://google.com/');
 
 doc.moveDown()
-  .fillColor('black')
-  .highlight(20, doc.y, doc.widthOfString('This text is highlighted!'), height)
-  .text('This text is highlighted!');
+    .fillColor('black')
+    .highlight(20, doc.y, doc.widthOfString('This text is highlighted!'), height)
+    .text('This text is highlighted!');
 
 doc.moveDown()
-.strike(20, doc.y, doc.widthOfString('STRIKE!'), height)
-.text('STRIKE!');
+    .strike(20, doc.y, doc.widthOfString('STRIKE!'), height)
+    .text('STRIKE!');
 
 doc.image('images/test.jpeg', 0, 15, {
-  width: 300
+    width: 300,
 }).text('Proprotional to width', 0, 0);
 
 doc.image('images/test.jpeg', 320, 15, {
-  fit: [100, 100]
-}).rect(320, 15, 100, 100).stroke().text('Fit', 320, 0);
+    fit: [100, 100],
+})
+    .rect(320, 15, 100, 100)
+    .stroke()
+    .text('Fit', 320, 0);
 
 doc.image('images/test.jpeg', 320, 145, {
-  width: 200,
-  height: 100
+    width: 200,
+    height: 100,
 }).text('Stretch', 320, 130);
 
 doc.image('images/test.jpeg', 320, 280, {
-  scale: 0.25
+    scale: 0.25,
 }).text('Scale', 320, 265);
 
-doc.image({ /* something like a buffer */ }, {
-  scale: 0.25
-}).text('Scale', 320, 265);
+doc.image(
+    {
+        /* something like a buffer */
+    },
+    {
+        scale: 0.25,
+    }
+).text('Scale', 320, 265);
 
-doc.text('Scale', {align: 'justify'});
+doc.text('Scale', { align: 'justify' });

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -166,3 +166,21 @@ doc.image(
 ).text('Scale', 320, 265);
 
 doc.text('Scale', { align: 'justify' });
+
+doc.goTo(0, 0, 0, 0, 'lorem');
+
+doc.image('path/to/image.png', {
+    fit: [250, 300],
+    align: 'center',
+    valign: 'center',
+});
+
+doc.image('path/to/image.png', {
+    cover: [250, 300],
+});
+
+doc.image('path/to/image.png', {
+    link: {},
+    goTo: {},
+    destination: 'lorem',
+});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested [changes](#changes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

# Changes

## interface PDFAnnotation<TDocument>

|   goTo (added)    |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/annotations.js#L40    |

## interface ImageOption

|   fit (edited)    |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L54    |

|   cover (added)   |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L65    |

|   align (added)   |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L78    |

|   valign (added)  |
|   -       |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L84    |

|   link (added)    |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L93    |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/annotations.js#L49   |

|   goTo (added)    |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L96    |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/annotations.js#L40   |

|   destination (added) |
|   -   |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/mixins/images.js#L99    |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/document.js#L186    |
|   https://github.com/foliojs/pdfkit/blob/87ebd521aee55e94e5b816f27e8696723a39e601/lib/name_tree.js#L14    |