### PR TITLE
[react-material-ui-form-validator] Update to v2.0.9

### DIFF
--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -18,6 +18,7 @@ export interface ValidatorFormProps {
 }
 export class ValidatorForm extends React.Component<ValidatorFormProps> {
     static addValidationRule(name: string, callback: (value: any) => boolean): void;
+    static removeValidationRule(name: string): void;
     isFormValid(dryRun: boolean): Promise<boolean>;
     resetValidations(): void;
 }

--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -18,7 +18,7 @@ export interface ValidatorFormProps {
 }
 export class ValidatorForm extends React.Component<ValidatorFormProps> {
     static addValidationRule(name: string, callback: (value: any) => boolean): void;
-    isFormValid(dryRun: boolean): boolean;
+    isFormValid(dryRun: boolean): Promise<boolean>;
     resetValidations(): void;
 }
 

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -10,6 +10,14 @@ class Test extends React.Component {
     onError = (errors: any[]) => {};
     onValidate = (isValid: boolean) => {};
 
+    componentDidMount() {
+        ValidatorForm.addValidationRule('isTruthy', value => value);
+    }
+
+    componentWillUnmount() {
+        ValidatorForm.removeValidationRule('isTruthy');
+    }
+
     render() {
         return (
             <ValidatorForm


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Release note v2.0.7: https://github.com/NewOldMax/react-material-ui-form-validator/releases/tag/2.0.7
  - Release note v2.0.9: https://github.com/NewOldMax/react-material-ui-form-validator/releases/tag/2.0.9
  - API Document: https://github.com/NewOldMax/react-form-validator-core#validatorform
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - Although this PR contains API change, react-material-ui-form-validator increments only patch version. Therefore I think I need not to update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
