### PR TITLE
[@types/ramda] Update useWith return type

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3068,7 +3068,7 @@ declare namespace R {
          * need to be transformed, although you can ignore them, it's best to pass an identity function so
          * that the new function reports the correct arity.
          */
-        useWith<F extends (...args: any) => any>(fn: F, transformers: ReadonlyArray<((...a: Array<any>) => any)>): F.Curry<F>;
+        useWith<F extends (...args: any) => any>(fn: F, transformers: ReadonlyArray<((...args: any) => any)>): F.Curry<F>;
 
         /**
          * Returns a list of all the enumerable own properties of the supplied object.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -29,6 +29,7 @@
 //                 Brekk Bockrath <https://github.com/brekk>
 //                 Aram Kharazyan <https://github.com/nemo108>
 //                 Jituan Lin <https://github.com/jituanlin>
+//                 Joshua Avalon <https://github.com/joshuaavalon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -3067,7 +3068,7 @@ declare namespace R {
          * need to be transformed, although you can ignore them, it's best to pass an identity function so
          * that the new function reports the correct arity.
          */
-        useWith(fn: ((...a: any[]) => any), transformers: Array<((...a: any[]) => any)>): (...a: any[]) => any;
+        useWith<F extends (...args: any) => any>(fn: F, transformers: ReadonlyArray<((...a: Array<any>) => any)>): F.Curry<F>;
 
         /**
          * Returns a list of all the enumerable own properties of the supplied object.


### PR DESCRIPTION
`useWith` return a function without type information. The new definition follows `curry`'s definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

* https://ramdajs.com/docs/#useWith

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
