### PR TITLE
[@types/fnando__sparkline] Amended svg parameter type.

### DIFF
--- a/types/fnando__sparkline/fnando__sparkline-tests.ts
+++ b/types/fnando__sparkline/fnando__sparkline-tests.ts
@@ -4,7 +4,7 @@ import { sparkline } from '@fnando/sparkline';
 import * as sparkline2 from '@fnando/sparkline';
 import sparkline3 from '@fnando/sparkline';
 
-const svg = document.createElement('svg') as any as SVGElement;
+const svg = document.createElement('svg') as any as SVGSVGElement;
 
 // number entries
 sparkline(svg, [1, 2, 3]);

--- a/types/fnando__sparkline/index.d.ts
+++ b/types/fnando__sparkline/index.d.ts
@@ -49,7 +49,7 @@ type SparklineNonNativeOptions<TEntry> = SparklineOptions | SparklineOptionsFetc
  * @param entries You can either provide an array of numbers or an array of objects that respond to .value. If you have a different data structure, see options.fetch.
  * @param options This optional argument allows you to further customize the sparkline.
  */
-export function sparkline<TEntry extends SparklineNativeEntry>(svg: SVGElement, entries: TEntry[], options?: SparklineNativeOptions<TEntry>): string;
-export function sparkline<TEntry>(svg: SVGElement, entries: TEntry[], options: SparklineNonNativeOptions<TEntry>): string;
+export function sparkline<TEntry extends SparklineNativeEntry>(svg: SVGSVGElement, entries: TEntry[], options?: SparklineNativeOptions<TEntry>): string;
+export function sparkline<TEntry>(svg: SVGSVGElement, entries: TEntry[], options: SparklineNonNativeOptions<TEntry>): string;
 
 export default sparkline;


### PR DESCRIPTION
The `svg` argument requires `width`, `height`, and `stroke-width` attributes, which are only present on the `SVGSVGElement`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/@fnando/sparkline
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
