### PR TITLE
history@3.x: Provide default type for Query type; since history@3.x provides a default query-string parser

### DIFF
--- a/types/history/v3/index.d.ts
+++ b/types/history/v3/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mjackson/history
 // Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 export as namespace History;
 
@@ -10,10 +11,10 @@ export type BeforeUnloadHook = () => string | boolean;
 export type CreateHistory<O, H> = (options?: HistoryOptions & O) => History & H;
 export type CreateHistoryEnhancer<O, H, E> = (createHistory: CreateHistory<O, H>) => CreateHistory<O, H & E>;
 
-export interface History {
+export interface History<Q = DefaultQuery, QL = DefaultQueryLike> {
     listenBefore(hook: TransitionHook): () => void;
     listen(listener: LocationListener): () => void;
-    transitionTo(location: Location): void;
+    transitionTo(location: Location<Q>): void;
     push(path: LocationDescriptor): void;
     replace(path: LocationDescriptor): void;
     go(n: number): void;
@@ -22,8 +23,8 @@ export interface History {
     createKey(): LocationKey;
     createPath(path: LocationDescriptor): Path;
     createHref(path: LocationDescriptor): Href;
-    createLocation(path?: LocationDescriptor, action?: Action, key?: LocationKey): Location;
-    getCurrentLocation(): Location;
+    createLocation(path?: LocationDescriptor, action?: Action, key?: LocationKey): Location<Q>;
+    getCurrentLocation(): Location<Q>;
 }
 
 export interface HistoryOptions {
@@ -34,10 +35,10 @@ export interface HistoryOptions {
 export type Hash = string;
 export type Href = string;
 
-export interface Location {
+export interface Location<Q = DefaultQuery> {
     pathname: Pathname;
     search: Search;
-    query: Query;
+    query: Query<Q>;
     hash: Hash;
     state: LocationState;
     action: Action;
@@ -47,7 +48,7 @@ export interface Location {
 export interface LocationDescriptorObject {
     pathname?: Pathname;
     search?: Search;
-    query?: Query;
+    query?: QueryLike;
     hash?: Hash;
     state?: LocationState;
 }
@@ -62,7 +63,19 @@ export type LocationState = any;
 
 export type Path = string; // Pathname + Search;
 export type Pathname = string;
-export type Query = any;
+
+type DefaultQuery<T = string> = {
+    [key: string]: T | T[] | null | undefined;
+};
+
+type DefaultQueryLike = {
+    [key: string]: any;
+};
+
+export type Query<T = DefaultQuery> = T;
+
+type QueryLike<T = DefaultQueryLike> = T;
+
 export type Search = string;
 
 export type TransitionHook = (location: Location, callback: (result: any) => void) => any;

--- a/types/react-router-redux/v3/index.d.ts
+++ b/types/react-router-redux/v3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rackt/react-router-redux
 // Definitions by: Isman Usoh <https://github.com/isman-usoh>, Noah Shipley <https://github.com/noah79>, Dimitri Rosenberg <https://github.com/rosendi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import * as Redux from "redux";
 import * as History from "history";

--- a/types/react-router-redux/v4/index.d.ts
+++ b/types/react-router-redux/v4/index.d.ts
@@ -6,7 +6,7 @@
 //                 Karol Janyst <https://github.com/LKay>,
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import { Action, Middleware, Store } from "redux";
 import { History, Location, LocationDescriptor } from "history";


### PR DESCRIPTION


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

- `history@3` uses `query-string@4.2.2` to provide the default querey string parsing. see:

    - https://github.com/ReactTraining/history/blob/314ce46f31f91e45a68e2f6d29cb974afc606842/modules/useQueries.js#L24

    - https://github.com/ReactTraining/history/blob/v3/docs/QuerySupport.md

    - https://github.com/ReactTraining/history/blob/314ce46f31f91e45a68e2f6d29cb974afc606842/package.json#L26


- In terms of the types I'm using: https://github.com/sindresorhus/query-string/blob/master/index.d.ts#L92-L94

- The API in `query-string@4.2.2` matches the types: https://github.com/sindresorhus/query-string/tree/v4.2.2#api


------

For context, I'm helping migrate sentry to typescript (https://github.com/getsentry/sentry), and I'm updating the types upstream on `history@3`, which will hopefully propagate to `react-router@3`. 