### PR TITLE
Add the ignoreOrder option to MiniCssExtractPlugin

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -27,6 +27,12 @@ declare namespace MiniCssExtractPlugin {
          */
         filename?: string;
         chunkFilename?: string;
+        /**
+         * For projects where CSS ordering has been mitigated through consistent 
+         * use of scoping or naming conventions, the CSS order warnings can be 
+         * disabled by setting this flag to true for the plugin.
+         */
+        ignoreOrder?: boolean;
     }
 }
 

--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -28,8 +28,8 @@ declare namespace MiniCssExtractPlugin {
         filename?: string;
         chunkFilename?: string;
         /**
-         * For projects where CSS ordering has been mitigated through consistent 
-         * use of scoping or naming conventions, the CSS order warnings can be 
+         * For projects where CSS ordering has been mitigated through consistent
+         * use of scoping or naming conventions, the CSS order warnings can be
          * disabled by setting this flag to true for the plugin.
          */
         ignoreOrder?: boolean;

--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for mini-css-extract-plugin 0.2
+// Type definitions for mini-css-extract-plugin 0.8
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
+//                 Spencer Miskoviak <https://github.com/skovy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -72,7 +72,7 @@ configuration = {
         new MiniCssExtractPlugin({
             filename: 'styles.css',
             chunkFilename: 'style.css',
-            ignoreOrder: true
+            ignoreOrder: true,
         }),
     ],
 };

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -65,3 +65,14 @@ configuration = {
         }),
     ],
 };
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
+            filename: 'styles.css',
+            chunkFilename: 'style.css',
+            ignoreOrder: true
+        }),
+    ],
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/webpack-contrib/mini-css-extract-plugin#remove-order-warnings
    - https://github.com/webpack-contrib/mini-css-extract-plugin/pull/422
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
