### PR TITLE
[@types/mongoose] Revert source type of model constructor to any

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -68,16 +68,6 @@ declare module "mongoose" {
   import mongoose = require('mongoose');
 
   /**
-   * Allows for nested objects and arrays to be partial
-   */
-  export type DeepPartial<T> = {
-    [P in keyof T]?:
-    T[P] extends (infer U)[] ? DeepPartial<U>[] :
-    T[P] extends object ? DeepPartial<T[P]> :
-    T[P];
-  };
-
-  /**
    * Gets and optionally overwrites the function used to pluralize collection names
    * @param fn function to use for pluralization of collection names
    * @returns the current function used to pluralize collection names (defaults to the `mongoose-legacy-pluralize` module's function)
@@ -2852,7 +2842,7 @@ declare module "mongoose" {
      *   Model#ensureIndexes. If an error occurred it is passed with the event.
      *   The fields, options, and index name are also passed.
      */
-    new(doc?: DeepPartial<T>): T;
+    new(doc?: any): T;
 
     /**
      * Requires a replica set running MongoDB >= 3.6.0. Watches the underlying collection for changes using MongoDB change streams.

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -807,23 +807,6 @@ ImageModel.findOne({}, function(err, doc) {
   }
 });
 
-/* Testing deep partials */
-interface NestedDoc extends mongoose.Document {
-  name: string;
-  image: ImageDoc;
-}
-var NestedDocSchema = new mongoose.Schema({
-  name: String,
-  image: ImageModel
-});
-const NestedModel = mongoose.model<NestedDoc>('Nested', NestedDocSchema);
-const nested = new NestedModel({
-  name: "name",
-  image: {
-    name: "name"
-  }
-})
-
 /* Using flatten maps example */
 interface Submission extends mongoose.Document {
   name: string;


### PR DESCRIPTION
The type checking added to the model constructor by @richarddd in

26587aa3aa75e0021180a9a7f9b4cb45e036002b
22761c884a9542171583f83ccd178acd0c1e3b11

Causes valid code not to pass type checking with not way of allowing it

As described in issue #37088:

1. It doesn't allow conversion made by Mongoose from source data types to the data types in the document: e.g. from [string to ObjectID](https://github.com/Automattic/mongoose/blob/5.6.11/lib/cast/objectid.js#L25), from [multiple string to boolean](https://mongoosejs.com/docs/schematypes.html#booleans), etc.
2. It doesn't allow settings the constructor type of a document (this is useful so you can access the model of a document using `doc.consutrctor` [1](https://stackoverflow.com/a/17685260/1705056).
3. It doesn't allow [custom schema types](https://mongoosejs.com/docs/customschematypes.html) which could have any arbitrary cast function

All of this are valid use cases for mongoose and the type checking should not
prevent them.

PR #37763 by richarddd tries to solve some of these issues but it only addresses some of them and doesn't even do it [successfully](As shown in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37088#issuecomment-522889112). 

Stricter type checking for the source of a document can be a good thing, but the
current solution by @richarddd is incorrect.

Please allow this revert back to `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

The lists of casts not supported by the current solution by @richarddd is endless, but here are some references:

string as source for numbers:
https://mongoosejs.com/docs/api.html#mongoose_Mongoose-Number

Custom casts
https://mongoosejs.com/docs/customschematypes.html

From source:
Casts made by mongoose by default:
https://github.com/Automattic/mongoose/tree/5.6.10/lib/cast

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


