### PR TITLE
feat(prometheus-gc-stats): Add `config` argument types

### DIFF
--- a/types/prometheus-gc-stats/index.d.ts
+++ b/types/prometheus-gc-stats/index.d.ts
@@ -3,7 +3,13 @@
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare namespace prometheusGcStats {
+    interface Config {
+        prefix?: string;
+    }
+}
+
 // register is typeof require('prom-client').Registry which has its own .d.ts
-declare function gcStats(register: any): () => void;
+declare function gcStats(register: any, config?: prometheusGcStats.Config): () => void;
 
 export = gcStats;

--- a/types/prometheus-gc-stats/prometheus-gc-stats-tests.ts
+++ b/types/prometheus-gc-stats/prometheus-gc-stats-tests.ts
@@ -3,3 +3,9 @@ import gcStats = require('prometheus-gc-stats');
 const testFunc = gcStats('something');
 // $ExpectType void
 testFunc();
+
+const testFuncWithConfig = gcStats('something', {
+    prefix: 'prefix_',
+});
+// $ExpectType void
+testFuncWithConfig();


### PR DESCRIPTION
Add `config` argument types to [prometheus-gc-stats](https://github.com/SimenB/node-prometheus-gc-stats) package.

- Related commit: https://github.com/SimenB/node-prometheus-gc-stats/commit/32a4c3cf0292bc441e8f39d9c6dd7e3132c55b62
- Related Pull Reqeust (DefinitelyTyped): Ref #28477 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.