### PR TITLE
angular: accept Window as argument to JQueryStatic

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -785,6 +785,9 @@ let elementArray = angular.element(document.querySelectorAll('div'));
 let elementReadyFn = angular.element(() => {
     console.log('ready');
 });
+angular.element(window);
+declare let windowService: angular.IWindowService;
+angular.element(windowService);
 
 // $timeout signature tests
 namespace TestTimeout {

--- a/types/angular/jqlite.d.ts
+++ b/types/angular/jqlite.d.ts
@@ -684,7 +684,7 @@ interface JQuery {
 }
 
 interface JQueryStatic {
-    (element: string | Element | Document | JQuery | ArrayLike<Element> | (() => void)): JQLite;
+    (element: string | Element | Document | Window | JQuery | ArrayLike<Element> | (() => void)): JQLite;
 }
 
 /**


### PR DESCRIPTION
Users write code like:
```
  angular.element(window)
  angular.element($window)  // IWindowService
```
but this fails with a type error under TypeScript 3.5, due to a change
in the type of of Window.  (Previously the only reason it compiled is
that Window was matching the ArrayLike<Element> param.)

Note that if you run the tests, the definition of JQueryStatic here
in the JQLite typings declaration-merges with the full JQuery
definition, which accepts any (!) so there is no type error.  But if
you use just this library without JQuery, the type errors without my
fix look like:

```
angular-tests.ts:788:17 - error TS2345: Argument of type 'Window' is not assignable to parameter of type 'string | Element | Document | JQuery | ArrayLike<Element> | (() => void)'.
  Type 'Window' is missing the following properties from type 'Document': activeElement, alinkColor, all, anchors, and 147 more.

788 angular.element(window);
                    ~~~~~~

angular-tests.ts:790:17 - error TS2345: Argument of type 'IWindowService' is not assignable to parameter of type 'string | Element | Document | JQuery | ArrayLike<Element> | (() => void)'.
  Type 'IWindowService' is missing the following properties from type 'Document': activeElement, alinkColor, all, anchors, and 147 more.
```

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/30654259/angular-elementwindow-scrolltop-is-throwing-is-not-a-function-with-webpac , random user using element(window)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
