### PR TITLE
[Heremaps] Add missing "noWrap" parameter in map options

### DIFF
--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Joshua Efiong <https://github.com/Josh-ES>
 //                 Bernd Hacker <https://github.com/denyo>
 //                 Ferdinand Armbruster <https://github.com/fx88>
+//                 Vladimir Dashukevich <https://github.com/life777>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -309,6 +310,7 @@ declare namespace H {
          * @property margin {number=} - The size in pixel of the supplemental area to render for each side of the map
          * @property padding {H.map.ViewPort.Padding=} - The padding in pixels for each side of the map
          * @property fixedCenter {boolean=} - Indicates whether the center of the map should remain unchanged if the viewport's size or padding has been changed, default is true
+         * @property noWrap {boolean=} - Indicates whether to wrap the world on longitude axes. When set to false, multiple worlds are rendered. When set to true, only one world will be rendered. Default is false.
          */
         interface Options {
             center?: H.geo.IPoint;
@@ -323,6 +325,7 @@ declare namespace H {
             margin?: number;
             padding?: H.map.ViewPort.Padding;
             fixedCenter?: boolean;
+            noWrap?: boolean;
         }
     }
 

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -310,7 +310,7 @@ declare namespace H {
          * @property margin {number=} - The size in pixel of the supplemental area to render for each side of the map
          * @property padding {H.map.ViewPort.Padding=} - The padding in pixels for each side of the map
          * @property fixedCenter {boolean=} - Indicates whether the center of the map should remain unchanged if the viewport's size or padding has been changed, default is true
-         * @property noWrap {boolean=} - Indicates whether to wrap the world on longitude axes. When set to false, multiple worlds are rendered. When set to true, only one world will be rendered. Default is false.
+         * @property noWrap {boolean=} - Indicates whether to wrap the world on longitude axes. When set to true, only one world will be rendered. Default is false, multiple worlds are rendered.
          */
         interface Options {
             center?: H.geo.IPoint;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.here.com/cn/documentation/maps/hls-chn/topics_api/h-map-options.html#h-map-options__nowrap>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.