### PR TITLE
[chart.js] add scriptable dataset options

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -1,11 +1,11 @@
-import { Chart, ChartData, Point } from 'chart.js';
+import { Chart, ChartData, Point, ChartColor } from 'chart.js';
 
 // alternative:
 // import chartjs = require('chart.js');
 // => chartjs.Chart
 
 const plugin = {
-    afterDraw: (chartInstance: Chart, easing: Chart.Easing, options?: any) => {},
+    afterDraw: (chartInstance: Chart, easing: Chart.Easing, options?: any) => { },
 };
 
 const ctx = new CanvasRenderingContext2D();
@@ -180,3 +180,24 @@ if (radialChart.aspectRatio !== null) {
     console.log(radialChart.aspectRatio * 2);
 }
 console.log(radialChart.options === radialChart.config.options);
+
+const chartWithScriptedOptions = new Chart(new CanvasRenderingContext2D(), {
+    type: "bar",
+    data: {
+        labels: ["a", "b", "c", "d", "e"],
+        datasets: [{
+            label: "test",
+            data: [1, 3, 5, 4, 2],
+            backgroundColor: ({ dataset, dataIndex }): ChartColor => {
+                if (dataset === undefined || dataset.data === undefined || dataIndex === undefined) {
+                    return "black";
+                }
+                const value = dataset.data[dataIndex];
+                if (typeof value !== "number") {
+                    return "black";
+                }
+                return value > 3 ? "red" : "green";
+            }
+        }],
+    }
+});

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -136,7 +136,6 @@ declare namespace Chart {
     type TextAlignment = 'left' | 'center' | 'right';
 
     type BorderAlignment = 'center' | 'inner';
-    
 
     interface ChartArea {
         top: number;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -135,6 +135,9 @@ declare namespace Chart {
 
     type TextAlignment = 'left' | 'center' | 'right';
 
+    type BorderAlignment = 'center' | 'inner';
+    
+
     interface ChartArea {
         top: number;
         right: number;
@@ -532,6 +535,7 @@ declare namespace Chart {
     interface ChartDataSets {
         cubicInterpolationMode?: 'default' | 'monotone';
         backgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        borderAlign?: BorderAlignment | BorderAlignment[] | Scriptable<BorderAlignment>;
         borderWidth?: number | number[] | Scriptable<number>;
         borderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         borderCapStyle?: 'butt' | 'round' | 'square';
@@ -541,6 +545,7 @@ declare namespace Chart {
         borderSkipped?: PositionType | Scriptable<PositionType>;
         data?: Array<number | null | undefined> | ChartPoint[];
         fill?: boolean | number | string;
+        hitRadius?: number | number[] | Scriptable<number>;
         hoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         hoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         hoverBorderWidth?: number | number[] | Scriptable<ChartColor>;
@@ -551,12 +556,15 @@ declare namespace Chart {
         pointBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointBorderWidth?: number | number[] | Scriptable<number>;
         pointRadius?: number | number[] | Scriptable<number>;
+        pointRotation?: number | number[] | Scriptable<number>;
         pointHoverRadius?: number | number[] | Scriptable<number>;
         pointHitRadius?: number | number[] | Scriptable<number>;
         pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderWidth?: number | number[] | Scriptable<number>;
         pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement> | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
+        radius?: number | number[] | Scriptable<number>;
+        rotation?: number | number[] | Scriptable<number>;
         xAxisID?: string;
         yAxisID?: string;
         type?: ChartType | string;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -541,13 +541,13 @@ declare namespace Chart {
         borderDash?: number[];
         borderDashOffset?: number;
         borderJoinStyle?: 'bevel' | 'round' | 'miter';
-        borderSkipped?: PositionType | Scriptable<PositionType>;
+        borderSkipped?: PositionType | PositionType[] | Scriptable<PositionType>;
         data?: Array<number | null | undefined> | ChartPoint[];
         fill?: boolean | number | string;
         hitRadius?: number | number[] | Scriptable<number>;
         hoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         hoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
-        hoverBorderWidth?: number | number[] | Scriptable<ChartColor>;
+        hoverBorderWidth?: number | number[] | Scriptable<number>;
         label?: string;
         lineTension?: number;
         steppedLine?: 'before' | 'after' | 'middle' | boolean;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -522,34 +522,41 @@ declare namespace Chart {
 
     type ChartColor = string | CanvasGradient | CanvasPattern | string[];
 
+    type Scriptable<T> = (ctx: {
+        chart?: Chart;
+        dataIndex?: number;
+        dataset?: ChartDataSets
+        datasetIndex?: number;
+    }) => T;
+
     interface ChartDataSets {
         cubicInterpolationMode?: 'default' | 'monotone';
-        backgroundColor?: ChartColor | ChartColor[];
-        borderWidth?: number | number[];
-        borderColor?: ChartColor | ChartColor[];
+        backgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        borderWidth?: number | number[] | Scriptable<number>;
+        borderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         borderCapStyle?: 'butt' | 'round' | 'square';
         borderDash?: number[];
         borderDashOffset?: number;
         borderJoinStyle?: 'bevel' | 'round' | 'miter';
-        borderSkipped?: PositionType;
+        borderSkipped?: PositionType | Scriptable<PositionType>;
         data?: Array<number | null | undefined> | ChartPoint[];
         fill?: boolean | number | string;
-        hoverBackgroundColor?: ChartColor | ChartColor[];
-        hoverBorderColor?: ChartColor | ChartColor[];
-        hoverBorderWidth?: number | number[];
+        hoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        hoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        hoverBorderWidth?: number | number[] | Scriptable<ChartColor>;
         label?: string;
         lineTension?: number;
         steppedLine?: 'before' | 'after' | 'middle' | boolean;
-        pointBorderColor?: ChartColor | ChartColor[];
-        pointBackgroundColor?: ChartColor | ChartColor[];
-        pointBorderWidth?: number | number[];
-        pointRadius?: number | number[];
-        pointHoverRadius?: number | number[];
-        pointHitRadius?: number | number[];
-        pointHoverBackgroundColor?: ChartColor | ChartColor[];
-        pointHoverBorderColor?: ChartColor | ChartColor[];
-        pointHoverBorderWidth?: number | number[];
-        pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement>;
+        pointBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        pointBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        pointBorderWidth?: number | number[] | Scriptable<number>;
+        pointRadius?: number | number[] | Scriptable<number>;
+        pointHoverRadius?: number | number[] | Scriptable<number>;
+        pointHitRadius?: number | number[] | Scriptable<number>;
+        pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
+        pointHoverBorderWidth?: number | number[] | Scriptable<number>;
+        pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement> | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
         xAxisID?: string;
         yAxisID?: string;
         type?: ChartType | string;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://www.chartjs.org/docs/2.8.0/general/options.html#scriptable-options
https://www.chartjs.org/docs/2.8.0/general/options.html#option-context

Scriptable options: 
- modified
  - pointBackgroundColor [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointBorderColor [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointBorderWidth [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointHitRadius [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointHoverBackgroundColor [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointHoverBorderWidth [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointHoverRadius [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointRadius [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - pointStyle [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - backgroundColor [[bar](https://www.chartjs.org/docs/2.8.0/charts/bar.html#dataset-properties)/[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - borderColor [[bar](https://www.chartjs.org/docs/2.8.0/charts/bar.html#dataset-properties)/[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - borderSkipped [[bar](https://www.chartjs.org/docs/2.8.0/charts/bar.html#dataset-properties)],
  - borderWidth [[bar](https://www.chartjs.org/docs/2.8.0/charts/bar.html#dataset-properties)/[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - hoverBackgroundColor [[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - hoverBorderColor [[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - hoverBorderWidth [[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)/[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - hoverRadius [[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
- added
  - pointRotation [[line](https://www.chartjs.org/docs/2.8.0/charts/line.html#dataset-properties)/[radar](https://www.chartjs.org/docs/2.8.0/charts/radar.html#dataset-properties)]
  - borderAlign [[doughnut](https://www.chartjs.org/docs/2.8.0/charts/doughnut.html#dataset-properties)/[polar](https://www.chartjs.org/docs/2.8.0/charts/polar.html#dataset-properties)]
  - hitRadius [[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - rotation [[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]
  - radius [[bubble](https://www.chartjs.org/docs/2.8.0/charts/bubble.html#dataset-properties)]

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.