### PR TITLE
Leaflet - added type definition for leaflet.icon.glyph

### DIFF
--- a/types/leaflet.icon.glyph/index.d.ts
+++ b/types/leaflet.icon.glyph/index.d.ts
@@ -35,10 +35,9 @@ declare module 'leaflet' {
             glyphSize?: string;
             glyphAnchor?: PointExpression;
         }
+    }
 
-        /**
-         * Creates a glyph icon.
-         */
-        function glyph(options?: GlyphOptions | GlyphIconOptions): Glyph;
+    namespace icon {
+        function glyph(options?: Icon.GlyphOptions | Icon.GlyphIconOptions): Icon.Glyph;
     }
 }

--- a/types/leaflet.icon.glyph/index.d.ts
+++ b/types/leaflet.icon.glyph/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for leaflet.icon.glyph 0.2
+// Project: https://github.com/Leaflet/Leaflet.Icon.Glyph
+// Definitions by: BePo65 <https://github.com/BePo65>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+    namespace Icon {
+        class Glyph extends Icon {
+            constructor(options?: GlyphOptions | GlyphIconOptions);
+            options: GlyphIconOptions;
+            createIcon(): HTMLElement;
+        }
+
+        interface GlyphOptions extends BaseIconOptions {
+            className?: string;
+            bgPos?: PointExpression;
+            bgSize?: PointExpression;
+            prefix?: string;
+            glyph?: string;
+            glyphColor?: string;
+            glyphSize?: string;
+            glyphAnchor?: PointExpression;
+        }
+
+        interface GlyphIconOptions extends IconOptions {
+            className?: string;
+            bgPos?: PointExpression;
+            bgSize?: PointExpression;
+            prefix?: string;
+            glyph?: string;
+            glyphColor?: string;
+            glyphSize?: string;
+            glyphAnchor?: PointExpression;
+        }
+
+        /**
+         * Creates a glyph icon.
+         */
+        function glyph(options?: GlyphOptions | GlyphIconOptions): Glyph;
+    }
+}

--- a/types/leaflet.icon.glyph/leaflet.icon.glyph-tests.ts
+++ b/types/leaflet.icon.glyph/leaflet.icon.glyph-tests.ts
@@ -3,7 +3,7 @@ import 'leaflet.icon.glyph';
 
 // Show a glyph from a "normal" font (e.g. an "A")
 const markerDefaultFont = L.marker([48.8588376, 2.276849], {
-    icon: L.Icon.glyph({
+    icon: L.icon.glyph({
         prefix: '',
         glyph: 'A',
     }),
@@ -11,7 +11,7 @@ const markerDefaultFont = L.marker([48.8588376, 2.276849], {
 
 // Show a glyph from material icons font (e.g. "package")
 const markerIconFont = L.marker([48.8588376, 2.276849], {
-    icon: L.Icon.glyph({
+    icon: L.icon.glyph({
         prefix: 'mdi',
         glyph: 'package',
     }),
@@ -19,7 +19,7 @@ const markerIconFont = L.marker([48.8588376, 2.276849], {
 
 // Show a glyph from material icons font (e.g. "package") with custom icon
 const markerIconFontWIthIconUrl = L.marker([48.8588376, 2.276849], {
-    icon: L.Icon.glyph({
+    icon: L.icon.glyph({
         iconUrl: 'leaflet/marker-icon.png',
         prefix: 'mdi',
         glyph: 'package',

--- a/types/leaflet.icon.glyph/leaflet.icon.glyph-tests.ts
+++ b/types/leaflet.icon.glyph/leaflet.icon.glyph-tests.ts
@@ -1,0 +1,27 @@
+import * as L from 'leaflet';
+import 'leaflet.icon.glyph';
+
+// Show a glyph from a "normal" font (e.g. an "A")
+const markerDefaultFont = L.marker([48.8588376, 2.276849], {
+    icon: L.Icon.glyph({
+        prefix: '',
+        glyph: 'A',
+    }),
+});
+
+// Show a glyph from material icons font (e.g. "package")
+const markerIconFont = L.marker([48.8588376, 2.276849], {
+    icon: L.Icon.glyph({
+        prefix: 'mdi',
+        glyph: 'package',
+    }),
+});
+
+// Show a glyph from material icons font (e.g. "package") with custom icon
+const markerIconFontWIthIconUrl = L.marker([48.8588376, 2.276849], {
+    icon: L.Icon.glyph({
+        iconUrl: 'leaflet/marker-icon.png',
+        prefix: 'mdi',
+        glyph: 'package',
+    }),
+});

--- a/types/leaflet.icon.glyph/tsconfig.json
+++ b/types/leaflet.icon.glyph/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/leaflet.icon.glyph/tsconfig.json
+++ b/types/leaflet.icon.glyph/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "leaflet.icon.glyph-tests.ts"
+    ]
+}

--- a/types/leaflet.icon.glyph/tslint.json
+++ b/types/leaflet.icon.glyph/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
added missing type definition for leaflet plugin leaflet.icon.glyph