### PR TITLE
[relay-runtime]: RecordSource exposes a toJSON method too

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -422,6 +422,7 @@ interface RecordSource {
     has(dataID: DataID): boolean;
     load(dataID: DataID, callback: (error: Error | null | undefined, record: Record | null | undefined) => void): void;
     size(): number;
+    toJSON(): Record;
 }
 export { RecordSource as IRecordSource };
 
@@ -1027,6 +1028,7 @@ declare class RelayInMemoryRecordSource implements MutableRecordSource {
     remove(dataID: DataID): void;
     set(dataID: DataID, record: Record): void;
     size(): number;
+    toJSON(): Record;
 }
 export { RelayInMemoryRecordSource as RecordSource };
 

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -14,14 +14,9 @@ export interface ConnectionMetadata {
     count: string | null | undefined;
 }
 
-// ./handlers/connection/RelayConnectionInterface
-export interface Record {
-    [key: string]: unknown;
-}
-
-export interface EdgeRecord extends Record {
+export interface EdgeRecord extends Record<string, unknown> {
     cursor: unknown;
-    node: Record;
+    node: Record<DataID, unknown>;
 }
 
 export interface PageInfo {
@@ -294,7 +289,7 @@ export type MissingFieldHandler =
           kind: 'scalar';
           handle: (
               field: NormalizationScalarField,
-              record: Record | null | undefined,
+              record: Record<string, unknown> | null | undefined,
               args: Variables,
               store: ReadonlyRecordSourceProxy
           ) => unknown;
@@ -303,7 +298,7 @@ export type MissingFieldHandler =
           kind: 'linked';
           handle: (
               field: NormalizationLinkedField,
-              record: Record | null | undefined,
+              record: Record<string, unknown> | null | undefined,
               args: Variables,
               store: ReadonlyRecordSourceProxy
           ) => DataID | null | undefined;
@@ -312,7 +307,7 @@ export type MissingFieldHandler =
           kind: 'pluralLinked';
           handle: (
               field: NormalizationLinkedField,
-              record: Record | null | undefined,
+              record: Record<string, unknown> | null | undefined,
               args: Variables,
               store: ReadonlyRecordSourceProxy
           ) => ReadonlyArray<DataID | null | undefined> | null | undefined;
@@ -416,13 +411,13 @@ interface ReadonlyRecordProxy {
 }
 
 interface RecordSource {
-    get(dataID: DataID): Record | null | undefined;
+    get(dataID: DataID): Record<string, unknown> | null | undefined;
     getRecordIDs(): ReadonlyArray<DataID>;
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;
-    load(dataID: DataID, callback: (error: Error | null | undefined, record: Record | null | undefined) => void): void;
+    load(dataID: DataID, callback: (error: Error | null | undefined, record: Record<string, unknown> | null | undefined) => void): void;
     size(): number;
-    toJSON(): Record;
+    toJSON(): Record<string, unknown>;
 }
 export { RecordSource as IRecordSource };
 
@@ -441,7 +436,7 @@ export interface MutableRecordSource extends RecordSource {
     clear(): void;
     delete(dataID: DataID): void;
     remove(dataID: DataID): void;
-    set(dataID: DataID, record: Record): void;
+    set(dataID: DataID, record: Record<string, unknown>): void;
 }
 
 type Scheduler = (callback: () => void) => void;
@@ -862,7 +857,7 @@ export interface Props {
 
 interface RecordMap {
     // theoretically, this should be `[dataID: DataID]`, but `DataID` is a string.
-    [dataID: string]: Record | undefined;
+    [dataID: string]: Record<string, unknown> | undefined;
 }
 export interface SelectorData {
     [key: string]: unknown;
@@ -1020,15 +1015,19 @@ declare class RelayInMemoryRecordSource implements MutableRecordSource {
     constructor(records?: RecordMap);
     clear(): void;
     delete(dataID: DataID): void;
-    get(dataID: DataID): Record | null | undefined;
+    get(dataID: DataID): Record<string, unknown> | null | undefined;
     getRecordIDs(): ReadonlyArray<DataID>;
     getStatus(dataID: DataID): RecordState;
     has(dataID: DataID): boolean;
-    load(dataID: DataID, callback: (error: Error | null | undefined, record: Record | null | undefined) => void): void;
+    load(
+        dataID: DataID,
+
+        callback: (error: Error | null | undefined, record: Record<string, unknown> | null | undefined) => void
+    ): void;
     remove(dataID: DataID): void;
-    set(dataID: DataID, record: Record): void;
+    set(dataID: DataID, record: Record<string, unknown>): void;
     size(): number;
-    toJSON(): Record;
+    toJSON(): Record<string, unknown>;
 }
 export { RelayInMemoryRecordSource as RecordSource };
 


### PR DESCRIPTION
With this PR I aim to expose the `toJSON` as a method on the RecordStore.

example:

```ts
const environment = new Environment(...);

environment
    .getStore()
    .getSource()
    .toJSON()
``` 

@voxmatt @alloy @ckknight  Did one of you guys mind reviewing this one?
