### PR TITLE
Add missing keyboardHidesTabBar declaration

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -972,6 +972,7 @@ export interface TabViewConfig {
     activeBackgroundColor?: string;
     inactiveTintColor?: string;
     inactiveBackgroundColor?: string;
+    keyboardHidesTabBar?: boolean;
     showLabel?: boolean;
     style?: StyleProp<ViewStyle>;
     labelStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
Adds a missing attribute definition according to what is defined in the tabs project here: https://github.com/react-navigation/tabs/blob/master/src/views/BottomTabBar.js#L24

This was not introduced in a new version, but potentially missed from beforehand.

Should also close off any confusion from this issue: https://github.com/react-navigation/tabs/issues/16

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/react-navigation/tabs/blob/master/src/views/BottomTabBar.js#L24
