### PR TITLE
[@types/pg] Generify query methods

### DIFF
--- a/types/pg-copy-streams/index.d.ts
+++ b/types/pg-copy-streams/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/brianc/node-pg-copy-streams
 // Definitions by: Brian Crowell <https://github.com/fluggo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/pg-ears/index.d.ts
+++ b/types/pg-ears/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/doesdev/pg-ears
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import { ClientConfig } from "pg";
 

--- a/types/pg-large-object/index.d.ts
+++ b/types/pg-large-object/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Joris-van-der-Wel/node-pg-large-object#readme
 // Definitions by: Mateusz Krupa <https://github.com/mateuszkrupa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/pg-pool/index.d.ts
+++ b/types/pg-pool/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/brianc/node-pg-pool
 // Definitions by: Leo Liang <https://github.com/aleung>, Nikita Tokarchuk <https://github.com/mainnika>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as pg from 'pg';
 

--- a/types/pg-query-stream/index.d.ts
+++ b/types/pg-query-stream/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/brianc/node-pg-query-stream
 // Definitions by: António Marques <https://github.com/asmarques>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -88,7 +88,7 @@ export interface QueryResult<R extends QueryResultRow = any> extends QueryResult
     rows: R[];
 }
 
-export interface QueryArrayResult<R = any[]> extends QueryResultBase {
+export interface QueryArrayResult<R extends any[] = any[]> extends QueryResultBase {
     rows: R[];
 }
 
@@ -162,10 +162,10 @@ export class Pool extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     // tslint:disable:no-unnecessary-generics
-    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
+    query<R extends any[] = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryConfig: QueryConfig<I>): Promise<QueryResult<R>>;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, values?: I): Promise<QueryResult<R>>;
-    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
+    query<R extends any[] = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryText: string, values: I, callback: (err: Error, result: QueryResult<R>) => void): void;
     // tslint:enable:no-unnecessary-generics
@@ -182,10 +182,10 @@ export class ClientBase extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     // tslint:disable:no-unnecessary-generics
-    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
+    query<R extends any[] = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryConfig: QueryConfig<I>): Promise<QueryResult<R>>;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, values?: I): Promise<QueryResult<R>>;
-    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
+    query<R extends any[] = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
     query<R extends QueryResultRow = any, I extends any[] = any[]>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<R>) => void): void;
     // tslint:enable:no-unnecessary-generics
@@ -217,7 +217,7 @@ export interface PoolClient extends ClientBase {
     release(err?: Error): void;
 }
 
-export class Query<R, I extends any[]> extends events.EventEmitter implements Submittable {
+export class Query<R extends QueryResultRow = any, I extends any[] = any> extends events.EventEmitter implements Submittable {
     constructor(queryTextOrConfig?: string | QueryConfig<I>, values?: I);
     submit: (connection: Connection) => void;
     on(event: "row", listener: (row: R, result?: ResultBuilder<R>) => void): this;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for pg 7.11
 // Project: http://github.com/brianc/node-postgres
-// Definitions by: Phips Peter <https://github.com/pspeter3>
+// Definitions by: Phips Peter <https://github.com/pspeter3>, Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 
@@ -48,17 +49,17 @@ export interface PoolConfig extends ClientConfig {
     Promise?: PromiseConstructorLike;
 }
 
-export interface QueryConfig {
+export interface QueryConfig<I extends any[] = any[]> {
     name?: string;
     text: string;
-    values?: any[];
+    values?: I;
 }
 
 export interface Submittable {
     submit: (connection: Connection) => void;
 }
 
-export interface QueryArrayConfig extends QueryConfig {
+export interface QueryArrayConfig<I extends any[] = any[]> extends QueryConfig<I> {
     rowMode: 'array';
 }
 
@@ -79,12 +80,16 @@ export interface QueryResultBase {
     fields: FieldDef[];
 }
 
-export interface QueryResult extends QueryResultBase {
-    rows: any[];
+export interface QueryResultRow {
+	[column: string]: any;
 }
 
-export interface QueryArrayResult extends QueryResultBase {
-    rows: any[][];
+export interface QueryResult<R extends QueryResultRow = any> extends QueryResultBase {
+    rows: R[];
+}
+
+export interface QueryArrayResult<R = any[]> extends QueryResultBase {
+    rows: R[];
 }
 
 export interface Notification {
@@ -93,8 +98,8 @@ export interface Notification {
     payload?: string;
 }
 
-export interface ResultBuilder extends QueryResult {
-    addRow(row: any): void;
+export interface ResultBuilder<R extends QueryResultRow = any> extends QueryResult<R> {
+    addRow(row: R): void;
 }
 
 export interface QueryParse {
@@ -156,12 +161,14 @@ export class Pool extends events.EventEmitter {
     end(callback: () => void): void;
 
     query<T extends Submittable>(queryStream: T): T;
-    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): void;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): void;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): void;
+    // tslint:disable:no-unnecessary-generics
+    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryConfig: QueryConfig<I>): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, values?: I): Promise<QueryResult<R>>;
+    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryText: string, values: I, callback: (err: Error, result: QueryResult<R>) => void): void;
+    // tslint:enable:no-unnecessary-generics
 
     on(event: "error", listener: (err: Error, client: PoolClient) => void): this;
     on(event: "connect" | "acquire" | "remove", listener: (client: PoolClient) => void): this;
@@ -174,12 +181,14 @@ export class ClientBase extends events.EventEmitter {
     connect(callback: (err: Error) => void): void;
 
     query<T extends Submittable>(queryStream: T): T;
-    query(queryConfig: QueryArrayConfig, values?: any[]): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): void;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): void;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): void;
+    // tslint:disable:no-unnecessary-generics
+    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, values?: I): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryConfig: QueryConfig<I>): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, values?: I): Promise<QueryResult<R>>;
+    query<R = any[], I extends any[] = any[]>(queryConfig: QueryArrayConfig<I>, callback: (err: Error, result: QueryArrayResult<R>) => void): void;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryTextOrConfig: string | QueryConfig<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
+    query<R extends QueryResultRow = any, I extends any[] = any[]>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<R>) => void): void;
+    // tslint:enable:no-unnecessary-generics
 
     copyFrom(queryText: string): stream.Writable;
     copyTo(queryText: string): stream.Readable;
