### PR TITLE
Add overloads to child_process.spawn for when options.stdio is a tuple of 3

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -98,9 +98,9 @@ declare module "child_process" {
         O extends null | Readable,
         E extends null | Readable,
     > extends ChildProcess {
-        stdin: I,
-        stdout: O,
-        stderr: E,
+        stdin: I;
+        stdout: O;
+        stderr: E;
         readonly stdio: [
             I,
             O,

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -92,24 +92,19 @@ declare module "child_process" {
         ];
     }
 
-    type StdioOptionToStream<
-        O extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        S extends Stream,
-    > = O extends undefined | null | 'pipe' ? S : null;
-
     // return this object when stdio option is a tuple of 3
-    interface ChildProcessForStdioTuple<
-        I extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        O extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        E extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+    interface ChildProcessByStdio<
+        I extends null | Writable,
+        O extends null | Readable,
+        E extends null | Readable,
     > extends ChildProcess {
-        stdin: StdioOptionToStream<I, Writable>;
-        stdout: StdioOptionToStream<O, Readable>;
-        stderr: StdioOptionToStream<E, Readable>;
+        stdin: I,
+        stdout: O,
+        stderr: E,
         readonly stdio: [
-            StdioOptionToStream<I, Writable>,
-            StdioOptionToStream<O, Readable>,
-            StdioOptionToStream<E, Readable>,
+            I,
+            O,
+            E,
             Readable | Writable | null | undefined, // extra, no modification
             Readable | Writable | null | undefined // extra, no modification
         ];
@@ -151,27 +146,99 @@ declare module "child_process" {
         stdio?: 'pipe' | Array<null | undefined | 'pipe'>;
     }
 
+    type StdioNull = 'inherit' | 'ignore' | Stream;
+    type StdioPipe = undefined | null | 'pipe';
+
     interface SpawnOptionsWithStdioTuple<
-        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stdin extends StdioNull | StdioPipe,
+        Stdout extends StdioNull | StdioPipe,
+        Stderr extends StdioNull | StdioPipe,
     > extends SpawnOptions {
         stdio: [Stdin, Stdout, Stderr];
     }
 
+    // overloads of spawn without 'args'
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
-    function spawn<
-        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-    >(command: string, options: SpawnOptionsWithStdioTuple<Stdin, Stdout, Stderr>): ChildProcessForStdioTuple<Stdin, Stdout, Stderr>;
+
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>,
+    ): ChildProcessByStdio<Writable, Readable, Readable>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioNull>,
+    ): ChildProcessByStdio<Writable, Readable, null>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioPipe>,
+    ): ChildProcessByStdio<Writable, null, Readable>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>,
+    ): ChildProcessByStdio<null, Readable, Readable>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioNull>,
+    ): ChildProcessByStdio<Writable, null, null>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioNull>,
+    ): ChildProcessByStdio<null, Readable, null>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioPipe>,
+    ): ChildProcessByStdio<null, null, Readable>;
+    function spawn(
+        command: string,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioNull>,
+    ): ChildProcessByStdio<null, null, null>;
+
     function spawn(command: string, options: SpawnOptions): ChildProcess;
+
+    // overloads of spawn with 'args'
     function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
-    function spawn<
-        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
-    >(command: string, args: ReadonlyArray<string>, options: SpawnOptionsWithStdioTuple<Stdin, Stdout, Stderr>): ChildProcessForStdioTuple<Stdin, Stdout, Stderr>;
+
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>,
+    ): ChildProcessByStdio<Writable, Readable, Readable>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioNull>,
+    ): ChildProcessByStdio<Writable, Readable, null>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioPipe>,
+    ): ChildProcessByStdio<Writable, null, Readable>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>,
+    ): ChildProcessByStdio<null, Readable, Readable>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioNull>,
+    ): ChildProcessByStdio<Writable, null, null>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioNull>,
+    ): ChildProcessByStdio<null, Readable, null>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioPipe>,
+    ): ChildProcessByStdio<null, null, Readable>;
+    function spawn(
+        command: string,
+        args: ReadonlyArray<string>,
+        options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioNull>,
+    ): ChildProcessByStdio<null, null, null>;
+
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -92,6 +92,29 @@ declare module "child_process" {
         ];
     }
 
