### PR TITLE
Add the missing Store instance to backbone-relational

### DIFF
--- a/types/backbone-relational/backbone-relational-tests.ts
+++ b/types/backbone-relational/backbone-relational-tests.ts
@@ -110,3 +110,8 @@ var theirHouse = new House({ id: 'house-2' });
 paul.set({ 'livesIn': theirHouse });
 
 alert('theirHouse.occupants=' + theirHouse.get('occupants').pluck('name'));
+
+BackboneRel.store.removeModelScope(window);
+BackboneRel.store.addModelScope(window);
+BackboneRel.store.unregister(Person);
+BackboneRel.store.reset();

--- a/types/backbone-relational/index.d.ts
+++ b/types/backbone-relational/index.d.ts
@@ -162,6 +162,7 @@ export class Store extends EventsMixin implements Events {
 
     update(model:Model):void;
 
+    // tslint:disable-next-line use-default-type-parameter
     unregister(type: Model | Collection<Model> | typeof Model): void;
 
     reset():void;

--- a/types/backbone-relational/index.d.ts
+++ b/types/backbone-relational/index.d.ts
@@ -162,7 +162,7 @@ export class Store extends EventsMixin implements Events {
 
     update(model:Model):void;
 
-    unregister(model:Model, collection:Collection<BModel>, options:any):void;
+    unregister(type: Model | Collection<Model> | typeof Model): void;
 
     reset():void;
 

--- a/types/backbone-relational/index.d.ts
+++ b/types/backbone-relational/index.d.ts
@@ -167,3 +167,5 @@ export class Store extends EventsMixin implements Events {
     reset():void;
 
 }
+
+export const store: Store;

--- a/types/backbone-relational/tslint.json
+++ b/types/backbone-relational/tslint.json
@@ -20,7 +20,6 @@
         "space-before-function-paren": false,
         "typedef-whitespace": false,
         "unified-signatures": false,
-        "use-default-type-parameter": false,
         "whitespace": false
     }
 }

--- a/types/backbone-relational/tslint.json
+++ b/types/backbone-relational/tslint.json
@@ -20,6 +20,7 @@
         "space-before-function-paren": false,
         "typedef-whitespace": false,
         "unified-signatures": false,
+        "use-default-type-parameter": false,
         "whitespace": false
     }
 }


### PR DESCRIPTION
backbone-relational exports a `Store` class. It also exports a default instance of this class, called `store` (note the lowercase `s`), but the latter was missing in the typings. So I added it.

The tests that were intended to test for the `store` export, revealed that `Store.unregister` was typed incorrectly. I fixed that as well.

Fixing that, I ran into an unwarranted linter error. `types/backbone/index.d.ts` exports `Model` and `Collection<TModel>`, where `TModel` defaults to `Model`. `types/backbone-relational/index.d.ts` imports these classes as `BModel` and `Collection`, respectively, and defines a `Model` class of its own that extends `BModel`. This confused the `use-default-type-parameter` linter rule when encountering `Collection<Model>` on line 166. I disabled the rule on that line.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). *This is nowadays automatically included with the tests.*
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - http://backbonerelational.org/#Store
    - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32883
    - https://github.com/PaulUithol/Backbone-relational/blob/4e2f5c005e798364e1d1b4fcb7dfa4cd5d1c6989/backbone-relational.js#L518-L522
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *Not applicable.*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.