### PR TITLE
Add type definition for non npm package amap-js-api-heatmap

### DIFF
--- a/types/amap-js-api-heatmap/amap-js-api-heatmap-tests.ts
+++ b/types/amap-js-api-heatmap/amap-js-api-heatmap-tests.ts
@@ -1,0 +1,87 @@
+declare const map: AMap.Map;
+
+// $ExpectError
+new AMap.Heatmap();
+// $ExpectType Heatmap
+new AMap.Heatmap(map);
+// $ExpectType Heatmap
+new AMap.Heatmap(map, {});
+// $ExpectType Heatmap
+const heatmap = new AMap.Heatmap(map, {
+    radius: 30,
+    gradient: {
+        0.4: 'rgb(0, 255, 255)',
+        0.65: 'rgb(0, 110, 255)',
+        0.85: 'rgb(100, 0, 255)',
+        1.0: 'rgb(100, 0, 255)'
+    },
+    opacity: [0, 0.5],
+    zooms: [1, 18]
+});
+
+// $ExpectType void
+heatmap.setMap(map);
+
+// $ExpectType void
+heatmap.setOptions();
+// $ExpectType void
+heatmap.setOptions({});
+// $ExpectType void
+heatmap.setOptions({
+    radius: 30,
+    gradient: {
+        0.4: 'rgb(0, 255, 255)',
+        0.65: 'rgb(0, 110, 255)',
+        0.85: 'rgb(100, 0, 255)',
+        1.0: 'rgb(100, 0, 255)'
+    },
+    opacity: [0, 0.5],
+    zooms: [1, 18]
+});
+
+// $ExpectType void
+heatmap.setDataSet({
+    data: [
+        {
+            lng: 114.08594700023525,
+            lat: 22.54699999968279,
+            count: 1
+        }
+    ],
+    max: 1
+});
+
+// $ExpectType void
+heatmap.setDataSet({
+    data: '',
+    dataParser: () => {
+        return {
+            data: [
+                {
+                    lng: 114.08594700023525,
+                    lat: 22.54699999968279,
+                    count: 1
+                }
+            ],
+            max: 1
+        };
+    }
+});
+
+// $ExpectType void
+heatmap.addDataPoint(1, 2);
+// $ExpectType void
+heatmap.addDataPoint(1, 2, 3);
+
+// $ExpectType void
+heatmap.show();
+
+// $ExpectType void
+heatmap.hide();
+// $ExpectType Map
+heatmap.getMap();
+
+const heatmapDataSet = heatmap.getDataSet();
+
+// $ExpectType Data[]
+heatmapDataSet.data;

--- a/types/amap-js-api-heatmap/index.d.ts
+++ b/types/amap-js-api-heatmap/index.d.ts
@@ -1,0 +1,127 @@
+// Type definitions for non-npm package amap-js-api-heatmap 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/layer#m_AMap.Heatmap
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+declare namespace AMap {
+    namespace Heatmap {
+        interface Options {
+            /**
+             * 热力图中单个点的半径，默认：30，单位：pixel
+             */
+            radius?: number;
+            /**
+             * 热力图的渐变区间
+             */
+            gradient?: { [key: string]: string };
+            /**
+             * 热力图透明度数组，取值范围[0,1]，0表示完全透明，1表示不透明
+             * 默认：[0,1]
+             */
+            opacity?: [number, number];
+            /**
+             * 支持的缩放级别范围，取值范围[3-18]
+             * 默认：[3,18]
+             */
+            zooms?: [number, number];
+
+            rejectMapMask?: boolean;
+            visible?: boolean;
+            radiusUnit?: string;
+            blur?: number;
+            zIndex?: number;
+            renderOnZooming?: boolean;
+            ['3d']?: {
+                heightScale?: number;
+                heightBezier?: number[];
+                gridSize?: number;
+                drawGridLine?: boolean;
+            };
+        }
+        interface Data {
+            /**
+             * 经度
+             */
+            lng: number;
+            /**
+             * 维度
+             */
+            lat: number;
+            /**
+             * 权重
+             */
+            count: number;
+        }
+        interface DataSet {
+            /**
+             * 权重的最大值
+             */
+            max?: number;
+            /**
+             * 坐标数据集
+             */
+            data: Data[];
+        }
+    }
+
+    class Heatmap {
+        /**
+         * 热力图
+         * @param map 地图对象
+         * @param opts 热力图选项
+         */
+        constructor(map: Map, opts?: Heatmap.Options);
+        /**
+         * 设置热力图要叠加的地图对象
+         * @param map 地图对象
+         */
+        setMap(map: Map): void;
+        /**
+         * 设置热力图属性
+         * @param opts 热力图属性
+         */
+        setOptions(opts?: Heatmap.Options): void;
+        /**
+         * 设置热力图展现的数据集，数据格式详见
+         * https://lbs.amap.com/api/javascript-api/reference/layer#m_AMap.Heatmap
+         * @param dataset 数据集
+         */
+        setDataSet(dataset: Heatmap.DataSet | {
+            data: string;
+            dataParser?(data: any): Heatmap.DataSet;
+        }): void;
+        /**
+         * 向热力图数据集中添加坐标点，count不填写时默认：1
+         * @param lng 经度
+         * @param lat 维度
+         * @param count 权重
+         */
+        addDataPoint(lng: number, lat: number, count?: number): void;
+        /**
+         * 隐藏热力图
+         */
+        hide(): void;
+        /**
+         * 显示热力图
+         */
+        show(): void;
+        /**
+         * 获取热力图叠加地图对象
+         */
+        getMap(): Map;
+        /**
+         * 	获取热力图的属性信息
+         */
+        getOptions(): Heatmap.Options;
+        /**
+         * 输出热力图的数据集，数据结构同setDataSet中的数据集
+         */
+        getDataSet(): Heatmap.DataSet;
+        // internal
+
+        setzIndex(zIndex: number): void;
+        getzIndex(): number;
+    }
+}

--- a/types/amap-js-api-heatmap/tsconfig.json
+++ b/types/amap-js-api-heatmap/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-heatmap-tests.ts"
+    ]
+}

--- a/types/amap-js-api-heatmap/tslint.json
+++ b/types/amap-js-api-heatmap/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
