### PR TITLE
Update option to current version

### DIFF
--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -19,7 +19,7 @@ declare function WebpackHotMiddleware(
 
 declare namespace WebpackHotMiddleware {
 	interface Options {
-		reload?: boolean;
+        reload?: boolean;
         name? string;
         timeout?: number;
         overlay?: boolean;
@@ -29,14 +29,14 @@ declare namespace WebpackHotMiddleware {
         autoConnect?: boolean;
         ansiColors?: {
             [key: string]: any
-        }
+        };
         overlayStyles?: {
             [key: string]: any
-        }
+        };
         overlayWarnings?: boolean;
         log?: false | Logger;
-		path?: string;
-		heartbeat?: number;
+        path?: string;
+        heartbeat?: number;
 	}
 
 	type Logger = (message?: any, ...optionalParams: any[]) => void;

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-hot-middleware 2.25.0
+// Type definitions for webpack-hot-middleware 2.25
 // Project: https://github.com/webpack-contrib/webpack-hot-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 Ron Martinez <https://github.com/icylace>
@@ -20,7 +20,7 @@ declare function WebpackHotMiddleware(
 declare namespace WebpackHotMiddleware {
 	interface Options {
         reload?: boolean;
-        name? string;
+        name?: string;
         timeout?: number;
         overlay?: boolean;
         noInfo?: boolean;

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for webpack-hot-middleware 2.16
+// Type definitions for webpack-hot-middleware 2.25.0
 // Project: https://github.com/webpack-contrib/webpack-hot-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 Ron Martinez <https://github.com/icylace>
 //                 Chris Abrams <https://github.com/chrisabrams>
+//                 Ilya Zelenko <https://github.com/iliyaZelenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,10 +19,24 @@ declare function WebpackHotMiddleware(
 
 declare namespace WebpackHotMiddleware {
 	interface Options {
-		log?: false | Logger;
+		reload?: boolean;
+        name? string;
+        timeout?: number;
+        overlay?: boolean;
+        noInfo?: boolean;
+        quiet?: boolean;
+        dynamicPublicPath?: boolean;
+        autoConnect?: boolean;
+        ansiColors?: {
+            [key: string]: any
+        }
+        overlayStyles?: {
+            [key: string]: any
+        }
+        overlayWarnings?: boolean;
+        log?: false | Logger;
 		path?: string;
 		heartbeat?: number;
-		reload?: boolean;
 	}
 
 	type Logger = (message?: any, ...optionalParams: any[]) => void;

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,9 +1,9 @@
 // Type definitions for webpack-hot-middleware 2.25
 // Project: https://github.com/webpack-contrib/webpack-hot-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
-//                 Ron Martinez <https://github.com/icylace>
-//                 Chris Abrams <https://github.com/chrisabrams>
-//                 Ilya Zelenko <https://github.com/iliyaZelenko>
+//				 Ron Martinez <https://github.com/icylace>
+//				 Chris Abrams <https://github.com/chrisabrams>
+//				 Ilya Zelenko <https://github.com/iliyaZelenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -19,24 +19,24 @@ declare function WebpackHotMiddleware(
 
 declare namespace WebpackHotMiddleware {
 	interface Options {
-        reload?: boolean;
-        name?: string;
-        timeout?: number;
-        overlay?: boolean;
-        noInfo?: boolean;
-        quiet?: boolean;
-        dynamicPublicPath?: boolean;
-        autoConnect?: boolean;
-        ansiColors?: {
-            [key: string]: any
-        };
-        overlayStyles?: {
-            [key: string]: any
-        };
-        overlayWarnings?: boolean;
-        log?: false | Logger;
-        path?: string;
-        heartbeat?: number;
+		reload?: boolean;
+		name?: string;
+		timeout?: number;
+		overlay?: boolean;
+		noInfo?: boolean;
+		quiet?: boolean;
+		dynamicPublicPath?: boolean;
+		autoConnect?: boolean;
+		ansiColors?: {
+			[key: string]: any
+		};
+		overlayStyles?: {
+			[key: string]: any
+		};
+		overlayWarnings?: boolean;
+		log?: false | Logger;
+		path?: string;
+		heartbeat?: number;
 	}
 
 	type Logger = (message?: any, ...optionalParams: any[]) => void;

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,9 +1,9 @@
 // Type definitions for webpack-hot-middleware 2.25
 // Project: https://github.com/webpack-contrib/webpack-hot-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
-//				 Ron Martinez <https://github.com/icylace>
-//				 Chris Abrams <https://github.com/chrisabrams>
-//				 Ilya Zelenko <https://github.com/iliyaZelenko>
+//               Ron Martinez <https://github.com/icylace>
+//               Chris Abrams <https://github.com/chrisabrams>
+//               Ilya Zelenko <https://github.com/iliyaZelenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Based on this docs: https://github.com/webpack-contrib/webpack-hot-middleware#client

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
