### PR TITLE
[@types/google-apps-script] Fix Range#setBackground(string) argument and Spreadsheet#getSheetByName(string) return type

### DIFF
--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -141,8 +141,7 @@ declare namespace GoogleAppsScript {
       getBooleanCondition(): BooleanCondition;
       getGradientCondition(): GradientCondition;
       getRanges(): Range[];
-      setBackground(color: string): ConditionalFormatRuleBuilder;
-      setBackground(color: null): ConditionalFormatRuleBuilder;
+      setBackground(color: string | null): ConditionalFormatRuleBuilder;
       setBold(bold: boolean): ConditionalFormatRuleBuilder;
       setFontColor(color: string): ConditionalFormatRuleBuilder;
       setGradientMaxpoint(color: string): ConditionalFormatRuleBuilder;

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -142,6 +142,7 @@ declare namespace GoogleAppsScript {
       getGradientCondition(): GradientCondition;
       getRanges(): Range[];
       setBackground(color: string): ConditionalFormatRuleBuilder;
+      setBackground(color: null): ConditionalFormatRuleBuilder;
       setBold(bold: boolean): ConditionalFormatRuleBuilder;
       setFontColor(color: string): ConditionalFormatRuleBuilder;
       setGradientMaxpoint(color: string): ConditionalFormatRuleBuilder;
@@ -1876,7 +1877,7 @@ declare namespace GoogleAppsScript {
       getRecalculationInterval(): RecalculationInterval;
       getRowHeight(rowPosition: Integer): Integer;
       getSelection(): Selection;
-      getSheetByName(name: string): Sheet;
+      getSheetByName(name: string): Sheet | null;
       getSheetId(): Integer;
       getSheetName(): string;
       getSheetValues(startRow: Integer, startColumn: Integer, numRows: Integer, numColumns: Integer): any[][];


### PR DESCRIPTION
- Range#setBackground can pass null as argument.
> setBackground(color)
> 
> Parameters
> Name | Type | Description
> -- | -- | --
> color | String | A color code in CSS notation (such as '#ffffff' or 'white'); **a null value resets the color.**
> 
> https://developers.google.com/apps-script/reference/spreadsheet/range#setBackground(String)


- if no sheet by that name, Spreadsheet # getSheetByName (string) Return type is null.
> getSheetByName(name)
> 
> Returns a sheet with the given name.
> If multiple sheets have the same name, the leftmost one is returned. **Returns null if there is no sheet with the given name.**
> 
> https://developers.google.com/apps-script/reference/spreadsheet/spreadsheet#getSheetByName(String)

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
