### PR TITLE
[csp-html-webpack-plugin] Add type definitions

### DIFF
--- a/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
+++ b/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
@@ -1,0 +1,89 @@
+import HtmlWebpackPlugin from "html-webpack-plugin";
+import CspHtmlWebpackPlugin from "csp-html-webpack-plugin";
+
+import { Configuration as WebpackConfiguration } from "webpack";
+
+// Should accept various CSP directive types.
+const policy: CspHtmlWebpackPlugin.Policy = {
+    "base-uri": "'self'",
+    "object-src": "'none'",
+    "script-src": ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+    "style-src": ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+    "block-all-mixed-content": "",
+    "report-uri": "http://reportcollector.example.com/collector.cgi"
+};
+
+// Should allow no parameters.
+new CspHtmlWebpackPlugin();
+
+// Should allow empty object parameters.
+new CspHtmlWebpackPlugin({}, {});
+
+// Should allow full parameters.
+new CspHtmlWebpackPlugin(policy, {
+    enabled: true,
+    hashingMethod: 'sha256',
+    hashEnabled: {
+        'script-src': true,
+        'style-src': true
+    },
+    nonceEnabled: {
+        'script-src': true,
+        'style-src': true
+    }
+});
+
+const optsWithEnableFunc: CspHtmlWebpackPlugin.AdditionalOptions = {
+    enabled(htmlPluginData) {
+        // $ExpectType string
+        htmlPluginData.outputName;
+        // $ExpectType string
+        htmlPluginData.html;
+
+        if (htmlPluginData.plugin.apply) {}
+
+        return true;
+    },
+    hashEnabled: {
+        'script-src': true,
+        'style-src': true
+    },
+    nonceEnabled: {
+        'script-src': true,
+        'style-src': true
+    }
+};
+
+// Can be added to Webpack configuration.
+const webpackConfig: WebpackConfiguration = {
+    plugins: [
+        new HtmlWebpackPlugin(),
+        new CspHtmlWebpackPlugin()
+    ]
+};
+
+// HtmlWebpackPlugin augmentations should work
+new HtmlWebpackPlugin({
+    // Original options should be present.
+    filename: "my_index.html",
+    template: "src/static/index.ejs",
+    // Added options should be present.
+    cspPlugin: {
+        enabled: true,
+        policy: {
+            'base-uri': "'self'",
+            'object-src': "'none'",
+            'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+            'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"]
+        },
+        hashingMethod: "sha384",
+        hashEnabled: {
+            'script-src': true,
+            'style-src': true
+        },
+        nonceEnabled: {
+            'script-src': true,
+            'style-src': true
+        }
+    }
+});

--- a/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
+++ b/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
@@ -1,16 +1,16 @@
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import CspHtmlWebpackPlugin from "csp-html-webpack-plugin";
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import CspHtmlWebpackPlugin from 'csp-html-webpack-plugin';
 
-import { Configuration as WebpackConfiguration } from "webpack";
+import { Configuration as WebpackConfiguration } from 'webpack';
 
 // Should accept various CSP directive types.
 const policy: CspHtmlWebpackPlugin.Policy = {
-    "base-uri": "'self'",
-    "object-src": "'none'",
-    "script-src": ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
-    "style-src": ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
-    "block-all-mixed-content": "",
-    "report-uri": "http://reportcollector.example.com/collector.cgi"
+  'base-uri': "'self'",
+  'object-src': "'none'",
+  'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+  'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+  'block-all-mixed-content': '',
+  'report-uri': 'http://reportcollector.example.com/collector.cgi',
 };
 
 // Should allow no parameters.
