### PR TITLE
New type definition for jsspec

### DIFF
--- a/types/jsspec__jsspec/index.d.ts
+++ b/types/jsspec__jsspec/index.d.ts
@@ -1,0 +1,286 @@
+// Type definitions for @jsspec/jsspec 0.0
+// Project: https://github.com/JSSpec/jsspec
+// Definitions by: HookyQR <https://github.com/HookyQR>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare namespace JSSpec {
+  interface ExampleOptions {
+    /**
+     * fail the test after _timeout_ milliseconds
+     */
+    timeout?: number;
+  }
+
+  interface ContextOptions {
+    /**
+     * fail the test after _timeout_ milliseconds
+     */
+    timeout?: number;
+    /**
+     * Run the contained Examples/Contexts in random order?
+     * - Run in random order if `true`
+     * - Run in definition order if `false`
+     */
+    random?: boolean;
+  }
+
+  interface Context {
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     * Use `options` to specify settings for running Examples in this context.
+     */
+    (title: string, options: ContextOptions, fn: Func): void;
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     */
+    (title: string, fn: Func): void;
+  }
+
+  interface SharedContext {
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     * Use `options` to specify settings for running Examples in this context.
+     */
+    (title: string, options: ContextOptions, fn: ArgFunc): void;
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     */
+    (title: string, fn: ArgFunc): void;
+  }
+
+  interface PendingContext {
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     *
+     * `fn` will not be run, but the context will be reported as pending.
+     * As the `fn` is not run, `options` has no effect.
+     */
+    (title: string, options: ContextOptions, fn: Func): void;
+    /**
+     * Create a new context with the `title` and defined in `fn`.
+     *
+     * `fn` will not be run, but the context will be reported as pending.
+     */
+    (title: string, fn?: Func): void;
+  }
+
+  interface Hook {
+    /**
+     * Provide a named hook, executing `fn`.
+     *
+     * An `async` function will be awaited.
+     *
+     * Use `options` to specify settings for running this hook
+     */
+    (name: string, options: ExampleOptions, fn: AsyncFunc|Func): void;
+    /**
+     * Provide a named hook, executing `fn`.
+     *
+     * An `async` function will be awaited.
+     */
+    (name: string, fn: AsyncFunc|Func): void;
+    /**
+     * Provide a hook, executing `fn`.
+     *
+     * An `async` function will be awaited.
+     */
+    (fn: AsyncFunc|Func): void;
+  }
+
+  interface Example {
+    /**
+     * Provide a test case with the given `title`, executing `fn`.
+     *
+     * Use `options` to specify settings for running this example
+     *
+     * An `async` function will be awaited.
+     */
+    (title: string, option: ExampleOptions, fn?: AsyncFunc|Func): void;
+    /**
+     * Provide a test case with the given `title`, executing `fn`.
+     *
+     * An `async` function will be awaited.
+     */
+    (title: string, fn: AsyncFunc|Func): void;
+  }
+
+  interface PendingExample {
+    /**
+     * Provide a pending test case with the given `title`. `fn` will note be executed.
+     *
+     * `options` will be ignored.
+     */
+    (title: string, option: ExampleOptions, fn?: AsyncFunc|Func): void;
+    /**
+     * Provide a pending test case with the given `title`. `fn` will not be executed.
+     */
+    (title: string, fn: AsyncFunc|Func): void;
+  }
+
+  interface LazyEvaluated {
+    /**
+     * Set a variable which can be accessed inside of an Example.
+     *
+     * `fn` will be executed to evaluate the initial state of `varName` when
+     * it is first accessed in an example (or supporting hook).
+     */
+    (varName: string, fn: Func): void;
+    /**
+     * Set a variable which can be accessed inside of an Example.
+     *
+     * `varName` is set to `value` when first accessed in an example (or supporting hook).
+     */
+    (varName: string, value: any): void;
+  }
+
+  interface Subject {
+    /**
+     * Set a variable which can be accessed inside of an Example.
+     * `subject` will refer to the same variable.
+     *
+     * `fn` will be executed to evaluate the initial state of `varName` when
+     * it is first accessed in an example (or supporting hook).
+     */
+    (varName: string, fn: Func): void;
+    /**
+     * Set a variable which can be accessed inside of an Example.
+     * `subject` will refer to the same variable.
+     *
+     * `varName` is set to `value` when first accessed in an example (or supporting hook).
+     */
+    (varName: string, value: any): void;
+    /**
+     * Set `subject` which can be accessed inside of an Example.
+     *
+     * `fn` will be executed to evaluate the initial state of `subject` when
+     * it is first accessed in an example (or supporting hook).
+     */
+    (fn: Func): void;
+    /**
+     * Set `subject` which can be accessed inside of an Example.
+     *
+     * `subject` is set to `value` when first accessed in an example (or supporting hook).
+     */
+    (value: any): void;
+  }
+  interface SharedInvocation {
+    /**
+     * Call the shared `contextName` into the current context.
+     * The shared context will be passed `contextArguments` on execution.
+     */
+    (contextName: string, ...contextArguments: any[]): void;
+  }
+  /**
+   * Sync Function - with optional arguments
+   */
+  type ArgFunc = (...args: any[]) => void;
+  /**
+   * Async Function
+   */
+  type AsyncFunc = () => PromiseLike<any>;
+  /**
+   * Sync Function
+   */
+  type Func = () => void;
+}
+
+/**
+ * Declare a lazy evaluated variable
+ */
+declare var set: JSSpec.LazyEvaluated;
+/**
+ * Declare the special lazy evaluated variable `subject`
+ */
+declare var subject: JSSpec.Subject;
+/**
+ * Execute before the first Example is executed in this context.
+ *
+ * If no example is executed, the hook will not be executed.
+ */
+declare var before: JSSpec.Hook;
+/**
+ * Execute after the final Example is executed in this context.
+ *
+ * If no example is executed, the hook will not be executed.
+ */
+declare var after: JSSpec.Hook;
+/**
+ * Execute once before every Example in this context.
+ *
+ * If no example is executed, the hook will not be executed.
+ */
+declare var beforeEach: JSSpec.Hook;
+/**
+ * Execute once after every Example in this context.
+ *
+ * If no example is executed, the hook will not be executed.
+ */
+declare var afterEach: JSSpec.Hook;
+/**
+ * Create a new Context
+ */
+declare var describe: JSSpec.Context;
+/**
+ * Create a new Context
+ */
+declare var context: JSSpec.Context;
+/**
+ * Create a Context that can be included into another Context.
+ *
+ * Lazy evaluators will be executed as if they were defined
+ * in the context where they called in with `includeContext`.
+ */
+declare var sharedExamples: JSSpec.SharedContext;
+/**
+ * Create a Context that can be executed in another Context.
+ *
+ * The context will be executed as though it were defined in the
+ * context it is called into with `itBehavesLike`.
+ */
+declare var sharedContext: JSSpec.SharedContext;
+/**
+ * Call a `sharedContext` into this context for evaluation.
+ *
+ * The called in context will be executed as though it were defined at the
+ * location where this method calls it in.
+ */
+declare var itBehavesLike: JSSpec.SharedInvocation;
+/**
+ * Call the `fn` of a `sharedExamples` into this context for evaluation.
+ *
+ * The called in context will be executed as though its content was written
+ * at the location where this method calls it in.
+ */
+declare var includeContext: JSSpec.SharedInvocation;
+/**
+ * Set an entire `describe` block as pending. The `fn` will
+ * not be executed.
+ */
+declare var xdescribe: JSSpec.PendingContext;
+/**
+ * Set an entire `context` block as pending. The `fn` will
+ * not be executed.
+ */
+declare var xcontext: JSSpec.PendingContext;
+/**
+ * Define an Example to be executed.
+ *
+ * The example has access to variables set through lazyEvaluators as
+ * global variables.
+ */
+declare var it: JSSpec.Example;
+/**
+ * Set an Example as pending. The `fn` will
+ * not be executed.
+ */
+declare var xit: JSSpec.PendingExample;
+/**
+ * Set an Example as pending. The `fn` will
+ * not be executed.
+ */
+declare var pend: JSSpec.PendingExample;
+
+declare module "jsspec" {
+  export = JSSpec;
+}

