### PR TITLE
Add missing FormState element to redux-form

### DIFF
--- a/types/redux-form/lib/reducer.d.ts
+++ b/types/redux-form/lib/reducer.d.ts
@@ -19,11 +19,11 @@ export interface FormStateMap {
 
 export interface FormState {
     registeredFields: RegisteredFieldState[];
-    fields?: {[name: string]: FieldState};
+    fields?: { [name: string]: FieldState };
     values?: { [fieldName: string]: any };
     active?: string;
     anyTouched?: boolean;
-    error: string;
+    error?: any;
     submitting?: boolean;
     submitErrors?: { [fieldName: string]: string };
     submitFailed?: boolean;

--- a/types/redux-form/lib/reducer.d.ts
+++ b/types/redux-form/lib/reducer.d.ts
@@ -23,6 +23,7 @@ export interface FormState {
     values?: { [fieldName: string]: any };
     active?: string;
     anyTouched?: boolean;
+    error: string;
     submitting?: boolean;
     submitErrors?: { [fieldName: string]: string };
     submitFailed?: boolean;


### PR DESCRIPTION
According to the [example](https://redux-form.com/8.2.2/examples/submitvalidation/) on the redux-form page, it is possible to have a general error field for the whole form. I confirmed this behaviour with redux-form 8.2.6.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-form.com/8.2.2/examples/submitvalidation/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I am not sure about this. I searched in the redux-form source code where the error field was added, but could not find it.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
