### PR TITLE
Remove uniontype in yarnpkg__lockfile

### DIFF
--- a/types/yarnpkg__lockfile/index.d.ts
+++ b/types/yarnpkg__lockfile/index.d.ts
@@ -14,7 +14,7 @@ export interface FirstLevelDependency {
 }
 
 export interface LockFileObject {
-  [packageName: string]: FirstLevelDependency | {};
+  [packageName: string]: FirstLevelDependency;
 }
 
 export function parse(

--- a/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
+++ b/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
@@ -2,12 +2,6 @@ import { parse, stringify, FirstLevelDependency } from '@yarnpkg/lockfile';
 
 function testFirstLevelDependency(obj: FirstLevelDependency) {}
 
-function isFirstLevelDependency(
-  obj: FirstLevelDependency | {},
-): obj is FirstLevelDependency {
-  return 'version' in obj;
-}
-
 const file = '';
 const parseResult = parse(file);
 const fileAgain = stringify(parseResult);
@@ -16,8 +10,6 @@ fileAgain.toLowerCase();
 if (parseResult.type === 'merge' || parseResult.type === 'success') {
   Object.keys(parseResult.object).forEach(k => {
     const value = parseResult.object[k];
-    if (isFirstLevelDependency(value)) {
-      testFirstLevelDependency(value);
-    }
+    testFirstLevelDependency(value);
   });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
