### PR TITLE
[proper-lockfile] Patches options.retries with the correct type

### DIFF
--- a/types/proper-lockfile/index.d.ts
+++ b/types/proper-lockfile/index.d.ts
@@ -6,12 +6,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { TimeoutsOptions } from "retry";
+import { OperationOptions } from "retry";
 
 export interface LockOptions {
     stale?: number; // default: 10000
     update?: number; // default: stale/2
-    retries?: number | TimeoutsOptions; // default: 0
+    retries?: number | OperationOptions; // default: 0
     realpath?: boolean; // default: true
     fs?: any; // default: graceful-fs
     onCompromised?: (err: Error) => any; // default: (err) => throw err

--- a/types/proper-lockfile/proper-lockfile-tests.ts
+++ b/types/proper-lockfile/proper-lockfile-tests.ts
@@ -51,3 +51,6 @@ checkSync('', { lockfilePath: 'some/file-lock' }); // $ExpectType boolean
 
 lock('', { retries: 5 });
 lock('', { retries: { retries: 5, factor: 2, minTimeout: 100, randomize: true } });
+
+// regression test for #37313
+lock('', { retries: { maxRetryTime: 20, unref: true } });


### PR DESCRIPTION
`proper-lockfile` is calling `retry.operation()` underneath so the correct type to use
for `LockOptions.retries` is `retry.OperationOptions` and not the more restricted
`retry.TimeoutsOptions`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/moxystudio/node-proper-lockfile/blob/master/lib/lockfile.js#L230
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/baf0d7df5d9e3d850c9c65dd2dbf00287b620d12/types/retry/index.d.ts#L81
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/baf0d7df5d9e3d850c9c65dd2dbf00287b620d12/types/retry/index.d.ts#L83
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.