### PR TITLE
Remove Stéphane Goetz from react definitions contributors

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -9,7 +9,6 @@
 //                 Digiguru <https://github.com/digiguru>
 //                 Eric Anderson <https://github.com/ericanderson>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
-//                 Stéphane Goetz <https://github.com/onigoetz>
 //                 Josh Rutherford <https://github.com/theruther4d>
 //                 Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Ferdy Budhidharma <https://github.com/ferdaber>


### PR DESCRIPTION
Hello,

sorry, this PR doesn't fit the template; I removed my name from the React definitions. I thought I would contribute to the definitions more actively, but in the end I didn't.