### PR TITLE
[stylelint] updated LintResult warnings to correct shape

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -3,12 +3,19 @@
 // Definitions by: Alan Agius <https://github.com/alan-agius4>
 //                 Filips Alpe <https://github.com/filipsalpe>
 //                 James Garbutt <https://github.com/43081j>
+//                 Bob Matcuk <https://github.com/bmatcuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 import * as postcss from 'postcss';
 
-export type FormatterType = "json" | "string" | "verbose" | "compact" | "unix";
+export type FormatterType =
+    | "json"
+    | "string"
+    | "verbose"
+    | "compact"
+    | "unix"
+    | ((results: LintResult[]) => string);
 
 export type SyntaxType = "css-in-js"
     | "html"
@@ -18,13 +25,15 @@ export type SyntaxType = "css-in-js"
     | "scss"
     | "sugarss";
 
+export type Severity = "warning" | "error";
+
 export interface Configuration {
     rules: Record<string, any>;
     extends: string | string[];
     plugins: string[];
     processors: string[];
     ignoreFiles: string|string[];
-    defaultSeverity: "warning"|"error";
+    defaultSeverity: Severity;
 }
 
 export interface LinterOptions {
@@ -54,11 +63,19 @@ export interface LinterResult {
     results: LintResult[];
 }
 
+export interface Warning {
+    line: number;
+    column: number;
+    rule: string;
+    severity: Severity;
+    text: string;
+}
+
 export interface LintResult {
     source: string;
     errored: boolean | undefined;
     ignored: boolean | undefined;
-    warnings: string[];
+    warnings: Warning[];
     deprecations: string[];
     invalidOptionWarnings: any[];
 }

--- a/types/stylelint/stylelint-tests.ts
+++ b/types/stylelint/stylelint-tests.ts
@@ -10,8 +10,9 @@ import {
     createRuleTester,
     RuleTesterContext,
     RuleTesterResult,
-    Plugin
-} from "stylelint";
+    Plugin,
+    Warning,
+} from 'stylelint';
 
 const options: Partial<LinterOptions> = {
     code: "div { color: red }",
@@ -29,6 +30,9 @@ lint(options).then((x: LinterResult) => {
     const err: boolean = x.errored;
     const output: string = x.output;
     const results: LintResult[] = x.results;
+    if (results.length > 0) {
+        const warnings: Warning[] = results[0].warnings;
+    }
 });
 
 const formatter: FormatterType = "json";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - "warnings" have actually been this way all the way back to v3.1.3 (as far back as the documentation goes): https://github.com/stylelint/stylelint/blob/3.1.3/docs/developer-guide/formatters.md
  - "formatter" has also accepted a function at least that far back as well: https://github.com/stylelint/stylelint/blob/3.1.3/docs/user-guide/node-api.md#formatter