### PR TITLE
Modify linkifyjs LinkifyOptions interface to allow extra return type for 'format'

### DIFF
--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -17,7 +17,7 @@ export type PossiblyByType<T> = T | { [type: string]: T | React.ReactElement | u
 
 // NOTE: According to the linkifyjs implementation, `format` can be just a
 // string, so we include it (even though this is not mentioned in the docs).
-export type FormatFunc = (value: string, type: string) => string | React.ReactElement;
+export type FormatFunc = (value: string, type: string) => React.ReactNode;
 
 export type EventHandler = (e: HTMLElement) => void;
 

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/SoapBox/linkifyjs#readme
 // Definitions by: Sean Zhu <https://github.com/szhu>
 //                 Ovidiu Bute <https://github.com/ovidiubute>
+//                 Sarah Vessels <https://github.com/cheshire137>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -10,6 +11,8 @@ import * as React from "react";
 export type PossiblyFuncOfHrefAndType<T> =
     | T
     | ((href: string, type: string) => T);
+
+export type ElementOrString = string | Element;
 
 // There's always a possibility that values at a string key can always be
 // undefined; i.e., if the key does not exist.
@@ -94,7 +97,7 @@ export interface LinkifyOptions {
      * NOTE: According to the linkifyjs implementation, `format` can be just a
      * string, but this is not mentioned in the docs, so we exclude it.
      */
-    format?: PossiblyByType<(value: string, type: string) => string>;
+    format?: PossiblyByType<(value: string, type: string) => ElementOrString>;
     //
 
     /**

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -12,11 +12,11 @@ export type PossiblyFuncOfHrefAndType<T> =
     | T
     | ((href: string, type: string) => T);
 
-export type ElementOrString = string | Element;
-
 // There's always a possibility that values at a string key can always be
 // undefined; i.e., if the key does not exist.
-export type PossiblyByType<T> = T | { [type: string]: T | undefined };
+export type PossiblyByType<T> = T | { [type: string]: T | React.ReactElement | undefined };
+
+export type FormatFunc = (value: string, type: string) => string | React.ReactElement;
 
 export type EventHandler = (e: HTMLElement) => void;
 
@@ -97,7 +97,7 @@ export interface LinkifyOptions {
      * NOTE: According to the linkifyjs implementation, `format` can be just a
      * string, but this is not mentioned in the docs, so we exclude it.
      */
-    format?: PossiblyByType<(value: string, type: string) => ElementOrString>;
+    format?: PossiblyByType<FormatFunc>;
     //
 
     /**

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -15,6 +15,8 @@ export type PossiblyFuncOfHrefAndType<T> =
 // undefined; i.e., if the key does not exist.
 export type PossiblyByType<T> = T | { [type: string]: T | React.ReactElement | undefined };
 
+// NOTE: According to the linkifyjs implementation, `format` can be just a
+// string, so we include it (even though this is not mentioned in the docs).
 export type FormatFunc = (value: string, type: string) => string | React.ReactElement;
 
 export type EventHandler = (e: HTMLElement) => void;
@@ -90,9 +92,6 @@ export interface LinkifyOptions {
      *
      * Accepts an object where each key is the link type (e.g., 'url', 'email',
      * etc.) and each value is the formatting function to use for that type.
-     *
-     * NOTE: According to the linkifyjs implementation, `format` can be just a
-     * string, but this is not mentioned in the docs, so we exclude it.
      */
     format?: PossiblyByType<FormatFunc>;
     //

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -31,9 +31,7 @@ export interface LinkifyOptions {
      * Also accepts a function that takes the unformatted href, the link type
      * (e.g., 'url', 'email', etc.) and returns the object.
      */
-    attributes?: PossiblyFuncOfHrefAndType<
-        React.AnchorHTMLAttributes<HTMLAnchorElement>
-    > | null;
+    attributes?: PossiblyFuncOfHrefAndType<React.AnchorHTMLAttributes<HTMLAnchorElement>> | null;
 
     /**
      * className
@@ -168,9 +166,7 @@ export interface LinkifyOptions {
      * Accepts an object where each key is the link type and each value is the
      * target to use for that type.
      */
-    target?: PossiblyByType<
-        PossiblyFuncOfHrefAndType<string | null | undefined>
-    >;
+    target?: PossiblyByType<PossiblyFuncOfHrefAndType<string | null | undefined>>;
 
     /**
      * validate

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/SoapBox/linkifyjs#readme
 // Definitions by: Sean Zhu <https://github.com/szhu>
 //                 Ovidiu Bute <https://github.com/ovidiubute>
-//                 Sarah Vessels <https://github.com/cheshire137>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/linkifyjs/linkifyjs-tests.tsx
+++ b/types/linkifyjs/linkifyjs-tests.tsx
@@ -68,13 +68,17 @@ describe("linkifyjs/html", () => {
         }
     });
 
-    linkifyHtml("", {
+    linkifyHtml('', {
         format(value, type) {
             if (type === 'url') {
                 return <span>{value}</span>;
             }
-            return <span>{value} ({type})</span>;
-        }
+            return (
+                <span>
+                    {value} ({type})
+                </span>
+            );
+        },
     });
 
     linkifyHtml("", {

--- a/types/linkifyjs/linkifyjs-tests.tsx
+++ b/types/linkifyjs/linkifyjs-tests.tsx
@@ -60,6 +60,7 @@ describe("linkifyjs/html", () => {
     /* format */
 
     linkifyHtml("", {
+        // Returns strings
         format(value, type) {
             if (type === "url" && value.length > 50) {
                 value = value.slice(0, 50) + "…";
@@ -68,16 +69,23 @@ describe("linkifyjs/html", () => {
         }
     });
 
-    linkifyHtml('', {
+    linkifyHtml("", {
+        // Returns elements
         format(value, type) {
-            if (type === 'url') {
-                return <span>{value}</span>;
+            if (type === "email") {
+                return <code>{value}</code>;
             }
-            return (
-                <span>
-                    {value} ({type})
-                </span>
-            );
+            return <span>{value}</span>;
+        },
+    });
+
+    linkifyHtml("", {
+        // Returns strings or elements
+        format(value, type) {
+            if (type === "email") {
+                return value;
+            }
+            return <span>{value}</span>;
         },
     });
 

--- a/types/linkifyjs/linkifyjs-tests.tsx
+++ b/types/linkifyjs/linkifyjs-tests.tsx
@@ -69,6 +69,15 @@ describe("linkifyjs/html", () => {
     });
 
     linkifyHtml("", {
+        format(value, type) {
+            if (type === 'url') {
+                return <span>{value}</span>;
+            }
+            return <span>{value} ({type})</span>;
+        }
+    });
+
+    linkifyHtml("", {
         format: {
             url(value) {
                 return value.length > 50 ? value.slice(0, 50) + "…" : value;

--- a/types/linkifyjs/linkifyjs-tests.tsx
+++ b/types/linkifyjs/linkifyjs-tests.tsx
@@ -60,12 +60,12 @@ describe("linkifyjs/html", () => {
     /* format */
 
     linkifyHtml("", {
-        // Returns strings
+        // Returns strings or numbers
         format(value, type) {
             if (type === "url" && value.length > 50) {
                 value = value.slice(0, 50) + "…";
             }
-            return value;
+            return 100;
         }
     });
 
@@ -86,6 +86,26 @@ describe("linkifyjs/html", () => {
                 return value;
             }
             return <span>{value}</span>;
+        },
+    });
+
+    linkifyHtml("", {
+        // Returns null or undefined
+        format(value, type) {
+            if (type === "email") {
+                return null;
+            }
+            return undefined;
+        },
+    });
+
+    linkifyHtml("", {
+        // Returns an array
+        format(value, type) {
+            if (type === "email") {
+                return ["type", type];
+            }
+            return ["value", value];
         },
     });
 


### PR DESCRIPTION
I noticed that I'm able to pass a `format` function that returns either a React component or a string, and Linkify renders either one. This modifies the type declaration for the `format` function so you can return React components in addition to strings. See https://soapbox.github.io/linkifyjs/docs/2.1.html#reactjs-interface for info about the React interface.