### PR TITLE
Improve typing of makeAsyncSelect.

### DIFF
--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -44,8 +44,8 @@ export class Async<OptionType> extends React.Component<Props<OptionType>, State<
   handleInputChange: (newValue: string, actionMeta: InputActionMeta) => string;
 }
 
-type ClassProps<T> = T extends new (...args: infer P) => any ? P : never;
-type FunctionProps<T> = T extends (...args: infer P) => any ? P : never;
+type ClassProps<T> = T extends new (props: infer P) => any ? P : never;
+type FunctionProps<T> = T extends (props: infer P) => any ? P : never;
 
 type SelectComponentProps<T> = T extends React.FunctionComponent<any>
     ? FunctionProps<T>

--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -44,6 +44,15 @@ export class Async<OptionType> extends React.Component<Props<OptionType>, State<
   handleInputChange: (newValue: string, actionMeta: InputActionMeta) => string;
 }
 
-export function makeAsyncSelect(SelectComponent: React.ComponentType<any>): Async<any>;
+type SelectComponentProps<T> = T extends React.FunctionComponent<any>
+    ? Parameters<T>[0]
+    : T extends React.ComponentClass<any> ? ConstructorParameters<T>[0] : unknown;
+
+type AsyncComponentProps<T extends React.ComponentType<any> = React.ComponentType<any>> = SelectComponentProps<T> &
+    AsyncProps<any>;
+
+export function makeAsyncSelect<T extends React.ComponentType<any> = React.ComponentType<any>>(
+    SelectComponent: T,
+): React.ComponentClass<AsyncComponentProps<T>>;
 
 export default Async;

--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -44,8 +44,8 @@ export class Async<OptionType> extends React.Component<Props<OptionType>, State<
   handleInputChange: (newValue: string, actionMeta: InputActionMeta) => string;
 }
 
-type ClassProps<T> = T extends new (...args: infer P) => any ? P[0] : never;
-type FunctionProps<T> = T extends (...args: infer P) => any ? P[0] : never;
+type ClassProps<T> = T extends new (...args: infer P) => any ? P : never;
+type FunctionProps<T> = T extends (...args: infer P) => any ? P : never;
 
 type SelectComponentProps<T> = T extends React.FunctionComponent<any>
     ? FunctionProps<T>

--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -44,9 +44,12 @@ export class Async<OptionType> extends React.Component<Props<OptionType>, State<
   handleInputChange: (newValue: string, actionMeta: InputActionMeta) => string;
 }
 
+type ClassProps<T> = T extends new (...args: infer P) => any ? P[0] : never;
+type FunctionProps<T> = T extends (...args: infer P) => any ? P[0] : never;
+
 type SelectComponentProps<T> = T extends React.FunctionComponent<any>
-    ? Parameters<T>[0]
-    : T extends React.ComponentClass<any> ? ConstructorParameters<T>[0] : unknown;
+    ? FunctionProps<T>
+    : T extends React.ComponentClass<any> ? ClassProps<T> : never;
 
 type AsyncComponentProps<T extends React.ComponentType<any> = React.ComponentType<any>> = SelectComponentProps<T> &
     AsyncProps<any>;


### PR DESCRIPTION
Improve typing of `makeAsyncSelect`, before change I wasn't able to properly use `makeAsyncSelect` decorator function because of 
TS error `error TS2604: JSX element type 'NAME' does not have any construct or call signatures.`, also props from `SelectComponent` wasn't inferred.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
