### PR TITLE
[@types/eslint] Add properties to Linter.Config type

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -370,6 +370,11 @@ linter.verify(SOURCE, { env: { node: true } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: true } }, 'test.js');
 linter.verify(SOURCE, { parser: 'custom-parser' }, 'test.js');
 linter.verify(SOURCE, { settings: { info: 'foo' } }, 'test.js');
+linter.verify(SOURCE, { processor: 'a-plugin/a-processor' }, 'test.js');
+linter.verify(SOURCE, { plugins: ['a-plugin'] }, 'test.js');
+linter.verify(SOURCE, { root: true }, 'test.js');
+linter.verify(SOURCE, { extends: 'eslint-config-bad-guy' }, 'test.js');
+linter.verify(SOURCE, { extends: ['eslint-config-bad-guy', 'eslint-config-roblox'] }, 'test.js');
 
 linter.verify(SOURCE, { rules: {} }, 'test.js');
 linter.verify(SOURCE, { rules: { quotes: 2 } }, 'test.js');
@@ -378,6 +383,18 @@ linter.verify(SOURCE, { rules: { 'no-unused-vars': [2, { vars: 'all' }] } }, 'te
 linter.verify(SOURCE, { rules: { 'no-console': 1 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 0 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'error' } }, 'test.js');
+linter.verify(SOURCE, {
+    rules: { 'no-console': 'error' },
+    overrides: [
+        {
+            excludedFiles: ['*-test.js', '*.spec.js'],
+            files: ['*-test.js', '*.spec.js'],
+            rules: {
+                'no-unused-expressions': 'off'
+            }
+        }
+    ]
+}, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'warn' } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'off' } }, 'test.js');
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -379,16 +379,28 @@ export namespace Linter {
     interface RuleLevelAndOptions extends Array<any> {
         0: RuleLevel;
     }
-
-    interface Config {
+    interface HasRules {
         rules?: {
             [name: string]: RuleLevel | RuleLevelAndOptions
         };
+    }
+
+    interface RuleOverride extends HasRules {
+        excludedFiles?: string[];
+        files?: string[];
+    }
+
+    interface Config extends HasRules {
         parser?: string;
         parserOptions?: ParserOptions;
         settings?: { [name: string]: any };
         env?: { [name: string]: boolean };
         globals?: { [name: string]: boolean };
+        extends?: string | string[];
+        overrides?: RuleOverride[];
+        processor?: string;
+        plugins?: string[];
+        root?: boolean;
     }
 
     interface ParserOptions {


### PR DESCRIPTION
Makes it so that any valid eslint config can be assignable to type
Linter.Config.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.