### PR TITLE
[react-helmet] Added TagUpdates type for onChangeClientState

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -10,6 +10,15 @@ type LinkProps = JSX.IntrinsicElements['link'];
 
 type MetaProps = JSX.IntrinsicElements['meta'];
 
+interface TagUpdates {
+    baseTag: Array<any>;
+    linkTags: Array<HTMLLinkElement>;
+    metaTags: Array<HTMLMetaElement>;
+    noscriptTags: Array<any>;
+    scriptTags: Array<HTMLScriptElement>;
+    styleTags: Array<HTMLStyleElement>;
+}
+
 export interface HelmetProps {
     async?: boolean;
     base?: any;
@@ -18,7 +27,7 @@ export interface HelmetProps {
     defer?: boolean;
     encodeSpecialCharacters?: boolean;
     htmlAttributes?: any;
-    onChangeClientState?: (newState: any) => void;
+    onChangeClientState?: (newState: any, addedTags: TagUpdates, removedTags: TagUpdates) => void;
     link?: LinkProps[];
     meta?: MetaProps[];
     noscript?: Array<any>;


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfl/react-helmet/blob/420810c644f94c3743f7b088321dbd62a8037b7b/src/HelmetUtils.js#L358
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


I wasn't able to run linter due to a problem with react: npm wan't able to find `csstype` and [setting `compileOptions.moduleResolution: "node"`](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24788) was failing too with error `Error: Unexpected compiler option moduleResolution`.