### PR TITLE
Express: use generics for params, default to dictionary

### DIFF
--- a/types/api-error-handler/index.d.ts
+++ b/types/api-error-handler/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/api-error-handler
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/apimocker/index.d.ts
+++ b/types/apimocker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/apimocker
 // Definitions by: Uchenna <https://github.com/uchilaka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler, Application } from 'express';
 

--- a/types/basicauth-middleware/index.d.ts
+++ b/types/basicauth-middleware/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nchaulet/basicauth-middleware
 // Definitions by: Nicolas Chaulet <https://github.com/nchaulet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from "express";
 type checkFunctionSync = (username: string, password: string) => boolean;

--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -7,7 +7,7 @@
 //                 Tomasz Łaziuk <https://github.com/tlaziuk>
 //                 Jason Walton <https://github.com/jwalton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/browser-sync/index.d.ts
+++ b/types/browser-sync/index.d.ts
@@ -6,7 +6,7 @@
 //                 Kiyotoshi Ichikawa <https://github.com/aznnomness>
 //                 Yuma Hashimoto <https://github.com/yuma84>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="serve-static" />

--- a/types/compression/index.d.ts
+++ b/types/compression/index.d.ts
@@ -4,7 +4,7 @@
 //                 Rob van der Burgt <https://github.com/rburgt>
 //                 Neil Bryson Cargamento <https://github.com/neilbryson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/connect-busboy/index.d.ts
+++ b/types/connect-busboy/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 //                 Chris Gedrim <https://github.com/chrisgedrim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as busboy from 'busboy';
 import { RequestHandler } from 'express';

--- a/types/connect-datadog/index.d.ts
+++ b/types/connect-datadog/index.d.ts
@@ -4,7 +4,7 @@
 //                 Michael Mifsud <https://github.com/xzyfer>
 //                 Lewis Vail <https://github.com/lewisvail3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 import dogstatsd = require('node-dogstatsd');

--- a/types/connect-ensure-login/index.d.ts
+++ b/types/connect-ensure-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/connect-ensure-login
 // Definitions by: Pavel Puchkov <https://github.com/0x6368656174>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from "express";
 

--- a/types/connect-flash/index.d.ts
+++ b/types/connect-flash/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/connect-flash
 // Definitions by: Andreas Gassmann <https://github.com/AndreasGassmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 

--- a/types/connect-history-api-fallback-exclusions/index.d.ts
+++ b/types/connect-history-api-fallback-exclusions/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Wirewheel/connect-history-api-fallback#readme
 // Definitions by: Tony Stone <https://github.com/tonystonee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bripkens/connect-history-api-fallback#readme
 // Definitions by: Douglas Duteil <https://github.com/douglasduteil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/connect-modrewrite/index.d.ts
+++ b/types/connect-modrewrite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tinganho/connect-modrewrite
 // Definitions by: Tingan Ho <https://github.com/tinganho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Xavier Stouder <https://github.com/xstoudi>
 //				   Seth Butler <https://github.com/sbutler2901>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 /// <reference types="express-session" />

--- a/types/connect-slashes/index.d.ts
+++ b/types/connect-slashes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/avinoamr/connect-slashes
 // Definitions by: Sam Herrmann <https://github.com/samherrmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/cookie-parser/index.d.ts
+++ b/types/cookie-parser/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Santi Albo <https://github.com/santialbo>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/troygoode/node-cors/
 // Definitions by: Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/easy-jsend/index.d.ts
+++ b/types/easy-jsend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-jsend
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/easy-xapi-utils/index.d.ts
+++ b/types/easy-xapi-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-xapi-utils
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/easy-xapi/index.d.ts
+++ b/types/easy-xapi/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-xapi
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="easy-jsend" />
 /// <reference types="bunyan" />

--- a/types/ejs-locals/index.d.ts
+++ b/types/ejs-locals/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/randometc/ejs-locals
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-bunyan-logger/index.d.ts
+++ b/types/express-bunyan-logger/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Shrey Jain <https://github.com/shreyjain1994>
 //                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import Bunyan = require('bunyan');
 import express = require('express');

--- a/types/express-busboy/index.d.ts
+++ b/types/express-busboy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yahoo/express-busboy
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as connectBusboy from 'connect-busboy';
 import * as express from 'express';

