### PR TITLE
[chai] Provide type definitions for chai.use

### DIFF
--- a/types/bardjs/index.d.ts
+++ b/types/bardjs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wardbell/bardjs
 // Definitions by: Andrew Archibald <https://github.com/TepigMC>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 /// <reference types="angular" />
 /// <reference types="chai" />

--- a/types/chai-almost/index.d.ts
+++ b/types/chai-almost/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/nmuldavin/chai-almost#readme
 // Definitions by: Lennard Schulz <https://github.com/kclnn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -29,5 +30,5 @@ declare global {
     }
 }
 
-declare function chaiAlmost(tolerance?: number): ((chai: any, utils: any) => void);
+declare function chaiAlmost(tolerance?: number): Chai.ChaiPlugin;
 export = chaiAlmost;

--- a/types/chai-arrays/index.d.ts
+++ b/types/chai-arrays/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/GaneshSPatil/chai-arrays
 // Definitions by: Clément Prévot <https://github.com/clementprevot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -27,11 +28,7 @@ declare global {
             sorted(val: any[], msg?: string): void;
         }
     }
-
-    interface Array<T> {
-        should: Chai.Assertion;
-    }
 }
 
-declare function chaiArrays(chai: any, utils: any): void;
+declare const chaiArrays: Chai.ChaiPlugin;
 export = chaiArrays;

--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -6,18 +6,17 @@
 //                 Mike Lazer-Walker <https://github.com/lazerwalker>,
 //                 Matt Bishop <https://github.com/mattbishop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
 declare module 'chai-as-promised' {
-    function chaiAsPromised(chai: any, utils: any): void;
-
-    namespace chaiAsPromised {
-        function transferPromiseness(assertion: Chai.PromisedAssertion, promise: PromiseLike<any>): void;
-
-        function transformAsserterArgs(values: any[]): any;
+    interface ChaiAsPromised extends Chai.ChaiPlugin {
+        transferPromiseness(assertion: Chai.PromisedAssertion, promise: PromiseLike<any>): void;
+        transformAsserterArgs(values: any[]): any;
     }
 
+    const chaiAsPromised: ChaiAsPromised;
     export = chaiAsPromised;
 }
 

--- a/types/chai-datetime/index.d.ts
+++ b/types/chai-datetime/index.d.ts
@@ -3,10 +3,11 @@
 // Definitions by: Cliff Burger <https://github.com/cliffburger>,
 //                 Matt Bishop <https://github.com/mattbishop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
-declare function chaiDateTime(chai: any, utils: any): void;
+declare const chaiDateTime: Chai.ChaiPlugin;
 export = chaiDateTime;
 
 declare global {

--- a/types/chai-dom/index.d.ts
+++ b/types/chai-dom/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/nathanboktae/chai-dom
 // Definitions by: Matt Lewis <https://github.com/mattlewis92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -56,11 +57,6 @@ declare namespace Chai {
 }
 
 declare module "chai-dom" {
-
-    function chaiDom(chai: any, utils: any): void;
-
-    namespace chaiDom {
-    }
-
+    const chaiDom: Chai.ChaiPlugin;
     export = chaiDom;
 }

--- a/types/chai-enzyme/index.d.ts
+++ b/types/chai-enzyme/index.d.ts
@@ -177,7 +177,7 @@ declare module "chai-enzyme" {
     import { ShallowWrapper, ReactWrapper } from "enzyme";
 
     type DebugWrapper = ShallowWrapper<any,any> | Cheerio | ReactWrapper<any, any>;
-    function chaiEnzyMe(wrapper?: (debugWrapper: DebugWrapper) => string): (chai: any) => void;
+    function chaiEnzyMe(wrapper?: (debugWrapper: DebugWrapper) => string): Chai.ChaiPlugin;
 
     module chaiEnzyMe {
     }

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chaijs/chai-fs
 // Definitions by: Dimitar Danailov <https://github.com/dimitardanailov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 /// <reference types="chai" />
@@ -214,7 +214,7 @@ declare global {
     }
 }
 
-declare function chaiFs(chai: any, utils: any): void;
+declare const chaiFs: Chai.ChaiPlugin;
 export = chaiFs;
 
 interface Object {

--- a/types/chai-fuzzy/index.d.ts
+++ b/types/chai-fuzzy/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://chaijs.com/plugins/chai-fuzzy
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -71,6 +72,6 @@ declare global {
 	}
 }
 
-declare function chaiFuzzy(chai: any, utils: any): void;
+declare const chaiFuzzy: Chai.ChaiPlugin;
 export = chaiFuzzy;
 

--- a/types/chai-jest-snapshot/index.d.ts
+++ b/types/chai-jest-snapshot/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/suchipi/chai-jest-snapshot#readme
 // Definitions by: Matt Perry <https://github.com/mattvperry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 /// <reference types="mocha" />
@@ -17,10 +17,7 @@ declare global {
     }
 }
 
