### PR TITLE
[@types/react-navigation-material-bottom-tabs]Added history and order to backBehavior type

### DIFF
--- a/types/react-navigation-material-bottom-tabs/index.d.ts
+++ b/types/react-navigation-material-bottom-tabs/index.d.ts
@@ -20,7 +20,7 @@ export interface TabConfig {
     initialRouteName?: string;
     order?: string[];
     paths?: NavigationPathsConfig;
-    backBehavior?: 'initialRoute' | 'none' | 'history';
+    backBehavior?: 'initialRoute' | 'order' | 'history' | 'none';
 }
 
 export function createMaterialBottomTabNavigator(

--- a/types/react-navigation-material-bottom-tabs/index.d.ts
+++ b/types/react-navigation-material-bottom-tabs/index.d.ts
@@ -20,7 +20,7 @@ export interface TabConfig {
     initialRouteName?: string;
     order?: string[];
     paths?: NavigationPathsConfig;
-    backBehavior?: 'initialRoute' | 'none';
+    backBehavior?: 'initialRoute' | 'none' | 'history';
 }
 
 export function createMaterialBottomTabNavigator(


### PR DESCRIPTION
I added `history` and `order` because they were not in `MaterialBottomTabNavigatorConfig/backBehavior`
https://reactnavigation.org/docs/en/material-bottom-tab-navigator.html#materialbottomtabnavigatorconfig