### PR TITLE
airtable: Add eachPage() typing

### DIFF
--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -52,6 +52,7 @@ declare global {
         interface Query<TFields extends object> {
             all(): Promise<Response<TFields>>;
             firstPage(): Promise<Response<TFields>>;
+            eachPage(pageCallback: (records: Response<TFields>, next: () => void) => void): Promise<void>;
         }
 
         type Response<TFields> = ReadonlyArray<Row<TFields>>;


### PR DESCRIPTION
Adds typing for the `eachPage` method.

```ts
await base('Some Table').select().eachPage((records, fetchNextPage) => {
   // Do something with the records
   fetchNextPage();
});

// All records  on all pages processed
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Airtable/airtable.js/blob/master/lib/query.js#L58-L108

