### PR TITLE
[@types/node] Update Buffer.from single argument

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -249,226 +249,268 @@ interface Buffer {
  * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
  */
 declare class Buffer extends Uint8Array {
-    /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
-     */
-    constructor(str: string, encoding?: BufferEncoding);
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
-     */
-    constructor(size: number);
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    constructor(array: Uint8Array);
-    /**
-     * Produces a Buffer backed by the same allocated memory as
-     * the given {ArrayBuffer}/{SharedArrayBuffer}.
-     *
-     *
-     * @param arrayBuffer The ArrayBuffer with which to share memory.
-     * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
-     */
-    constructor(arrayBuffer: ArrayBuffer | SharedArrayBuffer);
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    constructor(array: any[]);
-    /**
-     * Copies the passed {buffer} data onto a new {Buffer} instance.
-     *
-     * @param buffer The buffer to copy.
-     * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-     */
-    constructor(buffer: Buffer);
-    /**
-     * When passed a reference to the .buffer property of a TypedArray instance,
-     * the newly created Buffer will share the same allocated memory as the TypedArray.
-     * The optional {byteOffset} and {length} arguments specify a memory range
-     * within the {arrayBuffer} that will be shared by the Buffer.
-     *
-     * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
-     */
-    static from(arrayBuffer: ArrayBuffer | SharedArrayBuffer, byteOffset?: number, length?: number): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param data data to create a new Buffer
-     */
-    static from(data: number[]): Buffer;
-    static from(data: Uint8Array): Buffer;
-    /**
-     * Creates a new Buffer containing the given JavaScript string {str}.
-     * If provided, the {encoding} parameter identifies the character encoding.
-     * If not provided, {encoding} defaults to 'utf8'.
-     */
-    static from(str: string, encoding?: BufferEncoding): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param values to create a new Buffer
-     */
-    static of(...items: number[]): Buffer;
-    /**
-     * Returns true if {obj} is a Buffer
-     *
-     * @param obj object to test.
-     */
-    static isBuffer(obj: any): obj is Buffer;
-    /**
-     * Returns true if {encoding} is a valid encoding argument.
-     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
-     *
-     * @param encoding string to test.
-     */
-    static isEncoding(encoding: string): encoding is BufferEncoding;
-    /**
-     * Gives the actual byte length of a string. encoding defaults to 'utf8'.
-     * This is not the same as String.prototype.length since that returns the number of characters in a string.
-     *
-     * @param string string to test.
-     * @param encoding encoding used to evaluate (defaults to 'utf8')
-     */
-    static byteLength(
-        string: string | NodeJS.TypedArray | DataView | ArrayBuffer | SharedArrayBuffer,
-        encoding?: BufferEncoding
-    ): number;
-    /**
-     * Returns a buffer which is the result of concatenating all the buffers in the list together.
-     *
-     * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
-     * If the list has exactly one item, then the first item of the list is returned.
-     * If the list has more than one item, then a new Buffer is created.
-     *
-     * @param list An array of Buffer objects to concatenate
-     * @param totalLength Total length of the buffers when concatenated.
-     *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
-     */
-    static concat(list: Uint8Array[], totalLength?: number): Buffer;
-    /**
-     * The same as buf1.compare(buf2).
-     */
-    static compare(buf1: Uint8Array, buf2: Uint8Array): number;
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
-     *    If parameter is omitted, buffer will be filled with zeros.
-     * @param encoding encoding used for call to buf.fill while initalizing
-     */
-    static alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
-    /**
-     * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    static allocUnsafe(size: number): Buffer;
-    /**
-     * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    static allocUnsafeSlow(size: number): Buffer;
-    /**
-     * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
-     */
-    static poolSize: number;
+  /**
+   * Allocates a new buffer containing the given {str}.
+   *
+   * @param str String to store in buffer.
+   * @param encoding encoding to use, optional.  Default is 'utf8'
+   * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
+   */
+  constructor(str: string, encoding?: BufferEncoding);
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
+   */
+  constructor(size: number);
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  constructor(array: Uint8Array);
+  /**
+   * Produces a Buffer backed by the same allocated memory as
+   * the given {ArrayBuffer}/{SharedArrayBuffer}.
+   *
+   *
+   * @param arrayBuffer The ArrayBuffer with which to share memory.
+   * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
+   */
+  constructor(arrayBuffer: ArrayBuffer | SharedArrayBuffer);
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  constructor(array: any[]);
+  /**
+   * Copies the passed {buffer} data onto a new {Buffer} instance.
+   *
+   * @param buffer The buffer to copy.
+   * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
+   */
+  constructor(buffer: Buffer);
+  /**
+   * When passed a reference to the .buffer property of a TypedArray instance,
+   * the newly created Buffer will share the same allocated memory as the TypedArray.
+   * The optional {byteOffset} and {length} arguments specify a memory range
+   * within the {arrayBuffer} that will be shared by the Buffer.
+   *
+   * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
+   */
+  static from(
+    arrayBuffer: ArrayBuffer | SharedArrayBuffer,
+    byteOffset?: number,
+    length?: number,
+  ): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param data data to create a new Buffer
+   */
+  static from(
+    data: number[] | Uint8Array | string | ArrayBuffer | SharedArrayBuffer,
+  ): Buffer;
+  static from(data: number[]): Buffer;
+  /**
+   * Creates a new Buffer containing the given JavaScript string {str}.
+   * If provided, the {encoding} parameter identifies the character encoding.
+   * If not provided, {encoding} defaults to 'utf8'.
+   */
+  static from(str: string, encoding?: BufferEncoding): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param values to create a new Buffer
+   */
+  static of(...items: number[]): Buffer;
+  /**
+   * Returns true if {obj} is a Buffer
+   *
+   * @param obj object to test.
+   */
+  static isBuffer(obj: any): obj is Buffer;
+  /**
+   * Returns true if {encoding} is a valid encoding argument.
+   * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+   *
+   * @param encoding string to test.
+   */
+  static isEncoding(encoding: string): encoding is BufferEncoding;
+  /**
+   * Gives the actual byte length of a string. encoding defaults to 'utf8'.
+   * This is not the same as String.prototype.length since that returns the number of characters in a string.
+   *
+   * @param string string to test.
+   * @param encoding encoding used to evaluate (defaults to 'utf8')
+   */
+  static byteLength(
+    string:
+      | string
+      | NodeJS.TypedArray
+      | DataView
+      | ArrayBuffer
+      | SharedArrayBuffer,
+    encoding?: BufferEncoding,
+  ): number;
+  /**
+   * Returns a buffer which is the result of concatenating all the buffers in the list together.
+   *
+   * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
+   * If the list has exactly one item, then the first item of the list is returned.
+   * If the list has more than one item, then a new Buffer is created.
+   *
+   * @param list An array of Buffer objects to concatenate
+   * @param totalLength Total length of the buffers when concatenated.
+   *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
+   */
+  static concat(list: Uint8Array[], totalLength?: number): Buffer;
+  /**
+   * The same as buf1.compare(buf2).
+   */
+  static compare(buf1: Uint8Array, buf2: Uint8Array): number;
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
+   *    If parameter is omitted, buffer will be filled with zeros.
+   * @param encoding encoding used for call to buf.fill while initalizing
+   */
+  static alloc(
+    size: number,
+    fill?: string | Buffer | number,
+    encoding?: BufferEncoding,
+  ): Buffer;
+  /**
+   * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  static allocUnsafe(size: number): Buffer;
+  /**
+   * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  static allocUnsafeSlow(size: number): Buffer;
+  /**
+   * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
+   */
+  static poolSize: number;
 
-    write(string: string, encoding?: BufferEncoding): number;
-    write(string: string, offset: number, encoding?: BufferEncoding): number;
-    write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
-    toString(encoding?: string, start?: number, end?: number): string;
-    toJSON(): { type: 'Buffer'; data: number[] };
-    equals(otherBuffer: Uint8Array): boolean;
-    compare(
-        otherBuffer: Uint8Array,
-        targetStart?: number,
-        targetEnd?: number,
-        sourceStart?: number,
-        sourceEnd?: number
-    ): number;
-    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    /**
-     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
-     *
-     * This method is incompatible with `Uint8Array#slice()`, which returns a copy of the original memory.
-     *
-     * @param begin Where the new `Buffer` will start. Default: `0`.
-     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
-     */
-    slice(begin?: number, end?: number): Buffer;
-    /**
-     * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
-     *
-     * This method is compatible with `Uint8Array#subarray()`.
-     *
-     * @param begin Where the new `Buffer` will start. Default: `0`.
-     * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
-     */
-    subarray(begin?: number, end?: number): Buffer;
-    writeUIntLE(value: number, offset: number, byteLength: number): number;
-    writeUIntBE(value: number, offset: number, byteLength: number): number;
-    writeIntLE(value: number, offset: number, byteLength: number): number;
-    writeIntBE(value: number, offset: number, byteLength: number): number;
-    readUIntLE(offset: number, byteLength: number): number;
-    readUIntBE(offset: number, byteLength: number): number;
-    readIntLE(offset: number, byteLength: number): number;
-    readIntBE(offset: number, byteLength: number): number;
-    readUInt8(offset: number): number;
-    readUInt16LE(offset: number): number;
-    readUInt16BE(offset: number): number;
-    readUInt32LE(offset: number): number;
-    readUInt32BE(offset: number): number;
-    readInt8(offset: number): number;
-    readInt16LE(offset: number): number;
-    readInt16BE(offset: number): number;
-    readInt32LE(offset: number): number;
-    readInt32BE(offset: number): number;
-    readFloatLE(offset: number): number;
-    readFloatBE(offset: number): number;
-    readDoubleLE(offset: number): number;
-    readDoubleBE(offset: number): number;
-    reverse(): this;
-    swap16(): Buffer;
-    swap32(): Buffer;
-    swap64(): Buffer;
-    writeUInt8(value: number, offset: number): number;
-    writeUInt16LE(value: number, offset: number): number;
-    writeUInt16BE(value: number, offset: number): number;
-    writeUInt32LE(value: number, offset: number): number;
-    writeUInt32BE(value: number, offset: number): number;
-    writeInt8(value: number, offset: number): number;
-    writeInt16LE(value: number, offset: number): number;
-    writeInt16BE(value: number, offset: number): number;
-    writeInt32LE(value: number, offset: number): number;
-    writeInt32BE(value: number, offset: number): number;
-    writeFloatLE(value: number, offset: number): number;
-    writeFloatBE(value: number, offset: number): number;
-    writeDoubleLE(value: number, offset: number): number;
-    writeDoubleBE(value: number, offset: number): number;
+  write(string: string, encoding?: BufferEncoding): number;
+  write(string: string, offset: number, encoding?: BufferEncoding): number;
+  write(
+    string: string,
+    offset: number,
+    length: number,
+    encoding?: BufferEncoding,
+  ): number;
+  toString(encoding?: string, start?: number, end?: number): string;
+  toJSON(): { type: 'Buffer'; data: number[] };
+  equals(otherBuffer: Uint8Array): boolean;
+  compare(
+    otherBuffer: Uint8Array,
+    targetStart?: number,
+    targetEnd?: number,
+    sourceStart?: number,
+    sourceEnd?: number,
+  ): number;
+  copy(
+    targetBuffer: Uint8Array,
+    targetStart?: number,
+    sourceStart?: number,
+    sourceEnd?: number,
+  ): number;
+  /**
+   * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+   *
+   * This method is incompatible with `Uint8Array#slice()`, which returns a copy of the original memory.
+   *
+   * @param begin Where the new `Buffer` will start. Default: `0`.
+   * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+   */
+  slice(begin?: number, end?: number): Buffer;
+  /**
+   * Returns a new `Buffer` that references **the same memory as the original**, but offset and cropped by the start and end indices.
+   *
+   * This method is compatible with `Uint8Array#subarray()`.
+   *
+   * @param begin Where the new `Buffer` will start. Default: `0`.
+   * @param end Where the new `Buffer` will end (not inclusive). Default: `buf.length`.
+   */
+  subarray(begin?: number, end?: number): Buffer;
+  writeUIntLE(value: number, offset: number, byteLength: number): number;
+  writeUIntBE(value: number, offset: number, byteLength: number): number;
+  writeIntLE(value: number, offset: number, byteLength: number): number;
+  writeIntBE(value: number, offset: number, byteLength: number): number;
+  readUIntLE(offset: number, byteLength: number): number;
+  readUIntBE(offset: number, byteLength: number): number;
+  readIntLE(offset: number, byteLength: number): number;
+  readIntBE(offset: number, byteLength: number): number;
+  readUInt8(offset: number): number;
+  readUInt16LE(offset: number): number;
+  readUInt16BE(offset: number): number;
+  readUInt32LE(offset: number): number;
+  readUInt32BE(offset: number): number;
+  readInt8(offset: number): number;
+  readInt16LE(offset: number): number;
+  readInt16BE(offset: number): number;
+  readInt32LE(offset: number): number;
+  readInt32BE(offset: number): number;
+  readFloatLE(offset: number): number;
+  readFloatBE(offset: number): number;
+  readDoubleLE(offset: number): number;
+  readDoubleBE(offset: number): number;
+  reverse(): this;
+  swap16(): Buffer;
+  swap32(): Buffer;
+  swap64(): Buffer;
+  writeUInt8(value: number, offset: number): number;
+  writeUInt16LE(value: number, offset: number): number;
+  writeUInt16BE(value: number, offset: number): number;
+  writeUInt32LE(value: number, offset: number): number;
+  writeUInt32BE(value: number, offset: number): number;
+  writeInt8(value: number, offset: number): number;
+  writeInt16LE(value: number, offset: number): number;
+  writeInt16BE(value: number, offset: number): number;
+  writeInt32LE(value: number, offset: number): number;
+  writeInt32BE(value: number, offset: number): number;
+  writeFloatLE(value: number, offset: number): number;
+  writeFloatBE(value: number, offset: number): number;
+  writeDoubleLE(value: number, offset: number): number;
+  writeDoubleBE(value: number, offset: number): number;
 
-    fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+  fill(
+    value: string | Uint8Array | number,
+    offset?: number,
+    end?: number,
+    encoding?: BufferEncoding,
+  ): this;
 
-    indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
-    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: BufferEncoding): number;
-    entries(): IterableIterator<[number, number]>;
-    includes(value: string | number | Buffer, byteOffset?: number, encoding?: BufferEncoding): boolean;
-    keys(): IterableIterator<number>;
-    values(): IterableIterator<number>;
+  indexOf(
+    value: string | number | Uint8Array,
+    byteOffset?: number,
+    encoding?: BufferEncoding,
+  ): number;
+  lastIndexOf(
+    value: string | number | Uint8Array,
+    byteOffset?: number,
+    encoding?: BufferEncoding,
+  ): number;
+  entries(): IterableIterator<[number, number]>;
+  includes(
+    value: string | number | Buffer,
+    byteOffset?: number,
+    encoding?: BufferEncoding,
+  ): boolean;
+  keys(): IterableIterator<number>;
+  values(): IterableIterator<number>;
 }
 
 /*----------------------------------------------*

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -38,6 +38,7 @@
 //                 Thanik Bhongbhibhat <https://github.com/bhongy>
 //                 Marcin Kopacz <https://github.com/chyzwar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.
 

--- a/types/node/test/global.ts
+++ b/types/node/test/global.ts
@@ -39,3 +39,17 @@ const a: NodeJS.TypedArray = new Buffer(123);
     const stderr: Writable = process.stderr;
     writableFinished = process.stderr.writableFinished;
 }
+
+// When Buffer.from takes a single argument it can be a union of any accepted value
+let value: string | Buffer | ArrayBuffer | number[];
+const ranNum = Math.random();
+if (ranNum < 0.25) {
+    value = 'hello';
+} else if (ranNum < 0.5) {
+    value = Buffer.alloc(0);
+} else if (ranNum < 0.75) {
+    value = new ArrayBuffer(0);
+} else {
+    value = [1, 2, 3];
+}
+const buf: Buffer = Buffer.from(value);

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -289,142 +289,159 @@ interface Buffer extends Uint8Array {
  * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
  */
 declare const Buffer: {
-    /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
-     */
-    new(str: string, encoding?: string): Buffer;
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
-     */
-    new(size: number): Buffer;
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    new(array: Uint8Array): Buffer;
-    /**
-     * Produces a Buffer backed by the same allocated memory as
-     * the given {ArrayBuffer}/{SharedArrayBuffer}.
-     *
-     *
-     * @param arrayBuffer The ArrayBuffer with which to share memory.
-     * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
-     */
-    new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    new(array: any[]): Buffer;
-    /**
-     * Copies the passed {buffer} data onto a new {Buffer} instance.
-     *
-     * @param buffer The buffer to copy.
-     * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-     */
-    new(buffer: Buffer): Buffer;
-    prototype: Buffer;
-    /**
-     * When passed a reference to the .buffer property of a TypedArray instance,
-     * the newly created Buffer will share the same allocated memory as the TypedArray.
-     * The optional {byteOffset} and {length} arguments specify a memory range
-     * within the {arrayBuffer} that will be shared by the Buffer.
-     *
-     * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
-     */
-    from(arrayBuffer: ArrayBuffer | SharedArrayBuffer, byteOffset?: number, length?: number): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param data data to create a new Buffer
-     */
-    from(data: any[]): Buffer;
-    from(data: Uint8Array): Buffer;
-    /**
-     * Creates a new Buffer containing the given JavaScript string {str}.
-     * If provided, the {encoding} parameter identifies the character encoding.
-     * If not provided, {encoding} defaults to 'utf8'.
-     */
-    from(str: string, encoding?: string): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param values to create a new Buffer
-     */
-    of(...items: number[]): Buffer;
-    /**
-     * Returns true if {obj} is a Buffer
-     *
-     * @param obj object to test.
-     */
-    isBuffer(obj: any): obj is Buffer;
-    /**
-     * Returns true if {encoding} is a valid encoding argument.
-     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
-     *
-     * @param encoding string to test.
-     */
-    isEncoding(encoding: string): boolean | undefined;
-    /**
-     * Gives the actual byte length of a string. encoding defaults to 'utf8'.
-     * This is not the same as String.prototype.length since that returns the number of characters in a string.
-     *
-     * @param string string to test.
-     * @param encoding encoding used to evaluate (defaults to 'utf8')
-     */
-    byteLength(string: string | NodeJS.TypedArray | DataView | ArrayBuffer | SharedArrayBuffer, encoding?: string): number;
-    /**
-     * Returns a buffer which is the result of concatenating all the buffers in the list together.
-     *
-     * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
-     * If the list has exactly one item, then the first item of the list is returned.
-     * If the list has more than one item, then a new Buffer is created.
-     *
-     * @param list An array of Buffer objects to concatenate
-     * @param totalLength Total length of the buffers when concatenated.
-     *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
-     */
-    concat(list: Uint8Array[], totalLength?: number): Buffer;
-    /**
-     * The same as buf1.compare(buf2).
-     */
-    compare(buf1: Uint8Array, buf2: Uint8Array): number;
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
-     *    If parameter is omitted, buffer will be filled with zeros.
-     * @param encoding encoding used for call to buf.fill while initalizing
-     */
-    alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;
-    /**
-     * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    allocUnsafe(size: number): Buffer;
-    /**
-     * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    allocUnsafeSlow(size: number): Buffer;
-    /**
-     * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
-     */
-    poolSize: number;
+  /**
+   * Allocates a new buffer containing the given {str}.
+   *
+   * @param str String to store in buffer.
+   * @param encoding encoding to use, optional.  Default is 'utf8'
+   * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
+   */
+  new (str: string, encoding?: string): Buffer;
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
+   */
+  new (size: number): Buffer;
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  new (array: Uint8Array): Buffer;
+  /**
+   * Produces a Buffer backed by the same allocated memory as
+   * the given {ArrayBuffer}/{SharedArrayBuffer}.
+   *
+   *
+   * @param arrayBuffer The ArrayBuffer with which to share memory.
+   * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
+   */
+  new (arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  new (array: any[]): Buffer;
+  /**
+   * Copies the passed {buffer} data onto a new {Buffer} instance.
+   *
+   * @param buffer The buffer to copy.
+   * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
+   */
+  new (buffer: Buffer): Buffer;
+  prototype: Buffer;
+  /**
+   * When passed a reference to the .buffer property of a TypedArray instance,
+   * the newly created Buffer will share the same allocated memory as the TypedArray.
+   * The optional {byteOffset} and {length} arguments specify a memory range
+   * within the {arrayBuffer} that will be shared by the Buffer.
+   *
+   * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
+   */
+  from(
+    arrayBuffer: ArrayBuffer | SharedArrayBuffer,
+    byteOffset?: number,
+    length?: number,
+  ): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param data data to create a new Buffer
+   */
+  from(
+    data: number[] | Uint8Array | string | ArrayBuffer | SharedArrayBuffer,
+  ): Buffer;
+  /**
+   * Creates a new Buffer containing the given JavaScript string {str}.
+   * If provided, the {encoding} parameter identifies the character encoding.
+   * If not provided, {encoding} defaults to 'utf8'.
+   */
+  from(str: string, encoding?: string): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param values to create a new Buffer
+   */
+  of(...items: number[]): Buffer;
+  /**
+   * Returns true if {obj} is a Buffer
+   *
+   * @param obj object to test.
+   */
+  isBuffer(obj: any): obj is Buffer;
+  /**
+   * Returns true if {encoding} is a valid encoding argument.
+   * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+   *
+   * @param encoding string to test.
+   */
+  isEncoding(encoding: string): boolean | undefined;
+  /**
+   * Gives the actual byte length of a string. encoding defaults to 'utf8'.
+   * This is not the same as String.prototype.length since that returns the number of characters in a string.
+   *
+   * @param string string to test.
+   * @param encoding encoding used to evaluate (defaults to 'utf8')
+   */
+  byteLength(
+    string:
+      | string
+      | NodeJS.TypedArray
+      | DataView
+      | ArrayBuffer
+      | SharedArrayBuffer,
+    encoding?: string,
+  ): number;
+  /**
+   * Returns a buffer which is the result of concatenating all the buffers in the list together.
+   *
+   * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
+   * If the list has exactly one item, then the first item of the list is returned.
+   * If the list has more than one item, then a new Buffer is created.
+   *
+   * @param list An array of Buffer objects to concatenate
+   * @param totalLength Total length of the buffers when concatenated.
+   *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
+   */
+  concat(list: Uint8Array[], totalLength?: number): Buffer;
+  /**
+   * The same as buf1.compare(buf2).
+   */
+  compare(buf1: Uint8Array, buf2: Uint8Array): number;
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
+   *    If parameter is omitted, buffer will be filled with zeros.
+   * @param encoding encoding used for call to buf.fill while initalizing
+   */
+  alloc(
+    size: number,
+    fill?: string | Buffer | number,
+    encoding?: string,
+  ): Buffer;
+  /**
+   * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  allocUnsafe(size: number): Buffer;
+  /**
+   * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  allocUnsafeSlow(size: number): Buffer;
+  /**
+   * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
+   */
+  poolSize: number;
 };
 
 /*----------------------------------------------*

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -301,142 +301,159 @@ interface Buffer extends Uint8Array {
  * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
  */
 declare const Buffer: {
-    /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
-     */
-    new(str: string, encoding?: BufferEncoding): Buffer;
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
-     */
-    new(size: number): Buffer;
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    new(array: Uint8Array): Buffer;
-    /**
-     * Produces a Buffer backed by the same allocated memory as
-     * the given {ArrayBuffer}/{SharedArrayBuffer}.
-     *
-     *
-     * @param arrayBuffer The ArrayBuffer with which to share memory.
-     * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
-     */
-    new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
-    /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-     */
-    new(array: any[]): Buffer;
-    /**
-     * Copies the passed {buffer} data onto a new {Buffer} instance.
-     *
-     * @param buffer The buffer to copy.
-     * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-     */
-    new(buffer: Buffer): Buffer;
-    prototype: Buffer;
-    /**
-     * When passed a reference to the .buffer property of a TypedArray instance,
-     * the newly created Buffer will share the same allocated memory as the TypedArray.
-     * The optional {byteOffset} and {length} arguments specify a memory range
-     * within the {arrayBuffer} that will be shared by the Buffer.
-     *
-     * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
-     */
-    from(arrayBuffer: ArrayBuffer | SharedArrayBuffer, byteOffset?: number, length?: number): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param data data to create a new Buffer
-     */
-    from(data: number[]): Buffer;
-    from(data: Uint8Array): Buffer;
-    /**
-     * Creates a new Buffer containing the given JavaScript string {str}.
-     * If provided, the {encoding} parameter identifies the character encoding.
-     * If not provided, {encoding} defaults to 'utf8'.
-     */
-    from(str: string, encoding?: BufferEncoding): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param values to create a new Buffer
-     */
-    of(...items: number[]): Buffer;
-    /**
-     * Returns true if {obj} is a Buffer
-     *
-     * @param obj object to test.
-     */
-    isBuffer(obj: any): obj is Buffer;
-    /**
-     * Returns true if {encoding} is a valid encoding argument.
-     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
-     *
-     * @param encoding string to test.
-     */
-    isEncoding(encoding: string): encoding is BufferEncoding
-    /**
-     * Gives the actual byte length of a string. encoding defaults to 'utf8'.
-     * This is not the same as String.prototype.length since that returns the number of characters in a string.
-     *
-     * @param string string to test.
-     * @param encoding encoding used to evaluate (defaults to 'utf8')
-     */
-    byteLength(string: string | NodeJS.TypedArray | DataView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
-    /**
-     * Returns a buffer which is the result of concatenating all the buffers in the list together.
-     *
-     * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
-     * If the list has exactly one item, then the first item of the list is returned.
-     * If the list has more than one item, then a new Buffer is created.
-     *
-     * @param list An array of Buffer objects to concatenate
-     * @param totalLength Total length of the buffers when concatenated.
-     *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
-     */
-    concat(list: Uint8Array[], totalLength?: number): Buffer;
-    /**
-     * The same as buf1.compare(buf2).
-     */
-    compare(buf1: Uint8Array, buf2: Uint8Array): number;
-    /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
-     *    If parameter is omitted, buffer will be filled with zeros.
-     * @param encoding encoding used for call to buf.fill while initalizing
-     */
-    alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
-    /**
-     * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    allocUnsafe(size: number): Buffer;
-    /**
-     * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
-     * of the newly created Buffer are unknown and may contain sensitive data.
-     *
-     * @param size count of octets to allocate
-     */
-    allocUnsafeSlow(size: number): Buffer;
-    /**
-     * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
-     */
-    poolSize: number;
+  /**
+   * Allocates a new buffer containing the given {str}.
+   *
+   * @param str String to store in buffer.
+   * @param encoding encoding to use, optional.  Default is 'utf8'
+   * @deprecated since v10.0.0 - Use `Buffer.from(string[, encoding])` instead.
+   */
+  new (str: string, encoding?: BufferEncoding): Buffer;
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @deprecated since v10.0.0 - Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).
+   */
+  new (size: number): Buffer;
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  new (array: Uint8Array): Buffer;
+  /**
+   * Produces a Buffer backed by the same allocated memory as
+   * the given {ArrayBuffer}/{SharedArrayBuffer}.
+   *
+   *
+   * @param arrayBuffer The ArrayBuffer with which to share memory.
+   * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
+   */
+  new (arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
+  /**
+   * Allocates a new buffer containing the given {array} of octets.
+   *
+   * @param array The octets to store.
+   * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
+   */
+  new (array: any[]): Buffer;
+  /**
+   * Copies the passed {buffer} data onto a new {Buffer} instance.
+   *
+   * @param buffer The buffer to copy.
+   * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
+   */
+  new (buffer: Buffer): Buffer;
+  prototype: Buffer;
+  /**
+   * When passed a reference to the .buffer property of a TypedArray instance,
+   * the newly created Buffer will share the same allocated memory as the TypedArray.
+   * The optional {byteOffset} and {length} arguments specify a memory range
+   * within the {arrayBuffer} that will be shared by the Buffer.
+   *
+   * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
+   */
+  from(
+    arrayBuffer: ArrayBuffer | SharedArrayBuffer,
+    byteOffset?: number,
+    length?: number,
+  ): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param data data to create a new Buffer
+   */
+  from(
+    data: number[] | Uint8Array | string | ArrayBuffer | SharedArrayBuffer,
+  ): Buffer;
+  /**
+   * Creates a new Buffer containing the given JavaScript string {str}.
+   * If provided, the {encoding} parameter identifies the character encoding.
+   * If not provided, {encoding} defaults to 'utf8'.
+   */
+  from(str: string, encoding?: BufferEncoding): Buffer;
+  /**
+   * Creates a new Buffer using the passed {data}
+   * @param values to create a new Buffer
+   */
+  of(...items: number[]): Buffer;
+  /**
+   * Returns true if {obj} is a Buffer
+   *
+   * @param obj object to test.
+   */
+  isBuffer(obj: any): obj is Buffer;
+  /**
+   * Returns true if {encoding} is a valid encoding argument.
+   * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+   *
+   * @param encoding string to test.
+   */
+  isEncoding(encoding: string): encoding is BufferEncoding;
+  /**
+   * Gives the actual byte length of a string. encoding defaults to 'utf8'.
+   * This is not the same as String.prototype.length since that returns the number of characters in a string.
+   *
+   * @param string string to test.
+   * @param encoding encoding used to evaluate (defaults to 'utf8')
+   */
+  byteLength(
+    string:
+      | string
+      | NodeJS.TypedArray
+      | DataView
+      | ArrayBuffer
+      | SharedArrayBuffer,
+    encoding?: BufferEncoding,
+  ): number;
+  /**
+   * Returns a buffer which is the result of concatenating all the buffers in the list together.
+   *
+   * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.
+   * If the list has exactly one item, then the first item of the list is returned.
+   * If the list has more than one item, then a new Buffer is created.
+   *
+   * @param list An array of Buffer objects to concatenate
+   * @param totalLength Total length of the buffers when concatenated.
+   *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
+   */
+  concat(list: Uint8Array[], totalLength?: number): Buffer;
+  /**
+   * The same as buf1.compare(buf2).
+   */
+  compare(buf1: Uint8Array, buf2: Uint8Array): number;
+  /**
+   * Allocates a new buffer of {size} octets.
+   *
+   * @param size count of octets to allocate.
+   * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
+   *    If parameter is omitted, buffer will be filled with zeros.
+   * @param encoding encoding used for call to buf.fill while initalizing
+   */
+  alloc(
+    size: number,
+    fill?: string | Buffer | number,
+    encoding?: BufferEncoding,
+  ): Buffer;
+  /**
+   * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  allocUnsafe(size: number): Buffer;
+  /**
+   * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
+   * of the newly created Buffer are unknown and may contain sensitive data.
+   *
+   * @param size count of octets to allocate
+   */
+  allocUnsafeSlow(size: number): Buffer;
+  /**
+   * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.
+   */
+  poolSize: number;
 };
 
 /*----------------------------------------------*


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_buffer
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The definitions for Node Buffer.from when taking a single argument don't behave as expected.

Example (this doesn't compile):
```
function test(value: Buffer | string): Buffer {
    return Buffer.from(value)
}
```

However, this does compile:
```
function test(value: Buffer | string): Buffer {
    if (typeof value === 'string') {
        return Buffer.from(value)
    } else {
        return Buffer.from(value)
    }
}
```

These changes allow either to compile.

All other changes in this commit are from auto formatting.

