### PR TITLE
[stripe-v3] Support 'paymentmethod' event in Payment Request handler

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -623,12 +623,17 @@ declare namespace stripe {
             source: Source;
         }
 
+        interface StripePaymentMethodPaymentResponse extends StripePaymentResponse {
+            paymentMethod: paymentMethod.PaymentMethod;
+        }
+
         interface StripePaymentRequest {
             canMakePayment(): Promise<{ applePay?: boolean } | null>;
             show(): void;
             update(options: StripePaymentRequestUpdateOptions): void;
             on(event: 'token', handler: (response: StripeTokenPaymentResponse) => void): void;
             on(event: 'source', handler: (response: StripeSourcePaymentResponse) => void): void;
+            on(event: 'paymentmethod', handler: (response: StripePaymentMethodPaymentResponse) => void): void;
             on(event: 'cancel', handler: () => void): void;
             on(event: 'shippingaddresschange', handler: (response: { updateWith: (options: UpdateDetails) => void, shippingAddress: ShippingAddress }) => void): void;
             on(event: 'shippingoptionchange', handler: (response: { updateWith: (options: UpdateDetails) => void, shippingOption: ShippingOption }) => void): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://stripe.com/docs/stripe-js/reference#payment-request-on

This adds support for `paymentRequest.on("paymentmethod", handler)`. The `PaymentResponse` for a `paymentmethod` event contains a `paymentMethod` object, as indicated in the docs here: https://stripe.com/docs/stripe-js/reference#payment-response-object