### PR TITLE
[react-select] Export types from src/types.ts for use by package consumers

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -10,6 +10,33 @@ import { StateManager } from './src/stateManager';
 
 export default StateManager;
 
-export { createFilter } from './src/filters';
+export { createFilter, Config as CreateFilterConfig, Option as CreateFilterOption } from './src/filters';
 export { components } from './src/components/index';
-export { mergeStyles } from './src/styles';
+export { mergeStyles, Styles, StylesConfig, GetStyles } from './src/styles';
+export {
+    ActionMeta,
+    ActionTypes,
+    ClassNameList,
+    ClassNamesState,
+    CommonProps,
+    FocusDirection,
+    FocusEventHandler,
+    GroupedOptionsType,
+    GroupType,
+    InnerRef,
+    InputActionMeta,
+    InputActionTypes,
+    KeyboardEventHandler,
+    MenuPlacement,
+    MenuPosition,
+    MouseEventHandler,
+    OptionProps,
+    OptionsInnerProps,
+    OptionStateProps,
+    OptionsType,
+    PropsWithInnerRef,
+    PropsWithStyles,
+    Theme,
+    ThemeSpacing,
+    ValueType,
+} from './src/types';

--- a/types/react-select/src/components/Option.d.ts
+++ b/types/react-select/src/components/Option.d.ts
@@ -1,43 +1,7 @@
-import { ComponentType, ReactNode, MouseEventHandler } from 'react';
+import { CSSProperties, ComponentType } from 'react';
+import { OptionProps, OptionStateProps } from '../types';
 
-import { colors, spacing } from '../theme';
-import { CommonProps, PropsWithStyles, InnerRef } from '../types';
-
-interface State {
-  /** Whether the option is disabled. */
-  isDisabled: boolean;
-  /** Whether the option is focused. */
-  isFocused: boolean;
-  /** Whether the option is selected. */
-  isSelected: boolean;
-}
-interface InnerProps {
-  id: string;
-  key: string;
-  onClick: MouseEventHandler<HTMLDivElement>;
-  onMouseMove: MouseEventHandler<HTMLDivElement>;
-  onMouseOver: MouseEventHandler<HTMLDivElement>;
-  tabIndex: number;
-}
-export type OptionProps<OptionType> = PropsWithStyles &
-  CommonProps<OptionType> &
-  State & {
-    /** The children to be rendered. */
-    children: ReactNode,
-    /** Inner ref to DOM Node */
-    innerRef: InnerRef,
-    /** props passed to the wrapping element for the group. */
-    innerProps: InnerProps,
-    /* Text to be displayed representing the option. */
-    label: string,
-    /* Type is used by the menu to determine whether this is an option or a group.
-    In the case of option this is always `option`. */
-    type: 'option',
-    /* The data of the selected option. */
-    data: any,
-  };
-
-export function optionCSS(state: State): React.CSSProperties;
+export function optionCSS(state: OptionStateProps): CSSProperties;
 
 export const Option: ComponentType<OptionProps<any>>;
 

--- a/types/react-select/src/components/index.d.ts
+++ b/types/react-select/src/components/index.d.ts
@@ -40,9 +40,10 @@ import MultiValue, {
   MultiValueLabel,
   MultiValueRemove,
 } from './MultiValue';
-import Option, { OptionProps } from './Option';
+import Option from './Option';
 import Placeholder, { PlaceholderProps } from './Placeholder';
 import SingleValue, { SingleValueProps } from './SingleValue';
+import { OptionProps } from '../types';
 
 export type PlaceholderOrValue<OptionType> =
   | Element<ComponentType<PlaceholderProps<OptionType>>>

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -10,7 +10,7 @@ import { stripDiacritics } from './diacritics';
 
 export interface Option<OptionType = any> { label: string; value: string; data: OptionType; }
 
-export function createFilter<OptionType = Option<any>>(config: Config<OptionType> | null): (
+export function createFilter<OptionType = Option>(config: Config<OptionType> | null): (
   option: OptionType,
   rawInput: string
 ) => boolean;

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -1,16 +1,16 @@
-export interface Config {
+export interface Config<OptionType = any> {
   ignoreCase?: boolean;
   ignoreAccents?: boolean;
-  stringify?: (obj: any) => string;
+  stringify?: (obj: OptionType) => string;
   trim?: boolean;
   matchFrom?: 'any' | 'start';
 }
 
 import { stripDiacritics } from './diacritics';
 
-export interface Option { label: string; value: string; data: any; }
+export interface Option<OptionType = any> { label: string; value: string; data: OptionType; }
 
-export function createFilter(config: Config | null): (
-  option: Option,
+export function createFilter<OptionType = Option<any>>(config: Config<OptionType> | null): (
+  option: OptionType,
   rawInput: string
 ) => boolean;

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
@@ -87,17 +88,41 @@ export type FocusDirection =
   | 'first'
   | 'last';
 
-export type OptionProps = PropsWithInnerRef & {
-  data: any,
-  id: number,
-  index: number,
-  isDisabled: boolean,
-  isFocused: boolean,
-  isSelected: boolean,
+
+interface OptionsInnerProps {
+  id: string;
+  key: string;
+  onClick: MouseEventHandler;
+  onMouseMove: MouseEventHandler;
+  onMouseOver: MouseEventHandler;
+  tabIndex: number;
+}
+
+export interface OptionStateProps {
+  /** Whether the option is disabled. */
+  isDisabled: boolean;
+  /** Whether the option is focused. */
+  isFocused: boolean;
+  /** Whether the option is selected. */
+  isSelected: boolean;
+}
+
+export type OptionProps<OptionType> = PropsWithStyles &
+  CommonProps<OptionType> &
+  OptionStateProps & {
+  /** The children to be rendered. */
+  children: ReactNode,
+  /** Inner ref to DOM Node */
+  innerRef: InnerRef,
+  /** props passed to the wrapping element for the group. */
+  innerProps: OptionsInnerProps,
+  /* Text to be displayed representing the option. */
   label: string,
-  onClick: MouseEventHandler,
-  onMouseOver: MouseEventHandler,
-  value: any,
+  /* Type is used by the menu to determine whether this is an option or a group.
+  In the case of option this is always `option`. */
+  type: 'option',
+  /* The data of the selected option. */
+  data: OptionType,
 };
 
 export interface ThemeSpacing {

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import * as React from 'react';
 import { Props as SelectProps } from './Select';
 
@@ -88,8 +87,7 @@ export type FocusDirection =
   | 'first'
   | 'last';
 
-
-interface OptionsInnerProps {
+export interface OptionsInnerProps {
   id: string;
   key: string;
   onClick: MouseEventHandler;
@@ -111,7 +109,7 @@ export type OptionProps<OptionType> = PropsWithStyles &
   CommonProps<OptionType> &
   OptionStateProps & {
   /** The children to be rendered. */
-  children: ReactNode,
+  children: React.ReactNode,
   /** Inner ref to DOM Node */
   innerRef: InnerRef,
   /** props passed to the wrapping element for the group. */


### PR DESCRIPTION
The types in src/types are useful to users of react-select who want to write custom `Option` components or reuse those types and interfaces in their own props for any reason.  The main purpose of this PR is to export those types from the top level of the package so they can be used safely.

Importing them from a subpath in the package confuses non-typescript processors who are looking at the implementation files instead of the typings files.

This also has a fix for `createFilter` to make it generic to option type, and merges two slightly different definitions of `OptionProps` into one shared definition.

- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37444

