### PR TITLE
sqljs: Fix QueryResult

### DIFF
--- a/types/sql.js/module.d.ts
+++ b/types/sql.js/module.d.ts
@@ -2,14 +2,14 @@
 /// <reference types="emscripten" />
 
 export namespace SqlJs {
-    type ValueType = number | string | Uint8Array;
+    type ValueType = number | string | Uint8Array | null;
     type ParamsObject = Record<string, ValueType>;
     type ParamsCallback = (obj: ParamsObject) => void;
     type Config = Partial<typeof Module>;
 
     interface QueryResults {
         columns: string[];
-        values: ValueType[];
+        values: ValueType[][];
     }
 
     class Database {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) (Sort of did that by casting it to the types defined here, but without compiling definitely typed itself)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kripken/sql.js/blob/master/src/api.coffee#L102 and https://github.com/kripken/sql.js/blob/master/src/api.coffee#L300-L306

The QueryResults type contains an array of rows. Each row is an array of ValueType, where ValueType is either a string, number, some bytes or null. The old definition was wrong in that ValueType couldn't be null and that values was a ValueType[] instead of a ValueType[][]