### PR TITLE
Added missing baseline property to TextOptions

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 //                 Erik Berreßem <https://github.com/she11sh0cked>
+//                 Jeroen Vervaeke <https://github.com/jeroenvervaeke/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -146,6 +147,8 @@ declare namespace PDFKit.Mixins {
         /** the alignment of the text (center, justify, left, right) */
         //TODO check this
         align?: 'center' | 'justify' | 'left' | 'right' | string;
+        /** the vertical alignment of the text with respect to its insertion point */
+        baseline?: number | "svg-middle" | "middle" | "svg-central" | "bottom" | "ideographic" | "alphabetic" | "mathematical" | "hanging" | "top"
     }
 
     interface PDFText<TDocument> {

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -162,10 +162,14 @@ doc.image(
     },
     {
         scale: 0.25,
-    }
+    },
 ).text('Scale', 320, 265);
 
 doc.text('Scale', { align: 'justify' });
+
+doc.text('Baseline - string literal', { baseline: 'alphabetic' });
+
+doc.text('Baseline - numeric', { baseline: 10 });
 
 doc.goTo(0, 0, 0, 0, 'lorem');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - source: https://github.com/foliojs/pdfkit/blob/master/lib/mixins/text.js#L286
    - documentation: http://pdfkit.org/docs/text.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.