### PR TITLE
Add typings for jsonpointer

### DIFF
--- a/types/jsonpointer/index.d.ts
+++ b/types/jsonpointer/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-interface JSONPointer {
+export interface JSONPointer {
     /**
      * Looks up a JSON pointer in an object
      */
@@ -16,21 +16,17 @@ interface JSONPointer {
     set(object: object, value: any): void;
 }
 
-declare namespace JSONPointer {
-    /**
-     * Looks up a JSON pointer in an object
-     */
-    function get(object: object, pointer: string): any;
+/**
+ * Looks up a JSON pointer in an object
+ */
+export function get(object: object, pointer: string): any;
 
-    /**
-     * Set a value for a JSON pointer on object
-     */
-    function set(object: object, pointer: string, value: any): void;
+/**
+ * Set a value for a JSON pointer on object
+ */
+export function set(object: object, pointer: string, value: any): void;
 
-    /**
-     *  Builds a JSONPointer instance from a pointer value.
-     */
-    function compile(pointer: string): JSONPointer;
-}
-
-export = JSONPointer;
+/**
+ *  Builds a JSONPointer instance from a pointer value.
+ */
+export function compile(pointer: string): JSONPointer;

--- a/types/jsonpointer/index.d.ts
+++ b/types/jsonpointer/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for jsonpointer 4.0
+// Project: https://github.com/janl/node-jsonpointer#readme
+// Definitions by: Wessel Kuipers <https://github.com/WesselKuipers>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+interface JSONPointer {
+    /**
+     * Looks up a JSON pointer in an object
+     */
+    get(object: object): any;
+
+    /**
+     * Set a value for a JSON pointer on object
+     */
+    set(object: object, value: any): void;
+}
+
+declare namespace JSONPointer {
+    /**
+     * Looks up a JSON pointer in an object
+     */
+    function get(object: object, pointer: string): any;
+
+    /**
+     * Set a value for a JSON pointer on object
+     */
+    function set(object: object, pointer: string, value: any): void;
+
+    /**
+     *  Builds a JSONPointer instance from a pointer value.
+     */
+    function compile(pointer: string): JSONPointer;
+}
+
+export = JSONPointer;

--- a/types/jsonpointer/jsonpointer-tests.ts
+++ b/types/jsonpointer/jsonpointer-tests.ts
@@ -1,0 +1,17 @@
+import * as jsonpointer from 'jsonpointer';
+
+const obj = { foo: 1, bar: { baz: 2}, qux: [3, 4, 5]};
+
+jsonpointer.get(obj, '/foo');     // returns 1
+jsonpointer.get(obj, '/bar/baz'); // returns 2
+jsonpointer.get(obj, '/qux/0');   // returns 3
+jsonpointer.get(obj, '/qux/1');   // returns 4
+jsonpointer.get(obj, '/qux/2');   // returns 5
+jsonpointer.get(obj, '/quo');     // returns undefined
+
+jsonpointer.set(obj, '/foo', 6);   // sets obj.foo = 6;
+jsonpointer.set(obj, '/qux/-', 6); // sets obj.qux = [3, 4, 5, 6]
+
+const pointer = jsonpointer.compile('/foo');
+pointer.get(obj);    // returns 1
+pointer.set(obj, 1); // sets obj.foo = 1

--- a/types/jsonpointer/tsconfig.json
+++ b/types/jsonpointer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsonpointer-tests.ts"
+    ]
+}

--- a/types/jsonpointer/tslint.json
+++ b/types/jsonpointer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These typings are based on [jsonpointer.d.ts](https://github.com/janl/node-jsonpointer/blob/master/jsonpointer.d.ts). No NPM releases have been created since the typings were added, which is over 2 years ago. These types can be removed again once [this PR](https://github.com/janl/node-jsonpointer/pull/43) has been merged.

I modified the type of the `JSONPointer` interface based on the return value of [`compile()`](https://github.com/janl/node-jsonpointer/blob/master/jsonpointer.js#L79).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
