### PR TITLE
feat(toposort): second element of array can be undefined

### DIFF
--- a/types/toposort/index.d.ts
+++ b/types/toposort/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for toposort 2.0
 // Project: https://github.com/marcelklehr/toposort
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+//                 Prokop Simek <https://github.com/prokopsimek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function toposort(graph: ReadonlyArray<[string, string]>): ReadonlyArray<string>;
+declare function toposort(graph: Array<[string, string | undefined]>): string[];
 export = toposort;

--- a/types/toposort/toposort-tests.ts
+++ b/types/toposort/toposort-tests.ts
@@ -1,10 +1,11 @@
 import toposort = require('toposort');
 
-const testGraph: ReadonlyArray<[string, string]> = [
-    ["string1", "string2"],
-    ["string2", "string3"],
-    ["string3", "string1"]
+const testGraph: Array<[string, string | undefined]> = [
+    ['string1', 'string2'],
+    ['string2', 'string3'],
+    ['string3', 'string1'],
+    ['string4', undefined],
 ];
 
-// $ExpectType ReadonlyArray<string>
+// $ExpectType string[]
 toposort(testGraph);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/marcelklehr/toposort/blob/master/index.js#L83 (It doesn't matter if the edge is empty string or undefined. Toposort returns empty string even the undefined in the tree so you have to wrap it e.g. in `_.compact(...)` to filter out undefined and it's much worse filter out empty string.)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~