### PR TITLE
fix(googlemaps): Changed GeocoderGeometry.location to be LatLngLiteral

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -874,3 +874,15 @@ const directionsWaypointLocationPlace: google.maps.DirectionsWaypoint = {
 const directionsWaypointStopover: google.maps.DirectionsWaypoint = {
     stopover: true
 };
+
+/****** google.maps.GeocoderResult ********/
+
+var xmlHttp = new XMLHttpRequest();
+xmlHttp.open( "GET", 'https://maps.googleapis.com/maps/api/geocode/json?key=myAPIKey&address=cdmx,mexico', false );
+xmlHttp.send( null );
+var response = JSON.parse(xmlHttp.responseText);
+var results: google.maps.GeocoderResult[] = response.results;
+results[0].geometry.bounds;         // $ExpectType LatLngBounds
+results[0].geometry.location;       // $ExpectType LatLngLiteral
+results[0].geometry.location_type;  // $ExpectType GeocoderLocationType
+results[0].geometry.viewport;       // $ExpectType LatLngBounds

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -14,6 +14,7 @@
 //                  Colin Doig <https://github.com/captain-igloo>
 //                  Dmitry Demensky <https://github.com/demensky>
 //                  Vladimir Dashukevich <https://github.com/life777>
+//                  Raschid JF Rafaelly <https://github.com/RaschidJFR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 2.7
@@ -193,7 +194,7 @@ declare namespace google.maps {
          * in the v3.22 Map Controls}.
          */
         panControlOptions?: PanControlOptions;
-        /** 
+        /**
          * Defines a boundary that restricts the area of the map accessible to users.
          * When set, a user can only pan and zoom while the camera view stays inside the
          * limits of the boundary.
@@ -1695,7 +1696,7 @@ declare namespace google.maps {
 
     interface GeocoderGeometry {
         bounds: LatLngBounds;
-        location: LatLng;
+        location: LatLngLiteral;
         location_type: GeocoderLocationType;
         viewport: LatLngBounds;
     }


### PR DESCRIPTION
Even when [documentation](https://developers.google.com/maps/documentation/javascript/reference/geocoder#GeocoderGeometry) states that GeocoderResult.location should be LatLng, a Geocoder request retunrs this property actually as LatLngLiteral.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/geocoder#GeocoderGeometry
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
