### PR TITLE
nunjucks: Describe TemplateError interface

### DIFF
--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -4,13 +4,19 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+export type TemplateCallback<T> = (
+  err: lib.TemplateError | null,
+  res: T | null,
+) => void;
+export type Callback<E, T> = (err: E | null, res: T | null) => void;
+
 export function render(name: string, context?: object): string;
-export function render(name: string, context?: object, callback?: (err: any, res: string) => any): void;
+export function render(name: string, context?: object, callback?: TemplateCallback<string>): void;
 
 export function renderString(src: string, context: object): string;
-export function renderString(src: string, context: object, callback?: (err: any, res: string) => any): void;
+export function renderString(src: string, context: object, callback?: TemplateCallback<string>): void;
 
-export function compile(src: string, env?: Environment, callback?: (err: any, res: Template) => any): Template;
+export function compile(src: string, env?: Environment, callback?: TemplateCallback<Template>): Template;
 
 export function precompile(path: string, opts?: PrecompileOptions): string;
 export function precompileString(src: string, opts?: PrecompileOptions): string;
@@ -28,7 +34,7 @@ export interface PrecompileOptions {
 export class Template {
     constructor(src: string, env?: Environment, eagerCompile?: boolean);
     render(context?: object): string;
-    render(context?: object, callback?: (err: any, res: string) => any): void;
+    render(context?: object, callback?: TemplateCallback<string>): void;
 }
 
 export function configure(options: ConfigureOptions): Environment;
@@ -63,10 +69,10 @@ export class Environment {
 
     constructor(loader?: ILoader | ILoader[] | null, opts?: ConfigureOptions);
     render(name: string, context?: object): string;
-    render(name: string, context?: object, callback?: (err: any, res: string) => any): void;
+    render(name: string, context?: object, callback?: TemplateCallback<string>): void;
 
     renderString(name: string, context: object): string;
-    renderString(name: string, context: object, callback?: (err: any, res: string) => any): void;
+    renderString(name: string, context: object, callback?: TemplateCallback<string>): void;
 
     addFilter(name: string, func: (...args: any[]) => any, async?: boolean): void;
     getFilter(name: string): void;
@@ -79,7 +85,7 @@ export class Environment {
     addGlobal(name: string, value: any): void;
 
     getTemplate(name: string, eagerCompile?: boolean): Template;
-    getTemplate(name: string, eagerCompile?: boolean, callback?: (err: any, templ: Template) => Template): void;
+    getTemplate(name: string, eagerCompile?: boolean, callback?: Callback<Error, Template>): void;
 
     express(app: object): void;
 }
@@ -95,7 +101,7 @@ export function installJinjaCompat(): void;
 export interface ILoader {
     async?: boolean;
     getSource(name: string): LoaderSource;
-    getSource(name: string, callback: (err?: any, result?: LoaderSource) => void): void;
+    getSource(name: string, callback: Callback<Error, LoaderSource>): void;
     extend?(extender: ILoader): ILoader;
 }
 
@@ -146,5 +152,19 @@ export namespace runtime {
         length: number;
         valueOf(): string;
         toString(): string;
+    }
+}
+
+export namespace lib {
+    class TemplateError extends Error {
+        constructor(message: string, lineno: number, colno: number);
+
+        name: string; // always 'Template render error'
+        message: string;
+        stack: string;
+
+        cause?: Error;
+        lineno: number;
+        colno: number;
     }
 }

--- a/types/nunjucks/nunjucks-tests.ts
+++ b/types/nunjucks/nunjucks-tests.ts
@@ -5,7 +5,10 @@ nunjucks.configure({ autoescape: false });
 let rendered = nunjucks.render("./noexists.html");
 
 nunjucks.render('foo.html', { username: 'James' });
-nunjucks.render('async.html', (err: any, res: string) => {});
+nunjucks.render(
+  'async.html',
+  (err: nunjucks.lib.TemplateError | null, res: string | null) => {},
+);
 
 const ctx = { items: ["Hello", "this", "is", "for", "testing"] };
 const src = "{% for item in items %}{{item}}{% endfor %}";


### PR DESCRIPTION
- TemplateError is thrown when rendering.
- Fix callback signatures to reflect null values.

Second try at #37550. Now:
- Tested and works with my own code

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mozilla.github.io/nunjucks/api.html https://github.com/mozilla/nunjucks/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
