### PR TITLE
Node: Adds pnp to the process.versions field

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -696,6 +696,7 @@ declare namespace NodeJS {
         zlib: string;
         modules: string;
         openssl: string;
+        pnp?: string;
     }
 
     type Platform = 'aix'

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -631,6 +631,7 @@ declare namespace NodeJS {
         zlib: string;
         modules: string;
         openssl: string;
+        pnp?: string;
     }
 
     type Platform = 'aix'

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -664,6 +664,7 @@ declare namespace NodeJS {
         zlib: string;
         modules: string;
         openssl: string;
+        pnp?: string;
     }
 
     type Platform = 'aix'

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -469,6 +469,7 @@ declare namespace NodeJS {
         zlib: string;
         modules: string;
         openssl: string;
+        pnp?: string;
     }
 
     type Platform = 'aix'

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -606,6 +606,7 @@ declare namespace NodeJS {
         zlib: string;
         modules: string;
         openssl: string;
+        pnp?: string;
     }
 
     type Platform = 'aix'


### PR DESCRIPTION
Context: The PnP hook generated by Yarn injects a `pnp` variable into the `process.versions` object. This field is used by JS packages to branch their behavior if needed. I haven't documented it yet on our website, but a few packages already use it.

This isn't a Node feature per-se, but it's a very small change so I figured why not 🙂 An alternative would be to type the field with an generic index: `[key: string]: string`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yarnpkg/berry/blob/master/packages/berry-pnp/sources/loader/applyPatch.ts#L84
