### PR TITLE
Add types for npm-cache-filename

### DIFF
--- a/types/npm-cache-filename/index.d.ts
+++ b/types/npm-cache-filename/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for npm-cache-filename 1.0
+// Project: https://github.com/npm/npm-cache-filename
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function cf(root: string): (url: string) => string;
+declare function cf(root: string, url: string): string;
+
+export = cf;

--- a/types/npm-cache-filename/npm-cache-filename-tests.ts
+++ b/types/npm-cache-filename/npm-cache-filename-tests.ts
@@ -1,0 +1,6 @@
+import cf = require('npm-cache-filename');
+
+cf('/tmp/cache', 'https://registry.npmjs.org:1234/foo/bar'); // $ExpectType string
+
+const getFile = cf('/tmp/cache');
+getFile('https://registry.npmjs.org:1234/foo/bar'); // $ExpectType string

--- a/types/npm-cache-filename/tsconfig.json
+++ b/types/npm-cache-filename/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "npm-cache-filename-tests.ts"
+    ]
+}

--- a/types/npm-cache-filename/tslint.json
+++ b/types/npm-cache-filename/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
