### PR TITLE
graphql: Update dependents to ^14.5.3

### DIFF
--- a/types/apollo-codegen/package.json
+++ b/types/apollo-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/arangodb/package.json
+++ b/types/arangodb/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/express-graphql/package.json
+++ b/types/express-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-api-koa/package.json
+++ b/types/graphql-api-koa/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-date/package.json
+++ b/types/graphql-date/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-depth-limit/package.json
+++ b/types/graphql-depth-limit/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-errors/package.json
+++ b/types/graphql-errors/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-fields/package.json
+++ b/types/graphql-fields/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-iso-date/graphql-iso-date-tests.ts
+++ b/types/graphql-iso-date/graphql-iso-date-tests.ts
@@ -1,5 +1,9 @@
 import { GraphQLDate, GraphQLTime, GraphQLDateTime } from "graphql-iso-date";
 
+GraphQLDate.extensions;
+GraphQLTime.extensions;
+GraphQLDateTime.extensions;
+
 GraphQLDate.name;
 GraphQLTime.name;
 GraphQLDateTime.name;

--- a/types/graphql-iso-date/package.json
+++ b/types/graphql-iso-date/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-list-fields/package.json
+++ b/types/graphql-list-fields/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-query-complexity/package.json
+++ b/types/graphql-query-complexity/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-relay/package.json
+++ b/types/graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-resolve-batch/package.json
+++ b/types/graphql-resolve-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-type-json/package.json
+++ b/types/graphql-type-json/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-type-uuid/package.json
+++ b/types/graphql-type-uuid/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/graphql-upload/package.json
+++ b/types/graphql-upload/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/koa-graphql/package.json
+++ b/types/koa-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/optics-agent/package.json
+++ b/types/optics-agent/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }

--- a/types/relay-compiler/package.json
+++ b/types/relay-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "14.5.0"
+    "graphql": "^14.5.3"
   }
 }


### PR DESCRIPTION
The graphql package has seen some breaking changes to its TypeScript definitions in v14.5.2, so we bump dependents to point to the latest v14.5.3.

This also loosens dependencies to a caret range, to avoid having to update DefinitelyTyped on every release.

---

Example: new props were added to `GraphQLScalarType`: https://github.com/graphql/graphql-js/pull/2109/files#diff-bb859c1bf342df78b490f51af84bd5f0R291

This means that a dependent package locked to `graphql@14.5.0` fails type checking against `graphql >= 14.5.2`:

```typescript
// graphql@14.5.3
import { GraphQLScalarType } from 'graphql';
// @types/graphql-iso-date@3.3.2 > graphql@14.5.0
import { GraphQLDate } from 'graphql-iso-date';

const t: GraphQLScalarType = GraphQLDate;
// Property 'extensions' is missing in type 'import(...).GraphQLScalarType' but required in type 'import(...).GraphQLScalarType'.ts(2741)
```

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _see above_
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.