### PR TITLE
[victory] add `axisValue` to `victory` chart's `VictoryAxis` component props

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1121,6 +1121,12 @@ declare module "victory" {
      */
     axisLabelComponent?: React.ReactElement<any>;
     /**
+     * The axisValue prop may be used instead of axisAngle to position the
+     * dependent axis. Ths prop is useful when dependent axes should line up
+     * with values on the independent axis.
+     */
+    axisValue?: number | string | object;
+    /**
      * This prop specifies whether a given axis is intended to cross another axis.
      */
     crossAxis?: boolean;

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -219,6 +219,14 @@ test = (
     />
 );
 
+test = (
+    <VictoryAxis axisValue={3} />
+)
+
+test = (
+    <VictoryAxis axisValue="series1" />
+)
+
 // VictoryBar test
 test = (
     <VictoryBar

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -221,11 +221,11 @@ test = (
 
 test = (
     <VictoryAxis axisValue={3} />
-)
+);
 
 test = (
     <VictoryAxis axisValue="series1" />
-)
+);
 
 // VictoryBar test
 test = (


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://formidable.com/open-source/victory/docs/victory-axis/#axisvalue
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

