### PR TITLE
[@types/node] extends stream.Transform in crypto

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -118,14 +118,14 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    class Hash extends stream.Duplex {
+    class Hash extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Hash;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    class Hmac extends stream.Duplex {
+    class Hmac extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Hmac;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
@@ -193,7 +193,7 @@ declare module "crypto" {
         algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
     ): Cipher;
 
-    class Cipher extends stream.Duplex {
+    class Cipher extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
@@ -234,7 +234,7 @@ declare module "crypto" {
     ): DecipherGCM;
     function createDecipheriv(algorithm: string, key: BinaryLike, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
 
-    class Decipher extends stream.Duplex {
+    class Decipher extends stream.Transform {
         private constructor();
         update(data: Binary): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;

--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -34,13 +34,13 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    interface Hash extends NodeJS.ReadWriteStream {
+    interface Hash extends stream.Transform {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Hash;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    interface Hmac extends NodeJS.ReadWriteStream {
+    interface Hmac extends stream.Transform {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Hmac;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
         digest(): Buffer;
@@ -65,7 +65,7 @@ declare module "crypto" {
     function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
     function createCipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
 
-    interface Cipher extends NodeJS.ReadWriteStream {
+    interface Cipher extends stream.Transform {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Buffer | NodeJS.TypedArray | DataView, output_encoding: HexBase64BinaryEncoding): string;
@@ -107,7 +107,7 @@ declare module "crypto" {
     ): DecipherGCM;
     function createDecipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
 
-    interface Decipher extends NodeJS.ReadWriteStream {
+    interface Decipher extends stream.Transform {
         update(data: Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: any, output_encoding: Utf8AsciiBinaryEncoding): string;

--- a/types/node/v11/crypto.d.ts
+++ b/types/node/v11/crypto.d.ts
@@ -118,14 +118,14 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    class Hash extends stream.Duplex {
+    class Hash extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Hash;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    class Hmac extends stream.Duplex {
+    class Hmac extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Hmac;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
@@ -188,7 +188,7 @@ declare module "crypto" {
         algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
     ): Cipher;
 
-    class Cipher extends stream.Duplex {
+    class Cipher extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
@@ -229,7 +229,7 @@ declare module "crypto" {
     ): DecipherGCM;
     function createDecipheriv(algorithm: string, key: BinaryLike, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
 
-    class Decipher extends stream.Duplex {
+    class Decipher extends stream.Transform {
         private constructor();
         update(data: Binary): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -5229,6 +5229,7 @@ declare module "tls" {
 }
 
 declare module "crypto" {
+    import * as stream from "stream";
     export interface Certificate {
         exportChallenge(spkac: string | Buffer): Buffer;
         exportPublicKey(spkac: string | Buffer): Buffer;
@@ -5261,13 +5262,13 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    export interface Hash extends NodeJS.ReadWriteStream {
+    export interface Hash extends stream.Transform {
         update(data: string | Buffer | DataView): Hash;
         update(data: string | Buffer | DataView, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    export interface Hmac extends NodeJS.ReadWriteStream {
+    export interface Hmac extends stream.Transform {
         update(data: string | Buffer | DataView): Hmac;
         update(data: string | Buffer | DataView, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
         digest(): Buffer;
@@ -5275,7 +5276,7 @@ declare module "crypto" {
     }
     export function createCipher(algorithm: string, password: any): Cipher;
     export function createCipheriv(algorithm: string, key: any, iv: any): Cipher;
-    export interface Cipher extends NodeJS.ReadWriteStream {
+    export interface Cipher extends stream.Transform {
         update(data: Buffer | DataView): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Buffer | DataView, input_encoding: any, output_encoding: HexBase64BinaryEncoding): string;
@@ -5288,7 +5289,7 @@ declare module "crypto" {
     }
     export function createDecipher(algorithm: string, password: any): Decipher;
     export function createDecipheriv(algorithm: string, key: any, iv: any): Decipher;
-    export interface Decipher extends NodeJS.ReadWriteStream {
+    export interface Decipher extends stream.Transform {
         update(data: Buffer | DataView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Buffer | DataView, input_encoding: any, output_encoding: Utf8AsciiBinaryEncoding): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * This issue was pointed out in https://github.com/nodejs/node/pull/29302#discussion_r317758520
  * Cipher, Decipher, Hash, Hmac have been extending Transform for a long time:
    * https://github.com/nodejs/node/commit/c70c7781e3c231e18a9c9eafdddfff0c7471820a#diff-437b078f0e3aa5b13790315b3813fd4f
    * https://github.com/nodejs/node/commit/855caa82aaef5c6e6dd244b5d9df314994cb23eb 