### PR TITLE
[@types/got] Added beforeErrorHook type

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -387,13 +387,13 @@ got('example.com', {
     }
 });
 got('example.com', {
-    hooks: {
-        beforeError: [
-            (error) => {
-                return error;
-            }
-        ]
-    }
+  hooks: {
+    beforeError: [
+      error => {
+        return error;
+      },
+    ],
+  },
 });
 got('example.com', {
     hooks: {
@@ -423,35 +423,35 @@ got('example.com', {
     };
 
     got('example.com', {
-        hooks: {
-            beforeRequest: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeRedirect: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeRetry: [
-                async () => {
-                    await doSomethingAsync();
-                }
-            ],
-            beforeError: [
-                async (error) => {
-                    await doSomethingAsync();
-                    return error;
-                }
-            ],
-            afterResponse: [
-                async (response) => {
-                    await doSomethingAsync();
-                    return response;
-                }
-            ]
-        }
+      hooks: {
+        beforeRequest: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeRedirect: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeRetry: [
+          async () => {
+            await doSomethingAsync();
+          },
+        ],
+        beforeError: [
+          async error => {
+            await doSomethingAsync();
+            return error;
+          },
+        ],
+        afterResponse: [
+          async response => {
+            await doSomethingAsync();
+            return response;
+          },
+        ],
+      },
     });
 }
 

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -391,9 +391,9 @@ got('example.com', {
         beforeError: [
             error => {
                 return error;
-            },
-        ],
-    },
+            }
+        ]
+    }
 });
 got('example.com', {
     hooks: {
@@ -427,31 +427,31 @@ got('example.com', {
             beforeRequest: [
                 async () => {
                     await doSomethingAsync();
-                },
+                }
             ],
             beforeRedirect: [
                 async () => {
                     await doSomethingAsync();
-                },
+                }
             ],
             beforeRetry: [
                 async () => {
                     await doSomethingAsync();
-                },
+                }
             ],
             beforeError: [
-                async error => {
+                async (error) => {
                     await doSomethingAsync();
                     return error;
-                },
+                }
             ],
             afterResponse: [
-                async response => {
+                async (response) => {
                     await doSomethingAsync();
                     return response;
-                },
-            ],
-        },
+                }
+            ]
+        }
     });
 }
 

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -387,13 +387,13 @@ got('example.com', {
     }
 });
 got('example.com', {
-  hooks: {
-    beforeError: [
-      error => {
-        return error;
-      },
-    ],
-  },
+    hooks: {
+        beforeError: [
+            error => {
+                return error;
+            },
+        ],
+    },
 });
 got('example.com', {
     hooks: {
@@ -423,35 +423,35 @@ got('example.com', {
     };
 
     got('example.com', {
-      hooks: {
-        beforeRequest: [
-          async () => {
-            await doSomethingAsync();
-          },
-        ],
-        beforeRedirect: [
-          async () => {
-            await doSomethingAsync();
-          },
-        ],
-        beforeRetry: [
-          async () => {
-            await doSomethingAsync();
-          },
-        ],
-        beforeError: [
-          async error => {
-            await doSomethingAsync();
-            return error;
-          },
-        ],
-        afterResponse: [
-          async response => {
-            await doSomethingAsync();
-            return response;
-          },
-        ],
-      },
+        hooks: {
+            beforeRequest: [
+                async () => {
+                    await doSomethingAsync();
+                },
+            ],
+            beforeRedirect: [
+                async () => {
+                    await doSomethingAsync();
+                },
+            ],
+            beforeRetry: [
+                async () => {
+                    await doSomethingAsync();
+                },
+            ],
+            beforeError: [
+                async error => {
+                    await doSomethingAsync();
+                    return error;
+                },
+            ],
+            afterResponse: [
+                async response => {
+                    await doSomethingAsync();
+                    return response;
+                },
+            ],
+        },
     });
 }
 

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -388,6 +388,15 @@ got('example.com', {
 });
 got('example.com', {
     hooks: {
+        beforeError: [
+            (error) => {
+                return error;
+            }
+        ]
+    }
+});
+got('example.com', {
+    hooks: {
         afterResponse: [
             (response, retryWithMergedOptions) => {
                 if (response.statusCode === 401) { // Unauthorized
@@ -428,6 +437,12 @@ got('example.com', {
             beforeRetry: [
                 async () => {
                     await doSomethingAsync();
+                }
+            ],
+            beforeError: [
+                async (error) => {
+                    await doSomethingAsync();
+                    return error;
                 }
             ],
             afterResponse: [

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -107,18 +107,19 @@ declare namespace got {
     }
 
     type GotInstance<T = GotFn> = T &
-        Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> & {
-            stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
-            extend: GotExtend;
-            RequestError: typeof RequestError;
-            ReadError: typeof ReadError;
-            ParseError: typeof ParseError;
-            HTTPError: typeof HTTPError;
-            MaxRedirectsError: typeof MaxRedirectsError;
-            UnsupportedProtocolError: typeof UnsupportedProtocolError;
-            CancelError: typeof CancelError;
-            TimeoutError: typeof TimeoutError;
-        };
+        Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> &
+    {
+        stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
+        extend: GotExtend;
+        RequestError: typeof RequestError;
+        ReadError: typeof ReadError;
+        ParseError: typeof ParseError;
+        HTTPError: typeof HTTPError;
+        MaxRedirectsError: typeof MaxRedirectsError;
+        UnsupportedProtocolError: typeof UnsupportedProtocolError;
+        CancelError: typeof CancelError;
+        TimeoutError: typeof TimeoutError;
+    };
 
     interface GotExtend {
         (options: GotJSONOptions): GotInstance<GotJSONFn>;
@@ -182,7 +183,7 @@ declare namespace got {
      */
     type AfterResponseHook<Options, Body extends Buffer | string | object> = (
         response: Response<Body>,
-        retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>,
+        retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>
     ) => Response<Body> | Promise<Response<Body>>;
 
     interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
@@ -306,83 +307,48 @@ declare namespace got {
     interface GotEmitter {
         addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        addListener(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
+        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         on(event: 'request', listener: (req: http.ClientRequest) => void): this;
         on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        on(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
+        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         once(event: 'request', listener: (req: http.ClientRequest) => void): this;
         once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        once(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
+        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependListener(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
-        prependListener(
-            event: 'error',
-            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-        ): this;
+        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        prependListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependOnceListener(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
-        prependOnceListener(
-            event: 'error',
-            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-        ): this;
+        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        prependOnceListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        removeListener(
-            event: 'redirect',
-            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-        ): this;
-        removeListener(
-            event: 'error',
-            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-        ): this;
+        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        removeListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
     }
 
-    type GotError =
-        | RequestError
-        | ReadError
-        | ParseError
-        | HTTPError
-        | MaxRedirectsError
-        | UnsupportedProtocolError
-        | CancelError
-        | TimeoutError;
+    type GotError = RequestError | ReadError | ParseError | HTTPError | MaxRedirectsError | UnsupportedProtocolError | CancelError | TimeoutError;
 
     interface Progress {
         percent: number;

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -7,6 +7,7 @@
 //                 Matthew Bull <https://github.com/wingsbob>
 //                 Ryan Wilson-Perkin <https://github.com/ryanwilsonperkin>
 //                 Paul Hawxby <https://github.com/phawxby>
+//                 Ivy Witter <https://github.com/ivywit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -145,6 +146,7 @@ declare namespace got {
         beforeRequest?: Array<BeforeRequestHook<Options>>;
         beforeRedirect?: Array<BeforeRedirectHook<Options>>;
         beforeRetry?: Array<BeforeRetryHook<Options>>;
+        beforeError?: Array<BeforeErrorHook>;
         afterResponse?: Array<AfterResponseHook<Options, Body>>;
     }
 
@@ -169,6 +171,11 @@ declare namespace got {
      * @param retryCount Number of retry.
      */
     type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
+
+    /**
+     * @param error Request or parse error.
+     */
+    type BeforeErrorHook = <ErrorLike extends Error | GotError | ParseError | HTTPError | MaxRedirectsError>(error: ErrorLike) => Error | Promise<Error>;
 
     /**
      * @param response Response object.

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -22,371 +22,371 @@ import { CookieJar } from 'tough-cookie';
 export = got;
 
 declare class RequestError extends StdError {
-  name: 'RequestError';
+    name: 'RequestError';
 }
 
 declare class ReadError extends StdError {
-  name: 'ReadError';
+    name: 'ReadError';
 }
 
 declare class ParseError extends StdError {
-  name: 'ParseError';
-  statusCode: number;
-  statusMessage: string;
+    name: 'ParseError';
+    statusCode: number;
+    statusMessage: string;
 }
 
 declare class HTTPError extends StdError {
-  name: 'HTTPError';
-  statusCode: number;
-  statusMessage: string;
-  headers: http.IncomingHttpHeaders;
-  body: Buffer | string | object;
+    name: 'HTTPError';
+    statusCode: number;
+    statusMessage: string;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer | string | object;
 }
 
 declare class MaxRedirectsError extends StdError {
-  name: 'MaxRedirectsError';
-  statusCode: number;
-  statusMessage: string;
-  redirectUrls: string[];
+    name: 'MaxRedirectsError';
+    statusCode: number;
+    statusMessage: string;
+    redirectUrls: string[];
 }
 
 declare class UnsupportedProtocolError extends StdError {
-  name: 'UnsupportedProtocolError';
+    name: 'UnsupportedProtocolError';
 }
 
 declare class CancelError extends StdError {
-  name: 'CancelError';
+    name: 'CancelError';
 }
 
 declare class TimeoutError extends StdError {
-  name: 'TimeoutError';
+    name: 'TimeoutError';
 }
 
 declare class StdError extends Error {
-  code?: string;
-  host?: string;
-  hostname?: string;
-  method?: string;
-  path?: string;
-  protocol?: string;
-  url?: string;
-  response?: any;
+    code?: string;
+    host?: string;
+    hostname?: string;
+    method?: string;
+    path?: string;
+    protocol?: string;
+    url?: string;
+    response?: any;
 }
 
 declare const got: got.GotInstance;
 
 interface InternalRequestOptions extends https.RequestOptions {
-  // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
-  timeout?: any;
-  agent?: any;
+    // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
+    timeout?: any;
+    agent?: any;
 }
 
 declare namespace got {
-  interface GotFn {
-    (url: GotUrl): GotPromise<string>;
-    (url: GotUrl, options: GotJSONOptions): GotPromise<any>;
-    (url: GotUrl, options: GotFormOptions<string>): GotPromise<string>;
-    (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
-    (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;
-    (url: GotUrl, options: GotBodyOptions<null>): GotPromise<Buffer>;
-  }
+    interface GotFn {
+        (url: GotUrl): GotPromise<string>;
+        (url: GotUrl, options: GotJSONOptions): GotPromise<any>;
+        (url: GotUrl, options: GotFormOptions<string>): GotPromise<string>;
+        (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
+        (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;
+        (url: GotUrl, options: GotBodyOptions<null>): GotPromise<Buffer>;
+    }
 
-  interface GotJSONFn {
-    (url: GotUrl): GotPromise<any>;
-    (url: GotUrl, options: Partial<GotJSONOptions>): GotPromise<any>;
-  }
+    interface GotJSONFn {
+        (url: GotUrl): GotPromise<any>;
+        (url: GotUrl, options: Partial<GotJSONOptions>): GotPromise<any>;
+    }
 
-  interface GotFormFn<T extends string | null> {
-    (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
-    (url: GotUrl, options: Partial<GotFormOptions<T>>): GotPromise<T extends null ? Buffer : string>;
-  }
+    interface GotFormFn<T extends string | null> {
+        (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
+        (url: GotUrl, options: Partial<GotFormOptions<T>>): GotPromise<T extends null ? Buffer : string>;
+    }
 
-  interface GotBodyFn<T extends string | null> {
-    (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
-    (url: GotUrl, options: GotBodyOptions<T>): GotPromise<T extends null ? Buffer : string>;
-  }
+    interface GotBodyFn<T extends string | null> {
+        (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
+        (url: GotUrl, options: GotBodyOptions<T>): GotPromise<T extends null ? Buffer : string>;
+    }
 
-  type GotInstance<T = GotFn> = T &
-    Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> & {
-      stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
-      extend: GotExtend;
-      RequestError: typeof RequestError;
-      ReadError: typeof ReadError;
-      ParseError: typeof ParseError;
-      HTTPError: typeof HTTPError;
-      MaxRedirectsError: typeof MaxRedirectsError;
-      UnsupportedProtocolError: typeof UnsupportedProtocolError;
-      CancelError: typeof CancelError;
-      TimeoutError: typeof TimeoutError;
-    };
+    type GotInstance<T = GotFn> = T &
+        Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> & {
+            stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
+            extend: GotExtend;
+            RequestError: typeof RequestError;
+            ReadError: typeof ReadError;
+            ParseError: typeof ParseError;
+            HTTPError: typeof HTTPError;
+            MaxRedirectsError: typeof MaxRedirectsError;
+            UnsupportedProtocolError: typeof UnsupportedProtocolError;
+            CancelError: typeof CancelError;
+            TimeoutError: typeof TimeoutError;
+        };
 
-  interface GotExtend {
-    (options: GotJSONOptions): GotInstance<GotJSONFn>;
-    (options: GotFormOptions<string>): GotInstance<GotFormFn<string>>;
-    (options: GotFormOptions<null>): GotInstance<GotFormFn<null>>;
-    (options: GotBodyOptions<string>): GotInstance<GotBodyFn<string>>;
-    (options: GotBodyOptions<null>): GotInstance<GotBodyFn<null>>;
-  }
+    interface GotExtend {
+        (options: GotJSONOptions): GotInstance<GotJSONFn>;
+        (options: GotFormOptions<string>): GotInstance<GotFormFn<string>>;
+        (options: GotFormOptions<null>): GotInstance<GotFormFn<null>>;
+        (options: GotBodyOptions<string>): GotInstance<GotBodyFn<string>>;
+        (options: GotBodyOptions<null>): GotInstance<GotBodyFn<null>>;
+    }
 
-  type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
+    type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
 
-  type GotUrl = string | https.RequestOptions | Url | URL;
+    type GotUrl = string | https.RequestOptions | Url | URL;
 
-  /**
-   * Hooks allow modifications during the request lifecycle. Hook functions may be async and are
-   * run serially.
-   *
-   * @see https://github.com/sindresorhus/got#hooks
-   * @template Options Request options.
-   * @template Body Response body type.
-   */
-  interface Hooks<Options, Body extends Buffer | string | object> {
-    init?: Array<InitHook<Options>>;
-    beforeRequest?: Array<BeforeRequestHook<Options>>;
-    beforeRedirect?: Array<BeforeRedirectHook<Options>>;
-    beforeRetry?: Array<BeforeRetryHook<Options>>;
-    beforeError?: BeforeErrorHook[];
-    afterResponse?: Array<AfterResponseHook<Options, Body>>;
-  }
-
-  /**
-   * @param options Unnormalized request options.
-   */
-  type InitHook<Options> = (options: Options) => void;
-
-  /**
-   * @param options Normalized request options.
-   */
-  type BeforeRequestHook<Options> = (options: Options) => any;
-
-  /**
-   * @param options Normalized request options.
-   */
-  type BeforeRedirectHook<Options> = (options: Options) => any;
-
-  /**
-   * @param options Normalized request options.
-   * @param error Request error.
-   * @param retryCount Number of retry.
-   */
-  type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
-
-  /**
-   * @param error Request or parse error.
-   */
-  type BeforeErrorHook = (error: GotError | ParseError | HTTPError | MaxRedirectsError) => Error | Promise<Error>;
-
-  /**
-   * @param response Response object.
-   * @param retryWithMergedOptions Retries request with the updated options.
-   */
-  type AfterResponseHook<Options, Body extends Buffer | string | object> = (
-    response: Response<Body>,
-    retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>,
-  ) => Response<Body> | Promise<Response<Body>>;
-
-  interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
-    body?: string | Buffer | nodeStream.Readable;
-    hooks?: Hooks<GotBodyOptions<E>, string | Buffer | nodeStream.Readable>;
-  }
-
-  interface GotJSONOptions extends GotOptions<string | null> {
-    // Body must be an object or array. See https://github.com/sindresorhus/got/issues/511
-    body?: object;
-    form?: boolean;
-    json: true;
-    hooks?: Hooks<GotJSONOptions, object>;
-  }
-
-  interface GotFormOptions<E extends string | null> extends GotOptions<E> {
-    body?: Record<string, any>;
-    form: true;
-    json?: boolean;
-    hooks?: Hooks<GotFormOptions<E>, Record<string, any>>;
-  }
-
-  type RequestFunction = typeof https.request;
-
-  interface GotOptions<E extends string | null> extends InternalRequestOptions {
-    baseUrl?: string;
-    cookieJar?: CookieJar;
-    encoding?: E;
-    query?: Record<string, any> | URLSearchParams | string;
-    timeout?: number | TimeoutOptions;
-    retry?: number | RetryOptions;
-    followRedirect?: boolean;
-    decompress?: boolean;
-    useElectronNet?: boolean;
-    throwHttpErrors?: boolean;
-    agent?: http.Agent | boolean | AgentOptions;
-    cache?: Cache;
-    request?: RequestFunction;
-  }
-
-  /**
-   * Contains properties to constrain the duration of each phase of the request lifecycle.
-   *
-   * @see https://github.com/sindresorhus/got#timeout
-   */
-  interface TimeoutOptions {
     /**
-     * Starts when a socket is assigned and ends when the hostname has been resolved. Does not
-     * apply when using a Unix domain socket.
+     * Hooks allow modifications during the request lifecycle. Hook functions may be async and are
+     * run serially.
+     *
+     * @see https://github.com/sindresorhus/got#hooks
+     * @template Options Request options.
+     * @template Body Response body type.
      */
-    lookup?: number;
+    interface Hooks<Options, Body extends Buffer | string | object> {
+        init?: Array<InitHook<Options>>;
+        beforeRequest?: Array<BeforeRequestHook<Options>>;
+        beforeRedirect?: Array<BeforeRedirectHook<Options>>;
+        beforeRetry?: Array<BeforeRetryHook<Options>>;
+        beforeError?: BeforeErrorHook[];
+        afterResponse?: Array<AfterResponseHook<Options, Body>>;
+    }
+
     /**
-     * Starts when `lookup` completes (or when the socket is assigned if lookup does not apply
-     * to the request) and ends when the socket is connected.
+     * @param options Unnormalized request options.
      */
-    connect?: number;
+    type InitHook<Options> = (options: Options) => void;
+
     /**
-     * Starts when `connect` completes and ends when the handshaking process completes (HTTPS
-     * only).
+     * @param options Normalized request options.
      */
-    secureConnect?: number;
+    type BeforeRequestHook<Options> = (options: Options) => any;
+
     /**
-     * Starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
+     * @param options Normalized request options.
      */
-    socket?: number;
+    type BeforeRedirectHook<Options> = (options: Options) => any;
+
     /**
-     * Starts when the request has been written to the socket and ends when the response headers
-     * are received.
+     * @param options Normalized request options.
+     * @param error Request error.
+     * @param retryCount Number of retry.
      */
-    response?: number;
+    type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
+
     /**
-     * Starts when the socket is connected and ends with the request has been written to the
-     * socket.
+     * @param error Request or parse error.
      */
-    send?: number;
+    type BeforeErrorHook = (error: GotError | ParseError | HTTPError | MaxRedirectsError) => Error | Promise<Error>;
+
     /**
-     * Starts when the request is initiated and ends when the response's end event fires.
+     * @param response Response object.
+     * @param retryWithMergedOptions Retries request with the updated options.
      */
-    request?: number;
-  }
+    type AfterResponseHook<Options, Body extends Buffer | string | object> = (
+        response: Response<Body>,
+        retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>,
+    ) => Response<Body> | Promise<Response<Body>>;
 
-  type RetryFunction = (retry: number, error: any) => number;
+    interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
+        body?: string | Buffer | nodeStream.Readable;
+        hooks?: Hooks<GotBodyOptions<E>, string | Buffer | nodeStream.Readable>;
+    }
 
-  interface RetryOptions {
-    retries?: number | RetryFunction;
-    methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
-    statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
-    maxRetryAfter?: number;
+    interface GotJSONOptions extends GotOptions<string | null> {
+        // Body must be an object or array. See https://github.com/sindresorhus/got/issues/511
+        body?: object;
+        form?: boolean;
+        json: true;
+        hooks?: Hooks<GotJSONOptions, object>;
+    }
+
+    interface GotFormOptions<E extends string | null> extends GotOptions<E> {
+        body?: Record<string, any>;
+        form: true;
+        json?: boolean;
+        hooks?: Hooks<GotFormOptions<E>, Record<string, any>>;
+    }
+
+    type RequestFunction = typeof https.request;
+
+    interface GotOptions<E extends string | null> extends InternalRequestOptions {
+        baseUrl?: string;
+        cookieJar?: CookieJar;
+        encoding?: E;
+        query?: Record<string, any> | URLSearchParams | string;
+        timeout?: number | TimeoutOptions;
+        retry?: number | RetryOptions;
+        followRedirect?: boolean;
+        decompress?: boolean;
+        useElectronNet?: boolean;
+        throwHttpErrors?: boolean;
+        agent?: http.Agent | boolean | AgentOptions;
+        cache?: Cache;
+        request?: RequestFunction;
+    }
+
     /**
-     * Allowed error codes.
+     * Contains properties to constrain the duration of each phase of the request lifecycle.
+     *
+     * @see https://github.com/sindresorhus/got#timeout
      */
-    errorCodes?: string[];
-  }
+    interface TimeoutOptions {
+        /**
+         * Starts when a socket is assigned and ends when the hostname has been resolved. Does not
+         * apply when using a Unix domain socket.
+         */
+        lookup?: number;
+        /**
+         * Starts when `lookup` completes (or when the socket is assigned if lookup does not apply
+         * to the request) and ends when the socket is connected.
+         */
+        connect?: number;
+        /**
+         * Starts when `connect` completes and ends when the handshaking process completes (HTTPS
+         * only).
+         */
+        secureConnect?: number;
+        /**
+         * Starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
+         */
+        socket?: number;
+        /**
+         * Starts when the request has been written to the socket and ends when the response headers
+         * are received.
+         */
+        response?: number;
+        /**
+         * Starts when the socket is connected and ends with the request has been written to the
+         * socket.
+         */
+        send?: number;
+        /**
+         * Starts when the request is initiated and ends when the response's end event fires.
+         */
+        request?: number;
+    }
 
-  interface AgentOptions {
-    http: http.Agent;
-    https: https.Agent;
-  }
+    type RetryFunction = (retry: number, error: any) => number;
 
-  interface Cache {
-    set(key: string, value: any, ttl?: number): any;
-    get(key: string): any;
-    delete(key: string): any;
-  }
+    interface RetryOptions {
+        retries?: number | RetryFunction;
+        methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+        statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
+        maxRetryAfter?: number;
+        /**
+         * Allowed error codes.
+         */
+        errorCodes?: string[];
+    }
 
-  interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
-    body: B;
-    url: string;
-    requestUrl: string;
-    fromCache: boolean;
-    redirectUrls?: string[];
-    retryCount: number;
+    interface AgentOptions {
+        http: http.Agent;
+        https: https.Agent;
+    }
 
-    // got's Response is always a "response obtained from http.ClientRequest", therefore these two properties are never undefined
-    statusCode: number;
-    statusMessage: string;
-  }
+    interface Cache {
+        set(key: string, value: any, ttl?: number): any;
+        get(key: string): any;
+        delete(key: string): any;
+    }
 
-  type GotPromise<B extends Buffer | string | object> = Promise<Response<B>> & { cancel(): void };
+    interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
+        body: B;
+        url: string;
+        requestUrl: string;
+        fromCache: boolean;
+        redirectUrls?: string[];
+        retryCount: number;
 
-  interface GotEmitter {
-    addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    addListener(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-    addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+        // got's Response is always a "response obtained from http.ClientRequest", therefore these two properties are never undefined
+        statusCode: number;
+        statusMessage: string;
+    }
 
-    on(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    on(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-    on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    type GotPromise<B extends Buffer | string | object> = Promise<Response<B>> & { cancel(): void };
 
-    once(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    once(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-    once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    interface GotEmitter {
+        addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        addListener(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-    prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    prependListener(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    prependListener(
-      event: 'error',
-      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-    ): this;
-    prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+        on(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        on(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-    prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    prependOnceListener(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    prependOnceListener(
-      event: 'error',
-      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-    ): this;
-    prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+        once(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        once(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-    removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-    removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-    removeListener(
-      event: 'redirect',
-      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
-    ): this;
-    removeListener(
-      event: 'error',
-      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
-    ): this;
-    removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-    removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
-  }
+        prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        prependListener(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        prependListener(
+            event: 'error',
+            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+        ): this;
+        prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-  type GotError =
-    | RequestError
-    | ReadError
-    | ParseError
-    | HTTPError
-    | MaxRedirectsError
-    | UnsupportedProtocolError
-    | CancelError
-    | TimeoutError;
+        prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        prependOnceListener(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        prependOnceListener(
+            event: 'error',
+            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+        ): this;
+        prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-  interface Progress {
-    percent: number;
-    transferred: number;
-    total: number | null;
-  }
+        removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+        removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+        removeListener(
+            event: 'redirect',
+            listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+        ): this;
+        removeListener(
+            event: 'error',
+            listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+        ): this;
+        removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    }
+
+    type GotError =
+        | RequestError
+        | ReadError
+        | ParseError
+        | HTTPError
+        | MaxRedirectsError
+        | UnsupportedProtocolError
+        | CancelError
+        | TimeoutError;
+
+    interface Progress {
+        percent: number;
+        transferred: number;
+        total: number | null;
+    }
 }

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -22,337 +22,371 @@ import { CookieJar } from 'tough-cookie';
 export = got;
 
 declare class RequestError extends StdError {
-    name: 'RequestError';
+  name: 'RequestError';
 }
 
 declare class ReadError extends StdError {
-    name: 'ReadError';
+  name: 'ReadError';
 }
 
 declare class ParseError extends StdError {
-    name: 'ParseError';
-    statusCode: number;
-    statusMessage: string;
+  name: 'ParseError';
+  statusCode: number;
+  statusMessage: string;
 }
 
 declare class HTTPError extends StdError {
-    name: 'HTTPError';
-    statusCode: number;
-    statusMessage: string;
-    headers: http.IncomingHttpHeaders;
-    body: Buffer | string | object;
+  name: 'HTTPError';
+  statusCode: number;
+  statusMessage: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer | string | object;
 }
 
 declare class MaxRedirectsError extends StdError {
-    name: 'MaxRedirectsError';
-    statusCode: number;
-    statusMessage: string;
-    redirectUrls: string[];
+  name: 'MaxRedirectsError';
+  statusCode: number;
+  statusMessage: string;
+  redirectUrls: string[];
 }
 
 declare class UnsupportedProtocolError extends StdError {
-    name: 'UnsupportedProtocolError';
+  name: 'UnsupportedProtocolError';
 }
 
 declare class CancelError extends StdError {
-    name: 'CancelError';
+  name: 'CancelError';
 }
 
 declare class TimeoutError extends StdError {
-    name: 'TimeoutError';
+  name: 'TimeoutError';
 }
 
 declare class StdError extends Error {
-    code?: string;
-    host?: string;
-    hostname?: string;
-    method?: string;
-    path?: string;
-    protocol?: string;
-    url?: string;
-    response?: any;
+  code?: string;
+  host?: string;
+  hostname?: string;
+  method?: string;
+  path?: string;
+  protocol?: string;
+  url?: string;
+  response?: any;
 }
 
 declare const got: got.GotInstance;
 
 interface InternalRequestOptions extends https.RequestOptions {
-    // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
-    timeout?: any;
-    agent?: any;
+  // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
+  timeout?: any;
+  agent?: any;
 }
 
 declare namespace got {
-    interface GotFn {
-        (url: GotUrl): GotPromise<string>;
-        (url: GotUrl, options: GotJSONOptions): GotPromise<any>;
-        (url: GotUrl, options: GotFormOptions<string>): GotPromise<string>;
-        (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
-        (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;
-        (url: GotUrl, options: GotBodyOptions<null>): GotPromise<Buffer>;
-    }
+  interface GotFn {
+    (url: GotUrl): GotPromise<string>;
+    (url: GotUrl, options: GotJSONOptions): GotPromise<any>;
+    (url: GotUrl, options: GotFormOptions<string>): GotPromise<string>;
+    (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
+    (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;
+    (url: GotUrl, options: GotBodyOptions<null>): GotPromise<Buffer>;
+  }
 
-    interface GotJSONFn {
-        (url: GotUrl): GotPromise<any>;
-        (url: GotUrl, options: Partial<GotJSONOptions>): GotPromise<any>;
-    }
+  interface GotJSONFn {
+    (url: GotUrl): GotPromise<any>;
+    (url: GotUrl, options: Partial<GotJSONOptions>): GotPromise<any>;
+  }
 
-    interface GotFormFn<T extends string | null> {
-        (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
-        (url: GotUrl, options: Partial<GotFormOptions<T>>): GotPromise<T extends null ? Buffer : string>;
-    }
+  interface GotFormFn<T extends string | null> {
+    (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
+    (url: GotUrl, options: Partial<GotFormOptions<T>>): GotPromise<T extends null ? Buffer : string>;
+  }
 
-    interface GotBodyFn<T extends string | null> {
-        (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
-        (url: GotUrl, options: GotBodyOptions<T>): GotPromise<T extends null ? Buffer : string>;
-    }
+  interface GotBodyFn<T extends string | null> {
+    (url: GotUrl): GotPromise<T extends null ? Buffer : string>;
+    (url: GotUrl, options: GotBodyOptions<T>): GotPromise<T extends null ? Buffer : string>;
+  }
 
-    type GotInstance<T = GotFn> = T &
-        Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> &
-    {
-        stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
-        extend: GotExtend;
-        RequestError: typeof RequestError;
-        ReadError: typeof ReadError;
-        ParseError: typeof ParseError;
-        HTTPError: typeof HTTPError;
-        MaxRedirectsError: typeof MaxRedirectsError;
-        UnsupportedProtocolError: typeof UnsupportedProtocolError;
-        CancelError: typeof CancelError;
-        TimeoutError: typeof TimeoutError;
+  type GotInstance<T = GotFn> = T &
+    Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', T> & {
+      stream: GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', GotStreamFn>;
+      extend: GotExtend;
+      RequestError: typeof RequestError;
+      ReadError: typeof ReadError;
+      ParseError: typeof ParseError;
+      HTTPError: typeof HTTPError;
+      MaxRedirectsError: typeof MaxRedirectsError;
+      UnsupportedProtocolError: typeof UnsupportedProtocolError;
+      CancelError: typeof CancelError;
+      TimeoutError: typeof TimeoutError;
     };
 
-    interface GotExtend {
-        (options: GotJSONOptions): GotInstance<GotJSONFn>;
-        (options: GotFormOptions<string>): GotInstance<GotFormFn<string>>;
-        (options: GotFormOptions<null>): GotInstance<GotFormFn<null>>;
-        (options: GotBodyOptions<string>): GotInstance<GotBodyFn<string>>;
-        (options: GotBodyOptions<null>): GotInstance<GotBodyFn<null>>;
-    }
+  interface GotExtend {
+    (options: GotJSONOptions): GotInstance<GotJSONFn>;
+    (options: GotFormOptions<string>): GotInstance<GotFormFn<string>>;
+    (options: GotFormOptions<null>): GotInstance<GotFormFn<null>>;
+    (options: GotBodyOptions<string>): GotInstance<GotBodyFn<string>>;
+    (options: GotBodyOptions<null>): GotInstance<GotBodyFn<null>>;
+  }
 
-    type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
+  type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
 
-    type GotUrl = string | https.RequestOptions | Url | URL;
+  type GotUrl = string | https.RequestOptions | Url | URL;
 
+  /**
+   * Hooks allow modifications during the request lifecycle. Hook functions may be async and are
+   * run serially.
+   *
+   * @see https://github.com/sindresorhus/got#hooks
+   * @template Options Request options.
+   * @template Body Response body type.
+   */
+  interface Hooks<Options, Body extends Buffer | string | object> {
+    init?: Array<InitHook<Options>>;
+    beforeRequest?: Array<BeforeRequestHook<Options>>;
+    beforeRedirect?: Array<BeforeRedirectHook<Options>>;
+    beforeRetry?: Array<BeforeRetryHook<Options>>;
+    beforeError?: BeforeErrorHook[];
+    afterResponse?: Array<AfterResponseHook<Options, Body>>;
+  }
+
+  /**
+   * @param options Unnormalized request options.
+   */
+  type InitHook<Options> = (options: Options) => void;
+
+  /**
+   * @param options Normalized request options.
+   */
+  type BeforeRequestHook<Options> = (options: Options) => any;
+
+  /**
+   * @param options Normalized request options.
+   */
+  type BeforeRedirectHook<Options> = (options: Options) => any;
+
+  /**
+   * @param options Normalized request options.
+   * @param error Request error.
+   * @param retryCount Number of retry.
+   */
+  type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
+
+  /**
+   * @param error Request or parse error.
+   */
+  type BeforeErrorHook = (error: GotError | ParseError | HTTPError | MaxRedirectsError) => Error | Promise<Error>;
+
+  /**
+   * @param response Response object.
+   * @param retryWithMergedOptions Retries request with the updated options.
+   */
+  type AfterResponseHook<Options, Body extends Buffer | string | object> = (
+    response: Response<Body>,
+    retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>,
+  ) => Response<Body> | Promise<Response<Body>>;
+
+  interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
+    body?: string | Buffer | nodeStream.Readable;
+    hooks?: Hooks<GotBodyOptions<E>, string | Buffer | nodeStream.Readable>;
+  }
+
+  interface GotJSONOptions extends GotOptions<string | null> {
+    // Body must be an object or array. See https://github.com/sindresorhus/got/issues/511
+    body?: object;
+    form?: boolean;
+    json: true;
+    hooks?: Hooks<GotJSONOptions, object>;
+  }
+
+  interface GotFormOptions<E extends string | null> extends GotOptions<E> {
+    body?: Record<string, any>;
+    form: true;
+    json?: boolean;
+    hooks?: Hooks<GotFormOptions<E>, Record<string, any>>;
+  }
+
+  type RequestFunction = typeof https.request;
+
+  interface GotOptions<E extends string | null> extends InternalRequestOptions {
+    baseUrl?: string;
+    cookieJar?: CookieJar;
+    encoding?: E;
+    query?: Record<string, any> | URLSearchParams | string;
+    timeout?: number | TimeoutOptions;
+    retry?: number | RetryOptions;
+    followRedirect?: boolean;
+    decompress?: boolean;
+    useElectronNet?: boolean;
+    throwHttpErrors?: boolean;
+    agent?: http.Agent | boolean | AgentOptions;
+    cache?: Cache;
+    request?: RequestFunction;
+  }
+
+  /**
+   * Contains properties to constrain the duration of each phase of the request lifecycle.
+   *
+   * @see https://github.com/sindresorhus/got#timeout
+   */
+  interface TimeoutOptions {
     /**
-     * Hooks allow modifications during the request lifecycle. Hook functions may be async and are
-     * run serially.
-     *
-     * @see https://github.com/sindresorhus/got#hooks
-     * @template Options Request options.
-     * @template Body Response body type.
+     * Starts when a socket is assigned and ends when the hostname has been resolved. Does not
+     * apply when using a Unix domain socket.
      */
-    interface Hooks<Options, Body extends Buffer | string | object> {
-        init?: Array<InitHook<Options>>;
-        beforeRequest?: Array<BeforeRequestHook<Options>>;
-        beforeRedirect?: Array<BeforeRedirectHook<Options>>;
-        beforeRetry?: Array<BeforeRetryHook<Options>>;
-        beforeError?: Array<BeforeErrorHook>;
-        afterResponse?: Array<AfterResponseHook<Options, Body>>;
-    }
-
+    lookup?: number;
     /**
-     * @param options Unnormalized request options.
+     * Starts when `lookup` completes (or when the socket is assigned if lookup does not apply
+     * to the request) and ends when the socket is connected.
      */
-    type InitHook<Options> = (options: Options) => void;
-
+    connect?: number;
     /**
-     * @param options Normalized request options.
+     * Starts when `connect` completes and ends when the handshaking process completes (HTTPS
+     * only).
      */
-    type BeforeRequestHook<Options> = (options: Options) => any;
-
+    secureConnect?: number;
     /**
-     * @param options Normalized request options.
+     * Starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
      */
-    type BeforeRedirectHook<Options> = (options: Options) => any;
-
+    socket?: number;
     /**
-     * @param options Normalized request options.
-     * @param error Request error.
-     * @param retryCount Number of retry.
+     * Starts when the request has been written to the socket and ends when the response headers
+     * are received.
      */
-    type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
-
+    response?: number;
     /**
-     * @param error Request or parse error.
+     * Starts when the socket is connected and ends with the request has been written to the
+     * socket.
      */
-    type BeforeErrorHook = <ErrorLike extends Error | GotError | ParseError | HTTPError | MaxRedirectsError>(error: ErrorLike) => Error | Promise<Error>;
-
+    send?: number;
     /**
-     * @param response Response object.
-     * @param retryWithMergedOptions Retries request with the updated options.
+     * Starts when the request is initiated and ends when the response's end event fires.
      */
-    type AfterResponseHook<Options, Body extends Buffer | string | object> = (
-        response: Response<Body>,
-        retryWithMergedOptions: (updateOptions: Options) => GotPromise<Body>
-    ) => Response<Body> | Promise<Response<Body>>;
+    request?: number;
+  }
 
-    interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
-        body?: string | Buffer | nodeStream.Readable;
-        hooks?: Hooks<GotBodyOptions<E>, string | Buffer | nodeStream.Readable>;
-    }
+  type RetryFunction = (retry: number, error: any) => number;
 
-    interface GotJSONOptions extends GotOptions<string | null> {
-        // Body must be an object or array. See https://github.com/sindresorhus/got/issues/511
-        body?: object;
-        form?: boolean;
-        json: true;
-        hooks?: Hooks<GotJSONOptions, object>;
-    }
-
-    interface GotFormOptions<E extends string | null> extends GotOptions<E> {
-        body?: Record<string, any>;
-        form: true;
-        json?: boolean;
-        hooks?: Hooks<GotFormOptions<E>, Record<string, any>>;
-    }
-
-    type RequestFunction = typeof https.request;
-
-    interface GotOptions<E extends string | null> extends InternalRequestOptions {
-        baseUrl?: string;
-        cookieJar?: CookieJar;
-        encoding?: E;
-        query?: Record<string, any> | URLSearchParams | string;
-        timeout?: number | TimeoutOptions;
-        retry?: number | RetryOptions;
-        followRedirect?: boolean;
-        decompress?: boolean;
-        useElectronNet?: boolean;
-        throwHttpErrors?: boolean;
-        agent?: http.Agent | boolean | AgentOptions;
-        cache?: Cache;
-        request?: RequestFunction;
-    }
-
+  interface RetryOptions {
+    retries?: number | RetryFunction;
+    methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+    statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
+    maxRetryAfter?: number;
     /**
-     * Contains properties to constrain the duration of each phase of the request lifecycle.
-     *
-     * @see https://github.com/sindresorhus/got#timeout
+     * Allowed error codes.
      */
-    interface TimeoutOptions {
-        /**
-         * Starts when a socket is assigned and ends when the hostname has been resolved. Does not
-         * apply when using a Unix domain socket.
-         */
-        lookup?: number;
-        /**
-         * Starts when `lookup` completes (or when the socket is assigned if lookup does not apply
-         * to the request) and ends when the socket is connected.
-         */
-        connect?: number;
-        /**
-         * Starts when `connect` completes and ends when the handshaking process completes (HTTPS
-         * only).
-         */
-        secureConnect?: number;
-        /**
-         * Starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
-         */
-        socket?: number;
-        /**
-         * Starts when the request has been written to the socket and ends when the response headers
-         * are received.
-         */
-        response?: number;
-        /**
-         * Starts when the socket is connected and ends with the request has been written to the
-         * socket.
-         */
-        send?: number;
-        /**
-         * Starts when the request is initiated and ends when the response's end event fires.
-         */
-        request?: number;
-    }
+    errorCodes?: string[];
+  }
 
-    type RetryFunction = (retry: number, error: any) => number;
+  interface AgentOptions {
+    http: http.Agent;
+    https: https.Agent;
+  }
 
-    interface RetryOptions {
-        retries?: number | RetryFunction;
-        methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
-        statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
-        maxRetryAfter?: number;
-        /**
-         * Allowed error codes.
-         */
-        errorCodes?: string[];
-    }
+  interface Cache {
+    set(key: string, value: any, ttl?: number): any;
+    get(key: string): any;
+    delete(key: string): any;
+  }
 
-    interface AgentOptions {
-        http: http.Agent;
-        https: https.Agent;
-    }
+  interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
+    body: B;
+    url: string;
+    requestUrl: string;
+    fromCache: boolean;
+    redirectUrls?: string[];
+    retryCount: number;
 
-    interface Cache {
-        set(key: string, value: any, ttl?: number): any;
-        get(key: string): any;
-        delete(key: string): any;
-    }
+    // got's Response is always a "response obtained from http.ClientRequest", therefore these two properties are never undefined
+    statusCode: number;
+    statusMessage: string;
+  }
 
-    interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
-        body: B;
-        url: string;
-        requestUrl: string;
-        fromCache: boolean;
-        redirectUrls?: string[];
-        retryCount: number;
+  type GotPromise<B extends Buffer | string | object> = Promise<Response<B>> & { cancel(): void };
 
-        // got's Response is always a "response obtained from http.ClientRequest", therefore these two properties are never undefined
-        statusCode: number;
-        statusMessage: string;
-    }
+  interface GotEmitter {
+    addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    addListener(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+    addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-    type GotPromise<B extends Buffer | string | object> = Promise<Response<B>> & { cancel(): void };
+    on(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    on(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+    on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-    interface GotEmitter {
-        addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    once(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    once(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+    once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-        on(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    prependListener(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    prependListener(
+      event: 'error',
+      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+    ): this;
+    prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-        once(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    prependOnceListener(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    prependOnceListener(
+      event: 'error',
+      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+    ): this;
+    prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
-        prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        prependListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+    removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
+    removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
+    removeListener(
+      event: 'redirect',
+      listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void,
+    ): this;
+    removeListener(
+      event: 'error',
+      listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void,
+    ): this;
+    removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+    removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+  }
 
-        prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        prependOnceListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
+  type GotError =
+    | RequestError
+    | ReadError
+    | ParseError
+    | HTTPError
+    | MaxRedirectsError
+    | UnsupportedProtocolError
+    | CancelError
+    | TimeoutError;
 
-        removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
-        removeListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
-        removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
-        removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
-    }
-
-    type GotError = RequestError | ReadError | ParseError | HTTPError | MaxRedirectsError | UnsupportedProtocolError | CancelError | TimeoutError;
-
-    interface Progress {
-        percent: number;
-        transferred: number;
-        total: number | null;
-    }
+  interface Progress {
+    percent: number;
+    transferred: number;
+    total: number | null;
+  }
 }

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -172,9 +172,6 @@ declare namespace got {
      */
     type BeforeRetryHook<Options> = (options: Options, error: GotError, retryCount: number) => any;
 
-    /**
-     * @param error Request or parse error.
-     */
     type BeforeErrorHook = (error: GotError) => Error | Promise<Error>;
 
     /**

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -175,7 +175,7 @@ declare namespace got {
     /**
      * @param error Request or parse error.
      */
-    type BeforeErrorHook = (error: GotError | ParseError | HTTPError | MaxRedirectsError) => Error | Promise<Error>;
+    type BeforeErrorHook = (error: GotError) => Error | Promise<Error>;
 
     /**
      * @param response Response object.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got#hooksbeforeerror
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes:

Declaration of `beforeErrorHook` was missing so when implementing hook in a TypeScript project and error was thrown. This adds the hook's type to allow it's use in a TypeScript project.