### PR TITLE
[@types/gremlin] Moved authentication classes to right namespace

### DIFF
--- a/types/gremlin/gremlin-tests.ts
+++ b/types/gremlin/gremlin-tests.ts
@@ -5,14 +5,13 @@ import {
 } from "gremlin";
 
 const {
-  RemoteConnection,
-  RemoteStrategy,
-  RemoteTraversal,
-  DriverRemoteConnection,
-  Client,
-  ResultSet,
-  Authenticator,
-  PlainTextSaslAuthenticator,
+    RemoteConnection,
+    RemoteStrategy,
+    RemoteTraversal,
+    DriverRemoteConnection,
+    Client,
+    ResultSet,
+    auth: { Authenticator, PlainTextSaslAuthenticator },
 } = driver;
 
 const {

--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -46,14 +46,16 @@ declare namespace driver {
     first(): any;
   }
 
-  class Authenticator {
-    constructor(options?: any);
-    evaluateChallenge(challenge: string): any;
-  }
+ namespace auth {
+    class Authenticator {
+        constructor(options?: any);
+        evaluateChallenge(challenge: string): any;
+      }
 
-  class PlainTextSaslAuthenticator extends Authenticator {
-    constructor(username: string, password: string, authzid?: string);
-    evaluateChallenge(challenge: string): Promise<any>;
+      class PlainTextSaslAuthenticator extends Authenticator {
+          constructor(username: string, password: string, authzid?: string);
+          evaluateChallenge(challenge: string): Promise<any>;
+      }
   }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/tinkerpop/blob/86ac0c86714dea126600481d6f15ae3bd9d9bf38/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js#L49
  - The `Authenticator` & `PlainTextSaslAuthenticator` packages are not exported directly from driver, but rather from `driver.auth` in the npm package.
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **No**, version is stil 3.4.x
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.