### PR TITLE
Add graphql peer dependencies

### DIFF
--- a/types/apollo-upload-client/package.json
+++ b/types/apollo-upload-client/package.json
@@ -1,7 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "apollo-link": "^1.0.0",
-        "apollo-link-http-common": "^0.2.4"
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.4",
+        "graphql": "^14.5.3"
     }
 }

--- a/types/graphql-resolvers/package.json
+++ b/types/graphql-resolvers/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "graphql": "^14.5.3",
         "graphql-tools": "^4.0.5"
     }
 }

--- a/types/mobx-apollo/index.d.ts
+++ b/types/mobx-apollo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sonaye/mobx-apollo#readme
 // Definitions by: Paul Selden <https://github.com/pselden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     ApolloClient,

--- a/types/mobx-apollo/index.d.ts
+++ b/types/mobx-apollo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sonaye/mobx-apollo#readme
 // Definitions by: Paul Selden <https://github.com/pselden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import {
     ApolloClient,

--- a/types/mobx-apollo/package.json
+++ b/types/mobx-apollo/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "apollo-client": "^2.0.0"
+        "apollo-client": "^2.0.0",
+        "graphql": "^14.5.3"
     }
 }


### PR DESCRIPTION
Apollo has a peer dependency on graphql, but several DT packages don't install it. This caused the overnight build of DT to fail.