### PR TITLE
Package: bookshelf  // Modification: count type returns either a string or a number, not just a number due to Postgres limitation and bump knex version

### DIFF
--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -90,7 +90,7 @@ declare namespace Bookshelf {
 
 	class Model<T extends Model<any>> extends ModelBase<T> {
 		static collection<T extends Model<any>>(models?: T[], options?: CollectionOptions<T>): Collection<T>;
-		static count(column?: string, options?: SyncOptions): BlueBird<number>;
+		static count(column?: string, options?: SyncOptions): BlueBird<number | string>;
 		/** @deprecated use Typescript classes */
 		static extend<T extends Model<any>>(prototypeProperties?: any, classProperties?: any): Function; // should return a type
 		static fetchAll<T extends Model<any>>(): BlueBird<Collection<T>>;
@@ -101,7 +101,7 @@ declare namespace Bookshelf {
 
 		belongsTo<R extends Model<any>>(target: { new (...args: any[]): R }, foreignKey?: string, foreignKeyTarget?: string): R;
 		belongsToMany<R extends Model<any>>(target: { new (...args: any[]): R }, table?: string, foreignKey?: string, otherKey?: string, foreignKeyTarget?: string, otherKeyTarget?: string): Collection<R>;
-		count(column?: string, options?: SyncOptions): BlueBird<number>;
+		count(column?: string, options?: SyncOptions): BlueBird<number | string>;
 		destroy(options?: DestroyOptions): BlueBird<T>;
 		fetch(options?: FetchOptions): BlueBird<T>;
 		fetchAll(options?: FetchAllOptions): BlueBird<Collection<T>>;
@@ -244,7 +244,7 @@ declare namespace Bookshelf {
 		static forge<T>(attributes?: any, options?: ModelOptions): T;
 
 		attach(ids: any | any[], options?: SyncOptions): BlueBird<Collection<T>>;
-		count(column?: string, options?: SyncOptions): BlueBird<number>;
+		count(column?: string, options?: SyncOptions): BlueBird<number | string>;
 		create(model: { [key: string]: any }, options?: CollectionCreateOptions): BlueBird<T>;
 		detach(ids: any[], options?: SyncOptions): BlueBird<any>;
 		detach(options?: SyncOptions): BlueBird<any>;

--- a/types/bookshelf/package.json
+++ b/types/bookshelf/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "^0.16.1"
+        "knex": "^0.17.0"
     }
 }


### PR DESCRIPTION
1. 
See https://github.com/bookshelf/bookshelf/issues/1275
On Postgres `count()` returns a string and this is an intentional, known limitation as it could be a bigint. 

2. The supported knex version has been updated. See https://github.com/bookshelf/bookshelf/pull/1982 - the old knex types depended upon within this repository no longer work with the newest Bookshelf version 0.15.1 (https://github.com/bookshelf/bookshelf/releases)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bookshelf/bookshelf/issues/1275
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
