### PR TITLE
[cheerio] Add function and map forms of attr

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -55,6 +55,9 @@ var $multiEl = $('selector', 'selector', 'selector');
 $el.attr();
 $el.attr('id');
 $el.attr('id', 'favorite').html();
+$el.attr('id', (el, i, attr) => el.tagName + i * 2 + attr).html();
+$el.attr('id', el => el.tagName).html();
+$el.attr({ id: 'uniq', class: 'big' }).html();
 
 // props
 $el.prop('style')

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -1,9 +1,19 @@
 // Type definitions for Cheerio v0.22.0
 // Project: https://github.com/cheeriojs/cheerio
-// Definitions by: Bret Little <https://github.com/blittle>, VILIC VANE <http://vilic.info>, Wayne Maurer <https://github.com/wmaurer>, Umar Nizamani <https://github.com/umarniz>, LiJinyao <https://github.com/LiJinyao>, Chennakrishna <https://github.com/chennakrishna8>, AzSiAz <https://github.com/AzSiAz>, Ryo Ota <https://github.com/nwtgck>
+// Definitions by: Bret Little <https://github.com/blittle>
+//                 VILIC VANE <http://vilic.info>
+//                 Wayne Maurer <https://github.com/wmaurer>
+//                 Umar Nizamani <https://github.com/umarniz>
+//                 LiJinyao <https://github.com/LiJinyao>
+//                 Chennakrishna <https://github.com/chennakrishna8>
+//                 AzSiAz <https://github.com/AzSiAz>
+//                 Ryo Ota <https://github.com/nwtgck>
+//                 Rebecca Turner <https://github.com/9999years>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
+
+declare type AttrFunction = (el: CheerioElement, i: number, currentValue: string) => any;
 
 interface Cheerio {
     // Document References
@@ -17,7 +27,14 @@ interface Cheerio {
 
     attr(): {[attr: string]: string};
     attr(name: string): string;
-    attr(name: string, value: any): Cheerio;
+    attr(name: string, value: AttrFunction): Cheerio;
+    // `value` *can* be `any` here but:
+    // 1. That makes type-checking the function-type useless
+    // 2. It's converted to a string anyways
+    attr(name: string, value: string): Cheerio;
+    // The map's values *can* be `any` but they'll all be cast to strings
+    // regardless.
+    attr(map: {[key: string]: any}): Cheerio;
 
     data(): any;
     data(name: string): any;


### PR DESCRIPTION
The cheerio docs support passing "a map and function like jQuery"; thisadds those forms of calling `attr` and a few tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/cheerio#attr-name-value-
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**