-interface ChaiJestSnapshot {
-    /** Chai bootstrapper */
-    (chai: any, utils: any): void;
-
+interface ChaiJestSnapshot extends Chai.ChaiPlugin {
     /** Set snapshot file name */
     setFilename(filename: string): void;
 

--- a/types/chai-jquery/index.d.ts
+++ b/types/chai-jquery/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chaijs/chai-jquery
 // Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 /// <reference types="jquery" />

--- a/types/chai-json-schema/index.d.ts
+++ b/types/chai-json-schema/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/chaijs/chai-json-schema/, http://chaijs.com
 // Definitions by: Ulrich Heiniger <https://github.com/ulrichheiniger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 // <reference types="node"/>
 // <reference types="chai" />
@@ -24,6 +25,6 @@ declare global {
 	}
 }
 
-declare function chaiJsonSchema(chai: any, utils: any): void;
+declare const chaiJsonSchema: Chai.ChaiPlugin;
 declare namespace chaiJsonSchema { }
 export = chaiJsonSchema;

--- a/types/chai-moment/chai-moment-tests.ts
+++ b/types/chai-moment/chai-moment-tests.ts
@@ -3,10 +3,12 @@ import chaiMoment = require('chai-moment');
 
 use(chaiMoment);
 
+const g: ChaiMoment.Granularity = 'month';
+
 // bdd style
 expect('2019-03-14').to.be.afterMoment('2019-03-12', 'day');
 expect('2019-03-14').to.be.beforeMoment('2019-03-16');
-expect('2019-03-14').to.be.sameMoment('2019-03-14', 'day');
+expect('2019-03-14').to.be.sameMoment('2019-03-14', g);
 
 // tdd style
 assert.afterMoment('2019-03-14', '2019-03-12');

--- a/types/chai-moment/index.d.ts
+++ b/types/chai-moment/index.d.ts
@@ -2,24 +2,32 @@
 // Project: https://github.com/picardy/chai-moment
 // Definitions by: Chris Godsey <https://github.com/chrisgodsey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
 declare global {
-	namespace Chai {
-		interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
-            afterMoment(expected: string, granularity?: string): void;
-            beforeMoment(expected: string, granularity?: string): void;
-            sameMoment(expected: string, granularity?: string): void;
-		}
+    namespace ChaiMoment {
+        type Granularity = 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
+    }
 
-		interface Assert {
-            afterMoment(val: any, exp: any, granularity?: any, msg?: any): void;
-            beforeMoment(val: any, exp: any, granularity?: any, msg?: any): void;
-            sameMoment(val: any, exp: any, granularity?: any, msg?: any): void;
-		}
-	}
+    namespace Chai {
+        interface Assertion {
+            afterMoment(expected: any, granularity?: ChaiMoment.Granularity): void;
+            beforeMoment(expected: any, granularity?: ChaiMoment.Granularity): void;
+            sameMoment(expected: any, granularity?: ChaiMoment.Granularity): void;
+        }
+
+        interface AssertStatic {
+            afterMoment(val: any, exp: any, granularity: ChaiMoment.Granularity, msg?: string): void;
+            afterMoment(val: any, exp: any, msg?: string): void;
+            beforeMoment(val: any, exp: any, granularity?: ChaiMoment.Granularity, msg?: string): void;
+            beforeMoment(val: any, exp: any, msg?: string): void;
+            sameMoment(val: any, exp: any, granularity?: ChaiMoment.Granularity, msg?: string): void;
+            sameMoment(val: any, exp: any, msg?: string): void;
+        }
+    }
 }
 
