### PR TITLE
[aws-lambda] Use optional properties instead of union type with null

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -92,19 +92,19 @@ strOrUndefined = apiGwEvtReqCtx.domainName;
 strOrUndefined = apiGwEvtReqCtx.eventType;
 strOrUndefined = apiGwEvtReqCtx.extendedRequestId;
 str = apiGwEvtReqCtx.httpMethod;
-strOrNull = apiGwEvtReqCtx.identity.accessKey;
-strOrNull = apiGwEvtReqCtx.identity.accountId;
-strOrNull = apiGwEvtReqCtx.identity.apiKey;
-strOrNull = apiGwEvtReqCtx.identity.apiKeyId;
-strOrNull = apiGwEvtReqCtx.identity.caller;
-strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationProvider;
-strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationType;
-strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityId;
-strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityPoolId;
+strOrUndefined = apiGwEvtReqCtx.identity.accessKey;
+strOrUndefined = apiGwEvtReqCtx.identity.accountId;
+strOrUndefined = apiGwEvtReqCtx.identity.apiKey;
+strOrUndefined = apiGwEvtReqCtx.identity.apiKeyId;
+strOrUndefined = apiGwEvtReqCtx.identity.caller;
+strOrUndefined = apiGwEvtReqCtx.identity.cognitoAuthenticationProvider;
+strOrUndefined = apiGwEvtReqCtx.identity.cognitoAuthenticationType;
+strOrUndefined = apiGwEvtReqCtx.identity.cognitoIdentityId;
+strOrUndefined = apiGwEvtReqCtx.identity.cognitoIdentityPoolId;
 str = apiGwEvtReqCtx.identity.sourceIp;
-strOrNull = apiGwEvtReqCtx.identity.user;
-strOrNull = apiGwEvtReqCtx.identity.userAgent;
-strOrNull = apiGwEvtReqCtx.identity.userArn;
+strOrUndefined = apiGwEvtReqCtx.identity.user;
+strOrUndefined = apiGwEvtReqCtx.identity.userAgent;
+strOrUndefined = apiGwEvtReqCtx.identity.userArn;
 strOrUndefined = apiGwEvtReqCtx.messageDirection;
 strOrUndefinedOrNull = apiGwEvtReqCtx.messageId;
 str = apiGwEvtReqCtx.path;
@@ -116,7 +116,7 @@ str = apiGwEvtReqCtx.resourcePath;
 strOrUndefined = apiGwEvtReqCtx.routeKey;
 
 /* API Gateway Event */
-strOrNull = apiGwEvt.body;
+strOrUndefined = apiGwEvt.body;
 str = apiGwEvt.headers["example"];
 str = apiGwEvt.multiValueHeaders["example"][0];
 str = apiGwEvt.httpMethod;
@@ -139,7 +139,7 @@ str = albEvt.queryStringParameters!["example"];
 str = albEvt.headers!["example"];
 str = albEvt.multiValueQueryStringParameters!["example"][0];
 str = albEvt.multiValueHeaders!["example"][0];
-strOrNull = albEvt.body;
+strOrUndefined = albEvt.body;
 bool = albEvt.isBase64Encoded;
 
 /* Application Load Balancer Result */
@@ -502,7 +502,7 @@ cognitoUserPoolEvent.response = {
         }
     }
 };
-cognitoUserPoolEvent.response.claimsOverrideDetails!.groupOverrideDetails = null;
+cognitoUserPoolEvent.response.claimsOverrideDetails!.groupOverrideDetails = undefined;
 
 // CloudFormation Custom Resource
 switch (cloudformationCustomResourceEvent.RequestType) {
@@ -637,7 +637,7 @@ const CodePipelineEvent: AWSLambda.CodePipelineEvent = {
                         },
                         type: "S3"
                     },
-                    revision: null,
+                    revision: undefined,
                     name: "ArtifactName"
                 }
             ],

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -29,6 +29,7 @@
 //                 Roberto Zen <https://github.com/skyzenr>
 //                 Grzegorz Redlicki <https://github.com/redlickigrzegorz>
 //                 Juan Carbonel <https://github.com/juancarbonel>