@@ -21,69 +21,67 @@ new CspHtmlWebpackPlugin({}, {});
 
 // Should allow full parameters.
 new CspHtmlWebpackPlugin(policy, {
-    enabled: true,
-    hashingMethod: 'sha256',
-    hashEnabled: {
-        'script-src': true,
-        'style-src': true
-    },
-    nonceEnabled: {
-        'script-src': true,
-        'style-src': true
-    }
+  enabled: true,
+  hashingMethod: 'sha256',
+  hashEnabled: {
+    'script-src': true,
+    'style-src': true,
+  },
+  nonceEnabled: {
+    'script-src': true,
+    'style-src': true,
+  },
 });
 
 const optsWithEnableFunc: CspHtmlWebpackPlugin.AdditionalOptions = {
-    enabled(htmlPluginData) {
-        // $ExpectType string
-        htmlPluginData.outputName;
-        // $ExpectType string
-        htmlPluginData.html;
+  enabled(htmlPluginData) {
+    // $ExpectType string
+    htmlPluginData.outputName;
+    // $ExpectType string
+    htmlPluginData.html;
 
-        if (htmlPluginData.plugin.apply) {}
-
-        return true;
-    },
-    hashEnabled: {
-        'script-src': true,
-        'style-src': true
-    },
-    nonceEnabled: {
-        'script-src': true,
-        'style-src': true
+    if (htmlPluginData.plugin.apply) {
     }
+
+    return true;
+  },
+  hashEnabled: {
+    'script-src': true,
+    'style-src': true,
+  },
+  nonceEnabled: {
+    'script-src': true,
+    'style-src': true,
+  },
 };
 
 // Can be added to Webpack configuration.
 const webpackConfig: WebpackConfiguration = {
-    plugins: [
-        new HtmlWebpackPlugin(),
-        new CspHtmlWebpackPlugin()
-    ]
+  plugins: [new HtmlWebpackPlugin(), new CspHtmlWebpackPlugin()],
 };
 
 // HtmlWebpackPlugin augmentations should work
 new HtmlWebpackPlugin({
-    // Original options should be present.
-    filename: "my_index.html",
-    template: "src/static/index.ejs",
-    // Added options should be present.
-    cspPlugin: {
-        enabled: true,
-        policy: {
-            'base-uri': "'self'",
-            'object-src': "'none'",
-            'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
-            'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"]
-        },
-        hashingMethod: "sha384",
-        hashEnabled: {
-            'script-src': true,
-            'style-src': true
-        },
-        nonceEnabled: {
-            'script-src': true,
-            'style-src': true
-        }
-    }
+  // Original options should be present.
+  filename: 'my_index.html',
+  template: 'src/static/index.ejs',
+  // Added options should be present.
+  cspPlugin: {
+    enabled: true,
+    policy: {
+      'base-uri': "'self'",
+      'object-src': "'none'",
+      'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+      'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+    },
+    hashingMethod: 'sha384',
+    hashEnabled: {
+      'script-src': true,
+      'style-src': true,
+    },
+    nonceEnabled: {
+      'script-src': true,
+      'style-src': true,
+    },
+  },
 });

--- a/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
+++ b/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
@@ -1,5 +1,5 @@
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import CspHtmlWebpackPlugin from 'csp-html-webpack-plugin';
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+import CspHtmlWebpackPlugin = require('csp-html-webpack-plugin');
 
 import { Configuration as WebpackConfiguration } from 'webpack';
 

--- a/types/csp-html-webpack-plugin/index.d.ts
+++ b/types/csp-html-webpack-plugin/index.d.ts
@@ -1,0 +1,110 @@
+// Type definitions for csp-html-webpack-plugin 3.0
+// Project: https://github.com/slackhq/csp-html-webpack-plugin
+// Definitions by: Porama Ruengrairatanaroj <https://github.com/Seally>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+import { Compiler as WebpackCompiler } from "webpack";
+import HtmlWebpackPlugin = require("html-webpack-plugin");
+
+export = CspHtmlWebpackPlugin;
+
+declare class CspHtmlWebpackPlugin {
+    /**
+     * Setup for our plugin
+     * @param policy - the policy object
+     * @param additionalOpts - additional config options
+     */
+    constructor(
+        policy?: CspHtmlWebpackPlugin.Policy,
+        additionalOpts?: CspHtmlWebpackPlugin.AdditionalOptions
+    );
+
+    apply(compiler: WebpackCompiler): void;
+}
+
+declare namespace CspHtmlWebpackPlugin {
+    /**
+     * A flat object which defines your CSP policy. Values can either be a
+     * string or an array of strings.
+     *
+     * The default policy is:
+     *
+     * ```javascript
+     * {
+     *   'base-uri': "'self'",
+     *   'object-src': "'none'",
+     *   'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
+     *   'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"]
+     * }
+     * ```
+     */
+    interface Policy {
+        [directive: string]: string | string[];
+    }
+
+    /**
+     * Additional options. Defaults are:
+     *
+     * ```javascript
+     * {
+     *   enabled: true
+     *   hashingMethod: 'sha256',
+     *   hashEnabled: {
+     *     'script-src': true,
+     *     'style-src': true
+     *   },
+     *   nonceEnabled: {
+     *     'script-src': true,
+     *     'style-src': true
+     *   }
+     * }
+     * ```
+     */
+    interface AdditionalOptions {
+        /**
+         * If false, or the function returns false, the empty CSP tag will be
+         * stripped from the html output.
+         *
+         * * The `htmlPluginData` is passed into the function as its first
+         *   param.
+         * * If `enabled` is set the false, it will disable generating a CSP for
+         *   all instances of HtmlWebpackPlugin in your webpack config.
+         */
+        enabled?: boolean | ((htmlPluginData: HtmlPluginData) => boolean);
+        /**
+         * The hashing method. Your node version must also accept this hashing
+         * method.
+         */
+        hashingMethod?: "sha256" | "sha384" | "sha512";
+        /**
+         * A `<string, boolean>` entry for which policy rules are allowed to
+         * include hashes.
+         */
+        hashEnabled?: { [directive: string]: boolean };
+        /**
+         * A `<string, boolean>` entry for which policy rules are allowed to
+         * include nonces.
+         */
+        nonceEnabled?: { [directive: string]: boolean };
+    }
+}
+
+declare module "html-webpack-plugin" {
+    interface Options {
+        cspPlugin?: CspHtmlWebpackPlugin.AdditionalOptions & {
+            policy?: CspHtmlWebpackPlugin.Policy
+        };
+    }
+}
+
+// Copied here because the type needs to be extracted from a generic declared
+// under HtmlWebpackPlugin.Hooks interface. Furthermore, the hook's name changed
+// from 'htmlWebpackPluginAfterHtmlProcessing' in v3 to 'beforeEmit' in v4,
+// making extraction difficult, especially when CspHtmlWebpackPlugin itself has
+// been written to be HtmlWebpackPlugin-version agnostic.
+interface HtmlPluginData {
+    html: string;
+    outputName: string;
+    plugin: HtmlWebpackPlugin;
+}

--- a/types/csp-html-webpack-plugin/index.d.ts
+++ b/types/csp-html-webpack-plugin/index.d.ts
@@ -43,12 +43,6 @@ declare namespace CspHtmlWebpackPlugin {
         [directive: string]: string | string[];
     }
 
-    // Listed here because otherwise the type needs to be extracted from a
-    // generic property for HtmlWebpackPlugin.Hooks interface. Also, the hook's
-    // name changed from 'htmlWebpackPluginAfterHtmlProcessing' in v3 to
-    // 'beforeEmit' in v4, making referencing by name difficult, especially when
-    // CspHtmlWebpackPlugin itself has been written to be
-    // HtmlWebpackPlugin-version agnostic.
     interface HtmlPluginData {
         html: string;
         outputName: string;

--- a/types/csp-html-webpack-plugin/index.d.ts
+++ b/types/csp-html-webpack-plugin/index.d.ts
@@ -44,7 +44,7 @@ declare namespace CspHtmlWebpackPlugin {
         [directive: string]: string | string[];
     }
 
-    // HtmlWebpackPlugin v3 and v4 uses different hook interfaces. Figure out
+    // HtmlWebpackPlugin v3 and v4 use different hook interfaces. Figure out
     // which we're using and infer the generic type variable inside.
     type HtmlPluginData
         = HtmlWebpackPlugin.Hooks extends HtmlPluginDataHookV3<infer T> ? T

--- a/types/csp-html-webpack-plugin/index.d.ts
+++ b/types/csp-html-webpack-plugin/index.d.ts
@@ -43,6 +43,18 @@ declare namespace CspHtmlWebpackPlugin {
         [directive: string]: string | string[];
     }
 
+    // Listed here because otherwise the type needs to be extracted from a
+    // generic property for HtmlWebpackPlugin.Hooks interface. Also, the hook's
+    // name changed from 'htmlWebpackPluginAfterHtmlProcessing' in v3 to
+    // 'beforeEmit' in v4, making referencing by name difficult, especially when
+    // CspHtmlWebpackPlugin itself has been written to be
+    // HtmlWebpackPlugin-version agnostic.
+    interface HtmlPluginData {
+        html: string;
+        outputName: string;
+        plugin: HtmlWebpackPlugin;
+    }
+
     /**
      * Additional options. Defaults are:
      *
@@ -96,15 +108,4 @@ declare module "html-webpack-plugin" {
             policy?: CspHtmlWebpackPlugin.Policy
         };
     }
-}
-
-// Copied here because the type needs to be extracted from a generic declared
-// under HtmlWebpackPlugin.Hooks interface. Furthermore, the hook's name changed
-// from 'htmlWebpackPluginAfterHtmlProcessing' in v3 to 'beforeEmit' in v4,
-// making extraction difficult, especially when CspHtmlWebpackPlugin itself has
-// been written to be HtmlWebpackPlugin-version agnostic.
-interface HtmlPluginData {
-    html: string;
-    outputName: string;
-    plugin: HtmlWebpackPlugin;
 }

--- a/types/csp-html-webpack-plugin/tsconfig.json
+++ b/types/csp-html-webpack-plugin/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "esModuleInterop": true,
         "module": "commonjs",
         "lib": [
             "es6"

--- a/types/csp-html-webpack-plugin/tsconfig.json
+++ b/types/csp-html-webpack-plugin/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "csp-html-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/csp-html-webpack-plugin/tslint.json
+++ b/types/csp-html-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

_Note:_ With the conditional type trick for `HtmlPluginData`, VS Code seems to annoyingly report the type of `HtmlPluginData.plugin` to be `import('/path/to/html-webpack-plugin/index.d.ts')` instead of `HtmlWebpackPlugin`, but it's probably still better than the previous solution I've used.