### PR TITLE
fix(react-native-material-ui): add missing testID prop to some components

### DIFF
--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-material-ui 1.31
+// Type definitions for react-native-material-ui 1.32
 // Project: https://github.com/xotahal/react-native-material-ui
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -85,6 +85,7 @@ export interface BottomNavigationProps {
 export class BottomNavigation extends Component<BottomNavigationProps, any> {}
 
 export interface BottomNavigationAction {
+    testID?: string;
     icon: JSX.Element | string;
     label?: string;
     key?: string;
@@ -103,6 +104,7 @@ export namespace BottomNavigation {
 }
 
 export interface ButtonProps {
+    testID?: string;
     text: string;
     primary?: boolean;
     accent?: boolean;
@@ -320,6 +322,7 @@ export interface IconProps {
 export class Icon extends Component<IconProps, any> {}
 
 export interface IconToggleProps {
+    testID?: string;
     color?: string;
     underlayColor?: string;
     maxOpacity?: number;
@@ -364,6 +367,7 @@ export interface ListItemStyle {
 }
 
 export interface ListItemProps {
+    testID?: string;
     numberOfLines?: 1 | 2 | 3 | 'dynamic';
     leftElement?: JSX.Element | string;
     rightElement?: JSX.Element | string;

--- a/types/react-native-material-ui/react-native-material-ui-tests.tsx
+++ b/types/react-native-material-ui/react-native-material-ui-tests.tsx
@@ -13,6 +13,7 @@ import {
     DialogDefaultActions,
     BottomNavigation,
     Toolbar,
+    IconToggle,
     getTheme
 } from 'react-native-material-ui';
 
@@ -26,7 +27,7 @@ const theme = {
 
 const Example = () =>
     <ThemeContext.Provider value={getTheme(theme)}>
-        <View>
+        <View testID="viewTestID">
             <ActionButton style={{ positionContainer: { marginBottom: 3 }}} />
             <ActionButton icon="done" />
 
@@ -38,7 +39,8 @@ const Example = () =>
 
             <Badge />
 
-            <Button text="I'm a button" />
+            <IconToggle testID="iconToggleTestID" name="anIconToggle" />
+            <Button testID="buttonTestID" text="I'm a button" />
 
             <Card>
                 <ThemeContext.Consumer>
@@ -77,8 +79,9 @@ class BottomNavigationExample extends React.Component<null, {active: string}> {
 
     render() {
         return (
-            <BottomNavigation active={this.state.active} hidden={false} >
+            <BottomNavigation active={this.state.active} hidden={false}>
                 <BottomNavigation.Action
+                    testID="bottomNavActionTestID"
                     key="today"
                     icon="today"
                     label="Today"


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xotahal/react-native-material-ui/search?q=testID&unscoped_q=testID
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


### NOTES
I bumped the version to `1.32` but there's no such release.