### PR TITLE
[ldapjs] class OperationsError added

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -349,7 +349,9 @@ export class NoSuchAttributeError {
 export class ProtocolError {
 	constructor(error?: string);
 }
-
+export class OperationsError {
+	constructor(error?: string);
+}
 
 declare class Filter {
 	matches(obj: any): boolean;


### PR DESCRIPTION
The package does not already provide class OperationsError, although it is used in [docu](http://ldapjs.org/server.html#errors) for ldapjs.

Workaround as long this pull request is not merged: 
 `return next(new (<any>ldapjs).OperationsError('...'));`