### PR TITLE
tail: Allow null as separator in TailOptions, per docs

### DIFF
--- a/types/tail/index.d.ts
+++ b/types/tail/index.d.ts
@@ -6,7 +6,7 @@
 
 declare namespace Tail {
     interface TailOptions {
-        separator?: string | RegExp;
+        separator?: string | RegExp | null;
         fromBeginning?: boolean;
         fsWatchOptions?: Record<string, any>;
         follow?: boolean;


### PR DESCRIPTION
To have no separator, `tail` docs specify to pass `null`, so `null` should be valid to argument type. 

See: https://www.npmjs.com/package/tail#constructor-parameters

>- separator: the line separator token (default: /[\r]{0,1}\n/ to handle linux/mac (9+)/windows). **Pass null if your file is binary there's no line separator.**

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/tail#constructor-parameters

