### PR TITLE
[@testing-library/cypress] New type definition

### DIFF
--- a/types/testing-library__cypress/index.d.ts
+++ b/types/testing-library__cypress/index.d.ts
@@ -1,0 +1,698 @@
+// Type definitions for @testing-library/cypress 4.1
+// Project: https://github.com/testing-library/cypress-testing-library
+// Definitions by: Aaron Mc Adam <https://github.com/aaronmcadam>
+//                 Basti Buck <https://github.com/ppi-buck>
+//                 Stefano Magni <https://github.com/NoriSte>
+//                 Justin Hall <https://github.com/wKovacs64>
+//                 Brian Ng <https://github.com/existentialism>
+//                 Airat Aminev <https://github.com/airato>
+//                 Simon Jespersen <https://github.com/simjes>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import {
+    Matcher,
+    MatcherOptions as DTLMatcherOptions,
+    SelectorMatcherOptions as DTLSelectorMatcherOptions,
+} from '@testing-library/dom'
+
+import * as JQuery from 'jquery'
+
+export interface CTLMatcherOptions {
+    timeout?: number
+}
+
+export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions
+export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptions
+
+declare global {
+    namespace Cypress {
+        interface Chainable<Subject = any> {
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByPlaceholderText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryByPlaceholderText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByPlaceholderText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllByPlaceholderText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByPlaceholderText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            getByPlaceholderText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByPlaceholderText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            getAllByPlaceholderText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryBySelectText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryBySelectText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllBySelectText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllBySelectText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getBySelectText<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            getBySelectText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllBySelectText<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllBySelectText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryByText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllByText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            getByText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByText<E extends Node = HTMLElement>(id: Matcher, options?: SelectorMatcherOptions): Chainable<E[]>
+            getAllByText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByLabelText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryByLabelText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByLabelText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllByLabelText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByLabelText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<E>>
+            getByLabelText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByLabelText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<E[]>
+            getAllByLabelText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: SelectorMatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByAltText<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryByAltText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByAltText<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllByAltText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByAltText<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            getByAltText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByAltText<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllByAltText<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByTestId<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryByTestId<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByTestId<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryAllByTestId<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByTestId<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            getByTestId<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByTestId<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllByTestId<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByTitle<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryByTitle<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByTitle<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryAllByTitle<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByTitle<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            getByTitle<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByTitle<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllByTitle<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByDisplayValue<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryByDisplayValue<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByDisplayValue<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            queryAllByDisplayValue<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByDisplayValue<E extends Node = HTMLElement>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<E>>
+            getByDisplayValue<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByDisplayValue<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllByDisplayValue<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryByRole<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryByRole<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            queryAllByRole<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            queryAllByRole<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByRole<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<JQuery<E>>
+            getByRole<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `getBy*` APIs search for an element and throw an error if nothing found
+             * `getAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByRole<E extends Node = HTMLElement>(id: Matcher, options?: MatcherOptions): Chainable<E[]>
+            getAllByRole<K extends keyof HTMLElementTagNameMap>(
+                id: Matcher,
+                options?: MatcherOptions,
+            ): Chainable<Array<HTMLElementTagNameMap[K]>>
+        }
+    }
+}
+
+declare const Cypress: Cypress.Chainable
+export default Cypress

--- a/types/testing-library__cypress/testing-library__cypress-tests.ts
+++ b/types/testing-library__cypress/testing-library__cypress-tests.ts
@@ -1,0 +1,45 @@
+import Cypress from '@testing-library/cypress'
+
+// getBy*
+Cypress.getByPlaceholderText('foo')
+Cypress.getBySelectText('foo')
+Cypress.getByText('foo')
+Cypress.getByLabelText('foo')
+Cypress.getByAltText('foo')
+Cypress.getByTestId('foo')
+Cypress.getByTitle('foo')
+Cypress.getByDisplayValue('foo')
+Cypress.getByRole('foo')
+
+// getAllBy*
+Cypress.getAllByPlaceholderText('foo')
+Cypress.getAllBySelectText('foo')
+Cypress.getAllByText('foo')
+Cypress.getAllByLabelText('foo')
+Cypress.getAllByAltText('foo')
+Cypress.getAllByTestId('foo')
+Cypress.getAllByTitle('foo')
+Cypress.getAllByDisplayValue('foo')
+Cypress.getAllByRole('foo')
+
+// queryBy*
+Cypress.queryByPlaceholderText('foo')
+Cypress.queryBySelectText('foo')
+Cypress.queryByText('foo')
+Cypress.queryByLabelText('foo')
+Cypress.queryByAltText('foo')
+Cypress.queryByTestId('foo')
+Cypress.queryByTitle('foo')
+Cypress.queryByDisplayValue('foo')
+Cypress.queryByRole('foo')
+
+// queryAllBy*
+Cypress.queryAllByPlaceholderText('foo')
+Cypress.queryAllBySelectText('foo')
+Cypress.queryAllByText('foo')
+Cypress.queryAllByLabelText('foo')
+Cypress.queryAllByAltText('foo')
+Cypress.queryAllByTestId('foo')
+Cypress.queryAllByTitle('foo')
+Cypress.queryAllByDisplayValue('foo')
+Cypress.queryAllByRole('foo')

--- a/types/testing-library__cypress/tsconfig.json
+++ b/types/testing-library__cypress/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@testing-library/cypress": [
+                "testing-library__cypress"
+            ],
+            "@testing-library/dom": [
+                "testing-library__dom"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "testing-library__cypress-tests.ts"
+    ]
+}

--- a/types/testing-library__cypress/tslint.json
+++ b/types/testing-library__cypress/tslint.json
@@ -1,0 +1,13 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "semicolon": [
+            true,
+            "never"
+        ],
+        "whitespace": [
+            false
+        ],
+        "no-unnecessary-generics": false
+    }
+}


### PR DESCRIPTION
This is related to testing-library/cypress-testing-library#68, moving typings to `DefinitelyTyped`.

A couple of questions:
- Is the import of jquery for typings correct in `index.d.ts`? I was thinking I would need to add it to `paths` in `tsconfig.json`, but `npm run test` will fail with `In JQuery, unexpected path mapping for JQuery: 'jquery'`.
- Any suggestions to improve the typings to get rid of unnecessary generics? I've currently disabled the rule in linting, but I see this is located under [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes)

Any other feedback to improve this is appreciated

---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). **See question**
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project. **Inspired by other typings for testing-library__\***
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
