### PR TITLE
[@testing-library/vue] New type definition

### DIFF
--- a/types/testing-library__vue/index.d.ts
+++ b/types/testing-library__vue/index.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for @testing-library/vue 1.2
+// Project: https://github.com/testing-library/vue-testing-library
+// Definitions by: Tim Yates <https://github.com/cimbul>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+import { ThisTypedMountOptions, VueClass } from '@vue/test-utils';
+import Vue from 'vue';
+import { Store, StoreOptions } from 'vuex';
+import Router, { RouterOptions, RouteConfig } from 'vue-router';
+import { getQueriesForElement, BoundFunctions, queries, EventType, FireFunction } from '@testing-library/dom';
+
+// NOTE: fireEvent is overridden below
+export * from '@testing-library/dom';
+
+export function cleanup(): void;
+
+export interface RenderOptions<V extends Vue, S = {}> extends
+    // The props and store options special-cased by vue-testing-library and NOT passed to mount().
+    // In TS 3.5+: Omit<ThisTypedMountOptions<V>, "store" | "props">
+    Pick<ThisTypedMountOptions<V>, Exclude<keyof ThisTypedMountOptions<V>, "store" | "props">> {
+  props?: object;
+  store?: StoreOptions<S>;
+  routes?: RouteConfig[];
+}
+
+export type ConfigurationCallback<V extends Vue> =
+  (vue: V, store: Store<any>, router: Router) => Partial<ThisTypedMountOptions<V>> | void;
+
+export interface ComponentHarness extends BoundFunctions<typeof queries> {
+  container: HTMLElement;
+  baseElement: HTMLBodyElement;
+  debug(el?: HTMLElement): void;
+  unmount(): void;
+  isUnmounted(): boolean;
+  html(): string;
+  emitted(): { [name: string]: any[][] };
+  updateProps(props: object): Promise<void>;
+}
+
+export function render<V extends Vue>(
+  TestComponent: VueClass<V>,
+  options?: RenderOptions<V>,
+  configure?: ConfigurationCallback<V>
+): ComponentHarness;
+
+export type AsyncFireObject = {
+  [K in EventType]: (element: Document | Element | Window, options?: {}) => Promise<void>
+};
+
+export interface VueFireObject extends AsyncFireObject {
+  touch(element: Document | Element | Window): Promise<void>;
+  update(element: HTMLOptionElement): Promise<void>;
+  update(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement, value: string): Promise<void>;
+  update(element: HTMLElement, value?: string): Promise<void>;
+}
+
+export const fireEvent: FireFunction & VueFireObject;

--- a/types/testing-library__vue/package.json
+++ b/types/testing-library__vue/package.json
@@ -1,0 +1,9 @@
+{
+    "private": true,
+    "dependencies": {
+        "@vue/test-utils": "^1.0.0-beta.29",
+        "vue": "^2.6.10",
+        "vue-router": "^3.0.7",
+        "vuex": "^3.1.1"
+    }
+}

