### PR TITLE
@types/toposort: revert readonlyArray removals

### DIFF
--- a/types/toposort/index.d.ts
+++ b/types/toposort/index.d.ts
@@ -4,5 +4,5 @@
 //                 Prokop Simek <https://github.com/prokopsimek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function toposort(graph: Array<[string, string | undefined]>): string[];
+declare function toposort(graph: ReadonlyArray<[string, string | undefined]>): ReadonlyArray<string>;
 export = toposort;

--- a/types/toposort/toposort-tests.ts
+++ b/types/toposort/toposort-tests.ts
@@ -1,11 +1,11 @@
 import toposort = require('toposort');
 
-const testGraph: Array<[string, string | undefined]> = [
-    ['string1', 'string2'],
-    ['string2', 'string3'],
-    ['string3', 'string1'],
-    ['string4', undefined],
+const testGraph: ReadonlyArray<[string, string | undefined]> = [
+  ['string1', 'string2'],
+  ['string2', 'string3'],
+  ['string3', 'string1'],
+  ['string4', undefined],
 ];
 
-// $ExpectType string[]
+// $ExpectType ReadonlyArray<string>
 toposort(testGraph);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I wasn't able to review the previous PR in time, but the `ReadonlyArray` modifiers should not have been changed. See [common mistakes #3](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes). If you follow from https://github.com/marcelklehr/toposort/blob/3e3d72d1b48196ab0e87348d142ef23788a5bb67/index.js#L9 you'll see it never writes to its parameters.

@prokopsimek I know this is inconvenient but I think we should maintain the standard set by DefinitelyTyped.
