### PR TITLE
[amplitude-js] Allow setUserId to accept null

### DIFF
--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -36,6 +36,7 @@ module Amplitude.Tests {
         amplitude.setGroup('orgId', '15');
         amplitude.setGroup('orgId', ['15', '16']);
         amplitude.setUserId('joe@gmail.com');
+        amplitude.setUserId(null);
         amplitude.setUserProperties({ 'gender': 'female', 'sign_up_complete': true })
         amplitude.setVersionName('1.12.3');
         amplitude.isNewSession();

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -86,7 +86,7 @@ export class AmplitudeClient {
     getSessionId(): number;
 
     setDomain(domain: string): void;
-    setUserId(userId: string): void;
+    setUserId(userId: string | null): void;
 
     setDeviceId(id: string): void;
     regenerateDeviceId(): void;


### PR DESCRIPTION
According to amplitude JavaScript SDK Reference userId can be null.
This can be used to anonymize users after they log out.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://help.amplitude.com/hc/en-us/articles/115002889587-JavaScript-SDK-Reference
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.