### PR TITLE
Fix @types/frisby expectNot type

### DIFF
--- a/types/frisby/index.d.ts
+++ b/types/frisby/index.d.ts
@@ -35,7 +35,7 @@ export class FrisbySpec {
     del(url: string, params?: {}): FrisbySpec;
     done(doneFn: (...args: any[]) => void): FrisbySpec;
     expect(expectName: string, ...args: any[]): FrisbySpec;
-    expectNot(expectName: string): FrisbySpec;
+    expectNot(expectName: string, ...args: any[]): FrisbySpec;
     fetch(url: string, params?: {}, options?: {}): FrisbySpec;
     fromJSON(json: {}): FrisbySpec;
     get(url: string, params?: {}): FrisbySpec;


### PR DESCRIPTION
firsby's `expectNot` accepts the same arguments as `expect`.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.frisbyjs.com/expectations-assertions.html#expectnothandler-args and https://github.com/vlucas/frisby/blob/602584eaf8c1c3282864f14f530cfc64e4611c5c/src/frisby/spec.js#L377-L391

