### PR TITLE
[express-serve-static-core] Add optional generic to Send

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -25,3 +25,19 @@ app.get<{ foo: string }>('/:foo', req => {
 
 // Params cannot be a custom type that does not conform to constraint
 app.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
+
+// Response send methods accept an option generic type which will enforce
+// a check on the parameter passed in.
+app.get('/:foo', (req, res) => {
+    res.send({ test: true });
+    res.send<{ test: boolean }>({ test: true });
+    res.send<{ test: boolean }>({ test: 'string' }); // $ExpectError
+
+    res.json({ test: true });
+    res.json<{ test: boolean }>({ test: true });
+    res.json<{ test: boolean }>({ test: 'string' }); // $ExpectError
+
+    res.jsonp({ test: true });
+    res.jsonp<{ test: boolean }>({ test: true });
+    res.jsonp<{ test: boolean }>({ test: 'string' }); // $ExpectError
+});

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -488,7 +488,8 @@ export interface MediaType {
     subtype: string;
 }
 
-export type Send = (body?: any) => Response;
+// tslint:disable-next-line no-unnecessary-generics
+export type Send = <T = any>(body?: T) => Response;
 
 export interface Response extends http.ServerResponse, Express.Response {
     /**


### PR DESCRIPTION
`Send` has a type `any` passed in, I wanted a way to specify the type
I'm expecting to pass in so I get typechecking (eg.
`res.send<SomeVar>(test)` will assert `test` is typeof SomeVar)

This is optional and if no generic is provided it will fallback to the
existing `any` type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [See Assertion considered harmful final code example](https://basarat.gitbooks.io/typescript/docs/types/type-assertion.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.