### PR TITLE
[nodegit] Add createDetached definition

### DIFF
--- a/types/nodegit/remote.d.ts
+++ b/types/nodegit/remote.d.ts
@@ -28,6 +28,7 @@ export class Remote {
     static addPush(repo: Repository, remote: string, refspec: string): number;
     static create(repo: Repository, name: string, url: string): Remote;
     static createAnonymous(repo: Repository, url: string): Promise<Remote>;
+    static createDetached(url: string): Promise<Remote>;
     static createWithFetchspec(repo: Repository, name: string, url: string, fetch: string): Promise<Remote>;
     static delete(repo: Repository, name: string): Promise<number>;
     static initCallbacks(opts: RemoteCallbacks, version: number): number;


### PR DESCRIPTION
createDetached was added in [`0.24.0`](https://github.com/nodegit/nodegit.github.com/commit/c478a676467235352d123f529138e91f85dd1eac#diff-f6876d109ef3a13582ff4775489d636aR118)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.nodegit.org/api/remote/#createDetached
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.