### PR TITLE
[@types/redux-orm] correct throughFields property on many() object param

### DIFF
--- a/types/redux-orm/fields.d.ts
+++ b/types/redux-orm/fields.d.ts
@@ -8,6 +8,7 @@ export interface AttributeOpts {
 
 export class Attribute extends Field {
     constructor(opts?: AttributeOpts);
+    ['type']: 'attr';
 }
 
 export interface AttributeWithDefault extends Attribute {
@@ -18,10 +19,7 @@ export interface RelationalFieldOpts {
     to: string;
     relatedName?: string;
     through?: string;
-    throughFields?: {
-        to: string;
-        from: string;
-    };
+    throughFields?: [string, string];
     as?: string;
 }
 
@@ -30,14 +28,18 @@ export class RelationalField extends Field {
     constructor(opts: RelationalFieldOpts);
 }
 
-export class OneToOne extends RelationalField {}
+export class OneToOne extends RelationalField {
+    ['type']: 'oneToOne';
+}
 
 export class ForeignKey extends RelationalField {
     readonly index: true;
+    ['type']: 'fk';
 }
 
 export class ManyToMany extends RelationalField {
     readonly index: false;
+    ['type']: 'many';
 }
 
 export interface AttrCreator {

--- a/types/redux-orm/redux-orm-tests.ts
+++ b/types/redux-orm/redux-orm-tests.ts
@@ -44,6 +44,7 @@ class Book extends Model<typeof Book, BookFields> {
     static options = {
         idAttribute: 'title' as const
     };
+
     static reducer(action: RootAction, Book: ModelType<Book>) {
         switch (action.type) {
             case 'CREATE_BOOK':
@@ -380,11 +381,7 @@ const sessionFixture = () => {
 
     type TestSelector = (state: RootState) => Ref<Book>;
 
-    const selector0 = createOrmSelector(
-        orm,
-        s => s.db,
-        session => session.Book.first()!.ref
-    ) as TestSelector;
+    const selector0 = createOrmSelector(orm, s => s.db, session => session.Book.first()!.ref) as TestSelector;
 
     const selector1 = createOrmSelector(
         orm,
@@ -504,3 +501,6 @@ const sessionFixture = () => {
     Book.create({ title: 'foo', publisher: 'error' }); // $ExpectError
     Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: [3, author] }); // $ExpectError
 })();
+
+// redux-orm-types#18
+(() => many({ to: 'Bar', relatedName: 'foos', through: 'FooBar', throughFields: ['foo', 'bar'] }))();


### PR DESCRIPTION
Correct type of `RelationalFieldOpts.throughFields` property

fixes #37293 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
