### PR TITLE
[pino] Extend stdSerializers Object

### DIFF
--- a/types/koa-pino-logger/index.d.ts
+++ b/types/koa-pino-logger/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pinojs/koa-pino-logger, https://github.com/davidmarkclements/koa-pino-logger
 // Definitions by: Cameron Yan <https://github.com/khell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 /// <reference types="node"/>
 

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 import { IncomingMessage, ServerResponse } from 'http';
 import { DestinationStream, Level, Logger, LoggerOptions } from 'pino';

--- a/types/pino-multi-stream/index.d.ts
+++ b/types/pino-multi-stream/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pinojs/pino-multi-stream#readme
 // Definitions by: Jake Ginnivan <https://github.com/JakeGinnivan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 import {
     LoggerOptions as PinoLoggerOptions,
     Logger as PinoLogger,

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -7,7 +7,7 @@
 //                 Alex Ferrando <https://github.com/alferpal>
 //                 Oleksandr Sidko <https://github.com/mortiy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 /// <reference types="node"/>
 

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -15,6 +15,7 @@ import stream = require('stream');
 import http = require('http');
 import EventEmitter = require('events');
 import SonicBoom = require('sonic-boom');
+import * as pinoStdSerializers from 'pino-std-serializers';
 
 export = P;
 
@@ -39,6 +40,11 @@ declare namespace P {
      */
     const LOG_VERSION: number;
     const levels: LevelMapping;
+
+    type SerializedError = pinoStdSerializers.SerializedError;
+    type SerializedResponse = pinoStdSerializers.SerializedResponse;
+    type SerializedRequest = pinoStdSerializers.SerializedRequest;
+
     /**
      * Provides functions for serializing objects common to many projects.
      */
@@ -46,26 +52,63 @@ declare namespace P {
         /**
          * Generates a JSONifiable object from the HTTP `request` object passed to the `createServer` callback of Node's HTTP server.
          */
-        req(req: http.IncomingMessage): {
-            method: string;
-            url: string;
-            headers: http.IncomingHttpHeaders;
-            remoteAddress: string;
-            remotePort: number;
-        };
+        req: typeof pinoStdSerializers.req;
         /**
          * Generates a JSONifiable object from the HTTP `response` object passed to the `createServer` callback of Node's HTTP server.
          */
-        res(res: http.ServerResponse): { statusCode: number; header: string; };
+        res: typeof pinoStdSerializers.res;
         /**
          * Serializes an Error object.
          */
-        err(err: Error): {
-            type: string;
-            message: string;
-            stack: string;
-            [key: string]: any;
-        };
+        err: typeof pinoStdSerializers.err;
+        /**
+         * Returns an object:
+         * ```
+         * {
+         *   req: {}
+         * }
+         * ```
+         * where req is the request as serialized by the standard request serializer.
+         * @param req The request to serialize
+         * @return An object
+         */
+        mapHttpRequest: typeof pinoStdSerializers.mapHttpRequest;
+        /**
+         * Returns an object:
+         * ```
+         * {
+         *   res: {}
+         * }
+         * ```
+         * where res is the response as serialized by the standard response serializer.
+         * @param res The response to serialize.
+         * @return An object.
+         */
+        mapHttpResponse: typeof pinoStdSerializers.mapHttpResponse;
+        /**
+         * A utility method for wrapping the default error serializer. Allows custom serializers to work with the
+         * already serialized object.
+         * @param customSerializer The custom error serializer. Accepts a single parameter: the newly serialized
+         * error object. Returns the new (or updated) error object.
+         * @return A new error serializer.
+         */
+        wrapErrorSerializer: typeof pinoStdSerializers.wrapErrorSerializer;
+        /**
+         * A utility method for wrapping the default request serializer. Allows custom serializers to work with the
+         * already serialized object.
+         * @param customSerializer The custom request serializer. Accepts a single parameter: the newly serialized
+         * request object. Returns the new (or updated) request object.
+         * @return A new error serializer.
+         */
+        wrapRequestSerializer: typeof pinoStdSerializers.wrapRequestSerializer;
+        /**
+         * A utility method for wrapping the default response serializer. Allows custom serializers to work with the
+         * already serialized object.
+         * @param customSerializer The custom response serializer. Accepts a single parameter: the newly serialized
+         * response object. Returns the new (or updated) response object.
+         * @return A new error serializer.
+         */
+        wrapResponseSerializer: typeof pinoStdSerializers.wrapResponseSerializer;
     };
     /**
      * Provides functions for generating the timestamp property in the log output. You can set the `timestamp` option during

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -6,6 +6,7 @@
 //                 GP <https://github.com/paambaati>
 //                 Alex Ferrando <https://github.com/alferpal>
 //                 Oleksandr Sidko <https://github.com/mortiy>
+//                 Harris Lummis <https://github.com/lummish>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -1,4 +1,6 @@
 import pino = require('pino');
+import { IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
 
 const log = pino();
 const info = log.info;
@@ -18,8 +20,9 @@ const log2: pino.Logger = pino({
     safe: true,
     serializers: {
         req: pino.stdSerializers.req,
-        res: pino.stdSerializers.res
-    }
+        res: pino.stdSerializers.res,
+        err: pino.stdSerializers.err,
+    },
 });
 
 pino({
@@ -138,3 +141,24 @@ const pretty = pino({
 		search: 'foo == `bar`'
 	}
 });
+
+const wrappedErrSerializer = pino.stdSerializers.wrapErrorSerializer((err: pino.SerializedError) => {
+  return {...err, newProp: 'foo'};
+});
+const wrappedReqSerializer = pino.stdSerializers.wrapRequestSerializer((req: pino.SerializedRequest) => {
+  return {...req, newProp: 'foo'};
+});
+const wrappedResSerializer = pino.stdSerializers.wrapResponseSerializer((res: pino.SerializedResponse) => {
+  return {...res, newProp: 'foo'};
+});
+
+const socket = new Socket();
+const incomingMessage = new IncomingMessage(socket);
+const serverResponse = new ServerResponse(incomingMessage);
+
+const mappedHttpRequest: { req: pino.SerializedRequest } = pino.stdSerializers.mapHttpRequest(incomingMessage);
+const mappedHttpResponse: { res: pino.SerializedResponse } = pino.stdSerializers.mapHttpResponse(serverResponse);
+
+const serializedErr: pino.SerializedError = pino.stdSerializers.err(new Error());
+const serializedReq: pino.SerializedRequest = pino.stdSerializers.req(incomingMessage);
+const serializedRes: pino.SerializedResponse = pino.stdSerializers.res(serverResponse);

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -142,6 +142,7 @@ const pretty = pino({
 	}
 });
 
+// Properties/types imported from pino-std-serializers
 const wrappedErrSerializer = pino.stdSerializers.wrapErrorSerializer((err: pino.SerializedError) => {
   return {...err, newProp: 'foo'};
 });


### PR DESCRIPTION
- Add missing methods to stdSerializers object:
  - mapHttpRequest
  - mapHttpResponse
  - wrapErrorSerializer
  - wrapRequestSerializer
  - wrapResponseSerializer
- Import types from `pino-std-serializers`
- Replace existing property types of stdSerializers with imported types
- Add tests for serializers
- Export return types of serializers
- Bump minimum TypeScript versions of dependents as necessary

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [exported members of `pino-std-serializers`](https://github.com/pinojs/pino-std-serializers), [line where `serializers` is defined in `pino`](https://github.com/pinojs/pino/blob/43d398800fc8b0de189ccd9b11bc2afdb28524d9/pino.js#L58)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.