### PR TITLE
[promise-sftp] Return array from list()

### DIFF
--- a/types/promise-sftp/index.d.ts
+++ b/types/promise-sftp/index.d.ts
@@ -234,10 +234,10 @@ declare class PromiseSftp {
      * Retrieves a directory listing.
      * @param path - The path of the directory to get the listing of.
      */
-    list(path?: string): Promise<PromiseSftp.DirectoryListing>;
+    list(path?: string): Promise<PromiseSftp.DirectoryListing[]>;
 
     /** Alias to `#list()` */
-    listSafe(path: string): Promise<PromiseSftp.DirectoryListing>;
+    listSafe(path: string): Promise<PromiseSftp.DirectoryListing[]>;
 
     /**
      * Retrieve a file from the server.

--- a/types/promise-sftp/promise-sftp-tests.ts
+++ b/types/promise-sftp/promise-sftp-tests.ts
@@ -5,5 +5,8 @@ const sftp = new PromiseSftp();
 // $ExpectType () => boolean
 sftp.destroy;
 
+// $ExpectType Bluebird<DirectoryListing[]>
+sftp.list();
+
 // $ExpectType typeof STATUSES
 PromiseSftp.STATUSES;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint promise-sftp` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/realtymaps/promise-sftp

> `list([path <string>])`: Retrieves the directory listing of path. path defaults to '.'. Returned promise resolves to an array of objects with these properties: ...
