### PR TITLE
add undefined as possible setPosition-parameter

### DIFF
--- a/types/ol/Overlay.d.ts
+++ b/types/ol/Overlay.d.ts
@@ -58,7 +58,7 @@ export default class Overlay extends BaseObject {
     setElement(element: HTMLElement): void;
     setMap(map: PluggableMap): void;
     setOffset(offset: number[]): void;
-    setPosition(position: Coordinate): void;
+    setPosition(position: Coordinate | undefined): void;
     setPositioning(positioning: OverlayPositioning): void;
     on(type: string | string[], listener: ((p0: any) => void)): EventsKey | EventsKey[];
     once(type: string | string[], listener: ((p0: any) => void)): EventsKey | EventsKey[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://openlayers.org/en/latest/apidoc/module-ol_Overlay-Overlay.html#setPosition>>

As described in the API, setPosition allows undefined as parameter. Thus the little change.
