### PR TITLE
[react-select] Use a common interface for OptionProps

### DIFF
--- a/types/react-select/src/components/Option.d.ts
+++ b/types/react-select/src/components/Option.d.ts
@@ -1,44 +1,10 @@
-import { ComponentType, ReactNode, MouseEventHandler } from 'react';
+import { CSSProperties, ComponentType } from 'react';
+import { OptionProps, OptionStateProps } from '../types';
 
-import { colors, spacing } from '../theme';
-import { CommonProps, PropsWithStyles, InnerRef } from '../types';
-
-interface State {
-  /** Whether the option is disabled. */
-  isDisabled: boolean;
-  /** Whether the option is focused. */
-  isFocused: boolean;
-  /** Whether the option is selected. */
-  isSelected: boolean;
-}
-interface InnerProps {
-  id: string;
-  key: string;
-  onClick: MouseEventHandler<HTMLDivElement>;
-  onMouseMove: MouseEventHandler<HTMLDivElement>;
-  onMouseOver: MouseEventHandler<HTMLDivElement>;
-  tabIndex: number;
-}
-export type OptionProps<OptionType> = PropsWithStyles &
-  CommonProps<OptionType> &
-  State & {
-    /** The children to be rendered. */
-    children: ReactNode,
-    /** Inner ref to DOM Node */
-    innerRef: InnerRef,
-    /** props passed to the wrapping element for the group. */
-    innerProps: InnerProps,
-    /* Text to be displayed representing the option. */
-    label: string,
-    /* Type is used by the menu to determine whether this is an option or a group.
-    In the case of option this is always `option`. */
-    type: 'option',
-    /* The data of the selected option. */
-    data: any,
-  };
-
-export function optionCSS(state: State): React.CSSProperties;
+export function optionCSS(state: OptionStateProps): CSSProperties;
 
 export const Option: ComponentType<OptionProps<any>>;
+
+export { OptionProps };
 
 export default Option;

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -87,17 +87,40 @@ export type FocusDirection =
   | 'first'
   | 'last';
 
-export type OptionProps = PropsWithInnerRef & {
-  data: any,
-  id: number,
-  index: number,
-  isDisabled: boolean,
-  isFocused: boolean,
-  isSelected: boolean,
+export interface OptionsInnerProps {
+  id: string;
+  key: string;
+  onClick: MouseEventHandler;
+  onMouseMove: MouseEventHandler;
+  onMouseOver: MouseEventHandler;
+  tabIndex: number;
+}
+
+export interface OptionStateProps {
+  /** Whether the option is disabled. */
+  isDisabled: boolean;
+  /** Whether the option is focused. */
+  isFocused: boolean;
+  /** Whether the option is selected. */
+  isSelected: boolean;
+}
+
+export type OptionProps<OptionType> = PropsWithStyles &
+  CommonProps<OptionType> &
+  OptionStateProps & {
+  /** The children to be rendered. */
+  children: React.ReactNode,
+  /** Inner ref to DOM Node */
+  innerRef: InnerRef,
+  /** props passed to the wrapping element for the group. */
+  innerProps: OptionsInnerProps,
+  /* Text to be displayed representing the option. */
   label: string,
-  onClick: MouseEventHandler,
-  onMouseOver: MouseEventHandler,
-  value: any,
+  /* Type is used by the menu to determine whether this is an option or a group.
+  In the case of option this is always `option`. */
+  type: 'option',
+  /* The data of the selected option. */
+  data: OptionType,
 };
 
 export interface ThemeSpacing {


### PR DESCRIPTION
Previously there were two types named `OptionProps`, this merges them
into one.

Otherwise you might run into problems where you want to create a component that forwards props into `OptionProps` but the types don't match up. e.g.

```
import { components } from 'react-select';
import { OptionProps } from 'react-select/src/types';

const MyCustomOption: ComponentType<OptionProps> = props => {
    return (
      <components.Option {...props} label={bundle.title}>
          Hello {props.data.name}        
      </components.Option>
    );
  };
```

In this case you get a type error because `components.Option` accepts a different kind of `OptionProps` than the one you can import from.

The workaround (without this fix) is to use `props as any` when passing to `components.Option` but it's not ideal.
