### PR TITLE
Add type definitions for rollup-plugin-url

### DIFF
--- a/types/rollup-plugin-url/index.d.ts
+++ b/types/rollup-plugin-url/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for rollup-plugin-url 2.2
+// Project: https://github.com/Swatinem/rollup-plugin-url#readme
+// Definitions by: Jeroen Claassens <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="node" />
+import { Plugin } from 'rollup';
+
+interface PluginURLOptions {
+    limit?: number;
+    include?: string[];
+    exclude?: string[];
+    publicPath?: string;
+    emitFile?: boolean;
+    fileName?: string;
+    sourceDir?: string;
+    destDist?: string;
+}
+
+declare function url(options?: PluginURLOptions): Plugin;
+
+export default url;

--- a/types/rollup-plugin-url/package.json
+++ b/types/rollup-plugin-url/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4"
+    }
+}

--- a/types/rollup-plugin-url/rollup-plugin-url-tests.ts
+++ b/types/rollup-plugin-url/rollup-plugin-url-tests.ts
@@ -1,0 +1,5 @@
+import url from 'rollup-plugin-url';
+
+url(); // $ExpectType Plugin
+
+url({ emitFile: true, limit: 0 }); // $ExpectType Plugin

--- a/types/rollup-plugin-url/tsconfig.json
+++ b/types/rollup-plugin-url/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-url-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-url/tslint.json
+++ b/types/rollup-plugin-url/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.