--- a/types/jsspec__jsspec/index.d.ts
+++ b/types/jsspec__jsspec/index.d.ts
@@ -4,187 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-declare namespace JSSpec {
-  interface ExampleOptions {
-    /**
-     * fail the test after _timeout_ milliseconds
-     */
-    timeout?: number;
-  }
-
-  interface ContextOptions {
-    /**
-     * fail the test after _timeout_ milliseconds
-     */
-    timeout?: number;
-    /**
-     * Run the contained Examples/Contexts in random order?
-     * - Run in random order if `true`
-     * - Run in definition order if `false`
-     */
-    random?: boolean;
-  }
-
-  interface Context {
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     * Use `options` to specify settings for running Examples in this context.
-     */
-    (title: string, options: ContextOptions, fn: Func): void;
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     */
-    (title: string, fn: Func): void;
-  }
-
-  interface SharedContext {
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     * Use `options` to specify settings for running Examples in this context.
-     */
-    (title: string, options: ContextOptions, fn: ArgFunc): void;
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     */
-    (title: string, fn: ArgFunc): void;
-  }
-
-  interface PendingContext {
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     *
-     * `fn` will not be run, but the context will be reported as pending.
-     * As the `fn` is not run, `options` has no effect.
-     */
-    (title: string, options: ContextOptions, fn: Func): void;
-    /**
-     * Create a new context with the `title` and defined in `fn`.
-     *
-     * `fn` will not be run, but the context will be reported as pending.
-     */
-    (title: string, fn?: Func): void;
-  }
-
-  interface Hook {
-    /**
-     * Provide a named hook, executing `fn`.
-     *
-     * An `async` function will be awaited.
-     *
-     * Use `options` to specify settings for running this hook
-     */
-    (name: string, options: ExampleOptions, fn: AsyncFunc|Func): void;
-    /**
-     * Provide a named hook, executing `fn`.
-     *
-     * An `async` function will be awaited.
-     */
-    (name: string, fn: AsyncFunc|Func): void;
-    /**
-     * Provide a hook, executing `fn`.
-     *
-     * An `async` function will be awaited.
-     */
-    (fn: AsyncFunc|Func): void;
-  }
-
-  interface Example {
-    /**
-     * Provide a test case with the given `title`, executing `fn`.
-     *
-     * Use `options` to specify settings for running this example
-     *
-     * An `async` function will be awaited.
-     */
-    (title: string, option: ExampleOptions, fn?: AsyncFunc|Func): void;
-    /**
-     * Provide a test case with the given `title`, executing `fn`.
-     *
-     * An `async` function will be awaited.
-     */
-    (title: string, fn: AsyncFunc|Func): void;
-  }
-
-  interface PendingExample {
-    /**
-     * Provide a pending test case with the given `title`. `fn` will note be executed.
-     *
-     * `options` will be ignored.
-     */
-    (title: string, option: ExampleOptions, fn?: AsyncFunc|Func): void;
-    /**
-     * Provide a pending test case with the given `title`. `fn` will not be executed.
-     */
-    (title: string, fn: AsyncFunc|Func): void;
-  }
-
-  interface LazyEvaluated {
-    /**
-     * Set a variable which can be accessed inside of an Example.
-     *
-     * `fn` will be executed to evaluate the initial state of `varName` when
-     * it is first accessed in an example (or supporting hook).
-     */
-    (varName: string, fn: Func): void;
-    /**
-     * Set a variable which can be accessed inside of an Example.
-     *
-     * `varName` is set to `value` when first accessed in an example (or supporting hook).
-     */
-    (varName: string, value: any): void;
-  }
-
-  interface Subject {
-    /**
-     * Set a variable which can be accessed inside of an Example.
-     * `subject` will refer to the same variable.
-     *
-     * `fn` will be executed to evaluate the initial state of `varName` when
-     * it is first accessed in an example (or supporting hook).
-     */
-    (varName: string, fn: Func): void;
-    /**
-     * Set a variable which can be accessed inside of an Example.
-     * `subject` will refer to the same variable.
-     *
-     * `varName` is set to `value` when first accessed in an example (or supporting hook).
-     */
-    (varName: string, value: any): void;
-    /**
-     * Set `subject` which can be accessed inside of an Example.
-     *
-     * `fn` will be executed to evaluate the initial state of `subject` when
-     * it is first accessed in an example (or supporting hook).
-     */
-    (fn: Func): void;
-    /**
-     * Set `subject` which can be accessed inside of an Example.
-     *
-     * `subject` is set to `value` when first accessed in an example (or supporting hook).
-     */
-    (value: any): void;
-  }
-  interface SharedInvocation {
-    /**
-     * Call the shared `contextName` into the current context.
-     * The shared context will be passed `contextArguments` on execution.
-     */
-    (contextName: string, ...contextArguments: any[]): void;
-  }
-  /**
-   * Sync Function - with optional arguments
-   */
-  type ArgFunc = (...args: any[]) => void;
-  /**
-   * Async Function
-   */
-  type AsyncFunc = () => PromiseLike<any>;
-  /**
-   * Sync Function
-   */
-  type Func = () => void;
-}
-
 /**
  * Declare a lazy evaluated variable
  */
