### PR TITLE
Add types for distributions-poisson-quantile

### DIFF
--- a/types/distributions-poisson-quantile/distributions-poisson-quantile-tests.ts
+++ b/types/distributions-poisson-quantile/distributions-poisson-quantile-tests.ts
@@ -1,0 +1,75 @@
+import quantile from 'distributions-poisson-quantile';
+
+const number = quantile(0);
+number.toExponential();
+
+const numberArr = quantile([0]);
+numberArr.values();
+
+const noDTypeNumberArr = quantile([0], {});
+noDTypeNumberArr.values();
+
+const int8 = quantile([0], { dtype: 'int8' });
+int8.byteLength;
+
+const uint8 = quantile([0], { dtype: 'uint8' });
+uint8.byteLength;
+
+const uint8_clamped = quantile([0], { dtype: 'uint8_clamped' });
+uint8_clamped.byteLength;
+
+const int16 = quantile([0], { dtype: 'int16' });
+int16.byteLength;
+
+const uint16 = quantile([0], { dtype: 'uint16' });
+uint16.byteLength;
+
+const int32 = quantile([0], { dtype: 'int32' });
+int32.byteLength;
+
+const uint32 = quantile([0], { dtype: 'uint32' });
+uint32.byteLength;
+
+const float32 = quantile([0], { dtype: 'float32' });
+float32.byteLength;
+
+const float64 = quantile([0], { dtype: 'float64' });
+float64.byteLength;
+
+const noOptionsFloat64 = quantile(new Float32Array(1));
+noOptionsFloat64.byteLength;
+
+const noDTypeFloat64 = quantile(new Float32Array(1), {});
+noDTypeFloat64.byteLength;
+
+const undefDTypeFloat64 = quantile(new Float32Array(1), { dtype: undefined });
+undefDTypeFloat64.byteLength;
+
+const matrixLike = {
+    data: {},
+    shape: {},
+    offset: 0,
+    strides: {},
+    dtype: '',
+    length: 0,
+};
+
+const matrix = quantile(matrixLike);
+matrix.dtype;
+matrix.ndims;
+matrix.shape;
+matrix.offset;
+matrix.strides;
+matrix.length;
+matrix.nbytes;
+matrix.data;
+matrix.set(0, 0, 0);
+matrix.iset(0, 0);
+matrix.mset([0], [0], 0);
+matrix.sset('', 0);
+matrix.get(0, 0);
+matrix.iget(0);
+matrix.mget([0], [0]);
+matrix.sget('');
+matrix.toString();
+matrix.toJSON();

--- a/types/distributions-poisson-quantile/index.d.ts
+++ b/types/distributions-poisson-quantile/index.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for distributions-poisson-quantile 0.0
+// Project: https://github.com/distributions-io/poisson-quantile#readme
+// Definitions by: Daniel McNally <https://github.com/sangaman>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+declare function quantile(p: number, options?: Options): number;
+declare function quantile(p: number[], options?: Options & { dtype?: undefined }): number[];
+declare function quantile(p: Data, options?: Options & { dtype?: 'float64' }): Float64Array;
+declare function quantile(p: Data, options: Options & { dtype: 'int8' }): Int8Array;
+declare function quantile(p: Data, options: Options & { dtype: 'uint8' }): Uint8Array;
+declare function quantile(p: Data, options: Options & { dtype: 'uint8_clamped' }): Uint8ClampedArray;
+declare function quantile(p: Data, options: Options & { dtype: 'int16' }): Int16Array;
+declare function quantile(p: Data, options: Options & { dtype: 'uint16' }): Uint16Array;
+declare function quantile(p: Data, options: Options & { dtype: 'int32' }): Int32Array;
+declare function quantile(p: Data, options: Options & { dtype: 'uint32' }): Uint32Array;
+declare function quantile(p: Data, options: Options & { dtype: 'float32' }): Float32Array;
+declare function quantile(p: MatrixLike, options?: Options): Matrix;
+
+/**
+ * Evaluates the quantile function for a Poisson distribution.
+ * @param p input value
+ * @param options function options
+ * @returns quantile function value(s)
+ */
+declare function quantile(p: number | Data | MatrixLike, options?: Options): number | Data | Matrix;
+
+type Data = number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array;
+
+type DataType = 'int8' | 'uint8' | 'uint8_clamped' | 'int16' | 'uint16' | 'int32' | 'uint32' | 'float32' | 'float64';
+
+type MatrixCallback = (d: number, i: number, j: number, idx: number) => number;
+
+// derived from https://github.com/dstructs/matrix
+interface Matrix {
+    readonly dtype: DataType;
+    readonly ndims: number;
+    readonly shape: number[];
+    offset: number;
+    strides: number[];
+    readonly length: number;
+    readonly nbytes: number;
+    readonly data: Data;
+    set: (i: number, j: number, value: number) => Matrix;
+    iset: (idx: number, value: number) => Matrix;
+    mset: (idx: number[], colsOrValue: number[] | Matrix, value?: number | Matrix | MatrixCallback) => Matrix;
+    sset: (subsequence: string, value: number | Matrix | MatrixCallback) => Matrix;
+    get: (i: number, j: number) => Matrix;
+    iget: (index: number) => Matrix;
+    mget: (idx: number[], cols?: number[]) => Matrix[];
+    sget: (subsequence: string) => Matrix;
+    toString: () => string;
+    toJSON: () => string;
+}
+
+// derived from https://github.com/validate-io/matrix-like
+interface MatrixLike {
+    data: object;
+    shape: object;
+    offset: number;
+    strides: object;
+    dtype: string;
+    length: number;
+}
+
+interface Options {
+    /** mean parameter, default=1 */
+    lambda?: number;
+    /** boolean indicating if the function should return a new data structure, default=true */
+    copy?: boolean;
+    /** accessor function for accessing array values */
+    accessor?: (d: Data, i: number) => any;
+    /** deep get/set key path */
+    path?: string;
+    /** deep get/set key path separator, default="." */
+    sep?: string;
+    /** output data type, default="float64" */
+    dtype?: DataType;
+}
+
+export = quantile;

--- a/types/distributions-poisson-quantile/tsconfig.json
+++ b/types/distributions-poisson-quantile/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "distributions-poisson-quantile-tests.ts"
+    ]
+}

--- a/types/distributions-poisson-quantile/tslint.json
+++ b/types/distributions-poisson-quantile/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.