### PR TITLE
[reactstrap] Added range to list of allowable CustomInput types

### DIFF
--- a/types/reactstrap/lib/CustomInput.d.ts
+++ b/types/reactstrap/lib/CustomInput.d.ts
@@ -6,7 +6,8 @@ export type CustomInputType =
   | 'file'
   | 'radio'
   | 'checkbox'
-  | 'switch';
+  | 'switch'
+  | 'range';
 
 export interface CustomInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   [key: string]: any;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -4326,6 +4326,10 @@ class Example119 extends React.Component<any, any> {
           </CustomInput>
         </FormGroup>
         <FormGroup>
+          <Label for="exampleCustomRange">Custom Range</Label>
+          <CustomInput type="range" id="exampleCustomRange" name="customRange" />
+        </FormGroup>
+        <FormGroup>
           <Label for="exampleCustomFileBrowser">File Browser</Label>
           <CustomInput type="file" id="exampleCustomFileBrowser" name="customFile" />
         </FormGroup>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactstrap/reactstrap/pull/1601
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Custom ranges are part of Bootstrap 4 (https://getbootstrap.com/docs/4.3/components/forms/#range).  It is implemented in reactstrap, but is just missing in the documentation. I've submitted a PR to reactstrap to add an example into the documentation (https://github.com/reactstrap/reactstrap/pull/1601)