@@ -281,6 +100,165 @@ declare var xit: JSSpec.PendingExample;
  */
 declare var pend: JSSpec.PendingExample;
 
-declare module "jsspec" {
-  export = JSSpec;
+declare namespace JSSpec {
+    interface ExampleOptions {
+        /**
+         * fail the test after _timeout_ milliseconds
+         */
+        timeout?: number;
+    }
+
+    interface ContextOptions {
+        /**
+         * fail the test after _timeout_ milliseconds
+         */
+        timeout?: number;
+        /**
+         * Run the contained Examples/Contexts in random order?
+         * - Run in random order if `true`
+         * - Run in definition order if `false`
+         */
+        random?: boolean;
+    }
+
+    interface Context {
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         * Use `options` to specify settings for running Examples in this context.
+         */
+        (title: string, options: ContextOptions, fn: Func): void;
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         */
+        (title: string, fn: Func): void;
+    }
+
+    interface SharedContext {
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         * Use `options` to specify settings for running Examples in this context.
+         */
+        (title: string, options: ContextOptions, fn: ArgFunc): void;
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         */
+        (title: string, fn: ArgFunc): void;
+    }
+
+    interface PendingContext {
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         *
+         * `fn` will not be run, but the context will be reported as pending.
+         * As the `fn` is not run, `options` has no effect.
+         */
+        (title: string, options: ContextOptions, fn: Func): void;
+        /**
+         * Create a new context with the `title` and defined in `fn`.
+         *
+         * `fn` will not be run, but the context will be reported as pending.
+         */
+        (title: string, fn?: Func): void;
+    }
+
+    interface Hook {
+        /**
+         * Provide a named hook, executing `fn`.
+         *
+         * An `async` function will be awaited.
+         *
+         * Use `options` to specify settings for running this hook
+         */
+        (name: string, options: ExampleOptions, fn: AsyncFunc | Func): void;
+        /**
+         * Provide a named hook, executing `fn`.
+         *
+         * An `async` function will be awaited.
+         */
+        (name: string, fn: AsyncFunc | Func): void;
+        /**
+         * Provide a hook, executing `fn`.
+         *
+         * An `async` function will be awaited.
+         */
+        (fn: AsyncFunc | Func): void;
+    }
+
+    interface Example {
+        /**
+         * Provide a test case with the given `title`, executing `fn`.
+         *
+         * Use `options` to specify settings for running this example
+         *
+         * An `async` function will be awaited.
+         */
+        (title: string, option: ExampleOptions, fn?: AsyncFunc | Func): void;
+        /**
+         * Provide a test case with the given `title`, executing `fn`.
+         *
+         * An `async` function will be awaited.
+         */
+        (title: string, fn: AsyncFunc | Func): void;
+    }
+
+    interface PendingExample {
+        /**
+         * Provide a pending test case with the given `title`. `fn` will note be executed.
+         *
+         * `options` will be ignored.
+         */
+        (title: string, option: ExampleOptions, fn?: AsyncFunc | Func): void;
+        /**
+         * Provide a pending test case with the given `title`. `fn` will not be executed.
+         */
+        (title: string, fn: AsyncFunc | Func): void;
+    }
+
+    interface LazyEvaluated {
+        /**
+         * Set a variable which can be accessed inside of an Example.
+         *
+         * If `fnOrValue` is a function, it will be executed to evaluate the initial state of
+         * `varName` when it is first accessed in an example (or supporting hook).
+         */
+        (varName: string, fnOrValue: any): void;
+    }
+
+    interface Subject {
+        /**
+         * Set a variable which can be accessed inside of an Example.
+         * `subject` will refer to the same variable.
+         *
+         * If `fnOrValue` is a function, it will be executed to evaluate the initial state of
+         * `varName` or `subject` when it is first accessed in an example (or supporting hook).
+         */
+        (varName: string, fnOrValue: any): void;
+        /**
+         * Set `subject` which can be accessed inside of an Example.
+         *
+         * If `fnOrValue` is a function, it will be executed to evaluate the initial state of
+         * `subject` when it is first accessed in an example (or supporting hook).
+         */
+        (fnOrValue: any): void;
+    }
+
+    interface SharedInvocation {
+        /**
+         * Call the shared `contextName` into the current context.
+         * The shared context will be passed `contextArguments` on execution.
+         */
+        (contextName: string, ...contextArguments: any[]): void;
+    }
+    /**
+     * Sync Function - with optional arguments
+     */
+    type ArgFunc = (...args: any[]) => void;
+    /**
+     * Async Function
+     */
+    type AsyncFunc = () => PromiseLike<any>;
+    /**
+     * Sync Function
+     */
+    type Func = () => void;
 }

--- a/types/jsspec__jsspec/jsspec__jsspec-tests.ts
+++ b/types/jsspec__jsspec/jsspec__jsspec-tests.ts
@@ -1,0 +1,92 @@
+describe('something', () => {});
+describe('something', {}, () => {});
+describe('something', { timeout: 1, random: false }, () => {});
+
+context('something', () => {});
+context('something', {}, () => {});
+context('something', { timeout: 1, random: false }, () => {});
+
+sharedContext('something', () => {});
+sharedContext('something', {}, () => {});
+sharedContext('something', { timeout: 1, random: false }, () => {});
+
+sharedExamples('something', () => {});
+sharedExamples('something', {}, () => {});
+sharedExamples('something', { timeout: 1, random: false }, () => {});
+
+xdescribe('something', () => {});
+xdescribe('something', () => {});
+xdescribe('something', {}, () => {});
+xdescribe('something', { timeout: 1, random: false }, () => {});
+
+xcontext('something', () => {});
+xcontext('something', () => {});
+xcontext('something', {}, () => {});
+xcontext('something', { timeout: 1, random: false }, () => {});
+
+context('inner', () => {
+    set('thing', 1);
+    set('thing', () => 4);
+
+    subject('thing', 1);
+    subject('thing', () => 4);
+    subject(1);
+    subject(() => 4);
+
+    it('example', () => {});
+    it('example', async () => {});
+    it('example', {}, () => {});
+    it('example', { timeout: 1 }, () => {});
+
+    xit('example', () => {});
+    xit('example', async () => {});
+    xit('example', {}, () => {});
+    xit('example', { timeout: 1 }, () => {});
+
+    pend('example', () => {});
+    pend('example', async () => {});
+    pend('example', {}, () => {});
+    pend('example', { timeout: 1 }, () => {});
+
+    sharedContext('first', () => {});
+    sharedContext('first', (arg1: any) => arg1);
+    sharedContext('first', {}, () => {});
+    sharedContext('first', {}, (arg1: any) => arg1);
+    sharedContext('first', { timeout: 1, random: true }, () => {});
+
+    sharedExamples('first', () => {});
+    sharedExamples('first', (arg1: any) => arg1);
+    sharedExamples('first', {}, () => {});
+    sharedExamples('first', {}, (arg1: any) => arg1);
+    sharedExamples('first', { timeout: 1, random: true }, () => {});
+
+    includeContext('first');
+    includeContext('first', 1, () => {});
+
+    itBehavesLike('first');
+    itBehavesLike('first', 1, () => {});
+
+    afterEach(() => {});
+    afterEach('named', () => {});
+    afterEach('named', {}, () => {});
+    afterEach('named', { timeout: 1 }, () => {});
+    afterEach('named', { timeout: 1 }, async () => {});
+
+    beforeEach(() => {});
+    beforeEach('named', () => {});
+    beforeEach('named', {}, () => {});
+    beforeEach('named', { timeout: 1 }, () => {});
+    beforeEach('named', { timeout: 1 }, async () => {});
+
+    after(() => {});
+    after('named', () => {});
+    after('named', {}, () => {});
+    after('named', { timeout: 1 }, () => {});
+    after('named', { timeout: 1 }, async () => {});
+
+    before(() => {});
+    before('named', () => {});
+    before('named', {}, () => {});
+    before('named', { timeout: 1 }, () => {});
+    before('named', { timeout: 1 }, async () => {});
+});

--- a/types/jsspec__jsspec/tsconfig.json
+++ b/types/jsspec__jsspec/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "experimentalDecorators": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsspec__jsspec-tests.ts"
+    ]
+}

--- a/types/jsspec__jsspec/tslint.json
+++ b/types/jsspec__jsspec/tslint.json
@@ -1,0 +1,11 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "unified-signatures": false,
+        "interface-name": false,
+        "ban-types": false,
+        "no-single-declare-module": false,
+        "no-declare-current-package": false,
+        "callable-types": false
+    }
+}

--- a/types/jsspec__jsspec/tslint.json
+++ b/types/jsspec__jsspec/tslint.json
@@ -1,11 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "unified-signatures": false,
-        "interface-name": false,
-        "ban-types": false,
-        "no-single-declare-module": false,
-        "no-declare-current-package": false,
-        "callable-types": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
