### PR TITLE
[@types/sanitize-html] Adds escapeDisallowedTags

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -53,6 +53,7 @@ declare namespace sanitize {
     allowedClasses?: { [index: string]: string[] } | boolean;
     allowedIframeHostnames?: string[];
     allowIframeRelativeUrls?: boolean;
+    escapeDisallowedTags?: boolean;
     allowedSchemes?: string[] | boolean;
     allowedSchemesByTag?: { [index: string]: string[] } | boolean;
     allowedSchemesAppliedToAttributes?: string[];


### PR DESCRIPTION
## Purpose

This PR accompanies https://github.com/apostrophecms/sanitize-html/pull/169 which allows a boolean option called `escapeDisallowedTags` in the sanitize-html package.

The new option will display blacklisted HTML attributes as a string, rather than removing them entirely.