### PR TITLE
react-stripe-elements: fix handleCardSetup return type

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -51,7 +51,7 @@ export namespace ReactStripeElements {
 		handleCardSetup(
 			clientSecret: string,
 			data?: stripe.HandleCardSetupOptions
-		): Promise<stripe.PaymentIntentResponse>;
+		): Promise<stripe.SetupIntentResponse>;
 	}
 
 	interface InjectOptions {

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -300,7 +300,7 @@ class HandleCardSetup extends React.Component<InjectedStripeProps> {
     testHandleCardSetup = () => {
         this.props
             .stripe!.handleCardSetup('clientSecret')
-            .then((response) => response.paymentIntent);
+            .then((response) => response.setupIntent);
     }
 
     testHandleCardSetupWithData = () => {
@@ -312,7 +312,7 @@ class HandleCardSetup extends React.Component<InjectedStripeProps> {
                     }
                 },
             })
-            .then((response) => response.paymentIntent);
+            .then((response) => response.setupIntent);
     }
 
     testHandleCardSetupWithError = () => {


### PR DESCRIPTION
Fixes mistake introduces in #36981

`handleCardSetup` returns a SetupIntent, not a PaymentIntent like `handleCardPayment`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/react-stripe-elements/releases/tag/v4.0.0
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.