### PR TITLE
[@types/node] Http2ServerResponse extends Stream

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -37,6 +37,7 @@
 //                 Jordi Oliveras Rovira <https://github.com/j-oliveras>
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
 //                 Marcin Kopacz <https://github.com/chyzwar>
+//                 Trivikram Kamat <https://github.com/trivikr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.

--- a/types/node/v10/http2.d.ts
+++ b/types/node/v10/http2.d.ts
@@ -556,7 +556,7 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export class Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends stream.Stream {
         private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -6791,7 +6791,7 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export class Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends stream.Stream {
         private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -7213,7 +7213,7 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export class Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends stream.Stream {
         private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;


### PR DESCRIPTION
This was fixed in newer versions in #33527 but got missed in < v10
Http2ServerResponse extended Stream since it was introduced in v8.4.0 ([code](https://github.com/nodejs/node/blob/f70261fb3089b8acf5f68584ef0285a1c11f54fd/lib/internal/http2/compat.js#L427))

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/f70261fb3089b8acf5f68584ef0285a1c11f54fd/lib/internal/http2/compat.js#L427