### PR TITLE
[k6] Remove Response.timings.looking_up

### DIFF
--- a/types/k6/http.d.ts
+++ b/types/k6/http.d.ts
@@ -121,7 +121,6 @@ export interface Response {
     status: number;
     timings: {
         blocked: number;
-        looking_up: number;
         connecting: number;
         tls_handshaking: number;
         sending: number;


### PR DESCRIPTION
This was incorrectly included in previous updates. It's currently unavailable in the API. To be restored when future changes make it possible.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.k6.io/docs/response-k6http
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.