--- a/types/express-correlation-id/index.d.ts
+++ b/types/express-correlation-id/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/toboid/express-correlation-id#readme
 // Definitions by: Nate <https://github.com/natemara>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from "express-serve-static-core";
 

--- a/types/express-ejs-layouts/index.d.ts
+++ b/types/express-ejs-layouts/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Soarez/express-ejs-layouts
 // Definitions by: Erik Mavrinac <https://github.com/erikma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/express-flash-2/index.d.ts
+++ b/types/express-flash-2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jack2gs/express-flash-2
 // Definitions by: Matheus Salmi <https://github.com/mathsalmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/express-flash/index.d.ts
+++ b/types/express-flash/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/RGBboy/express-flash
 // Definitions by: Ian Mobley <https://github.com/iMobs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="connect-flash" />
 

--- a/types/express-form-data/index.d.ts
+++ b/types/express-form-data/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ortexx/express-form-data#readme
 // Definitions by: nomnes <https://github.com/NomNes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { NextHandleFunction } from 'connect';
 import { FormOptions } from 'multiparty';

--- a/types/express-formidable/index.d.ts
+++ b/types/express-formidable/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/noraesae/express-formidable
 // Definitions by: Torkild Dyvik Olsen <https://github.com/tdolsen>, Evan Shortiss <https://github.com/evanshortiss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 import { Fields, Files } from "formidable";

--- a/types/express-handlebars/index.d.ts
+++ b/types/express-handlebars/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ericf/express-handlebars
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>, Igor Dultsev <https://github.com/yhaskell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 interface PartialTemplateOptions {
     cache?: boolean;

