### PR TITLE
Simplify .editorconfig & .prettierrc.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,3 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 120
 indent_style = space
-
-[*.md]
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,8 @@ root = true
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[{*.json,*.yml,*.ts,*.tsx,*.md}]
+max_line_length = 120
 indent_style = space
 
+[*.md]
+indent_size = 2

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,20 +1,6 @@
 {
     "$schema": "http://json.schemastore.org/prettierrc",
-
-    "parser": "typescript",
-    "printWidth": 120,
-    "semi": true,
     "singleQuote": true,
-    "tabWidth": 4,
-    "trailingComma": "es5",
-
-    "overrides": [
-        {
-            "files": ["*.md"],
-            "options": {
-                "tabWidth": 2
-            }
-        }
-    ]
+    "trailingComma": "es5"
 }
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json.schemastore.org/prettierrc",
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "all"
 }
 


### PR DESCRIPTION
Move some prettier options to editorconfig, because [prettier supports editorconfig].

[prettier supports editorconfig]: https://prettier.io/blog/2017/12/05/1.9.0.html#add-editorconfig-support-3255-https-githubcom-prettier-prettier-pull-3255-by-josephfrazier-https-githubcom-josephfrazier