### PR TITLE
Added missing types to react-tag-input

### DIFF
--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -3,22 +3,28 @@
 // Definitions by: Ogglas <https://github.com/Ogglas>
 //                  Jan Karres <https://github.com/jankarres>
 //                  Matthew Berryman <https://github.com/matthewberryman>
+//                  Matthew Cavender <https://github.com/visionsofparadise>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
 
+export interface Tag {
+    id: string;
+    text: string;
+}
+
 export interface ReactTagsProps {
-    tags?: Array<{ id: string, text: string }>;
-    suggestions?: Array<{ id: string, text: string }>;
+    tags?: Tag[];
+    suggestions?: Tag[];
     delimiters?: number[];
     placeholder?: string;
     labelField?: string;
 
-    handleAddition: ((tag: {id: string, text: string}) => void);
+    handleAddition: ((tag: { id: string, text: string }) => void);
     handleDelete: ((i: number) => void);
     handleDrag?: ((tag: { id: string; text: string; }, currPos: number, newPos: number) => void);
-    handleFilterSuggestions?: ((textInputValue: string, possibleSuggestionsArray: Array<{ id: string, text: string }>) => Array<{ id: string, text: string }>);
+    handleFilterSuggestions?: ((textInputValue: string, possibleSuggestionsArray: Tag[]) => Tag[]);
     handleTagClick?: ((i: number) => void);
 
     autofocus?: boolean;
@@ -36,18 +42,20 @@ export interface ReactTagsProps {
     maxLength?: number;
 
     inline?: boolean;
+    inputFieldPosition?: 'top' | 'bottom' | 'inline';
     allowUnique?: boolean;
     allowDragDrop?: boolean;
+    renderSuggestion?(tag: Tag, query: string): React.ReactChild | void;
 
     classNames?: {
-        tags?: string,
-        tagInput?: string,
-        tagInputField?: string,
-        selected?: string,
-        tag?: string,
-        remove?: string,
-        suggestions?: string,
-        activeSuggestion?: string
+        tags?: string;
+        tagInput?: string;
+        tagInputField?: string;
+        selected?: string;
+        tag?: string;
+        remove?: string;
+        suggestions?: string;
+        activeSuggestion?: string;
     };
 }
 

--- a/types/react-tag-input/react-tag-input-tests.tsx
+++ b/types/react-tag-input/react-tag-input-tests.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { WithContext as ReactTags } from "react-tag-input";
-import { Tag } from './';
+import { WithContext as ReactTags, Tag } from "react-tag-input";
 
 const tags = Array({ id: "0", text: "test" }, { id: "1", text: "testing" });
 

--- a/types/react-tag-input/react-tag-input-tests.tsx
+++ b/types/react-tag-input/react-tag-input-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { WithContext as ReactTags } from "react-tag-input";
+import { Tag } from './';
 
 const tags = Array({ id: "0", text: "test" }, { id: "1", text: "testing" });
 
@@ -13,14 +14,21 @@ ReactDOM.render(
         delimiters={[13, 8, 188]} // Enter, Tab and Comma
         placeholder="Some placeholder text"
         labelField="Some label"
-
-        handleAddition={(tag: { id: string, text: string }) => console.log("Add: " + tag.text)}
-        handleDelete={(i: number) => console.log("Delete: " + i)}
-        handleDrag={(tag: { id: string; text: string; }, currPos: number, newPos: number) => console.log("Drag: " + tag.text)}
-        handleInputChange={(value: string) => console.log("Changed to: ", value)}
-        handleFilterSuggestions={(textInputValue: string, possibleSuggestionsArray: Array<{ id: string, text: string }>) => suggestions}
-        handleInputBlur={() => console.log("Blured")}
-
+        handleAddition={(tag: Tag) =>
+            console.log('Add: ' + tag.text)
+        }
+        handleDelete={(i: number) => console.log('Delete: ' + i)}
+        handleDrag={(
+            tag: Tag,
+            currPos: number,
+            newPos: number,
+        ) => console.log('Drag: ' + tag.text)}
+        handleInputChange={(value: string) => console.log('Changed to: ', value)}
+        handleFilterSuggestions={(
+            textInputValue: string,
+            possibleSuggestionsArray: Tag[],
+        ) => suggestions}
+        handleInputBlur={() => console.log('Blurred')}
         autofocus={false}
         allowDeleteFromEmptyInput={false}
         minQueryLength={0}
@@ -29,11 +37,9 @@ ReactDOM.render(
         readOnly={false}
         maxLength={64}
         inputFieldPosition="top"
-        renderSuggestion={({ id, text }, query) => console.log('tag' + id, text)}
-
+        renderSuggestion={({ id, text }: Tag, query: string) => console.log('tag' + id, text)}
         name="react-tags-field"
         id="react-tags-field"
-
         classNames={{
             tags: 'tagsClass',
             tagInput: 'tagInputClass',
@@ -42,8 +48,8 @@ ReactDOM.render(
             tag: 'tagClass',
             remove: 'removeClass',
             suggestions: 'suggestionsClass',
-            activeSuggestion: 'activeSuggestionClass'
+            activeSuggestion: 'activeSuggestionClass',
         }}
     />,
-    document.getElementById("app")
+    document.getElementById('app'),
 );

--- a/types/react-tag-input/react-tag-input-tests.tsx
+++ b/types/react-tag-input/react-tag-input-tests.tsx
@@ -28,6 +28,8 @@ ReactDOM.render(
         autocomplete={true}
         readOnly={false}
         maxLength={64}
+        inputFieldPosition="top"
+        renderSuggestion={({ id, text }, query) => console.log('tag' + id, text)}
 
         name="react-tags-field"
         id="react-tags-field"


### PR DESCRIPTION
Added missing types for options 'inputFieldPosition' and 'renderSuggestion'. Added 'Tag' type to refactor and for convenience. Tests for new fields added run and passed. TS lint run.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prakhar1989/react-tags#options