### PR TITLE
Shopify-js-buy-sdk: Updated method name, to match the updated version of the library.

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Martin Köhn <https://github.com/openminder>
 //                 Stephen Traiforos <https://github.com/straiforos>
 //                 Rosana Ruiz <https://github.com/totemika>
+//                 Juan Manuel Incaurgarat <https://github.com/kilinkis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -66,13 +67,13 @@ declare namespace ShopifyBuy {
 
         fetch(id: string): Promise<Cart>;
 
-        addLineItems(checkoutId: string, lineItems: LineItem[]): Promise<Cart>;
+        addLineItems(checkoutId: string | number, lineItems: LineItem[]): Promise<Cart>;
 
         /**
          * Remove all line items from cart
          */
         clearLineItems(
-            checkoutId: string,
+            checkoutId: string | number,
             lineItems: LineItem[]
         ): Promise<Cart>;
 
@@ -85,7 +86,7 @@ declare namespace ShopifyBuy {
          * Remove a line item from cart based on line item id
          */
         removeLineItems(
-            checkoutId: string,
+            checkoutId: string | number,
             lineItemIds: string[]
         ): Promise<Cart>;
 
@@ -93,7 +94,7 @@ declare namespace ShopifyBuy {
          * Update a line item quantity based on line item id
          */
         updateLineItem(
-            checkoutId:  string,
+            checkoutId:  string | number,
             lineItems: AttributeInput[]
         ): Promise<Cart>;
     }

--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -66,13 +66,13 @@ declare namespace ShopifyBuy {
 
         fetch(id: string): Promise<Cart>;
 
-        addLineItems(checkoutId: string | number, lineItems: LineItem[]): Promise<Cart>;
+        addLineItems(checkoutId: string, lineItems: LineItem[]): Promise<Cart>;
 
         /**
          * Remove all line items from cart
          */
         clearLineItems(
-            checkoutId: string | number,
+            checkoutId: string,
             lineItems: LineItem[]
         ): Promise<Cart>;
 
@@ -84,8 +84,8 @@ declare namespace ShopifyBuy {
         /**
          * Remove a line item from cart based on line item id
          */
-        removeLineItem(
-            checkoutId: string | number,
+        removeLineItems(
+            checkoutId: string,
             lineItemIds: string[]
         ): Promise<Cart>;
 
@@ -93,7 +93,7 @@ declare namespace ShopifyBuy {
          * Update a line item quantity based on line item id
          */
         updateLineItem(
-            checkoutId:  string | number,
+            checkoutId:  string,
             lineItems: AttributeInput[]
         ): Promise<Cart>;
     }


### PR DESCRIPTION
This PR brings the type definitions up to date with a new version of the JS library:

The method `removeLineItem` was renamed to `removeLineItems`. See [here](https://github.com/Shopify/js-buy-sdk/blob/master/tutorials/MIGRATION_GUIDE.md#removing-line-items).
Also updated the type for checkoutId to just 'string', as it is the only possible value.