### PR TITLE
react: function type as a state in useState

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -833,6 +833,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
+    // function useState<S extends Function>(lazyState: () => S): [S, Dispatch<SetStateAction<S>>];
     function useState<S>(initialState: S extends Function ? () => S : (() => S) | S): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is ommitted
     /**

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -833,7 +833,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    function useState<S>(initialState: S extends Function ? () => S : (() => S) | S): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is ommitted
     /**
      * Returns a stateful value, and a function to update it.

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -198,6 +198,13 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useState(0)[0];
     // $ExpectType undefined
     React.useState(undefined)[0];
+    // make sure that a state type extending Function is passed as a lazyInitialState
+    // $ExpectType () => undefined
+    React.useState(() => () => undefined)[0];
+    // $ExpectType undefined
+    React.useState(() => undefined)[0];
+    // $ExpectError
+    React.useState<() => undefined>(() => undefined);
     // make sure the generic argument does reject actual potentially undefined inputs
     // $ExpectError
     React.useState<number>(undefined)[0];


### PR DESCRIPTION
The issue is that you have to provide a `lazyInitialState` to have a state of a function type in order to work.

``` ts
// this is accepted by current type definition but react will think it is a lazy state
const [callback, setCallback] = useState<() => void>(() => undefined)

// this should be forced by the type definition
const [callback, setCallback] = useState<() => void>(() => () => undefined)
```

I'm having a hard time typing this correctly as for some reason typescript narrows down the types when relying on inference with a conditional type. Also tried to use overloading which did not work either. Not sure if that is a bug in typescript or if I am just to stupid.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
