### PR TITLE
[@types/got] added beforeErrorHook type

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -387,13 +387,13 @@ got('example.com', {
     }
 });
 got('example.com', {
-    hooks: {
-        beforeError: [
-            (error) => {
-                return error;
-            }
-        ]
-    }
+  hooks: {
+    beforeError: [
+      error => {
+        return error;
+      },
+    ],
+  },
 });
 got('example.com', {
     hooks: {
@@ -423,35 +423,35 @@ got('example.com', {
     };
 
     got('example.com', {
-        hooks: {
-            beforeRequest: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeRedirect: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeRetry: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeError: [
-                async (error) => {
-                    await doSomethingAsync();
-                    return error;
-                }
-            ],
-            afterResponse: [
-                async (response) => {
-                    await doSomethingAsync();
-                    return response;
-                }
-            ]
-        }
+      hooks: {
+        beforeRequest: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeRedirect: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeRetry: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeError: [
+          async error => {
+            await doSomethingAsync();
+            return error;
+          },
+        ],
+        afterResponse: [
+          async response => {
+            await doSomethingAsync();
+            return response;
+          },
+        ],
+      },
     });
 }
 

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -388,6 +388,15 @@ got('example.com', {
 });
 got('example.com', {
     hooks: {
+        beforeError: [
+            (error) => {
+                return error;
+            }
+        ]
+    }
+});
+got('example.com', {
+    hooks: {
         afterResponse: [
             (response, retryWithMergedOptions) => {
                 if (response.statusCode === 401) { // Unauthorized
@@ -428,6 +437,12 @@ got('example.com', {
             beforeRetry: [
                 async () => {
                     await doSomethingAsync();
+                }
+            ],
+            beforeError: [
+                async (error) => {
+                    await doSomethingAsync();
+                    return error;
                 }
             ],
             afterResponse: [

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -7,6 +7,7 @@
 //                 Matthew Bull <https://github.com/wingsbob>
 //                 Ryan Wilson-Perkin <https://github.com/ryanwilsonperkin>
 //                 Paul Hawxby <https://github.com/phawxby>
+//                 Ivy Witter <https://github.com/ivywit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -145,6 +146,7 @@ declare namespace got {
         beforeRequest?: Array<BeforeRequestHook<Options>>;
         beforeRedirect?: Array<BeforeRedirectHook<Options>>;
         beforeRetry?: Array<BeforeRetryHook<Options>>;
+        beforeError?: Array<BeforeErrorHook>;
         afterResponse?: Array<AfterResponseHook<Options, Body>>;
     }
 
@@ -169,6 +171,11 @@ declare namespace got {
      * @param retryCount Number of retry.
      */
     type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
+
+    /**
+     * @param error Request or parse error.
+     */
+    type BeforeErrorHook = <ErrorLike extends Error | GotError | ParseError | HTTPError | MaxRedirectsError>(error: ErrorLike) => Error | Promise<Error>;
 
     /**
      * @param response Response object.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got#hooksbeforeerror
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes:

Declaration of `beforeErrorHook` was missing so when implementing hook in a TypeScript project and error was thrown. This adds the hook's type to allow it's use in a TypeScript project.