### PR TITLE
redux-first-router: Make individual Query params optional

### DIFF
--- a/types/redux-first-router-restore-scroll/index.d.ts
+++ b/types/redux-first-router-restore-scroll/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/faceyspacey/redux-first-router-restore-scroll#readme
 // Definitions by: icopp <https://github.com/icopp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import { History, Location } from 'history';
 import { LocationState } from 'redux-first-router';

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -8,8 +8,9 @@
 //                 surgeboris <https://github.com/surgeboris>
 //                 geirsagberg <https://github.com/geirsagberg>
 //                 Harry Hedger <https://github.com/hedgerh>
+//                 Adam Rich <https://github.com/adam1658>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import {
     Dispatch,
@@ -298,7 +299,7 @@ export interface Options<TKeys = {}, TState = any> {
 }
 
 export interface Query {
-    [key: string]: string;
+    [key: string]: string | undefined;
 }
 
 export interface Params {


### PR DESCRIPTION
URL Query parameters are naturally optional - a user could navigate to one of your URLs without providing any parameters, or different parameters to what you expect. eg: you expect `query` to be `{a?: string, b?: string}`, and the user navigates to `/url?a=test` (b is missing).

My route actions include a query payload of type `{a?: string, b?: string}` to reflect this reality, but this is not assignable to redux-first-router's `interface Query = {[key: string]: string}` (added in #35500).
I'd like to change the definition to `interface Query = {[key: string]: string | undefined}` to support this use case.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> **See description above**
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
