### PR TITLE
[follow-redirects] add missing Options

### DIFF
--- a/types/follow-redirects/follow-redirects-tests.ts
+++ b/types/follow-redirects/follow-redirects-tests.ts
@@ -5,6 +5,9 @@ http.request({
     path: '/a/b',
     port: 8000,
     maxRedirects: 12,
+    beforeRedirect: (options) => {
+        options.followRedirects = false;
+    }
 }, (response) => {
     console.log(response.responseUrl, response.redirects);
     response.on('data', (chunk) => {

--- a/types/follow-redirects/index.d.ts
+++ b/types/follow-redirects/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for follow-redirects 1.5
+// Type definitions for follow-redirects 1.8
 // Project: https://github.com/follow-redirects/follow-redirects
-// Definitions by: Emily Klassen <https://github.com/forivall>
+// Definitions by: Emily Klassen <https://github.com/forivall>, Claas Ahlrichs <https://github.com/claasahl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -70,19 +70,26 @@ export interface RedirectableRequest<Request extends WrappableRequest, Response>
 
 export interface RedirectScheme<Options, Request extends WrappableRequest, Response> {
     request(
-        options: string | Options & FollowOptions,
+        options: string | Options & FollowOptions<Options>,
         callback?: (res: Response & FollowResponse) => void
     ): RedirectableRequest<Request, Response>;
     get(
-        options: string | Options & FollowOptions,
+        options: string | Options & FollowOptions<Options>,
         callback?: (res: Response & FollowResponse) => void
     ): RedirectableRequest<Request, Response>;
 }
 
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
-export interface FollowOptions {
+export interface FollowOptions<Options> {
+    followRedirects?: boolean;
     maxRedirects?: number;
     maxBodyLength?: number;
+    beforeRedirect?: (options: Options & FollowOptions<Options>) => void;
+    agents?: {
+        http?: coreHttp.Agent;
+        https?: coreHttps.Agent;
+    };
+    trackRedirects?: boolean;
 }
 
 export interface FollowResponse {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/follow-redirects/follow-redirects/releases/tag/v1.8.1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
