### PR TITLE
@types/react-native: Add missing props to FlatList.

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4156,9 +4156,19 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 
     /**
+     * Styling for internal View for ListFooterComponent
+     */
+    ListFooterComponentStyle?: ViewStyle | null;
+
+    /**
      * Rendered at the very beginning of the list.
      */
     ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+
+    /**
+     * Styling for internal View for ListHeaderComponent
+     */
+    ListHeaderComponentStyle?: ViewStyle | null;
 
     /**
      * Optional custom style for multi-item rows generated when numColumns > 1

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -369,7 +369,9 @@ export class FlatListTest extends React.Component<FlatListProps<number>, {}> {
                 renderItem={this._renderItem}
                 ItemSeparatorComponent={this._renderSeparator}
                 ListFooterComponent={null}
+                ListFooterComponentStyle={{ padding: 8 }}
                 ListHeaderComponent={null}
+                ListHeaderComponentStyle={{ padding: 8 }}
             />
         );
     }


### PR DESCRIPTION
- Added optional ListHeaderComponentStyle prop.
- Added optional ListFooterComponentStyle prop.

[`ListHeaderComponentStyle`](https://facebook.github.io/react-native/docs/flatlist#listheadercomponentstyle) and [`ListFooterComponentStyle`](https://facebook.github.io/react-native/docs/flatlist#listfootercomponentstyle) are missing from the prop types of FlatList. They have been added in RN 0.60 from the docs (although appear to work in 0.59 as well).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://facebook.github.io/react-native/docs/flatlist#listheadercomponentstyle
  - https://facebook.github.io/react-native/docs/flatlist#listfootercomponentstyle
