### PR TITLE
[@types/node] Allow to extends Http2ServerResponse and MyHttp2ServerRequest

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -583,7 +583,7 @@ declare module "http2" {
     }
 
     export class Http2ServerRequest extends stream.Readable {
-        private constructor();
+        public constructor();
 
         readonly aborted: boolean;
         readonly authority: string;
@@ -651,7 +651,7 @@ declare module "http2" {
     }
 
     export class Http2ServerResponse extends stream.Stream {
-        private constructor();
+        public constructor();
 
         addTrailers(trailers: OutgoingHttpHeaders): void;
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -583,7 +583,7 @@ declare module "http2" {
     }
 
     export class Http2ServerRequest extends stream.Readable {
-        public constructor();
+        constructor();
 
         readonly aborted: boolean;
         readonly authority: string;
@@ -651,7 +651,7 @@ declare module "http2" {
     }
 
     export class Http2ServerResponse extends stream.Stream {
-        public constructor();
+        constructor();
 
         addTrailers(trailers: OutgoingHttpHeaders): void;
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -583,7 +583,7 @@ declare module "http2" {
     }
 
     export class Http2ServerRequest extends stream.Readable {
-        constructor(stream: ServerHttp2Stream, headers: IncomingHttpHeaders, options: stream.ReadableOptions, rawHeaders: string);
+        constructor(stream: ServerHttp2Stream, headers: IncomingHttpHeaders, options: stream.ReadableOptions, rawHeaders: string[]);
 
         readonly aborted: boolean;
         readonly authority: string;

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -583,7 +583,7 @@ declare module "http2" {
     }
 
     export class Http2ServerRequest extends stream.Readable {
-        constructor();
+        constructor(stream: ServerHttp2Stream, headers: string[], options: stream.ReadableOptions, rawHeaders: string);
 
         readonly aborted: boolean;
         readonly authority: string;
@@ -651,7 +651,7 @@ declare module "http2" {
     }
 
     export class Http2ServerResponse extends stream.Stream {
-        constructor();
+        constructor(stream: ServerHttp2Stream);
 
         addTrailers(trailers: OutgoingHttpHeaders): void;
         readonly connection: net.Socket | tls.TLSSocket;

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -583,7 +583,7 @@ declare module "http2" {
     }
 
     export class Http2ServerRequest extends stream.Readable {
-        constructor(stream: ServerHttp2Stream, headers: string[], options: stream.ReadableOptions, rawHeaders: string);
+        constructor(stream: ServerHttp2Stream, headers: IncomingHttpHeaders, options: stream.ReadableOptions, rawHeaders: string);
 
         readonly aborted: boolean;
         readonly authority: string;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -36,6 +36,7 @@
 //                 Kyle Uehlein <https://github.com/kuehlein>
 //                 Jordi Oliveras Rovira <https://github.com/j-oliveras>
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
+//                 Marcin Kopacz <https://github.com/chyzwar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -384,6 +384,44 @@ import { URL } from 'url';
     settings = getUnpackedSettings(Uint8Array.from([]));
 }
 
+// Http2ServerRequest, Http2ServerResponse,
+{
+    class MyHttp2ServerRequest extends Http2ServerRequest {
+        foo: number;
+    }
+
+    class MyHttp2ServerResponse extends Http2ServerResponse {
+        bar: string;
+    }
+
+    function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}
+
+    let server: Http2Server;
+
+    server = createServer({
+        Http2ServerRequest: MyHttp2ServerRequest,
+        Http2ServerResponse: MyHttp2ServerResponse
+    });
+    server = createServer({
+        Http2ServerRequest: MyHttp2ServerRequest,
+        Http2ServerResponse: MyHttp2ServerResponse
+    }, reqListener);
+
+    server = createServer({ Http2ServerRequest: MyHttp2ServerRequest });
+    server = createServer({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener);
+
+    server = createSecureServer({
+        Http2ServerRequest: MyHttp2ServerRequest,
+        Http2ServerResponse: MyHttp2ServerResponse
+    });
+    server = createSecureServer({
+        Http2ServerRequest: MyHttp2ServerRequest,
+        Http2ServerResponse: MyHttp2ServerResponse
+    }, reqListener);
+    server = createSecureServer({ Http2ServerRequest: MyHttp2ServerRequest });
+    server = createSecureServer({ Http2ServerResponse: MyHttp2ServerResponse }, reqListener);
+}
+
 // constants
 {
     const consts = constants;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This makes constructor public for Http2ServerRequest and Http2ServerResponse. According to http2 docs, it is possible to extend these classes. 

@see https://nodejs.org/api/http2.html#http2_http2_createsecureserver_options_onrequesthandler

There will be a need for more changes in http2 to fully support custom req, res classes. 
