### PR TITLE
[@types/react-native-video] Added missing types for fullscreen-properties

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -53,6 +53,8 @@ export interface VideoProperties extends ViewProps {
   src?: any;
   seek?: number;
   fullscreen?: boolean;
+  fullscreenOrientation?: 'all' | 'landscape' | 'portrait';
+  fullscreenAutorotate?: boolean;
   onVideoLoadStart?(): void;
   onVideoLoad?(): void;
   onVideoBuffer?(): void;


### PR DESCRIPTION
Added two properties to the type definition. These are specified in the documentation and do have effect on fullscreen presentation, but are missing in the types.


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[fullscreenorientation docs](https://github.com/react-native-community/react-native-video#fullscreenorientation)
[fullscreenautorotate docs](https://github.com/react-native-community/react-native-video#fullscreenautorotate)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
