### PR TITLE
[@types/react-leaflet] Upgrade to cover v2.3.0 and v2.4.0

### DIFF
--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for react-leaflet 2.2
+// Type definitions for react-leaflet 2.4
 // Project: https://github.com/PaulLeCam/react-leaflet
-// Definitions by: Dave Leaver <https://github.com/danzel>, David Schneider <https://github.com/davschne>, Yui T. <https://github.com/yuit>
+// Definitions by: Dave Leaver <https://github.com/danzel>
+//                 David Schneider <https://github.com/davschne>
+//                 Yui T. <https://github.com/yuit>
+//                 Jeroen Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -137,6 +140,8 @@ export class MapComponent<P extends MapComponentProps, E extends Leaflet.Evented
 
 export interface MapProps extends MapEvents, Leaflet.MapOptions, Leaflet.LocateOptions, Leaflet.FitBoundsOptions {
     animate?: boolean;
+    duration?: number;
+    noMoveStart?: boolean;
     bounds?: Leaflet.LatLngBoundsExpression;
     boundsOptions?: Leaflet.FitBoundsOptions;
     children: Children;

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -469,3 +469,4 @@ export interface ContextProps {
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export function withLeaflet<T extends ContextProps>(WrappedComponent: React.ComponentType<T>): React.ComponentType<Omit<T, 'leaflet'>>;
+export function useLeaflet(): LeafletContext;

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -30,7 +30,8 @@ import {
     ZoomControl,
     LeafletProvider,
     withLeaflet,
-    Viewport
+    Viewport,
+    useLeaflet,
 } from 'react-leaflet';
 const { BaseLayer, Overlay } = LayersControl;
 
@@ -813,3 +814,6 @@ class CustomPolygon extends Path<PolygonProps, L.Polygon> {
     }
 }
 const leafletComponent = withLeaflet<PolygonProps>(CustomPolygon);
+
+// $ExpectType LeafletContext
+useLeaflet();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - v2.3.0 Release Notes: https://github.com/PaulLeCam/react-leaflet/releases/tag/v2.3.0
  - Primary Pull Request for v2.3.0: https://github.com/PaulLeCam/react-leaflet/pull/571/files
  - v2.4.0 Release Notes: https://github.com/PaulLeCam/react-leaflet/releases/tag/v2.4.0
  - Primary Pull Request for v2.4.0: https://github.com/PaulLeCam/react-leaflet/pull/593
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Should be noted that the changes made in v2.3.0 (the `useLeaflet` hook) could be tested better most likely, however I personally cannot figure out how to actually use it, and it's not being covered by any documentation or test code in the library itself. On top of that the fact that as far as I can tell you cannot even really use a Functional Component because you'd want to extend react-leaflet's type of `MapComponent` at the least, which extends `MapEvented` which in turn extends `React.Component`, and not `React.FunctionComponent`. 

That all said, if the library makes it properly clear how to use the `useLeaflet` hook then by all means we can add it to the typings test but until then alas... unless someone has a genius idea.