### PR TITLE
[yargs] choices accepts numbers

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -753,7 +753,7 @@ declare namespace yargs {
     type AsyncCompletionFunction = (current: string, argv: any, done: (completion: ReadonlyArray<string>) => void) => void;
     type PromiseCompletionFunction = (current: string, argv: any) => Promise<string[]>;
     type MiddlewareFunction<T = {}> = (args: Arguments<T>) => void;
-    type Choices = ReadonlyArray<string | true | undefined>;
+    type Choices = ReadonlyArray<string | number | true | undefined>;
     type PositionalOptionsType = "boolean" | "number" | "string";
 }
 

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -817,6 +817,9 @@ function Argv$scriptName() {
 type Color = "red" | "blue" | "green";
 const colors: ReadonlyArray<Color> = ["red", "blue", "green"];
 
+type Stage = 1 | 2 | 3 | 4;
+const stages: ReadonlyArray<Stage> = [1, 2, 3, 4];
+
 function Argv$inferOptionTypes() {
     // $ExpectType { [x: string]: unknown; a: (string | number)[] | undefined; b: boolean | undefined; c: number; n: number | undefined; s: string | undefined; _: string[]; $0: string; }
     yargs
@@ -842,9 +845,10 @@ function Argv$inferOptionTypes() {
         .option("s", { string: true })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; choices: Color; coerce: Date | undefined; count: number; normalize: string | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; choices: Color; numberChoices: Stage; coerce: Date | undefined; count: number; normalize: string | undefined; _: string[]; $0: string; }
     yargs
         .option("choices", { choices: colors, required: true })
+        .option("numberChoices", { choices: stages, demandOption: true })
         .option("coerce", { coerce: () => new Date() })
         .option("count", { count: true })
         .option("normalize", { normalize: true })
@@ -858,6 +862,9 @@ function Argv$inferOptionTypes() {
 
     // $ExpectType "red" | "blue" | "green" | undefined
     yargs.choices("x", colors).argv.x;
+
+    // $ExpectType number | undefined
+    yargs.choices('x', [1, 2, 3, 4]).argv.x;
 
     // $ExpectType number | undefined
     yargs.coerce("x", Date.parse).argv.x;


### PR DESCRIPTION
According to [docs](https://github.com/yargs/yargs/blob/master/docs/api.md#choiceskey-choices)

> If this method is called multiple times, all enumerated values will be merged together. Choices are generally strings or numbers, and value matching is case-sensitive.