### PR TITLE
Add missing RequestStub methods to jasmine-ajax

### DIFF
--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jasmine-ajax 3.1
+// Type definitions for jasmine-ajax 3.3
 // Project: https://github.com/jasmine/jasmine-ajax
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -48,10 +48,20 @@ interface JasmineAjaxRequestStubReturnOptions {
 	responseHeaders?: { [key: string]: string };
 }
 
+interface JasmineAjaxRequestStubErrorOptions {
+	status?: number;
+	statusText?: string;
+}
+
 interface JasmineAjaxRequestStub {
-	data?: string;
-	method?: string;
+	url: RegExp | string;
+	query: string;
+	data: string;
+	method: string;
 	andReturn(options: JasmineAjaxRequestStubReturnOptions): void;
+	andError(options: JasmineAjaxRequestStubErrorOptions): void;
+	andTimeout(): void;
+	andCallFunction(functionToCall: (JasmineAjaxRequest) => void): void;
 	matches(fullUrl: string, data: string, method: string): boolean;
 }
 

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -37,7 +37,7 @@ interface JasmineAjaxRequestTracker {
 	mostRecent(): JasmineAjaxRequest;
 	at(index: number): JasmineAjaxRequest;
 	filter(urlToMatch: RegExp): JasmineAjaxRequest[];
-	filter(urlToMatch: Function): JasmineAjaxRequest[];
+	filter(urlToMatch: (JasmineAjaxRequest) => boolean): JasmineAjaxRequest[];
 	filter(urlToMatch: string): JasmineAjaxRequest[];
 }
 

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for jasmine-ajax 3.3
 // Project: https://github.com/jasmine/jasmine-ajax
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
+//                 Julian Gonggrijp <https://github.com/jgonggrijp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -37,7 +37,7 @@ interface JasmineAjaxRequestTracker {
 	mostRecent(): JasmineAjaxRequest;
 	at(index: number): JasmineAjaxRequest;
 	filter(urlToMatch: RegExp): JasmineAjaxRequest[];
-	filter(urlToMatch: (JasmineAjaxRequest) => boolean): JasmineAjaxRequest[];
+	filter(urlToMatch: (request: JasmineAjaxRequest) => boolean): JasmineAjaxRequest[];
 	filter(urlToMatch: string): JasmineAjaxRequest[];
 }
 
@@ -62,7 +62,7 @@ interface JasmineAjaxRequestStub {
 	andReturn(options: JasmineAjaxRequestStubReturnOptions): void;
 	andError(options: JasmineAjaxRequestStubErrorOptions): void;
 	andTimeout(): void;
-	andCallFunction(functionToCall: (JasmineAjaxRequest) => void): void;
+	andCallFunction(functionToCall: (request: JasmineAjaxRequest) => void): void;
 	matches(fullUrl: string, data: string, method: string): boolean;
 }
 

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -26,7 +26,7 @@ interface JasmineAjaxRequest extends XMLHttpRequest {
 
 	respondWith(response: JasmineAjaxResponse): void;
 	responseTimeout(): void;
-	responseError(): void;
+	responseError(options?: JasmineAjaxRequestStubErrorOptions): void;
 }
 
 interface JasmineAjaxRequestTracker {

--- a/types/jasmine-ajax/jasmine-ajax-tests.ts
+++ b/types/jasmine-ajax/jasmine-ajax-tests.ts
@@ -1431,6 +1431,15 @@ describe('RequestStub', () => {
 		expect(stub)['toMatchRequest']('/foo', 'baz=quux&foo=bar');
 		expect(stub).not['toMatchRequest']('/foo', 'foo=bar');
 	});
+
+	it('has methods', () => {
+		jasmine.Ajax.stubRequest('/foo').andReturn({
+			status: 200,
+			contentType: 'application/json',
+			responseText: '{"success": true}',
+			responseHeaders: { 'X-Example': 'a value' },
+		});
+	});
 });
 
 describe('RequestTracker', () => {

--- a/types/jasmine-ajax/jasmine-ajax-tests.ts
+++ b/types/jasmine-ajax/jasmine-ajax-tests.ts
@@ -1439,6 +1439,33 @@ describe('RequestStub', () => {
 			responseText: '{"success": true}',
 			responseHeaders: { 'X-Example': 'a value' },
 		});
+		jasmine.Ajax.stubRequest('/bar').andReturn({});
+		jasmine.Ajax.stubRequest('/baz').andError({
+			status: 400,
+			statusText: 'Invalid',
+		});
+		jasmine.Ajax.stubRequest('/foobar').andError({});
+		jasmine.Ajax.stubRequest('/foobaz').andTimeout();
+		jasmine.Ajax.stubRequest('/barbaz').andCallFunction((xhr) => {
+			xhr.url === '/barbaz';
+			xhr.method === 'POST';
+			xhr.params === {};
+			xhr.username === 'jane_coder';
+			xhr.password === '12345';
+			xhr.requestHeaders === {Accept: 'application/json'};
+			xhr.data() === {query: 'bananas'};
+			xhr.respondWith({
+				status: 200,
+				contentType: 'application/json',
+				responseText: '{"success": true}',
+				responseHeaders: { 'X-Example': 'a value' },
+			});
+			xhr.responseTimeout();
+			xhr.responseError({
+				status: 400,
+				statusText: 'Invalid',
+			});
+		});
 	});
 });
 

--- a/types/jasmine-ajax/tslint.json
+++ b/types/jasmine-ajax/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "ban-types": false,
         "unified-signatures": false
     }
 }


### PR DESCRIPTION
I have code that uses `jasmine.Ajax.stubRequest('/some/url').andCallFunction()` and soon found out that the latter method hadn't been typed yet. So I added `.andCallFunction` to the `RequestStub` interface and while I was at it, also the missing `.andError` and `.andTimeout` methods and the `.url` and `.query` properties.

The `.data` and `.method` properties were needlessly optional. These properties are always created in the constructor, so I made them non-optional.

`.andCallFunction` was newly introduced in jasmine-ajax version 3.3. For this reason, I bumped the version number accordingly. However, I did not check whether the typings completely represent version 3.3 of jasmine-ajax.

As a habit when contributing to DefinitelyTyped, I always try whether there are any linter rule exceptions that can easily be re-enabled. In this case, I found that the `ban-types` rule could be met by a single line change, so I did that.

While adding tests, I noticed that the pre-existing tests seem to test for correct logic rather than correct typing. Those tests might have been copied verbatim from the jasmine-ajax codebase. The tests that I added, however, test for correct typing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine-ajax/blob/master/src/requestStub.js and https://github.com/jasmine/jasmine-ajax/pull/152
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **Not exactly. I'm adding methods that have been missing for a while (`RequestStub.andError` and `.andTimeout`) as well as a method that was first added in version 3.3 (`.andCallFunction`). I did not check whether the definitions are completely up-to-date with version 3.3, but I bumped the version because of the new method.**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. *Already present, but I removed one of the exceptions.*