### PR TITLE
chromecast-caf-sender: add __onGCastApiAvailable

### DIFF
--- a/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
+++ b/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
@@ -1,6 +1,8 @@
 cast.framework.VERSION === "1.0.06";
 cast.framework.setLoggerLevel(cast.framework.LoggerLevel.DEBUG);
 
+window.__onGCastApiAvailable = (available: boolean) => {};
+
 const context = cast.framework.CastContext.getInstance();
 context.getCastState() === cast.framework.CastState.CONNECTED;
 context.getSessionState() === cast.framework.SessionState.NO_SESSION;

--- a/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
+++ b/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 cast.framework.VERSION === "1.0.06";
 cast.framework.setLoggerLevel(cast.framework.LoggerLevel.DEBUG);
 

--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -11,6 +11,7 @@
 ////////////////////
 interface Window {
   cast: typeof cast;
+  __onGCastApiAvailable(available: boolean): void;
 }
 
 ////////////////////

--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://developers.google.com/cast/docs/caf_receiver_overview
 // Definitions by: Samuel Maddock <https://github.com/samuelmaddock>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 /// <reference types="chrome/chrome-cast" />
 

--- a/types/chromecast-caf-sender/tsconfig.json
+++ b/types/chromecast-caf-sender/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/chromecast-caf-sender/tsconfig.json
+++ b/types/chromecast-caf-sender/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
chromecast-caf-sender: add __onGCastApiAvailable callback definition. 

Docs: https://developers.google.com/cast/docs/chrome_sender/integrate#initialization

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.