### PR TITLE
[Node]: String.prototype has additional ES2019 methods

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -146,15 +146,22 @@ interface SymbolConstructor {
     readonly observable: symbol;
 }
 
-// Node.js ESNEXT support
+// Node.js ES2019/ESNEXT support
 interface String {
-    /** Removes whitespace from the left end of a string. */
+    /** The property trimStart is preferred. 
+    The trimLeft property is provided principally for compatibility with old code. 
+    It is recommended that the trimStart property be used in new ECMAScript(ES2019) code. */
     trimLeft(): string;
-    /** String.prototype.trimLeft.name === 'trimStart'; // ? true */
-    trimStart(): string;
-    /** Removes whitespace from the right end of a string. */
+    
+    /** The property trimEnd is preferred. 
+    The trimRight property is provided principally for compatibility with old code. 
+    It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code. */
     trimRight(): string;
-    /** String.prototype.trimRight.name === 'trimEnd'; // ? true */
+
+    /** Removes whitespace from the left end of a string. */
+    trimStart(): string;
+
+    /** Removes whitespace from the right end of a string. */
     trimEnd(): string;
 }
 

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -156,10 +156,10 @@ interface String {
     trimLeft(): string;
 
     /**
-    * The property trimEnd is preferred.
-    * The trimRight property is provided principally for compatibility with old code.
-    * It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code.
-    */
+     * The property trimEnd is preferred.
+     * The trimRight property is provided principally for compatibility with old code.
+     * It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code.
+     */
     trimRight(): string;
 
     /** Removes whitespace from the left end of a string. */

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -148,14 +148,18 @@ interface SymbolConstructor {
 
 // Node.js ES2019/ESNEXT support
 interface String {
-    /** The property trimStart is preferred. 
-    The trimLeft property is provided principally for compatibility with old code. 
-    It is recommended that the trimStart property be used in new ECMAScript(ES2019) code. */
+    /** 
+     * The property trimStart is preferred. 
+     * The trimLeft property is provided principally for compatibility with old code. 
+     * It is recommended that the trimStart property be used in new ECMAScript(ES2019) code. 
+     */
     trimLeft(): string;
     
-    /** The property trimEnd is preferred. 
-    The trimRight property is provided principally for compatibility with old code. 
-    It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code. */
+    /** 
+    * The property trimEnd is preferred. 
+    * The trimRight property is provided principally for compatibility with old code. 
+    * It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code. 
+    */
     trimRight(): string;
 
     /** Removes whitespace from the left end of a string. */

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -150,8 +150,12 @@ interface SymbolConstructor {
 interface String {
     /** Removes whitespace from the left end of a string. */
     trimLeft(): string;
+    /** String.prototype.trimLeft.name === 'trimStart'; // ? true */
+    trimStart(): string;
     /** Removes whitespace from the right end of a string. */
     trimRight(): string;
+    /** String.prototype.trimRight.name === 'trimEnd'; // ? true */
+    trimEnd(): string;
 }
 
 interface ImportMeta {

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -148,17 +148,17 @@ interface SymbolConstructor {
 
 // Node.js ES2019/ESNEXT support
 interface String {
-    /** 
-     * The property trimStart is preferred. 
-     * The trimLeft property is provided principally for compatibility with old code. 
-     * It is recommended that the trimStart property be used in new ECMAScript(ES2019) code. 
+    /**
+     * The property trimStart is preferred.
+     * The trimLeft property is provided principally for compatibility with old code.
+     * It is recommended that the trimStart property be used in new ECMAScript(ES2019) code.
      */
     trimLeft(): string;
-    
-    /** 
-    * The property trimEnd is preferred. 
-    * The trimRight property is provided principally for compatibility with old code. 
-    * It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code. 
+
+    /**
+    * The property trimEnd is preferred.
+    * The trimRight property is provided principally for compatibility with old code.
+    * It is recommended that the trimEnd property be used in new ECMAScript(ES2019) code.
     */
     trimRight(): string;
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -37,6 +37,7 @@
 //                 Jordi Oliveras Rovira <https://github.com/j-oliveras>
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
 //                 Marcin Kopacz <https://github.com/chyzwar>
+//                 Benjamin Vincent (Luxcium) <https://github.com/Luxcium>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1122,7 +1122,7 @@ import moduleModule = require('module');
 
 {
     const s = 'foo';
-  
+
     // The initial value of the trimLeft property is the same function object as the initial
     // value of the  String.prototype.trimStart property.
     assert(String.prototype.trimLeft.name === 'trimStart');
@@ -1131,7 +1131,7 @@ import moduleModule = require('module');
 
     // The initial value of the trimRight property is the same function object as the initial
     // value of the  String.prototype.trimEnd property.
-    assert(String.prototype.trimRight.name === 'trimEnd'); 
+    assert(String.prototype.trimRight.name === 'trimEnd');
     const s2a: string = s.trimRight();
     const s2b: string = s.trimEnd();
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1121,6 +1121,8 @@ import moduleModule = require('module');
 ////////////////////////////////////////////////////
 
 {
+    const s = 'foo';
+  
     // The initial value of the trimLeft property is the same function object as the initial
     // value of the  String.prototype.trimStart property.
     assert(String.prototype.trimLeft.name === 'trimStart');

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1121,7 +1121,15 @@ import moduleModule = require('module');
 ////////////////////////////////////////////////////
 
 {
-    const s = 'foo';
-    const s1: string = s.trimLeft();
-    const s2: string = s.trimRight();
+    // The initial value of the trimLeft property is the same function object as the initial
+    // value of the  String.prototype.trimStart property.
+    assert(String.prototype.trimLeft.name === 'trimStart');
+    const s1a: string = s.trimLeft();
+    const s1b: string = s.trimStart();
+
+    // The initial value of the trimRight property is the same function object as the initial
+    // value of the  String.prototype.trimEnd property.
+    assert(String.prototype.trimRight.name === 'trimEnd'); 
+    const s2a: string = s.trimRight();
+    const s2b: string = s.trimEnd();
 }


### PR DESCRIPTION
The properties trimStart and trimEnd are preferred. The trimLeft and trimRight properies are provided principally for compatibility with old code. It is recommended that the trimStart or trimEnd  properties be used in new ECMAScript code.

https://github.com/nodejs/node/commit/12a1b9b8049462e47181a298120243dc83e81c55#diff-5fb85405f1ec035ec82ebead4371e7e8

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://www.ecma-international.org/ecma-262/10.0/index.html#sec-string.prototype.trimend
https://www.ecma-international.org/ecma-262/10.0/index.html#sec-string.prototype.trimstart
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

B.2.3Additional Properties of the String.prototype Object : 
B.2.3.15String.prototype.trimLeft ( )
B.2.3.16String.prototype.trimRight ( )

trimStart and trimEnd on String.prototype as better-named alternatives to the widely implemented but non-standard String.prototype.trimLeft and trimRight built-ins. 

The initial value of the trimLeft property is the same function object as the initial value of the  String.prototype.trimStart property.
The initial value of the trimRight property is the same function object as the initial value of the  String.prototype.trimEnd property.

21.1.3.28String.prototype.trimEnd ( )
This function interprets a String value as a sequence of UTF-16 encoded code points, as described in 6.1.4.

The following steps are taken:

Let S be this value.
Return ? TrimString(S, "end").
NOTE
The trimEnd function is intentionally generic; it does not require that its this value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.

21.1.3.29String.prototype.trimStart ( )
This function interprets a String value as a sequence of UTF-16 encoded code points, as described in 6.1.4.

The following steps are taken:

Let S be this value.
Return ? TrimString(S, "start").
NOTE
The trimStart function is intentionally generic; it does not require that its this value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.
