### PR TITLE
[echarts] fix series-bar.itemStyle.color for linear gradient & radial gradient

### DIFF
--- a/types/echarts/options/series/bar.d.ts
+++ b/types/echarts/options/series/bar.d.ts
@@ -922,7 +922,15 @@ declare namespace echarts {
                  * "auto"
                  * @see https://ecomfe.github.io/echarts-doc/public/en/option.html#series-bar.itemStyle.color
                  */
-                color?: string;
+                color?: string | {
+                    type: 'linear',
+                    x: zrender.X,
+                    y: zrender.Y,
+                    x2: zrender.X2,
+                    y2: zrender.Y2,
+                    colorStops: zrender.ColorStops,
+                    globalCoord: zrender.GlobalCoords
+                };
 
                 /**
                  * The bodrder color of bar.

--- a/types/echarts/options/series/bar.d.ts
+++ b/types/echarts/options/series/bar.d.ts
@@ -924,12 +924,25 @@ declare namespace echarts {
                  */
                 color?: string | {
                     type: 'linear',
-                    x: zrender.X,
-                    y: zrender.Y,
-                    x2: zrender.X2,
-                    y2: zrender.Y2,
-                    colorStops: zrender.ColorStops,
-                    globalCoord: zrender.GlobalCoords
+                    x: number,
+                    y: number,
+                    x2: number,
+                    y2: number,
+                    colorStops: {
+                        offset: number,
+                        color: string
+                    }[],
+                    global: boolean
+                } | {
+                    type: 'radial',
+                    x: number,
+                    y: number,
+                    r: number,
+                    colorStops: {
+                        offset: number,
+                        color: string
+                    }[],
+                    global: boolean
                 };
 
                 /**


### PR DESCRIPTION
**documents just give a example for series-line,but series-bar works well.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://echarts.apache.org/en/option.html#series-line.itemStyle.color>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
