### PR TITLE
Adding jwk-to-pem types

### DIFF
--- a/types/jwk-to-pem/index.d.ts
+++ b/types/jwk-to-pem/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jwk-to-pem 2.0.1
+// Type definitions for jwk-to-pem 2.0
 // Project: https://github.com/Brightspace/node-jwk-to-pem
 // Definitions by: Rodrigo Sasaki <https://github.com/rodrigopsasaki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/jwk-to-pem/index.d.ts
+++ b/types/jwk-to-pem/index.d.ts
@@ -19,7 +19,7 @@ export interface JWK {
 }
 
 export interface JWKOptions {
-    private: boolean;
+    private?: boolean;
 }
 
-export function jwkToBuffer(jwk: JWK, opts: JWKOptions): string;
+export function jwkToBuffer(jwk: JWK, opts?: JWKOptions): string;

--- a/types/jwk-to-pem/index.d.ts
+++ b/types/jwk-to-pem/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for jwk-to-pem 2.0.1
+// Project: https://github.com/Brightspace/node-jwk-to-pem
+// Definitions by: Rodrigo Sasaki <https://github.com/rodrigopsasaki>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface JWK {
+    kty: string;
+    n: string;
+    e: string;
+    d?: string;
+    p?: string;
+    q?: string;
+    dp?: string;
+    dq?: string;
+    qi?: string;
+    crv?: string;
+    x?: string;
+    y?: string;
+}
+
+export interface JWKOptions {
+    private: boolean;
+}
+
+export function jwkToBuffer(jwk: JWK, opts: JWKOptions): string;

--- a/types/jwk-to-pem/jwk-to-pem-tests.ts
+++ b/types/jwk-to-pem/jwk-to-pem-tests.ts
@@ -1,10 +1,11 @@
-import { jwkToPem, JWK } from 'jwk-to-pem';
+import { jwkToBuffer, JWK, JWKOptions } from 'jwk-to-pem';
 
 const jwk: JWK = {
     kty: 'RSA',
-    n:
-        'oPuGyYsl8LAAgWJo_3yUkWRxsWlwn1IPlAgUlWzZUfwaqh-XxU8b9G8JKowz7ogeUo_9ks4lQAvsHxOzNBNKQBCpghQsgp8xoEH-eHuaduj5G6_hpKhPBkRdJRzVuFyDxEJGtr6x7oStFrbtfWhuAM3Mnu8NA0gAFffPOTEKKg07PbrM5kapnv1M0wlNc_3X4FUMocCjTTfXEG4fQmiPKNQz5U80zfjRiiKAMNVeWGS3IaR74ioOHM1emCzwLYVRpHyaFA6AxYG2GNfuVcwazxVRqhI3tws8gswZLZt475aOSWROluhawn307cqxJMUYVpf51ciBrdTIhQaywbWU2Q',
+    n: 'oPuGyYsl8LAAgWJo_3yUkWRxsWlwn1IPlAgUlWzZUfwaqh-XxU8b9G8JKowz7ogeUo_',
     e: 'AQAB',
 };
 
-jwkToPem(jwk); // $ExpectType string
+const options: JWKOptions = { private: false };
+
+jwkToBuffer(jwk, options); // $ExpectType string

--- a/types/jwk-to-pem/jwk-to-pem-tests.ts
+++ b/types/jwk-to-pem/jwk-to-pem-tests.ts
@@ -8,4 +8,5 @@ const jwk: JWK = {
 
 const options: JWKOptions = { private: false };
 
+jwkToBuffer(jwk); // $ExpectType string
 jwkToBuffer(jwk, options); // $ExpectType string

--- a/types/jwk-to-pem/jwk-to-pem-tests.ts
+++ b/types/jwk-to-pem/jwk-to-pem-tests.ts
@@ -1,0 +1,10 @@
+import { jwkToPem, JWK } from 'jwk-to-pem';
+
+const jwk: JWK = {
+    kty: 'RSA',
+    n:
+        'oPuGyYsl8LAAgWJo_3yUkWRxsWlwn1IPlAgUlWzZUfwaqh-XxU8b9G8JKowz7ogeUo_9ks4lQAvsHxOzNBNKQBCpghQsgp8xoEH-eHuaduj5G6_hpKhPBkRdJRzVuFyDxEJGtr6x7oStFrbtfWhuAM3Mnu8NA0gAFffPOTEKKg07PbrM5kapnv1M0wlNc_3X4FUMocCjTTfXEG4fQmiPKNQz5U80zfjRiiKAMNVeWGS3IaR74ioOHM1emCzwLYVRpHyaFA6AxYG2GNfuVcwazxVRqhI3tws8gswZLZt475aOSWROluhawn307cqxJMUYVpf51ciBrdTIhQaywbWU2Q',
+    e: 'AQAB',
+};
+
+jwkToPem(jwk); // $ExpectType string

--- a/types/jwk-to-pem/tsconfig.json
+++ b/types/jwk-to-pem/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jwk-to-pem-tests.ts"
+    ]
+}
+

--- a/types/jwk-to-pem/tslint.json
+++ b/types/jwk-to-pem/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.