### PR TITLE
[@types/stripe-v3] Support `payment_method` and `source` on PaymentIntent operations

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -467,6 +467,11 @@ declare namespace stripe {
                 token: string;
             }
         };
+        /**
+         * Instead of payment_method, the ID of a Source may be passed in.
+         * (Note that this is undocumented as of August 2019).
+         */
+       source?: string;
     }
     interface HandleCardSetupOptions {
         /**
@@ -933,6 +938,11 @@ declare namespace stripe {
             on_behalf_of: string | null;
 
             /**
+             * ID of the payment method used in this PaymentIntent.
+             */
+            payment_method: string | null;
+
+            /**
              * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
              */
             payment_method_types: string[];
@@ -951,6 +961,13 @@ declare namespace stripe {
              * Shipping information for this PaymentIntent.
              */
             shipping: ShippingDetails | null;
+
+            /**
+             * The ID of a Source (e.g. 'src_abc123' or 'card_abc123').
+             * Will be null unless this PaymentIntent was created with a source
+             * instead of a payment_method. (Undocumented as of August 2019)
+             */
+            source: string | null;
 
             /**
              * Extra information about a PaymentIntent. This will appear on your

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -257,6 +257,18 @@ describe("Stripe elements", () => {
                 console.log(result.paymentIntent.shipping && result.paymentIntent.shipping.address);
             }
         });
+
+        stripe
+          .handleCardPayment('{PAYMENT_INTENT_CLIENT_SECRET}', {
+            source: '{SOURCE_ID}',
+          })
+          .then(result => {
+            if (result.error) {
+              console.error(result.error.message);
+            } else if (result.paymentIntent) {
+              console.log(result.paymentIntent.source);
+            }
+          });
     });
 
     it("should handle card setup", () => {


### PR DESCRIPTION
### Summary

The `source` attribute is supported instead of `payment_method`. Although the [stripe docs for `PaymentIntent`] do not list it as an official attribute, you can see that it's returned in the example `GET PaymentIntent` response:

<img width="922" alt="Screen Shot 2019-08-20 at 2 19 21 PM" src="https://user-images.githubusercontent.com/319655/63376643-472c3d80-c35c-11e9-89a5-d5e130b44b23.png">

`PaymentIntent` is a new Stripe API, so it seems like they just haven't updated their docs yet.

### Template checklist 👇 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
