### PR TITLE
[@types/react] Make defaultValue of createContext<T>(...) optional

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -334,7 +334,7 @@ declare namespace React {
         displayName?: string;
     }
     function createContext<T>(
-        defaultValue: T,
+        defaultValue?: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
 


### PR DESCRIPTION
The `defaultValue` of `createContext<T>(...)` should be optional. According to [the docs](https://reactjs.org/docs/context.html#reactcreatecontext):

> The defaultValue argument is only used when a component does not have a matching Provider above it in the tree.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
