### PR TITLE
[@types/redux-orm] fix: static Model method issues

### DIFF
--- a/types/redux-orm/Model.d.ts
+++ b/types/redux-orm/Model.d.ts
@@ -1,8 +1,8 @@
 import { ModelTableOpts, TableOpts } from './db';
 import { IdAttribute } from './db/Table';
 import { AttributeWithDefault, FieldSpecMap, ForeignKey, ManyToMany, OneToOne } from './fields';
-import { Optional, OptionalKeys, Overwrite, PickByValue } from './helpers';
-import QuerySet, { LookupSpec, MutableQuerySet, SortIteratee, SortOrder } from './QuerySet';
+import { KnownKeys, OptionalKeys, PickByValue } from './helpers';
+import QuerySet, { MutableQuerySet } from './QuerySet';
 import { OrmSession } from './Session';
 
 /**
@@ -20,13 +20,6 @@ export type Serializable =
     | {
           [K: string]: Serializable | Serializable[];
       };
-
-/**
- * Object restricted to serializable properties only
- */
-export interface SerializableMap {
-    [K: string]: Serializable | Serializable[];
-}
 
 /**
  * A union of supported model field types
@@ -51,7 +44,7 @@ export interface ModelFieldMap {
  *
  * Either a primitive type matching Model's identifier type or an object implementing a `{ getId(): IdType<M> }` interface
  */
-export type IdOrModelLike<M extends Model> = IdType<M> | {getId(): IdType<M>; };
+export type IdOrModelLike<M extends Model> = IdType<M> | { getId(): IdType<M> };
 
 /**
  * The heart of an ORM, the data model.
@@ -176,9 +169,7 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
      * @throws {Error} If more than one entity matches the properties in `lookupObj`.
      * @return a {@link SessionBoundModel} instance that matches the properties in `lookupObj`.
      */
-    static get<M extends AnyModel, TProps extends LookupSpec<M>>(
-        lookupObj: TProps
-    ): SessionBoundModel<M, TProps> | null;
+    static get<M extends AnyModel>(lookupObj: QuerySet.LookupSpec<M>): SessionBoundModel<M> | null;
 
     /**
      * Returns a {@link Model} instance for the object with id `id`.
@@ -233,7 +224,7 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
     /**
      * @see {@link QuerySet.all}
      */
-    static all<M extends AnyModel>(this: ModelType<M>): QuerySet<M>;
+    static all(): QuerySet;
 
     /**
      * @see {@link QuerySet.at}
@@ -258,17 +249,20 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
     /**
      * @see {@link QuerySet.filter}
      */
-    static filter(props: LookupSpec<Model>): QuerySet;
+    static filter(props: QuerySet.LookupSpec<Model>): QuerySet;
 
     /**
      * @see {@link QuerySet.exclude}
      */
-    static exclude(props: LookupSpec<Model>): QuerySet;
+    static exclude(props: QuerySet.LookupSpec<Model>): QuerySet;
 
     /**
      * @see {@link QuerySet.orderBy}
      */
-    static orderBy(iteratees: ReadonlyArray<SortIteratee<Model>>, orders?: ReadonlyArray<SortOrder>): QuerySet;
+    static orderBy(
+        iteratees: ReadonlyArray<QuerySet.SortIteratee<Model>>,
+        orders?: ReadonlyArray<QuerySet.SortOrder>
+    ): QuerySet;
 
     /**
      * @see {@link QuerySet.count}
@@ -276,9 +270,13 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
     static count(): number;
 
     /**
-     * @see {@link QuerySet.exists}
+     * Returns a boolean indicating if an entity
+     * with the given props exists in the state.
+     *
+     * @param  props - a key-value that {@link Model} instances should have to be considered as existing.
+     * @return a boolean indicating if entity with `props` exists in the state
      */
-    static exists(): boolean;
+    static exists(props: Partial<Ref<Model>>): boolean;
 
     /**
      * @see {@link QuerySet.delete}
@@ -298,7 +296,7 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
      * Gets the id value of the current instance by looking up the id attribute.
      * @return The id value of the current instance.
      */
-    getId<Id extends Fields[IdAttribute<MClass>] = Fields[IdAttribute<MClass>]>(): Id extends undefined ? number: Id;
+    getId<Id extends Fields[IdAttribute<MClass>] = Fields[IdAttribute<MClass>]>(): Id extends undefined ? number : Id;
 
     /**
      * @return A string representation of this {@link Model} instance.
@@ -354,14 +352,6 @@ export default class Model<MClass extends typeof AnyModel = typeof AnyModel, Fie
 export class AnyModel extends Model {}
 
 /**
- * {@link Model#upsert} argument type
- *
- * Relations can be provided in a flexible manner for both many-to-many and foreign key associations
- * @see {@link IdOrModelLike}
- */
-export type UpsertProps<M extends Model> = Overwrite<Partial<CreateProps<M>>, {[K in IdKey<M>]-?: IdType<M>}>;
-
-/**
  * {@link Model#update} argument type
  *
  * All properties are optional.
@@ -369,14 +359,13 @@ export type UpsertProps<M extends Model> = Overwrite<Partial<CreateProps<M>>, {[
  * Relations can be provided in a flexible manner for both many-to-many and foreign key associations
  * @see {@link IdOrModelLike}
  */
