### PR TITLE
[@types/react-native-actionsheet] Add missing ActionSheetCustom

### DIFF
--- a/types/react-native-actionsheet/index.d.ts
+++ b/types/react-native-actionsheet/index.d.ts
@@ -7,9 +7,19 @@
 import * as React from 'react';
 
 export interface ActionSheetProps {
-    options: React.ReactNode[];
+    options: string[];
     onPress: (index: number) => void;
     title?: string;
+    message?: string;
+    tintColor?: string;
+    cancelButtonIndex?: number;
+    destructiveButtonIndex?: number;
+}
+
+export interface ActionSheetCustomProps {
+    options: React.ReactNode[];
+    onPress: (index: number) => void;
+    title?: React.ReactNode;
     message?: string;
     tintColor?: string;
     cancelButtonIndex?: number;
@@ -18,5 +28,9 @@ export interface ActionSheetProps {
 }
 
 export default class ActionSheet extends React.Component<ActionSheetProps> {
+    show: () => void;
+}
+
+export class ActionSheetCustom extends React.Component<ActionSheetCustomProps> {
     show: () => void;
 }

--- a/types/react-native-actionsheet/index.d.ts
+++ b/types/react-native-actionsheet/index.d.ts
@@ -22,6 +22,7 @@ export interface ActionSheetCustomProps {
     title?: React.ReactNode;
     message?: string;
     tintColor?: string;
+    buttonUnderlayColor?: string;
     cancelButtonIndex?: number;
     destructiveButtonIndex?: number;
     styles?: object;

--- a/types/react-native-actionsheet/react-native-actionsheet-tests.tsx
+++ b/types/react-native-actionsheet/react-native-actionsheet-tests.tsx
@@ -33,6 +33,7 @@ class CustomSheetExample extends React.Component {
                 title={<Text style={{ color: '#000', fontSize: 18 }}>Which one do you like?</Text>}
                 message="Test"
                 tintColor="white"
+                buttonUnderlayColor="rebeccapurple"
                 cancelButtonIndex={0}
                 destructiveButtonIndex={1}
                 styles={{}}

--- a/types/react-native-actionsheet/react-native-actionsheet-tests.tsx
+++ b/types/react-native-actionsheet/react-native-actionsheet-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import ActionSheet from 'react-native-actionsheet';
+import { Text } from 'react-native';
+import ActionSheet, { ActionSheetCustom } from 'react-native-actionsheet';
 
 class Example extends React.Component {
     render() {
@@ -8,6 +9,28 @@ class Example extends React.Component {
                 options={['1', '2', '3']}
                 onPress={index => {}}
                 title="Test"
+                message="Test"
+                tintColor="white"
+                cancelButtonIndex={0}
+                destructiveButtonIndex={1}
+            />
+        );
+    }
+}
+
+class CustomSheetExample extends React.Component {
+    render() {
+        return (
+            <ActionSheetCustom
+                options={[
+                    'Cancel',
+                    'Apple',
+                    <Text style={{ color: 'yellow' }}>Banana</Text>,
+                    'Watermelon',
+                    <Text style={{ color: 'red' }}>Durian</Text>,
+                ]}
+                onPress={index => {}}
+                title={<Text style={{ color: '#000', fontSize: 18 }}>Which one do you like?</Text>}
                 message="Test"
                 tintColor="white"
                 cancelButtonIndex={0}


### PR DESCRIPTION
Update `@types/react-native-actionsheet` to support [ActionSheetCustom](https://github.com/beefe/react-native-actionsheet#use-actionsheetcustom-directly).

The default `ActionSheet` class should match the options schema from `react-native-actionsheet`: https://github.com/beefe/react-native-actionsheet/blob/master/lib/options.js

The `ActionSheetCustom` class has the same options, but with these differences:

- `title` is a `ReactNode` instead of `string`.
- `options` is a `ReactNode[]` instead of `string[]`.
- `style` object can be given.

I have added a test that matches the example given in `react-native-actionsheet` project's README. I have also tested that the typings are working in my own project where I use the library.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/beefe/react-native-actionsheet#use-actionsheetcustom-directly
