### PR TITLE
[@types/node] generics on stream API on ts3.2

### DIFF
--- a/types/node/base.d.ts
+++ b/types/node/base.d.ts
@@ -27,7 +27,6 @@
 /// <reference path="querystring.d.ts" />
 /// <reference path="readline.d.ts" />
 /// <reference path="repl.d.ts" />
-/// <reference path="stream.d.ts" />
 /// <reference path="string_decoder.d.ts" />
 /// <reference path="timers.d.ts" />
 /// <reference path="tls.d.ts" />

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -626,31 +626,6 @@ declare namespace NodeJS {
         eventNames(): Array<string | symbol>;
     }
 
-    interface ReadableStream extends EventEmitter {
-        readable: boolean;
-        read(size?: number): string | Buffer;
-        setEncoding(encoding: string): this;
-        pause(): this;
-        resume(): this;
-        isPaused(): boolean;
-        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
-        unpipe(destination?: WritableStream): this;
-        unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
-        wrap(oldStream: ReadableStream): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
-    }
-
-    interface WritableStream extends EventEmitter {
-        writable: boolean;
-        write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
-        write(str: string, encoding?: string, cb?: (err?: Error | null) => void): boolean;
-        end(cb?: () => void): void;
-        end(data: string | Uint8Array, cb?: () => void): void;
-        end(str: string, encoding?: string, cb?: () => void): void;
-    }
-
-    interface ReadWriteStream extends ReadableStream, WritableStream { }
-
     interface Events extends EventEmitter { }
 
     interface Domain extends Events {

--- a/types/node/globals.stream.d.ts
+++ b/types/node/globals.stream.d.ts
@@ -1,0 +1,26 @@
+declare namespace NodeJS {
+  interface ReadableStream extends EventEmitter {
+    readable: boolean;
+    read(size?: number): string | Buffer;
+    setEncoding(encoding: string): this;
+    pause(): this;
+    resume(): this;
+    isPaused(): boolean;
+    pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    unpipe(destination?: WritableStream): this;
+    unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
+    wrap(oldStream: ReadableStream): this;
+    [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+  }
+
+  interface WritableStream extends EventEmitter {
+      writable: boolean;
+      write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
+      write(str: string, encoding?: string, cb?: (err?: Error | null) => void): boolean;
+      end(cb?: () => void): void;
+      end(data: string | Uint8Array, cb?: () => void): void;
+      end(str: string, encoding?: string, cb?: () => void): void;
+  }
+
+  interface ReadWriteStream extends ReadableStream, WritableStream { }
+}

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -54,6 +54,8 @@
 /// <reference path="base.d.ts" />
 
 // TypeScript 2.1-specific augmentations:
+/// <reference path="globals.stream.d.ts" />
+/// <reference path="stream.d.ts" />
 
 // Forward-declarations for needed types from es2015 and later (in case users are using `--lib es5`)
 // Empty interfaces are used here which merge fine with the real declarations in the lib XXX files

--- a/types/node/ts3.2/globals.stream.d.ts
+++ b/types/node/ts3.2/globals.stream.d.ts
@@ -1,0 +1,32 @@
+// tslint:disable-next-line:no-bad-reference
+/// <reference path="./globals.d.ts" />
+
+declare namespace NodeJS {
+  type StreamChunk = any;
+
+  interface ReadableStream<T = StreamChunk> extends EventEmitter {
+      readable: boolean;
+      read(size?: number): T;
+      setEncoding(encoding: string): this;
+      pause(): this;
+      resume(): this;
+      isPaused(): boolean;
+      pipe<W extends WritableStream<T>>(destination: W, options?: { end?: boolean; }): W;
+      unpipe(destination?: WritableStream<T>): this;
+      unshift(chunk: T | null, encoding?: BufferEncoding): void;
+      wrap(oldStream: ReadableStream<T>): this;
+
+      [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+  }
+
+  interface WritableStream<T = StreamChunk> extends EventEmitter {
+      writable: boolean;
+      write(chunk: T, cb?: (err?: Error | null) => void): boolean;
+      write(chunk: T, encoding?: string, cb?: (err?: Error | null) => void): boolean;
+      end(cb?: () => void): void;
+      end(chunk: T | null, cb?: () => void): void;
+      end(chunk: T | null, encoding?: string, cb?: () => void): void;
+  }
+
+  interface ReadWriteStream<W = StreamChunk, R = StreamChunk> extends ReadableStream<R>, WritableStream<W> { }
+}

--- a/types/node/ts3.2/index.d.ts
+++ b/types/node/ts3.2/index.d.ts
@@ -18,3 +18,5 @@
 // TypeScript 3.2-specific augmentations:
 /// <reference path="util.d.ts" />
 /// <reference path="globals.d.ts" />
+/// <reference path="globals.stream.d.ts" />
+/// <reference path="stream.d.ts" />

--- a/types/node/ts3.2/node-tests.ts
+++ b/types/node/ts3.2/node-tests.ts
@@ -17,7 +17,7 @@ import '../process';
 import '../querystring';
 import '../readline';
 import '../repl';
-import '../stream';
+import './stream';
 import '../tls';
 import '../tty';
 import '../util';

--- a/types/node/ts3.2/stream.d.ts
+++ b/types/node/ts3.2/stream.d.ts
@@ -1,0 +1,330 @@
+// tslint:disable-next-line:no-bad-reference
+/// <reference path="./globals.d.ts" />
+/// <reference path="./globals.stream.d.ts" />
+
+declare module "stream" {
+  import * as events from "events";
+
+  class internal<R> extends events.EventEmitter {
+      pipe<T extends NodeJS.WritableStream<R>>(destination: T, options?: { end?: boolean; }): T;
+  }
+
+  namespace internal {
+      class Stream<R = any> extends internal<R> { }
+
+      interface ReadableOptions<T = any> {
+          highWaterMark?: number;
+          encoding?: string;
+          objectMode?: boolean;
+          read?(this: Readable<T>, size: number): void;
+          destroy?(this: Readable<T>, error: Error | null, callback: (error: Error | null) => void): void;
+          autoDestroy?: boolean;
+      }
+
+      class Readable<T = any> extends Stream<T> implements NodeJS.ReadableStream<T> {
+          /**
+           * A utility method for creating Readable Streams out of iterators.
+           */
+          static from<T>(iterable: Iterable<T> | AsyncIterable<T>, options?: ReadableOptions<T>): Readable<T>;
+
+          readable: boolean;
+          readonly readableHighWaterMark: number;
+          readonly readableLength: number;
+          constructor(opts?: ReadableOptions<T>);
+          _read(size: number): void;
+          read(size?: number): T;
+          setEncoding(encoding: string): this;
+          pause(): this;
+          resume(): this;
+          isPaused(): boolean;
+          unpipe(destination?: NodeJS.WritableStream<T>): this;
+
+          /**
+           * Passing chunk as null signals the end of the stream (EOF)
+           */
+          unshift(chunk: T | null, encoding?: BufferEncoding): void;
+
+          wrap(oldStream: NodeJS.ReadableStream<T>): this;
+
+          /**
+           * Passing chunk as null signals the end of the stream (EOF)
+           */
+          push(chunk: T | null, encoding?: string): boolean;
+
+          _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+          destroy(error?: Error): void;
+
+          /**
+           * Event emitter
+           * The defined events on documents including:
+           * 1. close
+           * 2. data
+           * 3. end
+           * 4. readable
+           * 5. error
+           */
+          addListener(event: "close", listener: () => void): this;
+          addListener(event: "data", listener: (chunk: T) => void): this;
+          addListener(event: "end", listener: () => void): this;
+          addListener(event: "readable", listener: () => void): this;
+          addListener(event: "error", listener: (err: Error) => void): this;
+          addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          emit(event: "close"): boolean;
+          emit(event: "data", chunk: T): boolean;
+          emit(event: "end"): boolean;
+          emit(event: "readable"): boolean;
+          emit(event: "error", err: Error): boolean;
+          emit(event: string | symbol, ...args: any[]): boolean;
+
+          on(event: "close", listener: () => void): this;
+          on(event: "data", listener: (chunk: T) => void): this;
+          on(event: "end", listener: () => void): this;
+          on(event: "readable", listener: () => void): this;
+          on(event: "error", listener: (err: Error) => void): this;
+          on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          once(event: "close", listener: () => void): this;
+          once(event: "data", listener: (chunk: T) => void): this;
+          once(event: "end", listener: () => void): this;
+          once(event: "readable", listener: () => void): this;
+          once(event: "error", listener: (err: Error) => void): this;
+          once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          prependListener(event: "close", listener: () => void): this;
+          prependListener(event: "data", listener: (chunk: T) => void): this;
+          prependListener(event: "end", listener: () => void): this;
+          prependListener(event: "readable", listener: () => void): this;
+          prependListener(event: "error", listener: (err: Error) => void): this;
+          prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          prependOnceListener(event: "close", listener: () => void): this;
+          prependOnceListener(event: "data", listener: (chunk: T) => void): this;
+          prependOnceListener(event: "end", listener: () => void): this;
+          prependOnceListener(event: "readable", listener: () => void): this;
+          prependOnceListener(event: "error", listener: (err: Error) => void): this;
+          prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          removeListener(event: "close", listener: () => void): this;
+          removeListener(event: "data", listener: (chunk: T) => void): this;
+          removeListener(event: "end", listener: () => void): this;
+          removeListener(event: "readable", listener: () => void): this;
+          removeListener(event: "error", listener: (err: Error) => void): this;
+          removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+      }
+
+      interface WritableOptions<T = any> {
+          highWaterMark?: number;
+          decodeStrings?: boolean;
+          defaultEncoding?: string;
+          objectMode?: boolean;
+          emitClose?: boolean;
+          write?(this: Writable<T>, chunk: T, encoding: string, callback: (error?: Error | null) => void): void;
+          writev?(this: Writable<T>, chunks: Array<{ chunk: T, encoding: string }>, callback: (error?: Error | null) => void): void;
+          destroy?(this: Writable<T>, error: Error | null, callback: (error: Error | null) => void): void;
+          final?(this: Writable<T>, callback: (error?: Error | null) => void): void;
+          autoDestroy?: boolean;
+      }
+
+      class Writable<T = any> extends Stream implements NodeJS.WritableStream<T> {
+          readonly writable: boolean;
+          readonly writableFinished: boolean;
+          readonly writableHighWaterMark: number;
+          readonly writableLength: number;
+          constructor(opts?: WritableOptions<T>);
+          _write(chunk: T, encoding: string, callback: (error?: Error | null) => void): void;
+          _writev?(chunks: Array<{ chunk: T, encoding: string }>, callback: (error?: Error | null) => void): void;
+          _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+          _final(callback: (error?: Error | null) => void): void;
+          write(chunk: T, cb?: (error: Error | null | undefined) => void): boolean;
+          write(chunk: T, encoding: string, cb?: (error: Error | null | undefined) => void): boolean;
+          setDefaultEncoding(encoding: string): this;
+          end(cb?: () => void): void;
+          end(chunk: T | null, cb?: () => void): void;
+          end(chunk: T | null, encoding: string, cb?: () => void): void;
+          cork(): void;
+          uncork(): void;
+          destroy(error?: Error): void;
+
+          /**
+           * never because it will always throw
+           */
+          pipe(destination: never, options?: { end?: boolean; }): never;
+
+          /**
+           * Event emitter
+           * The defined events on documents including:
+           * 1. close
+           * 2. drain
+           * 3. error
+           * 4. finish
+           * 5. pipe
+           * 6. unpipe
+           */
+          addListener(event: "close", listener: () => void): this;
+          addListener(event: "drain", listener: () => void): this;
+          addListener(event: "error", listener: (err: Error) => void): this;
+          addListener(event: "finish", listener: () => void): this;
+          addListener(event: "pipe", listener: (src: Readable) => void): this;
+          addListener(event: "unpipe", listener: (src: Readable) => void): this;
+          addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          emit(event: "close"): boolean;
+          emit(event: "drain"): boolean;
+          emit(event: "error", err: Error): boolean;
+          emit(event: "finish"): boolean;
+          emit(event: "pipe", src: Readable): boolean;
+          emit(event: "unpipe", src: Readable): boolean;
+          emit(event: string | symbol, ...args: any[]): boolean;
+
+          on(event: "close", listener: () => void): this;
+          on(event: "drain", listener: () => void): this;
+          on(event: "error", listener: (err: Error) => void): this;
+          on(event: "finish", listener: () => void): this;
+          on(event: "pipe", listener: (src: Readable) => void): this;
+          on(event: "unpipe", listener: (src: Readable) => void): this;
+          on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          once(event: "close", listener: () => void): this;
+          once(event: "drain", listener: () => void): this;
+          once(event: "error", listener: (err: Error) => void): this;
+          once(event: "finish", listener: () => void): this;
+          once(event: "pipe", listener: (src: Readable) => void): this;
+          once(event: "unpipe", listener: (src: Readable) => void): this;
+          once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          prependListener(event: "close", listener: () => void): this;
+          prependListener(event: "drain", listener: () => void): this;
+          prependListener(event: "error", listener: (err: Error) => void): this;
+          prependListener(event: "finish", listener: () => void): this;
+          prependListener(event: "pipe", listener: (src: Readable) => void): this;
+          prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+          prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          prependOnceListener(event: "close", listener: () => void): this;
+          prependOnceListener(event: "drain", listener: () => void): this;
+          prependOnceListener(event: "error", listener: (err: Error) => void): this;
+          prependOnceListener(event: "finish", listener: () => void): this;
+          prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
+          prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+          prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+          removeListener(event: "close", listener: () => void): this;
+          removeListener(event: "drain", listener: () => void): this;
+          removeListener(event: "error", listener: (err: Error) => void): this;
+          removeListener(event: "finish", listener: () => void): this;
+          removeListener(event: "pipe", listener: (src: Readable) => void): this;
+          removeListener(event: "unpipe", listener: (src: Readable) => void): this;
+          removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+      }
+
+      interface DuplexOptions<W = any, R = any> extends ReadableOptions<R>, WritableOptions<W> {
+          allowHalfOpen?: boolean;
+          readableObjectMode?: boolean;
+          writableObjectMode?: boolean;
+          read?(this: Duplex<W, R>, size: number): void;
+          write?(this: Duplex<W, R>, chunk: W, encoding: string, callback: (error?: Error | null) => void): void;
+          writev?(this: Duplex<W, R>, chunks: Array<{ chunk: W, encoding: string }>, callback: (error?: Error | null) => void): void;
+          final?(this: Duplex<W, R>, callback: (error?: Error | null) => void): void;
+          destroy?(this: Duplex<W, R>, error: Error | null, callback: (error: Error | null) => void): void;
+      }
+
+      // Note: Duplex extends both Readable and Writable.
+      class Duplex<W = any, R = any> extends Readable<R> implements Writable<W> {
+          readonly writable: boolean;
+          readonly writableFinished: boolean;
+          readonly writableHighWaterMark: number;
+          readonly writableLength: number;
+          constructor(opts?: DuplexOptions<W, R>);
+          _write(chunk: W, encoding: string, callback: (error?: Error | null) => void): void;
+          _writev?(chunks: Array<{ chunk: W, encoding: string }>, callback: (error?: Error | null) => void): void;
+          _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+          _final(callback: (error?: Error | null) => void): void;
+          write(chunk: W, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
+          write(chunk: W, cb?: (error: Error | null | undefined) => void): boolean;
+          setDefaultEncoding(encoding: string): this;
+          end(cb?: () => void): void;
+          end(chunk: W, cb?: () => void): void;
+          end(chunk: W, encoding?: string, cb?: () => void): void;
+          cork(): void;
+          uncork(): void;
+      }
+
+      type TransformCallback<T = any> = (error?: Error | null, data?: T) => void;
+
+      interface TransformOptions<W = any, R = any> extends DuplexOptions<W, R> {
+          read?(this: Transform<W, R>, size: number): void;
+          write?(this: Transform<W, R>, chunk: W, encoding: string, callback: (error?: Error | null) => void): void;
+          writev?(this: Transform<W, R>, chunks: Array<{ chunk: W, encoding: string }>, callback: (error?: Error | null) => void): void;
+          final?(this: Transform<W, R>, callback: (error?: Error | null) => void): void;
+          destroy?(this: Transform<W, R>, error: Error | null, callback: (error: Error | null) => void): void;
+          transform?(this: Transform<W, R>, chunk: W, encoding: string, callback: TransformCallback<R>): void;
+          flush?(this: Transform<W, R>, callback: TransformCallback<R>): void;
+      }
+
+      class Transform<W = any, R = any> extends Duplex<W, R> {
+          constructor(opts?: TransformOptions<W, R>);
+          _transform(chunk: W, encoding: string, callback: TransformCallback<R>): void;
+          _flush(callback: TransformCallback<R>): void;
+      }
+
+      class PassThrough<T = any> extends Transform<T, T> { }
+
+      function finished(stream: NodeJS.ReadWriteStream<unknown, unknown>, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
+      function finished(stream: NodeJS.ReadableStream<unknown>, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
+      function finished(stream: NodeJS.WritableStream<unknown>, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
+      namespace finished {
+          function __promisify__(stream: NodeJS.ReadWriteStream<unknown, unknown>): Promise<void>;
+          function __promisify__(stream: NodeJS.ReadableStream<unknown>): Promise<void>;
+          function __promisify__(stream: NodeJS.WritableStream<unknown>): Promise<void>;
+      }
+
+      function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;
+      function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;
+      function pipeline<T extends NodeJS.WritableStream>(
+          stream1: NodeJS.ReadableStream,
+          stream2: NodeJS.ReadWriteStream,
+          stream3: NodeJS.ReadWriteStream,
+          stream4: T,
+          callback?: (err: NodeJS.ErrnoException | null) => void,
+      ): T;
+      function pipeline<T extends NodeJS.WritableStream>(
+          stream1: NodeJS.ReadableStream,
+          stream2: NodeJS.ReadWriteStream,
+          stream3: NodeJS.ReadWriteStream,
+          stream4: NodeJS.ReadWriteStream,
+          stream5: T,
+          callback?: (err: NodeJS.ErrnoException | null) => void,
+      ): T;
+      function pipeline(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>, callback?: (err: NodeJS.ErrnoException | null) => void): NodeJS.WritableStream;
+      function pipeline(
+          stream1: NodeJS.ReadableStream,
+          stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream,
+          ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream | ((err: NodeJS.ErrnoException | null) => void)>,
+      ): NodeJS.WritableStream;
+      namespace pipeline {
+          function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.WritableStream): Promise<void>;
+          function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.WritableStream): Promise<void>;
+          function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: NodeJS.WritableStream): Promise<void>;
+          function __promisify__(
+              stream1: NodeJS.ReadableStream,
+              stream2: NodeJS.ReadWriteStream,
+              stream3: NodeJS.ReadWriteStream,
+              stream4: NodeJS.ReadWriteStream,
+              stream5: NodeJS.WritableStream,
+          ): Promise<void>;
+          function __promisify__(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>): Promise<void>;
+          function __promisify__(
+              stream1: NodeJS.ReadableStream,
+              stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream,
+              ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream>,
+          ): Promise<void>;
+      }
+
+      interface Pipe { }
+  }
+
+  export = internal;
+}

--- a/types/node/ts3.2/test/stream.ts
+++ b/types/node/ts3.2/test/stream.ts
@@ -1,0 +1,376 @@
+import { Readable, Writable, Transform, finished, pipeline, Duplex } from "stream";
+import { promisify } from "util";
+import { createReadStream, createWriteStream } from "fs";
+import { createGzip, constants } from "zlib";
+import { ok as assert } from 'assert';
+
+// Simplified constructors
+function simplified_stream_ctor_test() {
+    new Readable({
+        read(size) {
+            // $ExpectType Readable<any>
+            this;
+            // $ExpectType number
+            size;
+        },
+        destroy(error, cb) {
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        }
+    });
+
+    new Writable({
+        write(chunk, enc, cb) {
+            // $ExpectType Writable<any>
+            this;
+            // $ExpectType any
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Writable<any>
+            this;
+            // $ExpectType { chunk: any; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Writable<any>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Writable<any>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        }
+    });
+
+    new Duplex({
+        read(size) {
+            // $ExpectType Duplex<any, any>
+            this;
+            // $ExpectType number
+            size;
+        },
+        write(chunk, enc, cb) {
+            // $ExpectType Duplex<any, any>
+            this;
+            // $ExpectType any
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Duplex<any, any>
+            this;
+            // $ExpectType { chunk: any; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Duplex<any, any>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Duplex<any, any>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        readableObjectMode: true,
+        writableObjectMode: true
+    });
+
+    new Transform({
+        read(size) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType number
+            size;
+        },
+        write(chunk, enc, cb) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType any
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType { chunk: any; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        transform(chunk, enc, cb) {
+            // $ExpectType Transform<any, any>
+            this;
+            // $ExpectType any
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType TransformCallback<any>
+            cb;
+        },
+        flush(cb) {
+            // $ExpectType TransformCallback<any>
+            cb;
+        },
+        allowHalfOpen: true,
+        readableObjectMode: true,
+        writableObjectMode: true
+    });
+}
+
+// Simplified generic constructors
+function simplified_generic_stream_ctor_test() {
+    // $ExpectType Uint8Array
+    new Readable<Uint8Array>({
+        read(size) {
+            // $ExpectType Readable<Uint8Array>
+            this;
+            // $ExpectType number
+            size;
+        },
+        destroy(error, cb) {
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        }
+    }).read();
+
+    const writable = new Writable<Buffer>({
+        write(chunk, enc, cb) {
+            // $ExpectType Writable<Buffer>
+            this;
+            // $ExpectType Buffer
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Writable<Buffer>
+            this;
+            // $ExpectType { chunk: Buffer; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Writable<Buffer>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Writable<Buffer>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        }
+    });
+    // $ExpectType boolean
+    writable.write(Buffer.from([1, 2]));
+    // $ExpectError
+    writable.write('abc');
+
+    const duplex = new Duplex<string, Buffer>({
+        read(size) {
+            // $ExpectType Duplex<string, Buffer>
+            this;
+            // $ExpectType number
+            size;
+        },
+        write(chunk, enc, cb) {
+            // $ExpectType Duplex<string, Buffer>
+            this;
+            // $ExpectType string
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Duplex<string, Buffer>
+            this;
+            // $ExpectType { chunk: string; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Duplex<string, Buffer>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Duplex<string, Buffer>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        readableObjectMode: true,
+        writableObjectMode: true
+    });
+
+    // $ExpectType boolean
+    duplex.write('foo');
+    // $ExpectType Buffer
+    duplex.read();
+
+    const transform = new Transform<string, string[]>({
+        read(size) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType number
+            size;
+        },
+        write(chunk, enc, cb) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType string
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        writev(chunks, cb) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType { chunk: string; encoding: string; }[]
+            chunks;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        destroy(error, cb) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType Error | null
+            error;
+            // $ExpectType (error: Error | null) => void
+            cb;
+        },
+        final(cb) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType (error?: Error | null | undefined) => void
+            cb;
+        },
+        transform(chunk, enc, cb) {
+            // $ExpectType Transform<string, string[]>
+            this;
+            // $ExpectType string
+            chunk;
+            // $ExpectType string
+            enc;
+            // $ExpectType TransformCallback<string[]>
+            cb;
+        },
+        flush(cb) {
+            // $ExpectType TransformCallback<string[]>
+            cb;
+        },
+        allowHalfOpen: true,
+        readableObjectMode: true,
+        writableObjectMode: true
+    });
+    /* $ExpectType number */
+    duplex.write('123');
+    // $ExpectType Buffer
+    duplex.read();
+
+    transform.write('abc');
+    transform.read().join('');
+}
+
+function streamPipelineFinished() {
+    const cancel = finished(process.stdin, (err?: Error | null) => {});
+    cancel();
+
+    pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
+}
+
+async function asyncStreamPipelineFinished() {
+    const fin = promisify(finished);
+    await fin(process.stdin);
+
+    const pipe = promisify(pipeline);
+    await pipe(process.stdin, process.stdout);
+}
+
+// http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
+function stream_readable_pipe_test() {
+    const rs = createReadStream(Buffer.from('file.txt'));
+    const r = createReadStream('file.txt');
+    const z = createGzip({ finishFlush: constants.Z_FINISH });
+    const w = createWriteStream('file.txt.gz');
+
+    assert(typeof z.bytesRead === 'number');
+    assert(typeof r.bytesRead === 'number');
+    assert(typeof r.path === 'string');
+    assert(rs.path instanceof Buffer);
+
+    r.pipe(z).pipe(w);
+
+    z.flush();
+    r.close();
+    z.close();
+    rs.close();
+}
+function stream_readable_pipe_generic_test() {
+    const source = new Duplex<string, number>();
+    const middle = new Duplex<number, symbol>();
+    const target = new Writable<symbol>();
+
+    // $ExpectType Writable<symbol>
+    source.pipe(middle).pipe(target);
+
+    // $ExpectError
+    target.pipe(middle);
+}

--- a/types/node/ts3.2/tsconfig.json
+++ b/types/node/ts3.2/tsconfig.json
@@ -1,7 +1,9 @@
 {
     "files": [
         "index.d.ts",
-        "node-tests.ts"
+        "node-tests.ts",
+
+        "test/stream.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",


### PR DESCRIPTION
## DON'T MERGE, This is a proposal

### Current
- Added generic support for every API used on stream
- Duplex and Transform is <Write, Read> because it seems to make sense
- Fix every mismatch that I found between the doc and the type definition
- Pipe on writable isn't valid, because it will always throw
- Is a breaking change, but tried to make it really compatible

### Suggestions
- Make the api more strictly in general
- Use unknown instead of any in listeners and on generic default use the right type
- Remove pipe from writable, it exists but even the doc doesn't say it

### Missing
- `pipeline()` but I will do it, if the proposal will be accepted

### Why breaking change?
```javascript
// this is still valid
new Writable({
    write(chunk, enc, cb) {
        // $ExpectType any
        chunk;
    },
    writev(chunks, cb) {
        // $ExpectType { chunk: any; encoding: string; }[]
        chunks;
    }
});

// because of type inference, this isn't valid anymore
new Writable({
    write(chunk: string, enc, cb) {
        // $ExpectType string
        chunk;
    },
    writev(chunks, cb) {
        // will fail, because now chunk is string
        // $ExpectType { chunk: any; encoding: string; }[]
        chunks;
    }
});

// it's easy to make it compatible again
new Writable<any>({
    write(chunk: string, enc, cb) {
        // $ExpectType string
        chunk;
    },
    writev(chunks, cb) {
        // $ExpectType { chunk: any; encoding: string; }[]
        chunks;
    }
});
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://nodejs.org/api/stream.html)