### PR TITLE
 ioredis: add lpopBuffer, lrangeBuffer and rpushBuffer (#37461)

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -135,6 +135,8 @@ declare namespace IORedis {
 
         rpush(key: KeyType, ...values: any[]): any;
 
+        rpushBuffer(key: string, ...values: Buffer[]): any;
+
         lpush(key: KeyType, ...values: any[]): any;
 
         rpushx(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
@@ -151,6 +153,9 @@ declare namespace IORedis {
 
         lpop(key: KeyType, callback: (err: Error, res: string) => void): void;
         lpop(key: KeyType): Promise<string>;
+
+        lpopBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
+        lpopBuffer(key: KeyType): Promise<Buffer>;
 
         brpop(...keys: KeyType[]): any;
 
@@ -170,6 +175,9 @@ declare namespace IORedis {
 
         lrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
         lrange(key: KeyType, start: number, stop: number): Promise<any>;
+
+        lrangeBuffer(key: KeyType, start: number, stop: number, callback: (err: Error, res: Buffer[]) => void): void;
+        lrangeBuffer(key: KeyType, start: number, stop: number): Promise<Buffer[]>;
 
         ltrim(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
         ltrim(key: KeyType, start: number, stop: number): Promise<any>;
@@ -579,6 +587,8 @@ declare namespace IORedis {
 
         rpush(key: KeyType, ...values: any[]): Pipeline;
 
+        rpushBuffer(key: string, ...values: Buffer[]): Pipeline;
+
         lpush(key: KeyType, ...values: any[]): Pipeline;
 
         rpushx(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
@@ -590,6 +600,8 @@ declare namespace IORedis {
         rpop(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
         lpop(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
+
+        lpopBuffer(key: KeyType, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
         brpop(...keys: KeyType[]): Pipeline;
 
@@ -604,6 +616,8 @@ declare namespace IORedis {
         lset(key: KeyType, index: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
         lrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+
+        lrangeBuffer(key: KeyType, start: number, stop: number, callback?: (err: Error, res: Buffer[]) => void): Pipeline;
 
         ltrim(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -44,6 +44,23 @@ redis.exists('foo', ((err, data) => data * 1));
 redis.set(Buffer.from('key'), '100');
 redis.setBuffer(Buffer.from('key'), '100', 'NX', 'EX', 10);
 
+const listData = ['foo', 'bar', 'baz'];
+listData.forEach(value => {
+    redis.rpushBuffer('bufferlist', Buffer.from(value));
+});
+redis.lpopBuffer('bufferlist', (err, result) => {
+    if (result.toString() !== listData[0]) {
+        console.log(result.toString());
+    }
+});
+redis.lrangeBuffer('bufferlist', 0, listData.length - 2, (err, results) => {
+    results.forEach((value, index) => {
+        if (value.toString() !== listData[index + 1]) {
+            console.log(value.toString());
+        }
+    });
+});
+
 new Redis();       // Connect to 127.0.0.1:6379
 new Redis(6380);   // 127.0.0.1:6380
 new Redis(6379, '192.168.1.1');       // 192.168.1.1:6379

--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -130,6 +130,8 @@ declare namespace IORedis {
 
         rpush(key: string, ...values: any[]): any;
 
+        rpushBuffer(key: string, ...values: Buffer[]): any;
+
         lpush(key: string, ...values: any[]): any;
 
         rpushx(key: string, value: any, callback: (err: Error, res: number) => void): void;
@@ -146,6 +148,9 @@ declare namespace IORedis {
 
         lpop(key: string, callback: (err: Error, res: string) => void): void;
         lpop(key: string): Promise<string>;
+
+        lpopBuffer(key: string, callback: (err: Error, res: Buffer) => void): void;
+        lpopBuffer(key: string): Promise<Buffer>;
 
         brpop(...keys: string[]): any;
 
@@ -165,6 +170,9 @@ declare namespace IORedis {
 
         lrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
         lrange(key: string, start: number, stop: number): Promise<any>;
+
+        lrangeBuffer(key: string, start: number, stop: number, callback: (err: Error, res: Buffer[]) => void): void;
+        lrangeBuffer(key: string, start: number, stop: number): Promise<Buffer[]>;
 
         ltrim(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
         ltrim(key: string, start: number, stop: number): Promise<any>;
@@ -536,6 +544,8 @@ declare namespace IORedis {
 
         rpush(key: string, ...values: any[]): Pipeline;
 
+        rpushBuffer(key: string, ...values: Buffer[]): Pipeline;
+
         lpush(key: string, ...values: any[]): Pipeline;
 
         rpushx(key: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
@@ -547,6 +557,8 @@ declare namespace IORedis {
         rpop(key: string, callback?: (err: Error, res: string) => void): Pipeline;
 
         lpop(key: string, callback?: (err: Error, res: string) => void): Pipeline;
+
+        lpopBuffer(key: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
         brpop(...keys: string[]): Pipeline;
 
@@ -561,6 +573,8 @@ declare namespace IORedis {
         lset(key: string, index: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
         lrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+
+        lrangeBuffer(key: string, start: number, stop: number, callback?: (err: Error, res: Buffer[]) => void): Pipeline;
 
         ltrim(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -34,6 +34,23 @@ redis.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 redis.exists('foo').then(result => result * 1);
 redis.exists('foo', ((err, data) => data * 1));
 
+const listData = ['foo', 'bar', 'baz'];
+listData.forEach(value => {
+    redis.rpushBuffer('bufferlist', Buffer.from(value));
+});
+redis.lpopBuffer('bufferlist', (err, result) => {
+    if (result.toString() !== listData[0]) {
+        console.log(result.toString());
+    }
+});
+redis.lrangeBuffer('bufferlist', 0, listData.length - 2, (err, results) => {
+    results.forEach((value, index) => {
+        if (value.toString() !== listData[index + 1]) {
+            console.log(value.toString());
+        }
+    });
+});
+
 new Redis();       // Connect to 127.0.0.1:6379
 new Redis(6380);   // 127.0.0.1:6380
 new Redis(6379, '192.168.1.1');       // 192.168.1.1:6379


### PR DESCRIPTION
add type definition and test of lpopBuffer, lrangeBuffer and rpushBuffer
issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37461

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
-- https://github.com/luin/ioredis#handle-binary-data
-- https://npmdoc.github.io/node-npmdoc-ioredis/build/apidoc.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
