### PR TITLE
[express-mung] Add exports to types

### DIFF
--- a/types/express-mung/index.d.ts
+++ b/types/express-mung/index.d.ts
@@ -9,16 +9,18 @@
 
 import { Request, Response, RequestHandler, ErrorRequestHandler } from "express";
 
-// Shut off automatic exporting, strict-export-declare-modifiers lint rule
-export {};
+export type Transform = (body: {}, request: Request, response: Response) => any;
+export type TransformAsync = (body: {}, request: Request, response: Response) => PromiseLike<any>;
+export type TransformHeader = (request: Request, response: Response) => any;
+export type TransformHeaderAsync = (request: Request, response: Response) => PromiseLike<any>;
+export type TransformChunk = (
+    chunk: string | Buffer,
+    encoding: string | null,
+    request: Request,
+    response: Response
+) => string | Buffer;
 
-type Transform = (body: {}, request: Request, response: Response) => any;
-type TransformAsync = (body: {}, request: Request, response: Response) => PromiseLike<any>;
-type TransformHeader = (request: Request, response: Response) => any;
-type TransformHeaderAsync = (request: Request, response: Response) => PromiseLike<any>;
-type TransformChunk = (chunk: string | Buffer, encoding: string | null, request: Request, response: Response) => string | Buffer;
-
-interface Options {
+export interface Options {
     mungError: boolean;
 }
 


### PR DESCRIPTION
In an app I am working on, I realized I wanted to access the types defined in `@types/express-mung` in my source code to construct objects of the same type to pass into `express-mung` functions. I realized they are not exported at the moment. 

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
