### PR TITLE
Added typings for datadog-winston

### DIFF
--- a/types/datadog-winston/datadog-winston-tests.ts
+++ b/types/datadog-winston/datadog-winston-tests.ts
@@ -1,0 +1,10 @@
+import { DataDogTransport } from "datadog-winston";
+
+const logger = new DataDogTransport({
+    apiKey: "<key>",
+    ddsource: "node.js",
+    ddtags: "key:value",
+    hostname: "hostname",
+    level: "error",
+    service: "service"
+});

--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for datadog-winston 1.0
+// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Definitions by: Matt Hintzke <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import * as Transport from "winston-transport";
+
+export interface DataDogTransportOptions extends Transport.TransportStreamOptions {
+    apiKey: string;
+    hostname: string;
+    service: string;
+    ddsource: string;
+    ddtags: string;
+}
+
+export class DataDogTransport extends Transport {
+    constructor(options?: DataDogTransportOptions);
+
+    log?(info: any, next: () => void): void;
+}

--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for datadog-winston 1.1
+// Type definitions for datadog-winston 1.0
 // Project: https://https://github.com/itsfadnis/datadog-winston
 // Definitions by: Matt Hintzke <https://github.com/mhintzke13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for datadog-winston 1.0.1
+// Type definitions for datadog-winston 1.1
 // Project: https://https://github.com/itsfadnis/datadog-winston
 // Definitions by: Matt Hintzke <https://github.com/mhintzke13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for datadog-winston 1.0
-// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
-// Definitions by: Matt Hintzke <https://github.com/me>
+// Project: https://https://github.com/itsfadnis/datadog-winston
+// Definitions by: Matt Hintzke <https://github.com/mhintzke13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for datadog-winston 1.0
+// Type definitions for datadog-winston 1.0.1
 // Project: https://https://github.com/itsfadnis/datadog-winston
 // Definitions by: Matt Hintzke <https://github.com/mhintzke13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/datadog-winston/package.json
+++ b/types/datadog-winston/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "winston-transport": "^4.3.0"
+    }
+}

--- a/types/datadog-winston/tsconfig.json
+++ b/types/datadog-winston/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "datadog-winston-tests.ts"
+    ]
+}

--- a/types/datadog-winston/tslint.json
+++ b/types/datadog-winston/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This is a very simple interface to the existing `datadog-winston` npm library. This is my first ever attempt at adding typings to a JS library, so please let me know if there is something I could do better.

Thanks!