### PR TITLE
node-forge: Reference `jsbn.BigInteger` in favor of own types

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -16,6 +16,8 @@
 
 /// <reference types="node" />
 
+import { BigInteger as JsbnBigInteger } from 'jsbn';
+
 declare module "node-forge" {
     type Byte = number;
     type Bytes = string;
@@ -26,12 +28,7 @@ declare module "node-forge" {
     type Encoding = "raw" | "utf8";
 
     namespace jsbn {
-        class BigInteger {
-            data: number[];
-            t: number;
-            s: number;
-            toString(): string;
-        }
+        type BigInteger = JsbnBigInteger;
     }
 
     namespace pem {

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -364,3 +364,8 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     console.log('created TLS client and server, doing handshake...');
     client.handshake();
 }
+
+{
+    const rsa = forge.pki.rsa.generateKeyPair(1024);
+    rsa.publicKey.e.toString(16);
+}


### PR DESCRIPTION
While node-forge technically does not use the `jsbn` package as its
dependency for all intents and purposes it is using the jsbn library,
no need to maintain these typings separately. Especially not when they
are clearly non-complete.

In fact the `@types/jsbn` typings already contains forge's special
`data` property which does not exist in stock `jsbn`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge/blob/master/lib/jsbn.js and https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a1f6013ddd509d0275acf72d1b202c9e432738eb/types/jsbn/index.d.ts#L19
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.