--- a/types/testing-library__vue/testing-library__vue-tests.ts
+++ b/types/testing-library__vue/testing-library__vue-tests.ts
@@ -1,0 +1,146 @@
+import * as lib from '@testing-library/vue';
+import Vue from 'vue';
+
+declare const elem: HTMLElement;
+declare const input: HTMLInputElement;
+declare const select: HTMLSelectElement;
+declare const option: HTMLOptionElement;
+declare const textarea: HTMLTextAreaElement;
+
+const SomeComponent = Vue.extend({
+    name: 'SomeComponent',
+    props: {
+        foo: Number,
+        bar: String,
+    },
+});
+
+lib.render(Vue);
+lib.render(SomeComponent);
+const component = lib.render(SomeComponent, {
+    // options for new Vue()
+    name: 'SomeComponent',
+    methods: {
+        glorb() { return 42; }
+    },
+    // options for vue-test-utils mount()
+    slots: {
+        quux: "<p>Baz</p>",
+    },
+    mocks: {
+        isThisFake() { return true; }
+    },
+    // options for vue-testing-library render()
+    props: {
+        foo: 9,
+        bar: "x",
+    },
+    store: {
+        state: {
+            foos: [4, 5],
+            bars: ["a", "b"],
+        },
+        getters: {
+            fooCount() { return this.foos.length; },
+        },
+    },
+    routes: [
+        {path: '/', name: 'home', component: SomeComponent},
+        {path: '/about', name: 'about', component: () => Promise.resolve(SomeComponent)},
+    ],
+});
+
+component.container; // $ExpectType HTMLElement
+component.baseElement; // $ExpectType HTMLBodyElement
+component.debug(); // $ExpectType void
+component.debug(elem); // $ExpectType void
+component.unmount(); // $ExpectType void
+component.isUnmounted(); // $ExpectType boolean
+component.html(); // $ExpectType string
+component.emitted(); // $ExpectType { [name: string]: any[][]; }
+component.updateProps({foo: "bar"}); // $ExpectType Promise<void>
+
+// Has bound queries
+component.getByLabelText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement
+component.getByPlaceholderText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByAltText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByTitle(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByDisplayValue(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByRole(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByTestId(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+component.getByText("foo"); // $ExpectType HTMLElement
+component.getByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement
+component.getAllByText("foo"); // $ExpectType HTMLElement[]
+component.getAllByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement[]
+component.queryByText("foo"); // $ExpectType HTMLElement | null
+component.queryByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement | null
+component.queryAllByText("foo"); // $ExpectType HTMLElement[]
+component.queryAllByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement[]
+component.findByText("foo"); // $ExpectType Promise<HTMLElement>
+component.findByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType Promise<HTMLElement>
+component.findAllByText("foo"); // $ExpectType Promise<HTMLElement[]>
+component.findAllByText(/some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType Promise<HTMLElement[]>
+
+lib.cleanup(); // $ExpectType void
+
+// Reexports queries from dom-testing-library
+lib.getByLabelText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement
+lib.getByPlaceholderText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByAltText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByTitle(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByDisplayValue(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByRole(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByTestId(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x}); // $ExpectType HTMLElement
+lib.getByText(elem, "foo"); // $ExpectType HTMLElement
+lib.getByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement
+lib.getAllByText(elem, "foo"); // $ExpectType HTMLElement[]
+lib.getAllByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement[]
+lib.queryByText(elem, "foo"); // $ExpectType HTMLElement | null
+lib.queryByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement | null
+lib.queryAllByText(elem, "foo"); // $ExpectType HTMLElement[]
+lib.queryAllByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType HTMLElement[]
+lib.findByText(elem, "foo"); // $ExpectType Promise<HTMLElement>
+lib.findByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType Promise<HTMLElement>
+lib.findAllByText(elem, "foo"); // $ExpectType Promise<HTMLElement[]>
+lib.findAllByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType Promise<HTMLElement[]>
+
+// Reexports event functions from dom-testing-library
+// Note that it does NOT make the core fireEvent() function asynchronous
+lib.fireEvent(elem, new Event('change')); // $ExpectType boolean
+lib.createEvent.click(elem); // $ExpectType Event
+lib.createEvent.click(elem, {foo: "bar"}); // $ExpectType Event
+lib.createEvent.keyDown(elem); // $ExpectType Event
+lib.createEvent.mouseEnter(elem); // $ExpectType Event
+
+// Changes fireEvent[event]() to be asynchronous
+lib.fireEvent.click(elem); // $ExpectType Promise<void>
+lib.fireEvent.click(elem, {foo: "bar"}); // $ExpectType Promise<void>
+lib.fireEvent.keyDown(elem); // $ExpectType Promise<void>
+lib.fireEvent.mouseEnter(elem); // $ExpectType Promise<void>
+
+// Adds update() function
+lib.fireEvent.update(input, "foo"); // $ExpectType Promise<void>
+lib.fireEvent.update(select, "bar"); // $ExpectType Promise<void>
+lib.fireEvent.update(textarea, "some\ntext"); // $ExpectType Promise<void>
+lib.fireEvent.update(option); // $ExpectType Promise<void>
+
+// Adds touch() function
+lib.fireEvent.touch(elem); // $ExpectType Promise<void>
+
+// Reexports async functions from dom-testing-library
+lib.wait(); // $ExpectType Promise<void>
+lib.wait(() => { throw new Error("nope"); }, {timeout: 3000, interval: 100});
+lib.waitForDomChange({container: select, timeout: 3000, mutationObserverOptions: {subtree: false}});
+lib.waitForElement(() => input); // $ExpectType Promise<HTMLInputElement>
+lib.waitForElement(() => option, {container: select, timeout: 3000, mutationObserverOptions: {subtree: false}}); // $ExpectType Promise<HTMLOptionElement>
+lib.waitForElementToBeRemoved(() => input); // $ExpectType Promise<HTMLInputElement>
+lib.waitForElementToBeRemoved(() => option, {container: select, timeout: 3000, mutationObserverOptions: {subtree: false}}); // $ExpectType Promise<HTMLOptionElement>
+
+// Reexports utilities from dom-testing-library
+lib.buildQueries((el: HTMLElement) => [el], (_: HTMLElement) => "something", (_: HTMLElement) => "error");
+lib.within(elem);
+lib.getQueriesForElement(elem);
+lib.getNodeText(elem); // $ExpectType string
+// lib.getRoles(elem); // $ExpectType { [name: string]: string[]; }
+lib.prettyDOM(elem); // $ExpectType string | false
+// lib.logRoles(elem); // $ExpectType string | false

--- a/types/testing-library__vue/tsconfig.json
+++ b/types/testing-library__vue/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "paths": {
+            "@testing-library/vue": ["testing-library__vue"],
+            "@testing-library/dom": ["testing-library__dom"]
+        },
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "testing-library__vue-tests.ts"
+    ]
+}

--- a/types/testing-library__vue/tslint.json
+++ b/types/testing-library__vue/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is for version 1.2. Version 2.0 was recently released two days ago, but the types will require minimal changes. I think it makes sense to get the types for this version published before making the update.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration` – **See testing-library/vue-testing-library#74 and testing-library/react-testing-library#437**
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project. **Didn't work with scoped package, so I adapted it from other `types/testing-library__*` definitions.**
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
