### PR TITLE
styled-sytem: Add OpacityProps as extension of ColorProps

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-system 5.0
+// Type definitions for styled-system 5.0.16
 // Project: https://github.com/jxnblk/styled-system#readme
 // Definitions by: Marshall Bowers <https://github.com/maxdeviant>
 //                 Ben McCormick <https://github.com/phobon>
@@ -14,6 +14,7 @@
 //                 Pedro Duarte <https://github.com/peduarte>
 //                 Dhalton Huber <https://github.com/Dhalton>
 //                 Elliot Bonneville <https://github.com/elliotbonneville>
+//                 Jack Caldwell <https://github.com/jackcaldwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -273,7 +274,7 @@ export interface BackgroundColorProps<TLength = TLengthStyledSystem> {
 
 export const backgroundColor: styleFn;
 
-export interface ColorProps extends TextColorProps, BackgroundColorProps {}
+export interface ColorProps extends TextColorProps, BackgroundColorProps, OpacityProps {}
 
 export const color: styleFn;
 


### PR DESCRIPTION
According to the reference table in the Styled System docs, opacity is one of the properties that is included with the 'color' styled function. I've added this change to reflect this. However, I could be misunderstanding, so please let me know if this is the case. Thanks.

Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-system.com/table
- [✓] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [✓] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.