-declare function chaiMoment(chai: any, utils: any): void;
+declare const chaiMoment: Chai.ChaiPlugin;
 export = chaiMoment;

--- a/types/chai-oequal/index.d.ts
+++ b/types/chai-oequal/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/wrwrwr/chai-oequal
 // Definitions by: Mizunashi Mana <https://github.com/mizunashi-mana>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -22,7 +23,7 @@ declare namespace Chai {
 }
 
 declare module 'chai-oequal' {
-    function chaiOequal(chai: any, utils: any): void;
+    const chaiOequal: Chai.ChaiPlugin;
     namespace chaiOequal {}
     export = chaiOequal;
 }

--- a/types/chai-roughly/index.d.ts
+++ b/types/chai-roughly/index.d.ts
@@ -2,6 +2,8 @@
 // Project: https://github.com/Turbo87/chai-roughly#readme
 // Definitions by: Tomasz Nguyen <https://github.com/swist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
 /// <reference types="chai" />
 
 declare global {
@@ -22,6 +24,6 @@ declare global {
     }
 }
 
-declare function chaiRoughly(chai: any, utils: any): void;
+declare const chaiRoughly: Chai.ChaiPlugin;
 declare namespace chaiRoughly { }
 export = chaiRoughly;

--- a/types/chai-spies/index.d.ts
+++ b/types/chai-spies/index.d.ts
@@ -4,6 +4,7 @@
 //                 Harm van der Werf <https://github.com/harm-less>
 //                 Jouni Suorsa <https://github.com/jounisuo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 

--- a/types/chai-string/index.d.ts
+++ b/types/chai-string/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/onechiporenko/chai-string
 // Definitions by: Nick Malaguti <https://github.com/nmalaguti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 ///<reference types="chai" />
 
@@ -48,6 +49,6 @@ declare global {
     }
 }
 
-declare function chaiString(chai: any, utils: any): void;
+declare const chaiString: Chai.ChaiPlugin;
 declare namespace chaiString { }
 export = chaiString;

--- a/types/chai-subset/index.d.ts
+++ b/types/chai-subset/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/debitoor/chai-subset
 // Definitions by: Sam Noedel <https://github.com/delta62>, Andrew Brown <https://github.com/AGBrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -16,5 +17,5 @@ declare global {
     }
 }
 
-declare function chaiSubset(chai: any, utils: any): void;
+declare const chaiSubset: Chai.ChaiPlugin;
 export = chaiSubset;

--- a/types/chai-things/index.d.ts
+++ b/types/chai-things/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/chaijs/chai-things
 // Definitions by: David Broder-Rodgers <https://github.com/DavidBR-SW/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -59,7 +60,7 @@ interface Array<T> {
 }
 
 declare module "chai-things" {
-    function chaiThings(chai: any, utils: any): void;
+    const chaiThings: Chai.ChaiPlugin;
     namespace chaiThings { }
     export = chaiThings;
 }

--- a/types/chai-uuid/index.d.ts
+++ b/types/chai-uuid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rfrench/chai-uuid
 // Definitions by: Harm van der Werf <https://github.com/harm-less>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 /// <reference types="chai" />
@@ -23,5 +23,5 @@ declare global {
 	}
 }
 
-declare function chaiUuid(chai: any, utils: any): void;
+declare const chaiUuid: Chai.ChaiPlugin;
 export = chaiUuid;

--- a/types/chai-webdriverio/index.d.ts
+++ b/types/chai-webdriverio/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/marcodejongh/chai-webdriverio
 // Definitions by: Nikolai Orekhov <https://github.com/sherlock1982>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="webdriverio" />
 /// <reference types="chai" />
