### PR TITLE
Change `react-transition-group` exports so the `Props` definitions ar…

### DIFF
--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -6,7 +6,34 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export { default as Transition } from './Transition';
-export { default as CSSTransition } from './CSSTransition';
-export { default as TransitionGroup } from './TransitionGroup';
-export { default as SwitchTransition } from './SwitchTransition';
+export {
+    default as Transition,
+    EndHandler,
+    EnterHandler,
+    ExitHandler,
+    TransitionActions,
+    TransitionChildren,
+    TransitionProps,
+    TransitionStatus,
+    UNMOUNTED,
+    EXITED,
+    ENTERING,
+    ENTERED,
+    EXITING,
+} from './Transition';
+export {
+    default as CSSTransition,
+    CSSTransitionClassNames,
+    CSSTransitionProps,
+} from './CSSTransition';
+export {
+    default as TransitionGroup,
+    IntrinsicTransitionGroupProps,
+    ComponentTransitionGroupProps,
+    TransitionGroupProps,
+} from './TransitionGroup';
+export {
+    default as SwitchTransition,
+    modes,
+    SwitchTransitionProps,
+} from './SwitchTransition';

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -1,9 +1,13 @@
-import * as React from "react";
-import { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from "react-transition-group/Transition";
-import { modes } from "react-transition-group/SwitchTransition";
-import { Transition, CSSTransition, TransitionGroup, SwitchTransition } from "react-transition-group";
+import * as React from 'react';
+import {
+    CSSTransition, CSSTransitionProps, SwitchTransition, Transition, TransitionGroup
+} from 'react-transition-group';
+import { modes } from 'react-transition-group/SwitchTransition';
+import {
+    ENTERED, ENTERING, EXITED, EXITING, TransitionStatus, UNMOUNTED
+} from 'react-transition-group/Transition';
 
-interface ContainerProps {
+interface ContainerProps extends Partial<CSSTransitionProps> {
     theme: string;
     children?: Element[];
 }


### PR DESCRIPTION
…e still exported.

Ref:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37405#issuecomment-519579770

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

