### PR TITLE
node-cleanup: Allow handler returning void

### DIFF
--- a/types/node-cleanup/index.d.ts
+++ b/types/node-cleanup/index.d.ts
@@ -9,7 +9,7 @@
 
 export = install;
 
-declare function install(cleanupHandler?: ((exitCode: number | null, signal: string | null) => boolean | undefined),
+declare function install(cleanupHandler?: ((exitCode: number | null, signal: string | null) => boolean | undefined | void),
                          stderrMessages?: { ctrl_C: string; uncaughtException: string }): void;
 
 declare namespace install {

--- a/types/node-cleanup/node-cleanup-tests.ts
+++ b/types/node-cleanup/node-cleanup-tests.ts
@@ -3,11 +3,15 @@ import nodeCleanup = require('node-cleanup');
 function cleanupHandler(exitCode: number | null, signal: string | null): boolean | undefined {
   return true;
 }
+function voidHandler(): void {
+  // do nothing
+}
 const stderrMessages = { ctrl_C: 'ctrl_c', uncaughtException: 'UncaughtException' };
 
 nodeCleanup();
 nodeCleanup(cleanupHandler);
 nodeCleanup(cleanupHandler, undefined);
 nodeCleanup(cleanupHandler, stderrMessages);
+nodeCleanup(voidHandler);
 nodeCleanup(undefined, stderrMessages);
 nodeCleanup.uninstall();


### PR DESCRIPTION
node-cleanup accepts even handlers that doesn't return anything. The current type defintion is unnecessarily strict.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.