### PR TITLE
[spotify-web-api-node] Added doc comments to api methods and some reponse interfaces

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -1057,12 +1057,20 @@ interface GetFeaturedPlaylistsOptions extends PaginationLocaleOptions {
     timestamp?: string;
 }
 
+/**
+ * Response returned when using Client Credentials authentication flow
+ * https://developer.spotify.com/documentation/general/guides/authorization-guide/#example-4
+ */
 interface ClientCredentialsGrantResponse {
     access_token: string;
     expires_in: number;
     token_type: string;
 }
 
+/**
+ * Response returned when requesting for access token
+ * https://developer.spotify.com/documentation/general/guides/authorization-guide/#2-have-your-application-request-refresh-and-access-tokens-spotify-returns-access-and-refresh-tokens
+ */
 interface AuthorizationCodeGrantResponse {
     access_token: string;
     expires_in: number;
@@ -1071,6 +1079,10 @@ interface AuthorizationCodeGrantResponse {
     token_type: string;
 }
 
+/**
+ * Response returned when requesting new access token (via refresh token)
+ * https://developer.spotify.com/documentation/general/guides/authorization-guide/#4-requesting-a-refreshed-access-token-spotify-returns-a-new-access-token-to-your-app
+ */
 interface RefreshAccessTokenResponse {
     access_token: string;
     expires_in: number;

--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -33,226 +33,848 @@ declare class SpotifyWebApi {
     setRefreshToken(refreshToken: string): void;
     resetRefreshToken(): void;
 
+    /**
+     * Look up a track.
+     * @param {string} trackId The track's ID.
+     * @param {Object} [options] The possible options, currently only market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getTrack('3Qm86XLflmIXVm1wcwkgDK').then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the track. Not returned if a callback is given.
+     */
     getTrack(trackId: string, options: MarketOptions, callback: Callback<SpotifyApi.SingleTrackResponse>): void;
     getTrack(trackId: string, options?: MarketOptions): Promise<Response<SpotifyApi.SingleTrackResponse>>;
 
+    /**
+     * Look up several tracks.
+     * @param {string[]} trackIds The IDs of the artists.
+     * @param {Object} [options] The possible options, currently only market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getArtists(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the artists. Not returned if a callback is given.
+     */
     getTracks(trackIds: ReadonlyArray<string>, options: MarketOptions, callback: Callback<SpotifyApi.MultipleTracksResponse>): void;
     getTracks(trackIds: ReadonlyArray<string>, options?: MarketOptions): Promise<Response<SpotifyApi.MultipleTracksResponse>>;
 
+    /**
+     * Look up an album.
+     * @param {string} albumId The album's ID.
+     * @param {Object} [options] The possible options, currently only market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAlbum('0sNOF9WDwhWunNAHPD3Baj').then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the album. Not returned if a callback is given.
+     */
     getAlbum(albumId: string, options: MarketOptions, callback: Callback<SpotifyApi.SingleAlbumResponse>): void;
     getAlbum(albumId: string, options?: MarketOptions): Promise<Response<SpotifyApi.SingleAlbumResponse>>;
 
+    /**
+     * Look up several albums.
+     * @param {string[]} albumIds The IDs of the albums.
+     * @param {Object} [options] The possible options, currently only market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAlbums(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the albums. Not returned if a callback is given.
+     */
     getAlbums(albumIds: ReadonlyArray<string>, options: MarketOptions, callback: Callback<SpotifyApi.MultipleAlbumsResponse>): void;
     getAlbums(albumIds: ReadonlyArray<string>, options?: MarketOptions): Promise<Response<SpotifyApi.MultipleAlbumsResponse>>;
 
+    /**
+     * Look up an artist.
+     * @param {string} artistId The artist's ID.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example api.getArtist('1u7kkVrr14iBvrpYnZILJR').then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the artist. Not returned if a callback is given.
+     */
     getArtist(artistId: string, callback: Callback<SpotifyApi.SingleArtistResponse>): void;
     getArtist(artistId: string): Promise<Response<SpotifyApi.SingleArtistResponse>>;
 
+    /**
+     * Look up several artists.
+     * @param {string[]} artistIds The IDs of the artists.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getArtists(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     *          about the artists. Not returned if a callback is given.
+     */
     getArtists(artistIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.MultipleArtistsResponse>): void;
     getArtists(artistIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.MultipleArtistsResponse>>;
 
+    /**
+     * Search for music entities of certain types.
+     * @param {string} query The search query.
+     * @param {string[]} types An array of item types to search across.
+     * Valid types are: 'album', 'artist', 'playlist', and 'track'.
+     * @param {Object} [options] The possible options, e.g. limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example search('Abba', ['track', 'playlist'], { limit : 5, offset : 1 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          search results. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     search(query: string, types: ReadonlyArray<SearchType>, options: SearchOptions, callback: Callback<SpotifyApi.SearchResponse>): void;
     search(query: string, types: ReadonlyArray<SearchType>, options?: SearchOptions): Promise<Response<SpotifyApi.SearchResponse>>;
 
+    /**
+     * Search for an album.
+     * @param {string} query The search query.
+     * @param {Object} [options] The possible options, e.g. limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example searchAlbums('Space Oddity', { limit : 5, offset : 1 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          search results. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     searchAlbums(query: string, options: SearchOptions, callback: Callback<SpotifyApi.SearchResponse>): void;
     searchAlbums(query: string, options?: SearchOptions): Promise<Response<SpotifyApi.SearchResponse>>;
 
+    /**
+     * Search for an artist.
+     * @param {string} query The search query.
+     * @param {Object} [options] The possible options, e.g. limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example searchArtists('David Bowie', { limit : 5, offset : 1 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          search results. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     searchArtists(query: string, options: SearchOptions, callback: Callback<SpotifyApi.SearchResponse>): void;
     searchArtists(query: string, options?: SearchOptions): Promise<Response<SpotifyApi.SearchResponse>>;
 
+    /**
+     * Search for a track.
+     * @param {string} query The search query.
+     * @param {Object} [options] The possible options, e.g. limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example searchTracks('Mr. Brightside', { limit : 3, offset : 2 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          search results. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     searchTracks(query: string, options: SearchOptions, callback: Callback<SpotifyApi.SearchResponse>): void;
     searchTracks(query: string, options?: SearchOptions): Promise<Response<SpotifyApi.SearchResponse>>;
 
+    /**
+     * Search for playlists.
+     * @param {string} query The search query.
+     * @param {Object} options The possible options.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example searchPlaylists('workout', { limit : 1, offset : 0 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          search results. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     searchPlaylists(query: string, options: SearchOptions, callback: Callback<SpotifyApi.SearchResponse>): void;
     searchPlaylists(query: string, options?: SearchOptions): Promise<Response<SpotifyApi.SearchResponse>>;
 
+    /**
+     * Get an artist's albums.
+     * @param {string} artistId The artist's ID.
+     * @options {Object} [options] The possible options, e.g. limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getArtistAlbums('0oSGxfWSnnOXhD2fKuz2Gy', { album_type : 'album', country : 'GB', limit : 2, offset : 5 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the albums
+     *          for the given artist. The result is paginated. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     getArtistAlbums(artistId: string, options: GetArtistAlbumsOptions, callback: Callback<SpotifyApi.ArtistsAlbumsResponse>): void;
     getArtistAlbums(artistId: string, options?: GetArtistAlbumsOptions): Promise<Response<SpotifyApi.ArtistsAlbumsResponse>>;
 
+    /**
+     * Get the tracks of an album.
+     * @param albumId the album's ID.
+     * @options {Object} [options] The possible options, e.g. limit.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAlbumTracks('41MnTivkwTO3UUJ8DrqEJJ', { limit : 5, offset : 1 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *                    tracks in the album. The result is paginated. If the promise is rejected.
+     *                    it contains an error object. Not returned if a callback is given.
+     */
     getAlbumTracks(albumId: string, options: PaginationMarketOptions, callback: Callback<SpotifyApi.AlbumTracksResponse>): void;
     getAlbumTracks(albumId: string, options?: PaginationMarketOptions): Promise<Response<SpotifyApi.AlbumTracksResponse>>;
 
+    /**
+     * Get an artist's top tracks.
+     * @param {string} artistId The artist's ID.
+     * @param {string} country The country/territory where the tracks are most popular. (format: ISO 3166-1 alpha-2)
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getArtistTopTracks('0oSGxfWSnnOXhD2fKuz2Gy', 'GB').then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          artist's top tracks in the given country. If the promise is rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     getArtistTopTracks(artistId: string, country: string, callback: Callback<SpotifyApi.ArtistsTopTracksResponse>): void;
     getArtistTopTracks(artistId: string, country: string): Promise<Response<SpotifyApi.ArtistsTopTracksResponse>>;
 
+    /**
+     * Get related artists.
+     * @param {string} artistId The artist's ID.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getArtistRelatedArtists('0oSGxfWSnnOXhD2fKuz2Gy').then(...)
+     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     *          related artists. If the promise is rejected, it contains an error object. Not returned if a callback is given.
+     */
     getArtistRelatedArtists(artistId: string, callback: Callback<SpotifyApi.ArtistsRelatedArtistsResponse>): void;
     getArtistRelatedArtists(artistId: string): Promise<Response<SpotifyApi.ArtistsRelatedArtistsResponse>>;
 
+    /**
+     * Get information about a user.
+     * @param userId The user ID.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getUser('thelinmichael').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     *          containing information about the user. If the promise is
+     *          rejected, it contains an error object. Not returned if a callback is given.
+     */
     getUser(userId: string, callback: Callback<SpotifyApi.UserProfileResponse>): void;
     getUser(userId: string): Promise<Response<SpotifyApi.UserProfileResponse>>;
 
+    /**
+     * Get information about the user that has signed in (the current user).
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getMe().then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     *          containing information about the user. The amount of information
+     *          depends on the permissions given by the user. If the promise is
+     *          rejected, it contains an error object. Not returned if a callback is given.
+     */
     getMe(callback: Callback<SpotifyApi.CurrentUsersProfileResponse>): void;
     getMe(): Promise<Response<SpotifyApi.CurrentUsersProfileResponse>>;
 
+    /**
+     * Get a user's playlists.
+     * @param {string} userId An optional id of the user. If you know the Spotify URI it is easy
+     * to find the id (e.g. spotify:user:<here_is_the_id>). If not provided, the id of the user that granted
+     * the permissions will be used.
+     * @param {Object} [options] The options supplied to this request.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getUserPlaylists('thelinmichael').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     *          a list of playlists. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     getUserPlaylists(userId: string, options: PaginationOptions, callback: Callback<SpotifyApi.ListOfUsersPlaylistsResponse>): void;
     getUserPlaylists(options: PaginationOptions, callback: Callback<SpotifyApi.ListOfUsersPlaylistsResponse>): void;
     getUserPlaylists(userId: string, options?: PaginationOptions): Promise<Response<SpotifyApi.ListOfUsersPlaylistsResponse>>;
     getUserPlaylists(options?: PaginationOptions): Promise<Response<SpotifyApi.ListOfUsersPlaylistsResponse>>;
 
+    /**
+     * Get a playlist.
+     * @param {string} playlistId The playlist's ID.
+     * @param {Object} [options] The options supplied to this request.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getPlaylist('3EsfV6XzCHU8SPNdbnFogK').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     *          the playlist. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     getPlaylist(playlistId: string, options: GetPlaylistOptions, callback: Callback<SpotifyApi.SinglePlaylistResponse>): void;
     getPlaylist(playlistId: string, options?: GetPlaylistOptions): Promise<Response<SpotifyApi.SinglePlaylistResponse>>;
 
+    /**
+     * Get tracks in a playlist.
+     * @param {string} playlistId The playlist's ID.
+     * @param {Object} [options] Optional options, such as fields.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getPlaylistTracks('3ktAYNcRHpazJ9qecm3ptn').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object that containing
+     * the tracks in the playlist. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     getPlaylistTracks(playlistId: string, options: GetPlaylistTracksOptions, callback: Callback<SpotifyApi.PlaylistTrackResponse>): void;
     getPlaylistTracks(playlistId: string, options?: GetPlaylistTracksOptions): Promise<Response<SpotifyApi.PlaylistTrackResponse>>;
 
+    /**
+     * Create a playlist.
+     * @param {string} userId The playlist's owner's user ID.
+     * @param {string} playlistName The name of the playlist.
+     * @param {Object} [options] The possible options, currently only public.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example createPlaylist('thelinmichael', 'My cool playlist!', { public : false }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing information about the
+     *          created playlist. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     createPlaylist(userId: string, playlistName: string, options: PlaylistDetailsOptions, callback: Callback<SpotifyApi.CreatePlaylistResponse>): void;
     createPlaylist(userId: string, playlistName: string, options?: PlaylistDetailsOptions): Promise<Response<SpotifyApi.CreatePlaylistResponse>>;
 
+    /**
+     * Follow a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {Object} [options] The possible options, currently only public.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     followPlaylist(playlistId: string, options: PublicOptions, callback: Callback<SpotifyApi.FollowPlaylistReponse>): void;
     followPlaylist(playlistId: string, options?: PublicOptions): Promise<Response<SpotifyApi.FollowPlaylistReponse>>;
 
+    /**
+     * Unfollow a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {Object} [options] The possible options, currently only public.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     unfollowPlaylist(playlistId: string, callback: Callback<SpotifyApi.UnfollowPlaylistReponse>): void;
     unfollowPlaylist(playlistId: string): Promise<Response<SpotifyApi.UnfollowPlaylistReponse>>;
 
+    /**
+     * Change playlist details.
+     * @param {string} playlistId The playlist's ID
+     * @param {Object} [options] The possible options, e.g. name, public.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example changePlaylistDetails('3EsfV6XzCHU8SPNdbnFogK', {name: 'New name', public: true}).then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     changePlaylistDetails(playlistId: string, options: ChangePlaylistOptions, callback: Callback<SpotifyApi.ChangePlaylistDetailsReponse>): void;
     changePlaylistDetails(playlistId: string, options?: ChangePlaylistOptions): Promise<Response<SpotifyApi.ChangePlaylistDetailsReponse>>;
 
+    /**
+     * Replace the image used to represent a specific playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {string} base64URI Base64 encoded JPEG image data, maximum payload size is 256 KB
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example uploadCustomPlaylistCoverImage('3EsfV6XzCHU8SPNdbnFogK', 'longbase64uri').then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     uploadCustomPlaylistCoverImage(playlistId: string, base64URI: string, callback: Callback<SpotifyApi.UploadCustomPlaylistCoverImageReponse>): void;
     uploadCustomPlaylistCoverImage(playlistId: string, base64URI: string): Promise<Response<SpotifyApi.UploadCustomPlaylistCoverImageReponse>>;
 
+    /**
+     * Add tracks to a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {string[]} tracks URIs of the tracks to add to the playlist.
+     * @param {Object} [options] Options, position being the only one.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example addTracksToPlaylist(3EsfV6XzCHU8SPNdbnFogK', ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]).then(...)
+     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     addTracksToPlaylist(playlistId: string, tracks: ReadonlyArray<string>, options: PositionOptions, callback: Callback<SpotifyApi.AddTracksToPlaylistResponse>): void;
     addTracksToPlaylist(playlistId: string, tracks: ReadonlyArray<string>, options?: PositionOptions): Promise<Response<SpotifyApi.AddTracksToPlaylistResponse>>;
 
+    /**
+     * Remove tracks from a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {Object[]} tracks An array of objects containing a property called uri with the track URI (String), and
+     * a an optional property called positions (int[]), e.g. { uri : "spotify:track:491rM2JN8KvmV6p0oDDuJT", positions : [0, 15] }
+     * @param {Object} options Options, snapshot_id being the only one.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     removeTracksFromPlaylist(playlistId: string, tracks: ReadonlyArray<Track>, options: SnapshotOptions, callback: Callback<SpotifyApi.RemoveTracksFromPlaylistResponse>): void;
     removeTracksFromPlaylist(playlistId: string, tracks: ReadonlyArray<Track>, options?: SnapshotOptions): Promise<Response<SpotifyApi.RemoveTracksFromPlaylistResponse>>;
 
+    /**
+     * Remove tracks from a playlist by position instead of specifying the tracks' URIs.
+     * @param {string} playlistId The playlist's ID
+     * @param {int[]} positions The positions of the tracks in the playlist that should be removed
+     * @param {string} snapshot_id The snapshot ID, or version, of the playlist. Required
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     removeTracksFromPlaylistByPosition(playlistId: string, positions: ReadonlyArray<number>, snapshotId: string, callback: Callback<SpotifyApi.RemoveTracksFromPlaylistResponse>): void;
     removeTracksFromPlaylistByPosition(playlistId: string, positions: ReadonlyArray<number>, snapshotId: string): Promise<Response<SpotifyApi.RemoveTracksFromPlaylistResponse>>;
 
+    /**
+     * Replace tracks in a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {Object[]} uris An array of track URIs (strings)
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns an empty object. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     replaceTracksInPlaylist(playlistId: string, uris: ReadonlyArray<string>, callback: Callback<SpotifyApi.ReplacePlaylistTracksResponse>): void;
     replaceTracksInPlaylist(playlistId: string, uris: ReadonlyArray<string>): Promise<Response<SpotifyApi.ReplacePlaylistTracksResponse>>;
 
+    /**
+     * Reorder tracks in a playlist.
+     * @param {string} playlistId The playlist's ID
+     * @param {int} rangeStart The position of the first track to be reordered.
+     * @param {int} insertBefore The position where the tracks should be inserted.
+     * @param {Object} options Optional parameters, i.e. range_length and snapshot_id.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     reorderTracksInPlaylist(playlistId: string, rangeStart: number, insertBefore: number, options: ReorderPlaylistTracksOptions, callback: Callback<SpotifyApi.ReorderPlaylistTracksResponse>): void;
     reorderTracksInPlaylist(playlistId: string, rangeStart: number, insertBefore: number, options?: ReorderPlaylistTracksOptions): Promise<Response<SpotifyApi.ReorderPlaylistTracksResponse>>;
 
+    /**
+     * Get audio features for a single track identified by its unique Spotify ID.
+     * @param {string} trackId The track ID
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAudioFeaturesForTrack('38P3Q4QcdjQALGF2Z92BmR').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     *          containing information about the audio features. If the promise is
+     *          rejected, it contains an error object. Not returned if a callback is given.
+     */
     getAudioFeaturesForTrack(trackId: string, callback: Callback<SpotifyApi.AudioFeaturesResponse>): void;
     getAudioFeaturesForTrack(trackId: string): Promise<Response<SpotifyApi.AudioFeaturesResponse>>;
 
+    /**
+     * Get audio analysis for a single track identified by its unique Spotify ID.
+     * @param {string} trackId The track ID
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAudioAnalysisForTrack('38P3Q4QcdjQALGF2Z92BmR').then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     *          containing information about the audio analysis. If the promise is
+     *          rejected, it contains an error object. Not returned if a callback is given.
+     */
     getAudioAnalysisForTrack(trackId: string, callback: Callback<SpotifyApi.AudioAnalysisResponse>): void;
     getAudioAnalysisForTrack(trackId: string): Promise<Response<SpotifyApi.AudioAnalysisResponse>>;
 
+    /**
+     * Get audio features for multiple tracks identified by their unique Spotify ID.
+     * @param {string[]} trackIds The track IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getAudioFeaturesForTracks(['38P3Q4QcdjQALGF2Z92BmR', '2HO2bnoMrpnZUbUqiilLHi']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     *          containing information about the audio features for the tracks. If the promise is
+     *          rejected, it contains an error object. Not returned if a callback is given.
+     */
     getAudioFeaturesForTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.MultipleAudioFeaturesResponse>): void;
     getAudioFeaturesForTracks(trackIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.MultipleAudioFeaturesResponse>>;
 
+    /**
+     * Create a playlist-style listening experience based on seed artists, tracks and genres.
+     * @param {Object} [options] The options supplied to this request.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example getRecommendations({ min_energy: 0.4, seed_artists: ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ'], min_popularity: 50 }).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     *          a list of tracks and a list of seeds. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     getRecommendations(options: GetRecommendationsOptions, callback: Callback<SpotifyApi.RecommendationsFromSeedsResponse>): void;
     getRecommendations(options?: GetRecommendationsOptions): Promise<Response<SpotifyApi.RecommendationsFromSeedsResponse>>;
 
+    /**
+     * Retrieve a URL where the user can give the application permissions.
+     * @param {string[]} scopes The scopes corresponding to the permissions the application needs.
+     * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
+     * @param {boolean} showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
+     * @returns {string} The URL where the user can give application permissions.
+     */
     createAuthorizeURL(scopes: ReadonlyArray<string>, state: string, showDialog?: boolean): string;
 
+    /**
+     * Retrieve the tracks that are saved to the authenticated users Your Music library.
+     * @param {Object} [options] Options, being market, limit, and/or offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which in turn contains
+     *          playlist track objects. Not returned if a callback is given.
+     */
     getMySavedTracks(options: PaginationMarketOptions, callback: Callback<SpotifyApi.UsersSavedTracksResponse>): void;
     getMySavedTracks(options?: PaginationMarketOptions): Promise<Response<SpotifyApi.UsersSavedTracksResponse>>;
 
+    /**
+     * Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library.
+     * @param {string[]} trackIds The track IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * of the returned array's elements correspond to the track ID in the request.
+     * The boolean value of true indicates that the track is part of the user's library, otherwise false.
+     * Not returned if a callback is given.
+     */
     containsMySavedTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.CheckUsersSavedTracksResponse>): void;
     containsMySavedTracks(trackIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.CheckUsersSavedTracksResponse>>;
 
+    /**
+     * Remove a track from the authenticated user's Your Music library.
+     * @param {string[]} trackIds The track IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error.
+     * Not returned if a callback is given.
+     */
     removeFromMySavedTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.RemoveUsersSavedTracksResponse>): void;
     removeFromMySavedTracks(trackIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.RemoveUsersSavedTracksResponse>>;
 
+    /**
+     * Add a track from the authenticated user's Your Music library.
+     * @param {string[]} trackIds The track IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
+     */
     addToMySavedTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.SaveTracksForUserResponse>): void;
     addToMySavedTracks(trackIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.SaveTracksForUserResponse>>;
 
+    /**
+     * Remove an album from the authenticated user's Your Music library.
+     * @param {string[]} albumIds The album IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error.
+     * Not returned if a callback is given.
+     */
     removeFromMySavedAlbums(albumIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.RemoveAlbumsForUserResponse>): void;
     removeFromMySavedAlbums(albumIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.RemoveAlbumsForUserResponse>>;
 
+    /**
+     * Add an album from the authenticated user's Your Music library.
+     * @param {string[]} albumIds The track IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
+     */
     addToMySavedAlbums(albumIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.SaveAlbumsForUserResponse>): void;
     addToMySavedAlbums(albumIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.SaveAlbumsForUserResponse>>;
 
+    /**
+     * Retrieve the albums that are saved to the authenticated users Your Music library.
+     * @param {Object} [options] Options, being market, limit, and/or offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which in turn contains
+     *          playlist album objects. Not returned if a callback is given.
+     */
     getMySavedAlbums(options: PaginationMarketOptions, callback: Callback<SpotifyApi.UsersSavedAlbumsResponse>): void;
     getMySavedAlbums(options?: PaginationMarketOptions): Promise<Response<SpotifyApi.UsersSavedAlbumsResponse>>;
 
+    /**
+     * Check if one or more albums is already saved in the current Spotify user’s “Your Music” library.
+     * @param {string[]} albumIds The album IDs
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * of the returned array's elements correspond to the album ID in the request.
+     * The boolean value of true indicates that the album is part of the user's library, otherwise false.
+     * Not returned if a callback is given.
+     */
     containsMySavedAlbums(albumIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.CheckUserSavedAlbumsResponse>): void;
     containsMySavedAlbums(albumIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.CheckUserSavedAlbumsResponse>>;
 
+    /**
+     * Get the current user's top artists based on calculated affinity.
+     * @param {Object} [options] Options, being time_range, limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of artists,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyTopArtists(options: GetTopOptions, callback: Callback<SpotifyApi.UsersTopArtistsResponse>): void;
     getMyTopArtists(options?: GetTopOptions): Promise<Response<SpotifyApi.UsersTopArtistsResponse>>;
 
+    /**
+     * Get the current user's top tracks based on calculated affinity.
+     * @param {Object} [options] Options, being time_range, limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyTopTracks(options: GetTopOptions, callback: Callback<SpotifyApi.UsersTopTracksResponse>): void;
     getMyTopTracks(options?: GetTopOptions): Promise<Response<SpotifyApi.UsersTopTracksResponse>>;
 
+    /**
+     * Get the Current User's Recently Played Tracks
+     * @param {Object} [options] Options, being type, after, limit, before.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyRecentlyPlayedTracks(options: BeforeOptions | AfterOptions, callback: Callback<SpotifyApi.UsersRecentlyPlayedTracksResponse>): void;
     getMyRecentlyPlayedTracks(options?: BeforeOptions | AfterOptions): Promise<Response<SpotifyApi.UsersRecentlyPlayedTracksResponse>>;
 
+    /**
+     * Get the Current User's Connect Devices
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyDevices(callback: Callback<SpotifyApi.UserDevicesResponse>): void;
     getMyDevices(): Promise<Response<SpotifyApi.UserDevicesResponse>>;
 
+    /**
+     * Get the Current User's Currently Playing Track.
+     * @param {Object} [options] Options, being market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyCurrentPlayingTrack(options: MarketOptions, callback: Callback<SpotifyApi.CurrentlyPlayingResponse>): void;
     getMyCurrentPlayingTrack(options?: MarketOptions): Promise<Response<SpotifyApi.CurrentlyPlayingResponse>>;
 
+    /**
+     * Get the Current User's Current Playback State
+     * @param {Object} [options] Options, being market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     getMyCurrentPlaybackState(options: MarketOptions, callback: Callback<SpotifyApi.CurrentPlaybackResponse>): void;
     getMyCurrentPlaybackState(options?: MarketOptions): Promise<Response<SpotifyApi.CurrentPlaybackResponse>>;
 
+    /**
+     * Transfer a User's Playback
+     * @param {Object} [options] Options, being market.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     transferMyPlayback(options: TransferPlaybackOptions, callback: Callback<void>): void;
     transferMyPlayback(options?: TransferPlaybackOptions): Promise<Response<void>>;
 
+    /**
+     * Starts or Resumes the Current User's Playback
+     * @param {Object} [options] Options, being device_id, context_uri, offset, uris.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     play(options: PlayOptions, callback: Callback<void>): void;
     play(options?: PlayOptions): Promise<Response<void>>;
 
+    /**
+     * Pauses the Current User's Playback
+     * @param {Object} [options] Options, for now device_id,
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackPause().then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     pause(options: DeviceOptions, callback: Callback<void>): void;
     pause(options?: DeviceOptions): Promise<Response<void>>;
 
+    /**
+     * Skip the Current User's Playback To Previous Track
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackPrevious().then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     skipToPrevious(callback: Callback<void>): void;
     skipToPrevious(): Promise<Response<void>>;
 
+    /**
+     * Skip the Current User's Playback To Next Track
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackNext().then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     skipToNext(callback: Callback<void>): void;
     skipToNext(): Promise<Response<void>>;
 
+    /**
+     * Seeks to the given position in the user’s currently playing track.
+     *
+     * @param {number} positionMs The position in milliseconds to seek to. Must be a positive number.
+     * @param {Object} options A JSON object with options that can be passed.
+     * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+     * one is the error object (null if no error), and the second is the value if the request succeeded.
+     * @return {Object} Null if a callback is provided, a `Promise` object otherwise
+     */
     seek(positionMs: number, options: DeviceOptions, callback: Callback<void>): void;
     seek(positionMs: number, options?: DeviceOptions): Promise<Response<void>>;
 
+    /**
+     * Set Repeat Mode On The Current User's Playback
+     * @param {Object} [options] Options, being state (track, context, off).
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackRepeat({state: 'context'}).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     setRepeat(options: RepeatOptions, callback: Callback<void>): void;
     setRepeat(options?: RepeatOptions): Promise<Response<void>>;
 
+    /**
+     * Set Shuffle Mode On The Current User's Playback
+     * @param {Object} [options] Options, being state (true, false).
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example playbackShuffle({state: 'false'}).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     *          otherwise an error. Not returned if a callback is given.
+     */
     setShuffle(options: ShuffleOptions, callback: Callback<void>): void;
     setShuffle(options?: ShuffleOptions): Promise<Response<void>>;
 
+    /**
+     * Set the volume for the user’s current playback device.
+     *
+     * @param {number} volumePercent The volume to set. Must be a value from 0 to 100 inclusive.
+     * @param {Object} options A JSON object with options that can be passed.
+     * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+     * one is the error object (null if no error), and the second is the value if the request succeeded.
+     * @return {Object} Null if a callback is provided, a `Promise` object otherwise
+     */
     setVolume(volumePercent: number, options: DeviceOptions, callback: Callback<void>): void;
     setVolume(volumePercent: number, options?: DeviceOptions): Promise<Response<void>>;
 
+    /**
+     * Add the current user as a follower of one or more other Spotify users.
+     * @param {string[]} userIds The IDs of the users to be followed.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example followUsers(['thelinmichael', 'wizzler']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     followUsers(userIds: ReadonlyArray<string>, callback: Callback<void>): void;
     followUsers(userIds: ReadonlyArray<string>): Promise<Response<void>>;
 
+    /**
+     * Add the current user as a follower of one or more artists.
+     * @param {string[]} artistIds The IDs of the artists to be followed.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example followArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     followArtists(artistIds: ReadonlyArray<string>, callback: Callback<void>): void;
     followArtists(artistIds: ReadonlyArray<string>): Promise<Response<void>>;
 
+    /**
+     * Remove the current user as a follower of one or more other Spotify users.
+     * @param {string[]} userIds The IDs of the users to be unfollowed.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example unfollowUsers(['thelinmichael', 'wizzler']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     unfollowUsers(userIds: ReadonlyArray<string>, callback: Callback<void>): void;
     unfollowUsers(userIds: ReadonlyArray<string>): Promise<Response<void>>;
 
+    /**
+     * Remove the current user as a follower of one or more artists.
+     * @param {string[]} artistIds The IDs of the artists to be unfollowed.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example unfollowArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     *          it contains an error object. Not returned if a callback is given.
+     */
     unfollowArtists(artistIds: ReadonlyArray<string>, callback: Callback<void>): void;
     unfollowArtists(artistIds: ReadonlyArray<string>): Promise<Response<void>>;
 
+    /**
+     * Check to see if the current user is following one or more other Spotify users.
+     * @param {string[]} userIds The IDs of the users to check if are followed by the current user.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example isFollowingUsers(['thelinmichael', 'wizzler']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     *          of the returned array's elements correspond to the users IDs in the request.
+     *          The boolean value of true indicates that the user is following that user, otherwise is not.
+     *          Not returned if a callback is given.
+     */
     isFollowingUsers(userIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.UserFollowsUsersOrArtistsResponse>): void;
     isFollowingUsers(userIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.UserFollowsUsersOrArtistsResponse>>;
 
+    /**
+     * Get the current user's followed artists.
+     * @param {Object} [options] Options, being after and limit.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * album objects. Not returned if a callback is given.
+     */
     getFollowedArtists(options: AfterOptions, callback: Callback<SpotifyApi.UsersFollowedArtistsResponse>): void;
     getFollowedArtists(options?: AfterOptions): Promise<Response<SpotifyApi.UsersFollowedArtistsResponse>>;
 
+    /**
+     * Check if users are following a playlist.
+     * @param {string} userId The playlist's owner's user ID
+     * @param {string} playlistId The playlist's ID
+     * @param {String[]} User IDs of the following users
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful returns an array of booleans. If rejected,
+     * it contains an error object. Not returned if a callback is given.
+     */
     areFollowingPlaylist(userId: string, playlistId: string, followerIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.UsersFollowPlaylistReponse>): void;
     areFollowingPlaylist(userId: string, playlistId: string, followerIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.UsersFollowPlaylistReponse>>;
 
+    /**
+     * Check to see if the current user is following one or more artists.
+     * @param {string[]} artistIds The IDs of the artists to check if are followed by the current user.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @example isFollowingArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
+     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     *          of the returned array's elements correspond to the artists IDs in the request.
+     *          The boolean value of true indicates that the user is following that artist, otherwise is not.
+     *          Not returned if a callback is given.
+     */
     isFollowingArtists(artistIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.UserFollowsUsersOrArtistsResponse>): void;
     isFollowingArtists(artistIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.UserFollowsUsersOrArtistsResponse>>;
 
+    /**
+     * Retrieve new releases
+     * @param {Object} [options] Options, being country, limit and/or offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * album objects. Not returned if a callback is given.
+     */
     getNewReleases(options: PaginationCountryOptions, callback: Callback<SpotifyApi.ListOfNewReleasesResponse>): void;
     getNewReleases(options?: PaginationCountryOptions): Promise<Response<SpotifyApi.ListOfNewReleasesResponse>>;
 
+    /**
+     * Retrieve featured playlists
+     * @param {Object} [options] Options, being country, locale, timestamp, limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * featured playlists. Not returned if a callback is given.
+     */
     getFeaturedPlaylists(options: GetFeaturedPlaylistsOptions, callback: Callback<SpotifyApi.ListOfFeaturedPlaylistsResponse>): void;
     getFeaturedPlaylists(options?: GetFeaturedPlaylistsOptions): Promise<Response<SpotifyApi.ListOfFeaturedPlaylistsResponse>>;
 
+    /**
+     * Retrieve a list of categories used to tag items in Spotify (e.g. in the 'Browse' tab)
+     * @param {Object} [options] Options, being country, locale, limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object of categories.
+     * Not returned if a callback is given.
+     */
     getCategories(options: PaginationLocaleOptions, callback: Callback<SpotifyApi.MultipleCategoriesResponse>): void;
     getCategories(options?: PaginationLocaleOptions): Promise<Response<SpotifyApi.MultipleCategoriesResponse>>;
 
+    /**
+     * Retrieve a category.
+     * @param {string} categoryId The id of the category to retrieve.
+     * @param {Object} [options] Options, being country, locale.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a category object.
+     * Not returned if a callback is given.
+     */
     getCategory(categoryId: string, options: LocaleOptions, callback: Callback<SpotifyApi.SingleCategoryResponse>): void;
     getCategory(categoryId: string, options?: LocaleOptions): Promise<Response<SpotifyApi.SingleCategoryResponse>>;
 
+    /**
+     * Retrieve playlists for a category.
+     * @param {string} categoryId The id of the category to retrieve playlists for.
+     * @param {Object} [options] Options, being country, limit, offset.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to a paging object containing simple playlists.
+     * Not returned if a callback is given.
+     */
     getPlaylistsForCategory(categoryId: string, options: PaginationCountryOptions, callback: Callback<SpotifyApi.CategoryPlaylistsReponse>): void;
     getPlaylistsForCategory(categoryId: string, options?: PaginationCountryOptions): Promise<Response<SpotifyApi.CategoryPlaylistsReponse>>;
 
+    /**
+     * Request an access token using the Client Credentials flow.
+     * Requires that client ID and client secret has been set previous to the call.
+     * @param {Object} options Options.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into an object containing the access token,
+     *          token type and time to expiration. If rejected, it contains an error object. Not returned if a callback is given.
+     */
     clientCredentialsGrant(options: {}, callback: Callback<ClientCredentialsGrantResponse>): void;
     clientCredentialsGrant(options?: {}): Promise<Response<ClientCredentialsGrantResponse>>;
 
+    /**
+     * Request an access token using the Authorization Code flow.
+     * Requires that client ID, client secret, and redirect URI has been set previous to the call.
+     * @param {string} code The authorization code returned in the callback in the Authorization Code flow.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves into an object containing the access token,
+     *          refresh token, token type and time to expiration. If rejected, it contains an error object.
+     *          Not returned if a callback is given.
+     */
     authorizationCodeGrant(code: string, callback: Callback<AuthorizationCodeGrantResponse>): void;
     authorizationCodeGrant(code: string): Promise<Response<AuthorizationCodeGrantResponse>>;
 
+    /**
+     * Refresh the access token given that it hasn't expired.
+     * Requires that client ID, client secret and refresh token has been set previous to the call.
+     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing the
+     *          access token, time to expiration and token type. If rejected, it contains an error object.
+     *          Not returned if a callback is given.
+     */
     refreshAccessToken(callback: Callback<RefreshAccessTokenResponse>): void;
     refreshAccessToken(): Promise<Response<RefreshAccessTokenResponse>>;
 }

--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -35,11 +35,11 @@ declare class SpotifyWebApi {
 
     /**
      * Look up a track.
-     * @param {string} trackId The track's ID.
-     * @param {Object} [options] The possible options, currently only market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param trackId The track's ID.
+     * @param options The possible options, currently only market.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getTrack('3Qm86XLflmIXVm1wcwkgDK').then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the track. Not returned if a callback is given.
      */
     getTrack(trackId: string, options: MarketOptions, callback: Callback<SpotifyApi.SingleTrackResponse>): void;
@@ -47,11 +47,11 @@ declare class SpotifyWebApi {
 
     /**
      * Look up several tracks.
-     * @param {string[]} trackIds The IDs of the artists.
-     * @param {Object} [options] The possible options, currently only market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param trackIds The IDs of the artists.
+     * @param options The possible options, currently only market.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getArtists(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the artists. Not returned if a callback is given.
      */
     getTracks(trackIds: ReadonlyArray<string>, options: MarketOptions, callback: Callback<SpotifyApi.MultipleTracksResponse>): void;
@@ -59,11 +59,11 @@ declare class SpotifyWebApi {
 
     /**
      * Look up an album.
-     * @param {string} albumId The album's ID.
-     * @param {Object} [options] The possible options, currently only market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param albumId The album's ID.
+     * @param options The possible options, currently only market.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAlbum('0sNOF9WDwhWunNAHPD3Baj').then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the album. Not returned if a callback is given.
      */
     getAlbum(albumId: string, options: MarketOptions, callback: Callback<SpotifyApi.SingleAlbumResponse>): void;
@@ -71,11 +71,11 @@ declare class SpotifyWebApi {
 
     /**
      * Look up several albums.
-     * @param {string[]} albumIds The IDs of the albums.
-     * @param {Object} [options] The possible options, currently only market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param albumIds The IDs of the albums.
+     * @param options The possible options, currently only market.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAlbums(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the albums. Not returned if a callback is given.
      */
     getAlbums(albumIds: ReadonlyArray<string>, options: MarketOptions, callback: Callback<SpotifyApi.MultipleAlbumsResponse>): void;
@@ -83,10 +83,10 @@ declare class SpotifyWebApi {
 
     /**
      * Look up an artist.
-     * @param {string} artistId The artist's ID.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistId The artist's ID.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example api.getArtist('1u7kkVrr14iBvrpYnZILJR').then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the artist. Not returned if a callback is given.
      */
     getArtist(artistId: string, callback: Callback<SpotifyApi.SingleArtistResponse>): void;
@@ -94,10 +94,10 @@ declare class SpotifyWebApi {
 
     /**
      * Look up several artists.
-     * @param {string[]} artistIds The IDs of the artists.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistIds The IDs of the artists.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getArtists(['0oSGxfWSnnOXhD2fKuz2Gy', '3dBVyJ7JuOMt4GE9607Qin']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing information
+     * @returns A promise that if successful, returns an object containing information
      *          about the artists. Not returned if a callback is given.
      */
     getArtists(artistIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.MultipleArtistsResponse>): void;
@@ -105,13 +105,13 @@ declare class SpotifyWebApi {
 
     /**
      * Search for music entities of certain types.
-     * @param {string} query The search query.
-     * @param {string[]} types An array of item types to search across.
+     * @param query The search query.
+     * @param types An array of item types to search across.
      * Valid types are: 'album', 'artist', 'playlist', and 'track'.
-     * @param {Object} [options] The possible options, e.g. limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options The possible options, e.g. limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example search('Abba', ['track', 'playlist'], { limit : 5, offset : 1 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          search results. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -120,11 +120,11 @@ declare class SpotifyWebApi {
 
     /**
      * Search for an album.
-     * @param {string} query The search query.
-     * @param {Object} [options] The possible options, e.g. limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param query The search query.
+     * @param options The possible options, e.g. limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example searchAlbums('Space Oddity', { limit : 5, offset : 1 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          search results. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -133,11 +133,11 @@ declare class SpotifyWebApi {
 
     /**
      * Search for an artist.
-     * @param {string} query The search query.
-     * @param {Object} [options] The possible options, e.g. limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param query The search query.
+     * @param options The possible options, e.g. limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example searchArtists('David Bowie', { limit : 5, offset : 1 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          search results. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -146,11 +146,11 @@ declare class SpotifyWebApi {
 
     /**
      * Search for a track.
-     * @param {string} query The search query.
-     * @param {Object} [options] The possible options, e.g. limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param query The search query.
+     * @param options The possible options, e.g. limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example searchTracks('Mr. Brightside', { limit : 3, offset : 2 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          search results. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -159,11 +159,11 @@ declare class SpotifyWebApi {
 
     /**
      * Search for playlists.
-     * @param {string} query The search query.
-     * @param {Object} options The possible options.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param query The search query.
+     * @param options The possible options.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example searchPlaylists('workout', { limit : 1, offset : 0 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          search results. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -172,11 +172,11 @@ declare class SpotifyWebApi {
 
     /**
      * Get an artist's albums.
-     * @param {string} artistId The artist's ID.
-     * @options {Object} [options] The possible options, e.g. limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistId The artist's ID.
+     * @param options The possible options, e.g. limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getArtistAlbums('0oSGxfWSnnOXhD2fKuz2Gy', { album_type : 'album', country : 'GB', limit : 2, offset : 5 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the albums
+     * @returns A promise that if successful, returns an object containing the albums
      *          for the given artist. The result is paginated. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -186,10 +186,10 @@ declare class SpotifyWebApi {
     /**
      * Get the tracks of an album.
      * @param albumId the album's ID.
-     * @options {Object} [options] The possible options, e.g. limit.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options The possible options, e.g. limit.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAlbumTracks('41MnTivkwTO3UUJ8DrqEJJ', { limit : 5, offset : 1 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *                    tracks in the album. The result is paginated. If the promise is rejected.
      *                    it contains an error object. Not returned if a callback is given.
      */
@@ -198,11 +198,11 @@ declare class SpotifyWebApi {
 
     /**
      * Get an artist's top tracks.
-     * @param {string} artistId The artist's ID.
-     * @param {string} country The country/territory where the tracks are most popular. (format: ISO 3166-1 alpha-2)
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistId The artist's ID.
+     * @param country The country/territory where the tracks are most popular. (format: ISO 3166-1 alpha-2)
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getArtistTopTracks('0oSGxfWSnnOXhD2fKuz2Gy', 'GB').then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          artist's top tracks in the given country. If the promise is rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
@@ -211,10 +211,10 @@ declare class SpotifyWebApi {
 
     /**
      * Get related artists.
-     * @param {string} artistId The artist's ID.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistId The artist's ID.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getArtistRelatedArtists('0oSGxfWSnnOXhD2fKuz2Gy').then(...)
-     * @returns {Promise|undefined} A promise that if successful, returns an object containing the
+     * @returns A promise that if successful, returns an object containing the
      *          related artists. If the promise is rejected, it contains an error object. Not returned if a callback is given.
      */
     getArtistRelatedArtists(artistId: string, callback: Callback<SpotifyApi.ArtistsRelatedArtistsResponse>): void;
@@ -223,9 +223,9 @@ declare class SpotifyWebApi {
     /**
      * Get information about a user.
      * @param userId The user ID.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getUser('thelinmichael').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     * @returns A promise that if successful, resolves to an object
      *          containing information about the user. If the promise is
      *          rejected, it contains an error object. Not returned if a callback is given.
      */
@@ -234,9 +234,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get information about the user that has signed in (the current user).
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getMe().then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     * @returns A promise that if successful, resolves to an object
      *          containing information about the user. The amount of information
      *          depends on the permissions given by the user. If the promise is
      *          rejected, it contains an error object. Not returned if a callback is given.
@@ -246,13 +246,13 @@ declare class SpotifyWebApi {
 
     /**
      * Get a user's playlists.
-     * @param {string} userId An optional id of the user. If you know the Spotify URI it is easy
+     * @param userId An optional id of the user. If you know the Spotify URI it is easy
      * to find the id (e.g. spotify:user:<here_is_the_id>). If not provided, the id of the user that granted
      * the permissions will be used.
-     * @param {Object} [options] The options supplied to this request.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options The options supplied to this request.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getUserPlaylists('thelinmichael').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     * @returns A promise that if successful, resolves to an object containing
      *          a list of playlists. If rejected, it contains an error object. Not returned if a callback is given.
      */
     getUserPlaylists(userId: string, options: PaginationOptions, callback: Callback<SpotifyApi.ListOfUsersPlaylistsResponse>): void;
@@ -262,11 +262,11 @@ declare class SpotifyWebApi {
 
     /**
      * Get a playlist.
-     * @param {string} playlistId The playlist's ID.
-     * @param {Object} [options] The options supplied to this request.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param playlistId The playlist's ID.
+     * @param options The options supplied to this request.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getPlaylist('3EsfV6XzCHU8SPNdbnFogK').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     * @returns A promise that if successful, resolves to an object containing
      *          the playlist. If rejected, it contains an error object. Not returned if a callback is given.
      */
     getPlaylist(playlistId: string, options: GetPlaylistOptions, callback: Callback<SpotifyApi.SinglePlaylistResponse>): void;
@@ -274,11 +274,11 @@ declare class SpotifyWebApi {
 
     /**
      * Get tracks in a playlist.
-     * @param {string} playlistId The playlist's ID.
-     * @param {Object} [options] Optional options, such as fields.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param playlistId The playlist's ID.
+     * @param options Optional options, such as fields.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getPlaylistTracks('3ktAYNcRHpazJ9qecm3ptn').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object that containing
+     * @returns A promise that if successful, resolves to an object that containing
      * the tracks in the playlist. If rejected, it contains an error object. Not returned if a callback is given.
      */
     getPlaylistTracks(playlistId: string, options: GetPlaylistTracksOptions, callback: Callback<SpotifyApi.PlaylistTrackResponse>): void;
@@ -286,12 +286,12 @@ declare class SpotifyWebApi {
 
     /**
      * Create a playlist.
-     * @param {string} userId The playlist's owner's user ID.
-     * @param {string} playlistName The name of the playlist.
-     * @param {Object} [options] The possible options, currently only public.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param userId The playlist's owner's user ID.
+     * @param playlistName The name of the playlist.
+     * @param options The possible options, currently only public.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example createPlaylist('thelinmichael', 'My cool playlist!', { public : false }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing information about the
+     * @returns A promise that if successful, resolves to an object containing information about the
      *          created playlist. If rejected, it contains an error object. Not returned if a callback is given.
      */
     createPlaylist(userId: string, playlistName: string, options: PlaylistDetailsOptions, callback: Callback<SpotifyApi.CreatePlaylistResponse>): void;
@@ -299,10 +299,10 @@ declare class SpotifyWebApi {
 
     /**
      * Follow a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {Object} [options] The possible options, currently only public.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @param playlistId The playlist's ID
+     * @param options The possible options, currently only public.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     followPlaylist(playlistId: string, options: PublicOptions, callback: Callback<SpotifyApi.FollowPlaylistReponse>): void;
@@ -310,10 +310,10 @@ declare class SpotifyWebApi {
 
     /**
      * Unfollow a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {Object} [options] The possible options, currently only public.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @param playlistId The playlist's ID
+     * @param options The possible options, currently only public.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     unfollowPlaylist(playlistId: string, callback: Callback<SpotifyApi.UnfollowPlaylistReponse>): void;
@@ -321,11 +321,11 @@ declare class SpotifyWebApi {
 
     /**
      * Change playlist details.
-     * @param {string} playlistId The playlist's ID
-     * @param {Object} [options] The possible options, e.g. name, public.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param playlistId The playlist's ID
+     * @param options The possible options, e.g. name, public.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example changePlaylistDetails('3EsfV6XzCHU8SPNdbnFogK', {name: 'New name', public: true}).then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     changePlaylistDetails(playlistId: string, options: ChangePlaylistOptions, callback: Callback<SpotifyApi.ChangePlaylistDetailsReponse>): void;
@@ -333,11 +333,11 @@ declare class SpotifyWebApi {
 
     /**
      * Replace the image used to represent a specific playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {string} base64URI Base64 encoded JPEG image data, maximum payload size is 256 KB
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param playlistId The playlist's ID
+     * @param base64URI Base64 encoded JPEG image data, maximum payload size is 256 KB
+     * @param callback Optional callback method to be called instead of the promise.
      * @example uploadCustomPlaylistCoverImage('3EsfV6XzCHU8SPNdbnFogK', 'longbase64uri').then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     uploadCustomPlaylistCoverImage(playlistId: string, base64URI: string, callback: Callback<SpotifyApi.UploadCustomPlaylistCoverImageReponse>): void;
@@ -345,12 +345,12 @@ declare class SpotifyWebApi {
 
     /**
      * Add tracks to a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {string[]} tracks URIs of the tracks to add to the playlist.
-     * @param {Object} [options] Options, position being the only one.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param playlistId The playlist's ID
+     * @param tracks URIs of the tracks to add to the playlist.
+     * @param options Options, position being the only one.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example addTracksToPlaylist(3EsfV6XzCHU8SPNdbnFogK', ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]).then(...)
-     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * @returns A promise that if successful returns an object containing a snapshot_id. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     addTracksToPlaylist(playlistId: string, tracks: ReadonlyArray<string>, options: PositionOptions, callback: Callback<SpotifyApi.AddTracksToPlaylistResponse>): void;
@@ -358,12 +358,12 @@ declare class SpotifyWebApi {
 
     /**
      * Remove tracks from a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {Object[]} tracks An array of objects containing a property called uri with the track URI (String), and
+     * @param playlistId The playlist's ID
+     * @param tracks An array of objects containing a property called uri with the track URI (String), and
      * a an optional property called positions (int[]), e.g. { uri : "spotify:track:491rM2JN8KvmV6p0oDDuJT", positions : [0, 15] }
-     * @param {Object} options Options, snapshot_id being the only one.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * @param options Options, snapshot_id being the only one.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns an object containing a snapshot_id. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     removeTracksFromPlaylist(playlistId: string, tracks: ReadonlyArray<Track>, options: SnapshotOptions, callback: Callback<SpotifyApi.RemoveTracksFromPlaylistResponse>): void;
@@ -371,11 +371,11 @@ declare class SpotifyWebApi {
 
     /**
      * Remove tracks from a playlist by position instead of specifying the tracks' URIs.
-     * @param {string} playlistId The playlist's ID
-     * @param {int[]} positions The positions of the tracks in the playlist that should be removed
-     * @param {string} snapshot_id The snapshot ID, or version, of the playlist. Required
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * @param playlistId The playlist's ID
+     * @param positions The positions of the tracks in the playlist that should be removed
+     * @param snapshot_id The snapshot ID, or version, of the playlist. Required
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns an object containing a snapshot_id. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     removeTracksFromPlaylistByPosition(playlistId: string, positions: ReadonlyArray<number>, snapshotId: string, callback: Callback<SpotifyApi.RemoveTracksFromPlaylistResponse>): void;
@@ -383,10 +383,10 @@ declare class SpotifyWebApi {
 
     /**
      * Replace tracks in a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {Object[]} uris An array of track URIs (strings)
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns an empty object. If rejected,
+     * @param playlistId The playlist's ID
+     * @param uris An array of track URIs (strings)
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns an empty object. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     replaceTracksInPlaylist(playlistId: string, uris: ReadonlyArray<string>, callback: Callback<SpotifyApi.ReplacePlaylistTracksResponse>): void;
@@ -394,12 +394,12 @@ declare class SpotifyWebApi {
 
     /**
      * Reorder tracks in a playlist.
-     * @param {string} playlistId The playlist's ID
-     * @param {int} rangeStart The position of the first track to be reordered.
-     * @param {int} insertBefore The position where the tracks should be inserted.
-     * @param {Object} options Optional parameters, i.e. range_length and snapshot_id.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
+     * @param playlistId The playlist's ID
+     * @param rangeStart The position of the first track to be reordered.
+     * @param insertBefore The position where the tracks should be inserted.
+     * @param options Optional parameters, i.e. range_length and snapshot_id.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns an object containing a snapshot_id. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     reorderTracksInPlaylist(playlistId: string, rangeStart: number, insertBefore: number, options: ReorderPlaylistTracksOptions, callback: Callback<SpotifyApi.ReorderPlaylistTracksResponse>): void;
@@ -407,10 +407,10 @@ declare class SpotifyWebApi {
 
     /**
      * Get audio features for a single track identified by its unique Spotify ID.
-     * @param {string} trackId The track ID
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param trackId The track ID
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAudioFeaturesForTrack('38P3Q4QcdjQALGF2Z92BmR').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     * @returns A promise that if successful, resolves to an object
      *          containing information about the audio features. If the promise is
      *          rejected, it contains an error object. Not returned if a callback is given.
      */
@@ -419,10 +419,10 @@ declare class SpotifyWebApi {
 
     /**
      * Get audio analysis for a single track identified by its unique Spotify ID.
-     * @param {string} trackId The track ID
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param trackId The track ID
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAudioAnalysisForTrack('38P3Q4QcdjQALGF2Z92BmR').then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     * @returns A promise that if successful, resolves to an object
      *          containing information about the audio analysis. If the promise is
      *          rejected, it contains an error object. Not returned if a callback is given.
      */
@@ -431,10 +431,10 @@ declare class SpotifyWebApi {
 
     /**
      * Get audio features for multiple tracks identified by their unique Spotify ID.
-     * @param {string[]} trackIds The track IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param trackIds The track IDs
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getAudioFeaturesForTracks(['38P3Q4QcdjQALGF2Z92BmR', '2HO2bnoMrpnZUbUqiilLHi']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object
+     * @returns A promise that if successful, resolves to an object
      *          containing information about the audio features for the tracks. If the promise is
      *          rejected, it contains an error object. Not returned if a callback is given.
      */
@@ -443,10 +443,10 @@ declare class SpotifyWebApi {
 
     /**
      * Create a playlist-style listening experience based on seed artists, tracks and genres.
-     * @param {Object} [options] The options supplied to this request.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options The options supplied to this request.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example getRecommendations({ min_energy: 0.4, seed_artists: ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ'], min_popularity: 50 }).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
+     * @returns A promise that if successful, resolves to an object containing
      *          a list of tracks and a list of seeds. If rejected, it contains an error object. Not returned if a callback is given.
      */
     getRecommendations(options: GetRecommendationsOptions, callback: Callback<SpotifyApi.RecommendationsFromSeedsResponse>): void;
@@ -454,18 +454,18 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve a URL where the user can give the application permissions.
-     * @param {string[]} scopes The scopes corresponding to the permissions the application needs.
-     * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
-     * @param {boolean} showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
-     * @returns {string} The URL where the user can give application permissions.
+     * @param scopes The scopes corresponding to the permissions the application needs.
+     * @param state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
+     * @param showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
+     * @returns The URL where the user can give application permissions.
      */
     createAuthorizeURL(scopes: ReadonlyArray<string>, state: string, showDialog?: boolean): string;
 
     /**
      * Retrieve the tracks that are saved to the authenticated users Your Music library.
-     * @param {Object} [options] Options, being market, limit, and/or offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which in turn contains
+     * @param options Options, being market, limit, and/or offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object which in turn contains
      *          playlist track objects. Not returned if a callback is given.
      */
     getMySavedTracks(options: PaginationMarketOptions, callback: Callback<SpotifyApi.UsersSavedTracksResponse>): void;
@@ -473,9 +473,9 @@ declare class SpotifyWebApi {
 
     /**
      * Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library.
-     * @param {string[]} trackIds The track IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * @param trackIds The track IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into an array of booleans. The order
      * of the returned array's elements correspond to the track ID in the request.
      * The boolean value of true indicates that the track is part of the user's library, otherwise false.
      * Not returned if a callback is given.
@@ -485,9 +485,9 @@ declare class SpotifyWebApi {
 
     /**
      * Remove a track from the authenticated user's Your Music library.
-     * @param {string[]} trackIds The track IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error.
+     * @param trackIds The track IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns null, otherwise an error.
      * Not returned if a callback is given.
      */
     removeFromMySavedTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.RemoveUsersSavedTracksResponse>): void;
@@ -495,18 +495,18 @@ declare class SpotifyWebApi {
 
     /**
      * Add a track from the authenticated user's Your Music library.
-     * @param {string[]} trackIds The track IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
+     * @param trackIds The track IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
      */
     addToMySavedTracks(trackIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.SaveTracksForUserResponse>): void;
     addToMySavedTracks(trackIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.SaveTracksForUserResponse>>;
 
     /**
      * Remove an album from the authenticated user's Your Music library.
-     * @param {string[]} albumIds The album IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error.
+     * @param albumIds The album IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns null, otherwise an error.
      * Not returned if a callback is given.
      */
     removeFromMySavedAlbums(albumIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.RemoveAlbumsForUserResponse>): void;
@@ -514,18 +514,18 @@ declare class SpotifyWebApi {
 
     /**
      * Add an album from the authenticated user's Your Music library.
-     * @param {string[]} albumIds The track IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
+     * @param albumIds The track IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns null, otherwise an error. Not returned if a callback is given.
      */
     addToMySavedAlbums(albumIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.SaveAlbumsForUserResponse>): void;
     addToMySavedAlbums(albumIds: ReadonlyArray<string>): Promise<Response<SpotifyApi.SaveAlbumsForUserResponse>>;
 
     /**
      * Retrieve the albums that are saved to the authenticated users Your Music library.
-     * @param {Object} [options] Options, being market, limit, and/or offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which in turn contains
+     * @param options Options, being market, limit, and/or offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object which in turn contains
      *          playlist album objects. Not returned if a callback is given.
      */
     getMySavedAlbums(options: PaginationMarketOptions, callback: Callback<SpotifyApi.UsersSavedAlbumsResponse>): void;
@@ -533,9 +533,9 @@ declare class SpotifyWebApi {
 
     /**
      * Check if one or more albums is already saved in the current Spotify user’s “Your Music” library.
-     * @param {string[]} albumIds The album IDs
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * @param albumIds The album IDs
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into an array of booleans. The order
      * of the returned array's elements correspond to the album ID in the request.
      * The boolean value of true indicates that the album is part of the user's library, otherwise false.
      * Not returned if a callback is given.
@@ -545,9 +545,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the current user's top artists based on calculated affinity.
-     * @param {Object} [options] Options, being time_range, limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of artists,
+     * @param options Options, being time_range, limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of artists,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyTopArtists(options: GetTopOptions, callback: Callback<SpotifyApi.UsersTopArtistsResponse>): void;
@@ -555,9 +555,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the current user's top tracks based on calculated affinity.
-     * @param {Object} [options] Options, being time_range, limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param options Options, being time_range, limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyTopTracks(options: GetTopOptions, callback: Callback<SpotifyApi.UsersTopTracksResponse>): void;
@@ -565,9 +565,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the Current User's Recently Played Tracks
-     * @param {Object} [options] Options, being type, after, limit, before.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param options Options, being type, after, limit, before.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyRecentlyPlayedTracks(options: BeforeOptions | AfterOptions, callback: Callback<SpotifyApi.UsersRecentlyPlayedTracksResponse>): void;
@@ -575,8 +575,8 @@ declare class SpotifyWebApi {
 
     /**
      * Get the Current User's Connect Devices
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyDevices(callback: Callback<SpotifyApi.UserDevicesResponse>): void;
@@ -584,9 +584,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the Current User's Currently Playing Track.
-     * @param {Object} [options] Options, being market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param options Options, being market.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyCurrentPlayingTrack(options: MarketOptions, callback: Callback<SpotifyApi.CurrentlyPlayingResponse>): void;
@@ -594,9 +594,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the Current User's Current Playback State
-     * @param {Object} [options] Options, being market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param options Options, being market.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     getMyCurrentPlaybackState(options: MarketOptions, callback: Callback<SpotifyApi.CurrentPlaybackResponse>): void;
@@ -604,9 +604,9 @@ declare class SpotifyWebApi {
 
     /**
      * Transfer a User's Playback
-     * @param {Object} [options] Options, being market.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @param options Options, being market.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     transferMyPlayback(options: TransferPlaybackOptions, callback: Callback<void>): void;
@@ -614,10 +614,10 @@ declare class SpotifyWebApi {
 
     /**
      * Starts or Resumes the Current User's Playback
-     * @param {Object} [options] Options, being device_id, context_uri, offset, uris.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options Options, being device_id, context_uri, offset, uris.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     play(options: PlayOptions, callback: Callback<void>): void;
@@ -625,10 +625,10 @@ declare class SpotifyWebApi {
 
     /**
      * Pauses the Current User's Playback
-     * @param {Object} [options] Options, for now device_id,
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options Options, for now device_id,
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackPause().then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     pause(options: DeviceOptions, callback: Callback<void>): void;
@@ -636,9 +636,9 @@ declare class SpotifyWebApi {
 
     /**
      * Skip the Current User's Playback To Previous Track
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackPrevious().then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     skipToPrevious(callback: Callback<void>): void;
@@ -646,9 +646,9 @@ declare class SpotifyWebApi {
 
     /**
      * Skip the Current User's Playback To Next Track
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackNext().then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     skipToNext(callback: Callback<void>): void;
@@ -657,21 +657,21 @@ declare class SpotifyWebApi {
     /**
      * Seeks to the given position in the user’s currently playing track.
      *
-     * @param {number} positionMs The position in milliseconds to seek to. Must be a positive number.
-     * @param {Object} options A JSON object with options that can be passed.
-     * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+     * @param positionMs The position in milliseconds to seek to. Must be a positive number.
+     * @param options A JSON object with options that can be passed.
+     * @param callback An optional callback that receives 2 parameters. The first
      * one is the error object (null if no error), and the second is the value if the request succeeded.
-     * @return {Object} Null if a callback is provided, a `Promise` object otherwise
+     * @returns Null if a callback is provided, a Promise otherwise
      */
     seek(positionMs: number, options: DeviceOptions, callback: Callback<void>): void;
     seek(positionMs: number, options?: DeviceOptions): Promise<Response<void>>;
 
     /**
      * Set Repeat Mode On The Current User's Playback
-     * @param {Object} [options] Options, being state (track, context, off).
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options Options, being state (track, context, off).
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackRepeat({state: 'context'}).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     setRepeat(options: RepeatOptions, callback: Callback<void>): void;
@@ -679,10 +679,10 @@ declare class SpotifyWebApi {
 
     /**
      * Set Shuffle Mode On The Current User's Playback
-     * @param {Object} [options] Options, being state (true, false).
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param options Options, being state (true, false).
+     * @param callback Optional callback method to be called instead of the promise.
      * @example playbackShuffle({state: 'false'}).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+     * @returns A promise that if successful, resolves into a paging object of tracks,
      *          otherwise an error. Not returned if a callback is given.
      */
     setShuffle(options: ShuffleOptions, callback: Callback<void>): void;
@@ -691,21 +691,21 @@ declare class SpotifyWebApi {
     /**
      * Set the volume for the user’s current playback device.
      *
-     * @param {number} volumePercent The volume to set. Must be a value from 0 to 100 inclusive.
-     * @param {Object} options A JSON object with options that can be passed.
-     * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+     * @param volumePercent The volume to set. Must be a value from 0 to 100 inclusive.
+     * @param options A JSON object with options that can be passed.
+     * @param callback An optional callback that receives 2 parameters. The first
      * one is the error object (null if no error), and the second is the value if the request succeeded.
-     * @return {Object} Null if a callback is provided, a `Promise` object otherwise
+     * @returns nothing if callback is provided, a Promise otherwise
      */
     setVolume(volumePercent: number, options: DeviceOptions, callback: Callback<void>): void;
     setVolume(volumePercent: number, options?: DeviceOptions): Promise<Response<void>>;
 
     /**
      * Add the current user as a follower of one or more other Spotify users.
-     * @param {string[]} userIds The IDs of the users to be followed.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param userIds The IDs of the users to be followed.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example followUsers(['thelinmichael', 'wizzler']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
     followUsers(userIds: ReadonlyArray<string>, callback: Callback<void>): void;
@@ -713,10 +713,10 @@ declare class SpotifyWebApi {
 
     /**
      * Add the current user as a follower of one or more artists.
-     * @param {string[]} artistIds The IDs of the artists to be followed.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistIds The IDs of the artists to be followed.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example followArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
     followArtists(artistIds: ReadonlyArray<string>, callback: Callback<void>): void;
@@ -724,10 +724,10 @@ declare class SpotifyWebApi {
 
     /**
      * Remove the current user as a follower of one or more other Spotify users.
-     * @param {string[]} userIds The IDs of the users to be unfollowed.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param userIds The IDs of the users to be unfollowed.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example unfollowUsers(['thelinmichael', 'wizzler']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
     unfollowUsers(userIds: ReadonlyArray<string>, callback: Callback<void>): void;
@@ -735,10 +735,10 @@ declare class SpotifyWebApi {
 
     /**
      * Remove the current user as a follower of one or more artists.
-     * @param {string[]} artistIds The IDs of the artists to be unfollowed.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistIds The IDs of the artists to be unfollowed.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example unfollowArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, simply resolves to an empty object. If rejected,
+     * @returns A promise that if successful, simply resolves to an empty object. If rejected,
      *          it contains an error object. Not returned if a callback is given.
      */
     unfollowArtists(artistIds: ReadonlyArray<string>, callback: Callback<void>): void;
@@ -746,10 +746,10 @@ declare class SpotifyWebApi {
 
     /**
      * Check to see if the current user is following one or more other Spotify users.
-     * @param {string[]} userIds The IDs of the users to check if are followed by the current user.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param userIds The IDs of the users to check if are followed by the current user.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example isFollowingUsers(['thelinmichael', 'wizzler']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * @returns A promise that if successful, resolves into an array of booleans. The order
      *          of the returned array's elements correspond to the users IDs in the request.
      *          The boolean value of true indicates that the user is following that user, otherwise is not.
      *          Not returned if a callback is given.
@@ -759,9 +759,9 @@ declare class SpotifyWebApi {
 
     /**
      * Get the current user's followed artists.
-     * @param {Object} [options] Options, being after and limit.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * @param options Options, being after and limit.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object which contains
      * album objects. Not returned if a callback is given.
      */
     getFollowedArtists(options: AfterOptions, callback: Callback<SpotifyApi.UsersFollowedArtistsResponse>): void;
@@ -769,11 +769,11 @@ declare class SpotifyWebApi {
 
     /**
      * Check if users are following a playlist.
-     * @param {string} userId The playlist's owner's user ID
-     * @param {string} playlistId The playlist's ID
-     * @param {String[]} User IDs of the following users
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful returns an array of booleans. If rejected,
+     * @param userId The playlist's owner's user ID
+     * @param playlistId The playlist's ID
+     * @param User IDs of the following users
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful returns an array of booleans. If rejected,
      * it contains an error object. Not returned if a callback is given.
      */
     areFollowingPlaylist(userId: string, playlistId: string, followerIds: ReadonlyArray<string>, callback: Callback<SpotifyApi.UsersFollowPlaylistReponse>): void;
@@ -781,10 +781,10 @@ declare class SpotifyWebApi {
 
     /**
      * Check to see if the current user is following one or more artists.
-     * @param {string[]} artistIds The IDs of the artists to check if are followed by the current user.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+     * @param artistIds The IDs of the artists to check if are followed by the current user.
+     * @param callback Optional callback method to be called instead of the promise.
      * @example isFollowingArtists(['0LcJLqbBmaGUft1e9Mm8HV', '3gqv1kgivAc92KnUm4elKv']).then(...)
-     * @returns {Promise|undefined} A promise that if successful, resolves into an array of booleans. The order
+     * @returns A promise that if successful, resolves into an array of booleans. The order
      *          of the returned array's elements correspond to the artists IDs in the request.
      *          The boolean value of true indicates that the user is following that artist, otherwise is not.
      *          Not returned if a callback is given.
@@ -794,9 +794,9 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve new releases
-     * @param {Object} [options] Options, being country, limit and/or offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * @param options Options, being country, limit and/or offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object which contains
      * album objects. Not returned if a callback is given.
      */
     getNewReleases(options: PaginationCountryOptions, callback: Callback<SpotifyApi.ListOfNewReleasesResponse>): void;
@@ -804,9 +804,9 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve featured playlists
-     * @param {Object} [options] Options, being country, locale, timestamp, limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object which contains
+     * @param options Options, being country, locale, timestamp, limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object which contains
      * featured playlists. Not returned if a callback is given.
      */
     getFeaturedPlaylists(options: GetFeaturedPlaylistsOptions, callback: Callback<SpotifyApi.ListOfFeaturedPlaylistsResponse>): void;
@@ -814,9 +814,9 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve a list of categories used to tag items in Spotify (e.g. in the 'Browse' tab)
-     * @param {Object} [options] Options, being country, locale, limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a paging object of categories.
+     * @param options Options, being country, locale, limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a paging object of categories.
      * Not returned if a callback is given.
      */
     getCategories(options: PaginationLocaleOptions, callback: Callback<SpotifyApi.MultipleCategoriesResponse>): void;
@@ -824,10 +824,10 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve a category.
-     * @param {string} categoryId The id of the category to retrieve.
-     * @param {Object} [options] Options, being country, locale.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing a category object.
+     * @param categoryId The id of the category to retrieve.
+     * @param options Options, being country, locale.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing a category object.
      * Not returned if a callback is given.
      */
     getCategory(categoryId: string, options: LocaleOptions, callback: Callback<SpotifyApi.SingleCategoryResponse>): void;
@@ -835,10 +835,10 @@ declare class SpotifyWebApi {
 
     /**
      * Retrieve playlists for a category.
-     * @param {string} categoryId The id of the category to retrieve playlists for.
-     * @param {Object} [options] Options, being country, limit, offset.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to a paging object containing simple playlists.
+     * @param categoryId The id of the category to retrieve playlists for.
+     * @param options Options, being country, limit, offset.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to a paging object containing simple playlists.
      * Not returned if a callback is given.
      */
     getPlaylistsForCategory(categoryId: string, options: PaginationCountryOptions, callback: Callback<SpotifyApi.CategoryPlaylistsReponse>): void;
@@ -847,9 +847,9 @@ declare class SpotifyWebApi {
     /**
      * Request an access token using the Client Credentials flow.
      * Requires that client ID and client secret has been set previous to the call.
-     * @param {Object} options Options.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into an object containing the access token,
+     * @param options Options.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into an object containing the access token,
      *          token type and time to expiration. If rejected, it contains an error object. Not returned if a callback is given.
      */
     clientCredentialsGrant(options: {}, callback: Callback<ClientCredentialsGrantResponse>): void;
@@ -858,9 +858,9 @@ declare class SpotifyWebApi {
     /**
      * Request an access token using the Authorization Code flow.
      * Requires that client ID, client secret, and redirect URI has been set previous to the call.
-     * @param {string} code The authorization code returned in the callback in the Authorization Code flow.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves into an object containing the access token,
+     * @param code The authorization code returned in the callback in the Authorization Code flow.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into an object containing the access token,
      *          refresh token, token type and time to expiration. If rejected, it contains an error object.
      *          Not returned if a callback is given.
      */
@@ -870,8 +870,8 @@ declare class SpotifyWebApi {
     /**
      * Refresh the access token given that it hasn't expired.
      * Requires that client ID, client secret and refresh token has been set previous to the call.
-     * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-     * @returns {Promise|undefined} A promise that if successful, resolves to an object containing the
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves to an object containing the
      *          access token, time to expiration and token type. If rejected, it contains an error object.
      *          Not returned if a callback is given.
      */
@@ -944,13 +944,13 @@ interface LocaleOptions extends CountryOptions {
     locale?: string;
 }
 
-interface PaginationMarketOptions extends PaginationOptions, MarketOptions {}
+interface PaginationMarketOptions extends PaginationOptions, MarketOptions { }
 
-interface PaginationCountryOptions extends PaginationOptions, CountryOptions {}
+interface PaginationCountryOptions extends PaginationOptions, CountryOptions { }
 
-interface PaginationLocaleOptions extends PaginationOptions, LocaleOptions {}
+interface PaginationLocaleOptions extends PaginationOptions, LocaleOptions { }
 
-interface GetPlaylistOptions extends MarketOptions, FieldsOptions {}
+interface GetPlaylistOptions extends MarketOptions, FieldsOptions { }
 
 interface PlaylistDetailsOptions extends PublicOptions {
     collaborative?: boolean;
@@ -969,7 +969,7 @@ interface GetArtistAlbumsOptions extends PaginationCountryOptions {
     include_groups?: string;
 }
 
-interface GetPlaylistTracksOptions extends PaginationMarketOptions, FieldsOptions {}
+interface GetPlaylistTracksOptions extends PaginationMarketOptions, FieldsOptions { }
 
 type SearchType = 'album' | 'artist' | 'playlist' | 'track';
 


### PR DESCRIPTION
## Summary
Copied jsdoc comments from js package repo to typings, so that comments would show up in vscode tooltips properly. Also fixed some inaccuracies in these comments.

## Template checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~Test the change in your own code. (Compile and run.)~ Does not apply, no definitions modified
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~ Same as above
- [ ] ~Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).~ Same as above
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/thelinmichael/spotify-web-api-node/blob/master/src/spotify-web-api.js) and [here](https://github.com/thelinmichael/spotify-web-api-node/blob/master/src/server-methods.js)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ Does not apply
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ Does not apply