### PR TITLE
[node] Allow undefined being passed as the error parameter

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -122,6 +122,9 @@ import { readFile } from 'fs';
     const arg1: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: Error | null, result: number) => void): void => { });
     const arg1NoResult: (arg: string) => Promise<any> = util.promisify((arg: string, cb: (err: Error | null) => void): void => { });
     const cbOptionalError: () => Promise<void | {}> = util.promisify((cb: (err?: Error | null) => void): void => { cb(); }); // tslint:disable-line void-return
+    const cbUndefinedError: () => Promise<number> = util.promisify(
+        (cb: (err: Error | undefined, length: number) => void) => cb(undefined, 2)
+    );
     assert(typeof util.promisify.custom === 'symbol');
     // util.deprecate
     const foo = () => {};

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -83,24 +83,27 @@ declare module "util" {
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
+    type Errback = (err?: Error | null) => void;
+    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+
     function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: Errback) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: Callback<TResult>) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Errback) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     function promisify(fn: Function): Function;
 

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -83,27 +83,27 @@ declare module "util" {
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
-    type Errback = (err?: Error | null) => void;
-    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+    type Callback = (err?: Error | null) => void;
+    type ValueCallback<TResult> = (err: Error | null | undefined, result: TResult) => void;
 
     function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: Errback) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: Callback<TResult>) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Errback) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<TResult>(fn: (callback: ValueCallback<TResult>) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: Callback) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: ValueCallback<TResult>) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: Callback) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: ValueCallback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Callback) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: ValueCallback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: ValueCallback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: ValueCallback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     function promisify(fn: Function): Function;
 

--- a/types/node/v10/util.d.ts
+++ b/types/node/v10/util.d.ts
@@ -87,24 +87,27 @@ declare module "util" {
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
+    type Errback = (err?: Error | null) => void;
+    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+
     function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: Errback) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: Callback<TResult>) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Errback) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     function promisify(fn: Function): Function;
 

--- a/types/node/v10/util.d.ts
+++ b/types/node/v10/util.d.ts
@@ -87,27 +87,27 @@ declare module "util" {
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
-    type Errback = (err?: Error | null) => void;
-    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+    type Callback = (err?: Error | null) => void;
+    type ValueCallback<TResult> = (err: Error | null | undefined, result: TResult) => void;
 
     function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: Errback) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: Callback<TResult>) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Errback) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<TResult>(fn: (callback: ValueCallback<TResult>) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: Callback) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: ValueCallback<TResult>) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: Callback) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: ValueCallback<TResult>) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: Callback) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: ValueCallback<TResult>) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: ValueCallback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: ValueCallback<TResult>) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     function promisify(fn: Function): Function;
 

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -5678,19 +5678,40 @@ declare module "util" {
     export function callbackify<T1, T2, T3, T4, T5, T6>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void;
     export function callbackify<T1, T2, T3, T4, T5, T6, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
+    type Errback = (err?: Error | null) => void;
+    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+
     export function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    export function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
-    export function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
-    export function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    export function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
-    export function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    export function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    export function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    export function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
-    export function promisify<T1, T2, T3, T4, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    export function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
-    export function promisify<T1, T2, T3, T4, T5, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
-    export function promisify<T1, T2, T3, T4, T5>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
+    export function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
+    export function promisify(fn: (callback: Errback) => void): () => Promise<void>;
+    export function promisify<T1, TResult>(
+        fn: (arg1: T1, callback: Callback<TResult>) => void
+    ): (arg1: T1) => Promise<TResult>;
+    export function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1, T2, TResult>(
+        fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void
+    ): (arg1: T1, arg2: T2) => Promise<TResult>;
+    export function promisify<T1, T2>(
+        fn: (arg1: T1, arg2: T2, callback: Errback) => void
+    ): (arg1: T1, arg2: T2) => Promise<void>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void
+    ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void
+    ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     export function promisify(fn: Function): Function;
 
     export class TextDecoder {

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -5678,39 +5678,39 @@ declare module "util" {
     export function callbackify<T1, T2, T3, T4, T5, T6>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void;
     export function callbackify<T1, T2, T3, T4, T5, T6, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
-    type Errback = (err?: Error | null) => void;
-    type Callback<TResult> = (err: Error | null | undefined, result: TResult) => void;
+    type Callback = (err?: Error | null) => void;
+    type ValueCallback<TResult> = (err: Error | null | undefined, result: TResult) => void;
 
     export function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    export function promisify<TResult>(fn: (callback: Callback<TResult>) => void): () => Promise<TResult>;
-    export function promisify(fn: (callback: Errback) => void): () => Promise<void>;
+    export function promisify<TResult>(fn: (callback: ValueCallback<TResult>) => void): () => Promise<TResult>;
+    export function promisify(fn: (callback: Callback) => void): () => Promise<void>;
     export function promisify<T1, TResult>(
-        fn: (arg1: T1, callback: Callback<TResult>) => void
+        fn: (arg1: T1, callback: ValueCallback<TResult>) => void
     ): (arg1: T1) => Promise<TResult>;
-    export function promisify<T1>(fn: (arg1: T1, callback: Errback) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1>(fn: (arg1: T1, callback: Callback) => void): (arg1: T1) => Promise<void>;
     export function promisify<T1, T2, TResult>(
-        fn: (arg1: T1, arg2: T2, callback: Callback<TResult>) => void
+        fn: (arg1: T1, arg2: T2, callback: ValueCallback<TResult>) => void
     ): (arg1: T1, arg2: T2) => Promise<TResult>;
     export function promisify<T1, T2>(
-        fn: (arg1: T1, arg2: T2, callback: Errback) => void
+        fn: (arg1: T1, arg2: T2, callback: Callback) => void
     ): (arg1: T1, arg2: T2) => Promise<void>;
     export function promisify<T1, T2, T3, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback<TResult>) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, callback: ValueCallback<TResult>) => void
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, callback: Errback) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, callback: Callback) => void
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     export function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback<TResult>) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: ValueCallback<TResult>) => void
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Errback) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: Callback) => void
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback<TResult>) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: ValueCallback<TResult>) => void
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Errback) => void
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: Callback) => void
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     export function promisify(fn: Function): Function;
 


### PR DESCRIPTION
This brings the changed signatures in line with the signatures that doesn't have a `TResult`.

Without this you cannot properly type promisified functions that returns `undefined` instead of `null` when there isn't an error, e.g. `getLength` on `form-data`. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/08977822ee40b69e424b09bdb5f30fb3edbe23a8/lib/internal/util.js#L287
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
