### PR TITLE
(@hapi/nes) fix: add reauthenticate method

### DIFF
--- a/types/hapi__nes/lib/client.d.ts
+++ b/types/hapi__nes/lib/client.d.ts
@@ -22,7 +22,7 @@ declare class Client {
     unsubscribe(path: string, handler?: Client.Handler): Promise<any>;
     subscriptions(): string[];
     overrideReconnectionAuth(auth: any): void;
-    reauthenticate(auth: any): Promise<any>;
+    reauthenticate(auth: any): Promise<true>;
 }
 
 declare namespace Client {

--- a/types/hapi__nes/lib/client.d.ts
+++ b/types/hapi__nes/lib/client.d.ts
@@ -22,6 +22,7 @@ declare class Client {
     unsubscribe(path: string, handler?: Client.Handler): Promise<any>;
     subscriptions(): string[];
     overrideReconnectionAuth(auth: any): void;
+    reauthenticate(auth: any): Promise<any>;
 }
 
 declare namespace Client {

--- a/types/hapi__nes/test/route-authentication-client.ts
+++ b/types/hapi__nes/test/route-authentication-client.ts
@@ -15,5 +15,8 @@ import NesClient = require('@hapi/nes/lib/client');
 var client = new NesClient.Client('ws://localhost');
 client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
+    return client.reauthenticate({ headers: { authorization: 'Bearer am9objpzZWNyZXQ=' } });
+}).then(() => {
+
     return client.request('hello');
 });


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/nes/blob/master/API.md#await-clientreauthenticateauth
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
