### PR TITLE
feat: Add type definitions for npm module `ospec`

### DIFF
--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -1,0 +1,106 @@
+// Type definitions for ospec 4.0
+// Project: https://github.com/MithrilJS/mithril.js/tree/next/ospec
+// Definitions by: Már Örlygsson <https://github.com/maranomynet>
+//                 Mike Linkovich <https://github.com/spacejack>
+//                 Isiah Meadows <https://github.com/isiahmeadows>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+declare namespace Ospec {
+    type AssertionDescriber = (description: string) => void;
+
+    interface Spy<Args extends any[] = any[], Returns = undefined> {
+        (...args: Args): Returns;
+        /** The number of times the function has been called */
+        callCount: number;
+        /** The arguments that were passed to the function in the last time it was called */
+        args: Args;
+        /** List of arguments that were passed to the function each tine it was called */
+        calls: Args[];
+    }
+
+    interface BasicAssertions<T = any> {
+        /** Asserts that two values are strictly equal */
+        equals(expected: T): AssertionDescriber;
+        /** Asserts that two values are **not** strictly equal */
+        notEquals(value: any): AssertionDescriber;
+    }
+
+    interface ObjectAssertions<T = any> extends BasicAssertions<T> {
+        /** Asserts that two objects are recursively equal */
+        deepEquals(expected: T): AssertionDescriber;
+        /** Asserts that two objects are **not** recursively equal */
+        notDeepEquals(value: object): AssertionDescriber;
+    }
+
+    interface FunctionAssertions<T = any> extends ObjectAssertions<T> {
+        // FIXME: Find a more appropriate type annotation for the `error` parameter
+        // NOTE: We're using `NewableFunction` because the API docs say "Object constructor"
+        // Still TypeScript seems to accept something like `nonNewableFunction = () => {}`
+        // which errors at runtime.
+
+        /** Asserts that the function throws an error of a given type */
+        throws(error: string | NewableFunction): AssertionDescriber;
+
+        /** Asserts that the function does **not** throw an error of given type */
+        notThrows(error: string | NewableFunction): AssertionDescriber; // See above
+    }
+
+    type Definer = (
+        done: (error?: Error | {} | null) => void,
+        timeout: (delay: number) => void,
+    ) => void | Promise<void>;
+
+    interface Result {
+        pass: boolean | null;
+        context: string;
+        message: string;
+        error: Error | null;
+        testError: Error | null;
+    }
+
+    type Reporter = (results: Result[]) => number;
+
+    interface Ospec {
+        /** Starts a function assertion */
+        <T extends () => void>(actual: T): FunctionAssertions<T>;
+        /** Starts an object assertion */
+        <T extends object>(actual: T): ObjectAssertions<T>;
+        /** Starts an assertion */
+        <T>(actual: T): BasicAssertions<T>;
+
+        /** Defines a test */
+        (name: string, assertions: Definer): void;
+
+        /** Defines a group of tests */
+        spec(name: string, tests: () => void): void;
+
+        /** Defines code to be run at the beginning of a test group */
+        before(setup: Definer): void;
+        /** Defines code to be run before each test in a group */
+        beforeEach(teardown: Definer): void;
+        /** Defines code to be run at the end of a test group */
+        after(setup: Definer): void;
+        /** Defines code to be run after each test in a group */
+        afterEach(teardown: Definer): void;
+
+        /** Returns a function that records the number of times it gets called, and its arguments */
+        spy<A extends any[], R>(fn?: (...args: A) => R): Spy<A, R>;
+
+        /** Amount of time (in milliseconds) to wait until bailing out of a test */
+        timeout(delay: number): void;
+        /** Configure the default amount of time (in milliseconds) to wait until bailing out of a group of tests */
+        specTimeout(delay: number): void;
+
+        /** Runs the test suite */
+        run(reporter?: Reporter): void;
+        /** Default reporter used by `o.run()` */
+        report: Reporter;
+
+        'new'(): Ospec;
+    }
+}
+
+declare const Ospec: Ospec.Ospec;
+export = Ospec;
+export as namespace Ospec;

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -25,12 +25,12 @@ declare namespace o {
         /** Asserts that two values are strictly equal */
         equals(expected: T): AssertionDescriber;
         /** Asserts that two values are **not** strictly equal */
-        notEquals(value: any): AssertionDescriber;
+        notEquals(value: T): AssertionDescriber;
 
         /** Asserts that two objects are recursively equal */
         deepEquals(this: Assertion<object>, expected: T): AssertionDescriber;
         /** Asserts that two objects are **not** recursively equal */
-        notDeepEquals(this: Assertion<object>, value: object): AssertionDescriber;
+        notDeepEquals(this: Assertion<object>, value: T): AssertionDescriber;
 
         /** Asserts that the function throws an error of a given type */
         throws(this: Assertion<() => any>, error: string | ObjectConstructor): AssertionDescriber;

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
-declare namespace Ospec {
+declare namespace o {
     type AssertionDescriber = (description: string) => void;
 
     interface Spy<Args extends any[], Returns> {
@@ -102,6 +102,6 @@ declare namespace Ospec {
     }
 }
 
-declare const Ospec: Ospec.Ospec;
-export = Ospec;
-export as namespace Ospec;
+declare const o: o.Ospec;
+export = o;
+export as namespace o;

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -4,7 +4,9 @@
 //                 Mike Linkovich <https://github.com/spacejack>
 //                 Isiah Meadows <https://github.com/isiahmeadows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.1
+
+type ObjectConstructor = new (...args: any[]) => any;
 
 declare namespace o {
     type AssertionDescriber = (description: string) => void;
@@ -34,16 +36,11 @@ declare namespace o {
     }
 
     interface FunctionAssertions<T = any> extends ObjectAssertions<T> {
-        // FIXME: Find a more appropriate type annotation for the `error` parameter
-        // NOTE: We're using `NewableFunction` because the API docs say "Object constructor"
-        // Still TypeScript seems to accept something like `nonNewableFunction = () => {}`
-        // which errors at runtime.
-
         /** Asserts that the function throws an error of a given type */
-        throws(error: string | NewableFunction): AssertionDescriber;
+        throws(error: string | ObjectConstructor): AssertionDescriber;
 
         /** Asserts that the function does **not** throw an error of given type */
-        notThrows(error: string | NewableFunction): AssertionDescriber; // See above
+        notThrows(error: string | ObjectConstructor): AssertionDescriber; // See above
     }
 
     type Definer = (

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -21,26 +21,21 @@ declare namespace o {
         readonly calls: Args[];
     }
 
-    interface BasicAssertions<T = any> {
+    interface Assertion<T> {
         /** Asserts that two values are strictly equal */
         equals(expected: T): AssertionDescriber;
         /** Asserts that two values are **not** strictly equal */
         notEquals(value: any): AssertionDescriber;
-    }
 
-    interface ObjectAssertions<T = any> extends BasicAssertions<T> {
         /** Asserts that two objects are recursively equal */
-        deepEquals(expected: T): AssertionDescriber;
+        deepEquals(this: Assertion<object>, expected: T): AssertionDescriber;
         /** Asserts that two objects are **not** recursively equal */
-        notDeepEquals(value: object): AssertionDescriber;
-    }
+        notDeepEquals(this: Assertion<object>, value: object): AssertionDescriber;
 
-    interface FunctionAssertions<T = any> extends ObjectAssertions<T> {
         /** Asserts that the function throws an error of a given type */
-        throws(error: string | ObjectConstructor): AssertionDescriber;
-
+        throws(this: Assertion<() => any>, error: string | ObjectConstructor): AssertionDescriber;
         /** Asserts that the function does **not** throw an error of given type */
-        notThrows(error: string | ObjectConstructor): AssertionDescriber; // See above
+        notThrows(this: Assertion<() => any>, error: string | ObjectConstructor): AssertionDescriber; // See above
     }
 
     type Definer = (
@@ -59,12 +54,8 @@ declare namespace o {
     type Reporter = (results: Result[]) => number;
 
     interface Ospec {
-        /** Starts a function assertion */
-        <T extends () => void>(actual: T): FunctionAssertions<T>;
-        /** Starts an object assertion */
-        <T extends object>(actual: T): ObjectAssertions<T>;
         /** Starts an assertion */
-        <T>(actual: T): BasicAssertions<T>;
+        <T>(actual: T): Assertion<T>;
 
         /** Defines a test */
         (name: string, assertions: Definer): void;

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -73,7 +73,7 @@ declare namespace o {
         afterEach(teardown: Definer): void;
 
         /** Returns a function that records the number of times it gets called, and its arguments */
-        spy<A extends any[]>(): Spy<A, undefined>; //tslint:disable no-unnecessary-generics
+        spy<A extends any[]>(): Spy<A, undefined>; // tslint:disable-line:no-unnecessary-generics
         spy<A extends any[], R>(fn: (...args: A) => R): Spy<A, R>;
 
         /** Amount of time (in milliseconds) to wait until bailing out of a test */

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -85,7 +85,7 @@ declare namespace Ospec {
         afterEach(teardown: Definer): void;
 
         /** Returns a function that records the number of times it gets called, and its arguments */
-        spy<A extends any[]>(): Spy<A, undefined>;
+        spy<A extends any[]>(): Spy<A, undefined>; //tslint:disable no-unnecessary-generics
         spy<A extends any[], R>(fn: (...args: A) => R): Spy<A, R>;
 
         /** Amount of time (in milliseconds) to wait until bailing out of a test */

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -38,10 +38,7 @@ declare namespace o {
         notThrows(this: Assertion<() => any>, error: string | ObjectConstructor): AssertionDescriber; // See above
     }
 
-    type Definer = (
-        done: (error?: Error | {} | null) => void,
-        timeout: (delay: number) => void,
-    ) => void | Promise<void>;
+    type Definer = (done: (error?: Error | null) => void, timeout: (delay: number) => void) => void | PromiseLike<any>;
 
     interface Result {
         pass: boolean | null;

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -9,14 +9,14 @@
 declare namespace Ospec {
     type AssertionDescriber = (description: string) => void;
 
-    interface Spy<Args extends any[] = any[], Returns = undefined> {
+    interface Spy<Args extends any[], Returns> {
         (...args: Args): Returns;
         /** The number of times the function has been called */
-        callCount: number;
+        readonly callCount: number;
         /** The arguments that were passed to the function in the last time it was called */
-        args: Args;
+        readonly args: Args;
         /** List of arguments that were passed to the function each tine it was called */
-        calls: Args[];
+        readonly calls: Args[];
     }
 
     interface BasicAssertions<T = any> {
@@ -85,7 +85,8 @@ declare namespace Ospec {
         afterEach(teardown: Definer): void;
 
         /** Returns a function that records the number of times it gets called, and its arguments */
-        spy<A extends any[], R>(fn?: (...args: A) => R): Spy<A, R>;
+        spy<A extends any[]>(): Spy<A, undefined>;
+        spy<A extends any[], R>(fn: (...args: A) => R): Spy<A, R>;
 
         /** Amount of time (in milliseconds) to wait until bailing out of a test */
         timeout(delay: number): void;

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -1,8 +1,8 @@
-// import o = require('ospec');
-import o, { Definer } from 'ospec'; // NOTE: this only works with  "esModuleInterop": true
+import o = require('ospec');
+// import o, { Definer } from 'ospec'; // NOTE: this only works with  "esModuleInterop": true
 
 const exampleTypeUse1: o.Definer = () => {};
-const exampleTypeUse2: Definer = () => {}; // NOTE: this only works with  "esModuleInterop": true
+// const exampleTypeUse2: Definer = () => {}; // NOTE: this only works with  "esModuleInterop": true
 
 // ======================================================================
 

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -16,12 +16,12 @@ o.spec('ospec typings', () => {
 
     // $ExpectType void
     o('o(actual) returns assertion interface based on input type', () => {
-        o(bool); // $ExpectType BasicAssertions<boolean>
-        o(numOrStr); // $ExpectType BasicAssertions<string | number>
-        o(arr); // $ExpectType ObjectAssertions<number[]>
-        o(obj); // $ExpectType ObjectAssertions<{ a: number; }>
-        o(new Date()); // $ExpectType ObjectAssertions<Date>
-        o(fn); // $ExpectType FunctionAssertions<() => void>
+        o(bool); // $ExpectType Assertion<boolean>
+        o(numOrStr); // $ExpectType Assertion<string | number>
+        o(arr); // $ExpectType Assertion<number[]>
+        o(obj); // $ExpectType Assertion<{ a: number; }>
+        o(new Date()); // $ExpectType Assertion<Date>
+        o(fn); // $ExpectType Assertion<() => void>
     });
 
     o('.equals() is type safe', () => {

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -170,6 +170,18 @@ o.spec('ospec typings', () => {
         timeout(1, 2);
     };
 
+    // Tests may return a promise-like value instead of calling done()
+    definerFn = () => {
+        return Promise.resolve('Whatever');
+    };
+    definerFn = (done, timeout) => {
+        timeout(9000);
+        // TODO: Find a way to discourage the use of done() in promise returning tests
+        // $_ExpectError
+        done();
+        return Promise.resolve('Whatever');
+    };
+
     o('async tests', definerFn);
     o.before(definerFn); // $ExpectType void
     o.after(definerFn); // $ExpectType void

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -149,13 +149,13 @@ o.spec('ospec typings', () => {
     definerFn = () => {};
     definerFn = done => {
         done(); // $ExpectType void
-
-        // Done accepts just about anything thrown at it.
         done(new Error('err'));
-        done('err');
-        done(1);
         done(null);
 
+        // $ExpectError
+        done('Error message');
+        // $ExpectError
+        done(1);
         // $ExpectError
         done(null, null);
     };

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -45,18 +45,38 @@ o.spec('ospec typings', () => {
         o(arr).equals(['hi']);
     });
 
-    o('.notEquals() accepts anything', () => {
-        o(bool).notEquals({}); // $ExpectType AssertionDescriber
+    o('.notEquals() is also type safe', () => {
+        o(bool).notEquals(true); // $ExpectType AssertionDescriber
+        o(bool).notEquals(true)('description text');
+        o(numOrStr).notEquals('hello');
+        o(numOrStr).notEquals(1);
+        o(fn).notEquals(() => {});
+        o(obj).notEquals({ a: 1 });
+        o(arr).notEquals([1, 2]);
+
+        // $ExpectError
+        o(bool).notEquals(1);
+        // $ExpectError
+        o(numOrStr).notEquals(true);
+        // $ExpectError
         o(fn).notEquals(1);
+        // $ExpectError
+        o(obj).notEquals({});
+        // $ExpectError
+        o(arr).notEquals(['hi']);
     });
 
     o('.deepEquals()/.notDeepEquals() only compares objects to object values', () => {
-        o(obj).deepEquals({ a: 1 });
+        o(obj).deepEquals({
+            a: 1,
+        });
         o(arr).deepEquals([1]); // $ExpectType AssertionDescriber
         o(fn).deepEquals(() => {}); // $ExpectType AssertionDescriber
-        o(obj).notDeepEquals({});
-        o(arr).notDeepEquals(['hi']); // $ExpectType AssertionDescriber
-        o(fn).notDeepEquals({}); // $ExpectType AssertionDescriber
+        o(obj).notDeepEquals({
+            a: 1,
+        });
+        o(arr).notDeepEquals([1]); // $ExpectType AssertionDescriber
+        o(fn).notDeepEquals(() => {}); // $ExpectType AssertionDescriber
 
         // $ExpectError
         o(obj).deepEquals(1);
@@ -70,6 +90,12 @@ o.spec('ospec typings', () => {
         o(numOrStr).deepEquals(1);
         // $ExpectError
         o(numOrStr).notDeepEquals(1);
+        // $ExpectError
+        o(obj).notDeepEquals({});
+        // $ExpectError
+        o(arr).notDeepEquals(['hi']); // $ExpectType AssertionDescriber
+        // $ExpectError
+        o(fn).notDeepEquals({}); // $ExpectType AssertionDescriber
     });
 
     o('.throws()/.notThrows() only available for function values', () => {

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -2,7 +2,7 @@
 import o, { Definer } from 'ospec'; // NOTE: this only works with  "esModuleInterop": true
 
 const exampleTypeUse1: o.Definer = () => {};
-const exampleTtypeUse2: Definer = () => {}; // NOTE: this only works with  "esModuleInterop": true
+const exampleTypeUse2: Definer = () => {}; // NOTE: this only works with  "esModuleInterop": true
 
 // ======================================================================
 

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -1,0 +1,208 @@
+// import o = require('ospec');
+import o, { Definer } from 'ospec'; // NOTE: this only works with  "esModuleInterop": true
+
+const exampleTypeUse1: o.Definer = () => {};
+const exampleTtypeUse2: Definer = () => {}; // NOTE: this only works with  "esModuleInterop": true
+
+// ======================================================================
+
+// $ExpectType void
+o.spec('ospec typings', () => {
+    const bool = false;
+    const numOrStr = Date.now() > 0 ? 'hi' : 42;
+    const obj = { a: 1 };
+    const arr = [1];
+    const fn = () => {};
+
+    // $ExpectType void
+    o('o(actual) returns assertion interface based on input type', () => {
+        o(bool); // $ExpectType BasicAssertions<boolean>
+        o(numOrStr); // $ExpectType BasicAssertions<string | number>
+        o(arr); // $ExpectType ObjectAssertions<number[]>
+        o(obj); // $ExpectType ObjectAssertions<{ a: number; }>
+        o(new Date()); // $ExpectType ObjectAssertions<Date>
+        o(fn); // $ExpectType FunctionAssertions<() => void>
+    });
+
+    o('.equals() is type safe', () => {
+        o(bool).equals(true); // $ExpectType AssertionDescriber
+        o(bool).equals(true)('description text');
+        o(numOrStr).equals('hello');
+        o(numOrStr).equals(1);
+        o(fn).equals(() => {});
+        o(obj).equals({ a: 1 });
+        o(arr).equals([1, 2]);
+
+        // $ExpectError
+        o(bool).equals(1);
+        // $ExpectError
+        o(numOrStr).equals(true);
+        // $ExpectError
+        o(fn).equals(1);
+        // $ExpectError
+        o(obj).equals({});
+        // $ExpectError
+        o(arr).equals(['hi']);
+    });
+
+    o('.notEquals() accepts anything', () => {
+        o(bool).notEquals({}); // $ExpectType AssertionDescriber
+        o(fn).notEquals(1);
+    });
+
+    o('.deepEquals()/.notDeepEquals() only compares objects to object values', () => {
+        o(obj).deepEquals({ a: 1 });
+        o(arr).deepEquals([1]); // $ExpectType AssertionDescriber
+        o(fn).deepEquals(() => {}); // $ExpectType AssertionDescriber
+        o(obj).notDeepEquals({});
+        o(arr).notDeepEquals(['hi']); // $ExpectType AssertionDescriber
+        o(fn).notDeepEquals({}); // $ExpectType AssertionDescriber
+
+        // $ExpectError
+        o(obj).deepEquals(1);
+        // $ExpectError
+        o(obj).notDeepEquals(1);
+        // $ExpectError
+        o(bool).deepEquals(1);
+        // $ExpectError
+        o(bool).notDeepEquals(1);
+        // $ExpectError
+        o(numOrStr).deepEquals(1);
+        // $ExpectError
+        o(numOrStr).notDeepEquals(1);
+    });
+
+    o('.throws()/.notThrows() only available for function values', () => {
+        o(fn).throws('baz'); // $ExpectType AssertionDescriber
+        o(fn).notThrows('baz'); // $ExpectType AssertionDescriber
+        o(fn).throws(Error);
+        // NOTE: ospec says trows/notThrows accepts "Object constructor"
+        o(fn).notThrows(String);
+
+        // $ExpectError
+        o(bool).throws('baz');
+        // $ExpectError
+        o(bool).notThrows('baz');
+
+        // `expected` must only be string or "Object constructor"
+        // $ExpectError
+        o(fn).throws(1);
+        // $ExpectError
+        o(fn).throws(1);
+
+        /*
+      // FIXME: find a way to make these lines error (See note in index.d.ts)
+      const nonNewableFn = () => {}
+      // $_ExpectError
+      a(fn).throws(nonNewableFn)
+      // $_ExpectError
+      a(fn).notThrows(nonNewableFn)
+    */
+    });
+
+    // ======================================================================
+
+    const dummySpy = o.spy();
+    dummySpy();
+    const {
+        callCount, // $ExpectType number
+        args, // $ExpectType any[]
+        calls, // $ExpectType any[][]
+    } = dummySpy;
+
+    const myFunc = (a: string, b?: boolean) => 42;
+    const spiedFunc = o.spy(myFunc);
+    type SpiedFuncParams = Parameters<typeof spiedFunc>; // $ExpectType [string, (boolean | undefined)?]
+    const _args1: SpiedFuncParams = ['hi', true];
+    const _args2: SpiedFuncParams = ['hi'];
+    spiedFunc(..._args1); // $ExpectType number
+    spiedFunc(..._args2); // $ExpectType number
+    spiedFunc.args; // $ExpectType [string, (boolean | undefined)?]
+    spiedFunc.calls; // $ExpectType [string, (boolean | undefined)?][]
+
+    // ======================================================================
+
+    let definerFn: o.Definer;
+    definerFn = () => {};
+    definerFn = done => {
+        done(); // $ExpectType void
+
+        // Done accepts just about anything thrown at it.
+        done(new Error('err'));
+        done('err');
+        done(1);
+        done(null);
+
+        // $ExpectError
+        done(null, null);
+    };
+    definerFn = (_, timeout) => {
+        timeout(42); // $ExpectType void
+
+        // $ExpectError
+        timeout();
+        // $ExpectError
+        timeout('42');
+        // $ExpectError
+        timeout(1, 2);
+    };
+
+    o('async tests', definerFn);
+    o.before(definerFn); // $ExpectType void
+    o.after(definerFn); // $ExpectType void
+    o.beforeEach(definerFn); // $ExpectType void
+    o.afterEach(definerFn); // $ExpectType void
+
+    // ======================================================================
+
+    o.specTimeout(42); // $ExpectType void
+    // $ExpectError
+    o.specTimeout();
+    // $ExpectError
+    o.specTimeout('42');
+
+    o('async test timeout', _ => {
+        o.timeout(42); // $ExpectType void
+
+        // $ExpectError
+        o.timeout();
+        // $ExpectError
+        o.timeout('42');
+    });
+
+    // ======================================================================
+
+    const myReporter: o.Reporter = results => {
+        const myResult = results[0]; // $ExpectType Result
+        return 0;
+    };
+
+    o.report = myReporter;
+    // $ExpectError
+    o.report = fn;
+
+    // ======================================================================
+
+    o.run(); // $ExpectType void
+    o.run(myReporter);
+    // $ExpectError
+    o.run(true);
+    // $ExpectError
+    o.run(fn);
+
+    // ======================================================================
+
+    const o2: o.Ospec = o.new();
+    o2.spec('New Ospec instance', () => {
+        o2('Works?', done => {
+            o2('Yes').equals('Yes');
+            done();
+        });
+    });
+
+    // $ExpectError
+    o.new(true);
+});
+
+// $ExpectError
+o.spec(() => {}); // Missing name parameter

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -90,14 +90,11 @@ o.spec('ospec typings', () => {
         // $ExpectError
         o(fn).throws(1);
 
-        /*
-      // FIXME: find a way to make these lines error (See note in index.d.ts)
-      const nonNewableFn = () => {}
-      // $_ExpectError
-      a(fn).throws(nonNewableFn)
-      // $_ExpectError
-      a(fn).notThrows(nonNewableFn)
-    */
+        const nonNewableFn = () => {};
+        // $ExpectError
+        o(fn).throws(nonNewableFn);
+        // $ExpectError
+        o(fn).notThrows(nonNewableFn);
     });
 
     // ======================================================================

--- a/types/ospec/tsconfig.json
+++ b/types/ospec/tsconfig.json
@@ -14,9 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/ospec/tsconfig.json
+++ b/types/ospec/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "ospec-tests.ts"
+    ]
+}

--- a/types/ospec/tslint.json
+++ b/types/ospec/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

