### PR TITLE
[@types/react-stripe-elements] add TokenType to createToken

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -43,7 +43,7 @@ export namespace ReactStripeElements {
 
     interface StripeProps {
         createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
-        createToken(options?: TokenOptions & { type: TokenType }): Promise<PatchedTokenResponse>;
+        createToken(options?: TokenOptions & { type?: TokenType }): Promise<PatchedTokenResponse>;
         paymentRequest: stripe.Stripe['paymentRequest'];
         createPaymentMethod(
             paymentMethodType: stripe.paymentMethod.paymentMethodType,

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -15,105 +15,99 @@
 import * as React from 'react';
 
 export namespace ReactStripeElements {
-	type ElementChangeResponse = stripe.elements.ElementChangeResponse;
-	type ElementsOptions = stripe.elements.ElementsOptions;
-	type TokenOptions = stripe.TokenOptions;
-	type TokenResponse = stripe.TokenResponse;
-	type SourceResponse = stripe.SourceResponse;
-	type SourceOptions = stripe.SourceOptions;
-	type HTMLStripeElement = stripe.elements.Element;
+    type ElementChangeResponse = stripe.elements.ElementChangeResponse;
+    type ElementsOptions = stripe.elements.ElementsOptions;
+    type TokenOptions = stripe.TokenOptions;
+    type TokenResponse = stripe.TokenResponse;
+    type SourceResponse = stripe.SourceResponse;
+    type SourceOptions = stripe.SourceOptions;
+    type HTMLStripeElement = stripe.elements.Element;
 
-	/**
-	 * There's a bug in @types/stripe which defines the property as
-	 * `declined_code` (with a 'd') but it's in fact `decline_code`
-	 */
-	type PatchedTokenResponse = TokenResponse & {
-		error?: { decline_code?: string };
-	};
+    /**
+     * There's a bug in @types/stripe which defines the property as
+     * `declined_code` (with a 'd') but it's in fact `decline_code`
+     */
+    type PatchedTokenResponse = TokenResponse & {
+        error?: { decline_code?: string };
+    };
 
-	interface StripeProviderOptions {
-		stripeAccount?: string;
-	}
-	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null; } & StripeProviderOptions;
+    interface StripeProviderOptions {
+        stripeAccount?: string;
+    }
+    type StripeProviderProps =
+        | { apiKey: string; stripe?: never } & StripeProviderOptions
+        | { apiKey?: never; stripe: stripe.Stripe | null } & StripeProviderOptions;
 
-  // From https://stripe.com/docs/stripe-js/reference#element-types
-  type TokenType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'paymentRequestButton' | 'iban' | 'idealBank';
+    // From https://stripe.com/docs/stripe-js/reference#element-types
+    type TokenType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'paymentRequestButton' | 'iban' | 'idealBank';
 
-	interface StripeProps {
-		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
-    createToken(options?: TokenOptions & { type: TokenType }): Promise<PatchedTokenResponse>;
-		paymentRequest: stripe.Stripe['paymentRequest'];
-		createPaymentMethod(
-			paymentMethodType: stripe.paymentMethod.paymentMethodType,
-			data?: stripe.CreatePaymentMethodOptions,
-		): Promise<stripe.PaymentMethodResponse>;
-		handleCardPayment(
-			clientSecret: string,
-			options?: stripe.HandleCardPaymentOptions
-		): Promise<stripe.PaymentIntentResponse>;
-		handleCardSetup(
-			clientSecret: string,
-			data?: stripe.HandleCardSetupOptions
-		): Promise<stripe.PaymentIntentResponse>;
-	}
+    interface StripeProps {
+        createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
+        createToken(options?: TokenOptions & { type: TokenType }): Promise<PatchedTokenResponse>;
+        paymentRequest: stripe.Stripe['paymentRequest'];
+        createPaymentMethod(
+            paymentMethodType: stripe.paymentMethod.paymentMethodType,
+            data?: stripe.CreatePaymentMethodOptions
+        ): Promise<stripe.PaymentMethodResponse>;
+        handleCardPayment(
+            clientSecret: string,
+            options?: stripe.HandleCardPaymentOptions
+        ): Promise<stripe.PaymentIntentResponse>;
+        handleCardSetup(
+            clientSecret: string,
+            data?: stripe.HandleCardSetupOptions
+        ): Promise<stripe.PaymentIntentResponse>;
+    }
 
-	interface InjectOptions {
-		withRef?: boolean;
-	}
+    interface InjectOptions {
+        withRef?: boolean;
+    }
 
-	interface InjectedStripeProps {
-		stripe?: StripeProps;
-	}
+    interface InjectedStripeProps {
+        stripe?: StripeProps;
+    }
 
-	interface ElementProps extends ElementsOptions {
-		id?: string;
+    interface ElementProps extends ElementsOptions {
+        id?: string;
 
-		className?: string;
+        className?: string;
 
-		elementRef?(ref: any): void;
+        elementRef?(ref: any): void;
 
-		onChange?(event: ElementChangeResponse): void;
+        onChange?(event: ElementChangeResponse): void;
 
-		onBlur?(event: ElementChangeResponse): void;
+        onBlur?(event: ElementChangeResponse): void;
 
-		onFocus?(event: ElementChangeResponse): void;
+        onFocus?(event: ElementChangeResponse): void;
 
-		onReady?(el: HTMLStripeElement): void;
-	}
+        onReady?(el: HTMLStripeElement): void;
+    }
 }
 
-export class StripeProvider extends React.Component<ReactStripeElements.StripeProviderProps> {
-}
+export class StripeProvider extends React.Component<ReactStripeElements.StripeProviderProps> {}
 
-export class Elements extends React.Component<stripe.elements.ElementsCreateOptions> {
-}
+export class Elements extends React.Component<stripe.elements.ElementsCreateOptions> {}
 
 export function injectStripe<P extends object>(
     WrappedComponent: React.ComponentType<P & ReactStripeElements.InjectedStripeProps>,
-    componentOptions?: ReactStripeElements.InjectOptions): React.ComponentType<P>;
+    componentOptions?: ReactStripeElements.InjectOptions
+): React.ComponentType<P>;
 
-export class CardElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class CardElement extends React.Component<ReactStripeElements.ElementProps> {}
 
-export class CardNumberElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class CardNumberElement extends React.Component<ReactStripeElements.ElementProps> {}
 
-export class CardExpiryElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class CardExpiryElement extends React.Component<ReactStripeElements.ElementProps> {}
 
 export class CardCvcElement extends React.Component<ReactStripeElements.ElementProps> {}
 
 // Deprecated but aliased until react-stripe-elements v5
 export class CardCVCElement extends CardCvcElement {}
 
-export class PostalCodeElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class PostalCodeElement extends React.Component<ReactStripeElements.ElementProps> {}
 
-export class PaymentRequestButtonElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class PaymentRequestButtonElement extends React.Component<ReactStripeElements.ElementProps> {}
 
-export class IbanElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class IbanElement extends React.Component<ReactStripeElements.ElementProps> {}
 
-export class IdealBankElement extends React.Component<ReactStripeElements.ElementProps> {
-}
+export class IdealBankElement extends React.Component<ReactStripeElements.ElementProps> {}

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -36,9 +36,12 @@ export namespace ReactStripeElements {
 	}
 	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null; } & StripeProviderOptions;
 
