### PR TITLE
styled-system: ColorProps now extends OpacityProps

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -14,6 +14,7 @@
 //                 Pedro Duarte <https://github.com/peduarte>
 //                 Dhalton Huber <https://github.com/Dhalton>
 //                 Elliot Bonneville <https://github.com/elliotbonneville>
+//                 Jack Caldwell <https://github.com/jackcaldwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -273,7 +274,7 @@ export interface BackgroundColorProps<TLength = TLengthStyledSystem> {
 
 export const backgroundColor: styleFn;
 
-export interface ColorProps extends TextColorProps, BackgroundColorProps {}
+export interface ColorProps extends TextColorProps, BackgroundColorProps, OpacityProps {}
 
 export const color: styleFn;
 

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -124,6 +124,8 @@ const test = () => (
         <Box color="grays.0" />
         // background color
         <Box bg="tomato" />
+        // opacity
+        <Box opacity={0.5} />
         // responsive width
         <Box width={[1, 1 / 2, 1 / 4]} />
         <Box width={{ sm: 1, md: 1 / 2, lg: 1 / 4 }} />


### PR DESCRIPTION
Added OpacityProps as one of the interfaces that ColorProps extends. This now lines up with how the library is described in the documentation. See https://styled-system.com/table - 'Color' section.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-system.com/table
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.