### PR TITLE
Add `editorKey` and `textDirectionality` props to `draft-js`

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -172,6 +172,7 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
                     <Editor
                         blockStyleFn={getBlockStyle}
                         customStyleMap={styleMap}
+                        editorKey="test-key"
                         editorState={this.state.editorState}
                         keyBindingFn={this.keyBindingFn}
                         handleKeyCommand={this.handleKeyCommand}

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -12,6 +12,7 @@
 //                 Claudio Procida <https://github.com/claudiopro>
 //                 Kevin Hawkinson <https://github.com/khawkinson>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
+//                 Ben Salili-James <https://github.com/benhjames>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -76,10 +77,19 @@ declare namespace Draft {
                 // regardless of input characters.
                 textAlignment?: DraftTextAlignment;
 
+                // Specify whether text directionality should be forced in a direction
+                // regardless of input characters.
+                textDirectionality?: DraftTextDirectionality;
+
                 // For a given `ContentBlock` object, return an object that specifies
                 // a custom block component and/or props. If no object is returned,
                 // the default `TextEditorBlock` is used.
                 blockRendererFn?(block: ContentBlock): any;
+
+                // Provide a map of block rendering configurations. Each block type maps to
+                // an element tag and an optional react element wrapper. This configuration
+                // is used for both rendering and paste processing.
+                blockRenderMap?: DraftBlockRenderMap
 
                 // Function that allows to define class names to apply to the given block when it is rendered.
                 blockStyleFn?(block: ContentBlock): string;
@@ -130,6 +140,10 @@ declare namespace Draft {
 
                 webDriverTestID?: string;
 
+                // If using server-side rendering, this prop is required to be set to
+                // avoid client/server mismatches.
+                editorKey?: string;
+
                 /**
                  * Cancelable event handlers, handled from the top level down. A handler
                  * that returns `handled` will be the last handler to execute for that event.
@@ -172,14 +186,11 @@ declare namespace Draft {
 
                 onBlur?(e: SyntheticEvent): void,
                 onFocus?(e: SyntheticEvent): void,
-
-                // Provide a map of block rendering configurations. Each block type maps to
-                // an element tag and an optional react element wrapper. This configuration
-                // is used for both rendering and paste processing.
-                blockRenderMap?: DraftBlockRenderMap
             }
 
             type DraftTextAlignment = "left" | "center" | "right";
+
+            type DraftTextDirectionality = "LTR" | "RTL" | "NEUTRAL";
         }
 
         namespace Components {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://draftjs.org/docs/api-reference-editor.html#textdirectionality
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
