### PR TITLE
react-native-material-dropdown: onChangeText props requires array, not object

### DIFF
--- a/types/react-native-material-dropdown/index.d.ts
+++ b/types/react-native-material-dropdown/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native-material-dropdown 0.11
 // Project: https://github.com/n4kz/react-native-material-dropdown
 // Definitions by: Jaydeep <https://github.com/jaydeep987>
+// Definitions by: Michael <https://github.com/mchappell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -88,7 +89,7 @@ export interface DropDownProps extends TouchableWithoutFeedbackProps {
   /** Event: When focus lost from dropdown */
   onBlur?(): void;
   /** Event: When change selected item */
-  onChangeText?(value: string, index: number, data: DropDownData): void;
+  onChangeText?(value: string, index: number, data: DropDownData[]): void;
 
   /** Render base component */
   renderBase?(props: RenderBaseProps): JSX.Element;

--- a/types/react-native-material-dropdown/index.d.ts
+++ b/types/react-native-material-dropdown/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for react-native-material-dropdown 0.11
 // Project: https://github.com/n4kz/react-native-material-dropdown
 // Definitions by: Jaydeep <https://github.com/jaydeep987>
-// Definitions by: Michael <https://github.com/mchappell>
+//                 Michael <https://github.com/mchappell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
The data prop passed by react-native-material-dropdown passes an array, not an object, the type def needs updating to reflect this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/n4kz/react-native-material-dropdown/blob/master/src/components/dropdown/index.js
