### PR TITLE
ReactStripeElements - adding support for handleCardPayment and handle…

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -38,7 +38,9 @@ export namespace ReactStripeElements {
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
 		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
-		paymentRequest: stripe.Stripe['paymentRequest'];
+        paymentRequest: stripe.Stripe['paymentRequest'];
+        handleCardPayment: stripe.Stripe['handleCardPayment'];
+        handleCardSetup: stripe.Stripe['handleCardSetup'];
 	}
 
 	interface InjectOptions {


### PR DESCRIPTION
with the new release of https://github.com/stripe/react-stripe-elements there's some typings missing for two new methods: 
- handleCardPayment
- handleCardPayment

here I'm just mapping those to stripe-v3 version doing:
stripe.Stripe['methodName'] like done in other mappings