--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -95,7 +95,7 @@ proxy("www.google.com", {
 
 const proxyOptions: proxy.ProxyOptions = {};
 
-app.use("/proxy/:port", proxy(req => "localhost:" + (Array.isArray(req.params) ? {} : req.params).port));
+app.use("/proxy/:port", proxy(req => "localhost:" + req.params.port));
 
 proxy("www.google.com", {
     filter: (req, res) => {

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -7,7 +7,7 @@
 //                  John L. Singleton <https://github.com/jsinglet>
 //                  Lindsay Wardell <https://github.com/lindsaykwardell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler, Request, Response, NextFunction } from "express";
 import { RequestOptions, IncomingHttpHeaders, OutgoingHttpHeaders } from "http";

--- a/types/express-jsonschema/index.d.ts
+++ b/types/express-jsonschema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/trainiac/express-jsonschema#readme
 // Definitions by: Arne Schubert <https://github.com/atd-schubert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Request, Response, NextFunction } from "express";
 import { JSONSchema4 } from "json-schema";

--- a/types/express-less/index.d.ts
+++ b/types/express-less/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/express-less
 // Definitions by: xyb <https://github.com/xieyubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-ntlm/index.d.ts
+++ b/types/express-ntlm/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/einfallstoll/express-ntlm
 // Definitions by: Emily Marigold Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { ConnectionOptions } from 'tls';
 

--- a/types/express-oauth-server/index.d.ts
+++ b/types/express-oauth-server/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oauthjs/express-oauth-server#readme, https://github.com/seegno/express-oauth-server
 // Definitions by: Arne Schubert <https://github.com/atd-schubert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 import * as OAuth2Server from 'oauth2-server';

--- a/types/express-openapi/index.d.ts
+++ b/types/express-openapi/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kogosoftwarellc/express-openapi
 // Definitions by: TANAKA Koichi <https://github.com/mugeso>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
  import express = require('express');

--- a/types/express-partials/index.d.ts
+++ b/types/express-partials/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/publicclass/express-partials
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -4,7 +4,7 @@
 //                 makepost <https://github.com/makepost>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require("express");
 

--- a/types/express-rate-limit/v2/index.d.ts
+++ b/types/express-rate-limit/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfriedly/express-rate-limit
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, makepost <https://github.com/makepost>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require("express");
 

--- a/types/express-redis-cache/express-redis-cache-tests.ts
+++ b/types/express-redis-cache/express-redis-cache-tests.ts
@@ -28,7 +28,7 @@ app.get('/user/:userid',
     // middleware to define cache name
     (req, res, next) => {
         // set cache name
-        res.express_redis_cache_name = 'user-' + (Array.isArray(req.params) ? {} : req.params).userid;
+        res.express_redis_cache_name = 'user-' + req.params.userid;
         next();
     },
     // cache middleware

--- a/types/express-request-id/index.d.ts
+++ b/types/express-request-id/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/floatdrop/express-request-id
 // Definitions by: jgeth <https://github.com/jgeth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from 'express-serve-static-core';
 

--- a/types/express-route-fs/index.d.ts
+++ b/types/express-route-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kripod/express-route-fs
 // Definitions by: Kristóf Poduszló <https://github.com/kripod>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 /**

--- a/types/express-routemap/index.d.ts
+++ b/types/express-routemap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/izelnakri/express-routemap#readme
 // Definitions by: icopp <https://github.com/icopp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Application } from 'express';
 

--- a/types/express-routes-versioning/index.d.ts
+++ b/types/express-routes-versioning/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Prasanna-sr/express-routes-versioning
 // Definitions by: Rogelio Negrete <https://github.com/weffe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Handler } from 'express';
 

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -6,19 +6,19 @@ app.listen(3000, (err: any) => {
     // no-op error callback
 });
 
-app.get('/:foo', (req, res) => {
+app.get('/:foo', req => {
     req.params.foo; // $ExpectType string
     req.params[0]; // $ExpectType string
 });
 
 // Params can used as an array
-app.get<express.ParamsArray>('/*', (req, res) => {
+app.get<express.ParamsArray>('/*', req => {
     req.params[0]; // $ExpectType string
     req.params.length; // $ExpectType number
 });
 
 // Params can be a custom type that conforms to constraint
-app.get<{ foo: string }>('/:foo', (req, res) => {
+app.get<{ foo: string }>('/:foo', req => {
     req.params.foo; // $ExpectType string
     req.params.bar; // $ExpectError
 });

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -16,3 +16,9 @@ app.get<express.ParamsArray>('/*', (req, res) => {
     req.params[0]; // $ExpectType string
     req.params.length; // $ExpectType number
 });
+
+// Params can be a custom type that conforms to constraint
+app.get<{foo: string}>('/:foo', (req, res) => {
+    req.params.foo; // $ExpectType string
+    req.params.bar; // $ExpectError
+});

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -5,3 +5,14 @@ app.listen(3000);
 app.listen(3000, (err: any) => {
     // no-op error callback
 });
+
+app.get('/:foo', (req, res) => {
+    req.params.foo; // $ExpectType string
+    req.params[0]; // $ExpectType string
+});
+
+// Params can used as an array
+app.get<express.ParamsArray>('/*', (req, res) => {
+    req.params[0]; // $ExpectType string
+    req.params.length; // $ExpectType number
+});

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -18,7 +18,7 @@ app.get<express.ParamsArray>('/*', (req, res) => {
 });
 
 // Params can be a custom type that conforms to constraint
-app.get<{foo: string}>('/:foo', (req, res) => {
+app.get<{ foo: string }>('/:foo', (req, res) => {
     req.params.foo; // $ExpectType string
     req.params.bar; // $ExpectError
 });

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -22,3 +22,6 @@ app.get<{ foo: string }>('/:foo', req => {
     req.params.foo; // $ExpectType string
     req.params.bar; // $ExpectError
 });
+
+// Params cannot be a custom type that does not conform to constraint
+app.get<{ foo: number }>('/:foo', () => {}); // $ExpectError

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -7,7 +7,7 @@
 //                 Sami Jaber <https://github.com/samijaber>
 //                 aereal <https://github.com/aereal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 // This extracts the core definitions from express to prevent a circular dependency between express and serve-static
 /// <reference types="node" />
@@ -31,20 +31,25 @@ export interface NextFunction {
     (err?: any): void;
 }
 
-export interface RequestHandler {
+export interface Dictionary<T> { [key: string]: T; }
+export type ParamsDictionary = Dictionary<string>;
+export type ParamsArray = string[];
+export type Params = ParamsDictionary | ParamsArray;
+
+export interface RequestHandler<P extends Params = ParamsDictionary> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2
-    (req: Request, res: Response, next: NextFunction): any;
+    (req: Request<P>, res: Response, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler = (err: any, req: Request, res: Response, next: NextFunction) => any;
+export type ErrorRequestHandler<P extends Params = ParamsDictionary> = (err: any, req: Request<P>, res: Response, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams = RequestHandler | ErrorRequestHandler | Array<RequestHandler | ErrorRequestHandler>;
+export type RequestHandlerParams<P extends Params = ParamsDictionary> = RequestHandler<P> | ErrorRequestHandler<P> | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
 
 export interface IRouterMatcher<T> {
-    (path: PathParams, ...handlers: RequestHandler[]): T;
-    (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: RequestHandler<P>[]): T;
+    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: RequestHandlerParams<P>[]): T;
     (path: PathParams, subApplication: Application): T;
 }
 
@@ -181,7 +186,7 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
-export interface Request extends http.IncomingMessage, Express.Request {
+export interface Request<P extends Params = ParamsDictionary> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
      *
@@ -433,7 +438,7 @@ export interface Request extends http.IncomingMessage, Express.Request {
 
     method: string;
 
-    params: any;
+    params: P;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: any): Response;

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -181,11 +181,6 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
-export interface Dictionary<T> { [key: string]: T; }
-export type ParamsDictionary = Dictionary<string>;
-export type ParamsArray = string[];
-export type Params = ParamsDictionary | ParamsArray;
-
 export interface Request extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
@@ -438,7 +433,7 @@ export interface Request extends http.IncomingMessage, Express.Request {
 
     method: string;
 
-    params: Params;
+    params: any;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: any): Response;

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -49,9 +49,9 @@ export type PathParams = string | RegExp | Array<string | RegExp>;
 export type RequestHandlerParams<P extends Params = ParamsDictionary> = RequestHandler<P> | ErrorRequestHandler<P> | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
 
 export interface IRouterMatcher<T> {
-    // tslint:disable-next-line no-unnecessary-generics
+    // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
     <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: Array<RequestHandler<P>>): T;
-    // tslint:disable-next-line no-unnecessary-generics
+    // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
     <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: Array<RequestHandlerParams<P>>): T;
     (path: PathParams, subApplication: Application): T;
 }

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -192,8 +192,10 @@ export type Errback = (err: Error) => void;
 /**
  * @param P  For most requests, this should be `ParamsDictionary`, but if you're
  * using this in a route handler for a route that uses a `RegExp` or a wildcard
- * string paths (e.g. "/user/*"), then `req.params` will be an array, in which
- * case you should use `Request<ParamsArray>` instead.
+ * string path (e.g. `'/user/*'`), then `req.params` will be an array, in which
+ * case you should use `ParamsArray` instead.
+ *
+ * @see https://expressjs.com/en/api.html#req.params
  *
  * @example
  *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -189,6 +189,17 @@ export interface RequestRanges extends RangeParserRanges { }
 
 export type Errback = (err: Error) => void;
 
+/**
+ * @param P  For most requests, this should be `ParamsDictionary`, but if you're
+ * using this in a route handler for a route that uses a `RegExp` or a wildcard
+ * string paths (e.g. "/user/*"), then `req.params` will be an array, in which
+ * case you should use `Request<ParamsArray>` instead.
+ *
+ * @example
+ *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`
+ *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
+ *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
+ */
 export interface Request<P extends Params = ParamsDictionary> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -192,8 +192,8 @@ export type Errback = (err: Error) => void;
 /**
  * @param P  For most requests, this should be `ParamsDictionary`, but if you're
  * using this in a route handler for a route that uses a `RegExp` or a wildcard
- * string path (e.g. `'/user/*'`), then `req.params` will be an array, in which
- * case you should use `ParamsArray` instead.
+ * `string` path (e.g. `'/user/*'`), then `req.params` will be an array, in
+ * which case you should use `ParamsArray` instead.
  *
  * @see https://expressjs.com/en/api.html#req.params
  *

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -32,6 +32,7 @@ export interface NextFunction {
 }
 
 export interface Dictionary<T> { [key: string]: T; }
+
 export type ParamsDictionary = Dictionary<string>;
 export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -48,8 +48,10 @@ export type PathParams = string | RegExp | Array<string | RegExp>;
 export type RequestHandlerParams<P extends Params = ParamsDictionary> = RequestHandler<P> | ErrorRequestHandler<P> | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
 
 export interface IRouterMatcher<T> {
-    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: RequestHandler<P>[]): T;
-    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: RequestHandlerParams<P>[]): T;
+    // tslint:disable-next-line no-unnecessary-generics
+    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: Array<RequestHandler<P>>): T;
+    // tslint:disable-next-line no-unnecessary-generics
+    <P extends Params = ParamsDictionary>(path: PathParams, ...handlers: Array<RequestHandlerParams<P>>): T;
     (path: PathParams, subApplication: Application): T;
 }
 

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -5,7 +5,7 @@
 //                 Naoto Yokoyama <https://github.com/builtinnya>
 //                 Ryan Cannon <https://github.com/ry7n>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/express-sitemap-xml/index.d.ts
+++ b/types/express-sitemap-xml/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/feross/express-sitemap-xml
 // Definitions by: Florian Keller <https://github.com/ffflorian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/express-slow-down/index.d.ts
+++ b/types/express-slow-down/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfriedly/express-slow-down
 // Definitions by: Jeremy Forsythe <https://github.com/jdforsythe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require("express");
 

--- a/types/express-socket.io-session/index.d.ts
+++ b/types/express-socket.io-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oskosk/express-socket.io-session
 // Definitions by: AylaJK <https://github.com/AylaJK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import socketio = require('socket.io');
 import express = require('express');

--- a/types/express-sslify/index.d.ts
+++ b/types/express-sslify/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/florianheinemann/express-sslify
 // Definitions by: Ben Grynhaus <https://github.com/bengry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from 'express';
 

--- a/types/express-urlrewrite/index.d.ts
+++ b/types/express-urlrewrite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kapouer/express-urlrewrite
 // Definitions by: Melvin Groenhoff <https://github.com/mgroenhoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 

--- a/types/express-useragent/index.d.ts
+++ b/types/express-useragent/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.org/package/express-useragent
 // Definitions by: Isman Usoh <https://github.com/isman-usoh/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 

--- a/types/express-version-request/index.d.ts
+++ b/types/express-version-request/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lirantal/express-version-request
 // Definitions by: Rogelio Negrete <https://github.com/weffe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Handler, Request } from 'express';
 

--- a/types/express-version-route/index.d.ts
+++ b/types/express-version-route/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lirantal/express-version-route
 // Definitions by: Rogelio Negrete <https://github.com/weffe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Handler } from 'express';
 

--- a/types/express-wechat-access/index.d.ts
+++ b/types/express-wechat-access/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/simmons8616/express-wechat-access
 // Definitions by: Simmons Zhang <https://github.com/simmons8616>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bithavoc/express-winston#readme
 // Definitions by: Alex Brick <https://github.com/bricka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { ErrorRequestHandler, Handler, Request, Response } from 'express';
 import { Format } from 'logform';

--- a/types/express-ws/express-ws-tests.ts
+++ b/types/express-ws/express-ws-tests.ts
@@ -60,7 +60,7 @@ router.ws(
     '/:id',
     (ws, req, next) => { next(); },
     (ws, req, next) => {
-        ws.send((Array.isArray(req.params) ? {} : req.params).id);
+        ws.send(req.params.id);
 
         ws.on('close', (code, reason) => {
             console.log('code:', code);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -117,6 +117,18 @@ namespace express_tests {
         res.render('regular');
     });
 
+    // Params defaults to dictionary
+    router.get('/user/:id', (req, res, next) => {
+        req.params.id; // $ExpectType string
+        req.params[0]; // $ExpectType string
+    });
+
+    // Params can used as an array
+    router.get<ParamsArray>('/*', (req, res, next) => {
+        req.params[0]; // $ExpectType string
+        req.params.length; // $ExpectType number
+    });
+
     app.use((req, res, next) => {
         // hacky trick, router is just a handler
         router(req, res, next);
@@ -158,7 +170,7 @@ namespace express_tests {
  *                         *
  ***************************/
 import * as http from 'http';
-import { RequestRanges } from 'express-serve-static-core';
+import { RequestRanges, ParamsArray } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -132,7 +132,7 @@ namespace express_tests {
     });
 
     // Params can be a custom type that conforms to constraint
-    router.get<{foo: string}>('/:foo', (req, res) => {
+    router.get<{ foo: string }>('/:foo', (req, res) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectError
     });

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -118,7 +118,7 @@ namespace express_tests {
     });
 
     // Params defaults to dictionary
-    router.get('/user/:id', (req, res, next) => {
+    router.get('/:foo', (req, res, next) => {
         req.params.id; // $ExpectType string
         req.params[0]; // $ExpectType string
     });

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -131,6 +131,12 @@ namespace express_tests {
         req.params.length; // $ExpectType number
     });
 
+    // Params can be a custom type that conforms to constraint
+    router.get<{foo: string}>('/:foo', (req, res) => {
+        req.params.foo; // $ExpectType string
+        req.params.bar; // $ExpectError
+    });
+
     app.use((req, res, next) => {
         // hacky trick, router is just a handler
         router(req, res, next);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,4 +1,6 @@
 import express = require('express');
+import * as http from 'http';
+import { RequestRanges, ParamsArray } from 'express-serve-static-core';
 
 namespace express_tests {
     const app = express();
@@ -169,8 +171,6 @@ namespace express_tests {
  * Test with other modules *
  *                         *
  ***************************/
-import * as http from 'http';
-import { RequestRanges, ParamsArray } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -120,13 +120,13 @@ namespace express_tests {
     });
 
     // Params defaults to dictionary
-    router.get('/:foo', (req, res, next) => {
+    router.get('/:foo', (req, res) => {
         req.params.foo; // $ExpectType string
         req.params[0]; // $ExpectType string
     });
 
     // Params can used as an array
-    router.get<ParamsArray>('/*', (req, res, next) => {
+    router.get<ParamsArray>('/*', (req, res) => {
         req.params[0]; // $ExpectType string
         req.params.length; // $ExpectType number
     });

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -120,19 +120,19 @@ namespace express_tests {
     });
 
     // Params defaults to dictionary
-    router.get('/:foo', (req, res) => {
+    router.get('/:foo', req => {
         req.params.foo; // $ExpectType string
         req.params[0]; // $ExpectType string
     });
 
     // Params can used as an array
-    router.get<ParamsArray>('/*', (req, res) => {
+    router.get<ParamsArray>('/*', req => {
         req.params[0]; // $ExpectType string
         req.params.length; // $ExpectType number
     });
 
     // Params can be a custom type that conforms to constraint
-    router.get<{ foo: string }>('/:foo', (req, res) => {
+    router.get<{ foo: string }>('/:foo', req => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectError
     });

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -121,7 +121,7 @@ namespace express_tests {
 
     // Params defaults to dictionary
     router.get('/:foo', (req, res, next) => {
-        req.params.id; // $ExpectType string
+        req.params.foo; // $ExpectType string
         req.params[0]; // $ExpectType string
     });
 

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -137,6 +137,9 @@ namespace express_tests {
         req.params.bar; // $ExpectError
     });
 
+    // Params cannot be a custom type that does not conform to constraint
+    router.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
+
     app.use((req, res, next) => {
         // hacky trick, router is just a handler
         router(req, res, next);

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,5 +1,4 @@
 import express = require('express');
-import { RequestRanges, ParamsDictionary } from 'express-serve-static-core';
 
 namespace express_tests {
     const app = express();
@@ -112,8 +111,7 @@ namespace express_tests {
         });
 
     router.get('/user/:id', (req, res, next) => {
-        const paramsDictionary: ParamsDictionary = Array.isArray(req.params) ? {} : req.params;
-        if (Number(paramsDictionary.id) === 0) next('route');
+        if (Number(req.params.id) === 0) next('route');
         else next();
     }, (req, res, next) => {
         res.render('regular');
@@ -160,6 +158,7 @@ namespace express_tests {
  *                         *
  ***************************/
 import * as http from 'http';
+import { RequestRanges } from 'express-serve-static-core';
 
 namespace node_tests {
     {

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://expressjs.com
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/feathersjs__errors/index.d.ts
+++ b/types/feathersjs__errors/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 //                 RazzM13 <https://github.com/RazzM13>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export interface FeathersErrorJSON {
     readonly name: string;

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -4,7 +4,7 @@
 //                 Peter Squicciarini <https://github.com/stripedpajamas>
 //                 Alex Bulanov <https://github.com/sapfear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /**
  * @param status the status code

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export = createHttpError;
 

--- a/types/http-proxy-middleware/index.d.ts
+++ b/types/http-proxy-middleware/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Zebulon McCorkle <https://github.com/zebMcCorkle>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/i18n-abide/index.d.ts
+++ b/types/i18n-abide/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mozilla/i18n-abide
 // Definitions by: Steven Bell <https://github.com/smbell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from 'express';
 

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -205,7 +205,7 @@ app.get('/ar', (_req: Express.Request, res: Express.Response) => {
     i18n.setLocale(res, 'ar');
     i18n.setLocale(res.locals, 'ar');
 
-    i18n.setLocale([req, res.locals], (Array.isArray(req.params) ? {} : req.params).lang);
+    i18n.setLocale([req, res.locals], req.params.lang);
     i18n.setLocale(res, 'ar', true);
 });
 

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 //                 FindQ <https://github.com/FindQ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare namespace i18n {
     interface ConfigurationOptions {

--- a/types/json-server/index.d.ts
+++ b/types/json-server/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/typicode/json-server
 // Definitions by: Jeremy Bensimon <https://github.com/jeremyben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { NextHandleFunction } from 'connect';
 import { Application, RequestHandler, Router } from 'express';

--- a/types/jwt-express/index.d.ts
+++ b/types/jwt-express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/AustP/jwt-express#readme
 // Definitions by: Nick Paddock <https://github.com/nickp10>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/kraken-js/index.d.ts
+++ b/types/kraken-js/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Timur Manyanov <https://github.com/darkwebdev>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Express } from 'express';
 

--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -5,7 +5,7 @@
 //                 Christian D. <https://github.com/pc-jedi>
 //                 Budi Irawan <https://github.com/deerawan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/logfmt/index.d.ts
+++ b/types/logfmt/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/csquared/node-logfmt#readme
 // Definitions by: Evan Broder <https://github.com/ebroder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/lusca/index.d.ts
+++ b/types/lusca/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/krakenjs/lusca#readme
 // Definitions by: Corbin Crutchley <https://github.com/crutchcorn>, Naoto Yokoyama <https://github.com/builtinnya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 //                 Paolo Scanferla <https://github.com/pscanf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -4,7 +4,7 @@
 //                 Gal Talmor <https://github.com/galtalmor>
 //                 Matt Terski <https://github.com/terski>
 // Definitions: https://github.com/DefinitelyType/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as AWS from "aws-sdk";
 import { StorageEngine } from "multer";

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -7,7 +7,7 @@
 //                 HyunSeob Lee <https://github.com/hyunseob>
 //                 Pierre Tchuente <https://github.com/PierreTchuente>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/named-routes/index.d.ts
+++ b/types/named-routes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/alubbe/named-routes#readme
 // Definitions by: Philipp Katz <https://github.com/qqilihq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/oauth-shim/index.d.ts
+++ b/types/oauth-shim/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/MrSwitch/node-oauth-shim
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 

--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -5,7 +5,7 @@
 //                  Daniel Fischer <https://github.com/d-fischer>,
 //                  Vitor Santos <https://github.com/rvitorsantos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import Express = require("express");
 

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/oauth2orize/
 // Definitions by: Wonshik Kim <https://github.com/wokim>, Kei Son <https://github.com/heycalmdown>, Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="express" />

--- a/types/parcel-bundler/index.d.ts
+++ b/types/parcel-bundler/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: pinage404 <https://github.com/pinage404>
 //                 Nick Woodward <https://github.com/nick-woodward>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as http from 'http';
 import * as https from 'https';

--- a/types/qs-middleware/index.d.ts
+++ b/types/qs-middleware/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/springernature/qs-middleware
 // Definitions by: Dave Cardwell <https://github.com/davecardwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require("express");
 import qs = require("qs");

--- a/types/rebind-host/index.d.ts
+++ b/types/rebind-host/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/truffls/node-rebind-host#readme
 // Definitions by: Tyler Johnson <https://github.com/tyler-johnson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Handler } from "express";
 

--- a/types/response-time/index.d.ts
+++ b/types/response-time/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>, TonyYang <https://github.com/TonyPythoneer>
 //                 Dan Manastireanu <https://github.com/danmana>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 /* =================== USAGE ===================

--- a/types/saml2-js/index.d.ts
+++ b/types/saml2-js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Clever/saml2
 // Definitions by: horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare module "saml2-js" {
 

--- a/types/send/index.d.ts
+++ b/types/send/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pillarjs/send
 // Definitions by: Mike Jerred <https://github.com/MikeJerred>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/serve-favicon/index.d.ts
+++ b/types/serve-favicon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/serve-favicon
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/serve-index/index.d.ts
+++ b/types/serve-index/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/serve-index
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 //                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/session-file-store/index.d.ts
+++ b/types/session-file-store/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Gevik Babakhani <https://github.com/blendsdk>
 //                 Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 import * as session from "express-session";

--- a/types/socket.io.users/index.d.ts
+++ b/types/socket.io.users/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nodets/socket.io.users
 // Definitions by: Makis Maropoulos <https://github.com/kataras>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { EventEmitter } from 'events';
 import { Application } from "express";

--- a/types/steam-login/index.d.ts
+++ b/types/steam-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://github.com/cpancake/steam-login
 // Definitions by: Nick Winans <https://github.com/Nicell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Request, RequestHandler } from 'express';
 

--- a/types/sticky-cluster/index.d.ts
+++ b/types/sticky-cluster/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/uqee/sticky-cluster
 // Definitions by: Austin Turner <https://github.com/paustint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node"/>
 import * as http from 'http';

--- a/types/streaming-json-stringify/index.d.ts
+++ b/types/streaming-json-stringify/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/stream-utils/streaming-json-stringify#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import * as stream from 'stream';

--- a/types/strong-error-handler/index.d.ts
+++ b/types/strong-error-handler/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/strongloop/strong-error-handler
 // Definitions by: Jacob Copeland <https://github.com/blankstar85>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Daniel Grove <https://github.com/drGrove>
 //                 Neil Bryson Cargamento <https://github.com/neilbryson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/type-is/index.d.ts
+++ b/types/type-is/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jshttp/type-is#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import { IncomingMessage } from 'http';

--- a/types/universal-analytics/index.d.ts
+++ b/types/universal-analytics/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/peaksandpies/universal-analytics
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Iker Pérez Brunelli <https://github.com/DarkerTV>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare namespace ua {
     type Callback = (error: Error | null, count: number) => void;

--- a/types/vitalsigns/index.d.ts
+++ b/types/vitalsigns/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/TomFrost/node-vitalsigns
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 ///<reference types="express"/>
 

--- a/types/yog-bigpipe/index.d.ts
+++ b/types/yog-bigpipe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/fex-team/yog-bigpipe
 // Definitions by: ssddi456 <https://github.com/ssddi456>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { EventEmitter } from 'events';
 import { Readable } from 'stream';


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502, I corrected the type of params from `any` to `Dictionary<string> | Array<string>`.

Whilst this change was correct, it [broke a lot of people's code](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502#issuecomment-522140845), e.g.

``` ts
app.get('/:foo', (req, res) => {
    req.params.foo; // previously `any`, now an error
});
```

This is because the user [was now required to narrow the type of `req.params` from a union to a dictionary or array](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502#issuecomment-522155668), depending on the path they had provided to Express.

``` ts
app.get('/:foo', (req, res) => {
    if (!Array.isArray(req.params)) {
        req.params.foo; // string
    }
});

app.get('/*', (req, res) => {
    if (Array.isArray(req.params)) {
        req.params.length; // number
        req.params[0]; // string
    }
});
```

We can improve this by using generics to default the params type to a dictionary (which we assume is the most common use case for params), but still allow it to be changed to an array (via an explicit generic).

``` ts
import { ParamsArray } from 'express-serve-static-core';

// Params defaults to dictionary
app.get('/:foo', (req, res) => {
    req.params.foo; // string
    req.params[0]; // string
});

// Params can used as an array
app.get<ParamsArray>('/*', (req, res) => {
    req.params[0]; // string
    req.params.length; // number
});
```

Thanks to @jwalton for the idea: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37502#issuecomment-522315748

Note: I had to bump the TS version of Express and all its dependants because I needed to use default generics in the Express types.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
