### PR TITLE
validator: Fix isMobilePhone function definition

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -168,14 +168,14 @@ declare namespace ValidatorJS {
     // check if the string matches to a valid MIME type (https://en.wikipedia.org/wiki/Media_type) format
     isMimeType(str: string): boolean;
 
-    // check if the string is a mobile phone number, (locale is one of
+    // check if the string is a mobile phone number, (locale is either an array of locales or one of
     // ['ar-AE', ar-DZ', 'ar-EG', 'ar-JO', 'ar-SA', 'ar-SY', 'be-BY', 'bg-BG', 'cs-CZ', 'de-DE',
     // 'da-DK', 'el-GR', 'en-AU', 'en-GB', 'en-HK', 'en-IN', 'en-KE', 'en-NG', 'en-NZ', 'en-UG',
     // 'en-RW', 'en-SG', 'en-TZ', 'en-PK', 'en-US', 'en-CA', 'en-ZA', 'en-ZM', 'es-ES', 'fa-IR',
     // 'fi-FI', 'fo-FO', 'fr-FR', 'he-IL', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'kk-KZ', 'kl-GL',
     // 'ko-KR', 'lt-LT', 'ms-MY', 'nb-NO', 'nn-NO', 'pl-PL', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK',
-    // 'sr-RS', 'th-TH', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-HK', 'zh-TW']).
-    isMobilePhone(str: string, locale: MobilePhoneLocale, options?: IsMobilePhoneOptions): boolean;
+    // 'sr-RS', 'th-TH', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-HK', 'zh-TW'] or defaults to 'any').
+    isMobilePhone(str: string, locale?: MobilePhoneLocale | MobilePhoneLocale[], options?: IsMobilePhoneOptions): boolean;
 
     // check if the string is a valid hex-encoded representation of a MongoDB ObjectId
     // (http://docs.mongodb.org/manual/reference/object-id/).

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -572,6 +572,8 @@ let any: any;
   result = validator.isMobilePhone('sample', 'zh-HK');
   result = validator.isMobilePhone('sample', 'zh-TW');
   result = validator.isMobilePhone('sample', 'any');
+  result = validator.isMobilePhone("sample");
+  result = validator.isMobilePhone("sample", [ "pl-PL", "pt-PT" ]);
 
   result = validator.isMongoId('sample');
 


### PR DESCRIPTION
isMobilePhone function is typed incorrectly: is allows only a single locale, but validator module accepts a list of locales and allows omitting the argument.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js (isMobilePhone section)
