### PR TITLE
Add types for parse-path

### DIFF
--- a/types/parse-path/index.d.ts
+++ b/types/parse-path/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for parse-path 4.0
+// Project: https://github.com/IonicaBizau/parse-path
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace parsePath {
+    type Protocol = 'http' | 'https' | 'ssh' | 'file' | 'git';
+
+    interface ParsedPath {
+        /** The url hash. */
+        hash: string;
+        /** The input url. */
+        href: string;
+        /** The url pathname. */
+        pathname: string;
+        /** The domain port. */
+        port: null | number;
+        /** The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`. */
+        protocol: Protocol;
+        /** An array with the url protocols (usually it has one element). */
+        protocols: Protocol[];
+        /** The url querystring, parsed as object. */
+        query: any;
+        /** The url domain (including subdomains). */
+        resource: string;
+        /** The url querystring value. */
+        search: string;
+        /** The authentication user (usually for ssh urls). */
+        user: string;
+    }
+}
+
+declare function parsePath(url: string): parsePath.ParsedPath;
+export = parsePath;

--- a/types/parse-path/parse-path-tests.ts
+++ b/types/parse-path/parse-path-tests.ts
@@ -1,0 +1,13 @@
+import parsePath = require('parse-path');
+
+const parsed = parsePath('http://www.example.com');
+
+parsed.hash; // $ExpectType string
+parsed.href; // $ExpectType string
+parsed.pathname; // $ExpectType string
+parsed.port; // $ExpectType number | null
+parsed.protocol; // $ExpectType Protocol
+parsed.protocols; // $ExpectType Protocol[]
+parsed.resource; // $ExpectType string
+parsed.search; // $ExpectType string
+parsed.user; // $ExpectType string

--- a/types/parse-path/tsconfig.json
+++ b/types/parse-path/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-path-tests.ts"
+    ]
+}

--- a/types/parse-path/tslint.json
+++ b/types/parse-path/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
