### PR TITLE
In simpl-schema, overload schema() method.

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Andreas Richter <https://github.com/arichter83>
 //                 Qkramer <https://github.com/Qkramer>
 //                 Deskoh <https://github.com/deskoh>
+//                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ValidationContext extends SimpleSchemaValidationContextStatic {
@@ -122,7 +123,8 @@ interface SimpleSchemaStatic {
   pick(...fields: string[]): SimpleSchemaStatic;
   omit(...fields: string[]): SimpleSchemaStatic;
   clean(doc: any, options?: CleanOption): any;
-  schema(key?: string): SchemaDefinition | SchemaDefinition[];
+  schema(key: string): SchemaDefinition;
+  schema(): SchemaDefinition[];
   getDefinition(key: string, propList?: any, functionContext?: any): any;
   keyIsInBlackBox(key: string): boolean;
   labels(labels: {[key: string]: string}): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/aldeed/simple-schema-js/blob/master/package/lib/SimpleSchema.js#L163

The `schema()` method has the following type definition:
```
schema(key?: string): SchemaDefinition | SchemaDefinition[];
```
Where in reality the method will return a `SchemaDefinition[]` only if no key was passed.
```
schema(key: string): SchemaDefinition;
schema(): SchemaDefinition[];
```

This change is based on the source code of `simpl-schema` (linked above is the location of the method).