### PR TITLE
video.js: Add missing option to controlBar

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1964,6 +1964,7 @@ declare namespace videojs {
 
 	interface ControlBarOptions extends ComponentOptions {
 		volumePanel?: VolumePanelOptions;
+		fullscreenToggle?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
   ```
   Type checking and linting in progress...
   ℹ ｢wdm｣: 
   ℹ ｢wdm｣: Compiled successfully.
   No type errors found
   No lint errors found
   Version: typescript 3.5.3, tslint 5.16.0
  ```
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  Since this is just a property and control options aren't tested, may not add value
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/collab-project/videojs-record#customizing-controls

Fixes:
```
ERROR in 
/js/components/VideoRecorder/VideoRecorder.tsx(68,49):
TS2345: Argument of type '{ controlBar: { fullscreenToggle: boolean; }; controls: boolean; fluid: boolean; plugins: {}; }' is not assignable to parameter of type 'VideoJsPlayerOptions'.
  Types of property 'controlBar' are incompatible.
    Type '{ fullscreenToggle: boolean; }' is not assignable to type 'false | ControlBarOptions | undefined'.
      Type '{ fullscreenToggle: boolean; }' has no properties in common with type 'ControlBarOptions'.
```