### PR TITLE
Added missing Chance.postcode() to @types/chance

### DIFF
--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -185,3 +185,5 @@ sentence = chance.sentence({punctuation: ';'});
 sentence = chance.sentence({punctuation: '!'});
 sentence = chance.sentence({punctuation: ':'});
 sentence = chance.sentence({words: 10, punctuation: '?'});
+
+const postcode: string = chance.postcode();

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -101,6 +101,7 @@ declare namespace Chance {
         locales(opts?: {region: true}): string[];
         longitude(opts?: Options): number;
         phone(opts?: Options): string;
+        postcode(): string;
         postal(): string;
         province(opts?: Options): string;
         state(opts?: Options): string;


### PR DESCRIPTION
It seems @types/chance is somewhat out of date with the actual `chance` package. If/when I have time, I will try and submit a PR which brings it fully up to date with the documented interface, but in the meantime, this PR just adds definition for one function that I need personally. This is my first DefinitelyTyped PR, so please let me know if I've got something wrong.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://chancejs.com/location/postcode.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