@@ -19,6 +20,6 @@ declare namespace Chai {
 }
 
 declare module 'chai-webdriverio' {
-    function chaiWebdriverIO(client: WebdriverIO.Client<void>, options?: any): (chai: any, utils: any) => void;
+    function chaiWebdriverIO(client: WebdriverIO.Client<void>, options?: any): Chai.ChaiPlugin;
     export = chaiWebdriverIO;
 }

--- a/types/chai-xml/index.d.ts
+++ b/types/chai-xml/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/krampstudio/chai-xml
 // Definitions by: Jeff Goddard <https://github.com/jedigo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 
@@ -34,5 +35,5 @@ declare namespace ChaiXml {
   }
 }
 
-declare  function chaiXml(chai: any, utils: any): void;
+declare const chaiXml: Chai.ChaiPlugin;
 export = chaiXml;

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -999,17 +999,91 @@ function _throw() {
 }
 
 function use() {
-    chai.use((_chai) => {
-        _chai.can.use.any();
-    });
+                   // Modified from:
+                   //   https://www.npmjs.com/package/chai-subset
+                   // But with added type annotations and some modifications to make the
+                   // linter whine less, and also a method (chai.assert.containSubset) removed
+                   // because we can't take advantage of namespace-declaration-merging here.
+                   function chaiSubset(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
+                       const Assertion = chai.Assertion;
+                       const assertionPrototype = Assertion.prototype;
 
-    const expect = chai
-        .use((_chai, util) => {
-        })
-        .use((_chai, util) => {
-        })
-        .expect;
-}
+                       Assertion.addMethod('containSubset', function(expected: Object) {
+                           const actual = utils.flag(this, 'object');
+                           const showDiff = chai.config.showDiff;
+
+                           assertionPrototype.assert.call(
+                               this,
+                               compare(expected, actual),
+                               'expected #{act} to contain subset #{exp}',
+                               'expected #{act} to not contain subset #{exp}',
+                               expected,
+                               actual,
+                               showDiff
+                           );
+                       });
+
+                       Assertion.addMethod('containSubset', function(expected: Object) {
+                           const actual = utils.flag(this, 'object');
+                           const showDiff = chai.config.showDiff;
+
+                           assertionPrototype.assert.call(
+                               this,
+                               compare(expected, actual),
+                               'expected #{act} to contain subset #{exp}',
+                               'expected #{act} to not contain subset #{exp}',
+                               expected,
+                               actual,
+                               showDiff
+                           );
+                       });
+
+                       function compare(expected: Object, actual: Object): boolean {
+                           if (expected === actual) {
+                               return true;
+                           }
+                           if (typeof actual !== typeof expected) {
+                               return false;
+                           }
+                           if (typeof expected !== 'object' || expected === null) {
+                               return expected === actual;
+                           }
+                           if (!!expected && !actual) {
+                               return false;
+                           }
+
+                           if (Array.isArray(expected) && Array.isArray(actual)) {
+                               if (typeof actual.length !== 'number') {
+                                   return false;
+                               }
+                               const aa = Array.prototype.slice.call(actual);
+                               return expected.every((exp: Object) => aa.some((act: Object) => compare(exp, act)));
+                           }
+
+                           if (expected instanceof Date) {
+                               if (actual instanceof Date) {
+                                   return expected.getTime() === actual.getTime();
+                               } else {
+                                   return false;
+                               }
+                           }
+
+                           return Object.keys(expected).every((key: string): boolean => {
+                               const eo = (expected as { [key: string]: Object })[key];
+                               const ao = (actual as { [key: string]: Object })[key];
+                               if (typeof eo === 'object' && eo !== null && ao !== null) {
+                                   return compare(eo, ao);
+                               }
+                               if (typeof eo === 'function') {
+                                   return eo(ao);
+                               }
+                               return ao === eo;
+                           });
+                       }
+                   }
+
+                   chai.use(chaiSubset);
+               }
 
 class Klass {
     val: number;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -38,13 +38,13 @@ declare namespace Chai {
             // method itself; any arguments
             method: (...args: any[]) => void,
             // called when property is accessed
-            chainingBehavior: () => void
+            chainingBehavior?: () => void
         ): void;
         overwriteChainableMethod(
             ctx: object,
             name: string,
             method: (...args: any[]) => void,
-            chainingBehavior: () => void
+            chainingBehavior?: () => void
         ): void;
         addLengthGuard(
             fn: Function,
@@ -127,7 +127,7 @@ declare namespace Chai {
         _obj: any;
     }
 
-    export interface AssertionStatic {
+    export interface AssertionStatic extends AssertionPrototype {
         prototype: AssertionPrototype;
 
         new (target: any, message?: string, ssfi?: Function, lockSsfi?: boolean): Assertion;
@@ -142,14 +142,14 @@ declare namespace Chai {
         addChainableMethod(
             name: string,
             method: (this: AssertionStatic, ...args: any[]) => void,
-            chainingBehavior: () => void
+            chainingBehavior?: () => void
         ): void;
         overwriteProperty(name: string, getter: (this: AssertionStatic) => any): void;
         overwriteMethod(name: string, method: (this: AssertionStatic, ...args: any[]) => any): void;
         overwriteChainableMethod(
             name: string,
             method: (this: AssertionStatic, ...args: any[]) => void,
-            chainingBehavior: () => void
+            chainingBehavior?: () => void
         ): void;
     }
 

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -14,6 +14,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+/// <reference types="pathval" />
+
 declare namespace Chai {
     type Message = string | (() => string);
 
@@ -21,14 +23,7 @@ declare namespace Chai {
         new(...args: any[]): Error;
     }
 
-    interface PathInfo {
-        parent: object;
-        name: string;
-        value?: any;
-        exists: boolean;
-    }
-
-    interface ChaiUtils {
+    interface ChaiUtils extends PathVal.PathValStatic {
         addChainableMethod(
             // object to define the method on, e.g. chai.Assertion.prototype
             ctx: object,
@@ -75,11 +70,6 @@ declare namespace Chai {
         compatibleMessage(thrown: Error, errMatcher: string | RegExp): boolean;
         getConstructorName(constructorFn: Function): string;
         getFuncName(constructorFn: Function): string | null;
-
-        // From pathval:
-        hasProperty(obj: object | undefined | null, name: Property): boolean;
-        getPathInfo(obj: object, path: string): PathInfo;
-        getPathValue(obj: object, path: string): object | undefined;
     }
 
     type ChaiPlugin = (chai: ChaiStatic, utils: ChaiUtils) => void;
@@ -100,7 +90,7 @@ declare namespace Chai {
     }
 
     export interface ExpectStatic {
-        (val: Object, message?: string): Assertion;
+        (val: any, message?: string): Assertion;
         fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
     }
 
@@ -129,7 +119,7 @@ declare namespace Chai {
     export interface AssertionStatic {
         prototype: AssertionPrototype;
 
-        new (target: Object, message?: string, ssfi?: Function, lockSsfi?: boolean): Assertion;
+        new (target: any, message?: string, ssfi?: Function, lockSsfi?: boolean): Assertion;
 
         // Deprecated properties:
         includeStack: boolean;
@@ -280,7 +270,7 @@ declare namespace Chai {
     }
 
     interface InstanceOf {
-        (constructor: Object, message?: string): Assertion;
+        (constructor: any, message?: string): Assertion;
     }
 
     interface CloseTo {
@@ -335,7 +325,7 @@ declare namespace Chai {
     }
 
     interface Include {
-        (value: Object | string | number, message?: string): Assertion;
+        (value: object | string | number, message?: string): Assertion;
         keys: Keys;
         deep: Deep;
         ordered: Ordered;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai 4.1
+// Type definitions for chai 4.2
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
@@ -14,16 +14,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-/// <reference types="pathval" />
-
 declare namespace Chai {
     type Message = string | (() => string);
+    type Property = string | symbol | number
+
+    interface PathInfo {
+        parent: object;
+        name: string;
+        value?: any;
+        exists: boolean;
+    }
 
     interface ErrorConstructor {
         new(...args: any[]): Error;
     }
 
-    interface ChaiUtils extends PathVal.PathValStatic {
+    interface ChaiUtils {
         addChainableMethod(
             // object to define the method on, e.g. chai.Assertion.prototype
             ctx: object,
@@ -70,6 +76,11 @@ declare namespace Chai {
         compatibleMessage(thrown: Error, errMatcher: string | RegExp): boolean;
         getConstructorName(constructorFn: Function): string;
         getFuncName(constructorFn: Function): string | null;
+
+        // Reexports from pathval:
+        hasProperty(obj: object | undefined | null, name: Property): boolean;
+        getPathInfo(obj: object, path: string): PathInfo;
+        getPathValue(obj: object, path: string): object | undefined;
     }
 
     type ChaiPlugin = (chai: ChaiStatic, utils: ChaiUtils) => void;
@@ -325,7 +336,7 @@ declare namespace Chai {
     }
 
     interface Include {
-        (value: object | string | number, message?: string): Assertion;
+        (value: any, message?: string): Assertion;
         keys: Keys;
         deep: Deep;
         ordered: Ordered;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai 4.1
+// Type definitions for chai 4.2
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
@@ -14,16 +14,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-/// <reference types="pathval" />
-
 declare namespace Chai {
     type Message = string | (() => string);
+    type ObjectProperty = string | symbol | number;
+
+    interface PathInfo {
+        parent: object;
+        name: string;
+        value?: any;
+        exists: boolean;
+    }
 
     interface ErrorConstructor {
         new(...args: any[]): Error;
     }
 
-    interface ChaiUtils extends PathVal.PathValStatic {
+    interface ChaiUtils {
         addChainableMethod(
             // object to define the method on, e.g. chai.Assertion.prototype
             ctx: object,
@@ -70,6 +76,11 @@ declare namespace Chai {
         compatibleMessage(thrown: Error, errMatcher: string | RegExp): boolean;
         getConstructorName(constructorFn: Function): string;
         getFuncName(constructorFn: Function): string | null;
+
+        // Reexports from pathval:
+        hasProperty(obj: object | undefined | null, name: ObjectProperty): boolean;
+        getPathInfo(obj: object, path: string): PathInfo;
+        getPathValue(obj: object, path: string): object | undefined;
     }
 
     type ChaiPlugin = (chai: ChaiStatic, utils: ChaiUtils) => void;
@@ -325,7 +336,7 @@ declare namespace Chai {
     }
 
     interface Include {
-        (value: object | string | number, message?: string): Assertion;
+        (value: any, message?: string): Assertion;
         keys: Keys;
         deep: Deep;
         ordered: Ordered;

--- a/types/d3kit/v1/index.d.ts
+++ b/types/d3kit/v1/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://www.npmjs.com/package/d3kit
 // Definitions by: Morgan Benton <https://github.com/morphatic/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 import * as d3 from "d3";
 

--- a/types/deep-equal-in-any-order/index.d.ts
+++ b/types/deep-equal-in-any-order/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/oprogramador/deep-equal-in-any-order#readme
 // Definitions by: Bastien Caudan <https://github.com/bcaudan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 declare global {
     namespace Chai {
@@ -11,5 +12,5 @@ declare global {
     }
 }
 
-declare function deepEqualInAnyOrder(chai: any, utils: any): void;
+declare const deepEqualInAnyOrder: Chai.ChaiPlugin;
 export = deepEqualInAnyOrder;

--- a/types/dirty-chai/index.d.ts
+++ b/types/dirty-chai/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/prodatakey/dirty-chai
 // Definitions by: Piotr Roszatycki <https://github.com/dex4er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 /// <reference types="chai-as-promised" />
@@ -24,5 +25,5 @@ declare global {
     }
 }
 
-declare function dirtyChai(chai: any, utils: any): void;
+declare const dirtyChai: Chai.ChaiPlugin;
 export = dirtyChai;

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -4,7 +4,7 @@
 //                 Simon Ihmig <https://github.com/simonihmig>
 //                 Mike North <https://github.com/mike-north>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import { TestContext, ModuleCallbacks } from "ember-test-helpers";
 import Ember from 'ember';

--- a/types/hexo-log/index.d.ts
+++ b/types/hexo-log/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://hexo.io/
 // Definitions by: segayuu <https://github.com/segayuu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 import bunyan = require('hexo-bunyan');
 import streams = require('stream');

--- a/types/hexo-util/index.d.ts
+++ b/types/hexo-util/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://hexo.io/
 // Definitions by: sega yuu <https://github.com/segayuu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 

--- a/types/hexo/index.d.ts
+++ b/types/hexo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://hexo.io/
 // Definitions by: KentarouTakeda <https://github.com/kentarouTakeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import EventEmitter = require('events');
 import moment = require('moment');

--- a/types/jsx-chai/index.d.ts
+++ b/types/jsx-chai/index.d.ts
@@ -2,17 +2,15 @@
 // Project: https://github.com/bkonkle/jsx-chai
 // Definitions by: Philipp Holzer <https://github.com/nupplaphil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
-
 
 interface JsxChaiStatic {
     jsxChai: jsxChaiFunction;
 }
 
-interface jsxChaiFunction {
-    (chai: any, utils: any): void;
-}
+type jsxChaiFunction = Chai.ChaiPlugin;
 
 declare var jsxChai: JsxChaiStatic;
 

--- a/types/karma-chai-sinon/index.d.ts
+++ b/types/karma-chai-sinon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tubalmartin/karma-chai-sinon
 // Definitions by: Václav Ostrožlík <https://github.com/vasek17>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 import Sinon = require('sinon');

--- a/types/karma-chai/index.d.ts
+++ b/types/karma-chai/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://xdissent.github.io/karma-chai
 // Definitions by: JayAndCatchFire <https://github.com/JayAndCatchFire>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 import chai = require('chai');
 

--- a/types/redux-test-utils/index.d.ts
+++ b/types/redux-test-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Knegusen/redux-test-utils#readme
 // Definitions by: Huw Martin <https://github.com/huwmartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 import { AnyAction, Store, Dispatch } from 'redux';
 

--- a/types/sinon-chai/index.d.ts
+++ b/types/sinon-chai/index.d.ts
@@ -4,7 +4,7 @@
 //                 Jed Mao <https://github.com/jedmao>
 //                 Eyal Lapid <https://github.com/elpdpt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 /// <reference types="sinon" />
@@ -104,6 +104,6 @@ declare global {
     }
 }
 
-declare function sinonChai(chai: any, utils: any): void;
+declare const sinonChai: Chai.ChaiPlugin;
 declare namespace sinonChai { }
 export = sinonChai;

--- a/types/sinon-chai/v2/index.d.ts
+++ b/types/sinon-chai/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/domenic/sinon-chai
 // Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid>, Jed Mao <https://github.com/jedmao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="chai" />
 /// <reference types="sinon" />
@@ -84,6 +84,6 @@ declare global {
     }
 }
 
-declare function sinonChai(chai: any, utils: any): void;
+declare const sinonChai: Chai.ChaiPlugin;
 declare namespace sinonChai { }
 export = sinonChai;


### PR DESCRIPTION
Provide types for the following APIs used in plugin development, as requested in #29922:
- `chai.util`
- `chai.use()`
- `chai.Assertion`

Closes #29922.

## Version number

This PR includes breaking changes which will cause code that was incorrect (but
type-checked without errors) to no longer compile by aligning the type
definitions with Chai's actual public interface.

The only members with a (potentially) breaking change, however, is `chai.use`, which takes a `Chai.ChaiPlugin` rather than a `(chai: any, utils: any) => void` function.

This puts us in the uncomfortable position of needing to release a breaking change *while* not getting out of sync with Chai's major version. I'm not entirely sure what the best way to resolve this is, but I'm open to suggestions. One thing we could do is look for packages that depend on `@types/chai` and see if this change would break them.

## TypeScript version bumps

**Note:** Version bumps to TypeScript 3.0 for better tuple type matching; a lot of Chai's plugin APIs accept an array which is used as arguments to `chai.Assertion.prototype.assert`; that function has several optional parameters, so the last few elements of the tuple are optional. Therefore, the tuple is variable-length, which wasn't supported until TypeScript 3.0.

As a consequence, this PR bumps the minimum TypeScript version for a **lot** of packages. Sorry about that.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/plugins/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A:** Already exists.
