### PR TITLE
Add promisified version of readdir.

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -889,6 +889,12 @@ declare module "fs" {
          * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
          */
         function __promisify__(path: PathLike, options: { encoding?: string | null; withFileTypes: true }): Promise<Dirent[]>;
+
+        /**
+         * Asynchronous readdir(3) - read a directory.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         */
+        function __promisify__(path: PathLike): Promise<string[]>;
     }
 
     /**


### PR DESCRIPTION
Reopen #37861 with test case
```javascript
type UnPromisify<T> = T extends Promise<infer U> ? U : never;
function putToResult<F extends (...args: any) => any>(
    fn: F
): (...args: Parameters<F>) => Promise<{ result: UnPromisify<ReturnType<F>> }>;

const readdir = util.promisify(fs.readdir);
const preaddir = putToResult(readdir);
const files = preaddir('/');
```