-export type UpdateProps<M extends Model> = Omit<UpsertProps<M>, IdKey<M>>;
 
 /**
  * @internal
  */
-export type CustomInstanceProps<M extends AnyModel, Props extends object> = PickByValue<
-    Omit<Props, Extract<keyof Props, keyof ModelFields<M>>>,
-    Serializable
+export type CustomInstanceProps<M extends AnyModel, Props extends object> = Omit<
+    Props,
+    Extract<keyof Props, KnownKeys<ModelBlueprint<M>>>
 >;
 
 /**
@@ -403,7 +392,7 @@ export type IdType<M extends Model> = IdKey<M> extends infer U
  * Type of {@link Model.ref} / database entry for a particular Model type
  */
 export type Ref<M extends AnyModel> = {
-    [K in keyof RefFields<M>]: ModelFields<M>[K] extends AnyModel ? IdType<ModelFields<M>[K]> : RefFields<M>[K]
+    [K in keyof RefFields<M>]: ModelFields<M>[K] extends AnyModel ? IdType<ModelFields<M>[K]> : RefFields<M>[K];
 };
 
 /**
@@ -425,7 +414,7 @@ export type RefPropOrSimple<M extends AnyModel, K extends string> = K extends ke
  */
 export type SessionBoundModel<M extends Model = any, InstanceProps extends object = {}> = M &
     { [K in keyof ModelFields<M>]: SessionBoundModelField<M, K> } &
-    CustomInstanceProps<M, InstanceProps>;
+    InstanceProps;
 
 /**
  * Static side of a particular {@link Model} with member signatures narrowed to provided {@link Model} type
@@ -434,9 +423,7 @@ export type SessionBoundModel<M extends Model = any, InstanceProps extends objec
  *
  * @inheritDoc
  */
