### PR TITLE
fix(redux-api-middleware): Update definitions to correctly allow non …

### DIFF
--- a/types/redux-api-middleware/index.d.ts
+++ b/types/redux-api-middleware/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for redux-api-middleware 3.0
 // Project: https://github.com/agraboso/redux-api-middleware
-// Definitions by: Andrew Luca <https://github.com/iamandrewluca>
+// Definitions by:  Andrew Luca <https://github.com/iamandrewluca>
+//                  Craig S <https://github.com/Mrman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -66,24 +67,24 @@ export function createMiddleware(options?: CreateMiddlewareOptions): Middleware;
 
 export interface RSAARequestTypeDescriptor<S = any, P = any, M = any> {
     type: string | symbol;
-    payload?: (action: RSAAAction, state: S) => P | P;
-    meta?: (action: RSAAAction, state: S) => M | M;
+    payload?: ((action: RSAAAction, state: S) => P) | P;
+    meta?: ((action: RSAAAction, state: S) => M) | M;
 }
 
 export interface RSAASuccessTypeDescriptor<S = any, P = any, M = any> {
     type: string | symbol;
-    payload?: (action: RSAAAction, state: S, res: any) => P | P;
-    meta?: (action: RSAAAction, state: S, res: any) => M | M;
+    payload?: ((action: RSAAAction, state: S, res: any) => P) | P;
+    meta?: ((action: RSAAAction, state: S, res: any) => M) | M;
 }
 
 export interface RSAAFailureTypeDescriptor<S = any, P = any, M = any> {
     type: string | symbol;
-    payload?: (action: RSAAAction, state: S) => P | P;
-    meta?: (action: RSAAAction, state: S, res: any) => M | M;
+    payload?: ((action: RSAAAction, state: S) => P) | P;
+    meta?: ((action: RSAAAction, state: S, res: any) => M) | M;
 }
 
 export interface RSAACall<S = any, P = any, M = any> {
-    endpoint: (state: S) => string | string;
+    endpoint: ((state: S) => string) | string;
     method: string;
     types: [
         string | symbol | RSAARequestTypeDescriptor<S, P, M>,
@@ -91,10 +92,10 @@ export interface RSAACall<S = any, P = any, M = any> {
         string | symbol | RSAAFailureTypeDescriptor<S, P, M>
     ];
     body?: ((state: S) => BodyInit | null) | BodyInit | null;
-    headers?: (state: S) => HeadersInit | HeadersInit;
-    options?: (state: S) => RequestInit | RequestInit;
+    headers?: ((state: S) => HeadersInit) | HeadersInit;
+    options?: ((state: S) => RequestInit) | RequestInit;
     credentials?: RequestCredentials;
-    bailout?: (state: S) => boolean | boolean;
+    bailout?: ((state: S) => boolean) | boolean;
     fetch?: typeof fetch;
     ok?: (res: Response) => boolean;
 }

--- a/types/redux-api-middleware/redux-api-middleware-tests.ts
+++ b/types/redux-api-middleware/redux-api-middleware-tests.ts
@@ -10,6 +10,8 @@ import {
     getJSON,
     createMiddleware,
     apiMiddleware,
+    RSAAAction,
+    RSAACall
 } from 'redux-api-middleware';
 
 {
@@ -102,4 +104,33 @@ import {
     // $ExpectType (next: Dispatch<AnyAction>) => (action: any) => any
     apiMiddleware({ getState: () => undefined, dispatch: (action: any) => action });
     apiMiddleware(); // $ExpectError
+}
+
+{
+    interface State {
+        path: string;
+        headers: HeadersInit;
+        options: RequestInit;
+        bailout: boolean;
+        body: null;
+    }
+
+    class StateDrivenRSAACall implements RSAACall<State> {
+        endpoint(state: State) { return state.path; }
+        headers(state: State) { return state.headers; }
+        options(state: State) { return state.options; }
+        body(state: State) { return state.body; }
+        bailout(state: State) { return state.bailout; }
+        method: 'GET';
+        types: ['REQ_TYPE', 'SUCCESS_TYPE', 'FAILURE_TYPE'];
+    }
+
+    class NonStateDrivenRSAACall implements RSAACall<State> {
+        endpoint: '/test/endpoint';
+        method: 'GET';
+        headers: { 'Content-Type': 'application/json' };
+        options: { redirect: 'follow' };
+        bailout: true;
+        types: ['REQ_TYPE', 'SUCCESS_TYPE', 'FAILURE_TYPE'];
+    }
 }


### PR DESCRIPTION
…function based api properties

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: As per discussion on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36666
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
