### PR TITLE
[office-js, office-js-preview] Deprecating number version of isSetSupported

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -980,15 +980,24 @@ declare namespace Office {
     }
 
     /**
-     * Provides information about what Requirement Sets are supported in current environment.
+     * Provides information about which Requirement Sets are supported in current environment.
      */
     interface RequirementSetSupport {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersion - The minimum required version; e.g., "1.4". Note: String type is recommended data type for this parameter. The use of number type is deprecated and will not be compatible with recent requirement sets.
+        * @param minVersionString - The minimum required version (e.g., "1.4").
         */
-       isSetSupported(name: string, minVersion?: string | number): boolean;
+       isSetSupported(name: string, minVersion?: string): boolean;
+
+       
+        /**
+        * Check if the specified requirement set is supported by the host Office application.
+        * @param name - Set name; e.g., "MatrixBindings".
+        * @param minVersion - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
+        * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
+        */
+       isSetSupported(name: string, minVersionNumber?: number): boolean;
     }
 
     /**

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -980,7 +980,7 @@ declare namespace Office {
     }
 
     /**
-     * Provides information about which Requirement Sets are supported in current environment.
+     * Provides information about which Requirement Sets are supported in the current environment.
      */
     interface RequirementSetSupport {
         /**
@@ -993,9 +993,10 @@ declare namespace Office {
        
         /**
         * Check if the specified requirement set is supported by the host Office application.
+        * @deprecated
         * @param name - Set name; e.g., "MatrixBindings".
         * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
-        * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
+        * The use of the number type is deprecated. This is because the JavaScript parser cannot differentiate between numeric values such as 1.1 and 1.10, where as it can for string values such as "1.1" and "1.10".
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;
     }

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -985,7 +985,7 @@ declare namespace Office {
     interface RequirementSetSupport {
         /**
         * Check if the specified requirement set is supported by the host Office application.
-        * @param name - Set name; e.g., "MatrixBindings".
+        * @param name - The requirement set name (e.g., "ExcelApi").
         * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
@@ -994,9 +994,9 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @deprecated
-        * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
-        * The use of the number type is deprecated. This is because the JavaScript parser cannot differentiate between numeric values such as 1.1 and 1.10, where as it can for string values such as "1.1" and "1.10".
+        * @param name - The requirement set name (e.g., "ExcelApi").
+        * @param minVersionNumber - The minimum required version (e.g., 1.4). 
+        * Warning: This overload of `isSetSupported` (where `minVersionNumber` is a number) is deprecated. Use the string overload of `isSetSupported` instead.
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;
     }

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -986,7 +986,7 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersionString - The minimum required version (e.g., "1.4").
+        * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
 
@@ -994,7 +994,7 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersion - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
+        * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
         * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -983,15 +983,14 @@ declare namespace Office {
      * Provides information about which Requirement Sets are supported in the current environment.
      */
     interface RequirementSetSupport {
-        /**
+       /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - The requirement set name (e.g., "ExcelApi").
         * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
 
-       
-        /**
+       /**
         * Check if the specified requirement set is supported by the host Office application.
         * @deprecated
         * @param name - The requirement set name (e.g., "ExcelApi").

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -973,15 +973,24 @@ declare namespace Office {
     }
 
     /**
-     * Provides information about what Requirement Sets are supported in current environment.
+     * Provides information about which Requirement Sets are supported in current environment.
      */
     interface RequirementSetSupport {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersion - The minimum required version; e.g., "1.4". Note: String type is recommended data type for this parameter. The use of number type is deprecated and will not be compatible with recent requirement sets.
+        * @param minVersionString - The minimum required version (e.g., "1.4").
         */
-       isSetSupported(name: string, minVersion?: string | number): boolean;
+       isSetSupported(name: string, minVersion?: string): boolean;
+
+       
+        /**
+        * Check if the specified requirement set is supported by the host Office application.
+        * @param name - Set name; e.g., "MatrixBindings".
+        * @param minVersion - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
+        * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
+        */
+       isSetSupported(name: string, minVersionNumber?: number): boolean;
     }
 
     /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -976,15 +976,14 @@ declare namespace Office {
      * Provides information about which Requirement Sets are supported in the current environment.
      */
     interface RequirementSetSupport {
-        /**
+       /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - The requirement set name (e.g., "ExcelApi").
         * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
 
-       
-        /**
+       /**
         * Check if the specified requirement set is supported by the host Office application.
         * @deprecated
         * @param name - The requirement set name (e.g., "ExcelApi").

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -973,7 +973,7 @@ declare namespace Office {
     }
 
     /**
-     * Provides information about which Requirement Sets are supported in current environment.
+     * Provides information about which Requirement Sets are supported in the current environment.
      */
     interface RequirementSetSupport {
         /**
@@ -986,9 +986,10 @@ declare namespace Office {
        
         /**
         * Check if the specified requirement set is supported by the host Office application.
+        * @deprecated
         * @param name - Set name; e.g., "MatrixBindings".
         * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
-        * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
+        * The use of the number type is deprecated. This is because the JavaScript parser cannot differentiate between numeric values such as 1.1 and 1.10, where as it can for string values such as "1.1" and "1.10".
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;
     }

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -979,7 +979,7 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersionString - The minimum required version (e.g., "1.4").
+        * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
 
@@ -987,7 +987,7 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersion - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
+        * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
         * The use of the number type is deprecated, as the JavaScript parser cannot tell the difference between `1.1` and `1.10`.
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -978,7 +978,7 @@ declare namespace Office {
     interface RequirementSetSupport {
         /**
         * Check if the specified requirement set is supported by the host Office application.
-        * @param name - Set name; e.g., "MatrixBindings".
+        * @param name - The requirement set name (e.g., "ExcelApi").
         * @param minVersion - The minimum required version (e.g., "1.4").
         */
        isSetSupported(name: string, minVersion?: string): boolean;
@@ -987,9 +987,9 @@ declare namespace Office {
         /**
         * Check if the specified requirement set is supported by the host Office application.
         * @deprecated
-        * @param name - Set name; e.g., "MatrixBindings".
-        * @param minVersionNumber - The minimum required version (e.g., 1.4). Warning: Your add-ins should use the string overload of `isSetSupported` instead. 
-        * The use of the number type is deprecated. This is because the JavaScript parser cannot differentiate between numeric values such as 1.1 and 1.10, where as it can for string values such as "1.1" and "1.10".
+        * @param name - The requirement set name (e.g., "ExcelApi").
+        * @param minVersionNumber - The minimum required version (e.g., 1.4). 
+        * Warning: This overload of `isSetSupported` (where `minVersionNumber` is a number) is deprecated. Use the string overload of `isSetSupported` instead.
         */
        isSetSupported(name: string, minVersionNumber?: number): boolean;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js-docs-pr/pull/1248
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.