### PR TITLE
Created type definitions for 'leaflet.featuregroup.subgroup'

### DIFF
--- a/types/leaflet.featuregroup.subgroup/index.d.ts
+++ b/types/leaflet.featuregroup.subgroup/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for leaflet.FeatureGroup.SubGroup 1.0
+// Project: https://github.com/ghybs/Leaflet.FeatureGroup.SubGroup
+// Definitions by: Thomas Revesz <https://github.com/drtomato>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+    namespace FeatureGroup {
+        /**
+         * An extended FeatureGroup that adds its child layers into a parent
+         * group when added to a map (e.g., through L.Control.Layers). Typical
+         * usage is to dynamically add and remove groups of markers from marker
+         * clusters.
+         */
+        class SubGroup<P = any> extends FeatureGroup<P> {
+            /**
+             * Instantiates a SubGroup.
+             */
+            constructor(parentGroup?: LayerGroup, layers?: Layer[]);
+
+            /**
+             * Changes the parent group into which child markers are added to or
+             * removed from.
+             */
+            setParentGroup(parentGroup: LayerGroup): this;
+
+            /**
+             * Removes the current sub-group from map before changing the parent
+             * group. Re-adds the sub-group to map if it was before changing.
+             */
+            setParentGroupSafe(parentGroup: LayerGroup): this;
+
+            /**
+             * Returns the current parent group.
+             */
+            getParentGroup(): LayerGroup;
+        }
+    }
+
+    namespace featureGroup {
+        /**
+         * Creates a feature subgroup, optionally given an initial parent group and a set of layers.
+         */
+        function subGroup(parentGroup?: LayerGroup, layers?: Layer[]): FeatureGroup.SubGroup;
+    }
+}

--- a/types/leaflet.featuregroup.subgroup/leaflet.featuregroup.subgroup-tests.ts
+++ b/types/leaflet.featuregroup.subgroup/leaflet.featuregroup.subgroup-tests.ts
@@ -1,0 +1,34 @@
+import * as L from 'leaflet';
+import 'leaflet.featuregroup.subgroup';
+
+// Setup
+interface MyProperties {
+	testProperty: string;
+}
+const parentGroup1: L.LayerGroup = L.layerGroup();
+const latLng: L.LatLng = L.latLng(10, 10);
+const layer: L.Layer = L.marker(latLng);
+const layers: L.Layer[] = [layer];
+
+// Construction using the constructor
+let subGroup = new L.FeatureGroup.SubGroup<MyProperties>();
+subGroup = new L.FeatureGroup.SubGroup<MyProperties>(parentGroup1);
+subGroup = new L.FeatureGroup.SubGroup<MyProperties>(parentGroup1, layers);
+
+// Construction using the 'leaflet-style' factory method
+subGroup = L.featureGroup.subGroup();
+subGroup = L.featureGroup.subGroup(parentGroup1);
+subGroup = L.featureGroup.subGroup(parentGroup1, layers);
+
+// Setting and getting the parent group
+const parentGroup2: L.LayerGroup = L.layerGroup();
+subGroup.setParentGroup(parentGroup2);
+subGroup.setParentGroupSafe(parentGroup2);
+const parentGroup3 = subGroup.getParentGroup();
+
+// Calling methods inherited from FeatureGroup
+const bounds: L.LatLngBounds = subGroup
+   .setStyle({})
+   .bringToFront()
+   .bringToBack()
+   .getBounds();

--- a/types/leaflet.featuregroup.subgroup/tsconfig.json
+++ b/types/leaflet.featuregroup.subgroup/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "leaflet.featuregroup.subgroup-tests.ts"
+    ]
+}

--- a/types/leaflet.featuregroup.subgroup/tslint.json
+++ b/types/leaflet.featuregroup.subgroup/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I am rather new at TypeScript and this is the first time I am trying to make a contribution here so apologies for any mistakes I may have made... Constructive feedback is always welcome. /Thomas

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project. (I WAS NOT AWARE OF THIS TOOL, I WROTE THE DEFINITION BY HAND)
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