-export interface ModelType<M extends AnyModel> extends QuerySet<M> {
-    new (props: ModelFields<M>): SessionBoundModel<M>;
-
+export interface ModelType<M extends AnyModel> extends QuerySet.QueryBuilder<M> {
     options: ModelTableOpts<ModelClass<M>>;
 
     modelName: ModelClass<M>['modelName'];
@@ -449,6 +436,11 @@ export interface ModelType<M extends AnyModel> extends QuerySet<M> {
     idExists(id: IdType<M>): boolean;
 
     /**
+     * @see {@link Model#exists}
+     */
+    exists(props: QuerySet.LookupProps<M>): boolean;
+
+    /**
      * @see {@link Model#withId}
      */
     withId(id: IdType<M>): SessionBoundModel<M> | null;
@@ -456,17 +448,22 @@ export interface ModelType<M extends AnyModel> extends QuerySet<M> {
     /**
      * @see {@link Model#get}
      */
-    get<TLookup extends LookupSpec<M>>(lookupSpec: TLookup): SessionBoundModel<M, TLookup> | null;
+    get(lookupSpec: QuerySet.LookupSpec<M>): SessionBoundModel<M> | null;
 
     /**
      * @see {@link Model#create}
      */
-    create<TProps extends CreateProps<M>>(props: TProps): SessionBoundModel<M, TProps>;
+    create<T extends CreateProps<M>>(props: T): SessionBoundModel<M, CustomInstanceProps<M, T>>;
 
     /**
      * @see {@link Model#upsert}
      */
-    upsert<TProps extends UpsertProps<M>>(props: TProps): SessionBoundModel<M, TProps>;
+    upsert<T extends UpsertProps<M>>(props: T): SessionBoundModel<M, CustomInstanceProps<M, T>>;
+
+    /**
+     * @see {@link QuerySet.update}
+     */
+    update(props: UpdateProps<M>): void;
 }
 
 /**
@@ -486,7 +483,10 @@ export type ModelFields<M extends Model> = ConstructorParameters<ModelClass<M>> 
 /**
  * @internal
  */
-export type FieldSpecKeys<M extends AnyModel, TField> = keyof PickByValue<ModelClass<M>['fields'], TField>;
+export type FieldSpecKeys<M extends AnyModel, TField> = Extract<
+    keyof ModelFields<M>,
+    keyof PickByValue<ModelClass<M>['fields'], TField>
+>;
 
 /**
  * @internal
@@ -512,27 +512,44 @@ export type SessionBoundModelField<M extends AnyModel, K extends keyof ModelFiel
  * @see {@link IdOrModelLike}
  */
 
-export type CreateProps<
-    M extends AnyModel,
-    RFields extends Required<ModelFields<M>> = Required<ModelFields<M>>
-> = Optional<
-    {
-        [K in keyof ModelFields<M>]: {
-            [P in K]: RFields[P] extends MutableQuerySet<infer RM>
-                ? ReadonlyArray<IdOrModelLike<RM>>
-                : (RFields[P] extends QuerySet
-                      ? never
-                      : RFields[P] extends AnyModel
-                      ? (P extends FieldSpecKeys<M, OneToOne | ForeignKey> ? IdOrModelLike<RFields[P]> : never)
-                      : RFields[P])
-        }[K]
-    },
-    OptionalCreatePropsKeys<M>
+export type ModelBlueprint<M extends AnyModel, Fields extends Required<ModelFields<M>> = Required<ModelFields<M>>> = {
+    [K in keyof Fields]: Fields[K] extends AnyModel
+        ? IdOrModelLike<Fields[K]>
+        : Fields[K] extends MutableQuerySet<infer RM>
+        ? ReadonlyArray<IdOrModelLike<RM>>
+        : Fields[K];
+};
+
+export type NonBlueprintKeys<M extends AnyModel> = Exclude<
+    keyof PickByValue<Required<ModelFields<M>>, AnyModel | QuerySet>,
+    FieldSpecKeys<M, OneToOne | ForeignKey> | keyof PickByValue<Required<ModelFields<M>>, MutableQuerySet>
 >;
 
-/**
- * @internal
- */
-export type OptionalCreatePropsKeys<M extends Model> = IdType<M> extends number
-    ? (IdKey<M> | OptionalKeys<ModelFields<M>> | FieldSpecKeys<M, AttributeWithDefault>)
-    : (OptionalKeys<ModelFields<M>> | FieldSpecKeys<M, AttributeWithDefault>);
+export type BlueprintProps<
+    M extends AnyModel,
+    ReqKeys extends keyof ModelBlueprint<M>,
+    OptKeys extends keyof ModelBlueprint<M>
+> = {
+    [K in ReqKeys]-?: K extends NonBlueprintKeys<M> ? never : ModelBlueprint<M>[K];
+} &
+    {
+        [K in OptKeys]+?: K extends NonBlueprintKeys<M> ? never : ModelBlueprint<M>[K];
+    };
+
+export type IdKeyOpt<M extends AnyModel> = IdType<M> extends number ? IdKey<M> : never;
+
+export type CreateProps<
+    M extends AnyModel,
+    Fields extends ModelFields<M> = ModelFields<M>,
+    MQsKeys extends keyof PickByValue<Fields, MutableQuerySet> = keyof PickByValue<Fields, MutableQuerySet>,
+    OptAttrKeys extends FieldSpecKeys<M, AttributeWithDefault> = FieldSpecKeys<M, AttributeWithDefault>,
+    OptKeys extends MQsKeys | OptionalKeys<Fields> | OptAttrKeys | IdKeyOpt<M> =
+        | MQsKeys
+        | OptionalKeys<Fields>
+        | OptAttrKeys
+        | IdKeyOpt<M>
+> = BlueprintProps<M, Exclude<keyof Fields, OptKeys>, OptKeys>;
+
+export type UpsertProps<M extends AnyModel> = BlueprintProps<M, IdKey<M>, Exclude<keyof ModelBlueprint<M>, IdKey<M>>>;
+
+export type UpdateProps<M extends AnyModel> = BlueprintProps<M, never, Exclude<keyof ModelBlueprint<M>, IdKey<M>>>;

--- a/types/redux-orm/QuerySet.d.ts
+++ b/types/redux-orm/QuerySet.d.ts
@@ -1,61 +1,5 @@
 import { QueryClause } from './db';
-import Model, {
-    AnyModel,
-    CustomInstanceProps,
-    IdOrModelLike,
-    ModelClass,
-    Ref,
-    SessionBoundModel,
-    UpdateProps
-} from './Model';
-
-/**
- * Optional ordering direction.
- *
- * {@see QuerySet.orderBy}
- */
-export type SortOrder = 'asc' | 'desc' | true | false;
-
-/**
- * Ordering clause.
- *
- * Either a key of SessionBoundModel or a evaluator function accepting plain object Model representation stored in the database.
- *
- * {@see QuerySet.orderBy}
- */
-export type SortIteratee<M extends Model> = keyof Ref<M> | { (row: Ref<M>): any };
-
-/**
- * Lookup clause as an object specifying props to match with plain object Model representation stored in the database.
- * {@see QuerySet.exclude}
- * {@see QuerySet.filter}
- */
-export type LookupProps<M extends Model> = Partial<Ref<M>>;
-
-/**
- * Lookup clause as predicate accepting plain object Model representation stored in the database.
- * {@see QuerySet.exclude}
- * {@see QuerySet.filter}
- */
-export type LookupPredicate<M extends Model> = (row: Ref<M>) => boolean;
-
-/**
- * A union of lookup clauses.
- * {@see QuerySet.exclude}
- * {@see QuerySet.filter}
- */
-export type LookupSpec<M extends Model> = LookupProps<M> | LookupPredicate<M>;
-
-/**
- * A lookup query result.
- *
- * May contain additional properties in case {@link LookupProps} clause had been supplied.
- * {@see QuerySet.exclude}
- * {@see QuerySet.filter}
- */
-export type LookupResult<M extends Model, TLookup extends LookupSpec<M>> = TLookup extends LookupPredicate<M>
-    ? QuerySet<M>
-    : QuerySet<M, CustomInstanceProps<M, LookupProps<M>>>;
+import Model, { AnyModel, IdType, ModelClass, Ref, Serializable, SessionBoundModel, UpdateProps } from './Model';
 
 /**
  * <p>
@@ -82,8 +26,11 @@ export type LookupResult<M extends Model, TLookup extends LookupSpec<M>> = TLook
  *
  * @template M type of {@link Model} instances returned by QuerySet's methods.
  * @template InstanceProps additional properties available on QuerySet's elements.
+ *
+ * @see {@link QuerySet.QueryBuilder}
  */
-export default class QuerySet<M extends AnyModel = any, InstanceProps extends object = {}> {
+export class QuerySet<M extends AnyModel = any, InstanceProps extends object = {}>
+    implements QuerySet.QueryBuilder<M, InstanceProps> {
     /**
      * Creates a `QuerySet`. The constructor is mainly for internal use;
      * Access QuerySet instances from {@link Model}.
@@ -94,6 +41,71 @@ export default class QuerySet<M extends AnyModel = any, InstanceProps extends ob
      */
     constructor(modelClass: ModelClass<M>, clauses: QueryClause[], opts?: object);
 
+    /**
+     * Checks if the {@link QuerySet} instance has any records matching the query
+     * in the database.
+     *
+     * @return `true` if the {@link QuerySet} instance contains entities, else `false`.
+     */
+    exists(): boolean;
+
+    /**
+     * Returns an array of the plain objects represented by the QuerySet.
+     * The plain objects are direct references to the store.
+     *
+     * @return references to the plain JS objects represented by the QuerySet
+     */
+    toRefArray(): ReadonlyArray<Ref<M> & InstanceProps>;
+
+    /**
+     * Returns an array of {@link SessionBoundModel} instances represented by the QuerySet.
+     *
+     * @return session bound model instances represented by the QuerySet
+     */
+    toModelArray(): ReadonlyArray<SessionBoundModel<M, InstanceProps>>;
+
+    /**
+     * Returns a string representation of QuerySet instance contents.
+     *
+     * @return string representation of QuerySet.
+     */
+    toString(): string;
+
+    at(index: number): SessionBoundModel<M, InstanceProps> | undefined;
+
+    first(): SessionBoundModel<M, InstanceProps> | undefined;
+
+    last(): SessionBoundModel<M, InstanceProps> | undefined;
+
+    all(): QuerySet<M, InstanceProps>;
+
+    filter(lookupObj: QuerySet.LookupSpec<M>): QuerySet<M, InstanceProps>;
+
+    exclude(lookupObj: QuerySet.LookupSpec<M>): QuerySet<M, InstanceProps>;
+
+    orderBy(
+        iteratees: QuerySet.SortIteratee<M> | ReadonlyArray<QuerySet.SortIteratee<M>>,
+        orders?: QuerySet.SortOrder | ReadonlyArray<QuerySet.SortOrder>
+    ): QuerySet<M, InstanceProps>;
+
+    count(): number;
+
+    update(mergeObj: UpdateProps<M>): void;
+
+    delete(): void;
+}
+
+/**
+ * A {@link QuerySet} extended with {@link ManyToMany} specific functionality.
+ */
+export interface MutableQuerySet<M extends AnyModel = any, InstanceProps extends object = {}>
+    extends QuerySet<M, InstanceProps> {
+    add: (...entitiesToAdd: Array<IdType<M> | M>) => void;
+    remove: (...entitiesToRemove: Array<IdType<M> | M>) => void;
+    clear: () => void;
+}
+
+export namespace QuerySet {
     /**
      * Register custom method on a `QuerySet` class specification.
      * QuerySet class may be attached to a {@link Model} class via {@link Model#querySetClass}
@@ -118,149 +130,153 @@ export default class QuerySet<M extends AnyModel = any, InstanceProps extends ob
      * // use shared method
      * const unreleased = customQs.unreleased();
      */
-    static addSharedMethod(methodName: string): void;
+    function addSharedMethod(methodName: string): void;
 
     /**
-     * Returns a new {@link QuerySet} instance with the same entities.
-     * @return a new QuerySet with the same entities.
+     * Interface for building queries in fluent style
      */
-    all(): QuerySet<M, InstanceProps>;
+    interface QueryBuilder<M extends AnyModel = any, InstanceProps extends object = {}> {
+        /**
+         * Returns the {@link SessionBoundModel} instance at index `index` in the {@link QuerySet} instance if
+         * `withRefs` flag is set to `false`, or a reference to the plain JavaScript
+         * object in the model state if `true`.
+         *
+         * @param  index - index of the model instance to get
+         * @return a {@link Model} derived {@link SessionBoundModel} instance at index
+         *                           `index` in the {@link QuerySet} instance,
+         *                           or undefined if the index is out of bounds.
+         */
+        at(index: number): SessionBoundModel<M, InstanceProps> | undefined;
+
+        /**
+         * Returns the session bound {@link Model} instance at index 0
+         * in the {@link QuerySet} instance or undefined if the instance is empty.
+         *
+         *  @return a {@link Model} derived {@link SessionBoundModel} instance or undefined.
+         */
+        first(): SessionBoundModel<M, InstanceProps> | undefined;
+
+        /**
+         * Returns the session bound {@link Model} instance at index `QuerySet.count() - 1`
+         * in the {@link QuerySet} instance or undefined if the instance is empty.
+         *
+         *  @return a {@link Model} derived {@link SessionBoundModel} instance or undefined.
+         */
+        last(): SessionBoundModel<M, InstanceProps> | undefined;
+
+        /**
+         * Returns a new {@link QuerySet} instance with the same entities.
+         * @return a new QuerySet with the same entities.
+         */
+        all(): QuerySet<M, InstanceProps>;
+
+        /**
+         * Returns a new {@link QuerySet} instance with entities that match properties in `lookupObj`.
+         *
+         * @param  lookupObj - the properties to match objects with ({@link LookupProps}).
+         * Can also be a function ({@link LookupPredicate}).
+         *
+         * @return a new {@link QuerySet} instance with objects that passed the filter.
+         */
+        filter(lookupObj: LookupSpec<M>): QuerySet<M, InstanceProps>;
+
+        /**
+         * Returns a new {@link QuerySet} instance with entities that do not match properties in `lookupObj`.
+         *
+         * @param  lookupObj - the properties to match objects with ({@link LookupProps}).
+         * Can also be a function ({@link LookupPredicate}).
+         *
+         * @return a new {@link QuerySet} instance with objects that passed the filter.
+         */
+        exclude(lookupObj: LookupSpec<M>): QuerySet<M, InstanceProps>;
+
+        /**
+         * Returns a new {@link QuerySet} instance with entities ordered by `iteratees` in ascending
+         * order, unless otherwise specified. Delegates to `lodash.orderBy`.
+         *
+         * @param  iteratees - an array or a single {@link SortIteratee} where each item can be a string or a
+         *                                           function. If a string is supplied, it should
+         *                                           correspond to property on the entity that will
+         *                                           determine the order. If a function is supplied,
+         *                                           it should return the value to order by.
+         *
+         * @param [orders] - the sort orders of `iteratees`. If unspecified, all iteratees
+         *                               will be sorted in ascending order. `true` and `'asc'`
+         *                               correspond to ascending order, and `false` and `'desc`
+         *                               to descending order. Accepts an array or a single {@link SortOrder}.
+         *
+         * @return a new {@link QuerySet} with objects ordered by `iteratees`.
+         */
+        orderBy(
+            iteratees: SortIteratee<M> | ReadonlyArray<SortIteratee<M>>,
+            orders?: SortOrder | ReadonlyArray<SortOrder>
+        ): QuerySet<M, InstanceProps>;
+
+        /**
+         * Records an update specified with `mergeObj` to all the objects
+         * in the {@link QuerySet} instance.
+         *
+         * @param  mergeObj - an object extending {@link UpdateProps}, to be merged with all the objects in this QuerySet.
+         */
+        update(mergeObj: UpdateProps<M>): void;
+
+        /**
+         * Records a deletion of all the objects in this {@link QuerySet} instance.
+         */
+        delete(): void;
+
+        /**
+         * Returns the number of {@link Model} instances represented by the QuerySet.
+         *
+         * @return length of the QuerySet
+         */
+        count(): number;
+    }
 
     /**
-     * Returns the {@link SessionBoundModel} instance at index `index` in the {@link QuerySet} instance if
-     * `withRefs` flag is set to `false`, or a reference to the plain JavaScript
-     * object in the model state if `true`.
+     * Optional ordering direction.
      *
-     * @param  index - index of the model instance to get
-     * @return a {@link Model} derived {@link SessionBoundModel} instance at index
-     *                           `index` in the {@link QuerySet} instance,
-     *                           or undefined if the index is out of bounds.
+     * {@see QuerySet.orderBy}
      */
-    at(index: number): SessionBoundModel<M, InstanceProps> | undefined;
+    type SortOrder = 'asc' | 'desc' | true | false;
 
     /**
-     * Returns the session bound {@link Model} instance at index 0
-     * in the {@link QuerySet} instance or undefined if the instance is empty.
+     * Ordering clause.
      *
-     *  @return a {@link Model} derived {@link SessionBoundModel} instance or undefined.
+     * Either a key of SessionBoundModel or a evaluator function accepting plain object Model representation stored in the database.
+     *
+     * {@see QuerySet.orderBy}
      */
-    first(): SessionBoundModel<M, InstanceProps> | undefined;
+    type SortIteratee<M extends Model> = keyof Ref<M> | { (row: Ref<M>): any };
 
     /**
-     * Returns the session bound {@link Model} instance at index `QuerySet.count() - 1`
-     * in the {@link QuerySet} instance or undefined if the instance is empty.
-     *
-     *  @return a {@link Model} derived {@link SessionBoundModel} instance or undefined.
+     * Lookup clause as an object specifying props to match with plain object Model representation stored in the database.
+     * {@see QuerySet.exclude}
+     * {@see QuerySet.filter}
      */
-    last(): SessionBoundModel<M, InstanceProps> | undefined;
+    type LookupProps<M extends Model> = Partial<Ref<M>> & Record<string, Serializable>;
 
     /**
-     * Returns a new {@link QuerySet} instance with entities that match properties in `lookupObj`.
-     *
-     * @param  lookupObj - the properties to match objects with ({@link LookupProps}).
-     * Can also be a function ({@link LookupPredicate}).
-     *
-     * @return a new {@link QuerySet} instance with objects that passed the filter.
+     * Lookup clause as predicate accepting plain object Model representation stored in the database.
+     * {@see QuerySet.exclude}
+     * {@see QuerySet.filter}
      */
-    filter<TLookup extends LookupSpec<M>>(lookupObj: TLookup): LookupResult<M, TLookup>;
+    type LookupPredicate<M extends Model> = (row: Ref<M>) => boolean;
 
     /**
-     * Returns a new {@link QuerySet} instance with entities that do not match properties in `lookupObj`.
-     *
-     * @param  lookupObj - the properties to match objects with ({@link LookupProps}).
-     * Can also be a function ({@link LookupPredicate}).
-     *
-     * @return a new {@link QuerySet} instance with objects that passed the filter.
+     * A union of lookup clauses.
+     * {@see QuerySet.exclude}
+     * {@see QuerySet.filter}
      */
-    exclude<TLookup extends LookupSpec<M>>(lookupObj: TLookup): LookupResult<M, TLookup>;
+    type LookupSpec<M extends Model> = LookupProps<M> | LookupPredicate<M>;
 
     /**
-     * Returns a new {@link QuerySet} instance with entities ordered by `iteratees` in ascending
-     * order, unless otherwise specified. Delegates to `lodash.orderBy`.
+     * A lookup query result.
      *
-     * @param  iteratees - an array or a single {@link SortIteratee} where each item can be a string or a
-     *                                           function. If a string is supplied, it should
-     *                                           correspond to property on the entity that will
-     *                                           determine the order. If a function is supplied,
-     *                                           it should return the value to order by.
-     *
-     * @param [orders] - the sort orders of `iteratees`. If unspecified, all iteratees
-     *                               will be sorted in ascending order. `true` and `'asc'`
-     *                               correspond to ascending order, and `false` and `'desc`
-     *                               to descending order. Accepts an array or a single {@link SortOrder}.
-     *
-     * @return a new {@link QuerySet} with objects ordered by `iteratees`.
+     * May contain additional properties in case {@link LookupProps} clause had been supplied.
+     * {@see QuerySet.exclude}
+     * {@see QuerySet.filter}
      */
-    orderBy(
-        iteratees: SortIteratee<M> | ReadonlyArray<SortIteratee<M>>,
-        orders?: SortOrder | ReadonlyArray<SortOrder>
-    ): QuerySet<M>;
-
-    /**
-     * Returns the number of {@link Model} instances represented by the QuerySet.
-     *
-     * @return length of the QuerySet
-     */
-    count(): number;
-
-    /**
-     * Checks if the {@link QuerySet} instance has any records matching the query
-     * in the database.
-     *
-     * @return `true` if the {@link QuerySet} instance contains entities, else `false`.
-     */
-    exists(): boolean;
-
-    /**
-     * Returns an array of the plain objects represented by the QuerySet.
-     * The plain objects are direct references to the store.
-     *
-     * @return references to the plain JS objects represented by the QuerySet
-     */
-    toRefArray(): ReadonlyArray<Ref<M>>;
-
-    /**
-     * Returns an array of {@link SessionBoundModel} instances represented by the QuerySet.
-     *
-     * @return session bound model instances represented by the QuerySet
-     */
-    toModelArray(): ReadonlyArray<SessionBoundModel<M, InstanceProps>>;
-
-    /**
-     * Records an update specified with `mergeObj` to all the objects
-     * in the {@link QuerySet} instance.
-     *
-     * @param  mergeObj - an object extending {@link UpdateProps}, to be merged with all the objects in this QuerySet.
-     */
-    update(mergeObj: UpdateProps<M>): void;
-
-    /**
-     * Records a deletion of all the objects in this {@link QuerySet} instance.
-     */
-    delete(): void;
-
-    /**
-     * Returns a string representation of QuerySet instance contents.
-     *
-     * @return string representation of QuerySet.
-     */
-    toString(): string;
 }
 
-/**
- * {@link QuerySet} extensions available on {@link ManyToMany} fields of session bound {@link Model} instances.
- *
- * @see {@link IdOrModelLike}
- */
-export interface ManyToManyExtensions<M extends AnyModel> {
-    add: (...entitiesToAdd: ReadonlyArray<IdOrModelLike<M>>) => void;
-    remove: (...entitiesToRemove: ReadonlyArray<IdOrModelLike<M>>) => void;
-    clear: () => void;
-}
-
-/**
- * A {@link QuerySet} extended with {@link ManyToMany} specific functionality - {@link ManyToManyExtensions}.
- */
-export interface MutableQuerySet<M extends AnyModel = any, InstanceProps extends object = {}>
-    extends ManyToManyExtensions<M>,
-        QuerySet<M, InstanceProps> {}
+export default QuerySet;

--- a/types/redux-orm/db/Database.d.ts
+++ b/types/redux-orm/db/Database.d.ts
@@ -1,7 +1,7 @@
 import { IndexedModelClasses, OrmState } from '../ORM';
 import { CREATE, DELETE, EXCLUDE, FAILURE, FILTER, ORDER_BY, SUCCESS, UPDATE } from '../constants';
 import { ModelTableOpts, Table } from './Table';
-import { SerializableMap } from '../Model';
+import { Serializable } from '../Model';
 import { BatchToken } from '../Session';
 
 /**
@@ -36,7 +36,7 @@ export interface QuerySpec {
 /**
  * Query result.
  */
-export interface QueryResult<Row extends SerializableMap = {}> {
+export interface QueryResult<Row extends Record<string, Serializable> = {}> {
     rows: ReadonlyArray<Row>;
 }
 

--- a/types/redux-orm/helpers.d.ts
+++ b/types/redux-orm/helpers.d.ts
@@ -11,13 +11,15 @@ export type Diff<T extends object, U extends object> = Pick<T, Exclude<keyof T, 
 
 export type PickByValue<T, ValueType> = Pick<T, { [Key in keyof T]: T[Key] extends ValueType ? Key : never }[keyof T]>;
 
-export type Overwrite<T extends object, U extends object, I = Diff<T, U> & Intersection<U, T>> = Pick<I, keyof I>;
-
-export type Optional<T extends object, K extends keyof T = keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
 export type Intersection<T extends object, U extends object> = Pick<
     T,
     Extract<keyof T, keyof U> & Extract<keyof U, keyof T>
 >;
 
 export type OptionalKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? K : never }[keyof T];
+
+export type KnownKeys<T> = {
+    [K in keyof T]: string extends K ? never : number extends K ? never : K;
+} extends { [_ in keyof T]: infer U }
+    ? U
+    : never;

--- a/types/redux-orm/index.d.ts
+++ b/types/redux-orm/index.d.ts
@@ -21,15 +21,7 @@ import Model, {
     UpdateProps,
     UpsertProps
 } from './Model';
-import QuerySet, {
-    LookupPredicate,
-    LookupProps,
-    LookupResult,
-    LookupSpec,
-    MutableQuerySet,
-    SortIteratee,
-    SortOrder
-} from './QuerySet';
+import QuerySet, { MutableQuerySet } from './QuerySet';
 import { OrmSession } from './Session';
 import { createDatabase, TableOpts, TableState } from './db';
 import { attr, Attribute, FieldSpecMap, fk, ForeignKey, many, ManyToMany, OneToOne, oneToOne } from './fields';
@@ -37,10 +29,6 @@ import { createReducer, createSelector, defaultUpdater, ORMReducer, ORMSelector 
 
 export {
     FieldSpecMap,
-    LookupResult,
-    LookupSpec,
-    LookupPredicate,
-    LookupProps,
     TableOpts,
     RefPropOrSimple,
     ModelFieldMap,
@@ -49,9 +37,7 @@ export {
     CreateProps,
     UpdateProps,
     ModelField,
-    SortIteratee,
     OrmSession as Session,
-    SortOrder,
     MutableQuerySet,
     createDatabase,
     createSelector,

--- a/types/redux-orm/redux-orm-tests.ts
+++ b/types/redux-orm/redux-orm-tests.ts
@@ -30,7 +30,7 @@ interface BookFields {
     title: string;
     coverArt: string;
     publisher: Publisher;
-    authors?: MutableQuerySet<Person>;
+    authors: MutableQuerySet<Person>;
 }
 
 class Book extends Model<typeof Book, BookFields> {
@@ -63,7 +63,7 @@ interface PersonFields {
     firstName: string;
     lastName: string;
     nationality?: string;
-    books?: MutableQuerySet<Book>;
+    books: MutableQuerySet<Book>;
 }
 
 class Person extends Model<typeof Person, PersonFields> {
@@ -198,7 +198,7 @@ const sessionFixture = () => {
     /** Upsert requires id to be provided */
     Book.upsert({ publisher: 1 }); // $ExpectError
 
-    // $ExpectType SessionBoundModel<Book, { title: string; publisher: number; }>
+    // $ExpectType SessionBoundModel<Book, Pick<{ title: string; publisher: number; }, never>>
     Book.upsert({ title: 'B1', publisher: 1 });
 
     /* Incompatible property types: */
@@ -274,7 +274,7 @@ const sessionFixture = () => {
 
     type basicBookKeys = Exclude<keyof typeof basicBook, keyof Model>; // $ExpectType "title" | "coverArt" | "publisher" | "authors"
     const basicBookTitle = basicBook.title; // $ExpectType string
-    const authors = basicBook.authors; // $ExpectType MutableQuerySet<Person, {}> | undefined
+    const authors = basicBook.authors; // $ExpectType MutableQuerySet<Person, {}>
     const unknownPropertyError = basicBook.customProp; // $ExpectError
 
     const customProp = { foo: 0, bar: true };
@@ -380,17 +380,17 @@ const sessionFixture = () => {
 
     type TestSelector = (state: RootState) => Ref<Book>;
 
+    const selector0 = createOrmSelector(
+        orm,
+        s => s.db,
+        session => session.Book.first()!.ref
+    ) as TestSelector;
+
     const selector1 = createOrmSelector(
         orm,
         s => s.db,
         s => s.bar,
         (session, title) => session.Book.get({ title })!.ref
-    ) as TestSelector;
-
-    const selector0 = createOrmSelector(
-        orm,
-        s => s.db,
-        session => session.Book.first()!.ref
     ) as TestSelector;
 
     const selector2 = createOrmSelector(
@@ -466,4 +466,41 @@ const sessionFixture = () => {
     selector4(state); // $ExpectType Ref<Book>
     selector5(state); // $ExpectType Ref<Book>
     selector6(state); // $ExpectType Ref<Book>
+})();
+
+// redux-orm-types#7
+(() => {
+    const { Book } = sessionFixture();
+
+    Book.exists({ title: 'foo' });
+    Book.all().exists();
+
+    Book.exists(); // $ExpectError
+    Book.exists('foo'); // $ExpectError
+    Book.all().exists({}); // $ExpectError
+})();
+
+// redux-orm-types#8
+(() => {
+    const { Book } = sessionFixture();
+
+    Book.all().toModelArray();
+    Book.all().toRefArray();
+    Book.toModelArray(); // $ExpectError
+    Book.toRefArray(); // $ExpectError
+})();
+
+// redux-orm-types#9
+(() => {
+    const { Book, Person, Publisher } = sessionFixture();
+
+    const author = Person.create({ id: '1', firstName: 'foo', lastName: 'bar', nationality: 'pl' });
+    const publisher = Publisher.create({ name: 'foo' });
+    Book.create({ title: 'foo', publisher: 1 });
+    Book.create({ title: 'foo', publisher: 1, coverArt: 'bar' });
+    Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: ['foo', author] });
+
+    Book.create({ title: 'foo', publisher: author }); // $ExpectError
+    Book.create({ title: 'foo', publisher: 'error' }); // $ExpectError
+    Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: [3, author] }); // $ExpectError
 })();


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Summary of changes: 
- Remove `Model.toRefArray` and `Model.toToModelArray` methods, since they are not copied from `QuerySet` during initial setup.
- correct `Model.exists` signature 
- fix for excessive `Model.create` argument requirements
