### PR TITLE
[node] v10 crypto: make encryption of private key optional

### DIFF
--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -258,8 +258,8 @@ declare module "crypto" {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        cipher: string;
-        passphrase: string;
+        cipher?: string;
+        passphrase?: string;
     }
 
     interface RSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_generatekeypair_type_options_callback>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The documentation for `crypto.generateKeyPair` says 

> cipher: <string> If specified, the private key will be encrypted with the given cipher and passphrase using PKCS#5 v2.0 password based encryption.

which means that `cipher` and `password` are not necessary which is not reflected correctly by the type definition. 

