### PR TITLE
[@types/readable-stream] Fix StringDecoder type usage in readable-stream

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -134,7 +134,7 @@ declare namespace _Readable {
         awaitDrain: number;
         defaultEncoding: string;
         readingMore: boolean;
-        decoder: StringDecoder | null;
+        decoder: typeof StringDecoder | null;
         encoding: string | null;
 
         // new (options: ReadableStateOptions, stream: _Readable): ReadableState;


### PR DESCRIPTION
StringDecoder is a value, but used as type. This gives an error ('StringDecoder' refers to a value, but is being used as a type here.) when trying to build. Add 'typeof' to fix this
