### PR TITLE
[google__maps] Fixes GeocodingComponents

### DIFF
--- a/types/google__maps/google__maps-tests.ts
+++ b/types/google__maps/google__maps-tests.ts
@@ -11,9 +11,18 @@ client
     .geocode({ address: 'Leaning Tower of Pisa' })
     .asPromise()
     .then(response => {
+        console.log(`Geocode Address Results: ${response.json.results.length} ${response.json.status}`);
         response.json.results.forEach(result => {
-            console.log(
-                result.geometry.location
-            );
+            console.log(result.geometry.location);
+        });
+    });
+
+client
+    .geocode({ components: { postal_code: '94043' } })
+    .asPromise()
+    .then(response => {
+        console.log(`Geocode Component Results: ${response.json.results.length} ${response.json.status}`);
+        response.json.results.forEach(result => {
+            console.log(result.geometry.location);
         });
     });

--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1985,7 +1985,7 @@ export interface GeocodingRequest {
  */
 export interface GeocodingComponents {
     /** matches `postal_code` and `postal_code_prefix`. */
-    postalCode?: string;
+    postal_code?: string;
     /**
      * matches a country name or a two letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) country code.
      * **Note:** The API follows the ISO standard for defining countries, and the filtering works best when using
@@ -1997,7 +1997,7 @@ export interface GeocodingComponents {
     /** matches against `locality` and `sublocality` types. */
     locality?: string;
     /** matches all the administrative_area levels. */
-    administrativeArea?: string;
+    administrative_area?: string;
 }
 
 export interface GeocodingResponse<STATUSES = GeocodingResponseStatus> {


### PR DESCRIPTION
The current typings on GeocodingComponents force an invalid query string for geocode api requests. API request parameters use snake_case properties.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering
