### PR TITLE
braintree-web ThreeDSecure

### DIFF
--- a/types/braintree-web/index.d.ts
+++ b/types/braintree-web/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Braintree-web v3.47.0
 // Project: https://github.com/braintree/braintree-web
 // Definitions by: Guy Shahine <https://github.com/chlela>
+//                 Michael Hodgins <https://github.com/michaelhodgins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -1147,6 +1148,33 @@ declare namespace braintree {
     liabilityShifted: boolean;
   }
 
+  interface ThreeDSecureVerifyCardOptions {
+    nonce: string;
+    bin: string;
+    amount: number | string;
+    challengeRequested?: boolean;
+    exemptionRequested?: boolean;
+    onLookupComplete: (data, next) => void;
+    email?: string;
+    mobilePhoneNumber?: string;
+    billingAddress?: {
+      givenName?: string;
+      surname?: string;
+      phoneNumber?: string;
+      streetAddress?: string;
+      extendedAddress?: string;
+      line3?: string;
+      locality?: string;
+      region?: string;
+      postalCode?: string;
+      countryCodeAlpha2?: string;
+    },
+    additionalInformation?: {[k: string]: any},
+    customer?: {},
+    addFrame?: (err?: BraintreeError, iframe?: HTMLIFrameElement) => void;
+    removeFrame?: () => void;
+  }
+
   export interface ThreeDSecure {
     /**
      * @static
@@ -1233,8 +1261,8 @@ declare namespace braintree {
      *   }
      * });
      */
-    verifyCard(options: { nonce: string, amount: number, addFrame: (err?: BraintreeError, iframe?: HTMLIFrameElement) => void, removeFrame?: () => void }): Promise<ThreeDSecureVerifyPayload>;
-    verifyCard(options: { nonce: string, amount: number, addFrame: (err?: BraintreeError, iframe?: HTMLIFrameElement) => void, removeFrame: () => void }, callback: callback): void;
+    verifyCard(options: ThreeDSecureVerifyCardOptions): Promise<ThreeDSecureVerifyPayload>;
+    verifyCard(options: ThreeDSecureVerifyCardOptions, callback: callback): void;
 
     /**
      * Cancel the 3DS flow and return the verification payload if available.


### PR DESCRIPTION
Add the correct options to the definition for ThreeDSecure::verifyCard(). The important change for me was to define that `amount` can be either a number or a string. The official documentation says number, but this is not consistent with the documentation in the JavaScript code, which shows either a number or a string can be used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://braintree.github.io/braintree-web/current/ThreeDSecure.html#verifyCard
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
