### PR TITLE
gtag.js: add support for 'js' command

### DIFF
--- a/types/gtag.js/gtag.js-tests.ts
+++ b/types/gtag.js/gtag.js-tests.ts
@@ -6,6 +6,7 @@ gtag('event', 'login', {
 });
 
 gtag('set', {currency: 'USD'});
+gtag('js', new Date());
 gtag('set', {
   country: 'US',
   currency: 'USD'

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -8,6 +8,7 @@ declare namespace Gtag {
   interface Gtag {
     (command: 'config', targetId: string, config?: ControlParams | EventParams | CustomParams): void;
     (command: 'set', config: CustomParams): void;
+    (command: 'js', config: Date): void;
     (command: 'event', eventName: EventNames | string, eventParams?: ControlParams |  EventParams | CustomParams): void;
   }
 


### PR DESCRIPTION
If changing an existing definition:
https://developers.google.com/analytics/devguides/collection/gtagjs/

``` 
gtag('js', new Date());
```

Now it works, because users typically add this line in the HTML. But nothing prevents them to call this function from .ts files