### PR TITLE
TabulatorTables: allow columnDefinition and removed "required" from title (in ColumnLayout)

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -831,10 +831,11 @@ declare namespace Tabulator {
     }
 
     interface ColumnLayout {
+        columns?: ColumnDefinition[];
         /** title - Required This is the title that will be displayed in the header for this column */
         title: string;
         /** field - Required (not required in icon/button columns) this is the key for this column in the data array*/
-        field: string;
+        field?: string;
         /** visible - (boolean, default - true) determines if the column is visible. (see Column Visibility for more details */
         visible?: boolean;
 


### PR DESCRIPTION
Allow columnDefinition in ColumnLayout: this allows to have "grouped" columns (Example: measurement group contains L W H).
Removed "required" from ColumnLayout.field: as comment says this is not required in icon/button columns, or group column (first edit in this commit). Comments says not required but field has missing '?'.

