### PR TITLE
Remove duplicate string, set `event_category` to optional

### DIFF
--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -23,7 +23,6 @@ declare namespace Gtag {
   }
 
   type EventNames = 'add_payment_info'
-    | 'add_payment_info'
     | 'add_to_cart'
     | 'add_to_wishlist'
     | 'begin_checkout'
@@ -67,7 +66,7 @@ declare namespace Gtag {
     transaction_id?: string;
     value?: number;
     event_label?: string;
-    event_category: string;
+    event_category?: string;
   }
 
   type Currency = string | number;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/analytics/devguides/collection/gtagjs/user-timings (Shows `event_category` is not required).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I have talked extensively with the person working on `gtag.js` and have been reassured that no required parameters are enforced in client-side code (it was previously required in an older Google analytics tool (not `gtag.js`)).  Additionally, `EventParams` is a blanket param object type shared across all events, so even if there are required params, what's required for one event might not be for another.