### PR TITLE
[@types/redux-orm] add last missing selector overload

### DIFF
--- a/types/redux-orm/redux-orm-tests.ts
+++ b/types/redux-orm/redux-orm-tests.ts
@@ -387,6 +387,12 @@ const sessionFixture = () => {
         (session, title) => session.Book.get({ title })!.ref
     ) as TestSelector;
 
+    const selector0 = createOrmSelector(
+        orm,
+        s => s.db,
+        session => session.Book.first()!.ref
+    ) as TestSelector;
+
     const selector2 = createOrmSelector(
         orm,
         s => s.db,
@@ -453,6 +459,7 @@ const sessionFixture = () => {
 
     const state = { db: orm.getEmptyState(), foo: 1, bar: 'foo' };
 
+    selector0(state); // $ExpectType Ref<Book>
     selector1(state); // $ExpectType Ref<Book>
     selector2(state); // $ExpectType Ref<Book>
     selector3(state); // $ExpectType Ref<Book>

--- a/types/redux-orm/redux.d.ts
+++ b/types/redux-orm/redux.d.ts
@@ -78,4 +78,10 @@ export function createSelector<S, I, R1, R>(
     ormSelector: ORMSelector<I, [R1], R>
 ): Selector<S, R>;
 
+export function createSelector<S, I, R>(
+    orm: ORM<I>,
+    ormStateSelector: Selector<S, OrmState<I>>,
+    ormSelector: ORMSelector<I, [], R>
+): Selector<S, R>;
+
 export function createSelector<I, R>(orm: ORM<I>, ormSelector: ORMSelector<I, [], R>): Selector<OrmState<I>, R>;


### PR DESCRIPTION
Adds missing `createSelector` overload, specifically the one accepting 3 parameters and returning root-state-accepting selector function.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).