### PR TITLE
Add types for highlightjs

### DIFF
--- a/types/highlightjs/highlightjs-tests.ts
+++ b/types/highlightjs/highlightjs-tests.ts
@@ -1,0 +1,9 @@
+import hljs = require('highlightjs');
+
+const code = "using System;\npublic class Test\n{\npublic static void Main()\n{\n// your code goes here\n}\n}";
+const lang = "cs";
+
+hljs.configure({ tabReplace: "    " }); // 4 spaces
+
+let hl = hljs.highlight(lang, code).value;
+hl = hljs.highlightAuto(code).value;

--- a/types/highlightjs/index.d.ts
+++ b/types/highlightjs/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for highlightjs 9.12
+// Project: https://github.com/isagalaev/highlight.js
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import highlightjs = require('highlight.js');
+export = highlightjs;

--- a/types/highlightjs/tsconfig.json
+++ b/types/highlightjs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "highlightjs-tests.ts"
+    ]
+}

--- a/types/highlightjs/tslint.json
+++ b/types/highlightjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The files were copied from highlight.js, only the types for v7 were removed since the versions for highlightjs start with 8.7.0.

Explanation: In multi-platform environments you can just import 'highlightjs' (instead of 'highlight.js') but then the types for 'highlight.js' are not compatible.