### PR TITLE
Simplify PromisedThrow types in chai-as-promised

### DIFF
--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -228,12 +228,8 @@ declare namespace Chai {
 
     interface PromisedThrow {
         (): PromisedAssertion;
-        (expected: string, message?: string): PromisedAssertion;
-        (expected: RegExp, message?: string): PromisedAssertion;
-        (constructor: Error, expected?: string, message?: string): PromisedAssertion;
-        (constructor: Error, expected?: RegExp, message?: string): PromisedAssertion;
-        (constructor: Function, expected?: string, message?: string): PromisedAssertion;
-        (constructor: Function, expected?: RegExp, message?: string): PromisedAssertion;
+        (expected: string | RegExp, message?: string): PromisedAssertion;
+        (constructor: Error | Function, expected?: string | RegExp, message?: string): PromisedAssertion;
     }
 
     interface PromisedRespondTo {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

This change simplifies the types without really changing them, but is required because function overloads do not nicely combine in TypeScript as you might expect. See https://github.com/microsoft/TypeScript/issues/14107 for some background on this. In the following code for example, the last line is an error:

```typescript
function f(arg: RegExp): void;
function f(arg: string): void;
function f() {}

f('hi');
f(/hi/);
f(Math.random() > 0.5 ? /hi/ : 'hi');
```

([Playground demo](https://www.typescriptlang.org/play/#code/GYVwdgxgLglg9mABMAFAQwE4HMBciBKAplgKIAeADgJR4BucMAJgNwCwAUKJLAsutngDOUDDDBYaiekzadw0eElRVEAbwC+HDqgDkACxg6qs1AHoDp49pQBZNFD0A6DGjCM4AWxQqAfIgAMjgCsiAD8iOYwpoh4+obGQA))

Even though the overloads can accept a string or a RegExp, they cannot accept `string | RegExp`. The same is true here. The fix for this is to combine the overloads, and that conveniently also simplifies the types too.