### PR TITLE
node-forge: Fix typings of ed25519 module

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -75,10 +75,6 @@ declare module "node-forge" {
         }
         var oids: oids;
 
-        namespace ed25519 {
-            type Key = ArrayBuffer;
-        }
-
         namespace rsa {
             type EncryptionScheme = 'RSAES-PKCS1-V1_5' | 'RSA-OAEP' | 'RAW' | 'NONE' | null;
             type SignatureScheme = 'RSASSA-PKCS1-V1_5' | pss.PSS | 'NONE' | null;
@@ -125,8 +121,18 @@ declare module "node-forge" {
         }
 
         namespace ed25519 {
-
             type NativeBuffer = Buffer | Uint8Array;
+            type Key = NativeBuffer;
+
+            type ToNativeBufferParameters = {
+                message: NativeBuffer | util.ByteBuffer
+            } | {
+                message: string;
+                encoding: 'binary' | 'utf8';
+            };
+
+            // `string`s will be converted by toNativeBuffer with `encoding: 'binary'`
+            type BinaryBuffer = NativeBuffer | util.ByteBuffer | string;
 
             namespace constants {
                 const PUBLIC_KEY_BYTE_LENGTH = 32;
@@ -136,24 +142,21 @@ declare module "node-forge" {
                 const HASH_BYTE_LENGTH = 64;
             }
 
-            function generateKeyPair(options?: { seed?: Buffer | Uint8Array | string }): {
+            // generateKeyPair does not currently accept `util.ByteBuffer` as the seed.
+            function generateKeyPair(options?: { seed?: NativeBuffer | string }): {
                 publicKey: NativeBuffer;
                 privateKey: NativeBuffer;
             };
 
-            function publicKeyFromPrivateKey(options: { privateKey: NativeBuffer }): NativeBuffer;
+            function publicKeyFromPrivateKey(options: { privateKey: BinaryBuffer }): NativeBuffer;
 
-            function sign(options: {
-                message: string,
-                encoding: string,
-                privateKey: NativeBuffer
+            function sign(options: ToNativeBufferParameters & {
+                privateKey: BinaryBuffer
             }): NativeBuffer;
 
-            function verify(options: {
-                message: string,
-                encoding: string,
-                signature: Buffer | Uint8Array | util.ByteBuffer | string,
-                publicKey: NativeBuffer
+            function verify(options: ToNativeBufferParameters & {
+                signature: BinaryBuffer,
+                publicKey: BinaryBuffer
             }): boolean;
         }
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -364,3 +364,19 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     console.log('created TLS client and server, doing handshake...');
     client.handshake();
 }
+
+{
+    const { privateKey } = forge.pki.ed25519.generateKeyPair();
+    const toSign = Buffer.from('test', 'utf8');
+    forge.pki.ed25519.sign({
+        message: toSign,
+        privateKey
+    });
+    
+    const toSign2 = 'foo';
+    forge.pki.ed25519.sign({
+        message: toSign2,
+        encoding: 'utf8',
+        privateKey
+    });
+}


### PR DESCRIPTION
This change makes the functions actually accept what they are documented
to accept based on the error messages. Specifically this allows to pass
node.js `Buffer`s to `sign` / `verify`, instead of needing to convert them
to a `string`, just for forge to convert them back to a `NativeBuffer`
internally.

This also fixes the type for `ed25519.Key`. `ArrayBuffer` does not appear
in forge's source code at all. Instead all functions accept something
containing bytes (i.e. the new `BinaryBuffer` alias) and return a
`NativeBuffer`. I opted to alias `Key` to `NativeBuffer`, because that's
what is being returned by `publicKeyFromPrivateKey` and `generateKeyPair`,
it's a subset of `BinaryBuffer` and does not cause `forge.pki.Key` (which
is the union of RSA and ed25519 keys) to become a kitchen sink type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge/blob/master/lib/ed25519.js, specifically: https://github.com/digitalbazaar/forge/blob/7e833b918c10c84494285c082a22e011fde86932/lib/ed25519.js#L175-L178 + all the calls to `messageToNativeBuffer` in the other functions.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.