### PR TITLE
Express: improve type of `Request['params']` aka `req.params`

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -95,7 +95,7 @@ proxy("www.google.com", {
 
 const proxyOptions: proxy.ProxyOptions = {};
 
-app.use("/proxy/:port", proxy(req => "localhost:" + req.params.port));
+app.use("/proxy/:port", proxy(req => "localhost:" + (Array.isArray(req.params) ? {} : req.params)['port']));
 
 proxy("www.google.com", {
     filter: (req, res) => {

--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -95,7 +95,7 @@ proxy("www.google.com", {
 
 const proxyOptions: proxy.ProxyOptions = {};
 
-app.use("/proxy/:port", proxy(req => "localhost:" + (Array.isArray(req.params) ? {} : req.params)['port']));
+app.use("/proxy/:port", proxy(req => "localhost:" + (Array.isArray(req.params) ? {} : req.params).port));
 
 proxy("www.google.com", {
     filter: (req, res) => {

--- a/types/express-redis-cache/express-redis-cache-tests.ts
+++ b/types/express-redis-cache/express-redis-cache-tests.ts
@@ -28,7 +28,7 @@ app.get('/user/:userid',
     // middleware to define cache name
     (req, res, next) => {
         // set cache name
-        res.express_redis_cache_name = 'user-' + req.params.userid;
+        res.express_redis_cache_name = 'user-' + (Array.isArray(req.params) ? {} : req.params).userid;
         next();
     },
     // cache middleware

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -181,9 +181,9 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
-type Dictionary<T> = { [key: string]: T };
+export interface Dictionary<T> { [key: string]: T; }
 export type ParamsDictionary = Dictionary<string>;
-export type ParamsArray = Array<string>;
+export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
 export interface Request extends http.IncomingMessage, Express.Request {

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -181,6 +181,11 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
+type Dictionary<T> = { [key: string]: T };
+export type ParamsDictionary = Dictionary<string>;
+export type ParamsArray = Array<string>;
+export type Params = ParamsDictionary | ParamsArray;
+
 export interface Request extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
@@ -433,7 +438,7 @@ export interface Request extends http.IncomingMessage, Express.Request {
 
     method: string;
 
-    params: any;
+    params: Params;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: any): Response;

--- a/types/express-ws/express-ws-tests.ts
+++ b/types/express-ws/express-ws-tests.ts
@@ -60,7 +60,7 @@ router.ws(
     '/:id',
     (ws, req, next) => { next(); },
     (ws, req, next) => {
-        ws.send(req.params.id);
+        ws.send((Array.isArray(req.params) ? {} : req.params).id);
 
         ws.on('close', (code, reason) => {
             console.log('code:', code);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -111,7 +111,8 @@ namespace express_tests {
         });
 
     router.get('/user/:id', (req, res, next) => {
-        if (Number(req.params.id) === 0) next('route');
+        const paramsDictionary: ParamsDictionary = Array.isArray(req.params) ? {} : req.params;
+        if (Number(paramsDictionary.id) === 0) next('route');
         else next();
     }, (req, res, next) => {
         res.render('regular');
@@ -158,7 +159,7 @@ namespace express_tests {
  *                         *
  ***************************/
 import * as http from 'http';
-import { RequestRanges } from 'express-serve-static-core';
+import { RequestRanges, ParamsDictionary } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,4 +1,5 @@
 import express = require('express');
+import { RequestRanges, ParamsDictionary } from 'express-serve-static-core';
 
 namespace express_tests {
     const app = express();
@@ -159,7 +160,6 @@ namespace express_tests {
  *                         *
  ***************************/
 import * as http from 'http';
-import { RequestRanges, ParamsDictionary } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -205,7 +205,7 @@ app.get('/ar', (_req: Express.Request, res: Express.Response) => {
     i18n.setLocale(res, 'ar');
     i18n.setLocale(res.locals, 'ar');
 
-    i18n.setLocale([req, res.locals], req.params.lang);
+    i18n.setLocale([req, res.locals], (Array.isArray(req.params) ? {} : req.params).lang);
     i18n.setLocale(res, 'ar', true);
 });
 


### PR DESCRIPTION
**Migration guide**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502#issuecomment-522155668

This will be a breaking change for many people, I'm sure, but it's the correct change to make I think? We could batch this with other breaking changes, if people feel that's necessary.

Users will now have to narrow the union. See an example of this in the tests.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/api.html#req.params
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.