### PR TITLE
[leaflet] Add missing TileLayerOptions properties

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -486,6 +486,8 @@ export class GridLayer extends Layer {
 export function gridLayer(options?: GridLayerOptions): GridLayer;
 
 export interface TileLayerOptions extends GridLayerOptions {
+    id?: string;
+    accessToken?: string;
     minZoom?: number;
     maxZoom?: number;
     maxNativeZoom?: number;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -218,6 +218,8 @@ mapPixelBounds = map.getPixelWorldBounds(12);
 
 let tileLayerOptions: L.TileLayerOptions = {};
 tileLayerOptions = {
+	id: 'mapbox.streets',
+	accessToken: 'your.mapbox.access.token',
 	minZoom: 0,
 	maxZoom: 18,
 	maxNativeZoom: 2,


### PR DESCRIPTION
`TitleLayerOptions` definition was missing properties from [getting started guide](https://leafletjs.com/examples/quick-start/)