### PR TITLE
[ws] Define interfaces for parameters to onopen, onclose, onerror and onmessage

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -5,6 +5,7 @@
 //                 Margus Lamp <https://github.com/mlamp>
 //                 Philippe D'Alva <https://github.com/TitaneBoy>
 //                 Orblazer <https://github.com/orblazer>
+//                 reduckted <https://github.com/reduckted>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -33,10 +34,10 @@ declare class WebSocket extends events.EventEmitter {
     CLOSING: number;
     CLOSED: number;
 
-    onopen: (event: { target: WebSocket }) => void;
-    onerror: (event: {error: any, message: string, type: string, target: WebSocket }) => void;
-    onclose: (event: { wasClean: boolean; code: number; reason: string; target: WebSocket }) => void;
-    onmessage: (event: { data: WebSocket.Data; type: string; target: WebSocket }) => void;
+    onopen: (event: WebSocket.OpenEvent) => void;
+    onerror: (event: WebSocket.ErrorEvent) => void;
+    onclose: (event: WebSocket.CloseEvent) => void;
+    onmessage: (event: WebSocket.MessageEvent) => void;
 
     constructor(address: string, options?: WebSocket.ClientOptions);
     constructor(address: string, protocols?: string | string[], options?: WebSocket.ClientOptions);
@@ -162,6 +163,30 @@ declare namespace WebSocket {
         };
         threshold?: number;
         concurrencyLimit?: number;
+    }
+
+    interface OpenEvent {
+        target: WebSocket;
+    }
+
+    interface ErrorEvent {
+        error: any;
+        message: string;
+        type: string;
+        target: WebSocket;
+    }
+
+    interface CloseEvent {
+        wasClean: boolean;
+        code: number;
+        reason: string;
+        target: WebSocket;
+    }
+
+    interface MessageEvent {
+        data: Data;
+        type: string;
+        target: WebSocket;
     }
 
     interface ServerOptions {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -114,3 +114,19 @@ import * as https from 'https';
     });
     ws.on('open', () => ws.send('something assume to be really long'));
 }
+
+{
+    const ws = new WebSocket('ws://www.host.com/path');
+    ws.onopen = (event: WebSocket.OpenEvent) => {
+        console.log(event.target);
+    };
+    ws.onerror = (event: WebSocket.ErrorEvent) => {
+        console.log(event.error, event.message, event.target, event.type);
+    };
+    ws.onclose = (event: WebSocket.CloseEvent) => {
+        console.log(event.code, event.reason, event.target, event.wasClean);
+    };
+    ws.onmessage = (event: WebSocket.MessageEvent) => {
+        console.log(event.data, event.target, event.type);
+    };
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Not applicable.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

----

I've refactored the event types that were defined inline for `onopen`, `onclose`, `onerror` and `onmessage` to interfaces so that they can be used like this:

```js
ws.onmessage = onSocketMessage;

function onSocketMessage(event: WebSocket.MessageEvent): void {
// ...
}
```

I believe this fixes #34575.

I have deliberately _not_ changed the event parameters to any of the `addEventListener` or `removeEventListener` functions because the properties for some of them were different and that would lead to a breaking change (for example, `data: any` used in `addEventListener` vs `data: WebSocket.Data` used in `onmessage`).