### PR TITLE
[googlemaps] Allow steps to be nested under google.maps.DirectionsLeg

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -793,3 +793,31 @@ const directionsWaypointLocationPlace: google.maps.DirectionsWaypoint = {
 const directionsWaypointStopover: google.maps.DirectionsWaypoint = {
     stopover: true,
 };
+
+/***** google.maps.DirectionsService *****/
+let directionsService = new google.maps.DirectionsService();
+
+directionsService.route({
+    avoidFerries: true,
+    avoidHighways: true,
+    avoidTolls: true,
+    destination: 'destination',
+    origin: 'origin',
+    provideRouteAlternatives: true,
+    transitOptions: {
+        arrivalTime: new Date(),
+        departureTime: new Date(),
+        modes: [
+            google.maps.TransitMode.BUS,
+            google.maps.TransitMode.RAIL
+        ],
+        routingPreference: google.maps.TransitRoutePreference.FEWER_TRANSFERS
+    },
+    travelMode: google.maps.TravelMode.TRANSIT,
+    unitSystem: google.maps.UnitSystem.IMPERIAL
+}, (result: google.maps.DirectionsResult, status: google.maps.DirectionsStatus) => {
+    const routes = result.routes; // $ExpectType DirectionsRoute[]
+    const legs = routes[0].legs; // $ExpectType DirectionsLeg[]
+    const steps = legs[0].steps; // $ExpectType DirectionsStep[]
+    steps[0].steps; // $ExpectType BaseDirectionsStep[]
+});

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1977,16 +1977,22 @@ declare namespace google.maps {
         via_waypoints: LatLng[];
     }
 
-    interface DirectionsStep {
+    interface BaseDirectionsStep {
         distance: Distance;
         duration: Duration;
         end_location: LatLng;
         instructions: string;
         path: LatLng[];
         start_location: LatLng;
-        steps: DirectionsStep;
         transit: TransitDetails;
         travel_mode: TravelMode;
+    }
+
+    interface DirectionsStep extends BaseDirectionsStep {
+        /**
+         * This field will only be available if travel_mode is set to TRANSIT.
+         */
+        steps: BaseDirectionsStep[];
     }
 
     interface Distance {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/directions/intro#Steps

Steps can contain steps (one level deep) when using `google.maps.travel_mode.TRANSIT`. The current definition contained a `steps` field, but it was not an array. This pull request changes steps to an array and prevents steps from being nested more than one level deep.