### PR TITLE
[@types/carbon-components-react] Type updates for 7.5 + DataTable type fixes.

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { DataTable, DataTableHeader, DataTableRow } from 'carbon-components-react';
+import {
+    DataTable,
+    DataTableHeader,
+    DataTableRow,
+    Table,
+    TableBatchActions,
+    TableHeader,
+    TableRow,
+} from 'carbon-components-react';
 
 interface Row1 extends DataTableRow {
     rowProp: string;
@@ -75,13 +83,48 @@ const t2 = (
 );
 
 // No types explicitly set on DataTable props
-const row = { id: '2', someRandomRowProp: 'test' };
+const rowData1 = { id: '2', someRandomRowProp: 'test' };
 const t3 = (
     <DataTable
         headers={[{ key: '1', header: 'Test', someRandomHeaderProp: 'test' }]}
-        rows={[row]}
+        rows={[rowData1]}
         render={data => {
-            let rowProps = data.getRowProps({ row, extra1: 'qwerty', ...row });
+            let rowProps = data.getRowProps({ row: rowData1, extra1: 'qwerty', ...rowData1 });
+            let a = rowProps.extra1;
+            let b = rowProps.someRandomRowProp;
+            return <div />;
+        }}
+    />
+);
+
+const headerData1 = { key: '1', header: 'Test', someRandomHeaderProp: 'test' };
+const t4 = (
+    <DataTable
+        headers={[headerData1]}
+        rows={[rowData1]}
+        render={data => {
+            let table = (<Table {...data.getTableProps()}>Content</Table>);
+            let header = (
+                <TableHeader {...data.getHeaderProps({ header: headerData1, randomAttr: "asdf" })}>
+                    {headerData1.header}
+                </TableHeader>
+            );
+            let header2 = (
+                <TableHeader {...data.getHeaderProps<ExtraStuff>({ header: headerData1, extra1: "test" })}>
+                    {headerData1.header}
+                </TableHeader>
+            );
+            let rowProps = data.getRowProps({ row: rowData1, extra1: 'qwerty', ...rowData1 });
+            let row = (
+                <TableRow {...rowProps}>
+                    Content
+                </TableRow>
+            );
+            let batchActions = (
+                <TableBatchActions {...data.getBatchActionProps({ spellCheck: true, randomAttr: "Asdf" })}>
+                    Content
+                </TableBatchActions>
+            );
             let a = rowProps.extra1;
             let b = rowProps.someRandomRowProp;
             return <div />;

--- a/types/carbon-components-react/components/DataTable/DataTable.d.ts
+++ b/types/carbon-components-react/components/DataTable/DataTable.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { InternationalProps, ShapeOf } from "../../typings/shared";
 import { DataTableSortState, DataTableSortStates } from "./state/sorting";
-import Table from "./Table";
+import Table, { TableCarbonProps } from "./Table";
 import TableActionList from "./TableActionList";
 import TableBatchAction from "./TableBatchAction";
 import TableBatchActions from "./TableBatchActions";
@@ -126,15 +126,6 @@ export interface DataTableCustomBatchActionsProps {
 
 // region DataTable
 
-export type DataTableSize = "compact" | "normal" | "short" | "tall";
-export interface DataTableExposedProps {
-    isSortable?: boolean,
-    shouldShowBorder?: boolean,
-    size?: DataTableSize,
-    useStaticWidth?: boolean,
-    useZebraStyles?: boolean,
-}
-
 // Custom Render Props
 export interface DataTableCustomRenderProps<
     R extends DataTableRow = DataTableRow,
@@ -153,7 +144,7 @@ export interface DataTableCustomRenderProps<
     getSelectionProps<E extends object = {}>(
         data?: ShapeOf<DataTableCustomSelectionData<R>, E>
     ): ShapeOf<DataTableCustomSelectionProps<R>, E> | ShapeOf<DataTableCustomSelectionProps<never>, E>;
-    getTableProps(): DataTableExposedProps;
+    getTableProps(): TableCarbonProps;
     headers: DataTableProps<R, H>['headers'];
     onInputChange(event: React.SyntheticEvent<HTMLInputElement>): void;
     radio?: DataTableProps<R, H>['radio'];
@@ -172,7 +163,7 @@ export type DataTableTranslationKey =
     | "carbon.table.row.select"
     | "carbon.table.row.unselect";
 
-interface DataTableInheritedProps extends InternationalProps<DataTableTranslationKey>, DataTableExposedProps { }
+interface DataTableInheritedProps extends InternationalProps<DataTableTranslationKey>, TableCarbonProps { }
 
 export interface DataTableProps<R extends DataTableRow = DataTableRow, H extends DataTableHeader = DataTableHeader>
     extends DataTableInheritedProps {

--- a/types/carbon-components-react/components/DataTable/DataTable.d.ts
+++ b/types/carbon-components-react/components/DataTable/DataTable.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { InternationalProps, ShapeOf } from "../../typings/shared";
+import { InternationalProps, ReactAttr, ReactDivAttr, ShapeOf } from '../../typings/shared';
 import { DataTableSortState, DataTableSortStates } from "./state/sorting";
 import Table, { TableCarbonProps } from "./Table";
 import TableActionList from "./TableActionList";
@@ -132,13 +132,13 @@ export interface DataTableCustomRenderProps<
     H extends DataTableHeader = DataTableHeader
 > {
     expandRow(rowId: R['id']): void;
-    getBatchActionProps<E extends object = {}>(
+    getBatchActionProps<E extends object = ReactDivAttr>(
         data?: ShapeOf<DataTableCustomBatchActionsData, E>
     ): ShapeOf<DataTableCustomBatchActionsProps, E>;
-    getHeaderProps<E extends object = {}>(
+    getHeaderProps<E extends object = ReactAttr>(
         data: ShapeOf<DataTableCustomHeaderData<H>, E>
     ): ShapeOf<DataTableCustomHeaderProps<H>, E>;
-    getRowProps<E extends object = {}>(
+    getRowProps<E extends object = ReactAttr<HTMLTableRowElement>>(
         data: ShapeOf<DataTableCustomRowData<R>, E>
     ): ShapeOf<DataTableCustomRowProps<R>, E>;
     getSelectionProps<E extends object = {}>(

--- a/types/carbon-components-react/components/DataTable/Table.d.ts
+++ b/types/carbon-components-react/components/DataTable/Table.d.ts
@@ -2,13 +2,17 @@ import * as React from "react";
 
 interface InheritedProps extends React.TableHTMLAttributes<HTMLTableElement> { }
 
-export interface TableProps extends InheritedProps {
+export type DataTableSize = "compact" | "normal" | "short" | "tall";
+
+export interface TableCarbonProps {
     isSortable?: boolean,
     shouldShowBorder?: boolean,
-    size?: "compact" | "normal" | "small" | "tall",
+    size?: DataTableSize,
     useStaticWidth?: boolean,
     useZebraStyles?: boolean,
 }
+
+export interface TableProps extends InheritedProps, TableCarbonProps { }
 
 declare const Table: React.FC<TableProps>;
 

--- a/types/carbon-components-react/components/DataTable/TableHeader.d.ts
+++ b/types/carbon-components-react/components/DataTable/TableHeader.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { InternationalProps, ReactButtonAttr } from "../../typings/shared";
+import { DataTableSortState } from './state/sorting';
 
 export type TableHeaderTranslationKey = "carbon.table.header.icon.description";
 interface InheritedProps extends
@@ -9,11 +10,10 @@ interface InheritedProps extends
     scope?: React.ThHTMLAttributes<any>["scope"],
 }
 
-export type SortDirection = "ascending" | "descending" | "none";
 export interface TableHeaderProps extends InheritedProps {
     isSortable?: boolean,
     isSortHeader?: boolean,
-    sortDirection?: SortDirection,
+    sortDirection?: DataTableSortState,
 }
 
 interface TableHeaderFC extends React.FC<TableHeaderProps> {

--- a/types/carbon-components-react/components/FileUploader/FileUploader.d.ts
+++ b/types/carbon-components-react/components/FileUploader/FileUploader.d.ts
@@ -7,7 +7,7 @@ interface SharedProps {
     buttonKind?: ButtonKind,
     disabled?: ReactInputAttr["disabled"],
     disableLabelChanges?: boolean,
-    labelText?: string
+    labelText?: React.ReactNode,
     listFiles?: boolean,
     multiple?: boolean,
 }

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.4
+// Type definitions for carbon-components-react 7.5
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -288,3 +288,5 @@ export { _ToggleSkeleton as ToggleSkeleton };
 export { _ToggleSmallSkeleton as ToggleSmallSkeleton };
 export { _IconSkeleton as IconSkeleton };
 export { _DatePickerSkeleton as DatePickerSkeleton };
+
+export * from "./typings/translation";

--- a/types/carbon-components-react/typings/translation.d.ts
+++ b/types/carbon-components-react/typings/translation.d.ts
@@ -1,0 +1,22 @@
+import {
+    DataTableTranslationKey,
+    TableBatchActionsTranslationKey,
+    TableHeaderTranslationKey,
+    TableToolbarTranslationKey,
+} from '../components/DataTable';
+import { ListBoxFieldTranslationKey } from '../components/ListBox/ListBoxField';
+import { ListBoxMenuIconTranslationKey } from '../components/ListBox/ListBoxMenuIcon';
+import { ListBoxSelectionTranslationKey } from '../components/ListBox/ListBoxSelection';
+import { NumberInputTranslationKey } from '../components/NumberInput';
+import { SideNavTranslationKey } from '../components/UIShell/SideNav';
+
+export type CarbonTranslationKey =
+    DataTableTranslationKey
+    | ListBoxFieldTranslationKey
+    | ListBoxMenuIconTranslationKey
+    | ListBoxSelectionTranslationKey
+    | NumberInputTranslationKey
+    | SideNavTranslationKey
+    | TableBatchActionsTranslationKey
+    | TableHeaderTranslationKey
+    | TableToolbarTranslationKey;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/master/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