+    type StdioOptionToStream<
+        O extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        S extends Stream,
+    > = O extends undefined | null | 'pipe' ? S : null;
+
+    // return this object when stdio option is a tuple of 3
+    interface ChildProcessForStdioTuple<
+        I extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        O extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        E extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+    > extends ChildProcess {
+        stdin: StdioOptionToStream<I, Writable>;
+        stdout: StdioOptionToStream<O, Readable>;
+        stderr: StdioOptionToStream<E, Readable>;
+        readonly stdio: [
+            StdioOptionToStream<I, Writable>,
+            StdioOptionToStream<O, Readable>,
+            StdioOptionToStream<E, Readable>,
+            Readable | Writable | null | undefined, // extra, no modification
+            Readable | Writable | null | undefined // extra, no modification
+        ];
+    }
+
     interface MessageOptions {
         keepOpen?: boolean;
     }
@@ -128,9 +151,27 @@ declare module "child_process" {
         stdio?: 'pipe' | Array<null | undefined | 'pipe'>;
     }
 
+    interface SpawnOptionsWithStdioTuple<
+        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+    > extends SpawnOptions {
+        stdio: [Stdin, Stdout, Stderr];
+    }
+
     function spawn(command: string, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
+    function spawn<
+        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+    >(command: string, options: SpawnOptionsWithStdioTuple<Stdin, Stdout, Stderr>): ChildProcessForStdioTuple<Stdin, Stdout, Stderr>;
     function spawn(command: string, options: SpawnOptions): ChildProcess;
     function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams;
+    function spawn<
+        Stdin extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stdout extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+        Stderr extends undefined | null | 'pipe' | 'ignore' | 'inherit' | Stream,
+    >(command: string, args: ReadonlyArray<string>, options: SpawnOptionsWithStdioTuple<Stdin, Stdout, Stderr>): ChildProcessForStdioTuple<Stdin, Stdout, Stderr>;
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
 
     interface ExecOptions extends CommonOptions {

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -308,6 +308,57 @@ async function testPromisify() {
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }));
     expectNonNull(childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }));
 
+    function expectStdio<Stdin, Stdout, Stderr>(...cps: Array<{
+        stdin: Stdin,
+        stdout: Stdout,
+        stderr: Stderr,
+        stdio: [Stdin, Stdout, Stderr, any, any]
+    }>): void {
+        return undefined;
+    }
+
+    expectStdio<Writable, Readable, Readable>(
+        childProcess.spawn('command', { stdio: ['pipe', 'pipe', 'pipe'] }),
+        childProcess.spawn('command', { stdio: [null, null, null] }),
+        childProcess.spawn('command', { stdio: [undefined, undefined, undefined] }),
+        childProcess.spawn('command', { stdio: ['pipe', null, undefined] }),
+    );
+
+    expectStdio<Writable, Readable, null>(
+        childProcess.spawn('command', { stdio: ['pipe', 'pipe', 'ignore'] }),
+        childProcess.spawn('command', { stdio: [null, null, 'inherit'] }),
+        childProcess.spawn('command', { stdio: [undefined, undefined, process.stdout] }),
+        childProcess.spawn('command', { stdio: ['pipe', null, process.stderr] }),
+    );
+
+    expectStdio<null, null, null>(
+        childProcess.spawn('command', { stdio: ['ignore', 'ignore', 'ignore'] }),
+        childProcess.spawn('command', { stdio: ['inherit', 'inherit', 'inherit'] }),
+        childProcess.spawn('command', { stdio: [process.stdin, process.stdout, process.stderr] }),
+        childProcess.spawn('command', { stdio: ['ignore', 'inherit', process.stderr] }),
+    );
+
+    expectStdio<Writable, Readable, Readable>(
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'pipe'] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, null] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, undefined] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', null, undefined] }),
+    );
+
+    expectStdio<Writable, Readable, null>(
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', 'pipe', 'ignore'] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [null, null, 'inherit'] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [undefined, undefined, process.stdout] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['pipe', null, process.stderr] }),
+    );
+
+    expectStdio<null, null, null>(
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['ignore', 'ignore', 'ignore'] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['inherit', 'inherit', 'inherit'] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: [process.stdin, process.stdout, process.stderr] }),
+        childProcess.spawn('command', ['a', 'b', 'c'], { stdio: ['ignore', 'inherit', process.stderr] }),
+    );
+
     function expectChildProcess(cp: childProcess.ChildProcess): void {
         return undefined;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [child_process options.stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
