### PR TITLE
[@mapbox/mapbox-sdk] Added types for mapbox-sdk-js

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,11 +8,11 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-                       constructor(config: SdkConfig);
-                       accessToken: string;
-                       origin?: string;
-                       createRequest(requestOptions: any): MapiRequest;
-                   }
+        constructor(config: SdkConfig);
+        accessToken: string;
+        origin?: string;
+        createRequest(requestOptions: any): MapiRequest;
+    }
 
     interface SdkConfig {
         accessToken: string;
@@ -1219,7 +1219,9 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
     export default function Tokens(config: SdkConfig | MapiClient): TokensService;
 
     interface TokensService {
-        /**List your access tokens. */
+        /**
+         * List your access tokens.
+         */
         listTokens(): MapiRequest;
         /**
          * Create a new access token.
@@ -1243,28 +1245,48 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
          * @param request
          */
         deleteToken(request: UpdateDeleteTokenRequest): MapiRequest;
-        /**List your available scopes. Each item is a metadata object about the scope, not just the string scope. */
+        /**
+         * List your available scopes. Each item is a metadata object about the scope, not just the string scope.
+         */
         listScopes(): MapiRequest;
     }
 
     interface Token {
-        /**the identifier for the token */
+        /**
+         * the identifier for the token
+         */
         id: string;
-        /**the type of token */
+        /**
+         * the type of token
+         */
         usage: string;
-        /**the client for the token, always 'api' */
+        /**
+         * the client for the token, always 'api'
+         */
         client: string;
-        /**if the token is a default token */
+        /**
+         * if the token is a default token
+         */
         default: boolean;
-        /**human friendly description of the token */
+        /**
+         * human friendly description of the token
+         */
         note: string;
-        /**	array of scopes granted to the token */
+        /**	
+         * array of scopes granted to the token
+         */
         scopes: string[];
-        /**date and time the token was created */
+        /**
+         * date and time the token was created
+         */
         created: string;
-        /**	date and time the token was last modified */
+        /**	
+         * date and time the token was last modified
+         */
         modified: string;
-        /**the token itself */
+        /**
+         * the token itself
+         */
         token: string;
     }
 

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,11 +8,11 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-        constructor(config: SdkConfig);
-        accessToken: string;
-        origin?: string;
-        createRequest(requestOptions: any): MapiRequest;
-    }
+                       constructor(config: SdkConfig);
+                       accessToken: string;
+                       origin?: string;
+                       createRequest(requestOptions: any): MapiRequest;
+                   }
 
     export interface SdkConfig {
         accessToken: string;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1,0 +1,1334 @@
+// Type definitions for @mapbox/mapbox-sdk 0.6.0
+// Project: https://github.com/mapbox/mapbox-sdk-js
+// Definitions by: Jeff Dye <https://github.com/jeffbdye> 
+//                 Mike O'Meara <https://github.com/mikeomeara1>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5.2
+
+declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
+  import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  export default class MapiClient {
+    constructor(config: SdkConfig)
+    accessToken: string;
+    origin?: string;
+    createRequest(requestOptions: any): MapiRequest;
+  }
+
+  export interface SdkConfig {
+    accessToken: string;
+    origin?: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
+  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+  import MapiClient from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+  import { MapiError } from '@mapbox/mapbox-sdk/lib/classes/mapi-error';
+
+  export interface EventEmitter {
+    response: MapiResponse;
+    error: MapiError;
+    downloadProgress: ProgressEvents;
+    uploadProgress: ProgressEvents;
+  }
+
+  export interface ProgressEvents {
+
+  }
+
+  export interface MapiRequest {
+    /** An event emitter */
+    emitter: EventEmitter;
+    /** This request's MapiClient. */
+    client: MapiClient;
+    /** If this request has been sent and received a response, the response is available on this property. */
+    response: MapiResponse | null;
+    /**  If this request has been sent and received an error in response, the error is available on this property. */
+    error: MapiError | Error | null;
+    /** If the request has been aborted (via abort), this property will be true. */
+    aborted: boolean;
+    /**  If the request has been sent, this property will be true.
+     * You cannot send the same request twice, so if you need to create a new request
+     * that is the equivalent of an existing one, use clone.
+     */
+    sent: boolean;
+    /** The request's path, including colon-prefixed route parameters. */
+    path: string;
+    /** The request's origin. */
+    origin: string;
+    /**  The request's HTTP method. */
+    method: string;
+    /** A query object, which will be transformed into a URL query string. */
+    // query: GeocodeRequest;
+    /**A route parameters object, whose values will be interpolated the path.  */
+    params: Object;
+    /** The request's headers, */
+    headers: Object;
+    /** Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'. */
+    body: Object | string | null;
+    /** A file to send with the request. The browser client accepts Blobs and ArrayBuffers. */
+    file: Blob | ArrayBuffer | string;
+    url(accessToken?: string): string;
+    send(): Promise<MapiResponse>;
+    abort(): void;
+    eachPage(callback: PageCallbackFunction): void;
+    clone(): MapiRequest;
+  }
+
+  export type PageCallbackFunction = {
+    error: MapiError,
+    response: MapiResponse,
+    next: () => void
+  }
+
+  export type MapboxProfile = "driving" |
+    "walking" |
+    "cycling";
+
+  export type DirectionsApproach = "unrestricted" | "curb";
+}
+
+declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+
+  export interface MapiResponse {
+    /**The response body, parsed as JSON. */
+    body: Object;
+    /**The raw response body. */
+    rawBody: string;
+    /**The response's status code. */
+    statusCode: number;
+    /**The parsed response headers. */
+    headers: Object;
+    /**The parsed response links */
+    links: Object;
+    /**The response's originating MapiRequest. */
+    request: MapiRequest;
+    hasNextPage(): boolean;
+    nextPage(): MapiRequest;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+
+  export interface MapiError {
+    /**The errored request. */
+    request: MapiRequest;
+    /** The type of error. Usually this is 'HttpError'.
+     * If the request was aborted, so the error was not sent from the server, the type will be 'RequestAbortedError'.
+     */
+    type: string;
+    /** The numeric status code of the HTTP response */
+    statusCode?: number;
+    /**  If the server sent a response body, this property exposes that response, parsed as JSON if possible. */
+    body?: Object | string;
+    /** Whatever message could be derived from the call site and HTTP response. */
+    message?: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/datasets' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Datasets Types
+  *********************************************************************************************************************/
+  export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
+
+  export interface DatasetsService {
+    /**List datasets in your account. */
+    listDatasets(): MapiRequest;
+    /**
+     *  Create a new, empty dataset.
+     * @param config Object
+     */
+    createDataset(config: { name?: string, description?: string }): MapiRequest;
+    /**
+     * Get metadata about a dataset.
+     * @param config
+     */
+    getMetadata(config: { datasetId: string }): MapiRequest;
+    /**
+     * Update user-defined properties of a dataset's metadata.
+     * @param config
+     */
+    updateMetadata(config: { datasetId?: string, name?: string, description?: string }): MapiRequest;
+    /**
+     * Delete a dataset, including all features it contains.
+     * @param config
+     */
+    deleteDataset(config: { datasetId?: string }): MapiRequest;
+    /**
+     * List features in a dataset.
+  
+      * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
+      * @param config
+      */
+    // implicit any
+    listFeatures(config: { datasetId: string, limit?: number, start?: string }): any;
+    /**
+     * Add a feature to a dataset or update an existing one.
+     * @param config
+     */
+    putFeature(config: { datasetId: string, featureId: string, feature: Object }): MapiRequest;
+    /**
+     * Get a feature in a dataset.
+     * @param config
+     */
+    // implicit any
+    getFeature(config: { datasetId: string, featureId: string }): any;
+    /**
+     * Delete a feature in a dataset.
+     * @param config
+     */
+    // implicit any
+    deleteFeature(config: { datasetId: string, featureId: string }): any;
+
+  }
+
+  export interface Dataset {
+    /** 	the username of the dataset owner */
+    owner: string;
+    /**id for an existing dataset */
+    id: string;
+    /*date and time the dataset was created */
+    created: string;
+    /* 	date and time the dataset was last modified */
+    modified: string;
+    /**the extent of features in the dataset as an array of west, south, east, north coordinates */
+    bounds: number[];
+    /**	the number of features in the dataset */
+    features: number;
+    /**	the size of the dataset in bytes */
+    size: number;
+    /**the name of the dataset */
+    name: string;
+    /**	the description of the dataset */
+    description: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/directions' {
+  import * as GeoJSON from 'geojson';
+  import { LngLatLike } from 'mapbox-gl';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+  import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+
+  export default function Directions(config: SdkConfig | MapiClient): DirectionsService;
+
+  export interface DirectionsService {
+    getDirections(request: DirectionsRequest): MapiRequest;
+  }
+
+  export type DirectionsProfile = MapboxProfile | "driving-traffic";
+
+  export type DirectionsAnnotation = "duration" | "distance" | "speed" | "congestion";
+  export type DirectionsGeometry = "geojson" | "polyline" | "polyline6";
+  export type DirectionsOverview = "full" | "simplified";
+  export type DirectionsUnits = "imperial" | "metric";
+  export type DirectionsSide = "left" | "right";
+  export type DirectionsMode = "driving" | "ferry" | "unaccessible" | "walking" | "cycling" | "train";
+  export type DirectionsClass = "toll" | "ferry" | "restricted" | "motorway" | "tunnel";
+  export type ManeuverModifier =
+    "uturn" |
+    "sharp right" |
+    "right" |
+    "slight right" |
+    "straight" |
+    "slight left" |
+    "left" |
+    "sharp left" |
+    "depart" |
+    "arrive";
+  export type ManeuverType = "turn" |
+    "new name" |
+    "depart" |
+    "arrive" |
+    "merge" |
+    "on ramp" |
+    "off ramp" |
+    "fork" |
+    "end of road" |
+    "continue" |
+    "roundabout" |
+    "rotary" |
+    "roundabout turn" |
+    "notification" |
+    "exit roundabout" |
+    "exit rotary";
+
+  export interface DirectionsRequest {
+    /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
+    profile: DirectionsProfile;
+    waypoints: DirectionsRequestWaypoint[];
+    /**Whether to try to return alternative routes. An alternative is classified as a route that is significantly
+     * different than the fastest route, but also still reasonably fast. Such a route does not exist in all circumstances.
+     * Currently up to two alternatives can be returned. Can be  true or  false (default).
+     */
+    alternatives?: boolean;
+    /**Whether or not to return additional metadata along the route. Possible values are:  duration ,  distance ,  speed , and congestion .
+     * Several annotations can be used by including them as a comma-separated list. See the RouteLeg object for more details on
+     * what is included with annotations.
+     */
+    annotations?: DirectionsAnnotation[];
+
+    /**Whether or not to return banner objects associated with the  routeSteps .
+     * Should be used in conjunction with  steps . Can be  true or  false . The default is  false .
+     */
+    bannerInstructions?: boolean;
+
+    /** Sets the allowed direction of travel when departing intermediate waypoints. If  true , the route will continue in the same
+     * direction of travel. If  false , the route may continue in the opposite direction of travel. Defaults to  true for mapbox/driving and
+     * false for  mapbox/walking and  mapbox/cycling .
+     */
+    continueStraight?: boolean;
+    /**Exclude certain road types from routing. Valid values depend on the profile in use.
+     * The default is to not exclude anything from the profile selected.
+     */
+    exclude?: DirectionsProfile[];
+    /**Format of the returned geometry. Allowed values are:  geojson (as LineString ),
+     * polyline with precision 5,  polyline6 (a polyline with precision 6). The default value is  polyline .
+     */
+    geometries?: DirectionsGeometry;
+    /**Language of returned turn-by-turn text instructions. See supported languages . The default is  en for English. */
+    language?: string;
+    /**Type of returned overview geometry. Can be  full (the most detailed geometry available),
+     * simplified (a simplified version of the full geometry), or  false (no overview geometry). The default is  simplified .
+     */
+    overview?: DirectionsOverview;
+
+    /**Emit instructions at roundabout exits. Can be  true or  false . The default is  false . */
+    roundaboutExits?: boolean;
+    /**Whether to return steps and turn-by-turn instructions. Can be  true or  false . The default is  false . */
+    steps?: boolean;
+    /**Whether or not to return SSML marked-up text for voice guidance along the route. Should be used in conjunction with steps .
+     * Can be  true or  false . The default is  false .
+     */
+    voiceInstructions?: boolean;
+    /**Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial . */
+    voiceUnits?: DirectionsUnits;
+
+  }
+
+  export interface DirectionsRequestWaypoint {
+    /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
+    coordinates: number[] | LngLatLike;
+    /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
+   * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
+   * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
+   * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
+   * while  bearings influences how you start from a waypoint. If provided, the list of approaches must be the same length as the list of waypoints.
+   * However, you can skip a coordinate and show its position in the list with the  ; separator.
+   */
+    approach?: DirectionsApproach;
+    /**Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. */
+    radius?: string | "unlimited";
+  }
+
+  export interface DirectionsResponse {
+    /**Array of Route objects ordered by descending recommendation rank. May contain at most two routes. */
+    routes: Route[];
+    /** Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
+     * The waypoints appear in the array in the order of the input coordinates.
+     */
+    waypoints: Waypoint[];
+    /**String indicating the state of the response. This is a separate code than the HTTP status code.
+     * On normal valid responses, the value will be Ok.
+     */
+    code: string;
+    uuid: string;
+  }
+
+  export interface Waypoint {
+    /**String with the name of the way the coordinate snapped to */
+    name: string;
+    /**Array of [ longitude, latitude ] for the snapped coordinate */
+    location: number[];
+    /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+     * This option should always be used in conjunction with the  radiuses parameter. The parameter takes two values per waypoint.
+     * The first value is an angle clockwise from true north between 0 and 360, and the second is the range of degrees the angle can deviate by.
+     * The recommended value for the range is 45° or 90°, as bearing measurements tend to be inaccurate.
+     * This is useful for making sure the new routes of rerouted vehicles continue traveling in their current direction.
+     * A request that does this would provide bearing and radius values for the first waypoint and leave the remaining values empty.
+     * If provided, the list of bearings must be the same length as the list of waypoints.
+     * However, you can skip a coordinate and show its position in the list with the  ; separator.
+     */
+    bearing?: number[];
+    /**Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
+    * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
+    * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
+    */
+    waypointName?: string;
+  }
+
+  export interface Route {
+    /**Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
+     * Depending on the overview parameter this is the complete route geometry (full), a simplified geometry
+     * to the zoom level at which the route can be displayed in full (simplified), or is not included (false)
+     */
+    geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
+    /**Array of RouteLeg objects. */
+    legs: Leg[];
+    /** String indicating which weight was used. The default is routability which is duration-based,
+     * with additional penalties for less desirable maneuvers.
+     */
+    weight_name: string;
+    /**Float indicating the weight in units described by weight_name */
+    weight: number;
+    /**Float indicating the estimated travel time in seconds. */
+    duration: number;
+    /**Float indicating the distance traveled in meters. */
+    distance: number;
+    /**String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. */
+    voiceLocale?: string;
+  }
+
+  export interface Leg {
+    /**Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) */
+    summary: string;
+    weight: number;
+    /**Number indicating the estimated travel time in seconds */
+    duration: number;
+    /** Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) */
+    steps: Step[];
+    /** Number indicating the distance traveled in meters */
+    distance: number;
+    /**An annotations object that contains additional details about each line segment along the route geometry.
+     * Each entry in an annotations field corresponds to a coordinate along the route geometry.
+     */
+    annotation: DirectionsAnnotation[];
+  }
+
+  export interface Step {
+    /**Array of objects representing all intersections along the step. */
+    intersections: Intersection[];
+    /**The legal driving side at the location for this step. Either left or right. */
+    driving_side: DirectionsSide;
+    /** Depending on the geometries parameter this is a GeoJSON LineString or a
+     * Polyline string representing the full route geometry from this RouteStep to the next RouteStep
+     */
+    geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
+    /**String indicating the mode of transportation. Possible values: */
+    mode: DirectionsMode;
+    /**One StepManeuver object */
+    maneuver: Maneuver;
+    /**Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
+     * Optionally included, if data is available. If multiple road designations are associated with the road, they are separated by semicolons.
+     * A road designation typically consists of an alphabetic network code (identifying the road type or numbering system), a space or hyphen,
+     * and a route number. You should not assume that the network code is globally unique: for example, a network code of “NH” may appear on a
+     * “National Highway” or “New Hampshire”. Moreover, a route number may not even uniquely identify a road within a given network.
+     */
+    ref?: string;
+    weight: number;
+    /**Number indicating the estimated time traveled time in seconds from the maneuver to the next RouteStep. */
+    duration: number;
+    /**String with the name of the way along which the travel proceeds */
+    name: string;
+    /** Number indicating the distance traveled in meters from the maneuver to the next RouteStep. */
+    distance: number;
+    voiceInstructions: VoiceInstruction[];
+    bannerInstructions: BannerInstruction[];
+    /**String with the destinations of the way along which the travel proceeds. Optionally included, if data is available. */
+    destinations?: string;
+    /**String with the exit numbers or names of the way. Optionally included, if data is available. */
+    exits?: string;
+    /** A string containing an IPA phonetic transcription indicating how to pronounce the name in the name property.
+     * This property is omitted if pronunciation data is unavailable for the step.
+     */
+    pronunciation?: string;
+
+
+  }
+
+  export interface Instruction {
+    /**String that contains all the text that should be displayed */
+    text: string;
+    /**Objects that, together, make up what should be displayed in the banner.
+     * Includes additional information intended to be used to aid in visual layout
+     */
+    components: Component[];
+    /**The type of maneuver. May be used in combination with the modifier (and, if it is a roundabout, the degrees) to for an icon to
+     * display. Possible values: 'turn', 'merge', 'depart', 'arrive', 'fork', 'off ramp', 'roundabout'
+     */
+    type?: string;
+    /** The modifier for the maneuver. Can be used in combination with the type (and, if it is a roundabout, the degrees)
+     * to for an icon to display. Possible values: 'left', 'right', 'slight left', 'slight right', 'sharp left', 'sharp right', 'straight', 'uturn'
+     */
+    modifier?: ManeuverModifier;
+    /**The degrees at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout. */
+    degrees?: number;
+    /** A string representing which side the of the street people drive on in that location. Can be 'left' or 'right'. */
+    driving_side: DirectionsSide;
+  }
+
+  export interface BannerInstruction {
+    /**float indicating in meters, how far from the upcoming maneuver
+     * the banner instruction should begin being displayed. Only 1 banner should be displayed at a time.
+     */
+    distanceAlongGeometry: number;
+    /**Most important content to display to the user. Our SDK displays this text larger and at the top. */
+    primary: Instruction;
+    /**Additional content useful for visual guidance. Our SDK displays this text slightly smaller and below the primary. Can be null. */
+    secondary?: Instruction[];
+    then?: any;
+    /**Additional information that is included if we feel the driver needs a heads up about something.
+     * Can include information about the next maneuver (the one after the upcoming one) if the step is short -
+     * can be null, or can be lane information. If we have lane information, that trumps information about the next maneuver.
+     */
+    sub?: Sub;
+  }
+
+  export interface Sub {
+    /** String that contains all the text that should be displayed */
+    text: string;
+    /**Objects that, together, make up what should be displayed in the banner.
+     * Includes additional information intended to be used to aid in visual layout
+     */
+    components: Component[];
+  }
+
+  export interface Component {
+    /**String giving you more context about the component which may help in visual markup/display choices.
+     * If the type of the components is unknown it should be treated as text. Note: Introduction of new types
+     * is not considered a breaking change. See the Types of Banner Components table below for more info on each type.
+     */
+    type: string;
+    /** The sub-string of the parent object's text that may have additional context associated with it */
+    text: string;
+    /**The abbreviated form of text. If this is present, there will also be an abbr_priority value.
+     * See the Examples of Abbreviations table below for an example of using abbr and abbr_priority.
+     */
+    abbr?: string;
+    /**An integer indicating the order in which the abbreviation abbr should be used in place of text.
+     * The highest priority is 0 and a higher integer value means it should have a lower priority. There are no gaps in
+     * integer values. Multiple components can have the same abbr_priority and when this happens all components with the
+     * same abbr_priority should be abbreviated at the same time. Finding no larger values of abbr_priority means that the
+     * string is fully abbreviated.
+     */
+    abbr_priority?: number;
+    /** String pointing to a shield image to use instead of the text. */
+    imageBaseURL?: string;
+    /** (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
+     * If the value is ['left', 'straight'], the driver can go straight or left from that lane
+     */
+    directions?: string[];
+    /**  (present if component is lane): A boolean telling you if that lane can be used to complete the upcoming maneuver.
+     * If multiple lanes are active, then they can all be used to complete the upcoming maneuver.
+     */
+    active: boolean;
+  }
+
+  export interface VoiceInstruction {
+    /** float indicating in meters, how far from the upcoming maneuver the voice instruction should begin. */
+    distanceAlongGeometry: number;
+    /**String containing the text of the verbal instruction. */
+    announcement: string;
+    /**String with SSML markup for proper text and pronunciation. Note: this property is designed for use with Amazon Polly.
+     * The SSML tags contained here may not work with other text-to-speech engines.
+     */
+    ssmlAnnouncement: string;
+  }
+
+  export interface Maneuver {
+    /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver */
+    bearing_after: number;
+    /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver */
+    bearing_before: number;
+    /**Array of [ longitude, latitude ] coordinates for the point of the maneuver */
+    location: number[];
+    /** Optional String indicating the direction change of the maneuver */
+    modifier?: ManeuverModifier;
+    /**String indicating the type of maneuver */
+    type: ManeuverType;
+    /**A human-readable instruction of how to execute the returned maneuver */
+    instruction: string;
+  }
+
+  export interface Intersection {
+    /**Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
+     * the direction of travel after the maneuver/passing the intersection.
+     * The value is not supplied for arrive maneuvers.
+     */
+    out?: number;
+    /** A list of entry flags, corresponding in a 1:1 relationship to the bearings.
+     * A value of true indicates that the respective road could be entered on a valid route.
+     * false indicates that the turn onto the respective road would violate a restriction.
+     */
+    entry: boolean[];
+    /**A list of bearing values (for example [0,90,180,270]) that are available at the intersection.
+     * The bearings describe all available roads at the intersection.
+     */
+    bearings: number[];
+    /**A [longitude, latitude] pair describing the location of the turn. */
+    location: number[];
+    /** Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the clockwise angle from true
+     * north to the direction of travel before the maneuver/passing the intersection. To get the bearing in the direction of driving,
+     * the bearing has to be rotated by a value of 180. The value is not supplied for departure maneuvers.
+     */
+    in?: number;
+    /**  An array of strings signifying the classes of the road exiting the intersection.  */
+    classes?: DirectionsClass[];
+    /**Array of Lane objects that represent the available turn lanes at the intersection.
+     * If no lane information is available for an intersection, the lanes property will not be present.
+     */
+    lanes: Lane[];
+  }
+
+  export interface Lane {
+    /**Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
+     * first two are marked as valid, then the driver can take either of the left lanes and stay on the route.
+     */
+    valid: boolean;
+    /**Array of signs for each turn lane. There can be multiple signs. For example, a turning lane can have a sign with an arrow pointing left and another sign with an arrow pointing straight.
+        Example Lane object
+        {
+            "valid": true,
+            "indications": [
+                "left"
+            ]
+          */
+    indications: string[];
+  }
+
+}
+
+declare module '@mapbox/mapbox-sdk/services/geocoding' {
+  import { LngLatLike } from 'mapbox-gl';
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Geocoder Types
+  *********************************************************************************************************************/
+  export type GeocodeMode = "mapbox.places" | "mapbox.places-permanent";
+
+
+  export type GeocodeQueryType = "country" |
+    "region" |
+    "postcode" |
+    "district" |
+    "place" |
+    "locality" |
+    "neighborhood" |
+    "address" |
+    "poi" |
+    "poi.landmark";
+
+  export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
+
+  export interface GeocodeService {
+    forwardGeocode(request: GeocodeRequest): MapiRequest;
+    reverseGeocode(request: GeocodeRequest): MapiRequest;
+  }
+
+  export interface IBBox {
+    minx: number;
+    miny: number;
+    maxx: number;
+    maxy: number;
+  }
+
+  export interface GeocodeRequest {
+    // A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
+    query: string | LngLatLike;
+    // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
+    mode: GeocodeMode;
+    // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes 
+    countries?: string[];
+    //Bias local results based on a provided location. Options are  longitude,latitude coordinates.
+    proximity?: number[];
+    //Filter results by one or more feature types
+    types?: GeocodeQueryType[];
+    //Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
+    autocomplete?: boolean;
+    //Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
+    bbox?: IBBox;
+    //Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
+    limit?: number;
+    // Specify the language to use for response text and, for forward geocoding, query result weighting. 
+    // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more 
+    // IETF subtags for country or script. 
+    language?: string[];
+  }
+
+  export interface GeocodeResponse {
+    /**	"Feature Collection" , a GeoJSON type from the GeoJSON specification . */
+    type: string;
+    /**	An array of space and punctuation-separated strings from the original query. */
+    query: string[];
+    /**An array of feature objects. */
+    features: GeocodeFeature[];
+    /**A string attributing the results of the Mapbox Geocoding API to Mapbox and links to Mapbox's terms of service and data sources. */
+    attribution: string;
+  }
+
+  export interface GeocodeFeature {
+    /** A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
+     * The  {id} suffix of the feature id is unstable and may change within versions.
+     */
+    id: string;
+    /**"Feature" , a GeoJSON type from the GeoJSON specification . */
+    type: string;
+    /**An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,
+     * address ,  poi , and  poi.landmark . Most features have only one type, but if the feature has multiple types,
+     * all applicable types will be listed in the array. (For example, Vatican City is a  country , region , and  place .)
+     */
+    place_type: string[];
+    /**	A numerical score from 0 (least relevant) to 0.99 (most relevant) measuring how well each returned feature matches the query.
+     * You can use the  relevance property to remove results that don't fully match the query.
+     */
+    relevance: number;
+    /**A string of the house number for the returned  address feature. Note that unlike the
+     * address property for  poi features, this property is outside the  properties object.
+     */
+    address?: string;
+    /**
+     * 	An object describing the feature. The property object is unstable and only Carmen GeoJSON properties are guaranteed.
+     * Your implementation should check for the presence of these values in a response before it attempts to use them.
+     */
+    properties: GeocodeProperties;
+    /**	A string representing the feature in the requested language, if specified. */
+    text: string;
+    /**A string representing the feature in the requested language, if specified, and its full result hierarchy. */
+    place_name: string;
+    /**A string analogous to the  text field that more closely matches the query than results in the specified language.
+     * For example, querying "Köln, Germany" with language set to English might return a feature with the
+     * text "Cologne" and the  matching_text "Köln".
+     */
+    matching_text: string;
+    /**A string analogous to the  place_name field that more closely matches the query than results in the specified language.
+     * For example, querying "Köln, Germany" with language set to English might return a feature with the place_name "Cologne, Germany"
+     * and a  matching_place_name of "Köln, North Rhine-Westphalia, Germany".
+     */
+    matching_place_name: string;
+    /**
+     * A string of the IETF language tag of the query's primary language.
+     * Can be used to identity text and place_name properties on this object
+     * in the format text_{language}, place_name_{language} and language_{language} 
+     */
+    language: string;
+    /**An array bounding box in the form [ minX,minY,maxX,maxY ] . */
+    bbox?: number[];
+    /**	An array in the form [ longitude,latitude ] at the center of the specified  bbox . */
+    center: number[];
+    /** An object describing the spatial geometry of the returned feature.*/
+    geometry: Geometry;
+    /** An array representing the hierarchy of encompassing parent features. Each parent feature may include any of the above properties.*/
+    context: GeocodeFeature[];
+  }
+
+  export interface Geometry {
+    /**" Point" , a GeoJSON type from the GeoJSON specification . */
+    type: string;
+    /** An array in the format [ longitude,latitude ] at the center of the specified  bbox . */
+    coordinates: number[];
+    /** A boolean value indicating if an  address is interpolated along a road network. This field is only present when the feature is interpolated. */
+    interpolated: boolean;
+  }
+
+  export interface GeocodeProperties extends GeocodeFeature {
+    /** The Wikidata identifier for the returned feature.*/
+    wikidata?: string;
+    /**A string of comma-separated categories for the returned  poi feature. */
+    category?: string;
+    /**A formatted string of the telephone number for the returned  poi feature. */
+    tel?: string;
+    /**	The name of a suggested Maki icon to visualize a  poi feature based on its  category . */
+    maki?: string;
+    /**A boolean value indicating whether a  poi feature is a landmark. Landmarks are
+     * particularly notable or long-lived features like schools, parks, museums and places of worship.
+     */
+    landmark?: boolean;
+    /**The ISO 3166-1 country and ISO 3166-2 region code for the returned feature. */
+    short_coide: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/map-matching' {
+  import { LngLatLike } from 'mapbox-gl';
+  import {
+    DirectionsProfile,
+    DirectionsAnnotation,
+    DirectionsGeometry,
+    DirectionsOverview,
+    Leg
+  } from '@mapbox/mapbox-sdk/services/directions';
+  import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Map Matching Types
+  *********************************************************************************************************************/
+  export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
+
+
+  export interface MapMatchingService {
+    getMatching(request: MapMatchingRequest): MapiRequest
+  }
+
+  export interface MapMatchingRequest {
+    /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
+    points: MapMatchingPoint[],
+    /** A directions profile ID. (optional, default driving) */
+    profile?: DirectionsProfile;
+    /**Specify additional metadata that should be returned. */
+    annotations?: DirectionsAnnotation;
+    /**Format of the returned geometry. (optional, default "polyline") */
+    geometries?: DirectionsGeometry;
+    /**Language of returned turn-by-turn text instructions. See supported languages. (optional, default "en") */
+    language?: string;
+    /** Type of returned overview geometry. (optional, default "simplified")*/
+    overview?: DirectionsOverview;
+    /**Whether to return steps and turn-by-turn instructions. (optional, default false) */
+    steps?: boolean;
+    /** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default false) */
+    tidy?: boolean;
+  }
+
+  export interface Point {
+    coordinates: LngLatLike;
+    /**Used to indicate how requested routes consider from which side of the road to approach a waypoint. */
+    approach?: DirectionsApproach;
+  }
+
+  export interface MapMatchingPoint extends Point {
+    /**A number in meters indicating the assumed precision of the used tracking device. */
+    radius?: number;
+    /**Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints. */
+    isWaypoint?: boolean;
+    /**Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless isWaypoint is true. */
+    waypointName?: boolean;
+    /**Datetime corresponding to the coordinate. */
+    timestamp?: string | number | Date;
+  }
+
+  export interface MapMatchingResponse {
+    /**an array of Match objects */
+    matchings: Matching[];
+    /**an array of Tracepoint objects representing the location an input point was matched with.
+     * Array of Waypoint objects representing all input points of the trace in the order they were matched.
+     * If a trace point is omitted by map matching because it is an outlier, the entry will be null.
+     */
+    tracepoints: Tracepoint[];
+    /**&a string depicting the state of the response; see below for options */
+    code: string;
+  }
+
+  export interface Tracepoint {
+    /** Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
+     * Split the trace at these points for incremental map matching.
+     */
+    alternatives_count: number;
+    /**Index of the waypoint inside the matched route. */
+    waypoint_index: number;
+    location: number[];
+    name: string;
+    /**Index to the match object in matchings the sub-trace was matched to. */
+    matchings_index: number;
+  }
+
+  export interface Matching {
+    /**a number between 0 (low) and 1 (high) indicating level of confidence in the returned match */
+    confidence: number;
+    geometry: string;
+    legs: Leg[];
+    distance: number;
+    duration: number;
+    weight_name: string;
+    weight: number;
+  }
+
+}
+
+declare module '@mapbox/mapbox-sdk/services/matrix' {
+  import {
+    DirectionsProfile,
+    DirectionsAnnotation
+  } from '@mapbox/mapbox-sdk/services/directions';
+  import { Point } from '@mapbox/mapbox-sdk/services/map-matching';
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Matrix Types
+  *********************************************************************************************************************/
+  export function Matrix(config: SdkConfig | MapiClient): MatrixService;
+
+  export interface MatrixService {
+    /**
+     * Get a duration and/or distance matrix showing travel times and distances between coordinates.
+     * @param request
+     */
+    getMatrix(request: MatrixRequest): MapiRequest
+  }
+
+  export interface MatrixRequest {
+    points: Point[];
+    profile?: DirectionsProfile;
+    sources?: number[];
+    destinations?: number[];
+    annotations?: DirectionsAnnotation;
+  }
+
+  export interface MatrixResponse {
+    code: string;
+    durations?: number[][];
+    distances?: number[][];
+    destinations: Destination[];
+    sources: Destination[];
+  }
+
+  export interface Destination {
+    location: number[];
+    name: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/optimization' {
+  import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Optimization Types
+  *********************************************************************************************************************/
+  export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
+
+  export interface OptimizationService {
+    getContours(config: OptimizationRequest): MapiRequest;
+  }
+
+  export interface OptimizationRequest {
+    /**A Mapbox Directions routing profile ID. */
+    profile: MapboxProfile;
+    /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
+    waypoints: OptimizationWaypoint[];
+    /**Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are: */
+    annotations?: "duration" | "speed" | "distance";
+    /**Specify the destination coordinate of the returned route. Accepts  any (default) or  last . */
+    destination?: "any" | "last";
+    /** Specify pick-up and drop-off locations for a trip by providing a  ; delimited list of number pairs that correspond with the coordinates list. The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location. */
+    distributions?: number[];
+    /**The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6). */
+    geometries?: "geojson" | "polyline" | "polyline6";
+    /**The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English). */
+    language?: string;
+    /**The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry). */
+    overview?: "full" | "simplified" | "false";
+    /**The coordinate at which to start the returned route. Accepts  any (default) or  first . */
+    source?: "any" | "first";
+    /** Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default). */
+    steps?: boolean;
+    /** Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes. */
+    roundtrip?: boolean;
+  }
+
+  export interface OptimizationWaypoint {
+    coordinates: number;
+    /** Used to indicate how requested routes consider from which side of the road to approach the waypoint. */
+    approach?: DirectionsApproach;
+    /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+     This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
+    and the second is the range of degrees the angle can deviate by. */
+    bearing?: number[];
+    /**Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment. */
+    radius?: number | "unlimited";
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/static' {
+  import { LngLatLike, LngLatBoundsLike } from 'mapbox-gl';
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Static Map Types
+  *********************************************************************************************************************/
+  export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
+
+  export interface StaticMapService {
+    /**
+     * Get a static map image..
+     * @param request
+     */
+    getStaticImage(request: StaticMapRequest): MapiRequest
+  }
+
+  export interface StaticMapRequest {
+    ownerId: string;
+    styleId: string;
+    width: number;
+    height: number;
+    position: {
+      coordinates: LngLatLike | "auto";
+      zoom: number;
+      bearing?: number;
+      pitch?: number;
+    } | "auto";
+    overlays?: CustomMarkerOverlay[] | PathOverlay[] | GeoJsonOverlay[];
+    highRes?: boolean;
+    insertOverlayBeforeLayer?: string;
+    attribution?: boolean;
+    logo?: boolean;
+  }
+
+  export interface CustomMarkerOverlay {
+    marker: CustomMarker
+  }
+
+  export interface CustomMarker {
+    coordinates: LngLatLike;
+    url: string;
+  }
+
+  export interface PathOverlay {
+    /**An array of coordinates describing the path. */
+    coordinates: LngLatBoundsLike[];
+    strokeWidth?: number;
+    strokeColor?: string;
+    /**Must be paired with strokeColor. */
+    strokeOpacity?: number;
+    /** Must be paired with strokeColor. */
+    fillColor?: string;
+    /** Must be paired with strokeColor. */
+    fillOpacity?: number;
+  }
+
+  export interface GeoJsonOverlay {
+    geoJson: Object;
+  }
+
+
+}
+
+declare module '@mapbox/mapbox-sdk/services/styles' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Style Types
+  *********************************************************************************************************************/
+  export function Styles(config: SdkConfig | MapiClient): StylesService;
+
+  export interface StylesService {
+    /**
+    * Get a style.
+    * @param styleId
+    * @param ownerId
+    */
+    getStyle(config: { styleId: string, ownerId?: string }): MapiRequest;
+    /**
+     * Create a style.
+     * @param style
+     * @param ownerId
+     */
+    createStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+    /**
+     * Update a style.
+     * @param styleId
+     * @param style
+     * @param lastKnownModification
+     * @param ownerId
+     */
+    // implicit any
+    updateStyle(config: { styleId: string, style: Style, lastKnownModification?: string | number | Date, ownerId?: string }): void;
+    /**
+     * Delete a style.
+     * @param style
+     * @param ownerId
+     */
+    deleteStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+    /**
+     * List styles in your account.
+     * @param start
+     * @param ownerId
+     */
+    listStyles(config: { start?: string, ownerId?: string }): MapiRequest;
+    /**
+     * Add an icon to a style, or update an existing one.
+     * @param styleId
+     * @param iconId
+     * @param file
+     * @param ownerId
+     */
+    putStyleIcon(config: { styleId: string, iconId: string, file: Blob | ArrayBuffer | string, ownerId?: string }): MapiRequest;
+    /**
+     * Remove an icon from a style.
+     * @param styleId
+     * @param iconId
+     * @param ownerId
+     */
+    // implicit any
+    deleteStyleIcon(config: { styleId: string, iconId: string, ownerId?: string }): void;
+    /**
+     * Get a style sprite's image or JSON document.
+     * @param styleId
+     * @param format
+     * @param highRes
+     * @param ownerId
+     */
+    getStyleSprite(config: { styleId: string, format?: "json" | "png", highRes?: boolean, ownerId?: string }): MapiRequest;
+    /**
+     * Get a font glyph range.
+     * @param fonts
+     * @param start
+     * @param end
+     * @param ownerId
+     */
+    getFontGlyphRange(config: { fonts: string[], start: number, end: number, ownerId?: string }): MapiRequest;
+    /**
+     * Get embeddable HTML displaying a map.
+     * @param config
+     * @param styleId
+     * @param scrollZoom
+     * @param title
+     * @param ownerId
+     */
+    getEmbeddableHtml(config: { config: Object, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
+  }
+
+  interface Style {
+    version: number;
+    name: string;
+    /**Information about the style that is used in Mapbox Studio. */
+    metadata: string;
+    sources: Sources;
+    sprite: string;
+    glyphs: string;
+    layers: string[];
+    /**Date and time the style was created. */
+    created: string;
+    /**	The ID of the style. */
+    id: string;
+    /**Date and time the style was last modified. */
+    modified: string;
+    /**The username of the style owner. */
+    owner: string;
+    /**	Access control for the style, either  public or  private . Private styles require an access token belonging to the owner,
+     * while public styles may be requested with an access token belonging to any user.
+     */
+    visibility: string;
+    /**Whether the style is a draft or has been published. */
+    draft: boolean;
+  }
+
+  interface Sources {
+  }
+
+
+}
+
+declare module '@mapbox/mapbox-sdk/services/tilequery' {
+  import * as mapboxgl from 'mapbox-gl';
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Tile Query (Places) Types
+  *********************************************************************************************************************/
+  export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
+
+  export interface TileQueryService {
+    /**
+     * Get a static map image..
+     * @param request
+     */
+    listFeatures(request: TileQueryRequest): MapiRequest
+  }
+
+  export interface TileQueryRequest {
+    /**The maps being queried. If you need to composite multiple layers, provide multiple map IDs. */
+    mapIds: string[];
+    /**The longitude and latitude to be queried. */
+    coordinates: mapboxgl.LngLatLike;
+    /**The approximate distance in meters to query for features. (optional, default 0) */
+    radius: number;
+    /**The number of features to return, between 1 and 50. (optional, default 5) */
+    limit: number;
+    /**Whether or not to deduplicate results. (optional, default true) */
+    dedupe: boolean;
+    /** Queries for a specific geometry type. */
+    geometry: GeometryType;
+    layers?: string[];
+  }
+
+  export type GeometryType = "polygon" | "linestring" | "point";
+
+
+}
+
+declare module '@mapbox/mapbox-sdk/services/tilesets' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Tileset Types
+  *********************************************************************************************************************/
+  export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
+
+  export interface TilesetsService {
+    listTilesets(config: { ownerId: string }): MapiRequest;
+  }
+
+  export interface Tileset {
+    type: string;
+    center: number[];
+    created: string;
+    description: string;
+    filesize: number;
+    id: string;
+    modified: string;
+    name: string;
+    visibility: string;
+    status: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/tokens' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Token Types
+  *********************************************************************************************************************/
+  export function Tokens(config: SdkConfig | MapiClient): TokensService;
+
+  export interface TokensService {
+    /**List your access tokens. */
+    listTokens(): MapiRequest;
+    /**
+     * Create a new access token.
+     * @param request
+     */
+    createToken(request: CreateTokenRequest): MapiRequest;
+    /**
+     * Create a new temporary access token.
+     * @param request
+     */
+    createTemporaryToken(request: TemporaryTokenRequest): MapiRequest;
+    /**
+     * Update an access token.
+     * @param request
+     */
+    updateToken(request: UpdateDeleteTokenRequest): MapiRequest;
+    /**Get data about the client's access token. */
+    getToken(): MapiRequest;
+    /**
+     * Delete an access token.
+     * @param request
+     */
+    deleteToken(request: UpdateDeleteTokenRequest): MapiRequest;
+    /**List your available scopes. Each item is a metadata object about the scope, not just the string scope. */
+    listScopes(): MapiRequest;
+  }
+
+  export interface Token {
+    /**the identifier for the token */
+    id: string;
+    /**the type of token */
+    usage: string;
+    /**the client for the token, always 'api' */
+    client: string;
+    /**if the token is a default token */
+    default: boolean;
+    /**human friendly description of the token */
+    note: string;
+    /**	array of scopes granted to the token */
+    scopes: string[];
+    /**date and time the token was created */
+    created: string;
+    /**	date and time the token was last modified */
+    modified: string;
+    /**the token itself */
+    token: string;
+  }
+
+  export interface CreateTokenRequest {
+    note?: string;
+    scopes?: string[];
+    resources?: string[];
+  }
+
+  export interface TemporaryTokenRequest {
+    expires: string;
+    scopes: string[];
+  }
+
+  export interface UpdateDeleteTokenRequest extends CreateTokenRequest {
+    tokenId: string;
+  }
+
+  export interface TokenDetail {
+    code: string;
+    token: Token;
+  }
+
+  export interface Scope {
+    id: string;
+    public: boolean;
+    description: string;
+  }
+}
+
+declare module '@mapbox/mapbox-sdk/services/uploads' {
+  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+
+  /*********************************************************************************************************************
+  * Uploads Types
+  *********************************************************************************************************************/
+  export function Uploads(config: SdkConfig | MapiClient): UploadsService;
+
+  export interface UploadsService {
+    /**
+     * List the statuses of all recent uploads.
+     * @param config
+     */
+    listUploads(config: { reverse?: boolean }): MapiRequest;
+    /**Create S3 credentials. */
+    createUploadCredentials(): MapiRequest;
+    /**
+     * Create an upload.
+     * @param config
+     */
+    createUpload(config: { mapId: string, url: string, tilesetName?: string }): MapiRequest;
+    /**
+     * Get an upload's status.
+     * @param config
+     */
+    // implicit any
+    getUpload(config: { uploadId: string }): any;
+    /**
+     * Delete an upload.
+     * @param config
+     */
+    // implicit any
+    deleteUpload(config: { uploadId: string }): any;
+
+  }
+
+  export interface S3Credentials {
+    accessKeyId: string;
+    bucket: string;
+    key: string;
+    secretAccessKey: string;
+    sessionToken: string;
+    url: string;
+  }
+
+  export interface UploadResponse {
+    complete: boolean;
+    tileset: string;
+    error?: any;
+    id: string;
+    name: string;
+    modified: string;
+    created: string;
+    owner: string;
+    progress: number;
+  }
+}

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1312,7 +1312,9 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
          * @param config
          */
         listUploads(config: { reverse?: boolean }): MapiRequest;
-        /**Create S3 credentials. */
+        /**
+         * Create S3 credentials. 
+         * */
         createUploadCredentials(): MapiRequest;
         /**
          * Create an upload.

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,11 +8,11 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-        constructor(config: SdkConfig);
-        accessToken: string;
-        origin?: string;
-        createRequest(requestOptions: any): MapiRequest;
-    }
+                       constructor(config: SdkConfig);
+                       accessToken: string;
+                       origin?: string;
+                       createRequest(requestOptions: any): MapiRequest;
+                   }
 
     interface SdkConfig {
         accessToken: string;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -331,17 +331,17 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         approach?: DirectionsApproach;
         /**
-         * Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. 
+         * Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius.
          */
         radius?: string | 'unlimited';
     }
 
     interface DirectionsResponse {
         /**
-         * Array of Route objects ordered by descending recommendation rank. May contain at most two routes. 
+         * Array of Route objects ordered by descending recommendation rank. May contain at most two routes.
          */
         routes: Route[];
-        /** 
+        /**
          * Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
          * The waypoints appear in the array in the order of the input coordinates.
          */
@@ -390,48 +390,48 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
         /**
-         * Array of RouteLeg objects. 
+         * Array of RouteLeg objects.
          */
         legs: Leg[];
-        /** 
+        /**
          * String indicating which weight was used. The default is routability which is duration-based,
          * with additional penalties for less desirable maneuvers.
          */
         weight_name: string;
-        /** 
-         * Float indicating the weight in units described by weight_name 
+        /**
+         * Float indicating the weight in units described by weight_name
          */
         weight: number;
-        /** 
-         * Float indicating the estimated travel time in seconds. 
+        /**
+         * Float indicating the estimated travel time in seconds.
          */
         duration: number;
-        /** 
-         * Float indicating the distance traveled in meters. 
+        /**
+         * Float indicating the distance traveled in meters.
          */
         distance: number;
-        /** 
-         * String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. 
+        /**
+         * String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language.
          */
         voiceLocale?: string;
     }
 
     interface Leg {
         /**
-         * Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) 
+         * Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false)
          */
         summary: string;
         weight: number;
         /**
-         * Number indicating the estimated travel time in seconds 
+         * Number indicating the estimated travel time in seconds
          */
         duration: number;
         /**
-         * Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) 
+         * Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false)
          */
         steps: Step[];
         /**
-         * Number indicating the distance traveled in meters 
+         * Number indicating the distance traveled in meters
          */
         distance: number;
         /**

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -640,15 +640,15 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         mode: GeocodeMode;
         // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes
         countries?: string[];
-        //Bias local results based on a provided location. Options are  longitude,latitude coordinates.
+        // Bias local results based on a provided location. Options are  longitude,latitude coordinates.
         proximity?: number[];
-        //Filter results by one or more feature types
+        // Filter results by one or more feature types
         types?: GeocodeQueryType[];
         //Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
         autocomplete?: boolean;
-        //Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
+        // Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
         bbox?: IBBox;
-        //Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
+        // Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
         limit?: number;
         // Specify the language to use for response text and, for forward geocoding, query result weighting.
         // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more
@@ -657,51 +657,71 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
     }
 
     interface GeocodeResponse {
-        /**	"Feature Collection" , a GeoJSON type from the GeoJSON specification . */
+        /**
+         * "Feature Collection" , a GeoJSON type from the GeoJSON specification.
+         */
         type: string;
-        /**	An array of space and punctuation-separated strings from the original query. */
+        /**
+         * An array of space and punctuation-separated strings from the original query.
+         */
         query: string[];
-        /**An array of feature objects. */
+        /**
+         * An array of feature objects.
+         */
         features: GeocodeFeature[];
-        /**A string attributing the results of the Mapbox Geocoding API to Mapbox and links to Mapbox's terms of service and data sources. */
+        /**
+         * A string attributing the results of the Mapbox Geocoding API to Mapbox and links to Mapbox's terms of service and data sources.
+         */
         attribution: string;
     }
 
     interface GeocodeFeature {
-        /** A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
+        /**
+         * A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
          * The  {id} suffix of the feature id is unstable and may change within versions.
          */
         id: string;
-        /**"Feature" , a GeoJSON type from the GeoJSON specification . */
+        /**
+         * "Feature" , a GeoJSON type from the GeoJSON specification.
+         * */
         type: string;
-        /**An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,
+        /**
+         * An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,
          * address ,  poi , and  poi.landmark . Most features have only one type, but if the feature has multiple types,
          * all applicable types will be listed in the array. (For example, Vatican City is a  country , region , and  place .)
          */
         place_type: string[];
-        /**	A numerical score from 0 (least relevant) to 0.99 (most relevant) measuring how well each returned feature matches the query.
+        /**
+         * A numerical score from 0 (least relevant) to 0.99 (most relevant) measuring how well each returned feature matches the query.
          * You can use the  relevance property to remove results that don't fully match the query.
          */
         relevance: number;
-        /**A string of the house number for the returned  address feature. Note that unlike the
+        /**
+         * A string of the house number for the returned  address feature. Note that unlike the
          * address property for  poi features, this property is outside the  properties object.
          */
         address?: string;
         /**
-         * 	An object describing the feature. The property object is unstable and only Carmen GeoJSON properties are guaranteed.
+         * An object describing the feature. The property object is unstable and only Carmen GeoJSON properties are guaranteed.
          * Your implementation should check for the presence of these values in a response before it attempts to use them.
          */
         properties: GeocodeProperties;
-        /**	A string representing the feature in the requested language, if specified. */
+        /**
+         * A string representing the feature in the requested language, if specified.
+         */
         text: string;
-        /**A string representing the feature in the requested language, if specified, and its full result hierarchy. */
+        /**
+         * A string representing the feature in the requested language, if specified, and its full result hierarchy.
+         */
         place_name: string;
-        /**A string analogous to the  text field that more closely matches the query than results in the specified language.
+        /**
+         * A string analogous to the  text field that more closely matches the query than results in the specified language.
          * For example, querying "Köln, Germany" with language set to English might return a feature with the
          * text "Cologne" and the  matching_text "Köln".
          */
         matching_text: string;
-        /**A string analogous to the  place_name field that more closely matches the query than results in the specified language.
+        /**
+         * A string analogous to the  place_name field that more closely matches the query than results in the specified language.
          * For example, querying "Köln, Germany" with language set to English might return a feature with the place_name "Cologne, Germany"
          * and a  matching_place_name of "Köln, North Rhine-Westphalia, Germany".
          */
@@ -712,39 +732,64 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
          * in the format text_{language}, place_name_{language} and language_{language}
          */
         language: string;
-        /**An array bounding box in the form [ minX,minY,maxX,maxY ] . */
+        /**
+         * An array bounding box in the form [ minX,minY,maxX,maxY ] .
+         */
         bbox?: number[];
-        /**	An array in the form [ longitude,latitude ] at the center of the specified  bbox . */
+        /**
+         * An array in the form [ longitude,latitude ] at the center of the specified  bbox .
+         */
         center: number[];
-        /** An object describing the spatial geometry of the returned feature.*/
+        /**
+         * An object describing the spatial geometry of the returned feature
+         */
         geometry: Geometry;
-        /** An array representing the hierarchy of encompassing parent features. Each parent feature may include any of the above properties.*/
+        /**
+         * An array representing the hierarchy of encompassing parent features. Each parent feature may include any of the above properties
+         */
         context: GeocodeFeature[];
     }
 
     interface Geometry {
-        /**" Point" , a GeoJSON type from the GeoJSON specification . */
+        /**
+         * Point, a GeoJSON type from the GeoJSON specification .
+         */
         type: string;
-        /** An array in the format [ longitude,latitude ] at the center of the specified  bbox . */
+        /**
+         * An array in the format [ longitude,latitude ] at the center of the specified  bbox .
+         */
         coordinates: number[];
-        /** A boolean value indicating if an  address is interpolated along a road network. This field is only present when the feature is interpolated. */
+        /**
+         * A boolean value indicating if an  address is interpolated along a road network. This field is only present when the feature is interpolated.
+         */
         interpolated: boolean;
     }
 
     interface GeocodeProperties extends GeocodeFeature {
-        /** The Wikidata identifier for the returned feature.*/
+        /**
+         * The Wikidata identifier for the returned feature.
+         */
         wikidata?: string;
-        /**A string of comma-separated categories for the returned  poi feature. */
+        /**
+         * A string of comma-separated categories for the returned  poi feature.
+         */
         category?: string;
-        /**A formatted string of the telephone number for the returned  poi feature. */
+        /**
+         * A formatted string of the telephone number for the returned  poi feature.
+         */
         tel?: string;
-        /**	The name of a suggested Maki icon to visualize a  poi feature based on its  category . */
+        /**
+         * The name of a suggested Maki icon to visualize a  poi feature based on its  category .
+         */
         maki?: string;
-        /**A boolean value indicating whether a  poi feature is a landmark. Landmarks are
+        /**
+         * A boolean value indicating whether a  poi feature is a landmark. Landmarks are
          * particularly notable or long-lived features like schools, parks, museums and places of worship.
          */
         landmark?: boolean;
-        /**The ISO 3166-1 country and ISO 3166-2 region code for the returned feature. */
+        /**
+         * The ISO 3166-1 country and ISO 3166-2 region code for the returned feature.
+         */
         short_coide: string;
     }
 }
@@ -771,68 +816,107 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
     }
 
     interface MapMatchingRequest {
-        /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
+        /**
+         * An ordered array of MapMatchingPoints, between 2 and 100 (inclusive).
+         */
         points: MapMatchingPoint[];
-        /** A directions profile ID. (optional, default driving) */
+        /**
+         * A directions profile ID. (optional, default driving)
+         */
         profile?: DirectionsProfile;
-        /**Specify additional metadata that should be returned. */
+        /**
+         * Specify additional metadata that should be returned.
+         */
         annotations?: DirectionsAnnotation;
-        /**Format of the returned geometry. (optional, default "polyline") */
+        /**
+         * Format of the returned geometry. (optional, default "polyline")
+         */
         geometries?: DirectionsGeometry;
-        /**Language of returned turn-by-turn text instructions. See supported languages. (optional, default "en") */
+        /**
+         * Language of returned turn-by-turn text instructions. See supported languages. (optional, default "en")
+         */
         language?: string;
-        /** Type of returned overview geometry. (optional, default "simplified")*/
+        /**
+         * Type of returned overview geometry. (optional, default "simplified"
+         */
         overview?: DirectionsOverview;
-        /**Whether to return steps and turn-by-turn instructions. (optional, default false) */
+        /**
+         * Whether to return steps and turn-by-turn instructions. (optional, default false)
+         */
         steps?: boolean;
-        /** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default false) */
+        /**
+         * Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default false)
+         */
         tidy?: boolean;
     }
 
     interface Point {
         coordinates: LngLatLike;
-        /**Used to indicate how requested routes consider from which side of the road to approach a waypoint. */
+        /**
+         * Used to indicate how requested routes consider from which side of the road to approach a waypoint.
+         */
         approach?: DirectionsApproach;
     }
 
     interface MapMatchingPoint extends Point {
-        /**A number in meters indicating the assumed precision of the used tracking device. */
+        /**
+         * A number in meters indicating the assumed precision of the used tracking device.
+         */
         radius?: number;
-        /**Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints. */
+        /**
+         * Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints.
+         */
         isWaypoint?: boolean;
-        /**Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless isWaypoint is true. */
+        /**
+         * Custom name for the waypoint used for the arrival instruction in banners and voice instructions.
+         * Will be ignored unless isWaypoint is true.
+         */
         waypointName?: boolean;
-        /**Datetime corresponding to the coordinate. */
+        /**
+         * Datetime corresponding to the coordinate.
+         */
         timestamp?: string | number | Date;
     }
 
     interface MapMatchingResponse {
-        /**an array of Match objects */
+        /**
+         * An array of Match objects.
+         */
         matchings: Matching[];
-        /**an array of Tracepoint objects representing the location an input point was matched with.
+        /**
+         * An array of Tracepoint objects representing the location an input point was matched with.
          * Array of Waypoint objects representing all input points of the trace in the order they were matched.
          * If a trace point is omitted by map matching because it is an outlier, the entry will be null.
          */
         tracepoints: Tracepoint[];
-        /**&a string depicting the state of the response; see below for options */
+        /**
+         * A string depicting the state of the response; see below for options
+         */
         code: string;
     }
 
     interface Tracepoint {
-        /** Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
+        /**
+         * Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
          * Split the trace at these points for incremental map matching.
          */
         alternatives_count: number;
-        /**Index of the waypoint inside the matched route. */
+        /**
+         * Index of the waypoint inside the matched route.
+         */
         waypoint_index: number;
         location: number[];
         name: string;
-        /**Index to the match object in matchings the sub-trace was matched to. */
+        /**
+         * Index to the match object in matchings the sub-trace was matched to.
+         */
         matchings_index: number;
     }
 
     interface Matching {
-        /**a number between 0 (low) and 1 (high) indicating level of confidence in the returned match */
+        /**
+         * a number between 0 (low) and 1 (high) indicating level of confidence in the returned match
+         */
         confidence: number;
         geometry: string;
         legs: Leg[];
@@ -841,7 +925,6 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         weight_name: string;
         weight: number;
     }
-
 }
 
 declare module '@mapbox/mapbox-sdk/services/matrix' {
@@ -893,7 +976,7 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
     /*********************************************************************************************************************
      * Optimization Types
      *********************************************************************************************************************/
-    export function Optimization(config: SdkConfig | MapiClient): OptimizationService; // SdkConfig | MapiClient
+    export default function Optimization(config: SdkConfig | MapiClient): OptimizationService; // SdkConfig | MapiClient
 
     interface OptimizationService {
         getContours(config: OptimizationRequest): MapiRequest;
@@ -918,7 +1001,8 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
         destination?: 'any' | 'last';
         /**
          * Specify pick-up and drop-off locations for a trip by providing a ; delimited list of number pairs that correspond with the coordinates list.
-         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list.
+         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list,
+         * and the second number indicates the index to the coordinate of the drop-off location in the coordinates list.
          * Each pair must contain exactly 2 numbers, which cannot be the same.
          * The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location.
          */

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jeff Dye <https://github.com/jeffbdye> 
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -182,7 +182,16 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         deleteFeature(config: { datasetId: string; featureId: string }): any;
     }
 
-    export type DataSetsFeature = GeoJSON.Point | GeoJSON.MultiPoint | GeoJSON.LineString | GeoJSON.MultiLineString | GeoJSON.Polygon | GeoJSON.MultiPolygon | GeoJSON.GeometryCollection | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
+    /** All GeoJSON types except for FeatureCollection. */
+    export type DataSetsFeature =
+        | GeoJSON.Point
+        | GeoJSON.MultiPoint
+        | GeoJSON.LineString
+        | GeoJSON.MultiLineString
+        | GeoJSON.Polygon
+        | GeoJSON.MultiPolygon
+        | GeoJSON.GeometryCollection
+        | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
 
     export interface Dataset {
         /** 	the username of the dataset owner */
@@ -1007,17 +1016,17 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
 
     export interface StylesService {
         /**
-        * Get a style.
-        * @param styleId
-        * @param ownerId
-        */
-        getStyle(config: { styleId: string, ownerId?: string }): MapiRequest;
+         * Get a style.
+         * @param styleId
+         * @param ownerId
+         */
+        getStyle(config: { styleId: string; ownerId?: string }): MapiRequest;
         /**
          * Create a style.
          * @param style
          * @param ownerId
          */
-        createStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+        createStyle(config: { style: Style; ownerId?: string }): MapiRequest;
         /**
          * Update a style.
          * @param styleId
@@ -1026,19 +1035,24 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param ownerId
          */
         // implicit any
-        updateStyle(config: { styleId: string, style: Style, lastKnownModification?: string | number | Date, ownerId?: string }): void;
+        updateStyle(config: {
+            styleId: string;
+            style: Style;
+            lastKnownModification?: string | number | Date;
+            ownerId?: string;
+        }): void;
         /**
          * Delete a style.
          * @param style
          * @param ownerId
          */
-        deleteStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+        deleteStyle(config: { style: Style; ownerId?: string }): MapiRequest;
         /**
          * List styles in your account.
          * @param start
          * @param ownerId
          */
-        listStyles(config: { start?: string, ownerId?: string }): MapiRequest;
+        listStyles(config: { start?: string; ownerId?: string }): MapiRequest;
         /**
          * Add an icon to a style, or update an existing one.
          * @param styleId
@@ -1046,7 +1060,12 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param file
          * @param ownerId
          */
-        putStyleIcon(config: { styleId: string, iconId: string, file: Blob | ArrayBuffer | string, ownerId?: string }): MapiRequest;
+        putStyleIcon(config: {
+            styleId: string;
+            iconId: string;
+            file: Blob | ArrayBuffer | string;
+            ownerId?: string;
+        }): MapiRequest;
         /**
          * Remove an icon from a style.
          * @param styleId
@@ -1054,7 +1073,7 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param ownerId
          */
         // implicit any
-        deleteStyleIcon(config: { styleId: string, iconId: string, ownerId?: string }): void;
+        deleteStyleIcon(config: { styleId: string; iconId: string; ownerId?: string }): void;
         /**
          * Get a style sprite's image or JSON document.
          * @param styleId
@@ -1062,7 +1081,12 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param highRes
          * @param ownerId
          */
-        getStyleSprite(config: { styleId: string, format?: "json" | "png", highRes?: boolean, ownerId?: string }): MapiRequest;
+        getStyleSprite(config: {
+            styleId: string;
+            format?: 'json' | 'png';
+            highRes?: boolean;
+            ownerId?: string;
+        }): MapiRequest;
         /**
          * Get a font glyph range.
          * @param fonts
@@ -1070,7 +1094,7 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param end
          * @param ownerId
          */
-        getFontGlyphRange(config: { fonts: string[], start: number, end: number, ownerId?: string }): MapiRequest;
+        getFontGlyphRange(config: { fonts: string[]; start: number; end: number; ownerId?: string }): MapiRequest;
         /**
          * Get embeddable HTML displaying a map.
          * @param config
@@ -1079,7 +1103,13 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param title
          * @param ownerId
          */
-        getEmbeddableHtml(config: { config: any, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
+        getEmbeddableHtml(config: {
+            config: any;
+            styleId: string;
+            scrollZoom?: boolean;
+            title?: boolean;
+            ownerId?: string;
+        }): MapiRequest;
     }
 
     interface Style {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,11 +8,11 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-                       constructor(config: SdkConfig);
-                       accessToken: string;
-                       origin?: string;
-                       createRequest(requestOptions: any): MapiRequest;
-                   }
+        constructor(config: SdkConfig);
+        accessToken: string;
+        origin?: string;
+        createRequest(requestOptions: any): MapiRequest;
+    }
 
     interface SdkConfig {
         accessToken: string;
@@ -634,37 +634,37 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
     }
 
     interface GeocodeRequest {
-        /** 
+        /**
          * A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
          */
         query: string | LngLatLike;
-        /** 
+        /**
          * Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
          */
         mode: GeocodeMode;
         /**
          * Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes
-         */ 
+         */
         countries?: string[];
         /**
          * Bias local results based on a provided location. Options are  longitude,latitude coordinates.
-         */ 
+         */
         proximity?: number[];
         /**
          * Filter results by one or more feature types
-         */ 
+         */
         types?: GeocodeQueryType[];
         /**
          * Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
-         */ 
+         */
         autocomplete?: boolean;
         /**
          * Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
-         */ 
+         */
         bbox?: IBBox;
         /**
          * Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
-         */ 
+         */
         limit?: number;
         /** Specify the language to use for response text and, for forward geocoding, query result weighting.
          * Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,11 +8,11 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-                       constructor(config: SdkConfig);
-                       accessToken: string;
-                       origin?: string;
-                       createRequest(requestOptions: any): MapiRequest;
-                   }
+        constructor(config: SdkConfig);
+        accessToken: string;
+        origin?: string;
+        createRequest(requestOptions: any): MapiRequest;
+    }
 
     interface SdkConfig {
         accessToken: string;
@@ -32,7 +32,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         uploadProgress: ProgressEvents;
     }
 
-    interface ProgressEvents {}
+    interface ProgressEvents { }
 
     interface MapiRequest {
         /** An event emitter */
@@ -621,7 +621,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         | 'poi'
         | 'poi.landmark';
 
-    export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
+    export default function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
 
     interface GeocodeService {
         forwardGeocode(request: GeocodeRequest): MapiRequest;
@@ -766,7 +766,7 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
     /*********************************************************************************************************************
      * Map Matching Types
      *********************************************************************************************************************/
-    export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
+    export default function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
 
     interface MapMatchingService {
         getMatching(request: MapMatchingRequest): MapiRequest;
@@ -855,7 +855,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
     /*********************************************************************************************************************
      * Matrix Types
      *********************************************************************************************************************/
-    export function Matrix(config: SdkConfig | MapiClient): MatrixService;
+    export default function Matrix(config: SdkConfig | MapiClient): MatrixService;
 
     interface MatrixService {
         /**
@@ -947,7 +947,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     /*********************************************************************************************************************
      * Static Map Types
      *********************************************************************************************************************/
-    export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
+    export default function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
 
     interface StaticMapService {
         /**
@@ -963,13 +963,13 @@ declare module '@mapbox/mapbox-sdk/services/static' {
         width: number;
         height: number;
         position:
-            | {
-                  coordinates: LngLatLike | 'auto';
-                  zoom: number;
-                  bearing?: number;
-                  pitch?: number;
-              }
-            | 'auto';
+        | {
+            coordinates: LngLatLike | 'auto';
+            zoom: number;
+            bearing?: number;
+            pitch?: number;
+        }
+        | 'auto';
         overlays?: CustomMarkerOverlay[] | PathOverlay[] | GeoJsonOverlay[];
         highRes?: boolean;
         insertOverlayBeforeLayer?: string;
@@ -1013,7 +1013,7 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
     /*********************************************************************************************************************
     * Style Types
     *********************************************************************************************************************/
-    export function Styles(config: SdkConfig | MapiClient): StylesService;
+    export default function Styles(config: SdkConfig | MapiClient): StylesService;
 
     interface StylesService {
         /**
@@ -1152,7 +1152,7 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
     /*********************************************************************************************************************
      * Tile Query (Places) Types
      *********************************************************************************************************************/
-    export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
+    export default function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
 
     interface TileQueryService {
         /**
@@ -1190,7 +1190,7 @@ declare module '@mapbox/mapbox-sdk/services/tilesets' {
     /*********************************************************************************************************************
      * Tileset Types
      *********************************************************************************************************************/
-    export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
+    export default function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
 
     interface TilesetsService {
         listTilesets(config: { ownerId: string }): MapiRequest;
@@ -1218,7 +1218,7 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
     /*********************************************************************************************************************
      * Token Types
      *********************************************************************************************************************/
-    export function Tokens(config: SdkConfig | MapiClient): TokensService;
+    export default function Tokens(config: SdkConfig | MapiClient): TokensService;
 
     interface TokensService {
         /**List your access tokens. */
@@ -1304,7 +1304,7 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
     /*********************************************************************************************************************
      * Uploads Types
      *********************************************************************************************************************/
-    export function Uploads(config: SdkConfig | MapiClient): UploadsService;
+    export default function Uploads(config: SdkConfig | MapiClient): UploadsService;
 
     interface UploadsService {
         /**
@@ -1313,8 +1313,8 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
          */
         listUploads(config: { reverse?: boolean }): MapiRequest;
         /**
-         * Create S3 credentials. 
-         * */
+         * Create S3 credentials.
+         */
         createUploadCredentials(): MapiRequest;
         /**
          * Create an upload.

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jeff Dye <https://github.com/jeffbdye> 
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -985,23 +985,29 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     }
 
     interface PathOverlay {
-        /**An array of coordinates describing the path. */
+        /**
+         * An array of coordinates describing the path.
+         */
         coordinates: LngLatBoundsLike[];
         strokeWidth?: number;
         strokeColor?: string;
-        /**Must be paired with strokeColor. */
+        /**
+         * Must be paired with strokeColor.
+         */
         strokeOpacity?: number;
-        /** Must be paired with strokeColor. */
+        /**
+         * Must be paired with strokeColor.
+         */
         fillColor?: string;
-        /** Must be paired with strokeColor. */
+        /**
+         * Must be paired with strokeColor.
+         */
         fillOpacity?: number;
     }
 
     interface GeoJsonOverlay {
         geoJson: GeoJSON.GeoJsonTypes;
     }
-
-
 }
 
 declare module '@mapbox/mapbox-sdk/services/styles' {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Jeff Dye <https://github.com/jeffbdye> 
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5.2
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -33,36 +33,63 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
     }
 
     interface MapiRequest {
-        /** An event emitter */
+        /**
+         * An event emitter.
+         */
         emitter: EventEmitter;
-        /** This request's MapiClient. */
+        /**
+         * This request's MapiClient.
+         */
         client: MapiClient;
-        /** If this request has been sent and received a response, the response is available on this property. */
+        /**
+         * If this request has been sent and received a response, the response is available on this property.
+         */
         response: MapiResponse | null;
-        /**  If this request has been sent and received an error in response, the error is available on this property. */
+        /**
+         * If this request has been sent and received an error in response, the error is available on this property.
+         */
         error: MapiError | Error | null;
-        /** If the request has been aborted (via abort), this property will be true. */
+        /**
+         * If the request has been aborted (via abort), this property will be true.
+         */
         aborted: boolean;
-        /**  If the request has been sent, this property will be true.
+        /**
+         * If the request has been sent, this property will be true.
          * You cannot send the same request twice, so if you need to create a new request
          * that is the equivalent of an existing one, use clone.
          */
         sent: boolean;
-        /** The request's path, including colon-prefixed route parameters. */
+        /**
+         * The request's path, including colon-prefixed route parameters.
+         */
         path: string;
-        /** The request's origin. */
+        /**
+         * The request's origin.
+         */
         origin: string;
-        /**  The request's HTTP method. */
+        /**
+         * The request's HTTP method.
+         */
         method: string;
-        /** A query object, which will be transformed into a URL query string. */
+        /**
+         * A query object, which will be transformed into a URL query string.
+         */
         query: any;
-        /**A route parameters object, whose values will be interpolated the path.  */
+        /**
+         * A route parameters object, whose values will be interpolated the path.
+         */
         params: any;
-        /** The request's headers, */
+        /**
+         * The request's headers.
+         */
         headers: any;
-        /** Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'. */
+        /**
+         * Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'.
+         */
         body: any | string | null;
-        /** A file to send with the request. The browser client accepts Blobs and ArrayBuffers. */
+        /**
+         * A file to send with the request. The browser client accepts Blobs and ArrayBuffers.
+         */
         file: Blob | ArrayBuffer | string;
         url(accessToken?: string): string;
         send(): Promise<MapiResponse>;
@@ -71,32 +98,44 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         clone(): MapiRequest;
     }
 
-    export type PageCallbackFunction = {
+    type PageCallbackFunction = {
         error: MapiError;
         response: MapiResponse;
         next: () => void;
     };
 
-    export type MapboxProfile = 'driving' | 'walking' | 'cycling';
+    type MapboxProfile = 'driving' | 'walking' | 'cycling';
 
-    export type DirectionsApproach = 'unrestricted' | 'curb';
+    type DirectionsApproach = 'unrestricted' | 'curb';
 }
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
     import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
     interface MapiResponse {
-        /**The response body, parsed as JSON. */
+        /**
+         * The response body, parsed as JSON.
+         */
         body: any;
-        /**The raw response body. */
+        /**
+         * The raw response body.
+         */
         rawBody: string;
-        /**The response's status code. */
+        /**
+         * The response's status code.
+         */
         statusCode: number;
-        /**The parsed response headers. */
+        /**
+         * The parsed response headers.
+         */
         headers: any;
-        /**The parsed response links */
+        /**
+         * The parsed response links
+         */
         links: any;
-        /**The response's originating MapiRequest. */
+        /**
+         * The response's originating MapiRequest.
+         */
         request: MapiRequest;
         hasNextPage(): boolean;
         nextPage(): MapiRequest;
@@ -107,17 +146,26 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
     import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
     interface MapiError {
-        /**The errored request. */
+        /**
+         * The errored request.
+         */
         request: MapiRequest;
-        /** The type of error. Usually this is 'HttpError'.
+        /**
+         * The type of error. Usually this is 'HttpError'.
          * If the request was aborted, so the error was not sent from the server, the type will be 'RequestAbortedError'.
          */
         type: string;
-        /** The numeric status code of the HTTP response */
+        /**
+         * The numeric status code of the HTTP response
+         */
         statusCode?: number;
-        /**  If the server sent a response body, this property exposes that response, parsed as JSON if possible. */
+        /**
+         * If the server sent a response body, this property exposes that response, parsed as JSON if possible.
+         */
         body?: any | string;
-        /** Whatever message could be derived from the call site and HTTP response. */
+        /**
+         * Whatever message could be derived from the call site and HTTP response.
+         */
         message?: string;
     }
 }
@@ -132,7 +180,9 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
     export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
 
     interface DatasetsService {
-        /**List datasets in your account. */
+        /**
+         * List datasets in your account.
+         */
         listDatasets(): MapiRequest;
         /**
          *  Create a new, empty dataset.
@@ -156,10 +206,9 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         deleteDataset(config: { datasetId?: string }): MapiRequest;
         /**
          * List features in a dataset.
-
-          * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
-          * @param config
-          */
+         * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
+         * @param config
+         */
         // implicit any
         listFeatures(config: { datasetId: string; limit?: number; start?: string }): any;
         /**
@@ -181,8 +230,10 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         deleteFeature(config: { datasetId: string; featureId: string }): any;
     }
 
-    /** All GeoJSON types except for FeatureCollection. */
-    export type DataSetsFeature =
+    /**
+     * All GeoJSON types except for FeatureCollection.
+     */
+    type DataSetsFeature =
         | GeoJSON.Point
         | GeoJSON.MultiPoint
         | GeoJSON.LineString
@@ -226,16 +277,16 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         getDirections(request: DirectionsRequest): MapiRequest;
     }
 
-    export type DirectionsProfile = MapboxProfile | 'driving-traffic';
+    type DirectionsProfile = MapboxProfile | 'driving-traffic';
 
-    export type DirectionsAnnotation = 'duration' | 'distance' | 'speed' | 'congestion';
-    export type DirectionsGeometry = 'geojson' | 'polyline' | 'polyline6';
-    export type DirectionsOverview = 'full' | 'simplified';
-    export type DirectionsUnits = 'imperial' | 'metric';
-    export type DirectionsSide = 'left' | 'right';
-    export type DirectionsMode = 'driving' | 'ferry' | 'unaccessible' | 'walking' | 'cycling' | 'train';
-    export type DirectionsClass = 'toll' | 'ferry' | 'restricted' | 'motorway' | 'tunnel';
-    export type ManeuverModifier =
+    type DirectionsAnnotation = 'duration' | 'distance' | 'speed' | 'congestion';
+    type DirectionsGeometry = 'geojson' | 'polyline' | 'polyline6';
+    type DirectionsOverview = 'full' | 'simplified';
+    type DirectionsUnits = 'imperial' | 'metric';
+    type DirectionsSide = 'left' | 'right';
+    type DirectionsMode = 'driving' | 'ferry' | 'unaccessible' | 'walking' | 'cycling' | 'train';
+    type DirectionsClass = 'toll' | 'ferry' | 'restricted' | 'motorway' | 'tunnel';
+    type ManeuverModifier =
         | 'uturn'
         | 'sharp right'
         | 'right'
@@ -246,7 +297,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         | 'sharp left'
         | 'depart'
         | 'arrive';
-    export type ManeuverType =
+    type ManeuverType =
         | 'turn'
         | 'new name'
         | 'depart'
@@ -265,54 +316,72 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         | 'exit rotary';
 
     interface DirectionsRequest {
-        /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
+        /**
+         * Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling
+         */
         profile: DirectionsProfile;
         waypoints: DirectionsRequestWaypoint[];
-        /**Whether to try to return alternative routes. An alternative is classified as a route that is significantly
+        /**
+         * Whether to try to return alternative routes. An alternative is classified as a route that is significantly
          * different than the fastest route, but also still reasonably fast. Such a route does not exist in all circumstances.
          * Currently up to two alternatives can be returned. Can be  true or  false (default).
          */
         alternatives?: boolean;
-        /**Whether or not to return additional metadata along the route. Possible values are:  duration ,  distance ,  speed , and congestion .
+        /**
+         * Whether or not to return additional metadata along the route. Possible values are:  duration ,  distance ,  speed , and congestion .
          * Several annotations can be used by including them as a comma-separated list. See the RouteLeg object for more details on
          * what is included with annotations.
          */
         annotations?: DirectionsAnnotation[];
 
-        /**Whether or not to return banner objects associated with the  routeSteps .
+        /**
+         * Whether or not to return banner objects associated with the  routeSteps .
          * Should be used in conjunction with  steps . Can be  true or  false . The default is  false .
          */
         bannerInstructions?: boolean;
 
-        /** Sets the allowed direction of travel when departing intermediate waypoints. If  true , the route will continue in the same
+        /**
+         * Sets the allowed direction of travel when departing intermediate waypoints. If  true , the route will continue in the same
          * direction of travel. If  false , the route may continue in the opposite direction of travel. Defaults to  true for mapbox/driving and
          * false for  mapbox/walking and  mapbox/cycling .
          */
         continueStraight?: boolean;
-        /**Exclude certain road types from routing. Valid values depend on the profile in use.
+        /**
+         * Exclude certain road types from routing. Valid values depend on the profile in use.
          * The default is to not exclude anything from the profile selected.
          */
         exclude?: DirectionsProfile[];
-        /**Format of the returned geometry. Allowed values are:  geojson (as LineString ),
+        /**
+         * Format of the returned geometry. Allowed values are:  geojson (as LineString ),
          * polyline with precision 5,  polyline6 (a polyline with precision 6). The default value is  polyline .
          */
         geometries?: DirectionsGeometry;
-        /**Language of returned turn-by-turn text instructions. See supported languages . The default is  en for English. */
+        /**
+         * Language of returned turn-by-turn text instructions. See supported languages . The default is  en for English.
+         */
         language?: string;
-        /**Type of returned overview geometry. Can be  full (the most detailed geometry available),
+        /**
+         * Type of returned overview geometry. Can be  full (the most detailed geometry available),
          * simplified (a simplified version of the full geometry), or  false (no overview geometry). The default is  simplified .
          */
         overview?: DirectionsOverview;
 
-        /**Emit instructions at roundabout exits. Can be  true or  false . The default is  false . */
+        /**
+         * Emit instructions at roundabout exits. Can be  true or  false . The default is  false .
+         */
         roundaboutExits?: boolean;
-        /**Whether to return steps and turn-by-turn instructions. Can be  true or  false . The default is  false . */
+        /**
+         * Whether to return steps and turn-by-turn instructions. Can be  true or  false . The default is  false .
+         */
         steps?: boolean;
-        /**Whether or not to return SSML marked-up text for voice guidance along the route. Should be used in conjunction with steps .
+        /**
+         * Whether or not to return SSML marked-up text for voice guidance along the route. Should be used in conjunction with steps .
          * Can be  true or  false . The default is  false .
          */
         voiceInstructions?: boolean;
-        /**Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial . */
+        /**
+         * Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial .
+         */
         voiceUnits?: DirectionsUnits;
     }
 
@@ -331,7 +400,10 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         approach?: DirectionsApproach;
         /**
-         * Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius.
+         * Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment.
+         * There must be as many radiuses as there are coordinates in the request, each separated by ';'.
+         * Values can be any number greater than 0 or the string 'unlimited'.
+         * A  NoSegment error is returned if no routable road is found within the radius.
          */
         radius?: string | 'unlimited';
     }
@@ -450,7 +522,8 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          * The legal driving side at the location for this step. Either left or right.
          */
         driving_side: DirectionsSide;
-        /** Depending on the geometries parameter this is a GeoJSON LineString or a
+        /**
+         * Depending on the geometries parameter this is a GeoJSON LineString or a
          * Polyline string representing the full route geometry from this RouteStep to the next RouteStep
          */
         geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
@@ -462,7 +535,8 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          * One StepManeuver object
          */
         maneuver: Maneuver;
-        /**Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
+        /**
+         * Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
          * Optionally included, if data is available. If multiple road designations are associated with the road, they are separated by semicolons.
          * A road designation typically consists of an alphabetic network code (identifying the road type or numbering system), a space or hyphen,
          * and a route number. You should not assume that the network code is globally unique: for example, a network code of “NH” may appear on a
@@ -590,7 +664,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         abbr_priority?: number;
         /**
          * String pointing to a shield image to use instead of the text.
-         * */
+         */
         imageBaseURL?: string;
         /**
          * (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
@@ -697,7 +771,6 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         indications: string[];
     }
-
 }
 
 declare module '@mapbox/mapbox-sdk/services/geocoding' {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -56,13 +56,13 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         /**  The request's HTTP method. */
         method: string;
         /** A query object, which will be transformed into a URL query string. */
-        // query: GeocodeRequest;
+        query: any;
         /**A route parameters object, whose values will be interpolated the path.  */
-        params: Object;
+        params: any;
         /** The request's headers, */
-        headers: Object;
+        headers: any;
         /** Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'. */
-        body: Object | string | null;
+        body: any | string | null;
         /** A file to send with the request. The browser client accepts Blobs and ArrayBuffers. */
         file: Blob | ArrayBuffer | string;
         url(accessToken?: string): string;
@@ -88,15 +88,15 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
 
     export interface MapiResponse {
         /**The response body, parsed as JSON. */
-        body: Object;
+        body: any;
         /**The raw response body. */
         rawBody: string;
         /**The response's status code. */
         statusCode: number;
         /**The parsed response headers. */
-        headers: Object;
+        headers: any;
         /**The parsed response links */
-        links: Object;
+        links: any;
         /**The response's originating MapiRequest. */
         request: MapiRequest;
         hasNextPage(): boolean;
@@ -117,7 +117,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
         /** The numeric status code of the HTTP response */
         statusCode?: number;
         /**  If the server sent a response body, this property exposes that response, parsed as JSON if possible. */
-        body?: Object | string;
+        body?: any | string;
         /** Whatever message could be derived from the call site and HTTP response. */
         message?: string;
     }
@@ -167,7 +167,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
          * Add a feature to a dataset or update an existing one.
          * @param config
          */
-        putFeature(config: { datasetId: string; featureId: string; feature: Object }): MapiRequest;
+        putFeature(config: { datasetId: string; featureId: string; feature: DataSetsFeature }): MapiRequest;
         /**
          * Get a feature in a dataset.
          * @param config
@@ -181,6 +181,8 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         // implicit any
         deleteFeature(config: { datasetId: string; featureId: string }): any;
     }
+
+    export type DataSetsFeature = GeoJSON.Point | GeoJSON.MultiPoint | GeoJSON.LineString | GeoJSON.MultiLineString | GeoJSON.Polygon | GeoJSON.MultiPolygon | GeoJSON.GeometryCollection | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
 
     export interface Dataset {
         /** 	the username of the dataset owner */
@@ -988,7 +990,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     }
 
     export interface GeoJsonOverlay {
-        geoJson: Object;
+        geoJson: GeoJSON.GeoJsonTypes;
     }
 
 
@@ -1077,7 +1079,7 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
          * @param title
          * @param ownerId
          */
-        getEmbeddableHtml(config: { config: Object, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
+        getEmbeddableHtml(config: { config: any, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
     }
 
     interface Style {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1161,24 +1161,34 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
     }
 
     interface TileQueryRequest {
-        /**The maps being queried. If you need to composite multiple layers, provide multiple map IDs. */
+        /**
+         * The maps being queried. If you need to composite multiple layers, provide multiple map IDs.
+         */
         mapIds: string[];
-        /**The longitude and latitude to be queried. */
+        /**
+         * The longitude and latitude to be queried.
+         */
         coordinates: mapboxgl.LngLatLike;
-        /**The approximate distance in meters to query for features. (optional, default 0) */
+        /**
+         * The approximate distance in meters to query for features. (optional, default 0)
+         */
         radius: number;
-        /**The number of features to return, between 1 and 50. (optional, default 5) */
+        /**
+         * The number of features to return, between 1 and 50. (optional, default 5)
+         */
         limit: number;
-        /**Whether or not to deduplicate results. (optional, default true) */
+        /**
+         * Whether or not to deduplicate results. (optional, default true)
+         */
         dedupe: boolean;
-        /** Queries for a specific geometry type. */
+        /**
+         * Queries for a specific geometry type.
+         */
         geometry: GeometryType;
         layers?: string[];
     }
 
-    export type GeometryType = 'polygon' | 'linestring' | 'point';
-
-
+    type GeometryType = 'polygon' | 'linestring' | 'point';
 }
 
 declare module '@mapbox/mapbox-sdk/services/tilesets' {
@@ -1238,7 +1248,9 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
          * @param request
          */
         updateToken(request: UpdateDeleteTokenRequest): MapiRequest;
-        /**Get data about the client's access token. */
+        /**
+         * Get data about the client's access token.
+         */
         getToken(): MapiRequest;
         /**
          * Delete an access token.
@@ -1272,7 +1284,7 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
          * human friendly description of the token
          */
         note: string;
-        /**	
+        /**
          * array of scopes granted to the token
          */
         scopes: string[];
@@ -1280,7 +1292,7 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
          * date and time the token was created
          */
         created: string;
-        /**	
+        /**
          * date and time the token was last modified
          */
         modified: string;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1114,32 +1114,40 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
     interface Style {
         version: number;
         name: string;
-        /**Information about the style that is used in Mapbox Studio. */
+        /**
+         * Information about the style that is used in Mapbox Studio.
+         */
         metadata: string;
-        sources: Sources;
+        sources: any;
         sprite: string;
         glyphs: string;
         layers: string[];
-        /**Date and time the style was created. */
+        /**
+         * Date and time the style was created.
+         */
         created: string;
-        /**	The ID of the style. */
+        /**
+         * The ID of the style.
+         */
         id: string;
-        /**Date and time the style was last modified. */
+        /**
+         * Date and time the style was last modified.
+         */
         modified: string;
-        /**The username of the style owner. */
+        /**
+         * The username of the style owner.
+         */
         owner: string;
-        /**	Access control for the style, either  public or  private . Private styles require an access token belonging to the owner,
+        /**
+         * Access control for the style, either  public or  private . Private styles require an access token belonging to the owner,
          * while public styles may be requested with an access token belonging to any user.
          */
         visibility: string;
-        /**Whether the style is a draft or has been published. */
+        /**
+         * Whether the style is a draft or has been published.
+         */
         draft: boolean;
     }
-
-    interface Sources {
-    }
-
-
 }
 
 declare module '@mapbox/mapbox-sdk/services/tilequery' {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -6,1329 +6,1329 @@
 // TypeScript Version: 3.5.2
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
-  import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  export default class MapiClient {
-    constructor(config: SdkConfig)
-    accessToken: string;
-    origin?: string;
-    createRequest(requestOptions: any): MapiRequest;
-  }
+    import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    export default class MapiClient {
+        constructor(config: SdkConfig)
+        accessToken: string;
+        origin?: string;
+        createRequest(requestOptions: any): MapiRequest;
+    }
 
-  export interface SdkConfig {
-    accessToken: string;
-    origin?: string;
-  }
+    export interface SdkConfig {
+        accessToken: string;
+        origin?: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
-  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
-  import MapiClient from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
-  import { MapiError } from '@mapbox/mapbox-sdk/lib/classes/mapi-error';
+    import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+    import MapiClient from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiError } from '@mapbox/mapbox-sdk/lib/classes/mapi-error';
 
-  export interface EventEmitter {
-    response: MapiResponse;
-    error: MapiError;
-    downloadProgress: ProgressEvents;
-    uploadProgress: ProgressEvents;
-  }
+    export interface EventEmitter {
+        response: MapiResponse;
+        error: MapiError;
+        downloadProgress: ProgressEvents;
+        uploadProgress: ProgressEvents;
+    }
 
-  export interface ProgressEvents {
+    export interface ProgressEvents {
 
-  }
+    }
 
-  export interface MapiRequest {
-    /** An event emitter */
-    emitter: EventEmitter;
-    /** This request's MapiClient. */
-    client: MapiClient;
-    /** If this request has been sent and received a response, the response is available on this property. */
-    response: MapiResponse | null;
-    /**  If this request has been sent and received an error in response, the error is available on this property. */
-    error: MapiError | Error | null;
-    /** If the request has been aborted (via abort), this property will be true. */
-    aborted: boolean;
-    /**  If the request has been sent, this property will be true.
-     * You cannot send the same request twice, so if you need to create a new request
-     * that is the equivalent of an existing one, use clone.
-     */
-    sent: boolean;
-    /** The request's path, including colon-prefixed route parameters. */
-    path: string;
-    /** The request's origin. */
-    origin: string;
-    /**  The request's HTTP method. */
-    method: string;
-    /** A query object, which will be transformed into a URL query string. */
-    // query: GeocodeRequest;
-    /**A route parameters object, whose values will be interpolated the path.  */
-    params: Object;
-    /** The request's headers, */
-    headers: Object;
-    /** Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'. */
-    body: Object | string | null;
-    /** A file to send with the request. The browser client accepts Blobs and ArrayBuffers. */
-    file: Blob | ArrayBuffer | string;
-    url(accessToken?: string): string;
-    send(): Promise<MapiResponse>;
-    abort(): void;
-    eachPage(callback: PageCallbackFunction): void;
-    clone(): MapiRequest;
-  }
+    export interface MapiRequest {
+        /** An event emitter */
+        emitter: EventEmitter;
+        /** This request's MapiClient. */
+        client: MapiClient;
+        /** If this request has been sent and received a response, the response is available on this property. */
+        response: MapiResponse | null;
+        /**  If this request has been sent and received an error in response, the error is available on this property. */
+        error: MapiError | Error | null;
+        /** If the request has been aborted (via abort), this property will be true. */
+        aborted: boolean;
+        /**  If the request has been sent, this property will be true.
+         * You cannot send the same request twice, so if you need to create a new request
+         * that is the equivalent of an existing one, use clone.
+         */
+        sent: boolean;
+        /** The request's path, including colon-prefixed route parameters. */
+        path: string;
+        /** The request's origin. */
+        origin: string;
+        /**  The request's HTTP method. */
+        method: string;
+        /** A query object, which will be transformed into a URL query string. */
+        // query: GeocodeRequest;
+        /**A route parameters object, whose values will be interpolated the path.  */
+        params: Object;
+        /** The request's headers, */
+        headers: Object;
+        /** Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'. */
+        body: Object | string | null;
+        /** A file to send with the request. The browser client accepts Blobs and ArrayBuffers. */
+        file: Blob | ArrayBuffer | string;
+        url(accessToken?: string): string;
+        send(): Promise<MapiResponse>;
+        abort(): void;
+        eachPage(callback: PageCallbackFunction): void;
+        clone(): MapiRequest;
+    }
 
-  export type PageCallbackFunction = {
-    error: MapiError,
-    response: MapiResponse,
-    next: () => void
-  }
+    export type PageCallbackFunction = {
+        error: MapiError,
+        response: MapiResponse,
+        next: () => void
+    }
 
-  export type MapboxProfile = "driving" |
-    "walking" |
-    "cycling";
+    export type MapboxProfile = "driving" |
+        "walking" |
+        "cycling";
 
-  export type DirectionsApproach = "unrestricted" | "curb";
+    export type DirectionsApproach = "unrestricted" | "curb";
 }
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
-  export interface MapiResponse {
-    /**The response body, parsed as JSON. */
-    body: Object;
-    /**The raw response body. */
-    rawBody: string;
-    /**The response's status code. */
-    statusCode: number;
-    /**The parsed response headers. */
-    headers: Object;
-    /**The parsed response links */
-    links: Object;
-    /**The response's originating MapiRequest. */
-    request: MapiRequest;
-    hasNextPage(): boolean;
-    nextPage(): MapiRequest;
-  }
+    export interface MapiResponse {
+        /**The response body, parsed as JSON. */
+        body: Object;
+        /**The raw response body. */
+        rawBody: string;
+        /**The response's status code. */
+        statusCode: number;
+        /**The parsed response headers. */
+        headers: Object;
+        /**The parsed response links */
+        links: Object;
+        /**The response's originating MapiRequest. */
+        request: MapiRequest;
+        hasNextPage(): boolean;
+        nextPage(): MapiRequest;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
-  export interface MapiError {
-    /**The errored request. */
-    request: MapiRequest;
-    /** The type of error. Usually this is 'HttpError'.
-     * If the request was aborted, so the error was not sent from the server, the type will be 'RequestAbortedError'.
-     */
-    type: string;
-    /** The numeric status code of the HTTP response */
-    statusCode?: number;
-    /**  If the server sent a response body, this property exposes that response, parsed as JSON if possible. */
-    body?: Object | string;
-    /** Whatever message could be derived from the call site and HTTP response. */
-    message?: string;
-  }
+    export interface MapiError {
+        /**The errored request. */
+        request: MapiRequest;
+        /** The type of error. Usually this is 'HttpError'.
+         * If the request was aborted, so the error was not sent from the server, the type will be 'RequestAbortedError'.
+         */
+        type: string;
+        /** The numeric status code of the HTTP response */
+        statusCode?: number;
+        /**  If the server sent a response body, this property exposes that response, parsed as JSON if possible. */
+        body?: Object | string;
+        /** Whatever message could be derived from the call site and HTTP response. */
+        message?: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/datasets' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Datasets Types
-  *********************************************************************************************************************/
-  export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
+    /*********************************************************************************************************************
+    * Datasets Types
+    *********************************************************************************************************************/
+    export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
 
-  export interface DatasetsService {
-    /**List datasets in your account. */
-    listDatasets(): MapiRequest;
-    /**
-     *  Create a new, empty dataset.
-     * @param config Object
-     */
-    createDataset(config: { name?: string, description?: string }): MapiRequest;
-    /**
-     * Get metadata about a dataset.
-     * @param config
-     */
-    getMetadata(config: { datasetId: string }): MapiRequest;
-    /**
-     * Update user-defined properties of a dataset's metadata.
-     * @param config
-     */
-    updateMetadata(config: { datasetId?: string, name?: string, description?: string }): MapiRequest;
-    /**
-     * Delete a dataset, including all features it contains.
-     * @param config
-     */
-    deleteDataset(config: { datasetId?: string }): MapiRequest;
-    /**
-     * List features in a dataset.
-  
-      * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
-      * @param config
-      */
-    // implicit any
-    listFeatures(config: { datasetId: string, limit?: number, start?: string }): any;
-    /**
-     * Add a feature to a dataset or update an existing one.
-     * @param config
-     */
-    putFeature(config: { datasetId: string, featureId: string, feature: Object }): MapiRequest;
-    /**
-     * Get a feature in a dataset.
-     * @param config
-     */
-    // implicit any
-    getFeature(config: { datasetId: string, featureId: string }): any;
-    /**
-     * Delete a feature in a dataset.
-     * @param config
-     */
-    // implicit any
-    deleteFeature(config: { datasetId: string, featureId: string }): any;
+    export interface DatasetsService {
+        /**List datasets in your account. */
+        listDatasets(): MapiRequest;
+        /**
+         *  Create a new, empty dataset.
+         * @param config Object
+         */
+        createDataset(config: { name?: string, description?: string }): MapiRequest;
+        /**
+         * Get metadata about a dataset.
+         * @param config
+         */
+        getMetadata(config: { datasetId: string }): MapiRequest;
+        /**
+         * Update user-defined properties of a dataset's metadata.
+         * @param config
+         */
+        updateMetadata(config: { datasetId?: string, name?: string, description?: string }): MapiRequest;
+        /**
+         * Delete a dataset, including all features it contains.
+         * @param config
+         */
+        deleteDataset(config: { datasetId?: string }): MapiRequest;
+        /**
+         * List features in a dataset.
+      
+          * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
+          * @param config
+          */
+        // implicit any
+        listFeatures(config: { datasetId: string, limit?: number, start?: string }): any;
+        /**
+         * Add a feature to a dataset or update an existing one.
+         * @param config
+         */
+        putFeature(config: { datasetId: string, featureId: string, feature: Object }): MapiRequest;
+        /**
+         * Get a feature in a dataset.
+         * @param config
+         */
+        // implicit any
+        getFeature(config: { datasetId: string, featureId: string }): any;
+        /**
+         * Delete a feature in a dataset.
+         * @param config
+         */
+        // implicit any
+        deleteFeature(config: { datasetId: string, featureId: string }): any;
 
-  }
+    }
 
-  export interface Dataset {
-    /** 	the username of the dataset owner */
-    owner: string;
-    /**id for an existing dataset */
-    id: string;
-    /*date and time the dataset was created */
-    created: string;
-    /* 	date and time the dataset was last modified */
-    modified: string;
-    /**the extent of features in the dataset as an array of west, south, east, north coordinates */
-    bounds: number[];
-    /**	the number of features in the dataset */
-    features: number;
-    /**	the size of the dataset in bytes */
-    size: number;
-    /**the name of the dataset */
-    name: string;
-    /**	the description of the dataset */
-    description: string;
-  }
+    export interface Dataset {
+        /** 	the username of the dataset owner */
+        owner: string;
+        /**id for an existing dataset */
+        id: string;
+        /*date and time the dataset was created */
+        created: string;
+        /* 	date and time the dataset was last modified */
+        modified: string;
+        /**the extent of features in the dataset as an array of west, south, east, north coordinates */
+        bounds: number[];
+        /**	the number of features in the dataset */
+        features: number;
+        /**	the size of the dataset in bytes */
+        size: number;
+        /**the name of the dataset */
+        name: string;
+        /**	the description of the dataset */
+        description: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/directions' {
-  import * as GeoJSON from 'geojson';
-  import { LngLatLike } from 'mapbox-gl';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
-  import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import * as GeoJSON from 'geojson';
+    import { LngLatLike } from 'mapbox-gl';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
-  export default function Directions(config: SdkConfig | MapiClient): DirectionsService;
+    export default function Directions(config: SdkConfig | MapiClient): DirectionsService;
 
-  export interface DirectionsService {
-    getDirections(request: DirectionsRequest): MapiRequest;
-  }
+    export interface DirectionsService {
+        getDirections(request: DirectionsRequest): MapiRequest;
+    }
 
-  export type DirectionsProfile = MapboxProfile | "driving-traffic";
+    export type DirectionsProfile = MapboxProfile | "driving-traffic";
 
-  export type DirectionsAnnotation = "duration" | "distance" | "speed" | "congestion";
-  export type DirectionsGeometry = "geojson" | "polyline" | "polyline6";
-  export type DirectionsOverview = "full" | "simplified";
-  export type DirectionsUnits = "imperial" | "metric";
-  export type DirectionsSide = "left" | "right";
-  export type DirectionsMode = "driving" | "ferry" | "unaccessible" | "walking" | "cycling" | "train";
-  export type DirectionsClass = "toll" | "ferry" | "restricted" | "motorway" | "tunnel";
-  export type ManeuverModifier =
-    "uturn" |
-    "sharp right" |
-    "right" |
-    "slight right" |
-    "straight" |
-    "slight left" |
-    "left" |
-    "sharp left" |
-    "depart" |
-    "arrive";
-  export type ManeuverType = "turn" |
-    "new name" |
-    "depart" |
-    "arrive" |
-    "merge" |
-    "on ramp" |
-    "off ramp" |
-    "fork" |
-    "end of road" |
-    "continue" |
-    "roundabout" |
-    "rotary" |
-    "roundabout turn" |
-    "notification" |
-    "exit roundabout" |
-    "exit rotary";
+    export type DirectionsAnnotation = "duration" | "distance" | "speed" | "congestion";
+    export type DirectionsGeometry = "geojson" | "polyline" | "polyline6";
+    export type DirectionsOverview = "full" | "simplified";
+    export type DirectionsUnits = "imperial" | "metric";
+    export type DirectionsSide = "left" | "right";
+    export type DirectionsMode = "driving" | "ferry" | "unaccessible" | "walking" | "cycling" | "train";
+    export type DirectionsClass = "toll" | "ferry" | "restricted" | "motorway" | "tunnel";
+    export type ManeuverModifier =
+        "uturn" |
+        "sharp right" |
+        "right" |
+        "slight right" |
+        "straight" |
+        "slight left" |
+        "left" |
+        "sharp left" |
+        "depart" |
+        "arrive";
+    export type ManeuverType = "turn" |
+        "new name" |
+        "depart" |
+        "arrive" |
+        "merge" |
+        "on ramp" |
+        "off ramp" |
+        "fork" |
+        "end of road" |
+        "continue" |
+        "roundabout" |
+        "rotary" |
+        "roundabout turn" |
+        "notification" |
+        "exit roundabout" |
+        "exit rotary";
 
-  export interface DirectionsRequest {
-    /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
-    profile: DirectionsProfile;
-    waypoints: DirectionsRequestWaypoint[];
-    /**Whether to try to return alternative routes. An alternative is classified as a route that is significantly
-     * different than the fastest route, but also still reasonably fast. Such a route does not exist in all circumstances.
-     * Currently up to two alternatives can be returned. Can be  true or  false (default).
-     */
-    alternatives?: boolean;
-    /**Whether or not to return additional metadata along the route. Possible values are:  duration ,  distance ,  speed , and congestion .
-     * Several annotations can be used by including them as a comma-separated list. See the RouteLeg object for more details on
-     * what is included with annotations.
-     */
-    annotations?: DirectionsAnnotation[];
+    export interface DirectionsRequest {
+        /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
+        profile: DirectionsProfile;
+        waypoints: DirectionsRequestWaypoint[];
+        /**Whether to try to return alternative routes. An alternative is classified as a route that is significantly
+         * different than the fastest route, but also still reasonably fast. Such a route does not exist in all circumstances.
+         * Currently up to two alternatives can be returned. Can be  true or  false (default).
+         */
+        alternatives?: boolean;
+        /**Whether or not to return additional metadata along the route. Possible values are:  duration ,  distance ,  speed , and congestion .
+         * Several annotations can be used by including them as a comma-separated list. See the RouteLeg object for more details on
+         * what is included with annotations.
+         */
+        annotations?: DirectionsAnnotation[];
 
-    /**Whether or not to return banner objects associated with the  routeSteps .
-     * Should be used in conjunction with  steps . Can be  true or  false . The default is  false .
-     */
-    bannerInstructions?: boolean;
+        /**Whether or not to return banner objects associated with the  routeSteps .
+         * Should be used in conjunction with  steps . Can be  true or  false . The default is  false .
+         */
+        bannerInstructions?: boolean;
 
-    /** Sets the allowed direction of travel when departing intermediate waypoints. If  true , the route will continue in the same
-     * direction of travel. If  false , the route may continue in the opposite direction of travel. Defaults to  true for mapbox/driving and
-     * false for  mapbox/walking and  mapbox/cycling .
-     */
-    continueStraight?: boolean;
-    /**Exclude certain road types from routing. Valid values depend on the profile in use.
-     * The default is to not exclude anything from the profile selected.
-     */
-    exclude?: DirectionsProfile[];
-    /**Format of the returned geometry. Allowed values are:  geojson (as LineString ),
-     * polyline with precision 5,  polyline6 (a polyline with precision 6). The default value is  polyline .
-     */
-    geometries?: DirectionsGeometry;
-    /**Language of returned turn-by-turn text instructions. See supported languages . The default is  en for English. */
-    language?: string;
-    /**Type of returned overview geometry. Can be  full (the most detailed geometry available),
-     * simplified (a simplified version of the full geometry), or  false (no overview geometry). The default is  simplified .
-     */
-    overview?: DirectionsOverview;
+        /** Sets the allowed direction of travel when departing intermediate waypoints. If  true , the route will continue in the same
+         * direction of travel. If  false , the route may continue in the opposite direction of travel. Defaults to  true for mapbox/driving and
+         * false for  mapbox/walking and  mapbox/cycling .
+         */
+        continueStraight?: boolean;
+        /**Exclude certain road types from routing. Valid values depend on the profile in use.
+         * The default is to not exclude anything from the profile selected.
+         */
+        exclude?: DirectionsProfile[];
+        /**Format of the returned geometry. Allowed values are:  geojson (as LineString ),
+         * polyline with precision 5,  polyline6 (a polyline with precision 6). The default value is  polyline .
+         */
+        geometries?: DirectionsGeometry;
+        /**Language of returned turn-by-turn text instructions. See supported languages . The default is  en for English. */
+        language?: string;
+        /**Type of returned overview geometry. Can be  full (the most detailed geometry available),
+         * simplified (a simplified version of the full geometry), or  false (no overview geometry). The default is  simplified .
+         */
+        overview?: DirectionsOverview;
 
-    /**Emit instructions at roundabout exits. Can be  true or  false . The default is  false . */
-    roundaboutExits?: boolean;
-    /**Whether to return steps and turn-by-turn instructions. Can be  true or  false . The default is  false . */
-    steps?: boolean;
-    /**Whether or not to return SSML marked-up text for voice guidance along the route. Should be used in conjunction with steps .
-     * Can be  true or  false . The default is  false .
-     */
-    voiceInstructions?: boolean;
-    /**Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial . */
-    voiceUnits?: DirectionsUnits;
+        /**Emit instructions at roundabout exits. Can be  true or  false . The default is  false . */
+        roundaboutExits?: boolean;
+        /**Whether to return steps and turn-by-turn instructions. Can be  true or  false . The default is  false . */
+        steps?: boolean;
+        /**Whether or not to return SSML marked-up text for voice guidance along the route. Should be used in conjunction with steps .
+         * Can be  true or  false . The default is  false .
+         */
+        voiceInstructions?: boolean;
+        /**Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial . */
+        voiceUnits?: DirectionsUnits;
 
-  }
+    }
 
-  export interface DirectionsRequestWaypoint {
-    /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
-    coordinates: number[] | LngLatLike;
-    /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
-   * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
-   * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
-   * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
-   * while  bearings influences how you start from a waypoint. If provided, the list of approaches must be the same length as the list of waypoints.
-   * However, you can skip a coordinate and show its position in the list with the  ; separator.
-   */
-    approach?: DirectionsApproach;
-    /**Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. */
-    radius?: string | "unlimited";
-  }
+    export interface DirectionsRequestWaypoint {
+        /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
+        coordinates: number[] | LngLatLike;
+        /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
+       * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
+       * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
+       * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
+       * while  bearings influences how you start from a waypoint. If provided, the list of approaches must be the same length as the list of waypoints.
+       * However, you can skip a coordinate and show its position in the list with the  ; separator.
+       */
+        approach?: DirectionsApproach;
+        /**Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. */
+        radius?: string | "unlimited";
+    }
 
-  export interface DirectionsResponse {
-    /**Array of Route objects ordered by descending recommendation rank. May contain at most two routes. */
-    routes: Route[];
-    /** Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
-     * The waypoints appear in the array in the order of the input coordinates.
-     */
-    waypoints: Waypoint[];
-    /**String indicating the state of the response. This is a separate code than the HTTP status code.
-     * On normal valid responses, the value will be Ok.
-     */
-    code: string;
-    uuid: string;
-  }
+    export interface DirectionsResponse {
+        /**Array of Route objects ordered by descending recommendation rank. May contain at most two routes. */
+        routes: Route[];
+        /** Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
+         * The waypoints appear in the array in the order of the input coordinates.
+         */
+        waypoints: Waypoint[];
+        /**String indicating the state of the response. This is a separate code than the HTTP status code.
+         * On normal valid responses, the value will be Ok.
+         */
+        code: string;
+        uuid: string;
+    }
 
-  export interface Waypoint {
-    /**String with the name of the way the coordinate snapped to */
-    name: string;
-    /**Array of [ longitude, latitude ] for the snapped coordinate */
-    location: number[];
-    /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
-     * This option should always be used in conjunction with the  radiuses parameter. The parameter takes two values per waypoint.
-     * The first value is an angle clockwise from true north between 0 and 360, and the second is the range of degrees the angle can deviate by.
-     * The recommended value for the range is 45° or 90°, as bearing measurements tend to be inaccurate.
-     * This is useful for making sure the new routes of rerouted vehicles continue traveling in their current direction.
-     * A request that does this would provide bearing and radius values for the first waypoint and leave the remaining values empty.
-     * If provided, the list of bearings must be the same length as the list of waypoints.
-     * However, you can skip a coordinate and show its position in the list with the  ; separator.
-     */
-    bearing?: number[];
-    /**Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
-    * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
-    * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
-    */
-    waypointName?: string;
-  }
+    export interface Waypoint {
+        /**String with the name of the way the coordinate snapped to */
+        name: string;
+        /**Array of [ longitude, latitude ] for the snapped coordinate */
+        location: number[];
+        /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+         * This option should always be used in conjunction with the  radiuses parameter. The parameter takes two values per waypoint.
+         * The first value is an angle clockwise from true north between 0 and 360, and the second is the range of degrees the angle can deviate by.
+         * The recommended value for the range is 45° or 90°, as bearing measurements tend to be inaccurate.
+         * This is useful for making sure the new routes of rerouted vehicles continue traveling in their current direction.
+         * A request that does this would provide bearing and radius values for the first waypoint and leave the remaining values empty.
+         * If provided, the list of bearings must be the same length as the list of waypoints.
+         * However, you can skip a coordinate and show its position in the list with the  ; separator.
+         */
+        bearing?: number[];
+        /**Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
+        * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
+        * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
+        */
+        waypointName?: string;
+    }
 
-  export interface Route {
-    /**Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
-     * Depending on the overview parameter this is the complete route geometry (full), a simplified geometry
-     * to the zoom level at which the route can be displayed in full (simplified), or is not included (false)
-     */
-    geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
-    /**Array of RouteLeg objects. */
-    legs: Leg[];
-    /** String indicating which weight was used. The default is routability which is duration-based,
-     * with additional penalties for less desirable maneuvers.
-     */
-    weight_name: string;
-    /**Float indicating the weight in units described by weight_name */
-    weight: number;
-    /**Float indicating the estimated travel time in seconds. */
-    duration: number;
-    /**Float indicating the distance traveled in meters. */
-    distance: number;
-    /**String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. */
-    voiceLocale?: string;
-  }
+    export interface Route {
+        /**Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
+         * Depending on the overview parameter this is the complete route geometry (full), a simplified geometry
+         * to the zoom level at which the route can be displayed in full (simplified), or is not included (false)
+         */
+        geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
+        /**Array of RouteLeg objects. */
+        legs: Leg[];
+        /** String indicating which weight was used. The default is routability which is duration-based,
+         * with additional penalties for less desirable maneuvers.
+         */
+        weight_name: string;
+        /**Float indicating the weight in units described by weight_name */
+        weight: number;
+        /**Float indicating the estimated travel time in seconds. */
+        duration: number;
+        /**Float indicating the distance traveled in meters. */
+        distance: number;
+        /**String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. */
+        voiceLocale?: string;
+    }
 
-  export interface Leg {
-    /**Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) */
-    summary: string;
-    weight: number;
-    /**Number indicating the estimated travel time in seconds */
-    duration: number;
-    /** Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) */
-    steps: Step[];
-    /** Number indicating the distance traveled in meters */
-    distance: number;
-    /**An annotations object that contains additional details about each line segment along the route geometry.
-     * Each entry in an annotations field corresponds to a coordinate along the route geometry.
-     */
-    annotation: DirectionsAnnotation[];
-  }
+    export interface Leg {
+        /**Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) */
+        summary: string;
+        weight: number;
+        /**Number indicating the estimated travel time in seconds */
+        duration: number;
+        /** Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) */
+        steps: Step[];
+        /** Number indicating the distance traveled in meters */
+        distance: number;
+        /**An annotations object that contains additional details about each line segment along the route geometry.
+         * Each entry in an annotations field corresponds to a coordinate along the route geometry.
+         */
+        annotation: DirectionsAnnotation[];
+    }
 
-  export interface Step {
-    /**Array of objects representing all intersections along the step. */
-    intersections: Intersection[];
-    /**The legal driving side at the location for this step. Either left or right. */
-    driving_side: DirectionsSide;
-    /** Depending on the geometries parameter this is a GeoJSON LineString or a
-     * Polyline string representing the full route geometry from this RouteStep to the next RouteStep
-     */
-    geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
-    /**String indicating the mode of transportation. Possible values: */
-    mode: DirectionsMode;
-    /**One StepManeuver object */
-    maneuver: Maneuver;
-    /**Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
-     * Optionally included, if data is available. If multiple road designations are associated with the road, they are separated by semicolons.
-     * A road designation typically consists of an alphabetic network code (identifying the road type or numbering system), a space or hyphen,
-     * and a route number. You should not assume that the network code is globally unique: for example, a network code of “NH” may appear on a
-     * “National Highway” or “New Hampshire”. Moreover, a route number may not even uniquely identify a road within a given network.
-     */
-    ref?: string;
-    weight: number;
-    /**Number indicating the estimated time traveled time in seconds from the maneuver to the next RouteStep. */
-    duration: number;
-    /**String with the name of the way along which the travel proceeds */
-    name: string;
-    /** Number indicating the distance traveled in meters from the maneuver to the next RouteStep. */
-    distance: number;
-    voiceInstructions: VoiceInstruction[];
-    bannerInstructions: BannerInstruction[];
-    /**String with the destinations of the way along which the travel proceeds. Optionally included, if data is available. */
-    destinations?: string;
-    /**String with the exit numbers or names of the way. Optionally included, if data is available. */
-    exits?: string;
-    /** A string containing an IPA phonetic transcription indicating how to pronounce the name in the name property.
-     * This property is omitted if pronunciation data is unavailable for the step.
-     */
-    pronunciation?: string;
+    export interface Step {
+        /**Array of objects representing all intersections along the step. */
+        intersections: Intersection[];
+        /**The legal driving side at the location for this step. Either left or right. */
+        driving_side: DirectionsSide;
+        /** Depending on the geometries parameter this is a GeoJSON LineString or a
+         * Polyline string representing the full route geometry from this RouteStep to the next RouteStep
+         */
+        geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
+        /**String indicating the mode of transportation. Possible values: */
+        mode: DirectionsMode;
+        /**One StepManeuver object */
+        maneuver: Maneuver;
+        /**Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
+         * Optionally included, if data is available. If multiple road designations are associated with the road, they are separated by semicolons.
+         * A road designation typically consists of an alphabetic network code (identifying the road type or numbering system), a space or hyphen,
+         * and a route number. You should not assume that the network code is globally unique: for example, a network code of “NH” may appear on a
+         * “National Highway” or “New Hampshire”. Moreover, a route number may not even uniquely identify a road within a given network.
+         */
+        ref?: string;
+        weight: number;
+        /**Number indicating the estimated time traveled time in seconds from the maneuver to the next RouteStep. */
+        duration: number;
+        /**String with the name of the way along which the travel proceeds */
+        name: string;
+        /** Number indicating the distance traveled in meters from the maneuver to the next RouteStep. */
+        distance: number;
+        voiceInstructions: VoiceInstruction[];
+        bannerInstructions: BannerInstruction[];
+        /**String with the destinations of the way along which the travel proceeds. Optionally included, if data is available. */
+        destinations?: string;
+        /**String with the exit numbers or names of the way. Optionally included, if data is available. */
+        exits?: string;
+        /** A string containing an IPA phonetic transcription indicating how to pronounce the name in the name property.
+         * This property is omitted if pronunciation data is unavailable for the step.
+         */
+        pronunciation?: string;
 
 
-  }
+    }
 
-  export interface Instruction {
-    /**String that contains all the text that should be displayed */
-    text: string;
-    /**Objects that, together, make up what should be displayed in the banner.
-     * Includes additional information intended to be used to aid in visual layout
-     */
-    components: Component[];
-    /**The type of maneuver. May be used in combination with the modifier (and, if it is a roundabout, the degrees) to for an icon to
-     * display. Possible values: 'turn', 'merge', 'depart', 'arrive', 'fork', 'off ramp', 'roundabout'
-     */
-    type?: string;
-    /** The modifier for the maneuver. Can be used in combination with the type (and, if it is a roundabout, the degrees)
-     * to for an icon to display. Possible values: 'left', 'right', 'slight left', 'slight right', 'sharp left', 'sharp right', 'straight', 'uturn'
-     */
-    modifier?: ManeuverModifier;
-    /**The degrees at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout. */
-    degrees?: number;
-    /** A string representing which side the of the street people drive on in that location. Can be 'left' or 'right'. */
-    driving_side: DirectionsSide;
-  }
+    export interface Instruction {
+        /**String that contains all the text that should be displayed */
+        text: string;
+        /**Objects that, together, make up what should be displayed in the banner.
+         * Includes additional information intended to be used to aid in visual layout
+         */
+        components: Component[];
+        /**The type of maneuver. May be used in combination with the modifier (and, if it is a roundabout, the degrees) to for an icon to
+         * display. Possible values: 'turn', 'merge', 'depart', 'arrive', 'fork', 'off ramp', 'roundabout'
+         */
+        type?: string;
+        /** The modifier for the maneuver. Can be used in combination with the type (and, if it is a roundabout, the degrees)
+         * to for an icon to display. Possible values: 'left', 'right', 'slight left', 'slight right', 'sharp left', 'sharp right', 'straight', 'uturn'
+         */
+        modifier?: ManeuverModifier;
+        /**The degrees at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout. */
+        degrees?: number;
+        /** A string representing which side the of the street people drive on in that location. Can be 'left' or 'right'. */
+        driving_side: DirectionsSide;
+    }
 
-  export interface BannerInstruction {
-    /**float indicating in meters, how far from the upcoming maneuver
-     * the banner instruction should begin being displayed. Only 1 banner should be displayed at a time.
-     */
-    distanceAlongGeometry: number;
-    /**Most important content to display to the user. Our SDK displays this text larger and at the top. */
-    primary: Instruction;
-    /**Additional content useful for visual guidance. Our SDK displays this text slightly smaller and below the primary. Can be null. */
-    secondary?: Instruction[];
-    then?: any;
-    /**Additional information that is included if we feel the driver needs a heads up about something.
-     * Can include information about the next maneuver (the one after the upcoming one) if the step is short -
-     * can be null, or can be lane information. If we have lane information, that trumps information about the next maneuver.
-     */
-    sub?: Sub;
-  }
+    export interface BannerInstruction {
+        /**float indicating in meters, how far from the upcoming maneuver
+         * the banner instruction should begin being displayed. Only 1 banner should be displayed at a time.
+         */
+        distanceAlongGeometry: number;
+        /**Most important content to display to the user. Our SDK displays this text larger and at the top. */
+        primary: Instruction;
+        /**Additional content useful for visual guidance. Our SDK displays this text slightly smaller and below the primary. Can be null. */
+        secondary?: Instruction[];
+        then?: any;
+        /**Additional information that is included if we feel the driver needs a heads up about something.
+         * Can include information about the next maneuver (the one after the upcoming one) if the step is short -
+         * can be null, or can be lane information. If we have lane information, that trumps information about the next maneuver.
+         */
+        sub?: Sub;
+    }
 
-  export interface Sub {
-    /** String that contains all the text that should be displayed */
-    text: string;
-    /**Objects that, together, make up what should be displayed in the banner.
-     * Includes additional information intended to be used to aid in visual layout
-     */
-    components: Component[];
-  }
+    export interface Sub {
+        /** String that contains all the text that should be displayed */
+        text: string;
+        /**Objects that, together, make up what should be displayed in the banner.
+         * Includes additional information intended to be used to aid in visual layout
+         */
+        components: Component[];
+    }
 
-  export interface Component {
-    /**String giving you more context about the component which may help in visual markup/display choices.
-     * If the type of the components is unknown it should be treated as text. Note: Introduction of new types
-     * is not considered a breaking change. See the Types of Banner Components table below for more info on each type.
-     */
-    type: string;
-    /** The sub-string of the parent object's text that may have additional context associated with it */
-    text: string;
-    /**The abbreviated form of text. If this is present, there will also be an abbr_priority value.
-     * See the Examples of Abbreviations table below for an example of using abbr and abbr_priority.
-     */
-    abbr?: string;
-    /**An integer indicating the order in which the abbreviation abbr should be used in place of text.
-     * The highest priority is 0 and a higher integer value means it should have a lower priority. There are no gaps in
-     * integer values. Multiple components can have the same abbr_priority and when this happens all components with the
-     * same abbr_priority should be abbreviated at the same time. Finding no larger values of abbr_priority means that the
-     * string is fully abbreviated.
-     */
-    abbr_priority?: number;
-    /** String pointing to a shield image to use instead of the text. */
-    imageBaseURL?: string;
-    /** (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
-     * If the value is ['left', 'straight'], the driver can go straight or left from that lane
-     */
-    directions?: string[];
-    /**  (present if component is lane): A boolean telling you if that lane can be used to complete the upcoming maneuver.
-     * If multiple lanes are active, then they can all be used to complete the upcoming maneuver.
-     */
-    active: boolean;
-  }
+    export interface Component {
+        /**String giving you more context about the component which may help in visual markup/display choices.
+         * If the type of the components is unknown it should be treated as text. Note: Introduction of new types
+         * is not considered a breaking change. See the Types of Banner Components table below for more info on each type.
+         */
+        type: string;
+        /** The sub-string of the parent object's text that may have additional context associated with it */
+        text: string;
+        /**The abbreviated form of text. If this is present, there will also be an abbr_priority value.
+         * See the Examples of Abbreviations table below for an example of using abbr and abbr_priority.
+         */
+        abbr?: string;
+        /**An integer indicating the order in which the abbreviation abbr should be used in place of text.
+         * The highest priority is 0 and a higher integer value means it should have a lower priority. There are no gaps in
+         * integer values. Multiple components can have the same abbr_priority and when this happens all components with the
+         * same abbr_priority should be abbreviated at the same time. Finding no larger values of abbr_priority means that the
+         * string is fully abbreviated.
+         */
+        abbr_priority?: number;
+        /** String pointing to a shield image to use instead of the text. */
+        imageBaseURL?: string;
+        /** (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
+         * If the value is ['left', 'straight'], the driver can go straight or left from that lane
+         */
+        directions?: string[];
+        /**  (present if component is lane): A boolean telling you if that lane can be used to complete the upcoming maneuver.
+         * If multiple lanes are active, then they can all be used to complete the upcoming maneuver.
+         */
+        active: boolean;
+    }
 
-  export interface VoiceInstruction {
-    /** float indicating in meters, how far from the upcoming maneuver the voice instruction should begin. */
-    distanceAlongGeometry: number;
-    /**String containing the text of the verbal instruction. */
-    announcement: string;
-    /**String with SSML markup for proper text and pronunciation. Note: this property is designed for use with Amazon Polly.
-     * The SSML tags contained here may not work with other text-to-speech engines.
-     */
-    ssmlAnnouncement: string;
-  }
+    export interface VoiceInstruction {
+        /** float indicating in meters, how far from the upcoming maneuver the voice instruction should begin. */
+        distanceAlongGeometry: number;
+        /**String containing the text of the verbal instruction. */
+        announcement: string;
+        /**String with SSML markup for proper text and pronunciation. Note: this property is designed for use with Amazon Polly.
+         * The SSML tags contained here may not work with other text-to-speech engines.
+         */
+        ssmlAnnouncement: string;
+    }
 
-  export interface Maneuver {
-    /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver */
-    bearing_after: number;
-    /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver */
-    bearing_before: number;
-    /**Array of [ longitude, latitude ] coordinates for the point of the maneuver */
-    location: number[];
-    /** Optional String indicating the direction change of the maneuver */
-    modifier?: ManeuverModifier;
-    /**String indicating the type of maneuver */
-    type: ManeuverType;
-    /**A human-readable instruction of how to execute the returned maneuver */
-    instruction: string;
-  }
+    export interface Maneuver {
+        /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver */
+        bearing_after: number;
+        /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver */
+        bearing_before: number;
+        /**Array of [ longitude, latitude ] coordinates for the point of the maneuver */
+        location: number[];
+        /** Optional String indicating the direction change of the maneuver */
+        modifier?: ManeuverModifier;
+        /**String indicating the type of maneuver */
+        type: ManeuverType;
+        /**A human-readable instruction of how to execute the returned maneuver */
+        instruction: string;
+    }
 
-  export interface Intersection {
-    /**Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
-     * the direction of travel after the maneuver/passing the intersection.
-     * The value is not supplied for arrive maneuvers.
-     */
-    out?: number;
-    /** A list of entry flags, corresponding in a 1:1 relationship to the bearings.
-     * A value of true indicates that the respective road could be entered on a valid route.
-     * false indicates that the turn onto the respective road would violate a restriction.
-     */
-    entry: boolean[];
-    /**A list of bearing values (for example [0,90,180,270]) that are available at the intersection.
-     * The bearings describe all available roads at the intersection.
-     */
-    bearings: number[];
-    /**A [longitude, latitude] pair describing the location of the turn. */
-    location: number[];
-    /** Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the clockwise angle from true
-     * north to the direction of travel before the maneuver/passing the intersection. To get the bearing in the direction of driving,
-     * the bearing has to be rotated by a value of 180. The value is not supplied for departure maneuvers.
-     */
-    in?: number;
-    /**  An array of strings signifying the classes of the road exiting the intersection.  */
-    classes?: DirectionsClass[];
-    /**Array of Lane objects that represent the available turn lanes at the intersection.
-     * If no lane information is available for an intersection, the lanes property will not be present.
-     */
-    lanes: Lane[];
-  }
+    export interface Intersection {
+        /**Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
+         * the direction of travel after the maneuver/passing the intersection.
+         * The value is not supplied for arrive maneuvers.
+         */
+        out?: number;
+        /** A list of entry flags, corresponding in a 1:1 relationship to the bearings.
+         * A value of true indicates that the respective road could be entered on a valid route.
+         * false indicates that the turn onto the respective road would violate a restriction.
+         */
+        entry: boolean[];
+        /**A list of bearing values (for example [0,90,180,270]) that are available at the intersection.
+         * The bearings describe all available roads at the intersection.
+         */
+        bearings: number[];
+        /**A [longitude, latitude] pair describing the location of the turn. */
+        location: number[];
+        /** Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the clockwise angle from true
+         * north to the direction of travel before the maneuver/passing the intersection. To get the bearing in the direction of driving,
+         * the bearing has to be rotated by a value of 180. The value is not supplied for departure maneuvers.
+         */
+        in?: number;
+        /**  An array of strings signifying the classes of the road exiting the intersection.  */
+        classes?: DirectionsClass[];
+        /**Array of Lane objects that represent the available turn lanes at the intersection.
+         * If no lane information is available for an intersection, the lanes property will not be present.
+         */
+        lanes: Lane[];
+    }
 
-  export interface Lane {
-    /**Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
-     * first two are marked as valid, then the driver can take either of the left lanes and stay on the route.
-     */
-    valid: boolean;
-    /**Array of signs for each turn lane. There can be multiple signs. For example, a turning lane can have a sign with an arrow pointing left and another sign with an arrow pointing straight.
-        Example Lane object
-        {
-            "valid": true,
-            "indications": [
-                "left"
-            ]
-          */
-    indications: string[];
-  }
+    export interface Lane {
+        /**Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
+         * first two are marked as valid, then the driver can take either of the left lanes and stay on the route.
+         */
+        valid: boolean;
+        /**Array of signs for each turn lane. There can be multiple signs. For example, a turning lane can have a sign with an arrow pointing left and another sign with an arrow pointing straight.
+            Example Lane object
+            {
+                "valid": true,
+                "indications": [
+                    "left"
+                ]
+              */
+        indications: string[];
+    }
 
 }
 
 declare module '@mapbox/mapbox-sdk/services/geocoding' {
-  import { LngLatLike } from 'mapbox-gl';
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { LngLatLike } from 'mapbox-gl';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Geocoder Types
-  *********************************************************************************************************************/
-  export type GeocodeMode = "mapbox.places" | "mapbox.places-permanent";
+    /*********************************************************************************************************************
+    * Geocoder Types
+    *********************************************************************************************************************/
+    export type GeocodeMode = "mapbox.places" | "mapbox.places-permanent";
 
 
-  export type GeocodeQueryType = "country" |
-    "region" |
-    "postcode" |
-    "district" |
-    "place" |
-    "locality" |
-    "neighborhood" |
-    "address" |
-    "poi" |
-    "poi.landmark";
+    export type GeocodeQueryType = "country" |
+        "region" |
+        "postcode" |
+        "district" |
+        "place" |
+        "locality" |
+        "neighborhood" |
+        "address" |
+        "poi" |
+        "poi.landmark";
 
-  export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
+    export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
 
-  export interface GeocodeService {
-    forwardGeocode(request: GeocodeRequest): MapiRequest;
-    reverseGeocode(request: GeocodeRequest): MapiRequest;
-  }
+    export interface GeocodeService {
+        forwardGeocode(request: GeocodeRequest): MapiRequest;
+        reverseGeocode(request: GeocodeRequest): MapiRequest;
+    }
 
-  export interface IBBox {
-    minx: number;
-    miny: number;
-    maxx: number;
-    maxy: number;
-  }
+    export interface IBBox {
+        minx: number;
+        miny: number;
+        maxx: number;
+        maxy: number;
+    }
 
-  export interface GeocodeRequest {
-    // A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
-    query: string | LngLatLike;
-    // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
-    mode: GeocodeMode;
-    // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes 
-    countries?: string[];
-    //Bias local results based on a provided location. Options are  longitude,latitude coordinates.
-    proximity?: number[];
-    //Filter results by one or more feature types
-    types?: GeocodeQueryType[];
-    //Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
-    autocomplete?: boolean;
-    //Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
-    bbox?: IBBox;
-    //Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
-    limit?: number;
-    // Specify the language to use for response text and, for forward geocoding, query result weighting. 
-    // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more 
-    // IETF subtags for country or script. 
-    language?: string[];
-  }
+    export interface GeocodeRequest {
+        // A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
+        query: string | LngLatLike;
+        // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
+        mode: GeocodeMode;
+        // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes 
+        countries?: string[];
+        //Bias local results based on a provided location. Options are  longitude,latitude coordinates.
+        proximity?: number[];
+        //Filter results by one or more feature types
+        types?: GeocodeQueryType[];
+        //Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
+        autocomplete?: boolean;
+        //Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
+        bbox?: IBBox;
+        //Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
+        limit?: number;
+        // Specify the language to use for response text and, for forward geocoding, query result weighting. 
+        // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more 
+        // IETF subtags for country or script. 
+        language?: string[];
+    }
 
-  export interface GeocodeResponse {
-    /**	"Feature Collection" , a GeoJSON type from the GeoJSON specification . */
-    type: string;
-    /**	An array of space and punctuation-separated strings from the original query. */
-    query: string[];
-    /**An array of feature objects. */
-    features: GeocodeFeature[];
-    /**A string attributing the results of the Mapbox Geocoding API to Mapbox and links to Mapbox's terms of service and data sources. */
-    attribution: string;
-  }
+    export interface GeocodeResponse {
+        /**	"Feature Collection" , a GeoJSON type from the GeoJSON specification . */
+        type: string;
+        /**	An array of space and punctuation-separated strings from the original query. */
+        query: string[];
+        /**An array of feature objects. */
+        features: GeocodeFeature[];
+        /**A string attributing the results of the Mapbox Geocoding API to Mapbox and links to Mapbox's terms of service and data sources. */
+        attribution: string;
+    }
 
-  export interface GeocodeFeature {
-    /** A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
-     * The  {id} suffix of the feature id is unstable and may change within versions.
-     */
-    id: string;
-    /**"Feature" , a GeoJSON type from the GeoJSON specification . */
-    type: string;
-    /**An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,
-     * address ,  poi , and  poi.landmark . Most features have only one type, but if the feature has multiple types,
-     * all applicable types will be listed in the array. (For example, Vatican City is a  country , region , and  place .)
-     */
-    place_type: string[];
-    /**	A numerical score from 0 (least relevant) to 0.99 (most relevant) measuring how well each returned feature matches the query.
-     * You can use the  relevance property to remove results that don't fully match the query.
-     */
-    relevance: number;
-    /**A string of the house number for the returned  address feature. Note that unlike the
-     * address property for  poi features, this property is outside the  properties object.
-     */
-    address?: string;
-    /**
-     * 	An object describing the feature. The property object is unstable and only Carmen GeoJSON properties are guaranteed.
-     * Your implementation should check for the presence of these values in a response before it attempts to use them.
-     */
-    properties: GeocodeProperties;
-    /**	A string representing the feature in the requested language, if specified. */
-    text: string;
-    /**A string representing the feature in the requested language, if specified, and its full result hierarchy. */
-    place_name: string;
-    /**A string analogous to the  text field that more closely matches the query than results in the specified language.
-     * For example, querying "Köln, Germany" with language set to English might return a feature with the
-     * text "Cologne" and the  matching_text "Köln".
-     */
-    matching_text: string;
-    /**A string analogous to the  place_name field that more closely matches the query than results in the specified language.
-     * For example, querying "Köln, Germany" with language set to English might return a feature with the place_name "Cologne, Germany"
-     * and a  matching_place_name of "Köln, North Rhine-Westphalia, Germany".
-     */
-    matching_place_name: string;
-    /**
-     * A string of the IETF language tag of the query's primary language.
-     * Can be used to identity text and place_name properties on this object
-     * in the format text_{language}, place_name_{language} and language_{language} 
-     */
-    language: string;
-    /**An array bounding box in the form [ minX,minY,maxX,maxY ] . */
-    bbox?: number[];
-    /**	An array in the form [ longitude,latitude ] at the center of the specified  bbox . */
-    center: number[];
-    /** An object describing the spatial geometry of the returned feature.*/
-    geometry: Geometry;
-    /** An array representing the hierarchy of encompassing parent features. Each parent feature may include any of the above properties.*/
-    context: GeocodeFeature[];
-  }
+    export interface GeocodeFeature {
+        /** A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
+         * The  {id} suffix of the feature id is unstable and may change within versions.
+         */
+        id: string;
+        /**"Feature" , a GeoJSON type from the GeoJSON specification . */
+        type: string;
+        /**An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,
+         * address ,  poi , and  poi.landmark . Most features have only one type, but if the feature has multiple types,
+         * all applicable types will be listed in the array. (For example, Vatican City is a  country , region , and  place .)
+         */
+        place_type: string[];
+        /**	A numerical score from 0 (least relevant) to 0.99 (most relevant) measuring how well each returned feature matches the query.
+         * You can use the  relevance property to remove results that don't fully match the query.
+         */
+        relevance: number;
+        /**A string of the house number for the returned  address feature. Note that unlike the
+         * address property for  poi features, this property is outside the  properties object.
+         */
+        address?: string;
+        /**
+         * 	An object describing the feature. The property object is unstable and only Carmen GeoJSON properties are guaranteed.
+         * Your implementation should check for the presence of these values in a response before it attempts to use them.
+         */
+        properties: GeocodeProperties;
+        /**	A string representing the feature in the requested language, if specified. */
+        text: string;
+        /**A string representing the feature in the requested language, if specified, and its full result hierarchy. */
+        place_name: string;
+        /**A string analogous to the  text field that more closely matches the query than results in the specified language.
+         * For example, querying "Köln, Germany" with language set to English might return a feature with the
+         * text "Cologne" and the  matching_text "Köln".
+         */
+        matching_text: string;
+        /**A string analogous to the  place_name field that more closely matches the query than results in the specified language.
+         * For example, querying "Köln, Germany" with language set to English might return a feature with the place_name "Cologne, Germany"
+         * and a  matching_place_name of "Köln, North Rhine-Westphalia, Germany".
+         */
+        matching_place_name: string;
+        /**
+         * A string of the IETF language tag of the query's primary language.
+         * Can be used to identity text and place_name properties on this object
+         * in the format text_{language}, place_name_{language} and language_{language} 
+         */
+        language: string;
+        /**An array bounding box in the form [ minX,minY,maxX,maxY ] . */
+        bbox?: number[];
+        /**	An array in the form [ longitude,latitude ] at the center of the specified  bbox . */
+        center: number[];
+        /** An object describing the spatial geometry of the returned feature.*/
+        geometry: Geometry;
+        /** An array representing the hierarchy of encompassing parent features. Each parent feature may include any of the above properties.*/
+        context: GeocodeFeature[];
+    }
 
-  export interface Geometry {
-    /**" Point" , a GeoJSON type from the GeoJSON specification . */
-    type: string;
-    /** An array in the format [ longitude,latitude ] at the center of the specified  bbox . */
-    coordinates: number[];
-    /** A boolean value indicating if an  address is interpolated along a road network. This field is only present when the feature is interpolated. */
-    interpolated: boolean;
-  }
+    export interface Geometry {
+        /**" Point" , a GeoJSON type from the GeoJSON specification . */
+        type: string;
+        /** An array in the format [ longitude,latitude ] at the center of the specified  bbox . */
+        coordinates: number[];
+        /** A boolean value indicating if an  address is interpolated along a road network. This field is only present when the feature is interpolated. */
+        interpolated: boolean;
+    }
 
-  export interface GeocodeProperties extends GeocodeFeature {
-    /** The Wikidata identifier for the returned feature.*/
-    wikidata?: string;
-    /**A string of comma-separated categories for the returned  poi feature. */
-    category?: string;
-    /**A formatted string of the telephone number for the returned  poi feature. */
-    tel?: string;
-    /**	The name of a suggested Maki icon to visualize a  poi feature based on its  category . */
-    maki?: string;
-    /**A boolean value indicating whether a  poi feature is a landmark. Landmarks are
-     * particularly notable or long-lived features like schools, parks, museums and places of worship.
-     */
-    landmark?: boolean;
-    /**The ISO 3166-1 country and ISO 3166-2 region code for the returned feature. */
-    short_coide: string;
-  }
+    export interface GeocodeProperties extends GeocodeFeature {
+        /** The Wikidata identifier for the returned feature.*/
+        wikidata?: string;
+        /**A string of comma-separated categories for the returned  poi feature. */
+        category?: string;
+        /**A formatted string of the telephone number for the returned  poi feature. */
+        tel?: string;
+        /**	The name of a suggested Maki icon to visualize a  poi feature based on its  category . */
+        maki?: string;
+        /**A boolean value indicating whether a  poi feature is a landmark. Landmarks are
+         * particularly notable or long-lived features like schools, parks, museums and places of worship.
+         */
+        landmark?: boolean;
+        /**The ISO 3166-1 country and ISO 3166-2 region code for the returned feature. */
+        short_coide: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/map-matching' {
-  import { LngLatLike } from 'mapbox-gl';
-  import {
-    DirectionsProfile,
-    DirectionsAnnotation,
-    DirectionsGeometry,
-    DirectionsOverview,
-    Leg
-  } from '@mapbox/mapbox-sdk/services/directions';
-  import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { LngLatLike } from 'mapbox-gl';
+    import {
+        DirectionsProfile,
+        DirectionsAnnotation,
+        DirectionsGeometry,
+        DirectionsOverview,
+        Leg
+    } from '@mapbox/mapbox-sdk/services/directions';
+    import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Map Matching Types
-  *********************************************************************************************************************/
-  export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
+    /*********************************************************************************************************************
+    * Map Matching Types
+    *********************************************************************************************************************/
+    export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
 
 
-  export interface MapMatchingService {
-    getMatching(request: MapMatchingRequest): MapiRequest
-  }
+    export interface MapMatchingService {
+        getMatching(request: MapMatchingRequest): MapiRequest
+    }
 
-  export interface MapMatchingRequest {
-    /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
-    points: MapMatchingPoint[],
-    /** A directions profile ID. (optional, default driving) */
-    profile?: DirectionsProfile;
-    /**Specify additional metadata that should be returned. */
-    annotations?: DirectionsAnnotation;
-    /**Format of the returned geometry. (optional, default "polyline") */
-    geometries?: DirectionsGeometry;
-    /**Language of returned turn-by-turn text instructions. See supported languages. (optional, default "en") */
-    language?: string;
-    /** Type of returned overview geometry. (optional, default "simplified")*/
-    overview?: DirectionsOverview;
-    /**Whether to return steps and turn-by-turn instructions. (optional, default false) */
-    steps?: boolean;
-    /** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default false) */
-    tidy?: boolean;
-  }
+    export interface MapMatchingRequest {
+        /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
+        points: MapMatchingPoint[],
+        /** A directions profile ID. (optional, default driving) */
+        profile?: DirectionsProfile;
+        /**Specify additional metadata that should be returned. */
+        annotations?: DirectionsAnnotation;
+        /**Format of the returned geometry. (optional, default "polyline") */
+        geometries?: DirectionsGeometry;
+        /**Language of returned turn-by-turn text instructions. See supported languages. (optional, default "en") */
+        language?: string;
+        /** Type of returned overview geometry. (optional, default "simplified")*/
+        overview?: DirectionsOverview;
+        /**Whether to return steps and turn-by-turn instructions. (optional, default false) */
+        steps?: boolean;
+        /** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default false) */
+        tidy?: boolean;
+    }
 
-  export interface Point {
-    coordinates: LngLatLike;
-    /**Used to indicate how requested routes consider from which side of the road to approach a waypoint. */
-    approach?: DirectionsApproach;
-  }
+    export interface Point {
+        coordinates: LngLatLike;
+        /**Used to indicate how requested routes consider from which side of the road to approach a waypoint. */
+        approach?: DirectionsApproach;
+    }
 
-  export interface MapMatchingPoint extends Point {
-    /**A number in meters indicating the assumed precision of the used tracking device. */
-    radius?: number;
-    /**Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints. */
-    isWaypoint?: boolean;
-    /**Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless isWaypoint is true. */
-    waypointName?: boolean;
-    /**Datetime corresponding to the coordinate. */
-    timestamp?: string | number | Date;
-  }
+    export interface MapMatchingPoint extends Point {
+        /**A number in meters indicating the assumed precision of the used tracking device. */
+        radius?: number;
+        /**Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints. */
+        isWaypoint?: boolean;
+        /**Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless isWaypoint is true. */
+        waypointName?: boolean;
+        /**Datetime corresponding to the coordinate. */
+        timestamp?: string | number | Date;
+    }
 
-  export interface MapMatchingResponse {
-    /**an array of Match objects */
-    matchings: Matching[];
-    /**an array of Tracepoint objects representing the location an input point was matched with.
-     * Array of Waypoint objects representing all input points of the trace in the order they were matched.
-     * If a trace point is omitted by map matching because it is an outlier, the entry will be null.
-     */
-    tracepoints: Tracepoint[];
-    /**&a string depicting the state of the response; see below for options */
-    code: string;
-  }
+    export interface MapMatchingResponse {
+        /**an array of Match objects */
+        matchings: Matching[];
+        /**an array of Tracepoint objects representing the location an input point was matched with.
+         * Array of Waypoint objects representing all input points of the trace in the order they were matched.
+         * If a trace point is omitted by map matching because it is an outlier, the entry will be null.
+         */
+        tracepoints: Tracepoint[];
+        /**&a string depicting the state of the response; see below for options */
+        code: string;
+    }
 
-  export interface Tracepoint {
-    /** Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
-     * Split the trace at these points for incremental map matching.
-     */
-    alternatives_count: number;
-    /**Index of the waypoint inside the matched route. */
-    waypoint_index: number;
-    location: number[];
-    name: string;
-    /**Index to the match object in matchings the sub-trace was matched to. */
-    matchings_index: number;
-  }
+    export interface Tracepoint {
+        /** Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
+         * Split the trace at these points for incremental map matching.
+         */
+        alternatives_count: number;
+        /**Index of the waypoint inside the matched route. */
+        waypoint_index: number;
+        location: number[];
+        name: string;
+        /**Index to the match object in matchings the sub-trace was matched to. */
+        matchings_index: number;
+    }
 
-  export interface Matching {
-    /**a number between 0 (low) and 1 (high) indicating level of confidence in the returned match */
-    confidence: number;
-    geometry: string;
-    legs: Leg[];
-    distance: number;
-    duration: number;
-    weight_name: string;
-    weight: number;
-  }
+    export interface Matching {
+        /**a number between 0 (low) and 1 (high) indicating level of confidence in the returned match */
+        confidence: number;
+        geometry: string;
+        legs: Leg[];
+        distance: number;
+        duration: number;
+        weight_name: string;
+        weight: number;
+    }
 
 }
 
 declare module '@mapbox/mapbox-sdk/services/matrix' {
-  import {
-    DirectionsProfile,
-    DirectionsAnnotation
-  } from '@mapbox/mapbox-sdk/services/directions';
-  import { Point } from '@mapbox/mapbox-sdk/services/map-matching';
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import {
+        DirectionsProfile,
+        DirectionsAnnotation
+    } from '@mapbox/mapbox-sdk/services/directions';
+    import { Point } from '@mapbox/mapbox-sdk/services/map-matching';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Matrix Types
-  *********************************************************************************************************************/
-  export function Matrix(config: SdkConfig | MapiClient): MatrixService;
+    /*********************************************************************************************************************
+    * Matrix Types
+    *********************************************************************************************************************/
+    export function Matrix(config: SdkConfig | MapiClient): MatrixService;
 
-  export interface MatrixService {
-    /**
-     * Get a duration and/or distance matrix showing travel times and distances between coordinates.
-     * @param request
-     */
-    getMatrix(request: MatrixRequest): MapiRequest
-  }
+    export interface MatrixService {
+        /**
+         * Get a duration and/or distance matrix showing travel times and distances between coordinates.
+         * @param request
+         */
+        getMatrix(request: MatrixRequest): MapiRequest
+    }
 
-  export interface MatrixRequest {
-    points: Point[];
-    profile?: DirectionsProfile;
-    sources?: number[];
-    destinations?: number[];
-    annotations?: DirectionsAnnotation;
-  }
+    export interface MatrixRequest {
+        points: Point[];
+        profile?: DirectionsProfile;
+        sources?: number[];
+        destinations?: number[];
+        annotations?: DirectionsAnnotation;
+    }
 
-  export interface MatrixResponse {
-    code: string;
-    durations?: number[][];
-    distances?: number[][];
-    destinations: Destination[];
-    sources: Destination[];
-  }
+    export interface MatrixResponse {
+        code: string;
+        durations?: number[][];
+        distances?: number[][];
+        destinations: Destination[];
+        sources: Destination[];
+    }
 
-  export interface Destination {
-    location: number[];
-    name: string;
-  }
+    export interface Destination {
+        location: number[];
+        name: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/optimization' {
-  import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest, MapboxProfile, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Optimization Types
-  *********************************************************************************************************************/
-  export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
+    /*********************************************************************************************************************
+    * Optimization Types
+    *********************************************************************************************************************/
+    export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
 
-  export interface OptimizationService {
-    getContours(config: OptimizationRequest): MapiRequest;
-  }
+    export interface OptimizationService {
+        getContours(config: OptimizationRequest): MapiRequest;
+    }
 
-  export interface OptimizationRequest {
-    /**A Mapbox Directions routing profile ID. */
-    profile: MapboxProfile;
-    /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
-    waypoints: OptimizationWaypoint[];
-    /**Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are: */
-    annotations?: "duration" | "speed" | "distance";
-    /**Specify the destination coordinate of the returned route. Accepts  any (default) or  last . */
-    destination?: "any" | "last";
-    /** Specify pick-up and drop-off locations for a trip by providing a  ; delimited list of number pairs that correspond with the coordinates list. The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location. */
-    distributions?: number[];
-    /**The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6). */
-    geometries?: "geojson" | "polyline" | "polyline6";
-    /**The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English). */
-    language?: string;
-    /**The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry). */
-    overview?: "full" | "simplified" | "false";
-    /**The coordinate at which to start the returned route. Accepts  any (default) or  first . */
-    source?: "any" | "first";
-    /** Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default). */
-    steps?: boolean;
-    /** Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes. */
-    roundtrip?: boolean;
-  }
+    export interface OptimizationRequest {
+        /**A Mapbox Directions routing profile ID. */
+        profile: MapboxProfile;
+        /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
+        waypoints: OptimizationWaypoint[];
+        /**Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are: */
+        annotations?: "duration" | "speed" | "distance";
+        /**Specify the destination coordinate of the returned route. Accepts  any (default) or  last . */
+        destination?: "any" | "last";
+        /** Specify pick-up and drop-off locations for a trip by providing a  ; delimited list of number pairs that correspond with the coordinates list. The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location. */
+        distributions?: number[];
+        /**The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6). */
+        geometries?: "geojson" | "polyline" | "polyline6";
+        /**The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English). */
+        language?: string;
+        /**The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry). */
+        overview?: "full" | "simplified" | "false";
+        /**The coordinate at which to start the returned route. Accepts  any (default) or  first . */
+        source?: "any" | "first";
+        /** Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default). */
+        steps?: boolean;
+        /** Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes. */
+        roundtrip?: boolean;
+    }
 
-  export interface OptimizationWaypoint {
-    coordinates: number;
-    /** Used to indicate how requested routes consider from which side of the road to approach the waypoint. */
-    approach?: DirectionsApproach;
-    /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
-     This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
-    and the second is the range of degrees the angle can deviate by. */
-    bearing?: number[];
-    /**Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment. */
-    radius?: number | "unlimited";
-  }
+    export interface OptimizationWaypoint {
+        coordinates: number;
+        /** Used to indicate how requested routes consider from which side of the road to approach the waypoint. */
+        approach?: DirectionsApproach;
+        /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+         This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
+        and the second is the range of degrees the angle can deviate by. */
+        bearing?: number[];
+        /**Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment. */
+        radius?: number | "unlimited";
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/static' {
-  import { LngLatLike, LngLatBoundsLike } from 'mapbox-gl';
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { LngLatLike, LngLatBoundsLike } from 'mapbox-gl';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Static Map Types
-  *********************************************************************************************************************/
-  export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
+    /*********************************************************************************************************************
+    * Static Map Types
+    *********************************************************************************************************************/
+    export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
 
-  export interface StaticMapService {
-    /**
-     * Get a static map image..
-     * @param request
-     */
-    getStaticImage(request: StaticMapRequest): MapiRequest
-  }
+    export interface StaticMapService {
+        /**
+         * Get a static map image..
+         * @param request
+         */
+        getStaticImage(request: StaticMapRequest): MapiRequest
+    }
 
-  export interface StaticMapRequest {
-    ownerId: string;
-    styleId: string;
-    width: number;
-    height: number;
-    position: {
-      coordinates: LngLatLike | "auto";
-      zoom: number;
-      bearing?: number;
-      pitch?: number;
-    } | "auto";
-    overlays?: CustomMarkerOverlay[] | PathOverlay[] | GeoJsonOverlay[];
-    highRes?: boolean;
-    insertOverlayBeforeLayer?: string;
-    attribution?: boolean;
-    logo?: boolean;
-  }
+    export interface StaticMapRequest {
+        ownerId: string;
+        styleId: string;
+        width: number;
+        height: number;
+        position: {
+            coordinates: LngLatLike | "auto";
+            zoom: number;
+            bearing?: number;
+            pitch?: number;
+        } | "auto";
+        overlays?: CustomMarkerOverlay[] | PathOverlay[] | GeoJsonOverlay[];
+        highRes?: boolean;
+        insertOverlayBeforeLayer?: string;
+        attribution?: boolean;
+        logo?: boolean;
+    }
 
-  export interface CustomMarkerOverlay {
-    marker: CustomMarker
-  }
+    export interface CustomMarkerOverlay {
+        marker: CustomMarker
+    }
 
-  export interface CustomMarker {
-    coordinates: LngLatLike;
-    url: string;
-  }
+    export interface CustomMarker {
+        coordinates: LngLatLike;
+        url: string;
+    }
 
-  export interface PathOverlay {
-    /**An array of coordinates describing the path. */
-    coordinates: LngLatBoundsLike[];
-    strokeWidth?: number;
-    strokeColor?: string;
-    /**Must be paired with strokeColor. */
-    strokeOpacity?: number;
-    /** Must be paired with strokeColor. */
-    fillColor?: string;
-    /** Must be paired with strokeColor. */
-    fillOpacity?: number;
-  }
+    export interface PathOverlay {
+        /**An array of coordinates describing the path. */
+        coordinates: LngLatBoundsLike[];
+        strokeWidth?: number;
+        strokeColor?: string;
+        /**Must be paired with strokeColor. */
+        strokeOpacity?: number;
+        /** Must be paired with strokeColor. */
+        fillColor?: string;
+        /** Must be paired with strokeColor. */
+        fillOpacity?: number;
+    }
 
-  export interface GeoJsonOverlay {
-    geoJson: Object;
-  }
+    export interface GeoJsonOverlay {
+        geoJson: Object;
+    }
 
 
 }
 
 declare module '@mapbox/mapbox-sdk/services/styles' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Style Types
-  *********************************************************************************************************************/
-  export function Styles(config: SdkConfig | MapiClient): StylesService;
+    /*********************************************************************************************************************
+    * Style Types
+    *********************************************************************************************************************/
+    export function Styles(config: SdkConfig | MapiClient): StylesService;
 
-  export interface StylesService {
-    /**
-    * Get a style.
-    * @param styleId
-    * @param ownerId
-    */
-    getStyle(config: { styleId: string, ownerId?: string }): MapiRequest;
-    /**
-     * Create a style.
-     * @param style
-     * @param ownerId
-     */
-    createStyle(config: { style: Style, ownerId?: string }): MapiRequest;
-    /**
-     * Update a style.
-     * @param styleId
-     * @param style
-     * @param lastKnownModification
-     * @param ownerId
-     */
-    // implicit any
-    updateStyle(config: { styleId: string, style: Style, lastKnownModification?: string | number | Date, ownerId?: string }): void;
-    /**
-     * Delete a style.
-     * @param style
-     * @param ownerId
-     */
-    deleteStyle(config: { style: Style, ownerId?: string }): MapiRequest;
-    /**
-     * List styles in your account.
-     * @param start
-     * @param ownerId
-     */
-    listStyles(config: { start?: string, ownerId?: string }): MapiRequest;
-    /**
-     * Add an icon to a style, or update an existing one.
-     * @param styleId
-     * @param iconId
-     * @param file
-     * @param ownerId
-     */
-    putStyleIcon(config: { styleId: string, iconId: string, file: Blob | ArrayBuffer | string, ownerId?: string }): MapiRequest;
-    /**
-     * Remove an icon from a style.
-     * @param styleId
-     * @param iconId
-     * @param ownerId
-     */
-    // implicit any
-    deleteStyleIcon(config: { styleId: string, iconId: string, ownerId?: string }): void;
-    /**
-     * Get a style sprite's image or JSON document.
-     * @param styleId
-     * @param format
-     * @param highRes
-     * @param ownerId
-     */
-    getStyleSprite(config: { styleId: string, format?: "json" | "png", highRes?: boolean, ownerId?: string }): MapiRequest;
-    /**
-     * Get a font glyph range.
-     * @param fonts
-     * @param start
-     * @param end
-     * @param ownerId
-     */
-    getFontGlyphRange(config: { fonts: string[], start: number, end: number, ownerId?: string }): MapiRequest;
-    /**
-     * Get embeddable HTML displaying a map.
-     * @param config
-     * @param styleId
-     * @param scrollZoom
-     * @param title
-     * @param ownerId
-     */
-    getEmbeddableHtml(config: { config: Object, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
-  }
+    export interface StylesService {
+        /**
+        * Get a style.
+        * @param styleId
+        * @param ownerId
+        */
+        getStyle(config: { styleId: string, ownerId?: string }): MapiRequest;
+        /**
+         * Create a style.
+         * @param style
+         * @param ownerId
+         */
+        createStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+        /**
+         * Update a style.
+         * @param styleId
+         * @param style
+         * @param lastKnownModification
+         * @param ownerId
+         */
+        // implicit any
+        updateStyle(config: { styleId: string, style: Style, lastKnownModification?: string | number | Date, ownerId?: string }): void;
+        /**
+         * Delete a style.
+         * @param style
+         * @param ownerId
+         */
+        deleteStyle(config: { style: Style, ownerId?: string }): MapiRequest;
+        /**
+         * List styles in your account.
+         * @param start
+         * @param ownerId
+         */
+        listStyles(config: { start?: string, ownerId?: string }): MapiRequest;
+        /**
+         * Add an icon to a style, or update an existing one.
+         * @param styleId
+         * @param iconId
+         * @param file
+         * @param ownerId
+         */
+        putStyleIcon(config: { styleId: string, iconId: string, file: Blob | ArrayBuffer | string, ownerId?: string }): MapiRequest;
+        /**
+         * Remove an icon from a style.
+         * @param styleId
+         * @param iconId
+         * @param ownerId
+         */
+        // implicit any
+        deleteStyleIcon(config: { styleId: string, iconId: string, ownerId?: string }): void;
+        /**
+         * Get a style sprite's image or JSON document.
+         * @param styleId
+         * @param format
+         * @param highRes
+         * @param ownerId
+         */
+        getStyleSprite(config: { styleId: string, format?: "json" | "png", highRes?: boolean, ownerId?: string }): MapiRequest;
+        /**
+         * Get a font glyph range.
+         * @param fonts
+         * @param start
+         * @param end
+         * @param ownerId
+         */
+        getFontGlyphRange(config: { fonts: string[], start: number, end: number, ownerId?: string }): MapiRequest;
+        /**
+         * Get embeddable HTML displaying a map.
+         * @param config
+         * @param styleId
+         * @param scrollZoom
+         * @param title
+         * @param ownerId
+         */
+        getEmbeddableHtml(config: { config: Object, styleId: string, scrollZoom?: boolean, title?: boolean, ownerId?: string }): MapiRequest;
+    }
 
-  interface Style {
-    version: number;
-    name: string;
-    /**Information about the style that is used in Mapbox Studio. */
-    metadata: string;
-    sources: Sources;
-    sprite: string;
-    glyphs: string;
-    layers: string[];
-    /**Date and time the style was created. */
-    created: string;
-    /**	The ID of the style. */
-    id: string;
-    /**Date and time the style was last modified. */
-    modified: string;
-    /**The username of the style owner. */
-    owner: string;
-    /**	Access control for the style, either  public or  private . Private styles require an access token belonging to the owner,
-     * while public styles may be requested with an access token belonging to any user.
-     */
-    visibility: string;
-    /**Whether the style is a draft or has been published. */
-    draft: boolean;
-  }
+    interface Style {
+        version: number;
+        name: string;
+        /**Information about the style that is used in Mapbox Studio. */
+        metadata: string;
+        sources: Sources;
+        sprite: string;
+        glyphs: string;
+        layers: string[];
+        /**Date and time the style was created. */
+        created: string;
+        /**	The ID of the style. */
+        id: string;
+        /**Date and time the style was last modified. */
+        modified: string;
+        /**The username of the style owner. */
+        owner: string;
+        /**	Access control for the style, either  public or  private . Private styles require an access token belonging to the owner,
+         * while public styles may be requested with an access token belonging to any user.
+         */
+        visibility: string;
+        /**Whether the style is a draft or has been published. */
+        draft: boolean;
+    }
 
-  interface Sources {
-  }
+    interface Sources {
+    }
 
 
 }
 
 declare module '@mapbox/mapbox-sdk/services/tilequery' {
-  import * as mapboxgl from 'mapbox-gl';
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import * as mapboxgl from 'mapbox-gl';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Tile Query (Places) Types
-  *********************************************************************************************************************/
-  export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
+    /*********************************************************************************************************************
+    * Tile Query (Places) Types
+    *********************************************************************************************************************/
+    export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
 
-  export interface TileQueryService {
-    /**
-     * Get a static map image..
-     * @param request
-     */
-    listFeatures(request: TileQueryRequest): MapiRequest
-  }
+    export interface TileQueryService {
+        /**
+         * Get a static map image..
+         * @param request
+         */
+        listFeatures(request: TileQueryRequest): MapiRequest
+    }
 
-  export interface TileQueryRequest {
-    /**The maps being queried. If you need to composite multiple layers, provide multiple map IDs. */
-    mapIds: string[];
-    /**The longitude and latitude to be queried. */
-    coordinates: mapboxgl.LngLatLike;
-    /**The approximate distance in meters to query for features. (optional, default 0) */
-    radius: number;
-    /**The number of features to return, between 1 and 50. (optional, default 5) */
-    limit: number;
-    /**Whether or not to deduplicate results. (optional, default true) */
-    dedupe: boolean;
-    /** Queries for a specific geometry type. */
-    geometry: GeometryType;
-    layers?: string[];
-  }
+    export interface TileQueryRequest {
+        /**The maps being queried. If you need to composite multiple layers, provide multiple map IDs. */
+        mapIds: string[];
+        /**The longitude and latitude to be queried. */
+        coordinates: mapboxgl.LngLatLike;
+        /**The approximate distance in meters to query for features. (optional, default 0) */
+        radius: number;
+        /**The number of features to return, between 1 and 50. (optional, default 5) */
+        limit: number;
+        /**Whether or not to deduplicate results. (optional, default true) */
+        dedupe: boolean;
+        /** Queries for a specific geometry type. */
+        geometry: GeometryType;
+        layers?: string[];
+    }
 
-  export type GeometryType = "polygon" | "linestring" | "point";
+    export type GeometryType = "polygon" | "linestring" | "point";
 
 
 }
 
 declare module '@mapbox/mapbox-sdk/services/tilesets' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Tileset Types
-  *********************************************************************************************************************/
-  export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
+    /*********************************************************************************************************************
+    * Tileset Types
+    *********************************************************************************************************************/
+    export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
 
-  export interface TilesetsService {
-    listTilesets(config: { ownerId: string }): MapiRequest;
-  }
+    export interface TilesetsService {
+        listTilesets(config: { ownerId: string }): MapiRequest;
+    }
 
-  export interface Tileset {
-    type: string;
-    center: number[];
-    created: string;
-    description: string;
-    filesize: number;
-    id: string;
-    modified: string;
-    name: string;
-    visibility: string;
-    status: string;
-  }
+    export interface Tileset {
+        type: string;
+        center: number[];
+        created: string;
+        description: string;
+        filesize: number;
+        id: string;
+        modified: string;
+        name: string;
+        visibility: string;
+        status: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/tokens' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Token Types
-  *********************************************************************************************************************/
-  export function Tokens(config: SdkConfig | MapiClient): TokensService;
+    /*********************************************************************************************************************
+    * Token Types
+    *********************************************************************************************************************/
+    export function Tokens(config: SdkConfig | MapiClient): TokensService;
 
-  export interface TokensService {
-    /**List your access tokens. */
-    listTokens(): MapiRequest;
-    /**
-     * Create a new access token.
-     * @param request
-     */
-    createToken(request: CreateTokenRequest): MapiRequest;
-    /**
-     * Create a new temporary access token.
-     * @param request
-     */
-    createTemporaryToken(request: TemporaryTokenRequest): MapiRequest;
-    /**
-     * Update an access token.
-     * @param request
-     */
-    updateToken(request: UpdateDeleteTokenRequest): MapiRequest;
-    /**Get data about the client's access token. */
-    getToken(): MapiRequest;
-    /**
-     * Delete an access token.
-     * @param request
-     */
-    deleteToken(request: UpdateDeleteTokenRequest): MapiRequest;
-    /**List your available scopes. Each item is a metadata object about the scope, not just the string scope. */
-    listScopes(): MapiRequest;
-  }
+    export interface TokensService {
+        /**List your access tokens. */
+        listTokens(): MapiRequest;
+        /**
+         * Create a new access token.
+         * @param request
+         */
+        createToken(request: CreateTokenRequest): MapiRequest;
+        /**
+         * Create a new temporary access token.
+         * @param request
+         */
+        createTemporaryToken(request: TemporaryTokenRequest): MapiRequest;
+        /**
+         * Update an access token.
+         * @param request
+         */
+        updateToken(request: UpdateDeleteTokenRequest): MapiRequest;
+        /**Get data about the client's access token. */
+        getToken(): MapiRequest;
+        /**
+         * Delete an access token.
+         * @param request
+         */
+        deleteToken(request: UpdateDeleteTokenRequest): MapiRequest;
+        /**List your available scopes. Each item is a metadata object about the scope, not just the string scope. */
+        listScopes(): MapiRequest;
+    }
 
-  export interface Token {
-    /**the identifier for the token */
-    id: string;
-    /**the type of token */
-    usage: string;
-    /**the client for the token, always 'api' */
-    client: string;
-    /**if the token is a default token */
-    default: boolean;
-    /**human friendly description of the token */
-    note: string;
-    /**	array of scopes granted to the token */
-    scopes: string[];
-    /**date and time the token was created */
-    created: string;
-    /**	date and time the token was last modified */
-    modified: string;
-    /**the token itself */
-    token: string;
-  }
+    export interface Token {
+        /**the identifier for the token */
+        id: string;
+        /**the type of token */
+        usage: string;
+        /**the client for the token, always 'api' */
+        client: string;
+        /**if the token is a default token */
+        default: boolean;
+        /**human friendly description of the token */
+        note: string;
+        /**	array of scopes granted to the token */
+        scopes: string[];
+        /**date and time the token was created */
+        created: string;
+        /**	date and time the token was last modified */
+        modified: string;
+        /**the token itself */
+        token: string;
+    }
 
-  export interface CreateTokenRequest {
-    note?: string;
-    scopes?: string[];
-    resources?: string[];
-  }
+    export interface CreateTokenRequest {
+        note?: string;
+        scopes?: string[];
+        resources?: string[];
+    }
 
-  export interface TemporaryTokenRequest {
-    expires: string;
-    scopes: string[];
-  }
+    export interface TemporaryTokenRequest {
+        expires: string;
+        scopes: string[];
+    }
 
-  export interface UpdateDeleteTokenRequest extends CreateTokenRequest {
-    tokenId: string;
-  }
+    export interface UpdateDeleteTokenRequest extends CreateTokenRequest {
+        tokenId: string;
+    }
 
-  export interface TokenDetail {
-    code: string;
-    token: Token;
-  }
+    export interface TokenDetail {
+        code: string;
+        token: Token;
+    }
 
-  export interface Scope {
-    id: string;
-    public: boolean;
-    description: string;
-  }
+    export interface Scope {
+        id: string;
+        public: boolean;
+        description: string;
+    }
 }
 
 declare module '@mapbox/mapbox-sdk/services/uploads' {
-  import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
-  import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+    import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+    import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
-  /*********************************************************************************************************************
-  * Uploads Types
-  *********************************************************************************************************************/
-  export function Uploads(config: SdkConfig | MapiClient): UploadsService;
+    /*********************************************************************************************************************
+    * Uploads Types
+    *********************************************************************************************************************/
+    export function Uploads(config: SdkConfig | MapiClient): UploadsService;
 
-  export interface UploadsService {
-    /**
-     * List the statuses of all recent uploads.
-     * @param config
-     */
-    listUploads(config: { reverse?: boolean }): MapiRequest;
-    /**Create S3 credentials. */
-    createUploadCredentials(): MapiRequest;
-    /**
-     * Create an upload.
-     * @param config
-     */
-    createUpload(config: { mapId: string, url: string, tilesetName?: string }): MapiRequest;
-    /**
-     * Get an upload's status.
-     * @param config
-     */
-    // implicit any
-    getUpload(config: { uploadId: string }): any;
-    /**
-     * Delete an upload.
-     * @param config
-     */
-    // implicit any
-    deleteUpload(config: { uploadId: string }): any;
+    export interface UploadsService {
+        /**
+         * List the statuses of all recent uploads.
+         * @param config
+         */
+        listUploads(config: { reverse?: boolean }): MapiRequest;
+        /**Create S3 credentials. */
+        createUploadCredentials(): MapiRequest;
+        /**
+         * Create an upload.
+         * @param config
+         */
+        createUpload(config: { mapId: string, url: string, tilesetName?: string }): MapiRequest;
+        /**
+         * Get an upload's status.
+         * @param config
+         */
+        // implicit any
+        getUpload(config: { uploadId: string }): any;
+        /**
+         * Delete an upload.
+         * @param config
+         */
+        // implicit any
+        deleteUpload(config: { uploadId: string }): any;
 
-  }
+    }
 
-  export interface S3Credentials {
-    accessKeyId: string;
-    bucket: string;
-    key: string;
-    secretAccessKey: string;
-    sessionToken: string;
-    url: string;
-  }
+    export interface S3Credentials {
+        accessKeyId: string;
+        bucket: string;
+        key: string;
+        secretAccessKey: string;
+        sessionToken: string;
+        url: string;
+    }
 
-  export interface UploadResponse {
-    complete: boolean;
-    tileset: string;
-    error?: any;
-    id: string;
-    name: string;
-    modified: string;
-    created: string;
-    owner: string;
-    progress: number;
-  }
+    export interface UploadResponse {
+        complete: boolean;
+        tileset: string;
+        error?: any;
+        id: string;
+        name: string;
+        modified: string;
+        created: string;
+        owner: string;
+        progress: number;
+    }
 }

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @mapbox/mapbox-sdk 0.6.0
+// Type definitions for @mapbox/mapbox-sdk 0.6
 // Project: https://github.com/mapbox/mapbox-sdk-js
 // Definitions by: Jeff Dye <https://github.com/jeffbdye>
 //                 Mike O'Meara <https://github.com/mikeomeara1>
@@ -44,11 +44,11 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         /**
          * If this request has been sent and received a response, the response is available on this property.
          */
-        response: MapiResponse | null;
+        response?: MapiResponse;
         /**
          * If this request has been sent and received an error in response, the error is available on this property.
          */
-        error: MapiError | Error | null;
+        error?: MapiError | Error;
         /**
          * If the request has been aborted (via abort), this property will be true.
          */
@@ -86,7 +86,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         /**
          * Data to send with the request. If the request has a body, it will also be sent with the header 'Content-Type: application/json'.
          */
-        body: any | string | null;
+        body?: any;
         /**
          * A file to send with the request. The browser client accepts Blobs and ArrayBuffers.
          */
@@ -98,11 +98,11 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         clone(): MapiRequest;
     }
 
-    type PageCallbackFunction = {
+    interface PageCallbackFunction {
         error: MapiError;
         response: MapiResponse;
         next: () => void;
-    };
+    }
 
     type MapboxProfile = 'driving' | 'walking' | 'cycling';
 
@@ -162,7 +162,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
         /**
          * If the server sent a response body, this property exposes that response, parsed as JSON if possible.
          */
-        body?: any | string;
+        body?: any;
         /**
          * Whatever message could be derived from the call site and HTTP response.
          */

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -317,9 +317,12 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
     }
 
     interface DirectionsRequestWaypoint {
-        /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
+        /**
+         * Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates.
+         */
         coordinates: number[] | LngLatLike;
-        /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
+        /**
+         * Used to indicate how requested routes consider from which side of the road to approach a waypoint.
          * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
          * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
          * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
@@ -327,18 +330,24 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          * However, you can skip a coordinate and show its position in the list with the  ; separator.
          */
         approach?: DirectionsApproach;
-        /**Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. */
+        /**
+         * Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. 
+         */
         radius?: string | 'unlimited';
     }
 
     interface DirectionsResponse {
-        /**Array of Route objects ordered by descending recommendation rank. May contain at most two routes. */
+        /**
+         * Array of Route objects ordered by descending recommendation rank. May contain at most two routes. 
+         */
         routes: Route[];
-        /** Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
+        /** 
+         * Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
          * The waypoints appear in the array in the order of the input coordinates.
          */
         waypoints: Waypoint[];
-        /**String indicating the state of the response. This is a separate code than the HTTP status code.
+        /**
+         * String indicating the state of the response. This is a separate code than the HTTP status code.
          * On normal valid responses, the value will be Ok.
          */
         code: string;
@@ -346,11 +355,16 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
     }
 
     interface Waypoint {
-        /**String with the name of the way the coordinate snapped to */
+        /**
+         * String with the name of the way the coordinate snapped to.
+         */
         name: string;
-        /**Array of [ longitude, latitude ] for the snapped coordinate */
+        /**
+         * Array of [ longitude, latitude ] for the snapped coordinate.
+         */
         location: number[];
-        /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+        /**
+         * Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
          * This option should always be used in conjunction with the  radiuses parameter. The parameter takes two values per waypoint.
          * The first value is an angle clockwise from true north between 0 and 360, and the second is the range of degrees the angle can deviate by.
          * The recommended value for the range is 45° or 90°, as bearing measurements tend to be inaccurate.
@@ -360,7 +374,8 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          * However, you can skip a coordinate and show its position in the list with the  ; separator.
          */
         bearing?: number[];
-        /**Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
+        /**
+         * Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
          * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
          * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
          */
@@ -368,55 +383,84 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
     }
 
     interface Route {
-        /**Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
+        /**
+         * Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
          * Depending on the overview parameter this is the complete route geometry (full), a simplified geometry
          * to the zoom level at which the route can be displayed in full (simplified), or is not included (false)
          */
         geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
-        /**Array of RouteLeg objects. */
+        /**
+         * Array of RouteLeg objects. 
+         */
         legs: Leg[];
-        /** String indicating which weight was used. The default is routability which is duration-based,
+        /** 
+         * String indicating which weight was used. The default is routability which is duration-based,
          * with additional penalties for less desirable maneuvers.
          */
         weight_name: string;
-        /**Float indicating the weight in units described by weight_name */
+        /** 
+         * Float indicating the weight in units described by weight_name 
+         */
         weight: number;
-        /**Float indicating the estimated travel time in seconds. */
+        /** 
+         * Float indicating the estimated travel time in seconds. 
+         */
         duration: number;
-        /**Float indicating the distance traveled in meters. */
+        /** 
+         * Float indicating the distance traveled in meters. 
+         */
         distance: number;
-        /**String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. */
+        /** 
+         * String of the locale used for voice instructions. Defaults to en, and can be any accepted instruction language. 
+         */
         voiceLocale?: string;
     }
 
     interface Leg {
-        /**Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) */
+        /**
+         * Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) 
+         */
         summary: string;
         weight: number;
-        /**Number indicating the estimated travel time in seconds */
+        /**
+         * Number indicating the estimated travel time in seconds 
+         */
         duration: number;
-        /** Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) */
+        /**
+         * Depending on the steps parameter, either an Array of RouteStep objects (true, default) or an empty array (false) 
+         */
         steps: Step[];
-        /** Number indicating the distance traveled in meters */
+        /**
+         * Number indicating the distance traveled in meters 
+         */
         distance: number;
-        /**An annotations object that contains additional details about each line segment along the route geometry.
+        /**
+         * An annotations object that contains additional details about each line segment along the route geometry.
          * Each entry in an annotations field corresponds to a coordinate along the route geometry.
          */
         annotation: DirectionsAnnotation[];
     }
 
     interface Step {
-        /**Array of objects representing all intersections along the step. */
+        /**
+         * Array of objects representing all intersections along the step.
+         */
         intersections: Intersection[];
-        /**The legal driving side at the location for this step. Either left or right. */
+        /**
+         * The legal driving side at the location for this step. Either left or right.
+         */
         driving_side: DirectionsSide;
         /** Depending on the geometries parameter this is a GeoJSON LineString or a
          * Polyline string representing the full route geometry from this RouteStep to the next RouteStep
          */
         geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
-        /**String indicating the mode of transportation. Possible values: */
+        /**
+         * String indicating the mode of transportation. Possible values:
+         */
         mode: DirectionsMode;
-        /**One StepManeuver object */
+        /**
+         * One StepManeuver object
+         */
         maneuver: Maneuver;
         /**Any road designations associated with the road or path leading from this step’s maneuver to the next step’s maneuver.
          * Optionally included, if data is available. If multiple road designations are associated with the road, they are separated by semicolons.
@@ -426,56 +470,82 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         ref?: string;
         weight: number;
-        /**Number indicating the estimated time traveled time in seconds from the maneuver to the next RouteStep. */
+        /**
+         * Number indicating the estimated time traveled time in seconds from the maneuver to the next RouteStep.
+         */
         duration: number;
-        /**String with the name of the way along which the travel proceeds */
+        /**
+         * String with the name of the way along which the travel proceeds
+         */
         name: string;
-        /** Number indicating the distance traveled in meters from the maneuver to the next RouteStep. */
+        /**
+         * Number indicating the distance traveled in meters from the maneuver to the next RouteStep.
+         */
         distance: number;
         voiceInstructions: VoiceInstruction[];
         bannerInstructions: BannerInstruction[];
-        /**String with the destinations of the way along which the travel proceeds. Optionally included, if data is available. */
+        /**
+         * String with the destinations of the way along which the travel proceeds. Optionally included, if data is available.
+         */
         destinations?: string;
-        /**String with the exit numbers or names of the way. Optionally included, if data is available. */
+        /**
+         * String with the exit numbers or names of the way. Optionally included, if data is available.
+         */
         exits?: string;
-        /** A string containing an IPA phonetic transcription indicating how to pronounce the name in the name property.
+        /**
+         * A string containing an IPA phonetic transcription indicating how to pronounce the name in the name property.
          * This property is omitted if pronunciation data is unavailable for the step.
          */
         pronunciation?: string;
     }
 
     interface Instruction {
-        /**String that contains all the text that should be displayed */
+        /**
+         * String that contains all the text that should be displayed.
+         */
         text: string;
-        /**Objects that, together, make up what should be displayed in the banner.
+        /**
+         * Objects that, together, make up what should be displayed in the banner.
          * Includes additional information intended to be used to aid in visual layout
          */
         components: Component[];
-        /**The type of maneuver. May be used in combination with the modifier (and, if it is a roundabout, the degrees) to for an icon to
+        /**
+         * The type of maneuver. May be used in combination with the modifier (and, if it is a roundabout, the degrees) to for an icon to
          * display. Possible values: 'turn', 'merge', 'depart', 'arrive', 'fork', 'off ramp', 'roundabout'
          */
         type?: string;
-        /** The modifier for the maneuver. Can be used in combination with the type (and, if it is a roundabout, the degrees)
+        /**
+         * The modifier for the maneuver. Can be used in combination with the type (and, if it is a roundabout, the degrees)
          * to for an icon to display. Possible values: 'left', 'right', 'slight left', 'slight right', 'sharp left', 'sharp right', 'straight', 'uturn'
          */
         modifier?: ManeuverModifier;
-        /**The degrees at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout. */
+        /**
+         * The degrees at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout.
+         */
         degrees?: number;
-        /** A string representing which side the of the street people drive on in that location. Can be 'left' or 'right'. */
+        /**
+         * A string representing which side the of the street people drive on in that location. Can be 'left' or 'right'.
+         */
         driving_side: DirectionsSide;
     }
 
     interface BannerInstruction {
-        /**float indicating in meters, how far from the upcoming maneuver
+        /**
+         * Float indicating in meters, how far from the upcoming maneuver
          * the banner instruction should begin being displayed. Only 1 banner should be displayed at a time.
          */
         distanceAlongGeometry: number;
-        /**Most important content to display to the user. Our SDK displays this text larger and at the top. */
+        /**
+         * Most important content to display to the user. Our SDK displays this text larger and at the top.
+         */
         primary: Instruction;
-        /**Additional content useful for visual guidance. Our SDK displays this text slightly smaller and below the primary. Can be null. */
+        /**
+         * Additional content useful for visual guidance. Our SDK displays this text slightly smaller and below the primary. Can be null.
+         */
         secondary?: Instruction[];
         then?: any;
-        /**Additional information that is included if we feel the driver needs a heads up about something.
+        /**
+         * Additional information that is included if we feel the driver needs a heads up about something.
          * Can include information about the next maneuver (the one after the upcoming one) if the step is short -
          * can be null, or can be lane information. If we have lane information, that trumps information about the next maneuver.
          */
@@ -483,114 +553,148 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
     }
 
     interface Sub {
-        /** String that contains all the text that should be displayed */
+        /**
+         * String that contains all the text that should be displayed.
+         */
         text: string;
-        /**Objects that, together, make up what should be displayed in the banner.
+        /**
+         * Objects that, together, make up what should be displayed in the banner.
          * Includes additional information intended to be used to aid in visual layout
          */
         components: Component[];
     }
 
     interface Component {
-        /**String giving you more context about the component which may help in visual markup/display choices.
+        /**
+         * String giving you more context about the component which may help in visual markup/display choices.
          * If the type of the components is unknown it should be treated as text. Note: Introduction of new types
          * is not considered a breaking change. See the Types of Banner Components table below for more info on each type.
          */
         type: string;
-        /** The sub-string of the parent object's text that may have additional context associated with it */
+        /**
+         * The sub-string of the parent object's text that may have additional context associated with it.
+         */
         text: string;
-        /**The abbreviated form of text. If this is present, there will also be an abbr_priority value.
+        /**
+         * The abbreviated form of text. If this is present, there will also be an abbr_priority value.
          * See the Examples of Abbreviations table below for an example of using abbr and abbr_priority.
          */
         abbr?: string;
-        /**An integer indicating the order in which the abbreviation abbr should be used in place of text.
+        /**
+         * An integer indicating the order in which the abbreviation abbr should be used in place of text.
          * The highest priority is 0 and a higher integer value means it should have a lower priority. There are no gaps in
          * integer values. Multiple components can have the same abbr_priority and when this happens all components with the
          * same abbr_priority should be abbreviated at the same time. Finding no larger values of abbr_priority means that the
          * string is fully abbreviated.
          */
         abbr_priority?: number;
-        /** String pointing to a shield image to use instead of the text. */
+        /**
+         * String pointing to a shield image to use instead of the text.
+         * */
         imageBaseURL?: string;
-        /** (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
+        /**
+         * (present if component is lane): An array indicating which directions you can go from a lane (left, right, or straight).
          * If the value is ['left', 'straight'], the driver can go straight or left from that lane
          */
         directions?: string[];
-        /**  (present if component is lane): A boolean telling you if that lane can be used to complete the upcoming maneuver.
+        /**
+         * (present if component is lane): A boolean telling you if that lane can be used to complete the upcoming maneuver.
          * If multiple lanes are active, then they can all be used to complete the upcoming maneuver.
          */
         active: boolean;
     }
 
     interface VoiceInstruction {
-        /** float indicating in meters, how far from the upcoming maneuver the voice instruction should begin. */
+        /**
+         * Float indicating in meters, how far from the upcoming maneuver the voice instruction should begin.
+         */
         distanceAlongGeometry: number;
-        /**String containing the text of the verbal instruction. */
+        /**
+         * String containing the text of the verbal instruction.
+         */
         announcement: string;
-        /**String with SSML markup for proper text and pronunciation. Note: this property is designed for use with Amazon Polly.
+        /**
+         * String with SSML markup for proper text and pronunciation. Note: this property is designed for use with Amazon Polly.
          * The SSML tags contained here may not work with other text-to-speech engines.
          */
         ssmlAnnouncement: string;
     }
 
     interface Maneuver {
-        /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver */
+        /**
+         * Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver
+         */
         bearing_after: number;
-        /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver */
+        /**
+         * Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver
+         */
         bearing_before: number;
-        /**Array of [ longitude, latitude ] coordinates for the point of the maneuver */
+        /**
+         * Array of [ longitude, latitude ] coordinates for the point of the maneuver
+         */
         location: number[];
-        /** Optional String indicating the direction change of the maneuver */
+        /**
+         * Optional String indicating the direction change of the maneuver
+         */
         modifier?: ManeuverModifier;
-        /**String indicating the type of maneuver */
+        /**
+         * String indicating the type of maneuver
+         */
         type: ManeuverType;
-        /**A human-readable instruction of how to execute the returned maneuver */
+        /**
+         * A human-readable instruction of how to execute the returned maneuver
+         */
         instruction: string;
     }
 
     interface Intersection {
-        /**Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
+        /**
+         * Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
          * the direction of travel after the maneuver/passing the intersection.
          * The value is not supplied for arrive maneuvers.
          */
         out?: number;
-        /** A list of entry flags, corresponding in a 1:1 relationship to the bearings.
+        /**
+         * A list of entry flags, corresponding in a 1:1 relationship to the bearings.
          * A value of true indicates that the respective road could be entered on a valid route.
          * false indicates that the turn onto the respective road would violate a restriction.
          */
         entry: boolean[];
-        /**A list of bearing values (for example [0,90,180,270]) that are available at the intersection.
+        /**
+         * A list of bearing values (for example [0,90,180,270]) that are available at the intersection.
          * The bearings describe all available roads at the intersection.
          */
         bearings: number[];
-        /**A [longitude, latitude] pair describing the location of the turn. */
+        /**
+         * A [longitude, latitude] pair describing the location of the turn.
+         */
         location: number[];
-        /** Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the clockwise angle from true
+        /**
+         * Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the clockwise angle from true
          * north to the direction of travel before the maneuver/passing the intersection. To get the bearing in the direction of driving,
          * the bearing has to be rotated by a value of 180. The value is not supplied for departure maneuvers.
          */
         in?: number;
-        /**  An array of strings signifying the classes of the road exiting the intersection.  */
+        /**
+         * An array of strings signifying the classes of the road exiting the intersection.
+         */
         classes?: DirectionsClass[];
-        /**Array of Lane objects that represent the available turn lanes at the intersection.
+        /**
+         * Array of Lane objects that represent the available turn lanes at the intersection.
          * If no lane information is available for an intersection, the lanes property will not be present.
          */
         lanes: Lane[];
     }
 
     interface Lane {
-        /**Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
+        /**
+         * Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
          * first two are marked as valid, then the driver can take either of the left lanes and stay on the route.
          */
         valid: boolean;
-        /**Array of signs for each turn lane. There can be multiple signs. For example, a turning lane can have a sign with an arrow pointing left and another sign with an arrow pointing straight.
-            Example Lane object
-            {
-                "valid": true,
-                "indications": [
-                    "left"
-                ]
-              */
+        /**
+         * Array of signs for each turn lane. There can be multiple signs. For example, a turning lane can have a sign with an arrow pointing left and another sign with an arrow pointing straight.
+         */
         indications: string[];
     }
 
@@ -605,9 +709,24 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
     /*********************************************************************************************************************
      * Geocoder Types
      *********************************************************************************************************************/
-    export type GeocodeMode = 'mapbox.places' | 'mapbox.places-permanent';
 
-    export type GeocodeQueryType =
+    export default function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
+
+    interface GeocodeService {
+        forwardGeocode(request: GeocodeRequest): MapiRequest;
+        reverseGeocode(request: GeocodeRequest): MapiRequest;
+    }
+
+    interface BoundingBox {
+        minLongitude: number;
+        minLatitude: number;
+        maxLongitude: number;
+        maxLatitude: number;
+    }
+
+    type GeocodeMode = 'mapbox.places' | 'mapbox.places-permanent';
+
+    type GeocodeQueryType =
         | 'country'
         | 'region'
         | 'postcode'
@@ -618,20 +737,6 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         | 'address'
         | 'poi'
         | 'poi.landmark';
-
-    export default function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
-
-    interface GeocodeService {
-        forwardGeocode(request: GeocodeRequest): MapiRequest;
-        reverseGeocode(request: GeocodeRequest): MapiRequest;
-    }
-
-    interface IBBox {
-        minx: number;
-        miny: number;
-        maxx: number;
-        maxy: number;
-    }
 
     interface GeocodeRequest {
         /**
@@ -661,12 +766,13 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         /**
          * Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
          */
-        bbox?: IBBox;
+        bbox?: BoundingBox;
         /**
          * Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
          */
         limit?: number;
-        /** Specify the language to use for response text and, for forward geocoding, query result weighting.
+        /**
+         * Specify the language to use for response text and, for forward geocoding, query result weighting.
          * Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more
          * IETF subtags for country or script.
          */

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -28,11 +28,9 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
     interface EventEmitter {
         response: MapiResponse;
         error: MapiError;
-        downloadProgress: ProgressEvents;
-        uploadProgress: ProgressEvents;
+        downloadProgress: ProgressEvent;
+        uploadProgress: ProgressEvent;
     }
-
-    interface ProgressEvents { }
 
     interface MapiRequest {
         /** An event emitter */

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -893,48 +893,50 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
     /*********************************************************************************************************************
      * Optimization Types
      *********************************************************************************************************************/
-    export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
+    export function Optimization(config: SdkConfig | MapiClient): OptimizationService; // SdkConfig | MapiClient
 
     interface OptimizationService {
         getContours(config: OptimizationRequest): MapiRequest;
     }
 
     interface OptimizationRequest {
-        /** 
+        /**
          * A Mapbox Directions routing profile ID.
          */
         profile: MapboxProfile;
-        /** 
+        /**
          * A semicolon-separated list of {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip.
          */
         waypoints: OptimizationWaypoint[];
-        /** 
+        /**
          * Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are:
          */
         annotations?: 'duration' | 'speed' | 'distance';
-        /** 
+        /**
          * Specify the destination coordinate of the returned route. Accepts  any (default) or  last .
          */
         destination?: 'any' | 'last';
-        /** 
+        /**
          * Specify pick-up and drop-off locations for a trip by providing a ; delimited list of number pairs that correspond with the coordinates list. 
-         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. 
+         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. 
+         * Each pair must contain exactly 2 numbers, which cannot be the same. 
          * The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location.
          */
         distributions?: number[];
-        /** 
+        /**
          * The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6).
          */
         geometries?: 'geojson' | 'polyline' | 'polyline6';
-        /** 
+        /**
          * The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English).
          */
         language?: string;
-        /** 
-         * The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry).
+        /**
+         * The type of the returned overview geometry. 
+         * Can be 'full' (the most detailed geometry available), 'simplified' (default, a simplified version of the full geometry), or 'false' (no overview geometry).
          */
         overview?: 'full' | 'simplified' | 'false';
-        /** 
+        /**
          * The coordinate at which to start the returned route. Accepts  any (default) or  first .
          */
         source?: 'any' | 'first';
@@ -943,7 +945,9 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
          */
         steps?: boolean;
         /**
-         * Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes.
+         * Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). 
+         * If roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. 
+         * See the Fixing Start and End Points section below for additional notes.
          */
         roundtrip?: boolean;
     }

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @mapbox/mapbox-sdk 0.6.0
 // Project: https://github.com/mapbox/mapbox-sdk-js
-// Definitions by: Jeff Dye <https://github.com/jeffbdye> 
+// Definitions by: Jeff Dye <https://github.com/jeffbdye>
 //                 Mike O'Meara <https://github.com/mikeomeara1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
@@ -156,7 +156,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         deleteDataset(config: { datasetId?: string }): MapiRequest;
         /**
          * List features in a dataset.
-      
+
           * This endpoint supports pagination. Use MapiRequest#eachPage or manually specify the limit and start options.
           * @param config
           */
@@ -917,9 +917,9 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
          */
         destination?: 'any' | 'last';
         /**
-         * Specify pick-up and drop-off locations for a trip by providing a ; delimited list of number pairs that correspond with the coordinates list. 
-         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. 
-         * Each pair must contain exactly 2 numbers, which cannot be the same. 
+         * Specify pick-up and drop-off locations for a trip by providing a ; delimited list of number pairs that correspond with the coordinates list.
+         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list.
+         * Each pair must contain exactly 2 numbers, which cannot be the same.
          * The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location.
          */
         distributions?: number[];
@@ -932,7 +932,7 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
          */
         language?: string;
         /**
-         * The type of the returned overview geometry. 
+         * The type of the returned overview geometry.
          * Can be 'full' (the most detailed geometry available), 'simplified' (default, a simplified version of the full geometry), or 'false' (no overview geometry).
          */
         overview?: 'full' | 'simplified' | 'false';
@@ -945,8 +945,8 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
          */
         steps?: boolean;
         /**
-         * Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). 
-         * If roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. 
+         * Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ).
+         * If roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible.
          * See the Fixing Start and End Points section below for additional notes.
          */
         roundtrip?: boolean;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -634,25 +634,42 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
     }
 
     interface GeocodeRequest {
-        // A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
+        /** 
+         * A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
+         */
         query: string | LngLatLike;
-        // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
+        /** 
+         * Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
+         */
         mode: GeocodeMode;
-        // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes
+        /**
+         * Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes
+         */ 
         countries?: string[];
-        // Bias local results based on a provided location. Options are  longitude,latitude coordinates.
+        /**
+         * Bias local results based on a provided location. Options are  longitude,latitude coordinates.
+         */ 
         proximity?: number[];
-        // Filter results by one or more feature types
+        /**
+         * Filter results by one or more feature types
+         */ 
         types?: GeocodeQueryType[];
-        //Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
+        /**
+         * Forward geocoding only. Return autocomplete results or not. Options are  true or  false and the default is  true .
+         */ 
         autocomplete?: boolean;
-        // Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
+        /**
+         * Forward geocoding only. Limit results to a bounding box. Options are in the format  minX,minY,maxX,maxY .
+         */ 
         bbox?: IBBox;
-        // Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
+        /**
+         * Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
+         */ 
         limit?: number;
-        // Specify the language to use for response text and, for forward geocoding, query result weighting.
-        // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more
-        // IETF subtags for country or script.
+        /** Specify the language to use for response text and, for forward geocoding, query result weighting.
+         * Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more
+         * IETF subtags for country or script.
+         */
         language?: string[];
     }
 
@@ -683,7 +700,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         id: string;
         /**
          * "Feature" , a GeoJSON type from the GeoJSON specification.
-         * */
+         */
         type: string;
         /**
          * An array of feature types describing the feature. Options are  country ,  region ,  postcode ,  district ,  place , locality ,  neighborhood ,

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -245,39 +245,39 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
 
     interface Dataset {
         /**
-         * The username of the dataset owner 
+         * The username of the dataset owner
          */
         owner: string;
         /**
-         * Id for an existing dataset 
+         * Id for an existing dataset
          */
         id: string;
         /*
-         * Date and time the dataset was created 
+         * Date and time the dataset was created
          */
         created: string;
-        /* 	
-         * Date and time the dataset was last modified 
+        /*
+         * Date and time the dataset was last modified
          */
         modified: string;
         /**
-         * The extent of features in the dataset as an array of west, south, east, north coordinates 
+         * The extent of features in the dataset as an array of west, south, east, north coordinates
          */
         bounds: number[];
-        /**	
-         * The number of features in the dataset 
+        /**
+         * The number of features in the dataset
          */
         features: number;
-        /**	
-         * The size of the dataset in bytes 
+        /**
+         * The size of the dataset in bytes
          */
         size: number;
         /**
-         * The name of the dataset 
+         * The name of the dataset
          */
         name: string;
-        /**	
-         * The description of the dataset 
+        /**
+         * The description of the dataset
          */
         description: string;
     }

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -14,7 +14,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
                        createRequest(requestOptions: any): MapiRequest;
                    }
 
-    export interface SdkConfig {
+    interface SdkConfig {
         accessToken: string;
         origin?: string;
     }
@@ -25,16 +25,16 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
     import MapiClient from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
     import { MapiError } from '@mapbox/mapbox-sdk/lib/classes/mapi-error';
 
-    export interface EventEmitter {
+    interface EventEmitter {
         response: MapiResponse;
         error: MapiError;
         downloadProgress: ProgressEvents;
         uploadProgress: ProgressEvents;
     }
 
-    export interface ProgressEvents {}
+    interface ProgressEvents {}
 
-    export interface MapiRequest {
+    interface MapiRequest {
         /** An event emitter */
         emitter: EventEmitter;
         /** This request's MapiClient. */
@@ -87,7 +87,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
     import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
-    export interface MapiResponse {
+    interface MapiResponse {
         /**The response body, parsed as JSON. */
         body: any;
         /**The raw response body. */
@@ -108,7 +108,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-error' {
     import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 
-    export interface MapiError {
+    interface MapiError {
         /**The errored request. */
         request: MapiRequest;
         /** The type of error. Usually this is 'HttpError'.
@@ -133,7 +133,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
      *********************************************************************************************************************/
     export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
 
-    export interface DatasetsService {
+    interface DatasetsService {
         /**List datasets in your account. */
         listDatasets(): MapiRequest;
         /**
@@ -194,7 +194,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         | GeoJSON.GeometryCollection
         | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
 
-    export interface Dataset {
+    interface Dataset {
         /** 	the username of the dataset owner */
         owner: string;
         /**id for an existing dataset */
@@ -224,7 +224,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
 
     export default function Directions(config: SdkConfig | MapiClient): DirectionsService;
 
-    export interface DirectionsService {
+    interface DirectionsService {
         getDirections(request: DirectionsRequest): MapiRequest;
     }
 
@@ -266,7 +266,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         | 'exit roundabout'
         | 'exit rotary';
 
-    export interface DirectionsRequest {
+    interface DirectionsRequest {
         /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
         profile: DirectionsProfile;
         waypoints: DirectionsRequestWaypoint[];
@@ -318,7 +318,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         voiceUnits?: DirectionsUnits;
     }
 
-    export interface DirectionsRequestWaypoint {
+    interface DirectionsRequestWaypoint {
         /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
         coordinates: number[] | LngLatLike;
         /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
@@ -333,7 +333,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         radius?: string | 'unlimited';
     }
 
-    export interface DirectionsResponse {
+    interface DirectionsResponse {
         /**Array of Route objects ordered by descending recommendation rank. May contain at most two routes. */
         routes: Route[];
         /** Array of Waypoint objects. Each waypoints is an input coordinate snapped to the road and path network.
@@ -347,7 +347,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         uuid: string;
     }
 
-    export interface Waypoint {
+    interface Waypoint {
         /**String with the name of the way the coordinate snapped to */
         name: string;
         /**Array of [ longitude, latitude ] for the snapped coordinate */
@@ -369,7 +369,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         waypointName?: string;
     }
 
-    export interface Route {
+    interface Route {
         /**Depending on the geometries parameter this is a GeoJSON LineString or a Polyline string.
          * Depending on the overview parameter this is the complete route geometry (full), a simplified geometry
          * to the zoom level at which the route can be displayed in full (simplified), or is not included (false)
@@ -391,7 +391,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         voiceLocale?: string;
     }
 
-    export interface Leg {
+    interface Leg {
         /**Depending on the summary parameter, either a String summarizing the route (true, default) or an empty String (false) */
         summary: string;
         weight: number;
@@ -407,7 +407,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         annotation: DirectionsAnnotation[];
     }
 
-    export interface Step {
+    interface Step {
         /**Array of objects representing all intersections along the step. */
         intersections: Intersection[];
         /**The legal driving side at the location for this step. Either left or right. */
@@ -446,7 +446,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         pronunciation?: string;
     }
 
-    export interface Instruction {
+    interface Instruction {
         /**String that contains all the text that should be displayed */
         text: string;
         /**Objects that, together, make up what should be displayed in the banner.
@@ -467,7 +467,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         driving_side: DirectionsSide;
     }
 
-    export interface BannerInstruction {
+    interface BannerInstruction {
         /**float indicating in meters, how far from the upcoming maneuver
          * the banner instruction should begin being displayed. Only 1 banner should be displayed at a time.
          */
@@ -484,7 +484,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         sub?: Sub;
     }
 
-    export interface Sub {
+    interface Sub {
         /** String that contains all the text that should be displayed */
         text: string;
         /**Objects that, together, make up what should be displayed in the banner.
@@ -493,7 +493,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         components: Component[];
     }
 
-    export interface Component {
+    interface Component {
         /**String giving you more context about the component which may help in visual markup/display choices.
          * If the type of the components is unknown it should be treated as text. Note: Introduction of new types
          * is not considered a breaking change. See the Types of Banner Components table below for more info on each type.
@@ -524,7 +524,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         active: boolean;
     }
 
-    export interface VoiceInstruction {
+    interface VoiceInstruction {
         /** float indicating in meters, how far from the upcoming maneuver the voice instruction should begin. */
         distanceAlongGeometry: number;
         /**String containing the text of the verbal instruction. */
@@ -535,7 +535,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         ssmlAnnouncement: string;
     }
 
-    export interface Maneuver {
+    interface Maneuver {
         /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right after the maneuver */
         bearing_after: number;
         /**Number between 0 and 360 indicating the clockwise angle from true north to the direction of travel right before the maneuver */
@@ -550,7 +550,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         instruction: string;
     }
 
-    export interface Intersection {
+    interface Intersection {
         /**Index into the bearings/entry array. Used to extract the bearing after the turn. Namely, The clockwise angle from true north to
          * the direction of travel after the maneuver/passing the intersection.
          * The value is not supplied for arrive maneuvers.
@@ -580,7 +580,7 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         lanes: Lane[];
     }
 
-    export interface Lane {
+    interface Lane {
         /**Boolean value for whether this lane can be taken to complete the maneuver. For instance, if the lane array has four objects and the
          * first two are marked as valid, then the driver can take either of the left lanes and stay on the route.
          */
@@ -623,19 +623,19 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
 
     export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
 
-    export interface GeocodeService {
+    interface GeocodeService {
         forwardGeocode(request: GeocodeRequest): MapiRequest;
         reverseGeocode(request: GeocodeRequest): MapiRequest;
     }
 
-    export interface IBBox {
+    interface IBBox {
         minx: number;
         miny: number;
         maxx: number;
         maxy: number;
     }
 
-    export interface GeocodeRequest {
+    interface GeocodeRequest {
         // A location. This will be a place name for forward geocoding or a coordinate pair (longitude, latitude) for reverse geocoding.
         query: string | LngLatLike;
         // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
@@ -658,7 +658,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         language?: string[];
     }
 
-    export interface GeocodeResponse {
+    interface GeocodeResponse {
         /**	"Feature Collection" , a GeoJSON type from the GeoJSON specification . */
         type: string;
         /**	An array of space and punctuation-separated strings from the original query. */
@@ -669,7 +669,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         attribution: string;
     }
 
-    export interface GeocodeFeature {
+    interface GeocodeFeature {
         /** A string feature id in the form  {type}.{id} where  {type} is the lowest hierarchy feature in the  place_type field.
          * The  {id} suffix of the feature id is unstable and may change within versions.
          */
@@ -724,7 +724,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         context: GeocodeFeature[];
     }
 
-    export interface Geometry {
+    interface Geometry {
         /**" Point" , a GeoJSON type from the GeoJSON specification . */
         type: string;
         /** An array in the format [ longitude,latitude ] at the center of the specified  bbox . */
@@ -733,7 +733,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         interpolated: boolean;
     }
 
-    export interface GeocodeProperties extends GeocodeFeature {
+    interface GeocodeProperties extends GeocodeFeature {
         /** The Wikidata identifier for the returned feature.*/
         wikidata?: string;
         /**A string of comma-separated categories for the returned  poi feature. */
@@ -768,11 +768,11 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
      *********************************************************************************************************************/
     export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
 
-    export interface MapMatchingService {
+    interface MapMatchingService {
         getMatching(request: MapMatchingRequest): MapiRequest;
     }
 
-    export interface MapMatchingRequest {
+    interface MapMatchingRequest {
         /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
         points: MapMatchingPoint[];
         /** A directions profile ID. (optional, default driving) */
@@ -791,13 +791,13 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         tidy?: boolean;
     }
 
-    export interface Point {
+    interface Point {
         coordinates: LngLatLike;
         /**Used to indicate how requested routes consider from which side of the road to approach a waypoint. */
         approach?: DirectionsApproach;
     }
 
-    export interface MapMatchingPoint extends Point {
+    interface MapMatchingPoint extends Point {
         /**A number in meters indicating the assumed precision of the used tracking device. */
         radius?: number;
         /**Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints. */
@@ -808,7 +808,7 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         timestamp?: string | number | Date;
     }
 
-    export interface MapMatchingResponse {
+    interface MapMatchingResponse {
         /**an array of Match objects */
         matchings: Matching[];
         /**an array of Tracepoint objects representing the location an input point was matched with.
@@ -820,7 +820,7 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         code: string;
     }
 
-    export interface Tracepoint {
+    interface Tracepoint {
         /** Number of probable alternative matchings for this trace point. A value of zero indicates that this point was matched unambiguously.
          * Split the trace at these points for incremental map matching.
          */
@@ -833,7 +833,7 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         matchings_index: number;
     }
 
-    export interface Matching {
+    interface Matching {
         /**a number between 0 (low) and 1 (high) indicating level of confidence in the returned match */
         confidence: number;
         geometry: string;
@@ -857,7 +857,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
      *********************************************************************************************************************/
     export function Matrix(config: SdkConfig | MapiClient): MatrixService;
 
-    export interface MatrixService {
+    interface MatrixService {
         /**
          * Get a duration and/or distance matrix showing travel times and distances between coordinates.
          * @param request
@@ -865,7 +865,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
         getMatrix(request: MatrixRequest): MapiRequest;
     }
 
-    export interface MatrixRequest {
+    interface MatrixRequest {
         points: Point[];
         profile?: DirectionsProfile;
         sources?: number[];
@@ -873,7 +873,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
         annotations?: DirectionsAnnotation;
     }
 
-    export interface MatrixResponse {
+    interface MatrixResponse {
         code: string;
         durations?: number[][];
         distances?: number[][];
@@ -881,7 +881,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
         sources: Destination[];
     }
 
-    export interface Destination {
+    interface Destination {
         location: number[];
         name: string;
     }
@@ -897,11 +897,11 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
      *********************************************************************************************************************/
     export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
 
-    export interface OptimizationService {
+    interface OptimizationService {
         getContours(config: OptimizationRequest): MapiRequest;
     }
 
-    export interface OptimizationRequest {
+    interface OptimizationRequest {
         /**A Mapbox Directions routing profile ID. */
         profile: MapboxProfile;
         /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
@@ -926,7 +926,7 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
         roundtrip?: boolean;
     }
 
-    export interface OptimizationWaypoint {
+    interface OptimizationWaypoint {
         coordinates: number;
         /** Used to indicate how requested routes consider from which side of the road to approach the waypoint. */
         approach?: DirectionsApproach;
@@ -949,7 +949,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
      *********************************************************************************************************************/
     export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
 
-    export interface StaticMapService {
+    interface StaticMapService {
         /**
          * Get a static map image..
          * @param request
@@ -957,7 +957,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
         getStaticImage(request: StaticMapRequest): MapiRequest;
     }
 
-    export interface StaticMapRequest {
+    interface StaticMapRequest {
         ownerId: string;
         styleId: string;
         width: number;
@@ -977,16 +977,16 @@ declare module '@mapbox/mapbox-sdk/services/static' {
         logo?: boolean;
     }
 
-    export interface CustomMarkerOverlay {
+    interface CustomMarkerOverlay {
         marker: CustomMarker;
     }
 
-    export interface CustomMarker {
+    interface CustomMarker {
         coordinates: LngLatLike;
         url: string;
     }
 
-    export interface PathOverlay {
+    interface PathOverlay {
         /**An array of coordinates describing the path. */
         coordinates: LngLatBoundsLike[];
         strokeWidth?: number;
@@ -999,7 +999,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
         fillOpacity?: number;
     }
 
-    export interface GeoJsonOverlay {
+    interface GeoJsonOverlay {
         geoJson: GeoJSON.GeoJsonTypes;
     }
 
@@ -1015,7 +1015,7 @@ declare module '@mapbox/mapbox-sdk/services/styles' {
     *********************************************************************************************************************/
     export function Styles(config: SdkConfig | MapiClient): StylesService;
 
-    export interface StylesService {
+    interface StylesService {
         /**
          * Get a style.
          * @param styleId
@@ -1154,7 +1154,7 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
      *********************************************************************************************************************/
     export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
 
-    export interface TileQueryService {
+    interface TileQueryService {
         /**
          * Get a static map image..
          * @param request
@@ -1162,7 +1162,7 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
         listFeatures(request: TileQueryRequest): MapiRequest;
     }
 
-    export interface TileQueryRequest {
+    interface TileQueryRequest {
         /**The maps being queried. If you need to composite multiple layers, provide multiple map IDs. */
         mapIds: string[];
         /**The longitude and latitude to be queried. */
@@ -1192,11 +1192,11 @@ declare module '@mapbox/mapbox-sdk/services/tilesets' {
      *********************************************************************************************************************/
     export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
 
-    export interface TilesetsService {
+    interface TilesetsService {
         listTilesets(config: { ownerId: string }): MapiRequest;
     }
 
-    export interface Tileset {
+    interface Tileset {
         type: string;
         center: number[];
         created: string;
@@ -1220,7 +1220,7 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
      *********************************************************************************************************************/
     export function Tokens(config: SdkConfig | MapiClient): TokensService;
 
-    export interface TokensService {
+    interface TokensService {
         /**List your access tokens. */
         listTokens(): MapiRequest;
         /**
@@ -1249,7 +1249,7 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
         listScopes(): MapiRequest;
     }
 
-    export interface Token {
+    interface Token {
         /**the identifier for the token */
         id: string;
         /**the type of token */
@@ -1270,27 +1270,27 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
         token: string;
     }
 
-    export interface CreateTokenRequest {
+    interface CreateTokenRequest {
         note?: string;
         scopes?: string[];
         resources?: string[];
     }
 
-    export interface TemporaryTokenRequest {
+    interface TemporaryTokenRequest {
         expires: string;
         scopes: string[];
     }
 
-    export interface UpdateDeleteTokenRequest extends CreateTokenRequest {
+    interface UpdateDeleteTokenRequest extends CreateTokenRequest {
         tokenId: string;
     }
 
-    export interface TokenDetail {
+    interface TokenDetail {
         code: string;
         token: Token;
     }
 
-    export interface Scope {
+    interface Scope {
         id: string;
         public: boolean;
         description: string;
@@ -1306,7 +1306,7 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
      *********************************************************************************************************************/
     export function Uploads(config: SdkConfig | MapiClient): UploadsService;
 
-    export interface UploadsService {
+    interface UploadsService {
         /**
          * List the statuses of all recent uploads.
          * @param config
@@ -1333,7 +1333,7 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
         deleteUpload(config: { uploadId: string }): any;
     }
 
-    export interface S3Credentials {
+    interface S3Credentials {
         accessKeyId: string;
         bucket: string;
         key: string;
@@ -1342,7 +1342,7 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
         url: string;
     }
 
-    export interface UploadResponse {
+    interface UploadResponse {
         complete: boolean;
         tileset: string;
         error?: any;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -244,23 +244,41 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
         | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
 
     interface Dataset {
-        /** 	the username of the dataset owner */
+        /**
+         * The username of the dataset owner 
+         */
         owner: string;
-        /**id for an existing dataset */
+        /**
+         * Id for an existing dataset 
+         */
         id: string;
-        /*date and time the dataset was created */
+        /*
+         * Date and time the dataset was created 
+         */
         created: string;
-        /* 	date and time the dataset was last modified */
+        /* 	
+         * Date and time the dataset was last modified 
+         */
         modified: string;
-        /**the extent of features in the dataset as an array of west, south, east, north coordinates */
+        /**
+         * The extent of features in the dataset as an array of west, south, east, north coordinates 
+         */
         bounds: number[];
-        /**	the number of features in the dataset */
+        /**	
+         * The number of features in the dataset 
+         */
         features: number;
-        /**	the size of the dataset in bytes */
+        /**	
+         * The size of the dataset in bytes 
+         */
         size: number;
-        /**the name of the dataset */
+        /**
+         * The name of the dataset 
+         */
         name: string;
-        /**	the description of the dataset */
+        /**	
+         * The description of the dataset 
+         */
         description: string;
     }
 }

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -8,7 +8,7 @@
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-client' {
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     export default class MapiClient {
-        constructor(config: SdkConfig)
+        constructor(config: SdkConfig);
         accessToken: string;
         origin?: string;
         createRequest(requestOptions: any): MapiRequest;
@@ -32,9 +32,7 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
         uploadProgress: ProgressEvents;
     }
 
-    export interface ProgressEvents {
-
-    }
+    export interface ProgressEvents {}
 
     export interface MapiRequest {
         /** An event emitter */
@@ -76,16 +74,14 @@ declare module '@mapbox/mapbox-sdk/lib/classes/mapi-request' {
     }
 
     export type PageCallbackFunction = {
-        error: MapiError,
-        response: MapiResponse,
-        next: () => void
-    }
+        error: MapiError;
+        response: MapiResponse;
+        next: () => void;
+    };
 
-    export type MapboxProfile = "driving" |
-        "walking" |
-        "cycling";
+    export type MapboxProfile = 'driving' | 'walking' | 'cycling';
 
-    export type DirectionsApproach = "unrestricted" | "curb";
+    export type DirectionsApproach = 'unrestricted' | 'curb';
 }
 
 declare module '@mapbox/mapbox-sdk/lib/classes/mapi-response' {
@@ -133,8 +129,8 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Datasets Types
-    *********************************************************************************************************************/
+     * Datasets Types
+     *********************************************************************************************************************/
     export default function Datasets(config: SdkConfig | MapiClient): DatasetsService;
 
     export interface DatasetsService {
@@ -144,7 +140,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
          *  Create a new, empty dataset.
          * @param config Object
          */
-        createDataset(config: { name?: string, description?: string }): MapiRequest;
+        createDataset(config: { name?: string; description?: string }): MapiRequest;
         /**
          * Get metadata about a dataset.
          * @param config
@@ -154,7 +150,7 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
          * Update user-defined properties of a dataset's metadata.
          * @param config
          */
-        updateMetadata(config: { datasetId?: string, name?: string, description?: string }): MapiRequest;
+        updateMetadata(config: { datasetId?: string; name?: string; description?: string }): MapiRequest;
         /**
          * Delete a dataset, including all features it contains.
          * @param config
@@ -167,25 +163,24 @@ declare module '@mapbox/mapbox-sdk/services/datasets' {
           * @param config
           */
         // implicit any
-        listFeatures(config: { datasetId: string, limit?: number, start?: string }): any;
+        listFeatures(config: { datasetId: string; limit?: number; start?: string }): any;
         /**
          * Add a feature to a dataset or update an existing one.
          * @param config
          */
-        putFeature(config: { datasetId: string, featureId: string, feature: Object }): MapiRequest;
+        putFeature(config: { datasetId: string; featureId: string; feature: Object }): MapiRequest;
         /**
          * Get a feature in a dataset.
          * @param config
          */
         // implicit any
-        getFeature(config: { datasetId: string, featureId: string }): any;
+        getFeature(config: { datasetId: string; featureId: string }): any;
         /**
          * Delete a feature in a dataset.
          * @param config
          */
         // implicit any
-        deleteFeature(config: { datasetId: string, featureId: string }): any;
-
+        deleteFeature(config: { datasetId: string; featureId: string }): any;
     }
 
     export interface Dataset {
@@ -222,42 +217,43 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         getDirections(request: DirectionsRequest): MapiRequest;
     }
 
-    export type DirectionsProfile = MapboxProfile | "driving-traffic";
+    export type DirectionsProfile = MapboxProfile | 'driving-traffic';
 
-    export type DirectionsAnnotation = "duration" | "distance" | "speed" | "congestion";
-    export type DirectionsGeometry = "geojson" | "polyline" | "polyline6";
-    export type DirectionsOverview = "full" | "simplified";
-    export type DirectionsUnits = "imperial" | "metric";
-    export type DirectionsSide = "left" | "right";
-    export type DirectionsMode = "driving" | "ferry" | "unaccessible" | "walking" | "cycling" | "train";
-    export type DirectionsClass = "toll" | "ferry" | "restricted" | "motorway" | "tunnel";
+    export type DirectionsAnnotation = 'duration' | 'distance' | 'speed' | 'congestion';
+    export type DirectionsGeometry = 'geojson' | 'polyline' | 'polyline6';
+    export type DirectionsOverview = 'full' | 'simplified';
+    export type DirectionsUnits = 'imperial' | 'metric';
+    export type DirectionsSide = 'left' | 'right';
+    export type DirectionsMode = 'driving' | 'ferry' | 'unaccessible' | 'walking' | 'cycling' | 'train';
+    export type DirectionsClass = 'toll' | 'ferry' | 'restricted' | 'motorway' | 'tunnel';
     export type ManeuverModifier =
-        "uturn" |
-        "sharp right" |
-        "right" |
-        "slight right" |
-        "straight" |
-        "slight left" |
-        "left" |
-        "sharp left" |
-        "depart" |
-        "arrive";
-    export type ManeuverType = "turn" |
-        "new name" |
-        "depart" |
-        "arrive" |
-        "merge" |
-        "on ramp" |
-        "off ramp" |
-        "fork" |
-        "end of road" |
-        "continue" |
-        "roundabout" |
-        "rotary" |
-        "roundabout turn" |
-        "notification" |
-        "exit roundabout" |
-        "exit rotary";
+        | 'uturn'
+        | 'sharp right'
+        | 'right'
+        | 'slight right'
+        | 'straight'
+        | 'slight left'
+        | 'left'
+        | 'sharp left'
+        | 'depart'
+        | 'arrive';
+    export type ManeuverType =
+        | 'turn'
+        | 'new name'
+        | 'depart'
+        | 'arrive'
+        | 'merge'
+        | 'on ramp'
+        | 'off ramp'
+        | 'fork'
+        | 'end of road'
+        | 'continue'
+        | 'roundabout'
+        | 'rotary'
+        | 'roundabout turn'
+        | 'notification'
+        | 'exit roundabout'
+        | 'exit rotary';
 
     export interface DirectionsRequest {
         /**Routing profile; either  mapbox/driving-traffic ,  mapbox/driving ,  mapbox/walking , or  mapbox/cycling */
@@ -309,22 +305,21 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
         voiceInstructions?: boolean;
         /**Which type of units to return in the text for voice instructions. Can be  imperial or  metric . Default is  imperial . */
         voiceUnits?: DirectionsUnits;
-
     }
 
     export interface DirectionsRequestWaypoint {
         /**Semicolon-separated list of  {longitude},{latitude} coordinate pairs to visit in order. There can be between 2 and 25 coordinates. */
         coordinates: number[] | LngLatLike;
         /**Used to indicate how requested routes consider from which side of the road to approach a waypoint.
-       * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
-       * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
-       * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
-       * while  bearings influences how you start from a waypoint. If provided, the list of approaches must be the same length as the list of waypoints.
-       * However, you can skip a coordinate and show its position in the list with the  ; separator.
-       */
+         * Accepts unrestricted (default) or  curb . If set to  unrestricted , the routes can approach waypoints from either side of the road.
+         * If set to  curb , the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the
+         * driving_side of the region in which the returned route is located. Note that the  approaches parameter influences how you arrive at a waypoint,
+         * while  bearings influences how you start from a waypoint. If provided, the list of approaches must be the same length as the list of waypoints.
+         * However, you can skip a coordinate and show its position in the list with the  ; separator.
+         */
         approach?: DirectionsApproach;
         /**Maximum distance in meters that each coordinate is allowed to move when snapped to a nearby road segment. There must be as many radiuses as there are coordinates in the request, each separated by  ; . Values can be any number greater than 0 or the string  unlimited . A  NoSegment error is returned if no routable road is found within the radius. */
-        radius?: string | "unlimited";
+        radius?: string | 'unlimited';
     }
 
     export interface DirectionsResponse {
@@ -357,9 +352,9 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          */
         bearing?: number[];
         /**Custom names for waypoints used for the arrival instruction in banners and voice instructions, each separated by  ; .
-        * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
-        * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
-        */
+         * Values can be any string and total number of all characters cannot exceed 500. If provided, the list of waypoint_names must be the same
+         * length as the list of waypoints, but you can skip a coordinate and show its position with the  ; separator.
+         */
         waypointName?: string;
     }
 
@@ -438,8 +433,6 @@ declare module '@mapbox/mapbox-sdk/services/directions' {
          * This property is omitted if pronunciation data is unavailable for the step.
          */
         pronunciation?: string;
-
-
     }
 
     export interface Instruction {
@@ -601,21 +594,21 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Geocoder Types
-    *********************************************************************************************************************/
-    export type GeocodeMode = "mapbox.places" | "mapbox.places-permanent";
+     * Geocoder Types
+     *********************************************************************************************************************/
+    export type GeocodeMode = 'mapbox.places' | 'mapbox.places-permanent';
 
-
-    export type GeocodeQueryType = "country" |
-        "region" |
-        "postcode" |
-        "district" |
-        "place" |
-        "locality" |
-        "neighborhood" |
-        "address" |
-        "poi" |
-        "poi.landmark";
+    export type GeocodeQueryType =
+        | 'country'
+        | 'region'
+        | 'postcode'
+        | 'district'
+        | 'place'
+        | 'locality'
+        | 'neighborhood'
+        | 'address'
+        | 'poi'
+        | 'poi.landmark';
 
     export function Geocoding(config: SdkConfig | MapiClient): GeocodeService;
 
@@ -636,7 +629,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         query: string | LngLatLike;
         // 	Either  mapbox.places for ephemeral geocoding, or  mapbox.places-permanent for storing results and batch geocoding.
         mode: GeocodeMode;
-        // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes 
+        // Limit results to one or more countries. Options are ISO 3166 alpha 2 country codes
         countries?: string[];
         //Bias local results based on a provided location. Options are  longitude,latitude coordinates.
         proximity?: number[];
@@ -648,9 +641,9 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         bbox?: IBBox;
         //Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
         limit?: number;
-        // Specify the language to use for response text and, for forward geocoding, query result weighting. 
-        // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more 
-        // IETF subtags for country or script. 
+        // Specify the language to use for response text and, for forward geocoding, query result weighting.
+        // Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more
+        // IETF subtags for country or script.
         language?: string[];
     }
 
@@ -707,7 +700,7 @@ declare module '@mapbox/mapbox-sdk/services/geocoding' {
         /**
          * A string of the IETF language tag of the query's primary language.
          * Can be used to identity text and place_name properties on this object
-         * in the format text_{language}, place_name_{language} and language_{language} 
+         * in the format text_{language}, place_name_{language} and language_{language}
          */
         language: string;
         /**An array bounding box in the form [ minX,minY,maxX,maxY ] . */
@@ -754,24 +747,23 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
         DirectionsAnnotation,
         DirectionsGeometry,
         DirectionsOverview,
-        Leg
+        Leg,
     } from '@mapbox/mapbox-sdk/services/directions';
     import { MapiRequest, DirectionsApproach } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Map Matching Types
-    *********************************************************************************************************************/
+     * Map Matching Types
+     *********************************************************************************************************************/
     export function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
 
-
     export interface MapMatchingService {
-        getMatching(request: MapMatchingRequest): MapiRequest
+        getMatching(request: MapMatchingRequest): MapiRequest;
     }
 
     export interface MapMatchingRequest {
         /**An ordered array of MapMatchingPoints, between 2 and 100 (inclusive). */
-        points: MapMatchingPoint[],
+        points: MapMatchingPoint[];
         /** A directions profile ID. (optional, default driving) */
         profile?: DirectionsProfile;
         /**Specify additional metadata that should be returned. */
@@ -844,17 +836,14 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
 }
 
 declare module '@mapbox/mapbox-sdk/services/matrix' {
-    import {
-        DirectionsProfile,
-        DirectionsAnnotation
-    } from '@mapbox/mapbox-sdk/services/directions';
+    import { DirectionsProfile, DirectionsAnnotation } from '@mapbox/mapbox-sdk/services/directions';
     import { Point } from '@mapbox/mapbox-sdk/services/map-matching';
     import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Matrix Types
-    *********************************************************************************************************************/
+     * Matrix Types
+     *********************************************************************************************************************/
     export function Matrix(config: SdkConfig | MapiClient): MatrixService;
 
     export interface MatrixService {
@@ -862,7 +851,7 @@ declare module '@mapbox/mapbox-sdk/services/matrix' {
          * Get a duration and/or distance matrix showing travel times and distances between coordinates.
          * @param request
          */
-        getMatrix(request: MatrixRequest): MapiRequest
+        getMatrix(request: MatrixRequest): MapiRequest;
     }
 
     export interface MatrixRequest {
@@ -893,8 +882,8 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Optimization Types
-    *********************************************************************************************************************/
+     * Optimization Types
+     *********************************************************************************************************************/
     export function Optimization(config: any): OptimizationService; // SdkConfig | MapiClient
 
     export interface OptimizationService {
@@ -907,19 +896,19 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
         /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
         waypoints: OptimizationWaypoint[];
         /**Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are: */
-        annotations?: "duration" | "speed" | "distance";
+        annotations?: 'duration' | 'speed' | 'distance';
         /**Specify the destination coordinate of the returned route. Accepts  any (default) or  last . */
-        destination?: "any" | "last";
+        destination?: 'any' | 'last';
         /** Specify pick-up and drop-off locations for a trip by providing a  ; delimited list of number pairs that correspond with the coordinates list. The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location. */
         distributions?: number[];
         /**The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6). */
-        geometries?: "geojson" | "polyline" | "polyline6";
+        geometries?: 'geojson' | 'polyline' | 'polyline6';
         /**The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English). */
         language?: string;
         /**The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry). */
-        overview?: "full" | "simplified" | "false";
+        overview?: 'full' | 'simplified' | 'false';
         /**The coordinate at which to start the returned route. Accepts  any (default) or  first . */
-        source?: "any" | "first";
+        source?: 'any' | 'first';
         /** Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default). */
         steps?: boolean;
         /** Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes. */
@@ -935,7 +924,7 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
         and the second is the range of degrees the angle can deviate by. */
         bearing?: number[];
         /**Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment. */
-        radius?: number | "unlimited";
+        radius?: number | 'unlimited';
     }
 }
 
@@ -945,8 +934,8 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Static Map Types
-    *********************************************************************************************************************/
+     * Static Map Types
+     *********************************************************************************************************************/
     export function StaticMap(config: SdkConfig | MapiClient): StaticMapService;
 
     export interface StaticMapService {
@@ -954,7 +943,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
          * Get a static map image..
          * @param request
          */
-        getStaticImage(request: StaticMapRequest): MapiRequest
+        getStaticImage(request: StaticMapRequest): MapiRequest;
     }
 
     export interface StaticMapRequest {
@@ -962,12 +951,14 @@ declare module '@mapbox/mapbox-sdk/services/static' {
         styleId: string;
         width: number;
         height: number;
-        position: {
-            coordinates: LngLatLike | "auto";
-            zoom: number;
-            bearing?: number;
-            pitch?: number;
-        } | "auto";
+        position:
+            | {
+                  coordinates: LngLatLike | 'auto';
+                  zoom: number;
+                  bearing?: number;
+                  pitch?: number;
+              }
+            | 'auto';
         overlays?: CustomMarkerOverlay[] | PathOverlay[] | GeoJsonOverlay[];
         highRes?: boolean;
         insertOverlayBeforeLayer?: string;
@@ -976,7 +967,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     }
 
     export interface CustomMarkerOverlay {
-        marker: CustomMarker
+        marker: CustomMarker;
     }
 
     export interface CustomMarker {
@@ -1127,8 +1118,8 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Tile Query (Places) Types
-    *********************************************************************************************************************/
+     * Tile Query (Places) Types
+     *********************************************************************************************************************/
     export function TileQuery(config: SdkConfig | MapiClient): TileQueryService;
 
     export interface TileQueryService {
@@ -1136,7 +1127,7 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
          * Get a static map image..
          * @param request
          */
-        listFeatures(request: TileQueryRequest): MapiRequest
+        listFeatures(request: TileQueryRequest): MapiRequest;
     }
 
     export interface TileQueryRequest {
@@ -1155,7 +1146,7 @@ declare module '@mapbox/mapbox-sdk/services/tilequery' {
         layers?: string[];
     }
 
-    export type GeometryType = "polygon" | "linestring" | "point";
+    export type GeometryType = 'polygon' | 'linestring' | 'point';
 
 
 }
@@ -1165,8 +1156,8 @@ declare module '@mapbox/mapbox-sdk/services/tilesets' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Tileset Types
-    *********************************************************************************************************************/
+     * Tileset Types
+     *********************************************************************************************************************/
     export function Tilesets(config: SdkConfig | MapiClient): TilesetsService;
 
     export interface TilesetsService {
@@ -1193,8 +1184,8 @@ declare module '@mapbox/mapbox-sdk/services/tokens' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Token Types
-    *********************************************************************************************************************/
+     * Token Types
+     *********************************************************************************************************************/
     export function Tokens(config: SdkConfig | MapiClient): TokensService;
 
     export interface TokensService {
@@ -1279,8 +1270,8 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
     import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 
     /*********************************************************************************************************************
-    * Uploads Types
-    *********************************************************************************************************************/
+     * Uploads Types
+     *********************************************************************************************************************/
     export function Uploads(config: SdkConfig | MapiClient): UploadsService;
 
     export interface UploadsService {
@@ -1295,7 +1286,7 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
          * Create an upload.
          * @param config
          */
-        createUpload(config: { mapId: string, url: string, tilesetName?: string }): MapiRequest;
+        createUpload(config: { mapId: string; url: string; tilesetName?: string }): MapiRequest;
         /**
          * Get an upload's status.
          * @param config
@@ -1308,7 +1299,6 @@ declare module '@mapbox/mapbox-sdk/services/uploads' {
          */
         // implicit any
         deleteUpload(config: { uploadId: string }): any;
-
     }
 
     export interface S3Credentials {

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -900,39 +900,69 @@ declare module '@mapbox/mapbox-sdk/services/optimization' {
     }
 
     interface OptimizationRequest {
-        /**A Mapbox Directions routing profile ID. */
+        /** 
+         * A Mapbox Directions routing profile ID.
+         */
         profile: MapboxProfile;
-        /**A semicolon-separated list of  {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip. */
+        /** 
+         * A semicolon-separated list of {longitude},{latitude} coordinates. There must be between 2 and 12 coordinates. The first coordinate is the start and end point of the trip.
+         */
         waypoints: OptimizationWaypoint[];
-        /**Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are: */
+        /** 
+         * Return additional metadata along the route. You can include several annotations as a comma-separated list. Possible values are:
+         */
         annotations?: 'duration' | 'speed' | 'distance';
-        /**Specify the destination coordinate of the returned route. Accepts  any (default) or  last . */
+        /** 
+         * Specify the destination coordinate of the returned route. Accepts  any (default) or  last .
+         */
         destination?: 'any' | 'last';
-        /** Specify pick-up and drop-off locations for a trip by providing a  ; delimited list of number pairs that correspond with the coordinates list. The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location. */
+        /** 
+         * Specify pick-up and drop-off locations for a trip by providing a ; delimited list of number pairs that correspond with the coordinates list. 
+         * The first number of a pair indicates the index to the coordinate of the pick-up location in the coordinates list, and the second number indicates the index to the coordinate of the drop-off location in the coordinates list. Each pair must contain exactly 2 numbers, which cannot be the same. 
+         * The returned solution will visit pick-up locations before visiting drop-off locations. The first location can only be a pick-up location, not a drop-off location.
+         */
         distributions?: number[];
-        /**The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6). */
+        /** 
+         * The format of the returned geometry. Allowed values are:  geojson (as LineString ),  polyline (default, a polyline with precision 5),  polyline6 (a polyline with precision 6).
+         */
         geometries?: 'geojson' | 'polyline' | 'polyline6';
-        /**The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English). */
+        /** 
+         * The language of returned turn-by-turn text instructions. See supported languages . The default is  en (English).
+         */
         language?: string;
-        /**The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry). */
+        /** 
+         * The type of the returned overview geometry. Can be  full (the most detailed geometry available),  simplified (default, a simplified version of the full geometry), or  false (no overview geometry).
+         */
         overview?: 'full' | 'simplified' | 'false';
-        /**The coordinate at which to start the returned route. Accepts  any (default) or  first . */
+        /** 
+         * The coordinate at which to start the returned route. Accepts  any (default) or  first .
+         */
         source?: 'any' | 'first';
-        /** Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default). */
+        /**
+         * Whether to return steps and turn-by-turn instructions ( true ) or not ( false , default).
+         */
         steps?: boolean;
-        /** Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes. */
+        /**
+         * Indicates whether the returned route is roundtrip, meaning the route returns to the first location ( true , default) or not ( false ). If  roundtrip=false , the  source and  destination parameters are required but not all combinations will be possible. See the Fixing Start and End Points section below for additional notes.
+         */
         roundtrip?: boolean;
     }
 
     interface OptimizationWaypoint {
         coordinates: number;
-        /** Used to indicate how requested routes consider from which side of the road to approach the waypoint. */
+        /**
+         * Used to indicate how requested routes consider from which side of the road to approach the waypoint.
+         */
         approach?: DirectionsApproach;
-        /**Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
-         This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
-        and the second is the range of degrees the angle can deviate by. */
+        /**
+         * Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+         * This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
+         * and the second is the range of degrees the angle can deviate by.
+         */
         bearing?: number[];
-        /**Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment. */
+        /**
+         * Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment.
+         */
         radius?: number | 'unlimited';
     }
 }

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -4,22 +4,25 @@ import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 
 const config: SdkConfig = {
-  accessToken: 'access-token'
+    accessToken: 'access-token',
 };
 const client = new MapiClient(config);
 
 const ds: DirectionsService = Directions(client);
 
 const mapiRequest: MapiRequest = ds.getDirections({
-  profile: 'walking',
-  waypoints: [{
-    coordinates: [1, 3]
-  }, {
-    coordinates: [2, 4]
-  }]
+    profile: 'walking',
+    waypoints: [
+        {
+            coordinates: [1, 3],
+        },
+        {
+            coordinates: [2, 4],
+        },
+    ],
 });
 
 const response = mapiRequest.send().then((response: MapiResponse) => {
-  const body = response.body as DirectionsResponse;
-  const route = body.routes;
+    const body = response.body as DirectionsResponse;
+    const route = body.routes;
 });

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -1,0 +1,25 @@
+import Directions, { DirectionsService, DirectionsResponse } from '@mapbox/mapbox-sdk/services/directions';
+import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
+import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
+import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+
+const config: SdkConfig = {
+  accessToken: 'access-token'
+};
+const client = new MapiClient(config);
+
+const ds: DirectionsService = Directions(client);
+
+const mapiRequest: MapiRequest = ds.getDirections({
+  profile: 'walking',
+  waypoints: [{
+    coordinates: [1, 3]
+  }, {
+    coordinates: [2, 4]
+  }]
+});
+
+const response = mapiRequest.send().then((response: MapiResponse) => {
+  const body = response.body as DirectionsResponse;
+  const route = body.routes;
+});

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -1,16 +1,17 @@
-import Directions, { DirectionsService, DirectionsResponse } from '@mapbox/mapbox-sdk/services/directions';
 import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-client';
 import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+import Directions, { DirectionsService, DirectionsResponse } from '@mapbox/mapbox-sdk/services/directions';
+import Styles, { StylesService } from '@mapbox/mapbox-sdk/services/styles';
 
 const config: SdkConfig = {
     accessToken: 'access-token',
 };
 const client = new MapiClient(config);
 
-const ds: DirectionsService = Directions(client);
+const directionsService: DirectionsService = Directions(client);
 
-const mapiRequest: MapiRequest = ds.getDirections({
+const mapiRequest: MapiRequest = directionsService.getDirections({
     profile: 'walking',
     waypoints: [
         {
@@ -22,7 +23,14 @@ const mapiRequest: MapiRequest = ds.getDirections({
     ],
 });
 
-const response = mapiRequest.send().then((response: MapiResponse) => {
+mapiRequest.send().then((response: MapiResponse) => {
     const body = response.body as DirectionsResponse;
     const route = body.routes;
+});
+
+const stylesService: StylesService = Styles(config);
+stylesService.putStyleIcon({
+    styleId: 'style-id',
+    iconId: 'icon-id',
+    file: 'path-to-file.file'
 });

--- a/types/mapbox__mapbox-sdk/tsconfig.json
+++ b/types/mapbox__mapbox-sdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6",
+          "dom"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "./index.d.ts",
+      "mapbox__mapbox-sdk-tests.ts"
+  ]
+}

--- a/types/mapbox__mapbox-sdk/tsconfig.json
+++ b/types/mapbox__mapbox-sdk/tsconfig.json
@@ -18,7 +18,7 @@
       "forceConsistentCasingInFileNames": true
   },
   "files": [
-      "./index.d.ts",
+      "index.d.ts",
       "mapbox__mapbox-sdk-tests.ts"
   ]
 }

--- a/types/mapbox__mapbox-sdk/tslint.json
+++ b/types/mapbox__mapbox-sdk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/mapbox__mapbox-sdk/tslint.json
+++ b/types/mapbox__mapbox-sdk/tslint.json
@@ -1,1 +1,3 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Hey, thanks for checking out this PR. I'm looking to add types for the mapbox javascript SDK here: https://github.com/mapbox/mapbox-sdk-js

The types didn't generate particularly from `dts-gen`, however the jsdoc comments helped in straightening out types originally presented by @mikeomeara1.

This is my first PR for type definitions, so please let me know if there's anything amiss.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
