### PR TITLE
Update BackstopJS types.

### DIFF
--- a/types/backstopjs/backstopjs-tests.ts
+++ b/types/backstopjs/backstopjs-tests.ts
@@ -23,7 +23,26 @@ backstop('test', {
 
 /** Custom example */
 
-const scenarios: Scenario[] = [{ label: 'fake', url: 'fakeUrl' }];
+const scenarios: Scenario[] = [
+  {
+    label: 'Microsoft',
+    url: 'https://microsoft.com/',
+    referenceUrl: '',
+    readyEvent: '',
+    readySelector: '',
+    delay: 0,
+    hideSelectors: [],
+    removeSelectors: [],
+    hoverSelector: '',
+    clickSelector: '',
+    postInteractionWait: 0,
+    selectors: [],
+    selectorExpansion: true,
+    expect: 0,
+    misMatchThreshold: 0.1,
+    requireSameDimensions: true,
+  },
+];
 const viewports: Viewport[] = [
   {
     name: 'phone',
@@ -37,6 +56,16 @@ const viewports: Viewport[] = [
   },
   {
     name: 'desktop',
+    width: 1280,
+    height: 1024,
+  },
+  {
+    label: 'tablet_v',
+    width: 1280,
+    height: 1024,
+  },
+  {
+    label: 'tablet_h',
     width: 1280,
     height: 1024,
   },

--- a/types/backstopjs/index.d.ts
+++ b/types/backstopjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for backstopjs 4.0
+// Type definitions for backstopjs 4.1.12
 // Project: https://github.com/garris/backstopjs#readme
 // Definitions by: Darío Blanco <https://github.com/darioblanco>, MindDoc <https://github.com/minddocdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -66,7 +66,7 @@ export interface Scenario {
   keyPressSelector?: KeypressSelector; // Press key in the DOM element prior to screenshot
   keyPressSelectors?: KeypressSelector[]; // Simulates multiple sequential keypress interactions
   label: string; // Tag saved with your reference images
-  misMatchThreshold?: string; // Percentage of different pixels allowed to pass test
+  misMatchThreshold?: number; // Percentage of different pixels allowed to pass test
   onBeforeScript?: string; // Used to set up browser state e.g. cookies
   onReadyScript?: string; // Used to modify UI state prior to screenshots e.g. hovers, clicks etc
   postInteractionWait?: number; // Wait for selector (ms) after interacting with hover or click
@@ -82,7 +82,17 @@ export interface Scenario {
   viewports?: Viewport[]; // Override global viewports
 }
 
-export interface Viewport {
+export type Viewport = ViewportNext | ViewportLegacy;
+
+export interface ViewportNext {
+  label: string;
+  width: number;
+  height: number;
+}
+
+// Create a Viewport version that uses `name` for legacy support.
+// https://github.com/garris/BackstopJS/blob/aa7de8ee059074f947768cfd04db1776348e1a7a/core/util/createBitmaps.js#L25
+export interface ViewportLegacy {
   name: 'phone' | 'tablet' | 'desktop';
   width: number;
   height: number;

--- a/types/backstopjs/index.d.ts
+++ b/types/backstopjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for backstopjs 4.1.12
+// Type definitions for backstopjs 4.1
 // Project: https://github.com/garris/backstopjs#readme
 // Definitions by: Darío Blanco <https://github.com/darioblanco>, MindDoc <https://github.com/minddocdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/backstopjs/index.d.ts
+++ b/types/backstopjs/index.d.ts
@@ -55,6 +55,7 @@ export interface KeypressSelector {
 
 /** The Backstop test definition. See https://github.com/garris/BackstopJS#advanced-scenarios */
 export interface Scenario {
+  [key: string]: any; // Allow for custom properties.
   clickSelector?: string; // Click the specified DOM element prior to screenshot
   clickSelectors?: string[]; // Simulates multiple sequential click interactions
   cookiePath?: string; // Import cookies in JSON format


### PR DESCRIPTION
Add support for `Viewport.label` which is more commonly used than `name`.
Seems to be a free form string, not a limited set of strings:
https://github.com/garris/BackstopJS/blob/aa7de8ee059074f947768cfd04db1776348e1a7a/examples/jsBasedConfig/backstopConfig.js

Looks like they may have switched from `name` to `label` in this commit:
https://github.com/garris/BackstopJS/commit/0535303326e658e69d78f6405aac390b620ff222#diff-9e67e5c53c6a24f5b7f26f857fff03ea

Change `misMatchThreshold` to a number:
https://github.com/garris/BackstopJS/blob/aa7de8ee059074f947768cfd04db1776348e1a7a/examples/jsBasedConfig/backstopConfig.js#L35

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
