### PR TITLE
[yup] Use TestOptionsMessage consistently throughout

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -49,8 +49,8 @@ export type AnySchemaConstructor =
     | ObjectSchemaConstructor;
 
 export type TestOptionsMessage<Extra extends Record<string, any> = {}> =
-    | string
-    | ((params: Extra & Partial<TestMessageParams>) => any);
+  | string
+  | ((params: Extra & Partial<TestMessageParams>) => any);
 
 export interface Schema<T> {
     clone(): this;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -11,6 +11,7 @@
 //                 Dan Rumney <https://github.com/dancrumb>
 //                 Desmond Koh <https://github.com/deskoh>
 //                 Maurice de Beijer <https://github.com/mauricedb>
+//                 Kalley Powell <https://github.com/kalley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -12,7 +12,7 @@
 //                 Desmond Koh <https://github.com/deskoh>
 //                 Maurice de Beijer <https://github.com/mauricedb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 export function reach<T>(schema: Schema<T>, path: string, value?: any, context?: any): Schema<T>;
 export function addMethod<T extends Schema<any>>(

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -45,7 +45,7 @@ export type AnySchemaConstructor =
 
 export type TestOptionsMessage<Extra extends Record<string, any> = {}> =
     | string
-    | ((params: Extra & Partial<TestMessageParams>) => any);
+    | ((params: Extra & Partial<TestMessageParams>) => string | Record<string, any>);
 
 export interface Schema<T> {
     clone(): this;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -14,16 +14,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export function reach<T>(
-    schema: Schema<T>,
-    path: string,
-    value?: any,
-    context?: any
-): Schema<T>;
+export function reach<T>(schema: Schema<T>, path: string, value?: any, context?: any): Schema<T>;
 export function addMethod<T extends Schema<any>>(
     schemaCtor: AnySchemaConstructor,
     name: string,
-    method: (this: T, ...args: any[]) => T
+    method: (this: T, ...args: any[]) => T,
 ): void;
 export function ref(path: string, options?: { contextPrefix: string }): Ref;
 export function lazy<T>(fn: (value: T) => Schema<T>): Lazy;
@@ -49,8 +44,8 @@ export type AnySchemaConstructor =
     | ObjectSchemaConstructor;
 
 export type TestOptionsMessage<Extra extends Record<string, any> = {}> =
-  | string
-  | ((params: Extra & Partial<TestMessageParams>) => any);
+    | string
+    | ((params: Extra & Partial<TestMessageParams>) => any);
 
 export interface Schema<T> {
     clone(): this;
@@ -79,11 +74,8 @@ export interface Schema<T> {
     test(
         name: string,
         message: TestOptionsMessage,
-        test: (
-            this: TestContext,
-            value?: any
-        ) => boolean | ValidationError | Promise<boolean | ValidationError>,
-        callbackStyleAsync?: boolean
+        test: (this: TestContext, value?: any) => boolean | ValidationError | Promise<boolean | ValidationError>,
+        callbackStyleAsync?: boolean,
     ): this;
     test(options: TestOptions): this;
     transform(fn: TransformFunction<this>): this;
@@ -103,7 +95,7 @@ export interface MixedSchema<T = any> extends Schema<T> {
     required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
     concat(schema: this): this;
-    concat<U >(schema: MixedSchema<U>): MixedSchema<T | U>;
+    concat<U>(schema: MixedSchema<U>): MixedSchema<T | U>;
 }
 
 export interface StringSchemaConstructor {
@@ -111,16 +103,13 @@ export interface StringSchemaConstructor {
     new (): StringSchema;
 }
 
-export interface StringSchema<T extends string | null | undefined = string>
-    extends Schema<T> {
+export interface StringSchema<T extends string | null | undefined = string> extends Schema<T> {
     length(limit: number | Ref, message?: TestOptionsMessage<{ length: number | Ref }>): StringSchema<T>;
     min(limit: number | Ref, message?: TestOptionsMessage<{ min: number | Ref }>): StringSchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage<{ max: number | Ref }>): StringSchema<T>;
     matches(
         regex: RegExp,
-        messageOrOptions?:
-            | TestOptionsMessage
-            | { message?: TestOptionsMessage; excludeEmptyString?: boolean }
+        messageOrOptions?: TestOptionsMessage | { message?: TestOptionsMessage; excludeEmptyString?: boolean },
     ): StringSchema<T>;
     email(message?: TestOptionsMessage): StringSchema<T>;
     url(message?: TestOptionsMessage): StringSchema<T>;
@@ -140,23 +129,16 @@ export interface NumberSchemaConstructor {
     new (): NumberSchema;
 }
 
-export interface NumberSchema<T extends number | null | undefined = number>
-    extends Schema<T> {
+export interface NumberSchema<T extends number | null | undefined = number> extends Schema<T> {
     min(limit: number | Ref, message?: TestOptionsMessage<{ min: number | Ref }>): NumberSchema<T>;
     max(limit: number | Ref, message?: TestOptionsMessage<{ max: number | Ref }>): NumberSchema<T>;
-    lessThan(
-        limit: number | Ref,
-        message?: TestOptionsMessage
-    ): NumberSchema<T>;
-    moreThan(
-        limit: number | Ref,
-        message?: TestOptionsMessage
-    ): NumberSchema<T>;
+    lessThan(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
+    moreThan(limit: number | Ref, message?: TestOptionsMessage): NumberSchema<T>;
     positive(message?: TestOptionsMessage): NumberSchema<T>;
     negative(message?: TestOptionsMessage): NumberSchema<T>;
     integer(message?: TestOptionsMessage): NumberSchema<T>;
     truncate(): NumberSchema<T>;
-    round(type: "floor" | "ceil" | "trunc" | "round"): NumberSchema<T>;
+    round(type: 'floor' | 'ceil' | 'trunc' | 'round'): NumberSchema<T>;
     nullable(isNullable?: true): NumberSchema<T | null>;
     nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): NumberSchema<T>;
@@ -169,14 +151,11 @@ export interface BooleanSchemaConstructor {
     new (): BooleanSchema;
 }
 
-export interface BooleanSchema<T extends boolean | null | undefined = boolean>
-    extends Schema<T> {
+export interface BooleanSchema<T extends boolean | null | undefined = boolean> extends Schema<T> {
     nullable(isNullable?: true): BooleanSchema<T | null>;
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): BooleanSchema<T>;
-    required(
-        message?: TestOptionsMessage
-    ): BooleanSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
 }
 
@@ -185,16 +164,9 @@ export interface DateSchemaConstructor {
     new (): DateSchema;
 }
 
-export interface DateSchema<T extends Date | null | undefined = Date>
-    extends Schema<T> {
-    min(
-        limit: Date | string | Ref,
-        message?: TestOptionsMessage<{ min: Date | string | Ref }>
-    ): DateSchema<T>;
-    max(
-        limit: Date | string | Ref,
-        message?: TestOptionsMessage<{ max: Date | string | Ref }>
-    ): DateSchema<T>;
+export interface DateSchema<T extends Date | null | undefined = Date> extends Schema<T> {
+    min(limit: Date | string | Ref, message?: TestOptionsMessage<{ min: Date | string | Ref }>): DateSchema<T>;
+    max(limit: Date | string | Ref, message?: TestOptionsMessage<{ max: Date | string | Ref }>): DateSchema<T>;
     nullable(isNullable?: true): DateSchema<T | null>;
     nullable(isNullable: false): DateSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): DateSchema<T>;
@@ -207,22 +179,16 @@ export interface ArraySchemaConstructor {
     new (): ArraySchema<{}>;
 }
 
-interface BasicArraySchema<T extends any[] | null | undefined>
-    extends Schema<T> {
+interface BasicArraySchema<T extends any[] | null | undefined> extends Schema<T> {
     min(limit: number | Ref, message?: TestOptionsMessage<{ min: number | Ref }>): this;
     max(limit: number | Ref, message?: TestOptionsMessage<{ max: number | Ref }>): this;
     ensure(): this;
     compact(
-        rejector?: (
-            value: InferredArrayType<T>,
-            index: number,
-            array: Array<InferredArrayType<T>>
-        ) => boolean
+        rejector?: (value: InferredArrayType<T>, index: number, array: Array<InferredArrayType<T>>) => boolean,
     ): this;
 }
 
-export interface NotRequiredNullableArraySchema<T>
-    extends BasicArraySchema<T[] | null | undefined> {
+export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T[] | null | undefined> {
     of<U>(type: Schema<U>): NotRequiredNullableArraySchema<U>;
     nullable(isNullable?: true): NotRequiredNullableArraySchema<T>;
     nullable(isNullable: false): NotRequiredArraySchema<T>;
@@ -240,8 +206,7 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T[] | null> {
     notRequired(): NotRequiredNullableArraySchema<T>;
 }
 
-export interface NotRequiredArraySchema<T>
-    extends BasicArraySchema<T[] | undefined> {
+export interface NotRequiredArraySchema<T> extends BasicArraySchema<T[] | undefined> {
     of<U>(type: Schema<U>): NotRequiredArraySchema<U>;
     nullable(isNullable?: true): NotRequiredNullableArraySchema<T>;
     nullable(isNullable: false): NotRequiredArraySchema<T>;
@@ -259,7 +224,7 @@ export interface ArraySchema<T> extends BasicArraySchema<T[]> {
 }
 
 export type ObjectSchemaDefinition<T extends object | null | undefined> = {
-    [field in keyof T]: Schema<T[field]> | Ref
+    [field in keyof T]: Schema<T[field]> | Ref;
 };
 
 /**
@@ -268,7 +233,7 @@ export type ObjectSchemaDefinition<T extends object | null | undefined> = {
  * [yup's `object.shape()` method](https://www.npmjs.com/package/yup#objectshapefields-object-nosortedges-arraystring-string-schema).
  */
 export type Shape<T extends object | null | undefined, U extends object> = {
-    [P in keyof T]: P extends keyof U ? U[P] : T[P]
+    [P in keyof T]: P extends keyof U ? U[P] : T[P];
 } &
     U;
 
@@ -277,17 +242,13 @@ export interface ObjectSchemaConstructor {
     new (): ObjectSchema<{}>;
 }
 
-export interface ObjectSchema<T extends object | null | undefined = object>
-    extends Schema<T> {
+export interface ObjectSchema<T extends object | null | undefined = object> extends Schema<T> {
     shape<U extends object>(
         fields: ObjectSchemaDefinition<U>,
-        noSortEdges?: Array<[string, string]>
+        noSortEdges?: Array<[string, string]>,
     ): ObjectSchema<Shape<T, U>>;
     from(fromKey: string, toKey: string, alias?: boolean): ObjectSchema<T>;
-    noUnknown(
-        onlyKnownKeys?: boolean,
-        message?: TestOptionsMessage
-    ): ObjectSchema<T>;
+    noUnknown(onlyKnownKeys?: boolean, message?: TestOptionsMessage): ObjectSchema<T>;
     transformKeys(callback: (key: any) => any): void;
     camelCase(): ObjectSchema<T>;
     constantCase(): ObjectSchema<T>;
@@ -300,11 +261,7 @@ export interface ObjectSchema<T extends object | null | undefined = object>
     concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;
 }
 
-export type TransformFunction<T> = (
-    this: T,
-    value: any,
-    originalValue: any
-) => any;
+export type TransformFunction<T> = (this: T, value: any, originalValue: any) => any;
 
 export interface WhenOptionsBuilderFunction<T> {
     (value: any, schema: T): T;
@@ -313,13 +270,7 @@ export interface WhenOptionsBuilderFunction<T> {
     (v1: any, v2: any, v3: any, v4: any, schema: T): T;
 }
 
-export type WhenOptionsBuilderObjectIs =
-    | ((...values: any[]) => boolean)
-    | boolean
-    | number
-    | null
-    | object
-    | string;
+export type WhenOptionsBuilderObjectIs = ((...values: any[]) => boolean) | boolean | number | null | object | string;
 
 export type WhenOptionsBuilderObject =
     | {
@@ -329,9 +280,7 @@ export type WhenOptionsBuilderObject =
       }
     | object;
 
-    export type WhenOptions<T> =
-    | WhenOptionsBuilderFunction<T>
-    | WhenOptionsBuilderObject;
+export type WhenOptions<T> = WhenOptionsBuilderFunction<T> | WhenOptionsBuilderObject;
 
 export interface TestContext {
     path: string;
@@ -339,10 +288,7 @@ export interface TestContext {
     parent: any;
     schema: Schema<any>;
     resolve: (value: any) => any;
-    createError: (params?: {
-        path?: string;
-        message?: string;
-    }) => ValidationError;
+    createError: (params?: { path?: string; message?: string }) => ValidationError;
 }
 
 export interface ValidateOptions {
@@ -384,10 +330,7 @@ export interface TestOptions {
     /**
      * Test function, determines schema validity
      */
-    test: (
-        this: TestContext,
-        value: any
-    ) => boolean | ValidationError | Promise<boolean | ValidationError>;
+    test: (this: TestContext, value: any) => boolean | ValidationError | Promise<boolean | ValidationError>;
 
     /**
      * The validation error message
@@ -439,17 +382,9 @@ export class ValidationError extends Error {
     params?: object;
 
     static isError(err: any): err is ValidationError;
-    static formatError(
-        message: string | ((params?: any) => string),
-        params?: any
-    ): string | ((params?: any) => string);
+    static formatError(message: string | ((params?: any) => string), params?: any): string | ((params?: any) => string);
 
-    constructor(
-        errors: string | string[],
-        value: any,
-        path: string,
-        type?: any
-    );
+    constructor(errors: string | string[], value: any, path: string, type?: any);
 }
 
 // It is tempting to declare `Ref` very simply, but there are problems with these approaches:
@@ -510,18 +445,16 @@ export interface LocaleObject {
     object?: MappedLocaleSchema<ObjectSchema<any>>;
 }
 
-export type InferType<T> = T extends Schema<infer P>
-    ? InnerInferType<P>
-    : never;
+export type InferType<T> = T extends Schema<infer P> ? InnerInferType<P> : never;
 
 // Shut off automatic exporting after this statement
 export {};
 
 type KeyOfUndefined<T> = {
-    [P in keyof T]-?: undefined extends T[P] ? P : never
+    [P in keyof T]-?: undefined extends T[P] ? P : never;
 }[keyof T];
 
-type Id<T> = {[K in keyof T]: T[K]};
+type Id<T> = { [K in keyof T]: T[K] };
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> = Id<NotRequiredProps<T> & RequiredProps<T>>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -201,6 +201,12 @@ mixed.test('with-context', 'it uses function context', testContext);
 mixed.test({
     test: testContext,
 });
+mixed.test({
+  message: ({ passed }) => (passed ? 'You passed' : 'You failed'),
+  name: 'checkParams',
+  params: { passed: true },
+  test: value => !!value,
+});
 
 // mixed with concat
 yup.object({ name: yup.string() }).concat(yup.object({ when: yup.date() })); // $ExpectType ObjectSchema<{ name: string; } & { when: Date; }>
@@ -286,12 +292,15 @@ strSchema.max(5, ({ min }) => `less than ${min}`);
 strSchema.matches(/(hi|bye)/);
 strSchema.matches(/(hi|bye)/, 'invalid');
 strSchema.matches(/(hi|bye)/, () => 'invalid');
+strSchema.matches(/(hi|bye)/, ({ regex }) => `Does not match ${regex}`);
 strSchema.email();
 strSchema.email('invalid');
 strSchema.email(() => 'invalid');
+strSchema.email(({ regex }) => `Does not match ${regex}`);
 strSchema.url();
 strSchema.url('bad url');
 strSchema.url(() => 'bad url');
+strSchema.url(({ regex }) => `Does not match ${regex}`);
 strSchema.ensure();
 strSchema.trim();
 strSchema.trim('trimmed');

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -484,7 +484,10 @@ yup.setLocale({
         required: options => options,
     },
     number: { max: 'Max message', min: 'Min message' },
-    string: { email: 'String message' },
+    string: {
+        email: 'String message',
+        length: ({ length }) => ({ key: 'stringLength', options: { length } }),
+    },
 });
 
 yup.setLocale({

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -358,8 +358,8 @@ arrSchema.compact((value, index, array) => value === array[index]);
 
 const arrOfObjSchema = yup.array().of(
     yup.object().shape({
-        field: yup.number()
-    })
+        field: yup.number(),
+    }),
 );
 arrOfObjSchema.compact((value, index, array) => {
     return value.field > 10 && array[index].field > 10;
@@ -462,6 +462,9 @@ const localeNotType3: LocaleObject = {
 };
 
 yup.setLocale({
+    mixed: {
+        required: options => options,
+    },
     number: { max: 'Max message', min: 'Min message' },
     string: { email: 'String message' },
 });
@@ -583,9 +586,7 @@ enum Gender {
 
 const personSchema = yup.object({
     firstName: yup.string(), // $ExpectType StringSchema<string>
-    gender: yup
-        .mixed<Gender>()
-        .oneOf([Gender.Male, Gender.Female]),
+    gender: yup.mixed<Gender>().oneOf([Gender.Male, Gender.Female]),
     email: yup
         .string()
         .nullable()
@@ -685,7 +686,10 @@ castPerson.children = undefined;
 
 const loginSchema = yup.object({
     password: yup.string(),
-    confirmPassword: yup.string().nullable().oneOf([yup.ref("password"), null]),
+    confirmPassword: yup
+        .string()
+        .nullable()
+        .oneOf([yup.ref('password'), null]),
 });
 
 function wrapper<T>(b: false, msx: MixedSchema<T>): MixedSchema<T>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -487,6 +487,13 @@ yup.setLocale({
     string: { email: 'String message' },
 });
 
+yup.setLocale({
+    // $ExpectError
+    string: {
+        nullable: 'message',
+    },
+});
+
 interface MyInterface {
     stringField: string;
     numberField: number;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -143,6 +143,9 @@ mixed.typeError('type error');
 mixed.typeError(() => 'type error');
 mixed.oneOf(['hello', 'world'], 'message');
 mixed.oneOf(['hello', 'world'], () => 'message');
+mixed.oneOf(['hello', 'world'], ({ values }) => `one of ${values}`);
+// $ExpectError
+mixed.oneOf(['hello', 'world'], ({ random }) => `one of ${random}`);
 mixed.notOneOf(['hello', 'world'], 'message');
 mixed.notOneOf(['hello', 'world'], () => 'message');
 mixed.when('isBig', {
@@ -267,10 +270,19 @@ strSchema.required('req');
 strSchema.required(() => 'req');
 strSchema.length(5, 'message');
 strSchema.length(5, () => 'message');
+strSchema.length(5, ({ length }) => `must be ${length}`);
+// $ExpectError
+strSchema.length(5, ({ min }) => `must be ${min}`);
 strSchema.min(5, 'message');
 strSchema.min(5, () => 'message');
+strSchema.min(5, ({ min }) => `more than ${min}`);
+// $ExpectError
+strSchema.min(5, ({ max }) => `more than ${max}`);
 strSchema.max(5, 'message');
 strSchema.max(5, () => 'message');
+strSchema.max(5, ({ max }) => `less than ${max}`);
+// $ExpectError
+strSchema.max(5, ({ min }) => `less than ${min}`);
 strSchema.matches(/(hi|bye)/);
 strSchema.matches(/(hi|bye)/, 'invalid');
 strSchema.matches(/(hi|bye)/, () => 'invalid');
@@ -297,9 +309,15 @@ numSchema.isValid(10); // => true
 numSchema.min(5);
 numSchema.min(5, 'message');
 numSchema.min(5, () => 'message');
+numSchema.min(5, ({ min }) => `more than ${min}`);
+// $ExpectError
+numSchema.min(5, ({ max }) => `more than ${max}`);
 numSchema.max(5);
 numSchema.max(5, 'message');
 numSchema.max(5, () => 'message');
+numSchema.max(5, ({ max }) => `less than ${max}`);
+// $ExpectError
+numSchema.max(5, ({ min }) => `more than ${min}`);
 numSchema.positive();
 numSchema.positive('pos');
 numSchema.positive(() => 'pos');

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -202,10 +202,10 @@ mixed.test({
     test: testContext,
 });
 mixed.test({
-  message: ({ passed }) => (passed ? 'You passed' : 'You failed'),
-  name: 'checkParams',
-  params: { passed: true },
-  test: value => !!value,
+    message: ({ passed }) => (passed ? 'You passed' : 'You failed'),
+    name: 'checkParams',
+    params: { passed: true },
+    test: value => !!value,
 });
 
 // mixed with concat


### PR DESCRIPTION
We were looking for a way to use `setLocale` like https://github.com/jquense/yup/issues/159. Which works fine, but the TS defs for it were not great. This makes at least some of the extra options for `TestOptionsMessage` explicit (I'm sure I missed some since we're not using all of them), and makes it so that the `LocaleObject` not only uses the definitions in the `Parameters`, but also does not allow for keys that don't accept a message.

Because of `Required`, I did have to bump the typescript version. If anyone would like me to, I'm more than happy to switch to using https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#i-want-to-use-features-from-typescript-31-or-above

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/issues/159
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _I didn't change anything specifically related to 0.27_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
