### PR TITLE
Make pg.QueryResult generic, increasing type safety

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -80,7 +80,7 @@ export interface QueryResultBase {
 }
 
 export type RowBase = {
-    [column: string]: any
+    [column: string]: any;
 }
 
 export interface QueryResult<R extends RowBase = any> extends QueryResultBase {

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -79,8 +79,12 @@ export interface QueryResultBase {
     fields: FieldDef[];
 }
 
-export interface QueryResult extends QueryResultBase {
-    rows: any[];
+export type RowBase = {
+    [column: string]: any
+}
+
+export interface QueryResult<R extends RowBase = any> extends QueryResultBase {
+    rows: R[];
 }
 
 export interface QueryArrayResult extends QueryResultBase {
@@ -93,8 +97,8 @@ export interface Notification {
     payload?: string;
 }
 
-export interface ResultBuilder extends QueryResult {
-    addRow(row: any): void;
+export interface ResultBuilder<R extends RowBase = any> extends QueryResult<R> {
+    addRow(row: R): void;
 }
 
 export interface QueryParse {
@@ -157,11 +161,11 @@ export class Pool extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
+    query<R extends RowBase = any>(queryConfig: QueryConfig): Promise<QueryResult<R>>;
+    query<R extends RowBase = any>(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult<R>>;
     query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): void;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): void;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): void;
+    query<R extends RowBase = any>(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult<R>) => void): void;
+    query<R extends RowBase = any>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<R>) => void): void;
 
     on(event: "error", listener: (err: Error, client: PoolClient) => void): this;
     on(event: "connect" | "acquire" | "remove", listener: (client: PoolClient) => void): this;
@@ -175,11 +179,11 @@ export class ClientBase extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
+    query<R extends RowBase = any>(queryConfig: QueryConfig): Promise<QueryResult<R>>;
+    query<R extends RowBase = any>(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult<R>>;
     query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): void;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): void;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): void;
+    query<R extends RowBase = any>(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult<R>) => void): void;
+    query<R extends RowBase = any>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<R>) => void): void;
 
     copyFrom(queryText: string): stream.Writable;
     copyTo(queryText: string): stream.Readable;
@@ -211,9 +215,9 @@ export interface PoolClient extends ClientBase {
 export class Query extends events.EventEmitter implements Submittable {
     constructor(queryTextOrConfig?: string | QueryConfig, values?: any[]);
     submit: (connection: Connection) => void;
-    on(event: "row", listener: (row: any, result?: ResultBuilder) => void): this;
+    on<R extends RowBase = any>(event: "row", listener: (row: R, result?: ResultBuilder<R>) => void): this;
     on(event: "error", listener: (err: Error) => void): this;
-    on(event: "end", listener: (result: ResultBuilder) => void): this;
+    on<R extends RowBase = any>(event: "end", listener: (result: ResultBuilder<R>) => void): this;
 }
 
 export class Events extends events.EventEmitter {


### PR DESCRIPTION
`any` is used as default type for backwards compatibility.