### PR TITLE
[@mapbox/mapbox-sdk] Use correct type for overlay

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1338,7 +1338,7 @@ declare module '@mapbox/mapbox-sdk/services/static' {
     }
 
     interface GeoJsonOverlay {
-        geoJson: GeoJSON.GeoJsonTypes;
+        geoJson: GeoJSON.GeoJSON;
     }
 }
 

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -3,6 +3,8 @@ import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 import Directions, { DirectionsService, DirectionsResponse } from '@mapbox/mapbox-sdk/services/directions';
 import Styles, { StylesService } from '@mapbox/mapbox-sdk/services/styles';
+import StaticMap, { StaticMapService } from '@mapbox/mapbox-sdk/services/static';
+import { LineString } from 'geojson';
 
 const config: SdkConfig = {
     accessToken: 'access-token',
@@ -33,4 +35,22 @@ stylesService.putStyleIcon({
     styleId: 'style-id',
     iconId: 'icon-id',
     file: 'path-to-file.file'
+});
+
+const staticMapService: StaticMapService = StaticMap(client);
+const geoOverlay: LineString = {
+    type: 'LineString',
+    coordinates: [[0, 1], [2, 3]]
+};
+staticMapService.getStaticImage({
+    ownerId: 'owner-id',
+    styleId: 'some-style',
+    width: 16,
+    height: 16,
+    position: 'auto',
+    overlays: [
+        {
+            geoJson: geoOverlay
+        }
+    ]
 });


### PR DESCRIPTION
Hey, I'm fixing a mistake with the types I'd put up a PR for not long ago. The type in question mentions it should be any valid GeoJSON for the `GeoJsonOverlay` interface, I'd incorrectly used the type which refers to all the valid string values for GeoJSON types rather than the actual GeoJSON types themselves. Thanks for taking a look!

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-sdk-js/blob/c0ae1604f9f05a91335c70a8535597e1517c1acb/docs/services.md#geojsonoverlay
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (no version change of the base lib, just a mistake in the types)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.