### PR TITLE
[@types/ws] Add property zlibInflateOptions

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -13,6 +13,7 @@ import * as events from 'events';
 import * as http from 'http';
 import * as https from 'https';
 import * as net from 'net';
+import * as zlib from 'zlib';
 
 // WebSocket socket.
 declare class WebSocket extends events.EventEmitter {
@@ -160,6 +161,7 @@ declare namespace WebSocket {
             dictionary?: Buffer | Buffer[] | DataView;
             info?: boolean;
         };
+        zlibInflateOptions?: zlib.ZlibOptions;
         threshold?: number;
         concurrencyLimit?: number;
     }

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -100,11 +100,14 @@ import * as https from 'https';
                 strategy: 0,
                 dictionary: new Buffer('test'),
                 info: false
+            },
+            zlibInflateOptions: {
+                chunkSize: 0
             }
         },
         verifyClient: (info: any, cb: any) => {
-            cb(true, 123, 'message', { Upgrade: "websocket" });
-        }
+            cb(true, 123, 'message', { Upgrade: 'websocket' });
+        },
     });
 }
 


### PR DESCRIPTION
Add property `zlibInflateOptions`.

`WebSocket.Server` can set `zlibInflateOptions`.
https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.