### PR TITLE
[yargs] update definition of .completion() to allow hiding it

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -158,9 +158,9 @@ declare namespace yargs {
         completion(cmd: string, func?: AsyncCompletionFunction): Argv<T>;
         completion(cmd: string, func?: SyncCompletionFunction): Argv<T>;
         completion(cmd: string, func?: PromiseCompletionFunction): Argv<T>;
-        completion(cmd: string, description?: string, func?: AsyncCompletionFunction): Argv<T>;
-        completion(cmd: string, description?: string, func?: SyncCompletionFunction): Argv<T>;
-        completion(cmd: string, description?: string, func?: PromiseCompletionFunction): Argv<T>;
+        completion(cmd: string, description?: string | false, func?: AsyncCompletionFunction): Argv<T>;
+        completion(cmd: string, description?: string | false, func?: SyncCompletionFunction): Argv<T>;
+        completion(cmd: string, description?: string | false, func?: PromiseCompletionFunction): Argv<T>;
 
         /**
          * Tells the parser that if the option specified by `key` is passed in, it should be interpreted as a path to a JSON config file.

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -387,6 +387,35 @@ function Argv$commandModule() {
     const commandArgs3: yargs.Arguments = builder2(yargs).argv;
 }
 
+function Argv$completion_hide() {
+    // no func
+    yargs.completion('completion', false).argv;
+
+    // sync func
+    yargs.completion('complation', false, (current, argv) => {
+        // 'current' is the current command being completed.
+        // 'argv' is the parsed arguments so far.
+        // simply return an array of completions.
+        return ['foo', 'bar'];
+    }).argv;
+
+    // async func
+    yargs.completion('complation', false, (current: string, argv: any, done: (completion: string[]) => void) => {
+        setTimeout(() => {
+            done(['apple', 'banana']);
+        }, 500);
+    }).argv;
+
+    // promise func
+    yargs.completion('complation', false, (current: string, argv: any) => {
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                resolve(['apple', 'banana']);
+            }, 10);
+        });
+    }).argv;
+}
+
 function Argv$completion_sync() {
     const argv = yargs
         .completion('completion', (current, argv) => {


### PR DESCRIPTION
Although the docs only [mention it in a different context](https://github.com/yargs/yargs/blob/master/docs/api.md#commandmodule), passing `false` for a description hides it from the `help` output.
