### PR TITLE
react-transition-group: fix export SwitchTransition

### DIFF
--- a/types/react-transition-group/SwitchTransition.d.ts
+++ b/types/react-transition-group/SwitchTransition.d.ts
@@ -48,4 +48,4 @@ declare namespace SwitchTransition {
  */
 declare class SwitchTransition extends Component<SwitchTransition.SwitchTransitionProps> {}
 
-export default SwitchTransition;
+export = SwitchTransition;


### PR DESCRIPTION
Fix the error:
> TS2604: JSX element type 'SwitchTransition' does not have any construct or call signatures


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
