### PR TITLE
[stripe] Add type signature for retrieveUpcoming invoices

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -9162,6 +9162,7 @@ declare namespace Stripe {
              * @param data Filtering options
              */
             retrieveUpcoming(data: invoices.IInvoiceUpcomingOptions, options: HeaderOptions, response?: IResponseFn<invoices.IInvoice>): Promise<invoices.IInvoice>;
+            retrieveUpcoming(data: invoices.IInvoiceUpcomingOptions, response?: IResponseFn<invoices.IInvoice>): Promise<invoices.IInvoice>;
             retrieveUpcoming(id: string, data: invoices.IInvoiceUpcomingOptions, options: HeaderOptions, response?: IResponseFn<invoices.IInvoice>): Promise<invoices.IInvoice>;
             retrieveUpcoming(id: string, data: invoices.IInvoiceUpcomingOptions, response?: IResponseFn<invoices.IInvoice>): Promise<invoices.IInvoice>;
             retrieveUpcoming(id: string, options: HeaderOptions, response?: IResponseFn<invoices.IInvoice>): Promise<invoices.IInvoice>;

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -28,6 +28,7 @@
 //                 Dylan Aspden <https://github.com/dhaspden>
 //                 Ethan Setnik <https://github.com/esetnik>
 //                 Pavel Ivanov <https://github.com/schfkt>
+//                 Chris Zieba <https://github.com/ChrisZieba>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1335,7 +1335,7 @@ stripe.subscriptions.create({ items: [{ plan: 'platypi-dev' }], customer: 'cus_5
     stripe.invoices
         .retrieveUpcoming({
             customer: 'cus_5rfJKDJkuxzh5Q',
-            subscription: subscription.id
+            subscription: subscription.id,
         })
         .then(invoices => {
             invoices; // $ExpectType invoices.IInvoice

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1338,7 +1338,7 @@ stripe.subscriptions.create({ items: [{ plan: 'platypi-dev' }], customer: 'cus_5
             subscription: subscription.id,
         })
         .then(invoices => {
-            invoices; // $ExpectType invoices.IInvoice
+            invoices; // $ExpectType IInvoice
         });
 });
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1335,8 +1335,7 @@ stripe.subscriptions.create({ items: [{ plan: 'platypi-dev' }], customer: 'cus_5
     stripe.invoices
         .retrieveUpcoming({
             customer: 'cus_5rfJKDJkuxzh5Q',
-            subscription: subscription.id,
-            subscription_items: [{ items: [{ id: subscription.items.data[0].id, plan: 'platypi' }] }],
+            subscription: subscription.id
         })
         .then(invoices => {
             invoices; // $ExpectType invoices.IInvoice

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1329,6 +1329,20 @@ stripe.invoices.retrieveUpcoming(
 stripe.invoices.retrieveUpcoming("cus_5rfJKDJkuxzh5Q").then((upcoming) => {
     // asynchronously called
 });
+stripe.subscriptions.create({ items: [{ plan: 'platypi-dev' }], customer: 'cus_5rfJKDJkuxzh5Q' }).then(subscription => {
+    // asynchronously called
+
+    stripe.invoices
+        .retrieveUpcoming({
+            customer: 'cus_5rfJKDJkuxzh5Q',
+            subscription: subscription.id,
+            subscription_items: [{ items: [{ id: subscription.items.data[0].id, plan: 'platypi' }] }],
+        })
+        .then(invoices => {
+            invoices; // $ExpectType invoices.IInvoice
+        });
+});
+
 stripe.invoices.listUpcomingLineItems({ limit: 5 }).then((lines) => {
     lines; // $ExpectType IList<IInvoiceLineItem>
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[https://stripe.com/docs/api/invoices/upcoming](https://stripe.com/docs/api/invoices/upcoming)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
