### PR TITLE
css-tree: WalkContext.atrule can be null

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -20,6 +20,7 @@ csstree.walk(ast, {
         node; // $ExpectType CssNode
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>
+        this.atrule; // $ExpectType Atrule | null
     },
     leave(node, item, list) {
         this.stylesheet; // $ExpectType StyleSheet

--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -16,6 +16,7 @@ csstree.walk(ast, {});
 
 csstree.walk(ast, {
     enter(node, item, list) {
+        this.root; // $ExpectType CssNode
         this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType CssNode
         item; // $ExpectType ListItem<CssNode>
@@ -23,10 +24,12 @@ csstree.walk(ast, {
         this.atrule; // $ExpectType Atrule | null
     },
     leave(node, item, list) {
+        this.root; // $ExpectType CssNode
         this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType CssNode
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>
+        this.atrule; // $ExpectType Atrule | null
     },
     visit: 'ClassSelector',
     reverse: false,

--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -16,14 +16,14 @@ csstree.walk(ast, {});
 
 csstree.walk(ast, {
     enter(node, item, list) {
-        this.stylesheet; // $ExpectType StyleSheet
+        this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType CssNode
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>
         this.atrule; // $ExpectType Atrule | null
     },
     leave(node, item, list) {
-        this.stylesheet; // $ExpectType StyleSheet
+        this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType CssNode
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -517,14 +517,14 @@ export function generate(ast: CssNode, options?: GenerateOptions): string;
 
 export interface WalkContext {
     root: CssNode;
-    stylesheet: StyleSheet;
+    stylesheet: StyleSheet | null;
     atrule: Atrule | null;
-    atrulePrelude: AtrulePrelude;
-    rule: Rule;
-    selector: SelectorList;
-    block: Block;
-    declaration: Declaration;
-    function: FunctionNode | PseudoClassSelector | PseudoElementSelector;
+    atrulePrelude: AtrulePrelude | null;
+    rule: Rule | null;
+    selector: SelectorList | null;
+    block: Block | null;
+    declaration: Declaration | null;
+    function: FunctionNode | PseudoClassSelector | PseudoElementSelector | null;
 }
 
 export type EnterOrLeaveFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => void;

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -518,7 +518,7 @@ export function generate(ast: CssNode, options?: GenerateOptions): string;
 export interface WalkContext {
     root: CssNode;
     stylesheet: StyleSheet;
-    atrule: Atrule;
+    atrule: Atrule | null;
     atrulePrelude: AtrulePrelude;
     rule: Rule;
     selector: SelectorList;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/csstree/csstree/blob/c5470408616d95a1926031ac0fc413785ea8faf2/lib/walker/create.js#L168

Note: While trying to commit, I got this error from a pre commit hook. I'm not sure what the problem is but I don't think my commit introduced this error.

```
husky > pre-commit (node v11.13.0)
✔  precise-commits: 2 modified file(s) found
✔  [1/2] Processing file: types/css-tree/css-tree-tests.ts
✖  precise-commits: An Error occurred

{ SyntaxError: ';' expected. (1:25)
> 1 | enter(node, item, list) {
    |                         ^
  2 |         this.stylesheet; // $ExpectType StyleSheet
  3 |         node; // $ExpectType CssNode
  4 |         item; // $ExpectType ListItem<CssNode>
```

Please let me know if I missed anything.