### PR TITLE
Fix mongoose populate options

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -3335,8 +3335,8 @@ declare module "mongoose" {
     select?: any;
     /** optional query conditions to match */
     match?: any;
-    /** optional name of the model to use for population */
-    model?: string;
+    /** optional model to use for population */
+    model?: string | Model<any>;
     /** optional query options like sort, limit, etc */
     options?: any;
     /** deep populate */


### PR DESCRIPTION
As you can check in [line 22 and 196](https://github.com/Automattic/mongoose/blob/master/lib/helpers/populate/getModelsMapForPopulate.js) the populate function can also accept an entire mongoose model.
You can check the [documentation](https://mongoosejs.com/docs/populate.html#cross-db-populate) too



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Automattic/mongoose/blob/master/lib/helpers/populate/getModelsMapForPopulate.js>> <<https://mongoosejs.com/docs/populate.html#cross-db-populate>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
