### PR TITLE
Express: Revert #37502, because it breaks things and doesn't solve the real problem.

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -95,7 +95,7 @@ proxy("www.google.com", {
 
 const proxyOptions: proxy.ProxyOptions = {};
 
-app.use("/proxy/:port", proxy(req => "localhost:" + (Array.isArray(req.params) ? {} : req.params).port));
+app.use("/proxy/:port", proxy(req => "localhost:" + req.params.port));
 
 proxy("www.google.com", {
     filter: (req, res) => {

--- a/types/express-redis-cache/express-redis-cache-tests.ts
+++ b/types/express-redis-cache/express-redis-cache-tests.ts
@@ -28,7 +28,7 @@ app.get('/user/:userid',
     // middleware to define cache name
     (req, res, next) => {
         // set cache name
-        res.express_redis_cache_name = 'user-' + (Array.isArray(req.params) ? {} : req.params).userid;
+        res.express_redis_cache_name = 'user-' + req.params.userid;
         next();
     },
     // cache middleware

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -181,11 +181,6 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
-export interface Dictionary<T> { [key: string]: T; }
-export type ParamsDictionary = Dictionary<string>;
-export type ParamsArray = string[];
-export type Params = ParamsDictionary | ParamsArray;
-
 export interface Request extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
@@ -438,7 +433,7 @@ export interface Request extends http.IncomingMessage, Express.Request {
 
     method: string;
 
-    params: Params;
+    params: any;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: any): Response;

--- a/types/express-ws/express-ws-tests.ts
+++ b/types/express-ws/express-ws-tests.ts
@@ -60,7 +60,7 @@ router.ws(
     '/:id',
     (ws, req, next) => { next(); },
     (ws, req, next) => {
-        ws.send((Array.isArray(req.params) ? {} : req.params).id);
+        ws.send(req.params.id);
 
         ws.on('close', (code, reason) => {
             console.log('code:', code);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,5 +1,4 @@
 import express = require('express');
-import { RequestRanges, ParamsDictionary } from 'express-serve-static-core';
 
 namespace express_tests {
     const app = express();
@@ -112,8 +111,7 @@ namespace express_tests {
         });
 
     router.get('/user/:id', (req, res, next) => {
-        const paramsDictionary: ParamsDictionary = Array.isArray(req.params) ? {} : req.params;
-        if (Number(paramsDictionary.id) === 0) next('route');
+        if (Number(req.params.id) === 0) next('route');
         else next();
     }, (req, res, next) => {
         res.render('regular');
@@ -160,6 +158,7 @@ namespace express_tests {
  *                         *
  ***************************/
 import * as http from 'http';
+import { RequestRanges } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -205,7 +205,7 @@ app.get('/ar', (_req: Express.Request, res: Express.Response) => {
     i18n.setLocale(res, 'ar');
     i18n.setLocale(res.locals, 'ar');
 
-    i18n.setLocale([req, res.locals], (Array.isArray(req.params) ? {} : req.params).lang);
+    i18n.setLocale([req, res.locals], req.params.lang);
     i18n.setLocale(res, 'ar', true);
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This reverts the changes introduced in #37502.  As I mentioned [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502#issuecomment-522203464), these changes are breaking, and create a lot of fussy make work and add a lot of unnecessary type checks to customer code.  And while there is a real problem the change is trying to address, there are other better approaches to addressing it that don't offload this work onto the caller, and could possibly be done in a non-breaking fashion.

Since this #37502 is a breaking change for an extremely popular project (express), it has HUGE impact.  We should revert it until we can either implement or rule out other possible solutions.