### PR TITLE
react-pdf: Update some types to use pdfjs-dist for better type safety

### DIFF
--- a/types/react-pdf/dist/Document.d.ts
+++ b/types/react-pdf/dist/Document.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { PDFDocumentProxy } from 'pdfjs-dist';
 
 export type RenderFunction = () => JSX.Element;
 
@@ -68,7 +69,7 @@ export interface Props {
     /**
      * Function called when the document is successfully loaded.
      */
-    onLoadSuccess?: (pdf: any) => void;
+    onLoadSuccess?: (pdf: PDFDocumentProxy) => void;
 
     /**
      * Function called when a password-protected PDF is loaded.

--- a/types/react-pdf/dist/Outline.d.ts
+++ b/types/react-pdf/dist/Outline.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { PDFTreeNode } from 'pdfjs-dist';
 
 export interface Props {
     /**
@@ -21,7 +22,7 @@ export interface Props {
     /**
      * Function called when the outline is successfully retrieved.
      */
-    onLoadSuccess?: (pdf: any) => void;
+    onLoadSuccess?: (outline: PDFTreeNode[]) => void;
 }
 
 export default class Outline extends React.Component<Props> { }

--- a/types/react-pdf/dist/Page.d.ts
+++ b/types/react-pdf/dist/Page.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { PDFPageProxy } from 'pdfjs-dist';
 
 export type RenderFunction = () => JSX.Element;
 
@@ -94,7 +95,7 @@ export interface Props {
     /**
      * Function called when the page is successfully loaded.
      */
-    onLoadSuccess?: (pdf: any) => void;
+    onLoadSuccess?: (page: PDFPageProxy) => void;
 
     /**
      * Function called in case of an error while rendering the page.

--- a/types/react-pdf/index.d.ts
+++ b/types/react-pdf/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: CodeDaraW <https://github.com/CodeDaraW>
 //                 Nathan Hardy <https://github.com/nhardy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import Document from './dist/Document';
 import Page from './dist/Page';

--- a/types/react-pdf/react-pdf-tests.tsx
+++ b/types/react-pdf/react-pdf-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Document, Page } from 'react-pdf';
+import { PDFDocumentProxy } from 'pdfjs-dist';
 
 interface State {
     numPages: number | null;
@@ -15,7 +16,7 @@ export class MyApp extends React.Component<{}, State> {
         };
     }
 
-    onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
+    onDocumentLoadSuccess = ({ numPages }: PDFDocumentProxy) => {
         this.setState({ numPages });
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/wojtekmaj/react-pdf/blob/e99c459bc9585d06ecaf108ca3c5ee7bd71c522a/src/Document.jsx https://github.com/wojtekmaj/react-pdf/blob/e99c459bc9585d06ecaf108ca3c5ee7bd71c522a/src/Page.jsx https://github.com/wojtekmaj/react-pdf/blob/e99c459bc9585d06ecaf108ca3c5ee7bd71c522a/src/Outline.jsx
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Minimum TypeScript version has been bumped to 3.0 to match the types for `pdfjs-dist`.
