### PR TITLE
koji-tools types

### DIFF
--- a/types/koji-tools/index.d.ts
+++ b/types/koji-tools/index.d.ts
@@ -10,14 +10,43 @@ export as namespace Koji;
 
 declare namespace Koji {
     // index.js methods
+
+    /**
+     * Server-side function that sets file watchers on all .koji customization
+     * files and allows for hot reloading of these properties.
+     */
+    function watch(): void;
+
     /**
      * Sets up Koji.config parameters for each client and handles communication
      * between the Koji live preview iframe and your app.
-     * @param options ???
      */
-    function pageLoad(options?: {}): void;
+    function pageLoad(options?: object): void;
 
-    function getConfig(): any;
+    /**
+     * Wrapper for fetch that takes objects from Koji.routes.
+     */
+    function request(route: object, params?: object): Promise<any>;
+
+    /**
+     * After the 'pwaPromptReady' event has fired, this function will make a popup
+     * installation prompt appear.
+     */
+    function pwaPrompt(): any;
+
+    /**
+     * An auto-generated list of all of the Koji Customization Controls (VCCs) your
+     * application has setup. When Koji.watch() is being used this list updates automatically.
+     */
+    const config: object;
+
+    /**
+     * A auto-generated list of routes based on koji.json files in your project that are
+     * used in Koji.request() to request the backend of your app.
+     */
+    const routes: object;
+
+    const pwa: any;
 
     /**
      * Registers a callback on a Koji event.
@@ -26,5 +55,9 @@ declare namespace Koji {
      */
     function on(event: string, callback: () => void): void;
 
-    function callEvent(event: string, params?: []): void;
+    /**
+     * Resolve the value of a user's secret from the Koji Keystore. Secrets are used for
+     * values that are not intended to be read by other users when a project is remixed.
+     */
+    function resolveSecret(key: string): string | null;
 }

--- a/types/koji-tools/index.d.ts
+++ b/types/koji-tools/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for koji-tools 0.5.1
+// Type definitions for koji-tools 0.5
 // Project: https://github.com/madewithkoji/koji-tools
-// Definitions by: Jeff Peterson <github.com/bdjeffyp>
+// Definitions by: Jeff Peterson <https://github.com/bdjeffyp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 // tslint:disable-next-line:export-just-namespace
 export = Koji;

--- a/types/koji-tools/index.d.ts
+++ b/types/koji-tools/index.d.ts
@@ -8,22 +8,22 @@ export = Koji;
 export as namespace Koji;
 
 declare namespace Koji {
-  // index.js methods
-  /**
-   * Sets up Koji.config parameters for each client and handles communication
-   * between the Koji live preview iframe and your app.
-   * @param options ???
-   */
-  function pageLoad(options?: {}): void;
+    // index.js methods
+    /**
+     * Sets up Koji.config parameters for each client and handles communication
+     * between the Koji live preview iframe and your app.
+     * @param options ???
+     */
+    function pageLoad(options?: {}): void;
 
-  function getConfig(): any;
+    function getConfig(): any;
 
-  /**
-   * Registers a callback on a Koji event.
-   * @param event name of the event being called
-   * @param callback method to execute when the event occurs
-   */
-  function on(event: string, callback: () => void): void;
+    /**
+     * Registers a callback on a Koji event.
+     * @param event name of the event being called
+     * @param callback method to execute when the event occurs
+     */
+    function on(event: string, callback: () => void): void;
 
-  function callEvent(event: string, params?: []): void;
+    function callEvent(event: string, params?: []): void;
 }

--- a/types/koji-tools/index.d.ts
+++ b/types/koji-tools/index.d.ts
@@ -4,60 +4,52 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-// tslint:disable-next-line:export-just-namespace
-export = Koji;
-export as namespace Koji;
+/**
+ * Server-side function that sets file watchers on all .koji customization
+ * files and allows for hot reloading of these properties.
+ */
+export function watch(): void;
 
