### PR TITLE
Mark optional properties from ArrayContaining and ObjectContaining

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -236,17 +236,17 @@ declare namespace jasmine {
     }
 
     interface ArrayContaining<T> {
-        new (sample: ArrayLike<T>): ArrayLike<T>;
+        new?(sample: ArrayLike<T>): ArrayLike<T>;
 
         asymmetricMatch(other: any): boolean;
-        jasmineToString(): string;
+        jasmineToString?(): string;
     }
 
     interface ObjectContaining<T> {
-        new (sample: Partial<T>): Partial<T>;
+        new?(sample: Partial<T>): Partial<T>;
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
-        jasmineToString(): string;
+        jasmineToString?(): string;
     }
 
     interface Block {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -837,6 +837,29 @@ describe("jasmine.any", () => {
     });
 });
 
+describe('custom asymmetry', function() {
+    const tester = {
+        asymmetricMatch: (actual: string) => {
+            const secondValue = actual.split(',')[1];
+            return secondValue === 'bar';
+        },
+    };
+
+    it('dives in deep', function() {
+        expect('foo,bar,baz,quux').toEqual(tester);
+    });
+
+    describe('when used with a spy', function() {
+        it('is useful for comparing arguments', function() {
+            const callback = jasmine.createSpy('callback');
+
+            callback('foo,bar,baz');
+
+            expect(callback).toHaveBeenCalledWith(tester);
+        });
+    });
+});
+
 describe("jasmine.objectContaining", () => {
     interface fooType {
         a: number;

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -245,17 +245,17 @@ declare namespace jasmine {
     }
 
     interface ArrayContaining<T> {
-        new (sample: ArrayLike<T>): ArrayLike<T>;
+        new?(sample: ArrayLike<T>): ArrayLike<T>;
 
         asymmetricMatch(other: any): boolean;
-        jasmineToString(): string;
+        jasmineToString?(): string;
     }
 
     interface ObjectContaining<T> {
-        new (sample: Partial<T>): Partial<T>;
+        new?(sample: Partial<T>): Partial<T>;
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
-        jasmineToString(): string;
+        jasmineToString?(): string;
     }
 
     interface Block {

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -839,6 +839,29 @@ describe("jasmine.any", () => {
     });
 });
 
+describe('custom asymmetry', function() {
+    const tester = {
+        asymmetricMatch: (actual: string) => {
+            const secondValue = actual.split(',')[1];
+            return secondValue === 'bar';
+        },
+    };
+
+    it('dives in deep', function() {
+        expect('foo,bar,baz,quux').toEqual(tester);
+    });
+
+    describe('when used with a spy', function() {
+        it('is useful for comparing arguments', function() {
+            const callback = jasmine.createSpy('callback');
+
+            callback('foo,bar,baz');
+
+            expect(callback).toHaveBeenCalledWith(tester);
+        });
+    });
+});
+
 describe("jasmine.objectContaining", () => {
     interface fooType {
         a: number;


### PR DESCRIPTION
Allows custom matchers defined at https://jasmine.github.io/2.6/introduction.html#section-Custom_asymmetric_equality_tester. Note that this is referencing an older version of jasmine but the runtime behavior is still the same and the typings should reflect that

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/2.6/introduction.html#section-Custom_asymmetric_equality_tester