### PR TITLE
[@types/csv2json] wrong type, returns is a Pumpify

### DIFF
--- a/types/csv2json/csv2json-tests.ts
+++ b/types/csv2json/csv2json-tests.ts
@@ -1,8 +1,11 @@
+import Pumpify = require("pumpify");
 import csv2json = require("csv2json");
 import fs = require("fs");
 
 fs.createReadStream('data.csv')
-  .pipe(csv2json({
-    separator: ';'
-  }))
+  .pipe(
+    // $ExpectType Pumpify
+    csv2json({
+      separator: ';'
+    }))
   .pipe(fs.createWriteStream('data.json'));

--- a/types/csv2json/index.d.ts
+++ b/types/csv2json/index.d.ts
@@ -3,9 +3,7 @@
 // Definitions by: Piotr Roszatycki <https://github.com/dex4er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
-
-import { Writable } from "stream";
+import Pumpify = require("pumpify");
 
 declare namespace csv2json {
   interface Options {
@@ -14,6 +12,6 @@ declare namespace csv2json {
   }
 }
 
-declare function csv2json(options?: csv2json.Options): Writable;
+declare function csv2json(options?: csv2json.Options): Pumpify;
 
 export = csv2json;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

It doesn't have a documentation, but you can test it easily.
```typescript
// will show you that the constructor actually is a Pumpify
require('csv2json')().constructor;
```
