### PR TITLE
export react-custom-scrollbars as namespace because it is a UMD module

### DIFF
--- a/types/react-custom-scrollbars/v3/index.d.ts
+++ b/types/react-custom-scrollbars/v3/index.d.ts
@@ -6,53 +6,55 @@
 
 import * as React from "react";
 
-declare module "react-custom-scrollbars" {
-    export interface positionValues {
-        top: number;
-        left: number;
-        clientWidth: number;
-        clientHeight: number;
-        scrollWidth: number;
-        scrollHeight: number;
-        scrollLeft: number;
-        scrollTop: number;
-    }
+export as namespace ReactCustomScrollbars;
 
-    export interface ScrollbarProps extends React.HTMLProps<Scrollbars> {
-        onScroll?: React.UIEventHandler<any>;
-        onScrollFrame?: (values: positionValues) => void;
-        onScrollStart?: () => void;
-        onScrollStop?: () => void;
-        onUpdate?: (values: positionValues) => void;
-
-        renderView?: React.StatelessComponent<any>;
-        renderTrackHorizontal?: React.StatelessComponent<any>;
-        renderTrackVertical?: React.StatelessComponent<any>;
-        renderThumbHorizontal?: React.StatelessComponent<any>;
-        renderThumbVertical?: React.StatelessComponent<any>;
-
-        autoHide?: boolean;
-        autoHideTimeout?: number;
-        autoHideDuration?: number;
-
-        thumbSize?: number;
-        thumbMinSize?: number;
-        universal?: boolean;
-    }
-
-    export default class Scrollbars extends React.Component<ScrollbarProps> {
-        scrollTop(top: number): void;
-        scrollLeft(left: number): void;
-        scrollToTop(): void;
-        scrollToBottom(): void;
-        scrollToLeft(): void;
-        scrollToRight(): void;
-        getScrollLeft(): number;
-        getScrollTop(): number;
-        getScrollWidth(): number;
-        getScrollHeight(): number;
-        getWidth(): number;
-        getHeight(): number;
-        getValues(): positionValues;
-    }
+export interface positionValues {
+    top: number;
+    left: number;
+    clientWidth: number;
+    clientHeight: number;
+    scrollWidth: number;
+    scrollHeight: number;
+    scrollLeft: number;
+    scrollTop: number;
 }
+
+export interface ScrollbarProps extends React.HTMLProps<Scrollbars> {
+    onScroll?: React.UIEventHandler<any>;
+    onScrollFrame?: (values: positionValues) => void;
+    onScrollStart?: () => void;
+    onScrollStop?: () => void;
+    onUpdate?: (values: positionValues) => void;
+
+    renderView?: React.StatelessComponent<any>;
+    renderTrackHorizontal?: React.StatelessComponent<any>;
+    renderTrackVertical?: React.StatelessComponent<any>;
+    renderThumbHorizontal?: React.StatelessComponent<any>;
+    renderThumbVertical?: React.StatelessComponent<any>;
+
+    autoHide?: boolean;
+    autoHideTimeout?: number;
+    autoHideDuration?: number;
+
+    thumbSize?: number;
+    thumbMinSize?: number;
+    universal?: boolean;
+}
+
+export class Scrollbars extends React.Component<ScrollbarProps> {
+    scrollTop(top: number): void;
+    scrollLeft(left: number): void;
+    scrollToTop(): void;
+    scrollToBottom(): void;
+    scrollToLeft(): void;
+    scrollToRight(): void;
+    getScrollLeft(): number;
+    getScrollTop(): number;
+    getScrollWidth(): number;
+    getScrollHeight(): number;
+    getWidth(): number;
+    getHeight(): number;
+    getValues(): positionValues;
+}
+
+export default Scrollbars;


### PR DESCRIPTION
Without doing this, tsc complains that node_modules/@types/react-custom-scrollbars/index.d.ts is not a module
This change also allows importing Scrollbars as the module default `import Scrollbars from` or as a named export `import {Scollbars} from` because either work.
Documentation that this is a UMD module: https://github.com/malte-wessel/react-custom-scrollbars/commit/f632d08e725f30ac40cdb6257752ad36b40c6fef