### PR TITLE
reactstrap - add 'form' prop to Row component

### DIFF
--- a/types/reactstrap/lib/Row.d.ts
+++ b/types/reactstrap/lib/Row.d.ts
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { CSSModule } from '../index';
 
-export interface RowProps extends React.HTMLProps<HTMLElement> {
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export interface RowProps extends Omit<React.HTMLProps<HTMLElement>, 'form'> {
   [key: string]: any;
   className?: string;
   cssModule?: CSSModule;
   tag?: React.ReactType;
   noGutters?: boolean;
+  form?: boolean;
 }
 
 declare class Row<T = {[key: string]: any}> extends React.Component<RowProps> {}

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -4528,3 +4528,34 @@ function Example127() {
         </div>
     );
 }
+
+function Example128() {
+  return (
+    <Form>
+      <Row form>
+        <Col md={6}>
+          <FormGroup>
+            <Label for="exampleEmail">Email</Label>
+            <Input
+              type="email"
+              name="email"
+              id="exampleEmail"
+              placeholder="with a placeholder"
+            />
+          </FormGroup>
+        </Col>
+        <Col md={6}>
+          <FormGroup>
+            <Label for="examplePassword">Password</Label>
+            <Input
+              type="password"
+              name="password"
+              id="examplePassword"
+              placeholder="password placeholder"
+            />
+          </FormGroup>
+        </Col>
+      </Row>
+    </Form>
+  );
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/reactstrap/reactstrap/blob/master/src/Row.js#L11>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

https://github.com/reactstrap/reactstrap/commit/205e80d9ba9b80dcccfa7a813d020babf133f0f5#diff-5bacd7cba2b21fde05e22db7b632cb3e added `form` prop to the `Row` component which is missing in the typings.

The `form` property does conflict with `react`'s typing, however. reactstrap's `RowProps` extends `React.HTMLProps`, which extends `AllHTMLAttributes`. The interface for `AllHTMLAttributes` already has a `form` property: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1719.

To make this work, I've elected to omit the `form` property so that it can be added to `RowProps` but don't know if this is an acceptable change.