### PR TITLE
Add type definitions for rollup-plugin-postcss

### DIFF
--- a/types/rollup-plugin-postcss/index.d.ts
+++ b/types/rollup-plugin-postcss/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for rollup-plugin-postcss 2.0
+// Project: https://github.com/egoist/rollup-plugin-postcss
+// Definitions by: Jeroen Claassens <https://github.com/favna>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="node" />
+import { Plugin } from 'rollup';
+import { CssNanoOptions } from 'cssnano';
+
+export interface PostCssPluginOptions {
+    extensions?: string[];
+    plugins?: any[];
+    inject?: boolean | {
+        insertAt?: 'top' | string;
+    };
+    extract?: boolean | string;
+    modules?: boolean | unknown;
+    autoModules?: boolean;
+    minimize?: boolean | CssNanoOptions;
+    sourceMap?: boolean | 'inline';
+    exec?: boolean;
+    config?: boolean | {
+        path: string;
+        ctx: any;
+    };
+    name?: any[] | any[][];
+    loaders?: any[];
+    namedExports?(...args: any[]): void | boolean;
+    parser?(...args: any[]): void | string;
+    syntax?(...args: any[]): void | string;
+    stringifier?(...args: any[]): void | string;
+    onImport?: (id: any) => void;
+}
+
+declare function postcss(options?: PostCssPluginOptions): Plugin;
+
+export default postcss;

--- a/types/rollup-plugin-postcss/package.json
+++ b/types/rollup-plugin-postcss/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4"
+    }
+}

--- a/types/rollup-plugin-postcss/rollup-plugin-postcss-tests.ts
+++ b/types/rollup-plugin-postcss/rollup-plugin-postcss-tests.ts
@@ -1,0 +1,5 @@
+import postcss from 'rollup-plugin-postcss';
+
+postcss(); // $ExpectType Plugin
+
+postcss({ modules: true, minimize: true }); // $ExpectType Plugin

--- a/types/rollup-plugin-postcss/tsconfig.json
+++ b/types/rollup-plugin-postcss/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-postcss-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-postcss/tslint.json
+++ b/types/rollup-plugin-postcss/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.