### PR TITLE
node-forge: Fix type of `pki.rsa.setPublicKey()`

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -118,7 +118,7 @@ declare module "node-forge" {
                 algorithm?: string;
             }
 
-            function setPublicKey(n: any, e: any): any;
+            function setPublicKey(n: jsbn.BigInteger, e: jsbn.BigInteger): PublicKey;
 
             function generateKeyPair(bits?: number, e?: number, callback?: (err: Error, keypair: KeyPair) => void): KeyPair;
             function generateKeyPair(options?: GenerateKeyPairOptions, callback?: (err: Error, keypair: KeyPair) => void): KeyPair;
@@ -311,7 +311,7 @@ declare module "node-forge" {
 
         function publicKeyToRSAPublicKey(publicKey: PublicKey): any;
 
-        function setRsaPublicKey(n: jsbn.BigInteger, e: jsbn.BigInteger): PublicKey;
+        type setRsaPublicKey = typeof rsa.setPublicKey;
 
         function wrapRsaPrivateKey(privateKey: asn1.Asn1): asn1.Asn1;
     }

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -1,6 +1,7 @@
 import * as forge from 'node-forge';
 
 let keypair = forge.pki.rsa.generateKeyPair({ bits: 512 });
+forge.pki.rsa.setPublicKey(keypair.privateKey.n, keypair.privateKey.e);
 let privateKeyPem = forge.pki.privateKeyToPem(keypair.privateKey);
 let publicKeyPem = forge.pki.publicKeyToPem(keypair.publicKey);
 let key = forge.pki.decryptRsaPrivateKey(privateKeyPem);


### PR DESCRIPTION
- Replace the `any`s by proper types.
- Return an `pki.rsa.PublicKey` instead of `pki.PublicKey` to be
  more specific (the latter also allows ed25519).
- Make `pki.setRsaPublicKey` an alias of `rsa.setPublicKey`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: I believe this change is “obviously” correct, but: https://github.com/digitalbazaar/forge/blob/7e833b918c10c84494285c082a22e011fde86932/lib/rsa.js#L1006-L1014 and https://github.com/digitalbazaar/forge/blob/7e833b918c10c84494285c082a22e011fde86932/lib/rsa.js#L1721
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.