### PR TITLE
angular-local-storage: fixed remove definition to match implementation

### DIFF
--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -129,13 +129,17 @@ declare module 'angular' {
              * Returns: value from local storage
              */
             keys(storageType?: StorageType): string[];
-            /**
-             * Remove an item from local storage by key.
+          /**
+             * Remove a list of items from the local storage by their given keys.
+             * The last item in the variable argument list can optionally be the StorageType.
+             * Which specifies whether to remove from the session storage or the local storage.
+             * If the last argument is not a valid storage type it is considered to be a key, 
+             * and localStorage is used by default .
              * If local storage is not supported, use cookies instead.
              * Returns: Boolean
              * @param key
              */
-            remove(key: string): boolean;
+            remove(...args: string[]): boolean;
             /**
              * Remove all data for this app from local storage.
              * If local storage is not supported, use cookies instead.


### PR DESCRIPTION
Allowed using storage type when we removing an item. 
The previous implementation only removed from the local storage ( or whatever the current storage type was provided), this was not inline with the underlying implementation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/grevory/angular-local-storage/blob/master/src/angular-local-storage.js#L228>
