### PR TITLE
[@types/node] Fix `cursorTo` requiring a `y` parameter

### DIFF
--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -142,7 +142,7 @@ declare module "readline" {
     /**
      * Moves this WriteStream's cursor to the specified position.
      */
-    function cursorTo(stream: NodeJS.WritableStream, x: number, y: number, callback?: () => void): boolean;
+    function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number, callback?: () => void): boolean;
     /**
      * Moves this WriteStream's cursor relative to its current position.
      */

--- a/types/node/test/readline.ts
+++ b/types/node/test/readline.ts
@@ -76,6 +76,7 @@ const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
     const x = 1;
     const y = 1;
 
+    readline.cursorTo(strm, x);
     readline.cursorTo(strm, x, y);
     readline.cursorTo(strm, x, y, () => {}); // $ExpectType boolean
 }


### PR DESCRIPTION
This effectively re-applies https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17684 after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37217.

We are using `readline.cursorTo(process.stdout, 0);` to move the cursor to the beginning of the current line, and after updating to `@types/node` to v12.7.1, it is no longer possible.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/427e5348a267b7c88879b47f8d942fc3e84b30e9/lib/readline.js#L1205
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
