### PR TITLE
[@types/mongoose] Add missing autoCreate?: boolean to ConnectionOptions type

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -346,6 +346,11 @@ declare module "mongoose" {
     };
     autoIndex?: boolean;
 
+    /** Before Mongoose builds indexes, it calls Model.createCollection() 
+     * to create the underlying collection in MongoDB if autoCreate 
+     * is set to true.(default: false) */
+    autoCreate?: boolean;
+
     /** Specify a journal write concern (default: false). */
     journal?: boolean;
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -28,6 +28,7 @@
 //                 Richard Davison <https://github.com/richarddd>
 //                 Brian Chen <https://github.com/ToucheSir>
 //                 Boris Figovsky <https://github.com/borfig>
+//                 Simon Driscoll <https://github.com/dinodeSimon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -29,7 +29,7 @@ const connection2: Promise<mongoose.Mongoose> = mongoose.connect(connectUri, {
   useFindAndModify: true,
   useCreateIndex: true,
   autoIndex: true,
-  autoCreate: true
+  autoCreate: true,
 });
 const connection3 = mongoose.connect(connectUri, function (error) {
   error.stack;

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -28,7 +28,8 @@ const connection2: Promise<mongoose.Mongoose> = mongoose.connect(connectUri, {
   useNewUrlParser: true,
   useFindAndModify: true,
   useCreateIndex: true,
-  autoIndex: true
+  autoIndex: true,
+  autoCreate: true
 });
 const connection3 = mongoose.connect(connectUri, function (error) {
   error.stack;


### PR DESCRIPTION
Added missing connection option for Mongoose.

From https://mongoosejs.com/docs/guide.html#autoCreate:

option: autoCreate
Before Mongoose builds indexes, it calls Model.createCollection() to create the underlying collection in MongoDB if autoCreate is set to true. Calling createCollection() sets the collection's default collation based on the collation option and establishes the collection as a capped collection if you set the capped schema option. Like autoIndex, setting autoCreate to true is helpful for development and test environments.

Unfortunately, createCollection() cannot change an existing collection. For example, if you add capped: 1024 to your schema and the existing collection is not capped, createCollection() will throw an error. Generally, autoCreate should be false for production environments.

const schema = new Schema({..}, { autoCreate: true, capped: 1024 });
const Clock = mongoose.model('Clock', schema);
// Mongoose will create the capped collection for you.
Unlike autoIndex, autoCreate is false by default. You can change this default by setting mongoose.set('autoCreate', true);


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongoosejs.com/docs/guide.html#autoCreate was not included in types for Mongoose