### PR TITLE
Add Node Buffer as accepted type to resemblejs

### DIFF
--- a/types/resemblejs/index.d.ts
+++ b/types/resemblejs/index.d.ts
@@ -3,13 +3,15 @@
 // Definitions by: Tim Perry <https://github.com/pimterry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 export = Resemble;
 export as namespace resemble;
 
 /**
  * Retrieve basic analysis for a single image (add compareTo to compare with another).
  */
-declare function Resemble(image: string | ImageData): Resemble.ResembleAnalysis;
+declare function Resemble(image: string | ImageData | Buffer): Resemble.ResembleAnalysis;
 
 declare namespace Resemble {
   /**
@@ -37,7 +39,7 @@ declare namespace Resemble {
     /**
      * Compare this image to another image, to get resemblance data
      */
-    compareTo(fileData: string | ImageData): ResembleComparison;
+    compareTo(fileData: string | ImageData | Buffer): ResembleComparison;
   }
 
   interface ResembleAnalysisResult {

--- a/types/resemblejs/resemblejs-tests.ts
+++ b/types/resemblejs/resemblejs-tests.ts
@@ -1,4 +1,8 @@
+import * as fs from 'fs';
+import {promisify} from 'util';
+import * as resemble from 'resemblejs';
 
+const readFile = promisify(fs.readFile);
 
 resemble.outputSettings({
   errorColor: {
@@ -30,4 +34,12 @@ resemble("images/image2.png").compareTo("images/image2.png")
                      .onComplete(function(data) {
   var diffImageDataUrl: string = data.getImageDataUrl();
   var difference: number = data.misMatchPercentage;
+});
+
+readFile('foo').then(fooFile => {
+  readFile('bar').then(barFile => {
+    resemble(fooFile).compareTo(barFile).onComplete(data => {
+      var diffImageDataUrl: string = data.getImageDataUrl();
+    });
+  });
 });


### PR DESCRIPTION
Resemblejs can also handle Node Buffers:
https://github.com/rsmbl/Resemble.js/blob/db6f0b8298b4865c0d28ff68fab842254a249b9d/resemble.js#L336-L339

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rsmbl/Resemble.js/blob/db6f0b8298b4865c0d28ff68fab842254a249b9d/resemble.js#L336-L339
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.