### PR TITLE
[ReactStripeElements] update method types

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-stripe-elements 1.2
+// Type definitions for react-stripe-elements 1.3
 // Project: https://github.com/stripe/react-stripe-elements#readme
 // Definitions by: dan-j <https://github.com/dan-j>
 //                 Santiago Doldan <https://github.com/santiagodoldan>
@@ -39,9 +39,19 @@ export namespace ReactStripeElements {
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
 		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
-        paymentRequest: stripe.Stripe['paymentRequest'];
-        handleCardPayment: stripe.Stripe['handleCardPayment'];
-        handleCardSetup: stripe.Stripe['handleCardSetup'];
+		paymentRequest: stripe.Stripe['paymentRequest'];
+		createPaymentMethod(
+			paymentMethodType: stripe.paymentMethod.paymentMethodType,
+			data?: stripe.CreatePaymentMethodOptions,
+		): Promise<stripe.PaymentMethodResponse>;
+		handleCardPayment(
+			clientSecret: string,
+			options?: stripe.HandleCardPaymentOptions
+		): Promise<stripe.PaymentIntentResponse>;
+		handleCardSetup(
+			clientSecret: string,
+			data?: stripe.HandleCardSetupOptions
+		): Promise<stripe.PaymentIntentResponse>;
 	}
 
 	interface InjectOptions {

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -241,3 +241,83 @@ const TestStripeProviderProps4: React.SFC<{
  * See: https://stripe.com/docs/stripe-js/reference#stripe-function for options.
  */
 const TestStripeProviderOptions: React.SFC = () => <StripeProvider apiKey="" stripeAccount="" />;
+
+class CreatePaymentMethod extends React.Component<InjectedStripeProps> {
+    testCreatePaymentMethod = () => {
+        this.props
+            .stripe!.createPaymentMethod('card')
+            .then((response) => response.paymentMethod);
+    }
+
+    testCreatePaymentMethodWithData = () => {
+        this.props
+            .stripe!.createPaymentMethod('card', {
+                billing_details: {
+                    name: 'John Doe',
+                },
+                metadata: {
+                    foo: 'bar',
+                }
+            })
+            .then((response) => response.paymentMethod);
+    }
+
+    testCreatePaymentMethodWithError = () => {
+        this.props
+            .stripe!.createPaymentMethod('card')
+            .then((response) => response.error);
+    }
+}
+
+class HandleCardPayment extends React.Component<InjectedStripeProps> {
+    testHandleCardPayment = () => {
+        this.props
+            .stripe!.handleCardPayment('clientSecret')
+            .then((response) => response.paymentIntent);
+    }
+
+    testHandleCardPaymentWithOptions = () => {
+        this.props
+            .stripe!.handleCardPayment('clientSecret', {
+                payment_method_data: {
+                    billing_details: {
+                      name: 'John Doe'
+                    }
+                },
+                receipt_email: 'john@doe.com',
+            })
+            .then((response) => response.paymentIntent);
+    }
+
+    testHandleCardPaymentWithError = () => {
+        this.props
+            .stripe!.handleCardPayment('clientSecret')
+            .then((response) => response.error);
+    }
+}
+
+class HandleCardSetup extends React.Component<InjectedStripeProps> {
+    testHandleCardSetup = () => {
+        this.props
+            .stripe!.handleCardSetup('clientSecret')
+            .then((response) => response.paymentIntent);
+    }
+
+    testHandleCardSetupWithData = () => {
+        this.props
+            .stripe!.handleCardSetup('clientSecret', {
+                payment_method_data: {
+                    billing_details: {
+                      name: 'John Doe'
+                    }
+                },
+            })
+            .then((response) => response.paymentIntent);
+    }
+
+    testHandleCardSetupWithError = () => {
+        this.props
+            .stripe!.handleCardSetup('clientSecret')
+            .then((response) => response.error);
+    }
+}


### PR DESCRIPTION
Added typings for createPaymentMethod
Updates the types for handleCardPayment and handleCardSetup to be in line with the latest api change in react-stripe-elements.

See: https://github.com/stripe/react-stripe-elements/releases/tag/v4.0.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.