### PR TITLE
[chartjs] Add support for 'enabled' in ticks major/minor configuration

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -452,7 +452,7 @@ declare namespace Chart {
 
     interface TickOptions extends NestedTickOptions {
         minor?: NestedTickOptions | false;
-        major?: NestedTickOptions | false;
+        major?: MajorTickOptions | false;
     }
 
     interface NestedTickOptions {
@@ -483,6 +483,10 @@ declare namespace Chart {
         stepSize?: number;
         suggestedMax?: number;
         suggestedMin?: number;
+    }
+
+    interface MajorTickOptions extends NestedTickOptions {
+        enabled?: boolean;
     }
 
     interface AngleLineOptions {


### PR DESCRIPTION

It's documented in https://www.chartjs.org/docs/latest/axes/styling.html but missing in typescript definition, forbidding usage of whole major/minor configuration.