### PR TITLE
Add type definitions for redux-duck

### DIFF
--- a/types/redux-duck/index.d.ts
+++ b/types/redux-duck/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for redux-duck 1.0
+// Project: https://github.com/PlatziDev/redux-duck/
+// Definitions by: Toni Ruottu <https://github.com/cyberixae>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+
+// See redux-duck-tests.ts for an example application!
+
+import { Reducer, Action, AnyAction } from 'redux';
+// import { FSA } from 'flux-standard-action';
+// flux-standard-action contains mostly types so it is not a dependency of redux-duck javascript package
+// flux-standard-action is written in javascript but the types are included in the same package
+// flux-standard-action is not part of types-publisher dependencywhitelist
+// https://github.com/redux-utilities/flux-standard-action/issues/119
+// below is a minimalistic implementation that should work until the above questions are answered
+export type FSAHack = Action<string> & {
+  payload?: any;
+};
+
+export type AppName = string;
+export type DuckName = string;
+export type ActionName = string;
+
+export type ActionType = string; // AppName/DuckName/ActionName or just DuckName/ActionName
+
+// Ducks define FSA actions
+export type ActionCreator<A extends FSAHack> = A extends { payload: any }
+  ? (a: A['payload']) => A
+  : () => A;
+
+// Ducks can listen for any actions (FSA or not)
+export type ActionHandlers<S = any, A extends Action = AnyAction> = {
+  [T in A['type']]?: (x: S, y: Extract<A, { type: T }>) => S;
+};
+
+export interface DuckBuilder<AppAction extends Action = AnyAction> {
+    defineType: (a: ActionName) => ActionType;
+    createAction: <T extends string & AppAction['type']>(a: T) => ActionCreator<Extract<AppAction, { type: T }>>;
+    createReducer: <S>(a: ActionHandlers<S, AppAction>, b: S) => Reducer<S, AppAction>;
+}
+
+export function createDuck(a: DuckName, b?: AppName): DuckBuilder;

--- a/types/redux-duck/package.json
+++ b/types/redux-duck/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "redux": "^4.0.1"
+    }
+}

--- a/types/redux-duck/redux-duck-tests.ts
+++ b/types/redux-duck/redux-duck-tests.ts
@@ -1,0 +1,129 @@
+// This example code explains how to setup app "Pond" with two ducks, "Alfred" and "Winnie"
+
+import { createDuck, DuckBuilder } from 'redux-duck';
+import { Action } from 'redux';
+
+// import { FSAAuto as FSA } from 'flux-standard-action';
+// flux-standard-action is written in javascript but the types are included in the same package
+// flux-standard-action is not part of types-publisher dependencywhitelist
+// https://github.com/redux-utilities/flux-standard-action/issues/119
+// below is a minimalistic implementation that should work until the above questions are answered
+type FSA<T extends string, P = undefined> = P extends undefined ? Action<T> : Action<T> & { payload: P };
+
+type Food = string;
+
+// State Interfaces
+
+export interface AlfredState {
+    readonly belly: Food[];
+    readonly happy: boolean;
+}
+
+export interface WinnieState {
+    readonly home: boolean;
+}
+
+// Action Types
+
+enum AlfredActions {
+    EAT = 'pond/alfred/EAT',
+    SLEEP = 'pond/alfred/SLEEP',
+}
+enum WinnieActions {
+    GO_TO_WORK = 'pond/winnie/GO_TO_WORK',
+    RETURN_HOME = 'pond/winnie/RETURN_HOME',
+}
+
+// Action Structures
+
+type AlfredAction =
+    | FSA<
+          AlfredActions.EAT,
+          {
+              readonly food: Food;
+          }
+      >
+    | FSA<AlfredActions.SLEEP>;
+
+type WinnieAction = FSA<WinnieActions.GO_TO_WORK> | FSA<WinnieActions.RETURN_HOME>;
+
+// Duck Initialization
+
+const initialAlfred: AlfredState = {
+    belly: [],
+    happy: true,
+};
+const initialWinnie: WinnieState = {
+    home: true,
+};
+
+// Global Configuration
+
+type PondAction = AlfredAction | WinnieAction;
+
+type PondDuckBuilder = DuckBuilder<PondAction>;
+
+// Duck Builders
+
+const alfredBuilder: PondDuckBuilder = createDuck('alfred', 'pond');
+const winnieBuilder: PondDuckBuilder = createDuck('winnie', 'pond');
+
+// Ducks
+
+// In practice Alfred and Winnie should be their on modules.
+// Here we just define an object for the respective exports.
+//
+// The module exports should match the "Redux Reducer Bundles"
+// specification https://github.com/erikras/ducks-modular-redux
+//
+// TypeScript modules can not currently implement interfaces
+// https://github.com/microsoft/TypeScript/issues/420
+
+const winnieExports = {
+    WinnieActions,
+    default: winnieBuilder.createReducer<WinnieState>(
+        {
+            [WinnieActions.GO_TO_WORK]: state => ({
+                ...state,
+                home: false,
+            }),
+            [WinnieActions.RETURN_HOME]: state => ({
+                ...state,
+                home: true,
+            }),
+            // Alfred doesn't export any action types so
+            // Winnie's state can not change based on them.
+        },
+        initialWinnie,
+    ),
+    goToWork: winnieBuilder.createAction(WinnieActions.GO_TO_WORK),
+    returnHome: winnieBuilder.createAction(WinnieActions.RETURN_HOME),
+};
+
+const alfredExports = {
+    default: alfredBuilder.createReducer<AlfredState>(
+        {
+            [AlfredActions.EAT]: (state, { payload: { food } }) => ({
+                ...state,
+                belly: [...state.belly, food],
+            }),
+            [AlfredActions.SLEEP]: state => ({
+                ...state,
+                belly: [],
+            }),
+            // Winnie's action types are exported and
+            // can therefore cause changes in Alfred.
+            [winnieExports.WinnieActions.GO_TO_WORK]: state => ({
+                ...state,
+                happy: false,
+            }),
+            [winnieExports.WinnieActions.RETURN_HOME]: state => ({
+                ...state,
+                happy: true,
+            }),
+        },
+        initialAlfred,
+    ),
+    eat: alfredBuilder.createAction(AlfredActions.EAT),
+    sleep: alfredBuilder.createAction(AlfredActions.SLEEP),
+};

--- a/types/redux-duck/tsconfig.json
+++ b/types/redux-duck/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "redux-duck-tests.ts"
+    ]
+}

--- a/types/redux-duck/tslint.json
+++ b/types/redux-duck/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.