+  // From https://stripe.com/docs/stripe-js/reference#element-types
+  type TokenType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'paymentRequestButton' | 'iban' | 'idealBank';
+
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
-		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
+    createToken(options?: TokenOptions & { type: TokenType }): Promise<PatchedTokenResponse>;
 		paymentRequest: stripe.Stripe['paymentRequest'];
 		createPaymentMethod(
 			paymentMethodType: stripe.paymentMethod.paymentMethodType,

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -17,7 +17,9 @@ import * as React from 'react';
 export namespace ReactStripeElements {
     type ElementChangeResponse = stripe.elements.ElementChangeResponse;
     type ElementsOptions = stripe.elements.ElementsOptions;
-    type TokenOptions = stripe.TokenOptions;
+    // From https://stripe.com/docs/stripe-js/reference#element-types
+    type TokenType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'paymentRequestButton' | 'iban' | 'idealBank';
+    type TokenOptions = stripe.TokenOptions & { type?: TokenType };
     type TokenResponse = stripe.TokenResponse;
     type SourceResponse = stripe.SourceResponse;
     type SourceOptions = stripe.SourceOptions;
@@ -38,12 +40,9 @@ export namespace ReactStripeElements {
         | { apiKey: string; stripe?: never } & StripeProviderOptions
         | { apiKey?: never; stripe: stripe.Stripe | null } & StripeProviderOptions;
 
-    // From https://stripe.com/docs/stripe-js/reference#element-types
-    type TokenType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'paymentRequestButton' | 'iban' | 'idealBank';
-
     interface StripeProps {
         createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
-        createToken(options?: TokenOptions & { type?: TokenType }): Promise<PatchedTokenResponse>;
+        createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
         paymentRequest: stripe.Stripe['paymentRequest'];
         createPaymentMethod(
             paymentMethodType: stripe.paymentMethod.paymentMethodType,


### PR DESCRIPTION
Solution for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37321. See this issue for more detailed information.

**TL;DR:** The [`react-stripe-elements` docs](https://github.com/stripe/react-stripe-elements#setting-up-your-payment-form-injectstripe) show that you can add a `type` option to `stripe.createToken`. This PR adds that option.

---

If the `type` type exists elsewhere it would be better to reuse it rather than recreating here.

Apologies for prettification commit. Hopefully, this is separated out nicely.

---

Authors: @sonnysangha @9Y5 @thchia @yhnavein @virzak @remotealex @santiagodoldan 
