### PR TITLE
[fabric] getElementOffset must returns {left, top} instead of {left, right}

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -5570,7 +5570,7 @@ interface IUtilDomMisc {
 	 * Returns offset for a given element
 	 * @param element Element to get offset for
 	 */
-	getElementOffset(element: HTMLElement): { left: number; right: number; };
+	getElementOffset(element: HTMLElement): { left: number; top: number; };
 	/**
 	 * Returns style attribute value of a given element
 	 * @param element Element to get style attribute for


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://fabricjs.com/docs/fabric.util.html#.getElementOffset
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
