### PR TITLE
[promise-ftp] Ensure list functions are correctly typed to return promises

### DIFF
--- a/types/promise-ftp/index.d.ts
+++ b/types/promise-ftp/index.d.ts
@@ -88,8 +88,8 @@ declare class PromiseFtp {
      * @param useCompression - defaults to false.
      * @returns the contents of the specified directory
      */
-    list(path?: string, useCompression?: boolean): FtpClient.ListingElement[];
-    list(useCompression: boolean): FtpClient.ListingElement[];
+    list(path?: string, useCompression?: boolean): Promise<FtpClient.ListingElement[]>;
+    list(useCompression: boolean): Promise<FtpClient.ListingElement[]>;
 
     /**
      * Optional "standard" commands (RFC 959)
@@ -107,7 +107,7 @@ declare class PromiseFtp {
         path?: string,
         useCompression?: boolean
     ): FtpClient.ListingElement[];
-    listSafe(useCompression: boolean): FtpClient.ListingElement[];
+    listSafe(useCompression: boolean): Promise<FtpClient.ListingElement[]>;
 
     /**
      * Retrieve a file at path from the server.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [All the methods in this section get wrapped in promises, but the typing didn't reflect that](https://github.com/realtymaps/promise-ftp/blob/master/lib/promiseFtp.coffee#L15)