### PR TITLE
[stripe] various Plan/Subscription properties are properly nullable/optional

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5624,16 +5624,16 @@ declare namespace Stripe {
             /**
              * A flat fee for the tier to be added into the total amount
              */
-            flat_amount: number;
+            flat_amount: number | null;
 
             /**
              * Up to and including to this quantity will be contained in the tier.
              */
-            up_to: number;
+            up_to: number | null;
             /**
              * Per unit price for units relevant to the tier.
              */
-            unit_amount: number;
+            unit_amount: number | null;
         }
 
         interface ITransformUsage {
@@ -5671,7 +5671,7 @@ declare namespace Stripe {
             /**
              * The amount in cents to be charged on the interval specified
              */
-            amount: number;
+            amount: number | null;
 
             /**
              * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
@@ -5736,7 +5736,7 @@ declare namespace Stripe {
             /**
              * Default number of trial days when subscribing a customer to this plan using `trial_from_plan=true`.
              */
-            trial_period_days: number;
+            trial_period_days: number | null;
 
             /**
              * Configures how the quantity per period should be determined, can be either `metered` or `licensed`. `licensed` will automatically bill the `quantity` set for a plan when adding it to a subscription, `metered` will aggregate the total usage based on usage records. Defaults to `licensed`.
@@ -7193,14 +7193,20 @@ declare namespace Stripe {
              * A positive decimal that represents the fee percentage of the subscription invoice amount that will be transferred to
              * the application owner's Stripe account each billing period.
              */
-            application_fee_percent: number;
+            application_fee_percent: number | null;
+
+            /**
+             * Either `charge_automatically`, or `send_invoice`.
+             * This field has been renamed to collection_method and will be removed in a future API version.
+             */
+            billing: SubscriptionBilling;
 
             /**
              * Either "charge_automatically", or "send_invoice". When charging automatically, Stripe will attempt to pay this subscription at the
              * end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an
              * invoice with payment instructions.
              */
-            billing: SubscriptionBilling;
+            collection_method: SubscriptionBilling;
 
             /**
              * Determines the date of the first full invoice, and, for plans with month or year intervals, the day of the month
@@ -7228,7 +7234,7 @@ declare namespace Stripe {
             /**
              * A date in the future at which the subscription will automatically get canceled.
              */
-            cancel_at: number;
+            cancel_at: number | null;
 
             /**
              * If the subscription has been canceled with the at_period_end flag set to true, cancel_at_period_end on the
@@ -7281,7 +7287,7 @@ declare namespace Stripe {
              * It must belong to the customer associated with the subscription and be in a chargeable state.
              * If not set, defaults to the customer’s default source. [Expandable]
              */
-            default_source: string;
+            default_source: string | null;
 
             /**
              * Describes the current discount applied to this subscription, if there is one. When billing, a discount applied to a
@@ -7364,7 +7370,7 @@ declare namespace Stripe {
             /**
              * If provided, each invoice created by this subscription will apply the tax rate, increasing the amount billed to the customer.
              */
-            tax_percent: number;
+            tax_percent: number | null;
 
             /**
              * If the subscription has a trial, the end of that trial.
@@ -7714,7 +7720,7 @@ declare namespace Stripe {
             /**
              * The quantity of the plan to which the customer should be subscribed.
              */
-            quantity: number;
+            quantity?: number;
 
             /**
              * The subscription this subscription_item belongs to.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://stripe.com/docs/api/plans/object, https://stripe.com/docs/api/subscriptions/object, https://stripe.com/docs/api/subscription_items/object)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
