### PR TITLE
[react-big-calendar] Change resourceTitleAccessor return type, remove outdated dayWrapper

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -14,6 +14,7 @@
 //                 Mark Nelissen <https://github.com/marknelissen>
 //                 Eric Kenney <https://github.com/KenneyE>
 //                 Paito Anderson <https://github.com/PaitoAnderson>
+//                 Jan Michalak <https://github.com/michalak111>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { Validator } from 'prop-types';
@@ -137,7 +138,6 @@ export interface Components<TEvent extends object = Event> {
     event?: React.ComponentType<EventProps<TEvent>>;
     eventWrapper?: React.ComponentType<EventWrapperProps<TEvent>>;
     eventContainerWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
-    dayWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     dateCellWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     timeSlotWrapper?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
     timeGutterHeader?: React.SFC | React.Component | React.ComponentClass | JSX.Element;
@@ -301,7 +301,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     resourceAccessor?: keyof TEvent | ((event: TEvent) => any);
     resources?: TResource[];
     resourceIdAccessor?: keyof TResource | ((resource: TResource) => any);
-    resourceTitleAccessor?: keyof TResource | ((resource: TResource) => string);
+    resourceTitleAccessor?: keyof TResource | ((resource: TResource) => any);
     defaultView?: View;
     defaultDate?: Date;
     className?: string;
@@ -326,7 +326,6 @@ export class Calendar<
 
 export interface components {
     dateCellWrapper: React.ComponentType;
-    dayWrapper: React.ComponentType;
     eventWrapper: React.ComponentType<Event>;
 }
 export function globalizeLocalizer(globalizeInstance: object): DateLocalizer;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`resurceTitleAccessor` - we can return any https://github.com/intljusticemission/react-big-calendar/blob/master/src/Calendar.js#L208

`dayWrapper` has been removed here https://github.com/intljusticemission/react-big-calendar/pull/1196
