### PR TITLE
add optional property `config` to StylelintPlugin options

### DIFF
--- a/types/stylelint-webpack-plugin/index.d.ts
+++ b/types/stylelint-webpack-plugin/index.d.ts
@@ -23,7 +23,17 @@ declare namespace StylelintWebpackPlugin {
 
     type Formatter = (messages: Message[], source: string) => string;
 
+    interface Config {
+        rules?: object;
+        extends?: string | string[];
+        plugins?: string[];
+        processors?: string[];
+        ignoreFiles?: string | string[];
+        defaultSeverity?: "warning" | "error";
+    }
+
     interface Options {
+        config?: Config;
         configFile?: string;
         context?: string;
         emitErrors?: boolean;


### PR DESCRIPTION
Add some type definitions, so we can pass configuration to `stylelint` directly, like this:

```js
// webpack config
{
  plugins: [
    new StylelintPlugin({
      config: {
        extends: [
          "stylelint-config-recommended",
          "stylelint-config-css-modules"
        ],
        rules: {
          // ...
        }
      }
    })
  ]
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/webpack-contrib/stylelint-webpack-plugin#options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

