### PR TITLE
Slonik - add support for json token type

### DIFF
--- a/types/slonik/index.d.ts
+++ b/types/slonik/index.d.ts
@@ -26,18 +26,7 @@ export type LogicalBooleanOperatorType = 'AND' | 'OR';
 // EXPRESSIONS AND TOKENS
 // ----------------------------------------------------------------------
 
-export type SerializableValueType = 
-    | string 
-    | number 
-    | boolean 
-    | SerializableValueObject 
-    | SerializableValueArray;
-
-interface SerializableValueObject {
-    [x: string]: SerializableValueType;
-}
-
-interface SerializableValueArray extends Array<SerializableValueType> { }
+export type SerializableValueType = any;
 
 export interface IdentifierTokenType {
     names: ReadonlyArray<string>;
@@ -119,6 +108,7 @@ export type SqlTokenType =
     AssignmentListTokenType |
     IdentifierTokenType |
     IdentifierListTokenType |
+    JsonSqlTokenType |
     RawSqlTokenType |
     SqlSqlTokenType<any> |
     TupleListSqlTokenType |

--- a/types/slonik/index.d.ts
+++ b/types/slonik/index.d.ts
@@ -26,7 +26,21 @@ export type LogicalBooleanOperatorType = 'AND' | 'OR';
 // EXPRESSIONS AND TOKENS
 // ----------------------------------------------------------------------
 
-export type SerializableValueType = any;
+export type SerializableValueType =
+    | string
+    | number
+    | boolean
+    | null
+    | object
+    | SerializableValueObject
+    | SerializableValueArray;
+
+export interface SerializableValueObject {
+  [x: string]: SerializableValueType;
+}
+
+export interface SerializableValueArray
+  extends ReadonlyArray<SerializableValueType> {}
 
 export interface IdentifierTokenType {
     names: ReadonlyArray<string>;

--- a/types/slonik/index.d.ts
+++ b/types/slonik/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for slonik 18.2
+// Type definitions for slonik 18.6
 // Project: https://github.com/gajus/slonik#readme
 // Definitions by: Sebastian Sebald <https://github.com/sebald>
 //                 Misha Kaletsky <https://github.com/mmkal>
@@ -25,6 +25,19 @@ export type LogicalBooleanOperatorType = 'AND' | 'OR';
 //
 // EXPRESSIONS AND TOKENS
 // ----------------------------------------------------------------------
+
+export type SerializableValueType = 
+    | string 
+    | number 
+    | boolean 
+    | SerializableValueObject 
+    | SerializableValueArray;
+
+interface SerializableValueObject {
+    [x: string]: SerializableValueType;
+}
+
+interface SerializableValueArray extends Array<SerializableValueType> { }
 
 export interface IdentifierTokenType {
     names: ReadonlyArray<string>;
@@ -58,6 +71,11 @@ export interface ArraySqlTokenType {
     memberType: string;
     type: typeof SlonikSymbol.ArrayTokenSymbol;
     values: PrimitiveValueExpressionType[];
+}
+
+export interface JsonSqlTokenType {
+    value: SerializableValueType;
+    type: typeof SlonikSymbol.JsonTokenSymbol;
 }
 
 export interface TupleSqlTokenType {
@@ -325,6 +343,9 @@ export interface SqlTaggedTemplateType {
     identifierList: (
         identifiers: IdentifierListMemberType[]
     ) => IdentifierListTokenType;
+    json: (
+        value: SerializableValueType
+    ) => JsonSqlTokenType;
     raw: (
         rawSql: string,
         values?: PrimitiveValueExpressionType[]

--- a/types/slonik/slonik-tests.ts
+++ b/types/slonik/slonik-tests.ts
@@ -284,6 +284,33 @@ createTimestampWithTimeZoneTypeParser();
   const query1 = sql`SELECT ${'baz'} FROM (${query0})`;
 
   await connection.query(sql`
+      SELECT (${sql.json([1, 2, { test: 12, other: 'test' }])})
+  `);
+
+  await connection.query(sql`
+      SELECT (${sql.json('test')})
+  `);
+
+  await connection.query(sql`
+      SELECT (${sql.json(null)})
+  `);
+
+  await connection.query(sql`
+      SELECT (${sql.json(123)})
+  `);
+
+  await connection.query(sql`
+      SELECT (${sql.json({
+        nested: {
+          object: { is: { this: 'test', other: 12, and: new Date('123') } },
+        },
+      })})
+  `);
+
+  // $ExpectError
+  sql`SELECT ${sql.json(undefined)}`;
+
+  await connection.query(sql`
       SELECT (${sql.valueList([1, 2, 3])})
   `);
 

--- a/types/slonik/symbols.d.ts
+++ b/types/slonik/symbols.d.ts
@@ -4,6 +4,7 @@ export const BooleanExpressionTokenSymbol: unique symbol;
 export const ComparisonPredicateTokenSymbol: unique symbol;
 export const IdentifierListTokenSymbol: unique symbol;
 export const IdentifierTokenSymbol: unique symbol;
+export const JsonTokenSymbol: unique symbol;
 export const RawSqlTokenSymbol: unique symbol;
 export const SqlTokenSymbol: unique symbol;
 export const ValueListTokenSymbol: unique symbol;


### PR DESCRIPTION
Add JSON helper support.
It's been available for quite some time but wasn't present in the types.
I've opted to use "any" instead of the more rigid Serializable, as json can serialize a very diverse set of objects.
What do you guys think? @gajus @sebald @mmkal 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/slonik/tree/d511ede91da9466864eafaaaa3efbc7e9a22fde1#slonik-query-building-sql-json
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

