### PR TITLE
MicroModal.close missing optional parameter from types

### DIFF
--- a/types/micromodal/index.d.ts
+++ b/types/micromodal/index.d.ts
@@ -55,7 +55,7 @@ declare namespace MicroModal {
     /**
      * Closes the active modal
      */
-    function close(): void;
+    function close(targetModal?: string): void
 }
 
 export default MicroModal;

--- a/types/micromodal/index.d.ts
+++ b/types/micromodal/index.d.ts
@@ -55,7 +55,7 @@ declare namespace MicroModal {
     /**
      * Closes the active modal
      */
-    function close(targetModal?: string): void
+    function close(targetModal?: string): void;
 }
 
 export default MicroModal;


### PR DESCRIPTION
`MicroModal.close` can be passed a parameter for the target modal, this is missing from the types.
For context see: https://github.com/ghosh/Micromodal/blob/master/src/index.js#L286

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
