### PR TITLE
Update incorrect export type on @reach/alert

### DIFF
--- a/types/reach__alert/index.d.ts
+++ b/types/reach__alert/index.d.ts
@@ -7,7 +7,9 @@
 import * as React from 'react';
 
 export type AlertProps = {
-    type?: "assertive" | "polite";
+  type?: 'assertive' | 'polite';
 } & React.HTMLProps<HTMLDivElement>;
 
-export const Alert: React.FC<AlertProps>;
+declare const Alert: React.FC<AlertProps>;
+
+export default Alert;

--- a/types/reach__alert/reach__alert-tests.tsx
+++ b/types/reach__alert/reach__alert-tests.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@reach/alert';
+import Alert from '@reach/alert';
 
 import * as React from "react";
 import { render } from "react-dom";


### PR DESCRIPTION
About
 - Remove incorrect named export
 - Add correct default export

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.unpkg.com/browse/@reach/alert@0.1.5/index.js - line 162
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - Applies to version 1
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
