### PR TITLE
mysql: ConnectionConfig.flags can be a string

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -557,7 +557,7 @@ export interface ConnectionConfig extends ConnectionOptions {
     /**
      * List of connection flags to use other than the default ones. It is also possible to blacklist default ones
      */
-    flags?: string[];
+    flags?: string | string[];
 
     /**
      * object with ssl parameters or a string containing name of ssl profile

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -431,3 +431,5 @@ connection = mysql.createConnection({debug: true});
 connection = mysql.createConnection({debug: ['ComQueryPacket', 'RowDataPacket']});
 connection = mysql.createConnection({dateStrings: ['DATE']});
 connection = mysql.createConnection({dateStrings: true});
+connection = mysql.createConnection({flags: '-FOUND_ROWS'});
+connection = mysql.createConnection({flags: ['-FOUND_ROWS']});


### PR DESCRIPTION
mysqljs/mysql [documents](https://github.com/mysqljs/mysql#connection-flags) connection flags to be a comma-separated string,
  although it also [accepts](https://github.com/mysqljs/mysql/blob/master/lib/ConnectionConfig.js#L146) an array of strings
sidorares/node-mysql2 [only accepts](https://github.com/sidorares/node-mysql2/blob/master/lib/connection_config.js#L155) a comma-separated string

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
