### PR TITLE
Edit rsocket-websocket-client ClientOptions typings

### DIFF
--- a/types/rsocket-websocket-client/RSocketWebSocketClient.d.ts
+++ b/types/rsocket-websocket-client/RSocketWebSocketClient.d.ts
@@ -12,15 +12,22 @@ import {
 } from 'rsocket-core';
 import * as ws from 'ws';
 
+export interface ClientOptions {
+    url: string;
+    wsCreator?: (url: string) => WebSocket;
+    debug?: boolean;
+    lengthPrefixedFrames?: boolean;
+}
+
 /**
  * A WebSocket transport client for use in browser environments.
  */
 export default class RSocketWebSocketClient implements DuplexConnection {
-  constructor(options: ws.ClientOptions, encoders?: Encoders<any>)
-  close(): void;
-  connect(): void;
-  connectionStatus(): Flowable<ConnectionStatus>;
-  receive(): Flowable<Frame>;
-  sendOne(frame: Frame): void;
-  send(frames: Flowable<Frame>): void;
-}
+                   constructor(options: ClientOptions, encoders?: Encoders<any>);
+                   close(): void;
+                   connect(): void;
+                   connectionStatus(): Flowable<ConnectionStatus>;
+                   receive(): Flowable<Frame>;
+                   sendOne(frame: Frame): void;
+                   send(frames: Flowable<Frame>): void;
+               }

--- a/types/rsocket-websocket-client/index.d.ts
+++ b/types/rsocket-websocket-client/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for rsocket-websocket-client 0.0
 // Project: https://github.com/rsocket/rsocket-js/
 // Definitions by: Adrian Hope-Bailie <https://github.com/adrianhopebailie>
+//                 Bryce Matheson <https://github.com/brycematheson1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
The source code for `rsocket-websocket-client` [here](https://github.com/rsocket/rsocket-js/blob/master/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js#L36) indicates what the typing of `ClientOptions` _should_ be.