### PR TITLE
Fix up Request.authInfo/user declarations in Passport

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -11,15 +11,18 @@
 
 declare global {
     namespace Express {
+        interface AuthInfo {}
+        interface User {}
+
         interface Request {
-            authInfo?: any;
-            user?: any;
+            authInfo?: AuthInfo;
+            user?: User;
 
             // These declarations are merged into express's Request type
-            login(user: any, done: (err: any) => void): void;
-            login(user: any, options: any, done: (err: any) => void): void;
-            logIn(user: any, done: (err: any) => void): void;
-            logIn(user: any, options: any, done: (err: any) => void): void;
+            login(user: User, done: (err: any) => void): void;
+            login(user: User, options: any, done: (err: any) => void): void;
+            logIn(user: User, done: (err: any) => void): void;
+            logIn(user: User, options: any, done: (err: any) => void): void;
 
             logout(): void;
             logOut(): void;

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -12,7 +12,9 @@
 
 declare global {
     namespace Express {
+        // tslint:disable-next-line:no-empty-interface
         interface AuthInfo {}
+        // tslint:disable-next-line:no-empty-interface
         interface User {}
 
         interface Request {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -6,6 +6,7 @@
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
 //                 Daniel Perez Alvarez <https://github.com/danielpa9708>
 //                 Kevin Stiehl <https://github.com/kstiehl>
+//                 Oleg Vaskevich <https://github.com/vaskevich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -150,6 +150,7 @@ declare global {
     namespace Express {
         interface User {
             username: string;
+            id?: string;
         }
     }
 }

--- a/types/passport/tslint.json
+++ b/types/passport/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "no-unnecessary-generics": false,
         "no-void-expression": false,
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/passport/tslint.json
+++ b/types/passport/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "no-unnecessary-generics": false,
         "no-void-expression": false,
-        "no-empty-interface": false,
         "npm-naming": false
     }
 }


### PR DESCRIPTION
Changing the type from `any` to an interface so that it can be merged as needed by users. I believe this was the intention as there was already a test that was declaring a `User` interface within Express.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.