### PR TITLE
Adds onBlur typings to rc-slider

### DIFF
--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -136,6 +136,10 @@ export interface SliderProps extends CommonApiProps {
      */
     onAfterChange?(value: number): void;
     /**
+     * Handle blur event on the control 
+     */
+    onBlur?: FocusEventHandler;
+    /**
      * Set initial value of slider.
      *  @default 0
      */

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -8,6 +8,7 @@
 //                 Nick Maddren <https://github.com/nicholasmaddren>
 //                 Roman Nevolin <https://github.com/nulladdict>
 //                 Mojtaba Izadmehr <https://github.com/m-izadmehr>
+//                 Andrey Yankovsky <https://github.com/yankovsky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -136,9 +137,9 @@ export interface SliderProps extends CommonApiProps {
      */
     onAfterChange?(value: number): void;
     /**
-     * Handle blur event on the control 
+     * Handle blur event on the control
      */
-    onBlur?: FocusEventHandler;
+    onBlur?: React.FocusEventHandler;
     /**
      * Set initial value of slider.
      *  @default 0

--- a/types/rc-slider/rc-slider-tests.tsx
+++ b/types/rc-slider/rc-slider-tests.tsx
@@ -24,7 +24,7 @@ const onChangeFunc1 = (string: number) => {};
 
 const onChangeFunc2 = (string: number[]) => {};
 
-const onBlurFunc = (e: React.FocusEvent) => {}
+const onBlurFunc = (e: React.FocusEvent) => {};
 
 ReactDOM.render(
     <Slider

--- a/types/rc-slider/rc-slider-tests.tsx
+++ b/types/rc-slider/rc-slider-tests.tsx
@@ -24,6 +24,8 @@ const onChangeFunc1 = (string: number) => {};
 
 const onChangeFunc2 = (string: number[]) => {};
 
+const onBlurFunc = (e: React.FocusEvent) => {}
+
 ReactDOM.render(
     <Slider
         className="bottomRight"
@@ -38,6 +40,7 @@ ReactDOM.render(
         dots={true}
         onBeforeChange={onChangeFunc1}
         onChange={onChangeFunc1}
+        onBlur={onBlurFunc}
         onAfterChange={onChangeFunc1}
         defaultValue={0.1}
         value={0.1}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-component/slider/blob/3a1be18dae10bce71e99417ad746b7c98e89954d/src/common/createSlider.jsx#L43 https://github.com/react-component/slider/blob/e853aac29fcf5e6b8f27d494f8898a6fb1fba546/tests/Slider.test.js#L240
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _It is just a small fix in typings_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
