### PR TITLE
Update missing options fields at xml2json

### DIFF
--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for xml2json 0.10
+// Type definitions for xml2json 0.11.2
 // Project: https://github.com/buglabs/node-xml2json
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>
+//                 Igor Strebezhev <https://github.com/xamgore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export function toJson(xml: string, options?: { object?: false } & JsonOptions): string;
 export function toJson(xml: string, options?: { object: true } & JsonOptions): {};
@@ -24,6 +25,10 @@ export interface XmlOptions {
      * @example
      */
     sanitize?: boolean;
+    /**
+     * Ignores all null values.
+     */
+    ignoreNull: boolean;
 }
 
 export interface JsonOptions {
@@ -64,7 +69,13 @@ export interface JsonOptions {
      */
     trim?: boolean;
     /**
-     * XML child nodes are always treated as arrays
+     * XML child nodes are always treated as arrays.
+     * You can specify a selective array of nodes for this to apply to instead of the whole document.
      */
-    arrayNotation?: boolean;
+    arrayNotation?: boolean | string[];
+    /**
+     * Changes the default textNode property from $t to _t when option is set to true.
+     * Alternatively a string can be specified which will override $t to what ever the string is.
+     */
+    alternateTextNode?: boolean;
 }

--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for xml2json 0.11.2
+// Type definitions for xml2json 0.11
 // Project: https://github.com/buglabs/node-xml2json
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>
 //                 Igor Strebezhev <https://github.com/xamgore>
@@ -28,7 +28,7 @@ export interface XmlOptions {
     /**
      * Ignores all null values.
      */
-    ignoreNull: boolean;
+    ignoreNull?: boolean;
 }
 
 export interface JsonOptions {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/buglabs/node-xml2json/blob/98272646816c5f5747970ee6906e206c1fdd6082/README.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
