### PR TITLE
[passport-local] Set general boolean as type for 'passReqToCallback'

### DIFF
--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -13,14 +13,14 @@ interface IStrategyOptions {
     usernameField?: string;
     passwordField?: string;
     session?: boolean;
-    passReqToCallback?: false;
+    passReqToCallback?: boolean;
 }
 
 interface IStrategyOptionsWithRequest {
     usernameField?: string;
     passwordField?: string;
     session?: boolean;
-    passReqToCallback: true;
+    passReqToCallback: boolean;
 }
 
 interface IVerifyOptions {


### PR DESCRIPTION
Resolve type error when setting 'passReqToCallback' to true when creating the local strategy.