### PR TITLE
Allow Lottie `loop` attribute to be type number

### DIFF
--- a/types/react-lottie/index.d.ts
+++ b/types/react-lottie/index.d.ts
@@ -10,8 +10,9 @@ import * as React from 'react';
 export interface Options {
     /**
      * Defines if the animation should play only once or repeatedly in an endless loop
+     * or the number of loops that should be completed before the animation ends
      */
-    loop?: boolean;
+    loop?: boolean | number;
     /**
      * Defines if the animation should immediately play when the component enters the DOM
      */


### PR DESCRIPTION
Loop attribute can be a boolean or number: https://github.com/airbnb/lottie-web/blob/master/index.d.ts#L53
