### PR TITLE
Add type definitions for request-debug@0.2

### DIFF
--- a/types/request-debug/index.d.ts
+++ b/types/request-debug/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for request-debug 0.2
+// Project: https://github.com/request/request-debug
+// Definitions by: Marcello Urbani <https://github.com/marcellourbani>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export = request_debug;
+
+import { CoreOptions, Headers, Request, RequestAPI, RequiredUriUrl, UriOptions, UrlOptions } from "request";
+
+declare namespace request_debug {
+  type LogPhase = "request" | "response" | "redirect" | "auth";
+
+  interface RequestData {
+    debugId: number;
+    method: string;
+    uri: string;
+    headers: Headers;
+    body?: any;
+  }
+
+  interface ResponseData {
+    debugId: number;
+    headers: Headers;
+    statusCode: number;
+    body?: any;
+  }
+
+  interface RedirectData {
+    debugId: number;
+    headers: Headers;
+    statusCode: number;
+    uri: string;
+  }
+  type LogData = RequestData | ResponseData | RedirectData;
+
+  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+    (type: "request", data: RequestData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+  }
+  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+    (type: "response", data: ResponseData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+  }
+  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+    (type: "redirect" | "auth", data: RedirectData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+  }
+  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+    (type: LogPhase, data: LogData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+  }
+
+  const log: LogCallback<Request, CoreOptions, RequiredUriUrl>;
+}
+
+declare function request_debug<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl>(
+  request: RequestAPI<TRequest, TOptions, TUriUrlOptions>,
+  cb?: request_debug.LogCallback<TRequest, TOptions, TUriUrlOptions >
+): void;

--- a/types/request-debug/index.d.ts
+++ b/types/request-debug/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/request/request-debug
 // Definitions by: Marcello Urbani <https://github.com/marcellourbani>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export = request_debug;
 

--- a/types/request-debug/index.d.ts
+++ b/types/request-debug/index.d.ts
@@ -9,48 +9,48 @@ export = request_debug;
 import { CoreOptions, Headers, Request, RequestAPI, RequiredUriUrl, UriOptions, UrlOptions } from "request";
 
 declare namespace request_debug {
-  type LogPhase = "request" | "response" | "redirect" | "auth";
+    type LogPhase = "request" | "response" | "redirect" | "auth";
 
-  interface RequestData {
-    debugId: number;
-    method: string;
-    uri: string;
-    headers: Headers;
-    body?: any;
-  }
+    interface RequestData {
+        debugId: number;
+        method: string;
+        uri: string;
+        headers: Headers;
+        body?: any;
+    }
 
-  interface ResponseData {
-    debugId: number;
-    headers: Headers;
-    statusCode: number;
-    body?: any;
-  }
+    interface ResponseData {
+        debugId: number;
+        headers: Headers;
+        statusCode: number;
+        body?: any;
+    }
 
-  interface RedirectData {
-    debugId: number;
-    headers: Headers;
-    statusCode: number;
-    uri: string;
-  }
-  type LogData = RequestData | ResponseData | RedirectData;
+    interface RedirectData {
+        debugId: number;
+        headers: Headers;
+        statusCode: number;
+        uri: string;
+    }
+    type LogData = RequestData | ResponseData | RedirectData;
 
-  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
-    (type: "request", data: RequestData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
-  }
-  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
-    (type: "response", data: ResponseData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
-  }
-  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
-    (type: "redirect" | "auth", data: RedirectData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
-  }
-  interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
-    (type: LogPhase, data: LogData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
-  }
+    interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+        (type: "request", data: RequestData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+    }
+    interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+        (type: "response", data: ResponseData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+    }
+    interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+        (type: "redirect" | "auth", data: RedirectData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+    }
+    interface LogCallback<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl> {
+        (type: LogPhase, data: LogData, r: RequestAPI<TRequest, TOptions, TUriUrlOptions>): void;
+    }
 
-  const log: LogCallback<Request, CoreOptions, RequiredUriUrl>;
+    const log: LogCallback<Request, CoreOptions, RequiredUriUrl>;
 }
 
 declare function request_debug<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions extends RequiredUriUrl>(
-  request: RequestAPI<TRequest, TOptions, TUriUrlOptions>,
-  cb?: request_debug.LogCallback<TRequest, TOptions, TUriUrlOptions >
+    request: RequestAPI<TRequest, TOptions, TUriUrlOptions>,
+    cb?: request_debug.LogCallback<TRequest, TOptions, TUriUrlOptions >
 ): void;

--- a/types/request-debug/request-debug-tests.ts
+++ b/types/request-debug/request-debug-tests.ts
@@ -1,0 +1,10 @@
+import request = require("request");
+import request_debug = require("request-debug");
+
+// no callback
+request_debug(request);
+
+const callback = (phase: request_debug.LogPhase, data: request_debug.LogData,
+                  request: request.RequestAPI<request.Request, request.CoreOptions, request.RequiredUriUrl>) => {};
+// with callback
+request_debug(request, callback);

--- a/types/request-debug/tsconfig.json
+++ b/types/request-debug/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "request-debug-tests.ts"
+    ]
+}

--- a/types/request-debug/tslint.json
+++ b/types/request-debug/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.