### PR TITLE
Update to reflect types for mui-datatables v2.8.0

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -103,12 +103,18 @@ export interface MUIDataTableTextLabels {
     selectedRows: MUIDataTableTextLabelsSelectedRows;
 }
 
+export interface MUIDataTableFilterOptions {
+    names?: string[];
+    display?: (filterList:string[], onChange: any, index: number, column: any) => void;
+    logic?: any;
+}
+
 export interface MUIDataTableColumnOptions {
     display?: Display;
     empty?: boolean;
     filter?: boolean;
     filterList?: string[];
-    filterOptions?: string[];
+    filterOptions?: MUIDataTableFilterOptions;
     filterType?: FilterType;
     sort?: boolean;
     searchable?: boolean;
@@ -117,6 +123,7 @@ export interface MUIDataTableColumnOptions {
     download?: boolean;
     viewColumns?: boolean;
     hint?: string;
+    customFilterListRender?: (value: any) => string;
     customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
     customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
@@ -134,6 +141,7 @@ export interface MUIDataTableOptions {
         changePage: number
     ) => React.ReactNode;
     customSearch?: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
+    customSearchRender?: (searchText: string, handleSearch: any, hideSearch: any, options: any) => React.Component;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     customToolbar?: () => React.ReactNode;
     customToolbarSelect?: (
@@ -172,6 +180,7 @@ export interface MUIDataTableOptions {
     onRowsDelete?: (rowsDeleted: any[]) => void;
     onRowsSelect?: (currentRowsSelected: any[], rowsSelected: any[]) => void;
     onSearchChange?: (searchText: string) => void;
+    onSearchOpen?: () => void;
     onTableChange?: (action: string, tableState: MUIDataTableState) => void;
     page?: number;
     pagination?: boolean;
@@ -183,9 +192,11 @@ export interface MUIDataTableOptions {
     rowsPerPage?: number;
     rowsPerPageOptions?: number[];
     rowsSelected?: any[];
+    rowsExpanded?: any[];
     search?: boolean;
     searchText?: string;
     selectableRows?: SelectableRows;
+    selectableRowsOnClick?: boolean;
     serverSide?: boolean;
     setRowProps?: (row: any[], rowIndex: number) => object;
     sort?: boolean;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 export type Display = 'true' | 'false' | 'excluded';
 export type SortDirection = 'asc' | 'desc';
-export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField';
+export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
 export type Responsive = 'stacked' | 'scroll';
 export type SelectableRows = 'multiple' | 'single' | 'none';
 
@@ -184,6 +184,7 @@ export interface MUIDataTableOptions {
     rowsPerPageOptions?: number[];
     rowsSelected?: any[];
     search?: boolean;
+    searchText?: string;
     selectableRows?: SelectableRows;
     serverSide?: boolean;
     setRowProps?: (row: any[], rowIndex: number) => object;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -105,7 +105,7 @@ export interface MUIDataTableTextLabels {
 
 export interface MUIDataTableFilterOptions {
     names?: string[];
-    display?: (filterList:string[], onChange: any, index: number, column: any) => void;
+    display?: (filterList: string[], onChange: any, index: number, column: any) => void;
     logic?: any;
 }
 

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -106,7 +106,7 @@ export interface MUIDataTableTextLabels {
 export interface MUIDataTableFilterOptions {
     names?: string[];
     display?: (filterList: string[], onChange: any, index: number, column: any) => void;
-    logic?: any;
+    logic?: (prop: string, filterValue: any[]) => boolean;
 }
 
 export interface MUIDataTableColumnOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/gregnb/mui-datatables>>
      example using filteroptions' display and logic parameters:
      https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

- Added interface type MUIDataTableFilterOptions as:
```
export interface MUIDataTableFilterOptions {
    names?: string[];
    display?: (filterList:string[], onChange: any, index: number, column: any) => void;
    logic?: any;
}
```
- Changed type of filterOptions in MUIDataTableColumnOptions to MUIDataTableFilterOptions (breaking change if filteroptions is used)
- Added `customFilterListRender?: (value: any) => string;` to MUIDataTableColumnOptions
- Added to MUIDataTableOptions:
```
selectableRowsOnClick?: boolean;
rowsExpanded?: any[];
onSearchOpen?: () => void;
customSearchRender?: (searchText: string, handleSearch: any, hideSearch: any, options: any) => 
React.Component;
```

For reviewer: 
1) as a typescript novice i'm not certain about the definition for the display and logic fields in MUIDataTableFilterOptions . A usage example is found [here](https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js). Also the return type for customSearchRender is in the documentation React.Component, is that correct? In the definitions file i see mostly React.ReactNode as returntype.
2) as a github novice: my previous pull request is somehow included in this one, so also searchText is added to MUIDataTableOptions and the value custom is added to FilterType. I created this PR by comparing my fork with the changes in branch skalma-patch-1 to the master. I could not find the way to remove this earlier commit with the changes from branch skalma-patch-2. Do i have to create a new fork to isolate these new changes?