### PR TITLE
[sharedb] Export middleware namespace, switch some JSON types to any

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -37,9 +37,9 @@ declare class sharedb {
      * @param action name of an action from https://github.com/share/sharedb#middlewares
      * @param fn listener invoked when the specified action occurs
      */
-    use<A extends keyof middleware.ActionContextMap>(
+    use<A extends keyof sharedb.middleware.ActionContextMap>(
         action: A,
-        fn: (context: middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
+        fn: (context: sharedb.middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
     ): void;
     static types: {
         register: (type: { name?: string, uri?: string, [key: string]: any}) => void;
@@ -114,82 +114,82 @@ declare namespace sharedb {
 
     type Path = ShareDB.Path;
     type ShareDBSourceOptions = ShareDB.ShareDBSourceOptions;
-}
 
-declare namespace middleware {
-    interface ActionContextMap {
-        afterSubmit: SubmitContext;
-        apply: ApplyContext;
-        commit: CommitContext;
-        connect: ConnectContext;
-        doc: DocContext;  // Deprecated, use 'readSnapshots' instead.
-        op: OpContext;
-        query: QueryContext;
-        readSnapshots: ReadSnapshotsContext;
-        receive: ReceiveContext;
-        reply: ReplyContext;
-        submit: SubmitContext;
-    }
+    namespace middleware {
+        interface ActionContextMap {
+            afterSubmit: SubmitContext;
+            apply: ApplyContext;
+            commit: CommitContext;
+            connect: ConnectContext;
+            doc: DocContext;  // Deprecated, use 'readSnapshots' instead.
+            op: OpContext;
+            query: QueryContext;
+            readSnapshots: ReadSnapshotsContext;
+            receive: ReceiveContext;
+            reply: ReplyContext;
+            submit: SubmitContext;
+        }
 
-    interface BaseContext {
-        action: keyof ActionContextMap;
-        agent: any;
-        backend: sharedb;
-    }
+        interface BaseContext {
+            action: keyof ActionContextMap;
+            agent: any;
+            backend: sharedb;
+        }
 
-    interface ApplyContext extends BaseContext, SubmitRequest {
-    }
+        interface ApplyContext extends BaseContext, SubmitRequest {
+        }
 
-    interface CommitContext extends BaseContext, SubmitRequest {
-    }
+        interface CommitContext extends BaseContext, SubmitRequest {
+        }
 
-    interface ConnectContext extends BaseContext {
-        stream: any;
-        req: any;  // Property always exists, value may be undefined
-    }
+        interface ConnectContext extends BaseContext {
+            stream: any;
+            req: any;  // Property always exists, value may be undefined
+        }
 
-    interface DocContext extends BaseContext {
-        collection: string;
-        id: string;
-        snapshot: ShareDB.Snapshot;
-    }
+        interface DocContext extends BaseContext {
+            collection: string;
+            id: string;
+            snapshot: ShareDB.Snapshot;
+        }
 
-    interface OpContext extends BaseContext {
-        collection: string;
-        id: string;
-        op: ShareDB.Op;
-    }
+        interface OpContext extends BaseContext {
+            collection: string;
+            id: string;
+            op: ShareDB.Op;
+        }
 
-    interface QueryContext extends BaseContext {
-        index: string;
-        collection: string;
-        projection: Projection | undefined;
-        fields: ProjectionFields | undefined;
-        channel: string;
-        query: ShareDB.JSONObject;
-        options: ShareDB.JSONObject;
-        db: sharedb.DB | null;
-        snapshotProjection: Projection | null;
-    }
+        interface QueryContext extends BaseContext {
+            index: string;
+            collection: string;
+            projection: Projection | undefined;
+            fields: ProjectionFields | undefined;
+            channel: string;
+            query: any;
+            options?: {[key: string]: any};
+            db: DB | null;
+            snapshotProjection: Projection | null;
+        }
 
-    interface ReadSnapshotsContext extends BaseContext {
-        collection: string;
-        snapshots: ShareDB.Snapshot[];
-        snapshotType: SnapshotType;
-    }
+        interface ReadSnapshotsContext extends BaseContext {
+            collection: string;
+            snapshots: ShareDB.Snapshot[];
+            snapshotType: SnapshotType;
+        }
 
-    interface ReceiveContext extends BaseContext {
-        data: ShareDB.JSONObject;  // ClientRequest, but before any validation
-    }
+        interface ReceiveContext extends BaseContext {
+            data: {[key: string]: any};  // ClientRequest, but before any validation
+        }
 
-    interface ReplyContext extends BaseContext {
-        request: ShareDB.ClientRequest;
-        reply: ShareDB.JSONObject;
-    }
+        interface ReplyContext extends BaseContext {
+            request: ShareDB.ClientRequest;
+            reply: {[key: string]: any};
+        }
 
-    type SnapshotType = 'current' | 'byVersion' | 'byTimestamp';
+        type SnapshotType = 'current' | 'byVersion' | 'byTimestamp';
 
-    interface SubmitContext extends BaseContext, SubmitRequest {
+        interface SubmitContext extends BaseContext, SubmitRequest {
+        }
     }
 }
 

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -11,7 +11,7 @@ export interface Snapshot {
     id: string;
     v: number;
     type: string | null;
-    data: JSONObject | undefined;
+    data?: any;
     m: SnapshotMeta | null;
 }
 
@@ -19,7 +19,7 @@ export interface SnapshotMeta {
     ctime: number;
     mtime: number;
     // Users can use server middleware to add additional metadata to snapshots.
-    [key: string]: JSONValue;
+    [key: string]: any;
 }
 
 export interface AddNumOp { p: Path; na: number; }
@@ -109,5 +109,5 @@ export interface ClientRequest {
     /** Short name of the request's action */
     a: RequestAction;
 
-    [propertyName: string]: JSONValue;
+    [propertyName: string]: any;
 }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -109,6 +109,13 @@ backend.use('reply', (context, callback) => {
         context.request,
         context.reply,
     );
+    // Usage note: It's only necessary to write `context.reply['data']` in
+    // TypeScript <= 2.1.
+    //
+    // In TypeScript 2.2+, `context.reply.data` is OK, as 2.2 added support for
+    // dotted property access for types with string index signatures.
+    console.log(context.reply && context.reply['data'] &&
+        context.reply['data'].someProperty);
     callback();
 });
 backend.use('readSnapshots', (context, callback) => {


### PR DESCRIPTION
## Changes

* It's often useful to pass middleware Context instances into other functions, so export the middleware namespace to allow the Context types to be referenced by function signatures in user code.
* Loosen some `JSONObject` and `JSONValue` to `any`. This allows access into custom nested properties, e.g. `receiveContext.data.author.name`, which is a common use-case in Share.
  * `QueryContext.query` is user-defined and could potentially be a string in some SQL adapters, so loosen its type to `any`.
  * `QueryContext.options` is an object that [has some built-in properties](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/agent.js#L334) and can have other properties that are user-defined, so it's now typed as `options?: {[key: string]: any}`. It's marked as optional since it's possible to call `Backend#queryFetch` or `#querySubscribe` directly without passing in options.
  * `ReceiveContext.data` [is checked to be an object](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/agent.js#L254-L260), so loosen its type to `{[key: string]: any}`.
  * `ReplyContext.reply` [is also checked to be an object](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/agent.js#L222-L234), so loosen its type the same way.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes. (See Changes section above)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A, this just changes typings)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (N/A, already has tslint.json)
