### PR TITLE
[selenium-webdriver] Add headless function for Firefox Options

### DIFF
--- a/types/selenium-webdriver/firefox.d.ts
+++ b/types/selenium-webdriver/firefox.d.ts
@@ -41,6 +41,12 @@ export class Options extends webdriver.Capabilities {
    * @see https://github.com/mozilla/geckodriver
    */
   useGeckoDriver(enable: boolean): Options;
+
+  /**
+   * Configures the geckodriver to start Firefox in headless mode.
+   * @return {!Options} A self reference.
+   */
+  headless(): Options
 }
 
 /**

--- a/types/selenium-webdriver/test/firefox.ts
+++ b/types/selenium-webdriver/test/firefox.ts
@@ -18,6 +18,7 @@ function TestFirefoxOptions() {
     options = options.setBinary('binary');
     options = options.setProfile('profile');
     options = options.setProxy({ proxyType: 'proxy' });
+    options = options.headless();
 }
 
 function TestServiceBuilder() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/firefox_exports_Options.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
