### PR TITLE
[googlepay] Add INTERAC in AllowedCardNetwork

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -1,4 +1,4 @@
-const allowedCardNetworks = new Array<google.payments.api.AllowedCardNetwork>('AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA');
+const allowedCardNetworks = new Array<google.payments.api.AllowedCardNetwork>('AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA', 'INTERAC');
 
 const allowedPaymentMethods = new Array<google.payments.api.PaymentMethod>({
     type: 'CARD',

--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -1,4 +1,11 @@
-const allowedCardNetworks = new Array<google.payments.api.AllowedCardNetwork>('AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA', 'INTERAC');
+const allowedCardNetworks = new Array<google.payments.api.AllowedCardNetwork>(
+    'AMEX',
+    'DISCOVER',
+    'JCB',
+    'MASTERCARD',
+    'VISA',
+    'INTERAC'
+);
 
 const allowedPaymentMethods = new Array<google.payments.api.PaymentMethod>({
     type: 'CARD',

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Florian Luccioni <https://github.com/Fluccioni>,
 //                 Radu Raicea <https://github.com/Radu-Raicea>,
 //                 Filip Stanis <https://github.com/fstanis>
+//                 Alexandre Couret <https://github.com/ozotek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace google.payments.api {
@@ -72,7 +73,7 @@ declare namespace google.payments.api {
     }
 
     type AllowedAuthMethod = 'PAN_ONLY' | 'CRYPTOGRAM_3DS';
-    type AllowedCardNetwork = 'AMEX' | 'DISCOVER' | 'JCB' | 'MASTERCARD' | 'VISA';
+    type AllowedCardNetwork = 'AMEX' | 'DISCOVER' | 'JCB' | 'MASTERCARD' | 'VISA' | 'INTERAC';
 
     interface CardParameters {
         allowedAuthMethods: AllowedAuthMethod[];


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/pay/api/web/guides/tutorial#supported-card-networks

Interac (a Canadian debit card network) was just released for Google Pay, as we can see from this [documentation](https://developers.google.com/pay/api/web/guides/tutorial#supported-card-networks) and this [article](https://www.interac.ca/en/googlepay.html).
This PR just adds the network in the `AllowedCardNetwork` type.