### PR TITLE
stripe: Add missing field to invoice and missing field value option t…

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3057,6 +3057,13 @@ declare namespace Stripe {
             closed: boolean;
 
             /**
+             * Either charge_automatically, or send_invoice. When charging automatically, Stripe will attempt to pay
+             * this invoice using the default source attached to the customer. When sending an invoice, Stripe will
+             * email this invoice to the customer with payment instructions.
+             */
+            collection_method?: "charge_automatically" | "send_invoice";
+
+            /**
              * Time at which the object was created. Measured in seconds since the Unix epoch.
              */
             created: number;
@@ -7279,7 +7286,7 @@ declare namespace Stripe {
             /**
              * The most recent invoice this subscription has generated. [Expandable]
              */
-            latest_invoice: null | invoices.IInvoice;
+            latest_invoice: invoices.IInvoice | string | null;
 
             /**
              * Has the value true if the object exists in live mode or the value false if the object exists in test mode.


### PR DESCRIPTION
…o subscription

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    Add string option to subscription
https://stripe.com/docs/api/subscriptions/object#subscription_object-latest_invoice
From https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml
latest_invoice:
          anyOf:
          - maxLength: 5000
            type: string
          - "$ref": "#/components/schemas/invoice"
          description: The most recent invoice this subscription has generated.
          nullable: true


IInvoice
    add collection_method to IInvoice
https://stripe.com/docs/api/invoices/object#invoice_object-collection_method
From https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml
collection_method:
          description: Either `charge_automatically`, or `send_invoice`. When charging
            automatically, Stripe will attempt to pay this invoice using the default
            source attached to the customer. When sending an invoice, Stripe will
            email this invoice to the customer with payment instructions.
          enum:
          - charge_automatically
          - send_invoice
          nullable: true
          type: string

