### PR TITLE
swagger-ui-dist additional typing

### DIFF
--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -1,22 +1,46 @@
 // Type definitions for swagger-ui-dist 3.x
 // Project: https://github.com/swagger-api/swagger-ui#readme
 // Definitions by: Haowen <https://github.com/haowen737>
+//                 Bryce <https://github.com/brycematheson1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/* =================== USAGE ===================
 
-    import * as SwaggerUIDist from "swagger-ui-dist"
-    const swaggerUiAssetPath = SwaggerUIDist.getAbsoluteFSPath()
-
- =============================================== */
-
-export as namespace SwaggerUIDist;
-
-/**
- * get an absolute path to swagger ui for static file serving
- */
-export function getAbsoluteFSPath(): string;
-export function absolutePath(): string;
-
-export const SwaggerUIBundle: any;
-export const SwaggerUIStandalonePreset: any;
+declare module 'swagger-ui-dist' {
+    /**
+     * get an absolute path to swagger ui for static file serving
+     */
+    export function getAbsoluteFSPath(): string;
+    export function absolutePath(): string;
+  
+    export interface SwaggerUIBundle {
+      (a: {
+        deepLinking: boolean;
+        dom_id: string;
+        presets: any[];
+        plugins: any;
+        urls: { name: string; url: string; }[];
+        layout: string;
+      }): any;
+      presets: any;
+      plugins: any;
+      [k: string]: any;
+  
+      getConfigs(): SwaggerConfigs;
+    }
+  
+    export const SwaggerUIBundle: SwaggerUIBundle;
+  
+    interface SwaggerConfigs {
+      requestInterceptor: ((request: SwaggerRequest) => request);
+      [k: string]: any;
+    }
+  
+    export interface SwaggerRequest {
+      url: string;
+      credentials: string;
+      [k: string]: any;
+    }
+  
+    export const SwaggerUIStandalonePreset: any;
+  }
+  

--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -4,43 +4,42 @@
 //                 Bryce <https://github.com/brycematheson1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export {};
+export as namespace SwaggerUIDist;
 
-declare module 'swagger-ui-dist' {
-    /**
-     * get an absolute path to swagger ui for static file serving
-     */
-    export function getAbsoluteFSPath(): string;
-    export function absolutePath(): string;
-  
-    export interface SwaggerUIBundle {
-      (a: {
-        deepLinking: boolean;
-        dom_id: string;
-        presets: any[];
-        plugins: any;
-        urls: { name: string; url: string; }[];
-        layout: string;
-      }): any;
-      presets: any;
-      plugins: any;
-      [k: string]: any;
-  
-      getConfigs(): SwaggerConfigs;
-    }
-  
-    export const SwaggerUIBundle: SwaggerUIBundle;
-  
-    interface SwaggerConfigs {
-      requestInterceptor: ((request: SwaggerRequest) => request);
-      [k: string]: any;
-    }
-  
-    export interface SwaggerRequest {
-      url: string;
-      credentials: string;
-      [k: string]: any;
-    }
-  
-    export const SwaggerUIStandalonePreset: any;
-  }
-  
+/**
+ * get an absolute path to swagger ui for static file serving
+ */
+export function getAbsoluteFSPath(): string;
+export function absolutePath(): string;
+
+interface SwaggerUIBundle {
+  (a: {
+    deepLinking: boolean;
+    dom_id: string;
+    presets: any[];
+    plugins: any;
+    urls: Array<[string, string]>;
+    layout: string;
+  }): any;
+  presets: any;
+  plugins: any;
+  [k: string]: any;
+
+  getConfigs(): SwaggerConfigs;
+}
+
+export const SwaggerUIBundle: SwaggerUIBundle;
+
+interface SwaggerConfigs {
+  requestInterceptor: ((request: SwaggerRequest) => SwaggerRequest);
+  [k: string]: any;
+}
+
+interface SwaggerRequest {
+  url: string;
+  credentials: string;
+  [k: string]: any;
+}
+
+export const SwaggerUIStandalonePreset: any;

--- a/types/swagger-ui-dist/swagger-ui-dist-tests.ts
+++ b/types/swagger-ui-dist/swagger-ui-dist-tests.ts
@@ -1,4 +1,10 @@
-import * as SwaggerUIDist from "swagger-ui-dist";
+import {
+    SwaggerRequest,
+    SwaggerUIBundle,
+    SwaggerUIStandalonePreset,
+    absolutePath,
+    getAbsoluteFSPath,
+} from 'swagger-ui-dist';
 
-SwaggerUIDist.getAbsoluteFSPath(); // $ExpectType string
-SwaggerUIDist.absolutePath(); // $ExpectType string
+getAbsoluteFSPath(); // $ExpectType string
+absolutePath(); // $ExpectType string

--- a/types/swagger-ui-dist/swagger-ui-dist-tests.ts
+++ b/types/swagger-ui-dist/swagger-ui-dist-tests.ts
@@ -1,10 +1,4 @@
-import {
-    SwaggerRequest,
-    SwaggerUIBundle,
-    SwaggerUIStandalonePreset,
-    absolutePath,
-    getAbsoluteFSPath,
-} from 'swagger-ui-dist';
+import * as SwaggerUIDist from "swagger-ui-dist";
 
-getAbsoluteFSPath(); // $ExpectType string
-absolutePath(); // $ExpectType string
+SwaggerUIDist.getAbsoluteFSPath(); // $ExpectType string
+SwaggerUIDist.absolutePath(); // $ExpectType string


### PR DESCRIPTION
Extended the fairly barebones typing of `swagger-ui-dist`. This is far from a full typing of `swagger-ui-dist` but is much more complete than it was before, and has `[k: string]: any;` sprinkled throughout definitions to account for the definitions that are still not in there. 