### PR TITLE
[selenium-webdriver] Fix missing/incorrect webdriver.Builder methods

### DIFF
--- a/types/selenium-webdriver/ie.d.ts
+++ b/types/selenium-webdriver/ie.d.ts
@@ -20,7 +20,7 @@ export class Driver extends webdriver.WebDriver {
    * @return {!Driver} A new driver instance.
    */
   static createSession(
-    options: webdriver.Capabilities|Options,
+    options?: webdriver.Capabilities|Options,
     opt_service?: remote.DriverService): Driver;
 
   /**

--- a/types/selenium-webdriver/ie.d.ts
+++ b/types/selenium-webdriver/ie.d.ts
@@ -1,4 +1,11 @@
 import * as webdriver from './index';
+import * as remote from './remote';
+
+/**
+ * IEDriverServer logging levels.
+ * @enum {string}
+ */
+export type Level = 'FATAL' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE';
 
 /**
  * A WebDriver client for Microsoft's Internet Explorer.
@@ -7,11 +14,14 @@ export class Driver extends webdriver.WebDriver {
   /**
    * Creates a new session for Microsoft's Internet Explorer.
    *
-   * @param {(capabilities.Capabilities|Options)=} opt_config The configuration
-   *     options.
+   * @param {(Capabilities|Options)=} options The configuration options.
+   * @param {(remote.DriverService)=} opt_service The `DriverService` to use
+   *   to start the IEDriverServer in a child process, optionally.
    * @return {!Driver} A new driver instance.
    */
-  static createSession(opt_config?: webdriver.Capabilities|Options): Driver;
+  static createSession(
+    options: webdriver.Capabilities|Options,
+    opt_service?: remote.DriverService): Driver;
 
   /**
    * This function is a no-op as file detectors are not supported by this
@@ -159,7 +169,7 @@ export class Options extends webdriver.Capabilities {
    * @param {Level} level The logging level.
    * @return {!Options} A self reference.
    */
-  setLogLevel(level: webdriver.logging.Level): Options;
+  setLogLevel(level: Level): Options;
 
   /**
    * Sets the IP address of the driver's host adapter.
@@ -188,4 +198,17 @@ export class Options extends webdriver.Capabilities {
    * @return {!Options} A self reference.
    */
   setProxy(proxy: webdriver.ProxyConfig): Options;
+}
+
+/**
+ * Creates {@link selenium-webdriver/remote.DriverService} instances that manage
+ * an [IEDriverServer](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver)
+ * server in a child process.
+ */
+export class ServiceBuilder extends remote.DriverService.Builder {
+  /**
+   * @param {string=} opt_exe Path to the server executable to use. If omitted,
+   *     the builder will attempt to locate the IEDriverServer on the system PATH.
+   */
+  constructor(opt_exe?: string);
 }

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1038,16 +1038,16 @@ export class Builder {
    * Any calls to {@link #withCapabilities} after this function will
    * overwrite these settings.
    *
-   * You may also define the target browser using the {@code SELENIUM_BROWSER}
-   * environment variable. If set, this environment variable should be of the
-   * form `browser[:[version][:platform]]`.
+   * <p>You may also define the target browser using the {@code
+   * SELENIUM_BROWSER} environment variable. If set, this environment variable
+   * should be of the form {@code browser[:[version][:platform]]}.
    *
-   * @param {(string|!Browser)} name The name of the target browser;
-   *     common defaults are available on the {@link webdriver.Browser} enum.
+   * @param {(string|Browser)} name The name of the target browser;
+   *     common defaults are available on the {@link Browser} enum.
    * @param {string=} opt_version A desired version; may be omitted if any
    *     version should be used.
-   * @param {(string|!capabilities.Platform)=} opt_platform
-   *     The desired platform; may be omitted if any platform may be used.
+   * @param {string=} opt_platform The desired platform; may be omitted if any
+   *     version may be used.
    * @return {!Builder} A self reference.
    */
   forBrowser(name: string, opt_version?: string, opt_platform?: string): Builder;
@@ -1074,12 +1074,11 @@ export class Builder {
   /**
    * Sets the default action to take with an unexpected alert before returning
    * an error.
-   *
-   * @param {?UserPromptHandler} behavior The desired behavior.
+   * @param {string} beahvior The desired behavior; should be 'accept',
+   *     'dismiss', or 'ignore'. Defaults to 'dismiss'.
    * @return {!Builder} A self reference.
-   * @see capabilities.Capabilities#setAlertBehavior
    */
-  setAlertBehavior(behavior?: UserPromptHandler): Builder;
+  setAlertBehavior(behavior?: string): Builder;
 
   /**
    * Sets Chrome-specific options for drivers created by this builder. Any
@@ -1175,7 +1174,7 @@ export class Builder {
   /**
    * Sets the logging preferences for the created session. Preferences may be
    * changed by repeated calls, or by calling {@link #withCapabilities}.
-   * @param {!(logging.Preferences|Object<string, string>)} prefs The
+   * @param {!(logging.Preferences|Object.<string, string>)} prefs The
    *     desired logging preferences.
    * @return {!Builder} A self reference.
    */
@@ -1357,32 +1356,6 @@ export interface ICapability {
 export const Capability: ICapability;
 
 /**
- * The possible default actions a WebDriver session can take to respond to
- * unhandled user prompts (`window.alert()`, `window.confirm()`, and
- * `window.prompt()`).
- *
- * accept: All prompts should be silently accepted.
- *
- * dismiss: All prompts should be silently dismissed.
- *
- * accept and notify: All prompts should be automatically accepted, but an
- *     error should be returned to the next (or currently executing)
- *     WebDriver command.
- *
- * dismiss and notify: All prompts should be automatically dismissed, but
- *     an error should be returned to the next (or currently executing)
- *     WebDriver command.
- *
- * ignore: All prompts should be left unhandled.
- */
-export type UserPromptHandler =
-  'accept' |
-  'dismiss' |
-  'accept and notify' |
-  'dismiss and notify' |
-  'ignore';
-
-/**
  * Describes a set of capabilities for a WebDriver session.
  */
 export class Capabilities {
@@ -1453,13 +1426,12 @@ export class Capabilities {
 
   /**
    * Sets the default action to take with an unexpected alert before returning
-   * an error. If unspecified, WebDriver will default to `'dismiss and notify'`
-   *
-   * @param {?UserPromptHandler} behavior The way WebDriver should respond to
-   *     unhandled user prompts.
+   * an error.
+   * @param {string} behavior The desired behavior; should be 'accept',
+   *     'dismiss', or 'ignore'. Defaults to 'dismiss'.
    * @return {!Capabilities} A self reference.
    */
-  setAlertBehavior(behavior?: UserPromptHandler): Capabilities;
+  setAlertBehavior(behavior?: string): Capabilities;
 
   /**
    * @param {string} key The capability to return.

--- a/types/selenium-webdriver/test/ie.ts
+++ b/types/selenium-webdriver/test/ie.ts
@@ -4,6 +4,7 @@ import * as webdriver from 'selenium-webdriver';
 
 function TestIeDriver() {
     let driver: ie.Driver;
+    driver = ie.Driver.createSession();
     driver = ie.Driver.createSession(webdriver.Capabilities.ie());
     driver = ie.Driver.createSession(new ie.Options());
     driver = ie.Driver.createSession(new ie.Options(), new remote.DriverService('/dev/null', {}));

--- a/types/selenium-webdriver/test/ie.ts
+++ b/types/selenium-webdriver/test/ie.ts
@@ -1,0 +1,41 @@
+import * as ie from 'selenium-webdriver/ie';
+import * as remote from 'selenium-webdriver/remote';
+import * as webdriver from 'selenium-webdriver';
+
+function TestIeDriver() {
+    let driver: ie.Driver;
+    driver = ie.Driver.createSession(webdriver.Capabilities.ie());
+    driver = ie.Driver.createSession(new ie.Options());
+    driver = ie.Driver.createSession(new ie.Options(), new remote.DriverService('/dev/null', {}));
+    driver.setFileDetector();
+
+    let baseDriver: webdriver.WebDriver = driver;
+}
+
+function TestIeOptions() {
+    let options: ie.Options = new ie.Options();
+
+    options = options.introduceFlakinessByIgnoringProtectedModeSettings(true);
+    options = options.ignoreZoomSetting(true);
+    options = options.initialBrowserUrl('url');
+    options = options.enablePersistentHover(true);
+    options = options.enableElementCacheCleanup(true);
+    options = options.requireWindowFocus(true);
+    options = options.browserAttachTimeout(10);
+    options = options.forceCreateProcessApi(true);
+    options = options.addArguments('a', 'b');
+    options = options.usePerProcessProxy(true);
+    options = options.ensureCleanSession(true);
+    options = options.setLogFile('path');
+    options = options.setLogLevel('FATAL');
+    options = options.setHost('hostname');
+    options = options.setExtractPath('path');
+    options = options.silent(true);
+}
+
+function TestIeServiceBuilder() {
+    let builder: ie.ServiceBuilder = new ie.ServiceBuilder();
+    builder = new ie.ServiceBuilder('exe');
+
+    let service: remote.DriverService = builder.build();
+}

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -3,6 +3,8 @@ import * as chrome from 'selenium-webdriver/chrome';
 import * as edge from 'selenium-webdriver/edge';
 import * as firefox from 'selenium-webdriver/firefox';
 import * as http from 'selenium-webdriver/http';
+import * as ie from 'selenium-webdriver/ie';
+import * as safari from 'selenium-webdriver/safari';
 import { Command } from 'selenium-webdriver/lib/command';
 
 function TestBuilder() {
@@ -16,13 +18,25 @@ function TestBuilder() {
     let cap: webdriver.Capabilities = builder.getCapabilities();
     let str: string = builder.getServerUrl();
 
-    builder = builder.setAlertBehavior('behavior');
+    builder = builder.setAlertBehavior('accept');
+    builder = builder.setAlertBehavior();
     builder = builder.setChromeOptions(new chrome.Options());
+    let chromeOpts: chrome.Options = builder.getChromeOptions();
+    builder = builder.setChromeService(new chrome.ServiceBuilder());
     builder = builder.setEdgeOptions(new edge.Options());
+    builder = builder.setEdgeService(new edge.ServiceBuilder());
     builder = builder.setFirefoxOptions(new firefox.Options());
+    let firefoxOpts: firefox.Options = builder.getFirefoxOptions();
+    builder = builder.setFirefoxService(new firefox.ServiceBuilder());
+    builder = builder.setIeOptions(new ie.Options());
+    builder = builder.setIeService(new ie.ServiceBuilder());
     builder = builder.setLoggingPrefs(new webdriver.logging.Preferences());
     builder = builder.setLoggingPrefs({ key: 'value' });
     builder = builder.setProxy({ proxyType: 'type' });
+    builder = builder.setSafariOptions(new safari.Options());
+    let safariOpts: safari.Options = builder.getSafariOptions();
+    builder = builder.usingHttpAgent({});
+    let httpAgent = builder.getHttpAgent();
     builder = builder.usingServer('http://someserver');
     builder = builder.withCapabilities(new webdriver.Capabilities());
     builder = builder.withCapabilities({ something: true });
@@ -97,6 +111,7 @@ function TestCapabilities() {
     capabilities = capabilities.setEnableNativeEvents(true);
     capabilities = capabilities.setScrollBehavior(1);
     capabilities = capabilities.setAlertBehavior('accept');
+    capabilities = capabilities.setAlertBehavior();
 
     anything = capabilities.toJSON();
 

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -18,7 +18,7 @@ function TestBuilder() {
     let cap: webdriver.Capabilities = builder.getCapabilities();
     let str: string = builder.getServerUrl();
 
-    builder = builder.setAlertBehavior('accept');
+    builder = builder.setAlertBehavior('behavior');
     builder = builder.setAlertBehavior();
     builder = builder.setChromeOptions(new chrome.Options());
     let chromeOpts: chrome.Options = builder.getChromeOptions();

--- a/types/selenium-webdriver/tsconfig.json
+++ b/types/selenium-webdriver/tsconfig.json
@@ -26,6 +26,7 @@
         "ie.d.ts",
         "remote.d.ts",
         "safari.d.ts",
+        "test/ie.ts",
         "test/index.ts",
         "test/chrome.ts",
         "test/firefox.ts",


### PR DESCRIPTION
I went through all the `Builder` methods on the implementation and corrected any differences I saw.

Some of these changes are breaking, but would only break cases that would already be broken at runtime.

Summary of changes:
* Adds typings for the following webdriver.Builder methods that were missing: `getChromeOptions`, `setChromeService`, `setEdgeService`, `getFirefoxOptions`, `setFirefoxService`, `setIeService`, `getSafariOptions`, `getHttpAgent`
  * The `getEdgeOptions` and `setSafariService` methods are missing intentionally, since they are missing in the [implementation](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/index.js)
* Adds missing `ie.ServiceBuilder` and `ie.Level` types
* Widens the return type of `Builder.getWebDriverProxy` to allow for it to return `null`, per the implementation and docs
* Makes `Builder` and `Capabilities`' `setAlertBehavior` parameter optional per the implementation.
* (BREAKING) fixes the `ie.Options.setLogLevel` signature to match the [implementation](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/ie.js), which uses an IE-specific log level and not the general logging.Level type.
* (BREAKING) replaces the incorrectly-named `Builder.setSafari` method with `Builder.setSafariOptions` to match the [implementation](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/index.js)
* (BREAKING) updates the type signature on `ie.Driver.createSession` to match the [implementation](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/ie.js)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [selenium-webdriver/index.js](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/index.js), [selenium-webdriver/ie.js](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/ie.js)
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
