### PR TITLE
[@types/graphql-resolvers] Allow passing arbitrary TArgs to all utilities

### DIFF
--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -25,13 +25,9 @@ export function allResolvers<TSource = any, TContext = any, TArgs = TArgsDefault
     resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function resolveDependee(
-    dependeeName: string
-): IFieldResolver<any, any, any>;
+export function resolveDependee(dependeeName: string): IFieldResolver<any, any, any>;
 
-export function resolveDependees(
-    dependeeNames: string[]
-): IFieldResolver<any, any, any>;
+export function resolveDependees(dependeeNames: string[]): IFieldResolver<any, any, any>;
 
 export function isDependee<TSource = any, TContext = any, TArgs = TArgsDefault>(
     resolver: IFieldResolver<TSource, TContext, TArgs>

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for graphql-resolvers 0.2
 // Project: https://github.com/lucasconstantino/graphql-resolvers#readme
 // Definitions by: Mike Engel <https://github.com/mike-engel>
+// Definitions by: Alejandro Corredor <https://github.com/aecorredor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for graphql-resolvers 0.2
 // Project: https://github.com/lucasconstantino/graphql-resolvers#readme
-// Definitions by: Mike Engel <https://github.com/mike-engel>, Alejandro Corredor <https://github.com/aecorredor>
-
+// Definitions by: Mike Engel <https://github.com/mike-engel>
+//                 Alejandro Corredor <https://github.com/aecorredor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mike Engel <https://github.com/mike-engel>
 //                 Alejandro Corredor <https://github.com/aecorredor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 3.0
 
 import { IFieldResolver } from "graphql-tools";
 
@@ -25,13 +25,13 @@ export function allResolvers<TSource = any, TContext = any, TArgs = TArgsDefault
     resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function resolveDependee<TArgs = TArgsDefault>(
+export function resolveDependee(
     dependeeName: string
-): IFieldResolver<any, any, TArgs>;
+): IFieldResolver<any, any, any>;
 
-export function resolveDependees<TArgs = TArgsDefault>(
+export function resolveDependees(
     dependeeNames: string[]
-): IFieldResolver<any, any, TArgs>;
+): IFieldResolver<any, any, any>;
 
 export function isDependee<TSource = any, TContext = any, TArgs = TArgsDefault>(
     resolver: IFieldResolver<TSource, TContext, TArgs>

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for graphql-resolvers 0.2
 // Project: https://github.com/lucasconstantino/graphql-resolvers#readme
 // Definitions by: Mike Engel <https://github.com/mike-engel>
-// Definitions by: Alejandro Corredor <https://github.com/aecorredor>
+//                 Alejandro Corredor <https://github.com/aecorredor>
+
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for graphql-resolvers 0.2
 // Project: https://github.com/lucasconstantino/graphql-resolvers#readme
-// Definitions by: Mike Engel <https://github.com/mike-engel>
-//                 Alejandro Corredor <https://github.com/aecorredor>
+// Definitions by: Mike Engel <https://github.com/mike-engel>, Alejandro Corredor <https://github.com/aecorredor>
 
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6

--- a/types/graphql-resolvers/index.d.ts
+++ b/types/graphql-resolvers/index.d.ts
@@ -8,30 +8,30 @@ import { IFieldResolver } from "graphql-tools";
 
 export const skip: undefined;
 
-export interface TArgs {
+export interface TArgsDefault {
     [argument: string]: any;
 }
 
-export function combineResolvers<TSource = any, TContext = any>(
+export function combineResolvers<TSource = any, TContext = any, TArgs = TArgsDefault>(
     ...resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function pipeResolvers<TSource = any, TContext = any>(
+export function pipeResolvers<TSource = any, TContext = any, TArgs = TArgsDefault>(
     ...resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function allResolvers<TSource = any, TContext = any>(
+export function allResolvers<TSource = any, TContext = any, TArgs = TArgsDefault>(
     resolvers: Array<IFieldResolver<TSource, TContext, TArgs>>
 ): IFieldResolver<TSource, TContext, TArgs>;
 
-export function resolveDependee(
+export function resolveDependee<TArgs = TArgsDefault>(
     dependeeName: string
 ): IFieldResolver<any, any, TArgs>;
 
-export function resolveDependees(
+export function resolveDependees<TArgs = TArgsDefault>(
     dependeeNames: string[]
 ): IFieldResolver<any, any, TArgs>;
 
-export function isDependee<TSource = any, TContext = any>(
+export function isDependee<TSource = any, TContext = any, TArgs = TArgsDefault>(
     resolver: IFieldResolver<TSource, TContext, TArgs>
 ): IFieldResolver<TSource, TContext, TArgs>;

--- a/types/graphql-resolvers/package.json
+++ b/types/graphql-resolvers/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "graphql-tools": "^4.0.2"
+        "graphql-tools": "^4.0.5"
     }
 }


### PR DESCRIPTION
I'm facing an issue when using `graphql-resolvers` along with `graphqlgen` (for generating resolver types: https://github.com/prisma/graphqlgen). I get correct generated types from `graphqlgen`, but when I try to create a resolver using `combineResolvers`, I get a type error.

Here is an example:
```js
contest: combineResolvers(authHelpers.isAuthenticated, contestResolver)
```

The snippet above gives me this typescript error:
```
Types of parameters 'args' and 'args' are incompatible.
    Property 'id' is missing in type 'TArgs' but required in type 'ArgsContest'.
```

Where my `contestResolver` has the type `(parent: undefined, args: QueryResolvers.ArgsContest, ctx: Context, info: GraphQLResolveInfo) => Contest | Promise<Contest>`.

Where `ArgsContests` is  
```
export interface ArgsContest {
    id: string;
}
```

And my `isAuthenticated` resolver has type `(parent: any, args: any, { me }: Context) => ForbiddenError | undefined`.

Since right now I have no way of passing my own `TArgs` I have no other way but to ignore the error.

With this PR I introduce the ability to pass a generic `TArgs` of my liking that let's me make typescript happy when using `graphqlgen` generated types. If no generic for that argument is passed, then `TArgsDefault` is used, which is equivalent to what the previous typings had.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:f changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/prisma/graphqlgen

