### PR TITLE
Add options argument to fs-extra.readdir

### DIFF
--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -14,6 +14,7 @@
 
 import * as fs from "fs";
 import Stats = fs.Stats;
+import Dirent = fs.Dirent;
 
 export * from "fs";
 
@@ -190,7 +191,13 @@ export function readFile(file: string | Buffer | number, encoding: string): Prom
 export function readFile(file: string | Buffer | number): Promise<Buffer>;
 
 export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+export function readdir(path: string | Buffer, options: { encoding?: string, withFileTypes?: false }, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+export function readdir(path: string | Buffer, options: { encoding: 'buffer', withFileTypes?: false }, callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
+export function readdir(path: string | Buffer, options: { encoding?: string, withFileTypes: true }, callback: (err: NodeJS.ErrnoException, files: Dirent[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
+export function readdir(path: string | Buffer, options: { encoding?: string, withFileTypes?: false }): Promise<string[]>;
+export function readdir(path: string | Buffer, options: { encoding: 'buffer', withFileTypes?: false }): Promise<Buffer[]>;
+export function readdir(path: string | Buffer, options: { encoding?: string, withFileTypes: true }): Promise<Dirent[]>;
 
 export function readlink(path: string | Buffer, callback: (err: NodeJS.ErrnoException, linkString: string) => any): void;
 export function readlink(path: string | Buffer): Promise<string>;


### PR DESCRIPTION
This is documented here: https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.