+//                 TATSUNO Yasuhiro <https://github.com/exoego>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -36,7 +37,7 @@
 export interface APIGatewayEventRequestContext {
     accountId: string;
     apiId: string;
-    authorizer?: AuthResponseContext | null;
+    authorizer?: AuthResponseContext;
     connectedAt?: number;
     connectionId?: string;
     domainName?: string;
@@ -45,22 +46,22 @@ export interface APIGatewayEventRequestContext {
     extendedRequestId?: string;
     httpMethod: string;
     identity: {
-        accessKey: string | null;
-        accountId: string | null;
-        apiKey: string | null;
-        apiKeyId: string | null;
-        caller: string | null;
-        cognitoAuthenticationProvider: string | null;
-        cognitoAuthenticationType: string | null;
-        cognitoIdentityId: string | null;
-        cognitoIdentityPoolId: string | null;
+        accessKey?: string;
+        accountId?: string;
+        apiKey?: string;
+        apiKeyId?: string;
+        caller?: string;
+        cognitoAuthenticationProvider?: string;
+        cognitoAuthenticationType?: string;
+        cognitoIdentityId?: string;
+        cognitoIdentityPoolId?: string;
         sourceIp: string;
-        user: string | null;
-        userAgent: string | null;
-        userArn: string | null;
+        user?: string;
+        userAgent?: string;
+        userArn?: string;
     };
     messageDirection?: string;
-    messageId?: string | null;
+    messageId?: string;
     path: string;
     stage: string;
     requestId: string;
@@ -73,16 +74,16 @@ export interface APIGatewayEventRequestContext {
 
 // API Gateway "event"
 export interface APIGatewayProxyEvent {
-    body: string | null;
+    body?: string;
     headers: { [name: string]: string };
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
     isBase64Encoded: boolean;
     path: string;
-    pathParameters: { [name: string]: string } | null;
-    queryStringParameters: { [name: string]: string } | null;
-    multiValueQueryStringParameters: { [name: string]: string[] } | null;
-    stageVariables: { [name: string]: string } | null;
+    pathParameters?: { [name: string]: string };
+    queryStringParameters?: { [name: string]: string };
+    multiValueQueryStringParameters?: { [name: string]: string[] };
+    stageVariables?: { [name: string]: string };
     requestContext: APIGatewayEventRequestContext;
     resource: string;
 }
@@ -102,7 +103,7 @@ export interface ALBEvent {
     headers?: { [header: string]: string };
     multiValueQueryStringParameters?: { [parameter: string]: string[] }; // URL encoded
     multiValueHeaders?: { [header: string]: string[] };
-    body: string | null;
+    body?: string;
     isBase64Encoded: boolean;
 }
 
@@ -116,9 +117,9 @@ export interface CustomAuthorizerEvent {
     httpMethod?: string;
     headers?: { [name: string]: string };
     multiValueHeaders?: { [name: string]: string[] };
-    pathParameters?: { [name: string]: string } | null;
-    queryStringParameters?: { [name: string]: string } | null;
-    multiValueQueryStringParameters?: { [name: string]: string[] } | null;
+    pathParameters?: { [name: string]: string };
+    queryStringParameters?: { [name: string]: string };
+    multiValueQueryStringParameters?: { [name: string]: string[] };
     stageVariables?: { [name: string]: string };
     requestContext?: APIGatewayEventRequestContext;
     domainName?: string;
@@ -329,7 +330,7 @@ export interface CognitoUserPoolTriggerEvent {
         claimsOverrideDetails?: {
             claimsToAddOrOverride?: { [key: string]: string };
             claimsToSuppress?: string[];
-            groupOverrideDetails?: null | {
+            groupOverrideDetails?: {
                 groupsToOverride?: string[];
                 iamRolesToOverride?: string[];
                 preferredRole?: string;
@@ -602,7 +603,7 @@ export type ArtifactLocation = S3ArtifactStore;
 
 export interface Artifact {
     name: string;
-    revision: string | null;
+    revision?: string;
     location: ArtifactLocation;
 }
 
@@ -956,7 +957,7 @@ export interface LexEvent {
     outputDialogMode: 'Text' | 'Voice';
     messageVersion: '1.0';
     sessionAttributes: { [key: string]: string };
-    requestAttributes: { [key: string]: string } | null;
+    requestAttributes?: { [key: string]: string };
 }
 
 export interface LexSlotResolution {


### PR DESCRIPTION
Because optional properties allow to omit keys:
```typescript
const o: AttributeValue = {
    S: "string"
};
```

But ` | null` do not (if I understand correctly):
```typescript
const o: AttributeValue = {
    S: "string",
    B: null,
    BS: null,
    BOOL: null,
    L: null,
    M: null,
    NS: null,
    NULL: null,
    SS: null
};
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
