### PR TITLE
feat(react-transition-group): types for v4.2 (SwitchTransition)

### DIFF
--- a/types/react-transition-group/SwitchTransition.d.ts
+++ b/types/react-transition-group/SwitchTransition.d.ts
@@ -6,21 +6,18 @@ export enum modes {
 }
 
 declare namespace SwitchTransition {
-
   interface SwitchTransitionProps {
     /**
      * Transition modes.
      * `out-in`: Current element transitions out first, then when complete, the new element transitions in.
      * `in-out: New element transitions in first, then when complete, the current element transitions out.`
-     *
-     * @type {'out-in'|'in-out'}
      */
-    mode?: modes.out | modes.in
+    mode?: modes.out | modes.in;
 
     /**
      * Any `Transition` or `CSSTransition` component
      */
-    children: React.ReactElement
+    children: React.ReactElement;
   }
 }
 

--- a/types/react-transition-group/SwitchTransition.d.ts
+++ b/types/react-transition-group/SwitchTransition.d.ts
@@ -1,0 +1,54 @@
+import { Component } from "react";
+
+export enum modes {
+  out = 'out-in',
+  in = 'in-out'
+}
+
+declare namespace SwitchTransition {
+
+  interface SwitchTransitionProps {
+    /**
+     * Transition modes.
+     * `out-in`: Current element transitions out first, then when complete, the new element transitions in.
+     * `in-out: New element transitions in first, then when complete, the current element transitions out.`
+     *
+     * @type {'out-in'|'in-out'}
+     */
+    mode?: modes.out | modes.in
+
+    /**
+     * Any `Transition` or `CSSTransition` component
+     */
+    children: React.ReactElement
+  }
+}
+
+/**
+ * A transition component inspired by the [vue transition modes](https://vuejs.org/v2/guide/transitions.html#Transition-Modes).
+ * You can use it when you want to control the render between state transitions.
+ * Based on the selected mode and the child's key which is the `Transition` or `CSSTransition` component, the `SwitchTransition` makes a consistent transition between them.
+ *
+ * If the `out-in` mode is selected, the `SwitchTransition` waits until the old child leaves and then inserts a new child.
+ * If the `in-out` mode is selected, the `SwitchTransition` inserts a new child first, waits for the new child to enter and then removes the old child
+ *
+ * ```jsx
+ * function App() {
+ *  const [state, setState] = useState(false);
+ *  return (
+ *    <SwitchTransition>
+ *      <FadeTransition key={state ? "Goodbye, world!" : "Hello, world!"}
+ *        addEndListener={(node, done) => node.addEventListener("transitionend", done, false)}
+ *        classNames='fade' >
+ *        <button onClick={() => setState(state => !state)}>
+ *          {state ? "Goodbye, world!" : "Hello, world!"}
+ *        </button>
+ *      </FadeTransition>
+ *    </SwitchTransition>
+ *  )
+ * }
+ * ```
+ */
+declare class SwitchTransition extends Component<SwitchTransition.SwitchTransitionProps> {}
+
+export default SwitchTransition;

