### PR TITLE
mocha-steps: update to 1.3 with mocha 6.0

### DIFF
--- a/types/mocha-steps/index.d.ts
+++ b/types/mocha-steps/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for mocha-steps 1.1
+// Type definitions for mocha-steps 1.3
 // Project: https://github.com/rprieto/mocha-steps
 // Definitions by: AryloYeung <https://github.com/Arylo>
+//                 Piotr Roszatycki <https://github.com/dex4er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
 /// <reference types="mocha" />
 
-declare var step: Mocha.IContextDefinition;
-declare var xstep: Mocha.IContextDefinition;
+declare function step(title: string, fn?: Mocha.Func): Mocha.Test;
+declare function xstep(title: string, fn?: Mocha.Func): Mocha.Test;

--- a/types/mocha-steps/index.d.ts
+++ b/types/mocha-steps/index.d.ts
@@ -7,5 +7,10 @@
 
 /// <reference types="mocha" />
 
-declare function step(title: string, fn?: Mocha.Func): Mocha.Test;
-declare function xstep(title: string, fn?: Mocha.Func): Mocha.Test;
+export function step(title: string, fn?: Mocha.Func): Mocha.Test;
+export function xstep(title: string, fn?: Mocha.Func): Mocha.Test;
+
+declare global {
+  function step(title: string, fn?: Mocha.Func): Mocha.Test;
+  function xstep(title: string, fn?: Mocha.Func): Mocha.Test;
+}

--- a/types/mocha-steps/mocha-steps-tests.ts
+++ b/types/mocha-steps/mocha-steps-tests.ts
@@ -1,9 +1,19 @@
+import * as MochaSteps from "mocha-steps";
+
 describe("Mocha Steps Test", () => {
     step("Step Test", () => {
         const module_name = "mocha-steps";
     });
 
     xstep("Skip Step Test", () => {
+        const module_name = "mocha-steps";
+    });
+
+    MochaSteps.step("Step Test", () => {
+        const module_name = "mocha-steps";
+    });
+
+    MochaSteps.xstep("Skip Step Test", () => {
         const module_name = "mocha-steps";
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rprieto/mocha-steps/blob/master/lib/mocha-steps.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`mocha-steps` 1.3 is compatible with Mocha 6.0 now. Package comes with own typings but are not fully correct: the package both exports functions and declares global.
