### PR TITLE
Make tests work with typescript@next

### DIFF
--- a/types/koa-morgan/koa-morgan-tests.ts
+++ b/types/koa-morgan/koa-morgan-tests.ts
@@ -12,11 +12,12 @@ app.use(morgan('tiny'));
 app.use(morgan(':remote-addr :method :url'));
 
 const tokenCallback: morgan.TokenCallbackFn = (req: IncomingMessage, res: ServerResponse): string => {
-    if (req.headers['request-id']) {
-        if (Array.isArray(req.headers['request-id'])) {
-            return (req.headers['request-id'] as string[]).join(';');
+    const rqid = req.headers['request-id'];
+    if (rqid) {
+        if (Array.isArray(rqid)) {
+            return rqid.join(';');
         } else {
-            return req.headers['request-id'] as string;
+            return rqid;
         }
     } else {
         return '-';

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -411,8 +411,8 @@ stripe.customers.create({
     let metadata: Stripe.IOptionsMetadata;
     const num = 123;
     metadata["test"] = str;
-    metadata["test"] = num;
     metadata["test"] === str;
+    metadata["test"] = num;
     metadata["test"] === num;
     metadata.testStr = str;
     metadata.testNum = num;


### PR DESCRIPTION
Which has better narrowing for element access, so some code needs to be reworded to work with old versions as well as typescript@next.

Specifically, koa-morgan's tests don't need an assertion anymore, and stripe's tests need to avoid a "12 is not comparable to string" error.