### PR TITLE
Fixed dirty-chai typing

### DIFF
--- a/types/dirty-chai/index.d.ts
+++ b/types/dirty-chai/index.d.ts
@@ -19,8 +19,8 @@ declare global {
         }
 
         interface PromisedAssertion extends Eventually, PromiseLike<any> {
-            (message?: string): Assertion;
-            ensure: Assertion;
+            (message?: string): PromisedAssertion;
+            ensure: PromisedAssertion;
         }
     }
 }


### PR DESCRIPTION
To handle Promise type correctly, the result must be a PromisedAssertion like as chai-as-promised