### PR TITLE
Mark additional packages as non-npm

### DIFF
--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Forge Viewer 6.6
+// Type definitions for non-npm package Forge Viewer 6.6
 // Project: https://forge.autodesk.com/en/docs/viewer/v6/reference/javascript/viewer3d/
 // Definitions by: Autodesk Forge Partner Development <https://github.com/Autodesk-Forge>, Alan Smith <https://github.com/alansmithnbs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google gtag.js API
+// Type definitions for non-npm package Google gtag.js API
 // Project: https://developers.google.com/gtagjs
 // Definitions by:  Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/lestate/tslint.json
+++ b/types/lestate/tslint.json
@@ -1,1 +1,7 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false,
+        "npm-naming": false
+    }
+}

--- a/types/playcanvas/index.d.ts
+++ b/types/playcanvas/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for playcanvas 0.221
+// Type definitions for non-npm package playcanvas 0.221
 // Project: https://github.com/playcanvas/engine
 // Definitions by: Philippe Vaillancourt <https://github.com/Neoflash1979>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yandex-maps 2.1
+// Type definitions for non-npm package yandex-maps 2.1
 // Project: https://github.com/Delagen/typings-yandex-maps
 // Definitions by: Delagen <https://github.com/Delagen>
 //                 gastwork13 <https://github.com/gastwork13>


### PR DESCRIPTION
Yesterday's update to dts-critic also made it better at detecting non-npm packages apparently.

Note that lestate seems to be missing completely, but I don't want to delete it without positive proof. Also, our infrastructure doesn't have the concept of 'delete' for packages, only 'replace'. So I just created an exemption for now.