### PR TITLE
Extended "overrideBrowserslist" option to support environment maps in "autoprefixer" package

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -16,5 +16,22 @@ const ap2: Transformer = autoprefixer({
     flexbox: true,
     grid: false,
     stats: {},
-    ignoreUnknownVersions: false
+    ignoreUnknownVersions: false,
+});
+
+// Using environment map in "overrideBrowserslist"
+const ap3: Transformer = autoprefixer({
+    overrideBrowserslist: {
+        production: [
+            '> 1%',
+            'ie 10',
+        ],
+        modern: [
+            'last 1 chrome version',
+            'last 1 firefox version',
+        ],
+        ssr: [
+            'node 12',
+        ],
+    },
 });

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for autoprefixer 9.6
 // Project: https://github.com/postcss/autoprefixer
-// Definitions by:  Armando Meziat <https://github.com/odnamrataizem>, murt <https://github.com/murt>
+// Definitions by: Armando Meziat <https://github.com/odnamrataizem>
+//                 murt <https://github.com/murt>
+//                 Slava Fomin II <https://github.com/slavafomin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -8,6 +10,8 @@ import { Plugin } from 'postcss';
 import { Stats } from 'browserslist';
 
 declare namespace autoprefixer {
+    type BrowserslistTarget = (string | string[] | { [key: string]: string[]; });
+
     interface Options {
         env?: string;
         cascade?: boolean;
@@ -18,7 +22,7 @@ declare namespace autoprefixer {
         grid?: false | 'autoplace' | 'no-autoplace';
         stats?: Stats;
         browsers?: string[] | string;
-        overrideBrowserslist?: string[] | string;
+        overrideBrowserslist?: BrowserslistTarget;
         ignoreUnknownVersions?: boolean;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserslist/browserslist#configuring-for-different-environments
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.