### PR TITLE
[@testing-library/vue] Update to 2.0 and relax dependency versions

### DIFF
--- a/types/testing-library__vue/index.d.ts
+++ b/types/testing-library__vue/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @testing-library/vue 1.2
+// Type definitions for @testing-library/vue 2.0
 // Project: https://github.com/testing-library/vue-testing-library
 // Definitions by: Tim Yates <https://github.com/cimbul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -48,10 +48,11 @@ export type AsyncFireObject = {
 };
 
 export interface VueFireObject extends AsyncFireObject {
+  (element: Document | Element | Window, event: Event): Promise<void>;
   touch(element: Document | Element | Window): Promise<void>;
   update(element: HTMLOptionElement): Promise<void>;
   update(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement, value: string): Promise<void>;
   update(element: HTMLElement, value?: string): Promise<void>;
 }
 
-export const fireEvent: FireFunction & VueFireObject;
+export const fireEvent: VueFireObject;

--- a/types/testing-library__vue/package.json
+++ b/types/testing-library__vue/package.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "@vue/test-utils": "^1.0.0-beta.29",
         "vue": "^2.6.10",
-        "vue-router": "^3.0.7",
-        "vuex": "^3.1.1"
+        "vue-router": "^3.0",
+        "vuex": "^3.0"
     }
 }

--- a/types/testing-library__vue/testing-library__vue-tests.ts
+++ b/types/testing-library__vue/testing-library__vue-tests.ts
@@ -104,15 +104,14 @@ lib.findByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace:
 lib.findAllByText(elem, "foo"); // $ExpectType Promise<HTMLElement[]>
 lib.findAllByText(elem, /some text/, {exact: true, trim: false, collapseWhitespace: true, normalizer: x => x, selector: '*'}); // $ExpectType Promise<HTMLElement[]>
 
-// Reexports event functions from dom-testing-library
-// Note that it does NOT make the core fireEvent() function asynchronous
-lib.fireEvent(elem, new Event('change')); // $ExpectType boolean
+// Reexports createEvent from dom-testing-library
 lib.createEvent.click(elem); // $ExpectType Event
 lib.createEvent.click(elem, {foo: "bar"}); // $ExpectType Event
 lib.createEvent.keyDown(elem); // $ExpectType Event
 lib.createEvent.mouseEnter(elem); // $ExpectType Event
 
-// Changes fireEvent[event]() to be asynchronous
+// Changes fireEvent to be asynchronous
+lib.fireEvent(elem, new Event('change')); // $ExpectType Promise<void>
 lib.fireEvent.click(elem); // $ExpectType Promise<void>
 lib.fireEvent.click(elem, {foo: "bar"}); // $ExpectType Promise<void>
 lib.fireEvent.keyDown(elem); // $ExpectType Promise<void>
@@ -141,6 +140,6 @@ lib.buildQueries((el: HTMLElement) => [el], (_: HTMLElement) => "something", (_:
 lib.within(elem);
 lib.getQueriesForElement(elem);
 lib.getNodeText(elem); // $ExpectType string
-// lib.getRoles(elem); // $ExpectType { [name: string]: string[]; }
+lib.getRoles(elem); // $ExpectType { [index: string]: HTMLElement[]; }
 lib.prettyDOM(elem); // $ExpectType string | false
-// lib.logRoles(elem); // $ExpectType string | false
+lib.logRoles(elem); // $ExpectType string


### PR DESCRIPTION
@testing-library/vue version 2.0 essentially just changed the return type of fireEvent().

vue-router and vuex are *not* listed as dependencies of @testing-library/vue. They are essentially optional, but we need them for the type definitions. Relaxing the version constraints makes it less likely that npm/yarn will install a private copy under `@types/testing-library__vue/node_modules/` simply becuase the user's package declares an older minor or patch release. (This happened in a project of mine after I installed the new types package.)

------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **See [tag comparison](https://github.com/testing-library/vue-testing-library/compare/1.2.0...2.0.1#diff-2cfdd145f61e8456ea199f8af800c145) and testing-library/vue-testing-library#75.**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **Exists.**
