### PR TITLE
storybook__addon-storyshots: Options are optional

### DIFF
--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -52,8 +52,10 @@ export function renderWithOptions(options?: SnapshotOptions): Test;
 
 export function getSnapshotFileName(context: StoryContext): string;
 
-// tslint:disable-next-line no-unnecessary-generics
-export default function initStoryshots<Rendered>(options: InitOptions<Rendered>): void;
+export default function initStoryshots<Rendered>(
+  // tslint:disable-next-line no-unnecessary-generics
+  options?: InitOptions<Rendered>,
+): void;
 
 export interface InitOptions<Rendered = any> {
     configPath?: string;

--- a/types/storybook__addon-storyshots/storybook__addon-storyshots-tests.ts
+++ b/types/storybook__addon-storyshots/storybook__addon-storyshots-tests.ts
@@ -10,6 +10,8 @@ import toJson from 'enzyme-to-json';
 import 'jest';
 import 'jest-specific-snapshot';
 
+initStoryshots();
+
 initStoryshots({
     integrityOptions: { cwd: '' },
     test: multiSnapshotWithOptions({}),


### PR DESCRIPTION
`initStoryshots()` can be called without options, as seen in [the Storyshots README](https://github.com/storybookjs/storybook/tree/a9038842ff8c8ad3adba748ac7fc969d9e464722/addons/storyshots/storyshots-core#configure-storyshots-for-html-snapshots).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

