### PR TITLE
 fix: remove the requirement for turning on the 'esModuleInterop' flag

### DIFF
--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -7,3 +7,4 @@
 export = isUrl
 
 declare const isUrl: (string: string) => boolean;
+// declare function isUrl(str: string): boolean;

--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -6,4 +6,4 @@
 
 export = isUrl
 
-declare function isUrl(string: string): boolean;
+declare const isUrl: (string: string) => boolean;

--- a/types/is-url/is-url-tests.ts
+++ b/types/is-url/is-url-tests.ts
@@ -1,4 +1,3 @@
-
 import isUrl = require('is-url');
 
 var isValid0: boolean = isUrl('https://github.com/segmentio/is-url');

--- a/types/is-url/is-url-tests.ts
+++ b/types/is-url/is-url-tests.ts
@@ -1,4 +1,4 @@
-import isUrl = require('is-url');
+import * as isUrl from 'is-url';
 
 var isValid0: boolean = isUrl('https://github.com/segmentio/is-url');
 var isValid1: boolean = isUrl('hogepiyo');


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
If the `function` is declared, an error message will popup require to turn on a flag:
![image](https://user-images.githubusercontent.com/10626756/61765360-179f1980-ae20-11e9-9b74-ad6f58dd39d4.png)
