### PR TITLE
fix(pdfMake): upgrade pageSize type

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -198,7 +198,7 @@ declare module "pdfmake/build/pdfmake" {
         ) => boolean;
         pageMargins?: Margins;
         pageOrientation?: PageOrientation;
-        pageSize?: PageSize;
+        pageSize?: PageSize | { width: number; height: number };
         styles?: Style;
     }
 


### PR DESCRIPTION
Hello ! I upgraded the definition type pdfMake for pageSize object being a string or an object (the link to the documentation is below).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://pdfmake.github.io/docs/document-definition-object/page/>
