### PR TITLE
Added optional arguments to solid-auth-client methods

### DIFF
--- a/types/solid-auth-client/index.d.ts
+++ b/types/solid-auth-client/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for solid-auth-client 2.3
 // Project: https://github.com/solid/solid-auth-client#readme
 // Definitions by: Vincent <https://github.com/Vinnl>
+//                 James <https://github.com/durandj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 import { EventEmitter } from 'events';
@@ -8,13 +9,26 @@ import { EventEmitter } from 'events';
 export interface Session {
     webId: string;
 }
+
+export interface AsyncStorage {
+    getItem(key: string): Promise<undefined | string>;
+    setItem(key: string, value: string): Promise<void>;
+    removeItem(key: string): Promise<void>;
+}
+
+interface LoginOptions {
+    callbackUri?: string;
+    popupUri?: string;
+    storage?: Storage | AsyncStorage;
+}
+
 export interface SolidAuthClient extends EventEmitter {
-    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
-    currentSession(): Promise<Session | undefined>;
-    trackSession(callback: (session?: Session) => void): void;
-    login(identityProvider: string): Promise<void>;
-    logout(): Promise<void>;
-    popupLogin(params: { popupUri: string }): Promise<Session>;
+  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+  currentSession(storage?: AsyncStorage): Promise<Session | undefined>;
+  trackSession(callback: (session?: Session) => void): void;
+  login(identityProvider: string, options?: LoginOptions): Promise<void>;
+  logout(storage?: AsyncStorage): Promise<void>;
+  popupLogin(params?: LoginOptions): Promise<Session>;
 }
 
 declare const instantiated: SolidAuthClient;

--- a/types/solid-auth-client/solid-auth-client-tests.ts
+++ b/types/solid-auth-client/solid-auth-client-tests.ts
@@ -17,11 +17,34 @@ async function login(idp: string) {
     alert(`Logged in as ${session.webId}`);
 }
 
+async function loginWithOptions(idp: string) {
+  const session = await auth.currentSession();
+  if (!session)
+    await auth.login(idp, {
+      callbackUri: '/callback',
+      popupUri: 'https://solid.community/common/popup.html',
+      storage: localStorage,
+    });
+  else alert(`Logged in as ${session.webId}`);
+}
+
 async function popupLogin() {
   let session = await auth.currentSession();
   const popupUri = 'https://solid.community/common/popup.html';
   if (!session)
     session = await auth.popupLogin({ popupUri });
+  alert(`Logged in as ${session.webId}`);
+}
+
+async function popupLoginWIthOptions() {
+  let session = await auth.currentSession();
+  const popupUri = 'https://solid.community/common/popup.html';
+  if (!session)
+    session = await auth.popupLogin({
+      callbackUri: '/callback',
+      popupUri,
+      storage: localStorage,
+    });
   alert(`Logged in as ${session.webId}`);
 }
 


### PR DESCRIPTION
There are a few optional arguments that can be passed to
the client methods that aren't present in the types currently.
I've added them as they are in the 2.3.0 version of the client
the existing types say they target.

Client source code: https://github.com/solid/solid-auth-client/blob/master/src/solid-auth-client.js
Storage source code: https://github.com/solid/solid-auth-client/blob/master/src/storage.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
