### PR TITLE
react-aria-modal: Changes to onExit, it should be optional

### DIFF
--- a/types/react-aria-modal/index.d.ts
+++ b/types/react-aria-modal/index.d.ts
@@ -164,7 +164,7 @@ export interface AriaModalProps {
      * That also makes it easier to create your own "close modal" buttons; because you
      * have the function that closes the modal right there, written by you, at your disposal.
      */
-    onExit(): any;
+    onExit?(): any;
 
     /**
      * If true, the modal dialog's focus trap will be paused.


### PR DESCRIPTION
Changed onExit from required to optional.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidtheclark/react-aria-modal

According to library source code we have
`exit = event => {
    if (this.props.onExit) {
      this.props.onExit(event);
    }
  };`
