### PR TITLE
Make CodeMirror.Editor extend CodeMirror.Doc

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -161,7 +161,7 @@ declare namespace CodeMirror {
         [keyName: string]: false | string | ((instance: Editor) => void | typeof Pass);
     }
 
-    interface Editor {
+    interface Editor extends Doc {
 
         /** Tells you whether the editor currently has focus. */
         hasFocus(): boolean;


### PR DESCRIPTION
Per the documentation at https://codemirror.net/doc/manual.html#api

> Methods prefixed with `doc.` can, unless otherwise specified, be called both on `CodeMirror` (editor) instances and `CodeMirror.Doc` instances. Methods prefixed with `cm.` are only available on `CodeMirror` instances.

Thus, the `Editor` interface should extend the `Doc` interface.


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html#api
