### PR TITLE
[react-loadable-visibility] add types for react-loadable-visibility

### DIFF
--- a/types/react-loadable-visibility/index.d.ts
+++ b/types/react-loadable-visibility/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for react-loadable-visibility 3.0
+// Project: https://github.com/stratiformltd/react-loadable-visibility#readme
+// Definitions by: Daniel Bartholomae <https://github.com/dbartholomae>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Loadable from './loadable-components';
+export default Loadable;

--- a/types/react-loadable-visibility/loadable-components.d.ts
+++ b/types/react-loadable-visibility/loadable-components.d.ts
@@ -1,0 +1,2 @@
+import Loadable from '@loadable/component';
+export default Loadable;

--- a/types/react-loadable-visibility/react-loadable-visibility-tests.tsx
+++ b/types/react-loadable-visibility/react-loadable-visibility-tests.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import LoadableComponentVisibilityAsDefaultImport from 'react-loadable-visibility';
+import LoadableComponentVisibility from 'react-loadable-visibility/loadable-components';
+import ReactLoadableVisibility from 'react-loadable-visibility/react-loadable';
+
+interface Props {
+    title: string;
+}
+
+const TestComponent: React.FunctionComponent<Props> = ({ title }) => {
+    return <div>{title} component</div>;
+};
+
+const testComponentModule = Promise.resolve(TestComponent);
+
+function Loading() {
+  return <div>Loading...</div>;
+}
+
+const LoadableComponentAsDefaultImportComponent = LoadableComponentVisibilityAsDefaultImport(
+  () => testComponentModule,
+  {
+    fallback: <Loading />,
+  },
+);
+
+const LoadableComponentComponent = LoadableComponentVisibility(
+  () => testComponentModule,
+  {
+    fallback: <Loading />,
+  },
+);
+
+const ReactLoadableComponent = ReactLoadableVisibility({
+  loader: () => testComponentModule,
+  loading: Loading,
+});
+
+function App() {
+  return (
+    <div>
+      <LoadableComponentAsDefaultImportComponent title='test' />
+      <LoadableComponentComponent title='test' />
+      <ReactLoadableComponent title='test' />
+    </div>
+  );
+}

--- a/types/react-loadable-visibility/react-loadable.d.ts
+++ b/types/react-loadable-visibility/react-loadable.d.ts
@@ -1,0 +1,2 @@
+import * as Loadable from 'react-loadable';
+export default Loadable;

--- a/types/react-loadable-visibility/tsconfig.json
+++ b/types/react-loadable-visibility/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@loadable/component": [
+                "loadable__component"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "loadable-components.d.ts",
+        "react-loadable.d.ts",
+        "react-loadable-visibility-tests.tsx"
+    ]
+}

--- a/types/react-loadable-visibility/tslint.json
+++ b/types/react-loadable-visibility/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Do not merge this PR yet, there is still one issue I would appreciate help with.

This is my first try at definition files (I usually write TypeScript directly) and my first PR to DefinitelyTyped, so a good eye from a reviewer would be appreciated. Specifically I am not sure how to best type the pass-through of default exporting a function in `react-loadable.d.ts` and would need an expert to help before this PR can be merged. I cannot `import Loadable from 'react-loadable'` since it is declared via `export =`, but I neither can `import * as Loadable from 'react-loadable'` since `Loadable` is a function and module imports can not be called. What to do?

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