-declare namespace Koji {
-    // index.js methods
+/**
+ * Sets up Koji.config parameters for each client and handles communication
+ * between the Koji live preview iframe and your app.
+ */
+export function pageLoad(options?: object): void;
 
-    /**
-     * Server-side function that sets file watchers on all .koji customization
-     * files and allows for hot reloading of these properties.
-     */
-    function watch(): void;
+/**
+ * Wrapper for fetch that takes objects from Koji.routes.
+ */
+export function request(route: object, params?: object): Promise<any>;
 
-    /**
-     * Sets up Koji.config parameters for each client and handles communication
-     * between the Koji live preview iframe and your app.
-     */
-    function pageLoad(options?: object): void;
+/**
+ * After the 'pwaPromptReady' event has fired, this function will make a popup
+ * installation prompt appear.
+ */
+export function pwaPrompt(): any;
 
-    /**
-     * Wrapper for fetch that takes objects from Koji.routes.
-     */
-    function request(route: object, params?: object): Promise<any>;
+/**
+ * An auto-generated list of all of the Koji Customization Controls (VCCs) your
+ * application has setup. When Koji.watch() is being used this list updates automatically.
+ */
+export const config: object;
 
-    /**
-     * After the 'pwaPromptReady' event has fired, this function will make a popup
-     * installation prompt appear.
-     */
-    function pwaPrompt(): any;
+/**
+ * A auto-generated list of routes based on koji.json files in your project that are
+ * used in Koji.request() to request the backend of your app.
+ */
+export const routes: object;
 
-    /**
-     * An auto-generated list of all of the Koji Customization Controls (VCCs) your
-     * application has setup. When Koji.watch() is being used this list updates automatically.
-     */
-    const config: object;
+export const pwa: any;
 
-    /**
-     * A auto-generated list of routes based on koji.json files in your project that are
-     * used in Koji.request() to request the backend of your app.
-     */
-    const routes: object;
+/**
+ * Registers a callback on a Koji event.
+ * @param event name of the event being called
+ * @param callback method to execute when the event occurs
+ */
+export function on(event: string, callback: () => void): void;
 
-    const pwa: any;
-
-    /**
-     * Registers a callback on a Koji event.
-     * @param event name of the event being called
-     * @param callback method to execute when the event occurs
-     */
-    function on(event: string, callback: () => void): void;
-
-    /**
-     * Resolve the value of a user's secret from the Koji Keystore. Secrets are used for
-     * values that are not intended to be read by other users when a project is remixed.
-     */
-    function resolveSecret(key: string): string | null;
-}
+/**
+ * Resolve the value of a user's secret from the Koji Keystore. Secrets are used for
+ * values that are not intended to be read by other users when a project is remixed.
+ */
+export function resolveSecret(key: string): string | null;

--- a/types/koji-tools/index.d.ts
+++ b/types/koji-tools/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for koji-tools 0.5.1
+// Project: https://github.com/madewithkoji/koji-tools
+// Definitions by: Jeff Peterson <github.com/bdjeffyp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// tslint:disable-next-line:export-just-namespace
+export = Koji;
+export as namespace Koji;
+
+declare namespace Koji {
+  // index.js methods
+  /**
+   * Sets up Koji.config parameters for each client and handles communication
+   * between the Koji live preview iframe and your app.
+   * @param options ???
+   */
+  function pageLoad(options?: {}): void;
+
+  function getConfig(): any;
+
+  /**
+   * Registers a callback on a Koji event.
+   * @param event name of the event being called
+   * @param callback method to execute when the event occurs
+   */
+  function on(event: string, callback: () => void): void;
+
+  function callEvent(event: string, params?: []): void;
+}

--- a/types/koji-tools/koji-tools-tests.ts
+++ b/types/koji-tools/koji-tools-tests.ts
@@ -1,6 +1,11 @@
-import * as Koji from 'koji-tools';
+import * as Koji from "koji-tools";
 
+Koji.watch();
 Koji.pageLoad();
-Koji.getConfig();
-Koji.on("test", () => {});
-Koji.callEvent("test");
+Koji.request({ url: "www.test.org" });
+Koji.pwaPrompt();
+const myConfig = Koji.config;
+const myRoutes = Koji.routes;
+const myPwaInstaller = Koji.pwa;
+Koji.on("test", () => "Hello, world!");
+const mySecret = Koji.resolveSecret("verySecretKey");

--- a/types/koji-tools/koji-tools-tests.ts
+++ b/types/koji-tools/koji-tools-tests.ts
@@ -1,0 +1,6 @@
+import * as Koji from 'koji-tools';
+
+Koji.pageLoad();
+Koji.getConfig();
+Koji.on("test", () => {});
+Koji.callEvent("test");

--- a/types/koji-tools/koji-tools-tests.ts
+++ b/types/koji-tools/koji-tools-tests.ts
@@ -1,11 +1,11 @@
-import * as Koji from "koji-tools";
+import * as Koji from 'koji-tools';
 
 Koji.watch();
 Koji.pageLoad();
-Koji.request({ url: "www.test.org" });
+Koji.request({ url: 'www.test.org' });
 Koji.pwaPrompt();
 const myConfig = Koji.config;
 const myRoutes = Koji.routes;
 const myPwaInstaller = Koji.pwa;
-Koji.on("test", () => "Hello, world!");
-const mySecret = Koji.resolveSecret("verySecretKey");
+Koji.on('test', () => 'Hello, world!');
+const mySecret = Koji.resolveSecret('verySecretKey');

--- a/types/koji-tools/tsconfig.json
+++ b/types/koji-tools/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "koji-tools-tests.ts"
+    ]
+}

--- a/types/koji-tools/tslint.json
+++ b/types/koji-tools/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
