### PR TITLE
[@types/mongodb] Mark `_id` as optional for `insert` and `insertMany` methods

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -995,19 +995,19 @@ export interface Collection<TSchema = Default> {
     initializeUnorderedBulkOp(options?: CommonOptions): UnorderedBulkOperation;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne */
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: TSchema, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insert(docs: Omit<TSchema, '_id'>, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: TSchema, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
+    insert(docs: Omit<TSchema, '_id'>, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: TSchema, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insert(docs: Omit<TSchema, '_id'>, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany */
-    insertMany(docs: TSchema[], callback: MongoCallback<InsertWriteOpResult>): void;
-    insertMany(docs: TSchema[], options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult>;
-    insertMany(docs: TSchema[], options: CollectionInsertManyOptions, callback: MongoCallback<InsertWriteOpResult>): void;
+    insertMany(docs: Omit<TSchema, '_id'>[], callback: MongoCallback<InsertWriteOpResult>): void;
+    insertMany(docs: Omit<TSchema, '_id'>[], options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult>;
+    insertMany(docs: Omit<TSchema, '_id'>[], options: CollectionInsertManyOptions, callback: MongoCallback<InsertWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne */
-    insertOne(docs: TSchema, callback: MongoCallback<InsertOneWriteOpResult>): void;
-    insertOne(docs: TSchema, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
-    insertOne(docs: TSchema, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insertOne(docs: Omit<TSchema, '_id'>, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insertOne(docs: Omit<TSchema, '_id'>, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
+    insertOne(docs: Omit<TSchema, '_id'>, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#isCapped */
     isCapped(options?: { session: ClientSession }): Promise<any>;
     isCapped(callback: MongoCallback<any>): void;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -995,19 +995,19 @@ export interface Collection<TSchema = Default> {
     initializeUnorderedBulkOp(options?: CommonOptions): UnorderedBulkOperation;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne */
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: Omit<TSchema, '_id'>, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insert(docs: Omit<TSchema, '_id'> & { _id?: any }, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: Omit<TSchema, '_id'>, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
+    insert(docs: Omit<TSchema, '_id'> & { _id?: any }, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
     /** @deprecated Use insertOne, insertMany or bulkWrite */
-    insert(docs: Omit<TSchema, '_id'>, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insert(docs: Omit<TSchema, '_id'> & { _id?: any }, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany */
-    insertMany(docs: Omit<TSchema, '_id'>[], callback: MongoCallback<InsertWriteOpResult>): void;
-    insertMany(docs: Omit<TSchema, '_id'>[], options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult>;
-    insertMany(docs: Omit<TSchema, '_id'>[], options: CollectionInsertManyOptions, callback: MongoCallback<InsertWriteOpResult>): void;
+    insertMany(docs: Array<Omit<TSchema, '_id'> & { _id?: any }>, callback: MongoCallback<InsertWriteOpResult>): void;
+    insertMany(docs: Array<Omit<TSchema, '_id'> & { _id?: any }>, options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult>;
+    insertMany(docs: Array<Omit<TSchema, '_id'> & { _id?: any }>, options: CollectionInsertManyOptions, callback: MongoCallback<InsertWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne */
-    insertOne(docs: Omit<TSchema, '_id'>, callback: MongoCallback<InsertOneWriteOpResult>): void;
-    insertOne(docs: Omit<TSchema, '_id'>, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
-    insertOne(docs: Omit<TSchema, '_id'>, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insertOne(docs: Omit<TSchema, '_id'> & { _id?: any }, callback: MongoCallback<InsertOneWriteOpResult>): void;
+    insertOne(docs: Omit<TSchema, '_id'> & { _id?: any }, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult>;
+    insertOne(docs: Omit<TSchema, '_id'> & { _id?: any }, options: CollectionInsertOneOptions, callback: MongoCallback<InsertOneWriteOpResult>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#isCapped */
     isCapped(options?: { session: ClientSession }): Promise<any>;
     isCapped(callback: MongoCallback<any>): void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongodb.github.io/node-mongodb-native/3.2/api/Collection.html#insert

---

```ts
interface User {
  _id: string;
  name: string;
}

const doc: Partial<User> = {
  name: 'john',
};


db.users.insert(doc); // db.users = Collection<User>
```

This would throw an error, as `_id` is required. We could define `_id` as optional to fix this. But in every other case than `insert`, `_id` is always present. When sharing types between mongo and graphql, for example with [`graphql-code-gen`](https://graphql-code-generator.com), marking `_id` as optional is not really a serious option. But even besides that, optional _id's are often unwanted. As every user entity should have an `_id` anyway.

This PR marks the `_id` property as `optional any` for all `Collection<T>.insert` statements.

---

resolves #33740