### PR TITLE
airtable: add boolean, number, and collaborator field types

### DIFF
--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -3,6 +3,10 @@ import * as Airtable from 'airtable';
 interface Row extends Airtable.FieldSet {
   field1: string;
   attachments: Airtable.Attachment[];
+  booleanField: boolean;
+  numberField: number;
+  singleCollaborator: Airtable.Collaborator;
+  multiCollaborators: Airtable.Collaborator[];
 }
 
 const airtable = new Airtable();
@@ -18,6 +22,8 @@ async () => {
         for (const row of rows) {
             row.id; // $ExpectType string
             row.fields.field1; // $ExpectType string
+            row.fields.booleanField; // $ExpectType boolean
+            row.fields.numberField; // $ExpectType number
             for (const attachment of row.fields.attachments) {
                 attachment.id; // $ExpectType string
                 attachment.filename; // $ExpectType string
@@ -37,6 +43,14 @@ async () => {
                   attachment.thumbnails.small.width; // $ExpectType number
                   attachment.thumbnails.small.url; // $ExpectType string
                 }
+            }
+            row.fields.singleCollaborator.id; // $ExpectType string
+            row.fields.singleCollaborator.email; // $ExpectType string
+            row.fields.singleCollaborator.name; // $ExpectType string
+            for (const collaborator of row.fields.multiCollaborators) {
+                collaborator.id; // $ExpectType string
+                collaborator.email; // $ExpectType string
+                collaborator.name; // $ExpectType string
             }
         }
     }

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -18,6 +18,10 @@ declare global {
             [key: string]:
                 | undefined
                 | string
+                | number
+                | boolean
+                | Collaborator
+                | ReadonlyArray<Collaborator>
                 | ReadonlyArray<string>
                 | ReadonlyArray<Attachment>;
         }
@@ -78,6 +82,12 @@ declare global {
             url: string;
             width: number;
             height: number;
+        }
+
+        interface Collaborator {
+          id: string;
+          email: string;
+          name: string;
         }
     }
 }


### PR DESCRIPTION
Adds additional field types to better model Airtable tables.
 
Example response from Airtable API:
```json
{
    "records": [
        {
            "createdTime": "2019-08-03T19:11:05.000Z",
            "fields": {
                "Example Checkbox": true,
                "Example Collaborator": {
                    "email": "[redacted]",
                    "id": "[redacted]",
                    "name": "John Smith"
                },
                "Example Number": 0,
                "Example Text": "Test name"
            },
            "id": "[redacted]"
        }
    ]
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Can't link to API docs because it's dynamic based on current user's login. Here's screenshot from Airtable docs of an example table with the field types:

![airtable](https://user-images.githubusercontent.com/7342570/62429599-64f37480-b6c5-11e9-878d-a768899ff69a.png)


 


