### PR TITLE
[@types/react-native] AccessibilityInfo needs forward port to RN0.60 API

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6910,7 +6910,15 @@ export interface ShareStatic {
     dismissedAction: "dismissedAction";
 }
 
-type AccessibilityEventName = "change" | "announcementFinished";
+type AccessibilityEventName =
+    "change" | // deprecated, maps to screenReaderChanged
+    "boldTextChanged" | // iOS-only Event
+    "grayscaleChanged" | // iOS-only Event
+    "invertColorsChanged" | // iOS-only Event
+    "reduceMotionChanged" |
+    "screenReaderChanged" |
+    "reduceTransparencyChanged" | // iOS-only Event
+    "announcementFinished"; // iOS-only Event
 
 type AccessibilityChangeEvent = boolean;
 
@@ -6926,21 +6934,60 @@ type AccessibilityEvent = AccessibilityChangeEvent | AccessibilityAnnoucementFin
  */
 export interface AccessibilityInfoStatic {
     /**
-     * Query whether a screen reader is currently enabled.
-     * Returns a promise which resolves to a boolean. The result is true when a screen reader is enabled and false otherwise.
+     * Query whether bold text is currently enabled.
+     *
+     * @platform ios
      */
-    fetch: () => Promise<boolean>;
+    isBoldTextEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether grayscale is currently enabled.
+     *
+     * @platform ios
+     */
+    isGrayscaleEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether invert colors is currently enabled.
+     *
+     * @platform ios
+     */
+    isInvertColorsEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether reduce motion is currently enabled.
+     */
+    isReduceMotionEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether reduce transparency is currently enabled.
+     *
+     * @platform ios
+     */
+    isReduceTransparencyEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether a screen reader is currently enabled.
+     */
+    isScreenReaderEnabled: () => Promise<boolean>;
+
+    /**
+     * Query whether a screen reader is currently enabled.
+     *
+     * @deprecated use isScreenReaderChanged instead
+     */
+    fetch(): () => Promise<boolean>;
 
     /**
      * Add an event handler. Supported events:
-     *  - change: Fires when the state of the screen reader changes.
-     *            The argument to the event handler is a boolean.
-     *            The boolean is true when a screen reader is enabled and false otherwise.
-     *
      * - announcementFinished: iOS-only event. Fires when the screen reader has finished making an announcement.
      *                         The argument to the event handler is a dictionary with these keys:
      *                          - announcement: The string announced by the screen reader.
      *                          - success: A boolean indicating whether the announcement was successfully made.
+     * - AccessibilityEventName constants other than announcementFinished: Fires on accessibility feature change.
+     *            The argument to the event handler is a boolean.
+     *            The boolean is true when the related event's feature is enabled and false otherwise.
+     *
      */
     addEventListener: (eventName: AccessibilityEventName, handler: (event: AccessibilityEvent) => void) => void;
 


### PR DESCRIPTION
AccessibilityInfo was expanded between RN59 and RN60 to include lots
of accessibility feature information beyond just screen reader status.

This updates the typings to match the docs: https://facebook.github.io/react-native/docs/accessibilityinfo

I have trouble running both `npm test` and `npm run lint react-native` for some reason, it complains of naming issues, but...I have not created a new package I am just editing an existing one? It definitely works for me in testing though, and is required to fix https://github.com/microsoft/reactxp/issues/1125

[Updated after determining the old upstream API exists but was merely deprecated]: The old APIs are deprecated but still exist, so this PR preserves them and just adds the new APIs that should be used going forward

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [!] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [!] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/accessibilityinfo
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