--- a/types/react-transition-group/SwitchTransition.d.ts
+++ b/types/react-transition-group/SwitchTransition.d.ts
@@ -10,7 +10,7 @@ declare namespace SwitchTransition {
     /**
      * Transition modes.
      * `out-in`: Current element transitions out first, then when complete, the new element transitions in.
-     * `in-out: New element transitions in first, then when complete, the current element transitions out.`
+     * `in-out`: New element transitions in first, then when complete, the current element transitions out.
      */
     mode?: 'out-in' | 'in-out';
 

--- a/types/react-transition-group/SwitchTransition.d.ts
+++ b/types/react-transition-group/SwitchTransition.d.ts
@@ -12,7 +12,7 @@ declare namespace SwitchTransition {
      * `out-in`: Current element transitions out first, then when complete, the new element transitions in.
      * `in-out: New element transitions in first, then when complete, the current element transitions out.`
      */
-    mode?: modes.out | modes.in;
+    mode?: 'out-in' | 'in-out';
 
     /**
      * Any `Transition` or `CSSTransition` component

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-transition-group 2.9
+// Type definitions for react-transition-group 4.2.1
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 //                 Epskampie <https://github.com/Epskampie>
@@ -9,9 +9,11 @@
 import CSSTransition = require("./CSSTransition");
 import Transition from "./Transition";
 import TransitionGroup = require("./TransitionGroup");
+import SwitchTransition = require("./SwitchTransition");
 
 export {
     CSSTransition,
     Transition,
-    TransitionGroup
+    TransitionGroup,
+    SwitchTransition
 };

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-transition-group 4.2.1
+// Type definitions for react-transition-group 4.2
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 //                 Epskampie <https://github.com/Epskampie>

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import CSSTransition = require("react-transition-group/CSSTransition");
 import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from "react-transition-group/Transition";
 import TransitionGroup = require("react-transition-group/TransitionGroup");
-import SwitchTransition = require("react-transition-group/SwitchTransition");
+import SwitchTransition, { modes } from "react-transition-group/SwitchTransition";
 import Components = require("react-transition-group");
 
 interface ContainerProps {
@@ -39,93 +39,179 @@ const Test: React.StatelessComponent = () => {
     }
 
     return (
-        <TransitionGroup
-            component={Container}
-            theme="test"
-            className="animated-list"
-            childFactory={ (child: React.ReactElement) => child }
-        >
-            <Components.Transition
-                in
-                mountOnEnter
-                unmountOnExit
-                appear
-                enter
-                exit
-                timeout={ 500 }
-                addEndListener={ handleEndListener }
-                onEnter={ handleEnter }
-                onEntering={ handleEnter }
-                onEntered={ handleEnter }
-                onExit={ handleExit }
-                onExiting={ handleExit }
-                onExited={ handleExit }
+        <>
+            <SwitchTransition>
+                <Components.Transition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                >
+                    <div>{ "test" }</div>
+                </Components.Transition>
+            </SwitchTransition>
+
+            <SwitchTransition mode="in-out">
+                <Components.Transition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                >
+                    <div>{ "test" }</div>
+                </Components.Transition>
+            </SwitchTransition>
+
+            <SwitchTransition mode={modes.in}>
+                <Components.Transition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                >
+                    <div>{ "test" }</div>
+                </Components.Transition>
+            </SwitchTransition>
+
+            <SwitchTransition mode={modes.out}>
+                <Components.Transition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                >
+                    <div>{ "test" }</div>
+                </Components.Transition>
+            </SwitchTransition>
+
+            <TransitionGroup
+                component={Container}
+                theme="test"
+                className="animated-list"
+                childFactory={ (child: React.ReactElement) => child }
             >
-                <div>{ "test" }</div>
-            </Components.Transition>
-            <Components.Transition in timeout={500}>
-                {(status) => {
-                     switch (status) {
-                         case ENTERING:
-                         case ENTERED:
-                         case EXITING:
-                         case EXITED:
-                         case UNMOUNTED:
-                             return <div>{status}</div>;
-                     }
-                }}
-            </Components.Transition>
+                <Components.Transition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                >
+                    <div>{ "test" }</div>
+                </Components.Transition>
+                <Components.Transition in timeout={500}>
+                    {(status) => {
+                        switch (status) {
+                            case ENTERING:
+                            case ENTERED:
+                            case EXITING:
+                            case EXITED:
+                            case UNMOUNTED:
+                                return <div>{status}</div>;
+                        }
+                    }}
+                </Components.Transition>
 
-            <Components.Transition in timeout={500}>
-                {statusAsArgument}
-            </Components.Transition>
+                <Components.Transition in timeout={500}>
+                    {statusAsArgument}
+                </Components.Transition>
 
-            <Transition
-                timeout={ { enter : 500, exit : 500 } }
-            >
-                <div>{ "test" }</div>
-            </Transition>
+                <Transition
+                    timeout={ { enter : 500, exit : 500 } }
+                >
+                    <div>{ "test" }</div>
+                </Transition>
 
-            <Components.CSSTransition
-                in
-                mountOnEnter
-                unmountOnExit
-                appear
-                enter
-                exit
-                timeout={ 500 }
-                addEndListener={ handleEndListener }
-                onEnter={ handleEnter }
-                onEntering={ handleEnter }
-                onEntered={ handleEnter }
-                onExit={ handleExit }
-                onExiting={ handleExit }
-                onExited={ handleExit }
-                classNames="fade"
-            >
-                <div>{ "test" }</div>
-            </Components.CSSTransition>
+                <Components.CSSTransition
+                    in
+                    mountOnEnter
+                    unmountOnExit
+                    appear
+                    enter
+                    exit
+                    timeout={ 500 }
+                    addEndListener={ handleEndListener }
+                    onEnter={ handleEnter }
+                    onEntering={ handleEnter }
+                    onEntered={ handleEnter }
+                    onExit={ handleExit }
+                    onExiting={ handleExit }
+                    onExited={ handleExit }
+                    classNames="fade"
+                >
+                    <div>{ "test" }</div>
+                </Components.CSSTransition>
 
-            <CSSTransition
-                timeout={ { enter : 500, exit : 500 } }
-                classNames={ {
-                    appear: "fade-appear",
-                    appearActive: "fade-active-appear",
-                    appearDone: "fade-done-appear",
-                    enter: "fade-enter",
-                    enterActive: "fade-active-enter",
-                    enterDone: "fade-done-enter",
-                    exit: "fade-exit",
-                    exitActive: "fade-active-exit",
-                    exitDone: "fade-done-exit",
-                } }
-            >
-                <div>{ "test" }</div>
-            </CSSTransition>
+                <CSSTransition
+                    timeout={ { enter : 500, exit : 500 } }
+                    classNames={ {
+                        appear: "fade-appear",
+                        appearActive: "fade-active-appear",
+                        appearDone: "fade-done-appear",
+                        enter: "fade-enter",
+                        enterActive: "fade-active-enter",
+                        enterDone: "fade-done-enter",
+                        exit: "fade-exit",
+                        exitActive: "fade-active-exit",
+                        exitDone: "fade-done-exit",
+                    } }
+                >
+                    <div>{ "test" }</div>
+                </CSSTransition>
 
-            <CSSTransition timeout={ 100 }>
-                <div>{ "test" }</div>
-            </CSSTransition>
-        </TransitionGroup>
+                <CSSTransition timeout={ 100 }>
+                    <div>{ "test" }</div>
+                </CSSTransition>
+            </TransitionGroup>
+        </>
     );
 };

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import CSSTransition = require("react-transition-group/CSSTransition");
 import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from "react-transition-group/Transition";
 import TransitionGroup = require("react-transition-group/TransitionGroup");
+import SwitchTransition = require("react-transition-group/SwitchTransition");
 import Components = require("react-transition-group");
 
 interface ContainerProps {

--- a/types/react-transition-group/tsconfig.json
+++ b/types/react-transition-group/tsconfig.json
@@ -24,6 +24,7 @@
         "CSSTransition.d.ts",
         "Transition.d.ts",
         "TransitionGroup.d.ts",
+        "SwitchTransition.d.ts",
         "react-transition-group-tests.tsx"
     ]
 }


### PR DESCRIPTION
### Description
This adds the `<SwitchTransition />` component, and the `modes` export from `react-transition-group` to `@types/react-transition-group`: https://github.com/reactjs/react-transition-group/blob/master/src/SwitchTransition.js

This also bumps the version to `v4.2` to match: https://github.com/reactjs/react-transition-group/releases/tag/v4.2.0

Tests have been added to test that the `<SwitchTransition />` accepts the expected types.