### PR TITLE
Add missing `options` property for pollyjs__persister

### DIFF
--- a/types/pollyjs__persister/index.d.ts
+++ b/types/pollyjs__persister/index.d.ts
@@ -1,10 +1,12 @@
 // Type definitions for @pollyjs/persister 2.0
 // Project: https://github.com/netflix/pollyjs/tree/master/packages/@pollyjs/persister
 // Definitions by: feinoujc <https://github.com/feinoujc>
+//                 silverchen <https://github.com/silverchen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export default class Persister {
     static readonly name: string;
     static readonly type: string;
+    options: any;
     persist(): Promise<void>;
 }

--- a/types/pollyjs__persister/index.d.ts
+++ b/types/pollyjs__persister/index.d.ts
@@ -7,6 +7,6 @@
 export default class Persister {
     static readonly name: string;
     static readonly type: string;
-    options: any;
+    readonly options: any;
     persist(): Promise<void>;
 }

--- a/types/pollyjs__persister/pollyjs__persister-tests.ts
+++ b/types/pollyjs__persister/pollyjs__persister-tests.ts
@@ -2,3 +2,6 @@ import Persister from '@pollyjs/persister';
 
 Persister.name;
 Persister.type;
+
+const persister = new Persister();
+persister.options;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Netflix/pollyjs/blob/c82292fa5d995f6e7773730eac0a67d53571e113/packages/%40pollyjs/persister/src/index.js#L29>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
