### PR TITLE
[lodash] Add missing multiply import

### DIFF
--- a/types/lodash.multiply/index.d.ts
+++ b/types/lodash.multiply/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for lodash.multiply 4.9
+// Project: http://lodash.com/
+// Definitions by: Brian Zengel <https://github.com/bczengel>, Ilya Mochalov <https://github.com/chrootsu>, Stepan Mikhaylyuk <https://github.com/stepancar>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+// Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
+
+import { multiply } from "lodash";
+export = multiply;

--- a/types/lodash.multiply/tsconfig.json
+++ b/types/lodash.multiply/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/lodash.multiply/tslint.json
+++ b/types/lodash.multiply/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/lodash/multiply.d.ts
+++ b/types/lodash/multiply.d.ts
@@ -1,0 +1,2 @@
+import { multiply } from './index';
+export = multiply;

--- a/types/lodash/scripts/generate-modules.ts
+++ b/types/lodash/scripts/generate-modules.ts
@@ -310,6 +310,7 @@ function allModuleNames(): string[] {
         "min",
         "minBy",
         "mixin",
+        "multiply",
         "negate",
         "noConflict",
         "noop",

--- a/types/lodash/ts3.1/multiply.d.ts
+++ b/types/lodash/ts3.1/multiply.d.ts
@@ -1,0 +1,2 @@
+import { multiply } from './index';
+export = multiply;

--- a/types/lodash/ts3.1/tsconfig.json
+++ b/types/lodash/ts3.1/tsconfig.json
@@ -193,6 +193,7 @@
         "min.d.ts",
         "minBy.d.ts",
         "mixin.d.ts",
+        "multiply.d.ts",
         "negate.d.ts",
         "noConflict.d.ts",
         "noop.d.ts",

--- a/types/lodash/tsconfig.json
+++ b/types/lodash/tsconfig.json
@@ -193,6 +193,7 @@
         "min.d.ts",
         "minBy.d.ts",
         "mixin.d.ts",
+        "multiply.d.ts",
         "negate.d.ts",
         "noConflict.d.ts",
         "noop.d.ts",


### PR DESCRIPTION
## Background

While importing multiply like this works `import { multiply } from 'lodash';` the import like this doesn't work `import multiply from 'lodash/multiply';`.

Then I just noticed that for some reason file that makes this import correct for typescript was missing so I added it.

Here is also picture from lodash docs that shows you can import specific functions like this:
![image](https://user-images.githubusercontent.com/12229968/63574113-b5a51180-c58f-11e9-9da4-0a2b4359fd7d.png)


What do you guys think? :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
