### PR TITLE
types/fancybox - Fix strict compilation errors

### DIFF
--- a/types/fancybox/index.d.ts
+++ b/types/fancybox/index.d.ts
@@ -19,7 +19,7 @@ interface FancyBoxPlainObject {
 
 interface FancyBoxGroupItemWithFilledProps extends FancyBoxGroupItem {
     $thumb?: JQuery;
-    thumb?;
+    thumb?: any;
     contentType?: string;
     index?: number;
 }
@@ -712,7 +712,7 @@ interface FancyBoxInstanceMethods {
      * Update content size and position for all slides
      * @param e
      */
-    update(e): void;
+    update(e: any): void;
     /**
      * Update infobar values, navigation button states and reveal caption
      */
@@ -728,7 +728,7 @@ interface FancyBoxInstanceMethods {
      * @param slide
      * @param e
      */
-    updateSlide(slide: FancyBoxSlide, e?): void;
+    updateSlide(slide: FancyBoxSlide, e?: any): void;
 }
 
 interface FancyBoxInstance extends FancyBoxInstanceMethods {


### PR DESCRIPTION
Fixing these strict compilation errors:
error TS7008: Member 'thumb' implicitly has an 'any' type.
error TS7006: Parameter 'e' implicitly has an 'any' type.
error TS7006: Parameter 'e' implicitly has an 'any' type.