### PR TITLE
[@types/email-templates] fix: render option is not function

### DIFF
--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -33,7 +33,7 @@ interface EmailConfig {
     /**
      * Pass a custom render function if necessary
      */
-    render?: { view: string, locals: any };
+    render?: ( view: string, locals: any ) => Promise<any>;
     /**
      * force text-only rendering of template (disregards template folder)
      */

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -33,7 +33,7 @@ interface EmailConfig {
     /**
      * Pass a custom render function if necessary
      */
-    render?: ( view: string, locals: any ) => Promise<any>;
+    render?: (view: string, locals: any) => Promise<any>;
     /**
      * force text-only rendering of template (disregards template folder)
      */

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-email-templates 3.5
+// Type definitions for node-email-templates 6.0
 // Project: https://github.com/niftylettuce/email-templates
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 //                 Matus Gura <https://github.com/gurisko>


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[ link to source code ](https://github.com/niftylettuce/email-templates/blob/d835be74c3d190c7b9c84e14ba57227d025c503f/src/index.js#L79)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
