### PR TITLE
Added pdfmake node types

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -4,6 +4,7 @@
 //                 Rajab Shakirov <https://github.com/radziksh>
 //                 Enzo Volkmann <https://github.com/evolkmann>
 //                 Andi Pätzold <https://github.com/andipaetzold>
+//                 Seva Maltsev <https://github.com/TwoAbove>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -275,4 +276,36 @@ declare module "pdfmake/build/pdfmake" {
         fonts: { [name: string]: TFontFamilyTypes };
         createPdf(documentDefinitions: TDocumentDefinitions): TCreatedPdf;
     }
+}
+
+declare module 'pdfmake/src/printer' {
+	import * as PDFKit from 'pdfkit';
+	import * as PDFMake from 'pdfmake/build/pdfmake';
+
+	interface FontDescriptors {
+		[fontName: string]: {
+			normal: string | Buffer;
+			bold: string | Buffer;
+			italics: string | Buffer;
+			bolditalics: string | Buffer;
+		}
+	}
+
+	interface DocOptions {
+        tableLayouts?: any;
+        fontLayoutCache?: boolean;
+        bufferPages?: boolean;
+        autoPrint?: boolean;
+        progressCallback?: () => number; // number => (amount done / total)
+    }
+
+	export default class PdfPrinter {
+		constructor(fontDescriptors: FontDescriptors);
+		fontDescriptors: FontDescriptors;
+
+		createPdfKitDocument(
+			docDefinition: PDFMake.TDocumentDefinitions,
+			options?: DocOptions
+		): PDFKit.PDFDocument;
+	}
 }

--- a/types/pdfmake/pdfmake-tests.ts
+++ b/types/pdfmake/pdfmake-tests.ts
@@ -1,5 +1,15 @@
+import PdfMakeNode from 'pdfmake/src/printer';
 import * as pdfMake from 'pdfmake/build/pdfmake';
 import * as pdfFonts from 'pdfmake/build/vfs_fonts';
+
+const RobotoFont = {
+    Roboto: {
+        bold: Buffer.from(pdfFonts.pdfMake.vfs['Roboto-Medium.ttf'], 'base64'),
+        bolditalics: Buffer.from(pdfFonts.pdfMake.vfs['Roboto-MediumItalic.ttf'], 'base64'),
+        italics: Buffer.from(pdfFonts.pdfMake.vfs['Roboto-Italic.ttf'], 'base64'),
+        normal: Buffer.from(pdfFonts.pdfMake.vfs['Roboto-Regular.ttf'], 'base64'),
+    },
+};
 
 const definitions = [
     {
@@ -1325,10 +1335,12 @@ const definitions = [
 
 const createPdf = () => {
   const pdf = pdfMake;
+  const nodePdf = new PdfMakeNode(RobotoFont);
   pdf.vfs = pdfFonts.pdfMake.vfs;
 
   for (const definition of definitions) {
       const typedDefinition: pdfMake.TDocumentDefinitions = definition;
       pdfMake.createPdf(typedDefinition).download();
+      nodePdf.createPdfKitDocument(typedDefinition);
   }
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bpampuch/pdfmake/blob/0.1/src/printer.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.



________

I'd Like some help, @m1llen1um @radziksh @evolkmann @andipaetzold 

I want to reuse the definitions from `pdfmake/build/pdfmake` (specifically, `TDocumentDefinitions`). But that breaks tests. 

What is the solution for this? 

Thanks!