### PR TITLE
airtable: update SelectOptions to match airtable docs

### DIFF
--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -12,7 +12,27 @@ const base = airtable.base('app id');
 const table = base('table name') as Airtable.Table<Row>;
 
 async () => {
-    const query = table.select();
+    const query = table.select({
+        fields: [
+            'field1',
+        ],
+        filterByFormula: `NOT({Example Text} = '')`,
+        maxRecords: 100,
+        pageSize: 10,
+        sort: [
+            {
+                field: 'field1',
+            },
+            {
+                field: 'attachments',
+                direction: 'asc',
+            },
+        ],
+        view: 'test-view',
+        cellFormat: 'json',
+        timeZone: 'test-tz',
+        userLocale: 'test-locale',
+    });
     {
         const rows = await query.all();
         for (const row of rows) {

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -45,8 +45,21 @@ declare global {
             destroy(...args: any[]): Promise<any>;
         }
 
+        interface SortParameter {
+          field: string;
+          direction?: 'asc' | 'desc';
+        }
+
         interface SelectOptions {
+            fields?: string[];
+            filterByFormula?: string;
+            maxRecords?: number;
+            pageSize?: number;
+            sort?: SortParameter[];
             view?: string;
+            cellFormat?: 'json' | 'string';
+            timeZone?: string;
+            userLocale?: string;
         }
 
         interface Query<TFields extends object> {


### PR DESCRIPTION
Without these additional options the only way to call `.select()` without type errors was to cast to `any`:
```ts
table.select({ maxRecords: 10 } as any);
```

I tried use something like `<keyof TFields>` on the `fields` and `sort` options so those option values can be type checked (and for nicer autocomplete) but since `FieldSet` uses dynamic keys I wasn't successful in getting anything except `string` as the field type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: API docs are behind login-wall. See attachement

![select-docs](https://user-images.githubusercontent.com/7342570/62429997-c3235600-b6cb-11e9-95b7-87b9a0b66715.png)


