### PR TITLE
[react-select] Change type definition for mergeStyles

### DIFF
--- a/types/react-select/src/styles.d.ts
+++ b/types/react-select/src/styles.d.ts
@@ -72,4 +72,4 @@ export const defaultStyles: Styles;
 // Merge Utility
 // Allows consumers to extend a base Select with additional styles
 
-export function mergeStyles(source: any, target: any): CSSProperties;
+export function mergeStyles(source: StylesConfig, target: StylesConfig): StylesConfig;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

mergeStyles (https://github.com/JedWatson/react-select/blob/c22a4b20aef2161ebaa3a0373de7e0e179e73693/packages/react-select/src/styles.js#L100) is actually merging 2 style configs so the type definition should be changed to reflect the correct types.
