### PR TITLE
types/jest: add missing function getTimerCount

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -22,6 +22,7 @@
 //                 Gregor Stamać <https://github.com/gstamac>
 //                 ExE Boss <https://github.com/ExE-Boss>
 //                 Alex Bolenok <https://github.com/quassnoi>
+//                 Mario Beltrán Alarcón <https://github.com/Belco90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -96,6 +97,10 @@ declare namespace jest {
      * to execute in the future.
      */
     function clearAllTimers(): typeof jest;
+    /**
+     * Returns the number of fake timers still left to run.
+     */
+    function getTimerCount(): number;
     /**
      * Indicates that the module system should never return a mocked version
      * of the specified module, including all of the specificied module's dependencies.
@@ -1612,6 +1617,7 @@ declare namespace jest {
 
     interface FakeTimers {
         clearAllTimers(): void;
+        getTimerCount(): number;
         runAllImmediates(): void;
         runAllTicks(): void;
         runAllTimers(): void;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1123,7 +1123,9 @@ const environment = {
         },
         useFakeTimers() {},
         useRealTimers() {},
-        getTimerCount() {},
+        getTimerCount() {
+            return 1;
+        },
     },
     testFilePath: '',
     moduleMocker: {},

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1123,6 +1123,7 @@ const environment = {
         },
         useFakeTimers() {},
         useRealTimers() {},
+        getTimerCount() {},
     },
     testFilePath: '',
     moduleMocker: {},


### PR DESCRIPTION
Add typing for `jest.getTimerCount` method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/en/jest-object#jestgettimercount
