### PR TITLE
[cookie-signature] Fix return type of unsign function

### DIFF
--- a/types/cookie-signature/index.d.ts
+++ b/types/cookie-signature/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for cookie-signature 1.0
 // Project: https://github.com/tj/node-cookie-signature, https://github.com/visionmedia/node-cookie-signature
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
+//                 Junyoung Choi <https://github.com/Rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** Sign the given `val` with `secret`. */

--- a/types/cookie-signature/index.d.ts
+++ b/types/cookie-signature/index.d.ts
@@ -10,4 +10,4 @@ export function sign(value: string, secret: string): string;
  * Unsign and decode the given `val` with `secret`,
  * returning `false` if the signature is invalid.
  */
-export function unsign(value: string, secret: string): string | boolean;
+export function unsign(value: string, secret: string): string | false;


### PR DESCRIPTION
`unsign` function returns `string` or `false`, but not `true`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
