### PR TITLE
[mapbox-gl] Added setZoomRate and setWheelZoomRate

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -496,6 +496,10 @@ declare namespace mapboxgl {
         enable(): void;
 
         disable(): void;
+
+        setZoomRate(zoomRate: number): void;
+
+        setWheelZoomRate(wheelZoomRate: number): void;
     }
 
     /**

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -883,3 +883,9 @@ expectType<mapboxgl.Expression>([
 	['concat', ['get', 'area'], 'foobar', { 'font-scale': 0.8 }]
 ]);
 expectType<mapboxgl.Expression>(['coalesce', ['get', 'property'], ['get', 'property']]);
+
+/*
+ *	ScrollZoomHandler
+ */
+expectType<void>(new mapboxgl.Map().scrollZoom.setZoomRate(1));
+expectType<void>(new mapboxgl.Map().scrollZoom.setWheelZoomRate(1));


### PR DESCRIPTION
Hello there, I've added types for methods `setZoomRate` and `setWheelZoomRate` that were previously merged on mapbox-gl repo (https://github.com/mapbox/mapbox-gl-js/pull/7863).
Hope I've done it right!

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-gl-js/pull/7863
