### PR TITLE
[@types/ramda] Update definition for `flatten` function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1408,7 +1408,9 @@ declare namespace R {
          * Returns a new list by pulling every item out of it (and all its sub-arrays) and putting
          * them in a new array, depth-first.
          */
-        flatten<T>(x: ReadonlyArray<T[]> | ReadonlyArray<ReadonlyArray<T>> | ReadonlyArray<T>): T[];
+        flatten<T>(x: ReadonlyArray<T[]>): T[];
+        flatten<T>(x:  ReadonlyArray<ReadonlyArray<T>>): T[];
+        flatten<T>(x: ReadonlyArray<T>): T[];
 
         /**
          * Returns a new function much like the supplied one, except that the first two arguments'


### PR DESCRIPTION
When I use `R.flatten` function, it shows the error as follows:

![image](https://user-images.githubusercontent.com/8966348/63236557-c2182a00-c270-11e9-972c-de404e567352.png)

The function type is a mismatch. So I checked the type definition:

```ts
flatten<T>(x: ReadonlyArray<T[]> | ReadonlyArray<ReadonlyArray<T>> | ReadonlyArray<T>): T[];
```

I think we should use type reload to define this function:

```ts
flatten<T>(x: ReadonlyArray<T[]>): T[];
flatten<T>(x:  ReadonlyArray<ReadonlyArray<T>>): T[];
flatten<T>(x: ReadonlyArray<T>): T[];
```


