### PR TITLE
Add type definitions for `react-inspector`

### DIFF
--- a/types/react-inspector/index.d.ts
+++ b/types/react-inspector/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://formatjs.io/react/, https://github.com/yahoo/react-intl
 // Definitions by: Roger Clotet <https://github.com/rogerclotet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 
@@ -73,9 +73,21 @@ interface InspectorProps {
 }
 
 export class Inspector extends React.Component<InspectorProps & { table?: boolean }> {}
-
 export class ObjectInspector extends React.Component<InspectorProps> {}
-export class DomInspector extends React.Component<Omit<InspectorProps, 'data'> & { data: object }> {}
 export class TableInspector extends React.Component<InspectorProps> {}
+
+interface DomInspectorProps {
+    data: object;
+    name?: string;
+    columns?: ReadonlyArray<string>;
+    expandLevel?: number;
+    expandPaths?: string | ReadonlyArray<string>;
+    showNonenumerable?: boolean;
+    sortObjectKeys?: boolean | ((a: any, b: any) => number);
+    nodeRenderer?: nodeRenderer;
+    theme?: 'chromeLight' | 'chromeDark' | Theme;
+}
+
+export class DomInspector extends React.Component<DomInspectorProps> {}
 
 export default Inspector;

--- a/types/react-inspector/index.d.ts
+++ b/types/react-inspector/index.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for react-inspector 3.0
+// Project: http://formatjs.io/react/, https://github.com/yahoo/react-intl
+// Definitions by: Roger Clotet <https://github.com/rogerclotet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+import * as React from 'react';
+
+type nodeRenderer = (params: {
+    depth: number;
+    name: string;
+    data: any;
+    isNonEnumerable: boolean;
+    expanded: boolean;
+}) => React.ReactNode;
+
+interface Theme {
+    BASE_FONT_FAMILY: string;
+    BASE_FONT_SIZE: string;
+    BASE_LINE_HEIGHT: number;
+
+    BASE_BACKGROUND_COLOR: string;
+    BASE_COLOR: string;
+
+    OBJECT_PREVIEW_ARRAY_MAX_PROPERTIES: number;
+    OBJECT_PREVIEW_OBJECT_MAX_PROPERTIES: number;
+    OBJECT_NAME_COLOR: string;
+    OBJECT_VALUE_NULL_COLOR: string;
+    OBJECT_VALUE_UNDEFINED_COLOR: string;
+    OBJECT_VALUE_REGEXP_COLOR: string;
+    OBJECT_VALUE_STRING_COLOR: string;
+    OBJECT_VALUE_SYMBOL_COLOR: string;
+    OBJECT_VALUE_NUMBER_COLOR: string;
+    OBJECT_VALUE_BOOLEAN_COLOR: string;
+    OBJECT_VALUE_FUNCTION_PREFIX_COLOR: string;
+
+    HTML_TAG_COLOR: string;
+    HTML_TAGNAME_COLOR: string;
+    HTML_TAGNAME_TEXT_TRANSFORM: string;
+    HTML_ATTRIBUTE_NAME_COLOR: string;
+    HTML_ATTRIBUTE_VALUE_COLOR: string;
+    HTML_COMMENT_COLOR: string;
+    HTML_DOCTYPE_COLOR: string;
+
+    ARROW_COLOR: string;
+    ARROW_MARGIN_RIGHT: number;
+    ARROW_FONT_SIZE: number;
+    ARROW_ANIMATION_DURATION: string;
+
+    TREENODE_FONT_FAMILY: string;
+    TREENODE_FONT_SIZE: string;
+    TREENODE_LINE_HEIGHT: number;
+    TREENODE_PADDING_LEFT: number;
+
+    TABLE_BORDER_COLOR: string;
+    TABLE_TH_BACKGROUND_COLOR: string;
+    TABLE_TH_HOVER_COLOR: string;
+    TABLE_SORT_ICON_COLOR: string;
+    TABLE_DATA_BACKGROUND_IMAGE: string;
+    TABLE_DATA_BACKGROUND_SIZE: string;
+}
+
+interface InspectorProps {
+    data: any;
+    name?: string;
+    columns?: ReadonlyArray<string>;
+    expandLevel?: number;
+    expandPaths?: string | ReadonlyArray<string>;
+    showNonenumerable?: boolean;
+    sortObjectKeys?: boolean | ((a: any, b: any) => number);
+    nodeRenderer?: nodeRenderer;
+    theme?: 'chromeLight' | 'chromeDark' | Theme;
+}
+
+export class Inspector extends React.Component<InspectorProps & { table?: boolean }> {}
+
+export class ObjectInspector extends React.Component<InspectorProps> {}
+export class DomInspector extends React.Component<Omit<InspectorProps, 'data'> & { data: object }> {}
+export class TableInspector extends React.Component<InspectorProps> {}
+
+export default Inspector;

--- a/types/react-inspector/package.json
+++ b/types/react-inspector/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "csstype": "^2.0.0"
+    }
+}

--- a/types/react-inspector/react-inspector-tests.tsx
+++ b/types/react-inspector/react-inspector-tests.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import Inspector, { DomInspector, ObjectInspector, TableInspector } from 'react-inspector';
+
+class TestInspector extends React.Component {
+    render() {
+        return (
+            <>
+                <Inspector
+                    data={{ foo: 'bar' }}
+                    name="test"
+                    expandLevel={1}
+                    expandPaths={'foo'}
+                    showNonenumerable={true}
+                    sortObjectKeys
+                    theme={'chromeLight'}
+                />
+                <Inspector
+                    table
+                    data={{ foo: 'bar' }}
+                    name="test"
+                    columns={['foo']}
+                    expandLevel={1}
+                    expandPaths={'foo'}
+                    showNonenumerable={true}
+                    sortObjectKeys
+                    theme={'chromeLight'}
+                />
+            </>
+        );
+    }
+}
+
+class TestObjectInspector extends React.Component {
+    render() {
+        return (
+            <ObjectInspector
+                data={{ foo: 'bar' }}
+                name="test"
+                expandLevel={1}
+                expandPaths={'foo'}
+                showNonenumerable={true}
+                sortObjectKeys
+                theme={'chromeLight'}
+            />
+        );
+    }
+}
+
+class TestDomInspector extends React.Component {
+    render() {
+        return (
+            <DomInspector
+                data={{ foo: 'bar' }}
+                name="test"
+                expandLevel={1}
+                expandPaths={'foo'}
+                showNonenumerable={true}
+                sortObjectKeys
+                theme={'chromeLight'}
+            />
+        );
+    }
+}
+
+class TestTableInspector extends React.Component {
+    render() {
+        return (
+            <TableInspector
+                data={{ foo: 'bar' }}
+                name="test"
+                columns={['foo']}
+                expandLevel={1}
+                expandPaths={'foo'}
+                showNonenumerable={true}
+                sortObjectKeys
+                theme={'chromeLight'}
+            />
+        );
+    }
+}

--- a/types/react-inspector/tsconfig.json
+++ b/types/react-inspector/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "jsx": "react",
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-inspector-tests.tsx"
+    ]
+}

--- a/types/react-inspector/tslint.json
+++ b/types/react-inspector/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type definitions for https://github.com/storybookjs/react-inspector

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.