### PR TITLE
[@wordpress/block-editor] fix incorrect prop type

### DIFF
--- a/types/wordpress__block-editor/components/alignment-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/alignment-toolbar.d.ts
@@ -9,8 +9,8 @@ declare namespace AlignmentToolbar {
             title: string;
         }>;
         children?: never;
-        value: string;
-        onChange(newValue?: string): void;
+        value: string | undefined;
+        onChange(newValue: string | undefined): void;
     }
 }
 

--- a/types/wordpress__block-editor/components/block-alignment-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/block-alignment-toolbar.d.ts
@@ -7,7 +7,7 @@ declare namespace BlockAlignmentToolbar {
         controls?: Control[];
         isCollapsed?: boolean;
         onChange(newValue: Control | undefined): void;
-        value: Control;
+        value: Control | undefined;
     }
 }
 

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -15,6 +15,7 @@ const STYLES = [{ css: '.foo { color: red; }' }, { css: '.bar { color: blue; }',
 //
 // alignment-toolbar
 //
+<be.AlignmentToolbar value={undefined} onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
 <be.AlignmentToolbar value="left" onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
 <be.AlignmentToolbar
     alignmentControls={[{ align: 'center', icon: 'carrot', title: 'Center' }]}
@@ -25,6 +26,7 @@ const STYLES = [{ css: '.foo { color: red; }' }, { css: '.bar { color: blue; }',
 //
 // block-alignment-toolbar
 //
+<be.BlockAlignmentToolbar value={undefined} onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
 <be.BlockAlignmentToolbar value="left" onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
 <be.BlockAlignmentToolbar
     isCollapsed


### PR DESCRIPTION
**Note to reviewer:** The change reflects the fact that the `value` prop of these components must be set, but if set to `undefined` this means that the setting is toggled off.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.