### PR TITLE
Update openlayers Feature, VectorLayer to match documentation for get/setStyle, getStyleFunction

### DIFF
--- a/types/ol/Feature.d.ts
+++ b/types/ol/Feature.d.ts
@@ -13,12 +13,12 @@ export default class Feature extends BaseObject {
     getGeometry(): Geometry;
     getGeometryName(): string;
     getId(): number | string;
-    getStyle(): StyleLike;
-    getStyleFunction(): StyleFunction;
+    getStyle(): StyleLike | null;
+    getStyleFunction(): StyleFunction | undefined;
     setGeometry(geometry: Geometry | undefined): void;
     setGeometryName(name: string): void;
     setId(id: number | string | undefined): void;
-    setStyle(style: StyleLike): void;
+    setStyle(style: StyleLike | null): void;
     on(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => void): void;

--- a/types/ol/index.d.ts
+++ b/types/ol/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ol 5.3
 // Project: https://github.com/openlayers/openlayers, https://openlayers.org
 // Definitions by: Rifa'i M. Hanif <https://github.com/hanreev>
+//                 Steve Heuertz <https://github.com/sheuertz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/ol/layer/Vector.d.ts
+++ b/types/ol/layer/Vector.d.ts
@@ -39,13 +39,13 @@ export default class VectorLayer extends Layer {
     getRenderOrder(): (p0: Feature, p1: Feature) => number;
     getSource(): VectorSource;
     getSource(): Source;
-    getStyle(): StyleLike;
-    getStyleFunction(): StyleFunction;
+    getStyle(): StyleLike | null | undefined;
+    getStyleFunction(): StyleFunction | undefined;
     getUpdateWhileAnimating(): boolean;
     getUpdateWhileInteracting(): boolean;
     setDeclutter(declutter: boolean): void;
     setRenderOrder(renderOrder: OrderFunction | undefined | undefined): void;
-    setStyle(style: Style | Style[] | StyleFunction | undefined | undefined): void;
+    setStyle(style: Style | Style[] | StyleFunction | undefined | null): void;
     on(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => void): void;


### PR DESCRIPTION
Updated Feature definition to support passing null to setStyle(), and adding null as possible return value on getStyle(). Added undefined as possible return value on getStyleFunction(). Updated VectorLayer definition to support passing null to setStyle(), and adding null and undefined as possible return value on getStyle(). Added undefined as possible return value on getStyleFunction().

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html>>
<<https://openlayers.org/en/latest/apidoc/module-ol_layer_Vector-VectorLayer.html>>