@@ -208,12 +217,12 @@ export interface PoolClient extends ClientBase {
     release(err?: Error): void;
 }
 
-export class Query extends events.EventEmitter implements Submittable {
-    constructor(queryTextOrConfig?: string | QueryConfig, values?: any[]);
+export class Query<R, I extends any[]> extends events.EventEmitter implements Submittable {
+    constructor(queryTextOrConfig?: string | QueryConfig<I>, values?: I);
     submit: (connection: Connection) => void;
-    on(event: "row", listener: (row: any, result?: ResultBuilder) => void): this;
+    on(event: "row", listener: (row: R, result?: ResultBuilder<R>) => void): this;
     on(event: "error", listener: (err: Error) => void): this;
-    on(event: "end", listener: (result: ResultBuilder) => void): this;
+    on(event: "end", listener: (result: ResultBuilder<R>) => void): this;
 }
 
 export class Events extends events.EventEmitter {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -46,6 +46,16 @@ client.query('SELECT $1::text as name', ['brianc'], (err, res) => {
   client.end();
 });
 
+interface Person {
+  name: string;
+}
+
+client.query<Person, [string]>('SELECT $1::text as name', ['brianc'], (err, res) => {
+  if (err) throw err;
+  console.log(res.rows[0].name);
+  client.end();
+});
+
 const query = {
   name: 'get-name',
   text: 'SELECT $1::text',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *not applicable*
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *(not applicable)*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

<hr>

I generified the `query` methods as well as the corresponding interfaces. `R` will be the return type of the query, `I` a tuple for the parameters.

A usage example:
```ts
interface Person {
    name: string;
    naughty: boolean;
}

/* 
   The types are defined here:
   - The return type R will be the 'Person' interface defined above
   - The parameters (I for input) will be a string and boolean (in order)
*/
client.query<Person, [string, boolean]>(
    'SELECT * FROM user WHERE name = $1 AND naughty = $2',
    [ 'Johnny', true ], // this array will be typechecked
    (err, result) => console.log(result.rows[0].name) // this will now have a 'string' type
);
```
These additional type checks are aimed at users who have interfaces for their database types (for example auto-generated by [schemats](https://github.com/sweetiq/schemats)).
It is **100% opt-in and backwards compatible** with the use of generic defaults added in TS 2.3.

The usefulness `R` parameter (for the return type) pretty much speaks for itself, it enables intellisense/typechecking without the use of annoying type assertions.

The `I` parameter (the inputs) might be too repetitive/over-safe for some people, which is why it comes after the (more useful) returntype generic. For my use-case I'm automatically generating parts of these method calls, and an extra sanity check is very much welcome in that case. It's also a very welcome safeguard when refactoring database types, although that probably doesn't happen too often for most people.

Because these generics are meant to check the parameters supplied directly the `no-unnecessary-generics` rule doesn't apply here. The `dtslint` page says:

> Generic type parameters allow you to relate the type of one thing to another; if they are used only once, *they can be replaced with their type constraint.*

The emphasized part doesn't apply here, because the whole idea of these generics is to have users (optionally) manually provide an extra layer of security by specifying *their own types*. `any` is a perfectly valid type constraint here, the generics enable users to narrow it down to their own types if they so wish.