### PR TITLE
Declare namespace instead of simple export

### DIFF
--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -7,120 +7,119 @@
 //                 Coskun Deniz <deniz@tassomai.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type CallbackFunction = (...args: any[]) => any;
+declare namespace Vimeo {
+    export type CallbackFunction = (...args: any[]) => any;
 
-export interface Error {name: string; message: string; method: string; }
+    export interface Error {name: string; message: string; method: string; }
 
-export interface PasswordError extends Error {name: "PasswordError"; message: string; method: string; }
-export interface PrivacyError extends Error {name: "PrivacyError"; message: string; method: string; }
-export interface InvalidTrackLanguageError extends Error {name: "InvalidTrackLanguageError"; message: string; method: string; }
-export interface InvalidTrackError extends Error {name: "InvalidTrackError"; message: string; method: string; }
-export interface UnsupportedError extends Error {name: "UnsupportedError"; message: string; method: string; }
-export interface ContrastError extends Error {name: "ContrastError"; message: string; method: string; }
-export interface InvalidCuePoint extends Error {name: "InvalidCuePoint"; message: string; method: string; }
-export interface RangeError extends Error {name: "RangeError"; message: string; method: string; }
-export interface TypeError extends Error {name: "TypeError"; message: string; method: string; }
+    export interface PasswordError extends Error {name: "PasswordError"; message: string; method: string; }
+    export interface PrivacyError extends Error {name: "PrivacyError"; message: string; method: string; }
+    export interface InvalidTrackLanguageError extends Error {name: "InvalidTrackLanguageError"; message: string; method: string; }
+    export interface InvalidTrackError extends Error {name: "InvalidTrackError"; message: string; method: string; }
+    export interface UnsupportedError extends Error {name: "UnsupportedError"; message: string; method: string; }
+    export interface ContrastError extends Error {name: "ContrastError"; message: string; method: string; }
+    export interface InvalidCuePoint extends Error {name: "InvalidCuePoint"; message: string; method: string; }
+    export interface RangeError extends Error {name: "RangeError"; message: string; method: string; }
+    export interface TypeError extends Error {name: "TypeError"; message: string; method: string; }
 
-export type EventName = "play" | "pause" | "ended" | "timeupdate" | "progress" | "seeked" | "seeking" | "texttrackchange" |
-                        "cuechange" | "cuepoint" | "volumechange" | "playbackratechange" | "bufferstart" | "bufferend" | "error" | "loaded" |  string;
-export type EventCallback = (data: any) => any;
+    export type EventName = "play" | "pause" | "ended" | "timeupdate" | "progress" | "seeked" | "seeking" | "texttrackchange" |
+                            "cuechange" | "cuepoint" | "volumechange" | "playbackratechange" | "bufferstart" | "bufferend" | "error" | "loaded" |  string;
+    export type EventCallback = (data: any) => any;
 
-export type VimeoTimeRange = [number, number];
-export type VimeoVideoQuality = "4K" | "2K" | "1080p" | "720p" | "540p" | "360p" | "240p";
+    export type VimeoTimeRange = [number, number];
+    export type VimeoVideoQuality = "4K" | "2K" | "1080p" | "720p" | "540p" | "360p" | "240p";
 
-export class Player {
-    constructor(element: HTMLIFrameElement|HTMLElement|string, options?: Options);
+    export class Player {
+        constructor(element: HTMLIFrameElement|HTMLElement|string, options?: Options);
 
-    on(event: EventName, callback: EventCallback): void;
-    off(event: EventName, callback?: EventCallback): void;
-    loadVideo(id: number): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
-    ready(): VimeoPromise<void, Error>;
-    enableTextTrack(language: string, kind?: string): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
-    disableTextTrack(): VimeoPromise<void, Error>;
-    pause(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
-    play(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
-    unload(): VimeoPromise<void, Error>;
-    getAutopause(): VimeoPromise<boolean, UnsupportedError | Error>;
-    setAutopause(autopause: boolean): VimeoPromise<boolean, UnsupportedError | Error>;
-    getColor(): VimeoPromise<string, Error>;
-    setColor(color: string): VimeoPromise<string, ContrastError | TypeError | Error>;
-    addCuePoint(time: number, data: VimeoCuePointData): VimeoPromise<string, UnsupportedError | RangeError | Error>;
-    removeCuePoint(id: string): VimeoPromise<string, UnsupportedError | InvalidCuePoint | Error>;
-    getCuePoints(): VimeoPromise<VimeoCuePoint[], UnsupportedError | Error>;
-    getBuffered(): VimeoPromise<VimeoTimeRange[], Error>;
-    getCurrentTime(): VimeoPromise<number, Error>;
-    setCurrentTime(seconds: number): VimeoPromise<number, RangeError | Error>;
-    getDuration(): VimeoPromise<number, Error>;
-    getEnded(): VimeoPromise<boolean, Error>;
-    getLoop(): VimeoPromise<boolean, Error>;
-    setLoop(loop: boolean): VimeoPromise<boolean, Error>;
-    getPaused(): VimeoPromise<boolean, Error>;
-    getPlayed(): VimeoPromise<VimeoTimeRange[], Error>;
-    getSeekable(): VimeoPromise<VimeoTimeRange[], Error>;
-    getSeeking(): VimeoPromise<boolean, Error>;
-    getPlaybackRate(): VimeoPromise<number, Error>;
-    setPlaybackRate(playbackRate: number): VimeoPromise<number, RangeError | Error>;
-    getTextTracks(): VimeoPromise<VimeoTextTrack[], Error>;
-    getVideoEmbedCode(): VimeoPromise<string, Error>;
-    getVideoId(): VimeoPromise<number, Error>;
-    getVideoTitle(): VimeoPromise<string, Error>;
-    getVideoWidth(): VimeoPromise<number, Error>;
-    getVideoHeight(): VimeoPromise<number, Error>;
-    getVideoUrl(): VimeoPromise<string, PrivacyError | Error>;
-    getVolume(): VimeoPromise<number, Error>;
-    setVolume(volume: number): VimeoPromise<number, RangeError | Error>;
-    destroy(): VimeoPromise<void, Error>;
+        on(event: EventName, callback: EventCallback): void;
+        off(event: EventName, callback?: EventCallback): void;
+        loadVideo(id: number): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
+        ready(): VimeoPromise<void, Error>;
+        enableTextTrack(language: string, kind?: string): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
+        disableTextTrack(): VimeoPromise<void, Error>;
+        pause(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
+        play(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
+        unload(): VimeoPromise<void, Error>;
+        getAutopause(): VimeoPromise<boolean, UnsupportedError | Error>;
+        setAutopause(autopause: boolean): VimeoPromise<boolean, UnsupportedError | Error>;
+        getColor(): VimeoPromise<string, Error>;
+        setColor(color: string): VimeoPromise<string, ContrastError | TypeError | Error>;
+        addCuePoint(time: number, data: VimeoCuePointData): VimeoPromise<string, UnsupportedError | RangeError | Error>;
+        removeCuePoint(id: string): VimeoPromise<string, UnsupportedError | InvalidCuePoint | Error>;
+        getCuePoints(): VimeoPromise<VimeoCuePoint[], UnsupportedError | Error>;
+        getBuffered(): VimeoPromise<VimeoTimeRange[], Error>;
+        getCurrentTime(): VimeoPromise<number, Error>;
+        setCurrentTime(seconds: number): VimeoPromise<number, RangeError | Error>;
+        getDuration(): VimeoPromise<number, Error>;
+        getEnded(): VimeoPromise<boolean, Error>;
+        getLoop(): VimeoPromise<boolean, Error>;
+        setLoop(loop: boolean): VimeoPromise<boolean, Error>;
+        getPaused(): VimeoPromise<boolean, Error>;
+        getPlayed(): VimeoPromise<VimeoTimeRange[], Error>;
+        getSeekable(): VimeoPromise<VimeoTimeRange[], Error>;
+        getSeeking(): VimeoPromise<boolean, Error>;
+        getPlaybackRate(): VimeoPromise<number, Error>;
+        setPlaybackRate(playbackRate: number): VimeoPromise<number, RangeError | Error>;
+        getTextTracks(): VimeoPromise<VimeoTextTrack[], Error>;
+        getVideoEmbedCode(): VimeoPromise<string, Error>;
+        getVideoId(): VimeoPromise<number, Error>;
+        getVideoTitle(): VimeoPromise<string, Error>;
+        getVideoWidth(): VimeoPromise<number, Error>;
+        getVideoHeight(): VimeoPromise<number, Error>;
+        getVideoUrl(): VimeoPromise<string, PrivacyError | Error>;
+        getVolume(): VimeoPromise<number, Error>;
+        setVolume(volume: number): VimeoPromise<number, RangeError | Error>;
+        destroy(): VimeoPromise<void, Error>;
+    }
+
+    export interface VimeoCuePoint {
+        time: number;
+        data: VimeoCuePointData;
+        id: string;
+    }
+
+    export interface VimeoCuePointData {
+        [key: string]: any;
+    }
+
+    export interface VimeoTextTrack {
+        language: string;
+        kind: string;
+        label: string;
+        mode?: string;
+    }
+
+    export interface Options {
+        id?: number;
+        url?: string;
+        autopause?: boolean;
+        autoplay?: boolean;
+        background?: boolean;
+        byline?: boolean;
+        color?: string;
+        controls?: boolean;
+        dnt?: boolean;
+        height?: number;
+        loop?: boolean;
+        maxheight?: number;
+        maxwidth?: number;
+        muted?: boolean;
+        playsinline?: boolean;
+        portrait?: boolean;
+        responsive?: boolean;
+        speed?: boolean;
+        quality?: VimeoVideoQuality;
+        texttrack?: string;
+        title?: boolean;
+        transparent?: boolean;
+        width?: number;
+    }
+
+    export interface VimeoPromise<Result, Reason> extends Promise<Result> {
+        (
+            successCallback?: (promiseValue: Result) => void,
+            rejectCallback?: (reasonValue: Reason) => void
+        ): Promise<Result>;
+    }
 }
-
-export interface VimeoCuePoint {
-    time: number;
-    data: VimeoCuePointData;
-    id: string;
-}
-
-export interface VimeoCuePointData {
-    [key: string]: any;
-}
-
-export interface VimeoTextTrack {
-    language: string;
-    kind: string;
-    label: string;
-    mode?: string;
-}
-
-export interface Options {
-    id?: number;
-    url?: string;
-    autopause?: boolean;
-    autoplay?: boolean;
-    background?: boolean;
-    byline?: boolean;
-    color?: string;
-    controls?: boolean;
-    dnt?: boolean;
-    height?: number;
-    loop?: boolean;
-    maxheight?: number;
-    maxwidth?: number;
-    muted?: boolean;
-    playsinline?: boolean;
-    portrait?: boolean;
-    responsive?: boolean;
-    speed?: boolean;
-    quality?: VimeoVideoQuality;
-    texttrack?: string;
-    title?: boolean;
-    transparent?: boolean;
-    width?: number;
-}
-
-export interface VimeoPromise<Result, Reason> extends Promise<Result> {
-    (
-        successCallback?: (promiseValue: Result) => void,
-        rejectCallback?: (reasonValue: Reason) => void
-    ): Promise<Result>;
-}
-
-/*~ You can declare properties of the module using const, let, or var */
-export default Player;


### PR DESCRIPTION
Just a proposal. YouTube video types are declared in a namespace so PHPStorm and other IDEs can use the types easier.

It has to be tested with current implementations that uses the removed "export default Player".