### PR TITLE
[swagger-jsdoc] Allow typings to work with --esModuleInterop flag disabled

### DIFF
--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -3,16 +3,16 @@
 // Definitions by: Daniel Grove <https://github.com/drGrove>
 //                 Neil Bryson Cargamento <https://github.com/neilbryson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.2
 
 /* =================== USAGE ===================
 
     import * as express from 'express';
-    import swaggerJSDoc, { Options }  from 'swagger-jsdoc';
+    import * as swaggerJSDoc  from 'swagger-jsdoc';
 
     const app = express();
 
-    const options: Options = {
+    const options: swaggerJSDoc.Options = {
         swaggerDefinition: {
           info: {
             title: 'Hello World',
@@ -38,30 +38,38 @@
 
  =============================================== */
 
-export interface ApiInformation {
-    description?: string;
-    title: string;
-    version: string;
+/**
+ * Returns validated Swagger specification in JSON format.
+ */
+declare function swaggerJSDoc(options?: swaggerJSDoc.Options): object;
+
+declare namespace swaggerJSDoc {
+    interface ApiInformation {
+        description?: string;
+        title: string;
+        version: string;
+    }
+
+    interface ServerInformation {
+        url: string;
+        [key: string]: any;
+    }
+
+    interface SwaggerDefinition {
+        basePath?: string;
+        host?: string;
+        info: ApiInformation;
+        openapi?: string;
+        servers?: ReadonlyArray<ServerInformation>;
+        [key: string]: any;
+    }
+
+    interface Options {
+        apis?: ReadonlyArray<string>;
+        definition?: SwaggerDefinition;
+        swaggerDefinition?: SwaggerDefinition;
+        [key: string]: any;
+    }
 }
 
-export interface ServerInformation {
-    url: string;
-    [key: string]: any;
-}
-
-export interface SwaggerDefinition {
-    basePath?: string;
-    host?: string;
-    info: ApiInformation;
-    openapi?: string;
-    servers?: ReadonlyArray<ServerInformation>;
-    [key: string]: any;
-}
-
-export interface Options {
-    apis?: ReadonlyArray<string>;
-    swaggerDefinition: SwaggerDefinition;
-    [key: string]: any;
-}
-
-export default function swaggerJSDoc(options?: Options): any;
+export = swaggerJSDoc;

--- a/types/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/types/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -1,9 +1,9 @@
 import * as express from 'express';
-import swaggerJSDoc, { Options } from 'swagger-jsdoc';
+import * as swaggerJSDoc from 'swagger-jsdoc';
 
 const app = express();
 
-const options: Options = {
+const options: swaggerJSDoc.Options = {
     swaggerDefinition: {
         info: {
             title: 'A test api',


### PR DESCRIPTION
## Summary
* Allow typings to work with --esModuleInterop flag disabled
* Decreased minimum TypeScript version from 2.8 to 2.2
* Made `Options.swaggerDefinition` optional

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

