### PR TITLE
Make haversine and geojson types compatible [haversine]

### DIFF
--- a/types/haversine/haversine-tests.ts
+++ b/types/haversine/haversine-tests.ts
@@ -1,4 +1,5 @@
 import haversine = require('haversine');
+import { Feature, Point } from 'geojson';
 
 const start: haversine.CoordinateLongitudeLatitude = {
   longitude: 48.1548256,
@@ -75,12 +76,14 @@ const startGeoJSON = {
     },
 };
 
-const endGeoJSON = {
+// Ensure that types/haversine is compatible with types/geojson.
+const endGeoJSON: Feature<Point> = {
     type: 'Feature',
     geometry: {
         type: 'Point',
         coordinates: endLatLon,
     },
+    properties: {},
 };
 
 const optionsGeoJSON: haversine.Options = {

--- a/types/haversine/index.d.ts
+++ b/types/haversine/index.d.ts
@@ -25,7 +25,7 @@ declare namespace haversine {
 
     interface GeoJSON {
         geometry: {
-            coordinates: LatLonTuple
+            coordinates: number[];  // matches Point type in types/geojson.
         };
     }
 


### PR DESCRIPTION
This is slightly less precise than the previous version, but being compatible with the geojson typings seems desirable:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e901b4ff62b35981e5b6d1a4aac3009f6764b358/types/geojson/index.d.ts#L41

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See GeoJSON typings link above.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
