### PR TITLE
mongodb: findOneOptions: use maxTimeMS rather than maxTimeMs

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1636,7 +1636,7 @@ export interface FindOneOptions {
     promoteBuffers?: boolean;
     readPreference?: ReadPreference | string;
     partial?: boolean;
-    maxTimeMs?: number;
+    maxTimeMS?: number;
     collation?: CollationDocument;
     session?: ClientSession;
 }

--- a/types/mongodb/v2/index.d.ts
+++ b/types/mongodb/v2/index.d.ts
@@ -1073,7 +1073,7 @@ export interface FindOneOptions {
     raw?: boolean,
     readPreference?: ReadPreference | string,
     partial?: boolean,
-    maxTimeMs?: number
+    maxTimeMS?: number
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#~insertWriteOpResult


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#findOne (already linked within the code -- looks like it was just a typo. Note that the other options have this set correctly)

> maxTimeMS | number |   | optionalNumber of miliseconds to wait before aborting the query.
-- | -- | -- | --