### PR TITLE
Fix types for `emoji-mart` emojiIndex

### DIFF
--- a/types/emoji-mart/dist-es/components/category.d.ts
+++ b/types/emoji-mart/dist-es/components/category.d.ts
@@ -3,15 +3,15 @@ import React = require('react');
 import { Emoji, EmojiData, EmojiProps, I18n, CategoryName } from '..';
 
 export interface Props {
-    emojis?: Array<string|EmojiData>;
-    hasStickyPosition?: boolean;
-    id: CategoryName;
-    name: string;
-    native: boolean;
-    perLine: number;
-    emojiProps: EmojiProps;
-    recent?: string[];
-    i18n: I18n;
+  emojis?: Array<string | EmojiData>;
+  hasStickyPosition?: boolean;
+  id: CategoryName;
+  name: string;
+  native: boolean;
+  perLine: number;
+  emojiProps: EmojiProps;
+  recent?: string[];
+  i18n: I18n;
 }
 
 export default class Category extends React.Component<Props> {

--- a/types/emoji-mart/dist-es/components/category.d.ts
+++ b/types/emoji-mart/dist-es/components/category.d.ts
@@ -3,15 +3,15 @@ import React = require('react');
 import { Emoji, EmojiData, EmojiProps, I18n, CategoryName } from '..';
 
 export interface Props {
-  emojis?: Array<string | EmojiData>;
-  hasStickyPosition?: boolean;
-  id: CategoryName;
-  name: string;
-  native: boolean;
-  perLine: number;
-  emojiProps: EmojiProps;
-  recent?: string[];
-  i18n: I18n;
+    emojis?: Array<string | EmojiData>;
+    hasStickyPosition?: boolean;
+    id: CategoryName;
+    name: string;
+    native: boolean;
+    perLine: number;
+    emojiProps: EmojiProps;
+    recent?: string[];
+    i18n: I18n;
 }
 
 export default class Category extends React.Component<Props> {

--- a/types/emoji-mart/dist-es/index.d.ts
+++ b/types/emoji-mart/dist-es/index.d.ts
@@ -20,9 +20,9 @@ export {
     BaseEmoji,
     CustomEmoji,
     EmojiData,
+    EmojiEntry,
     EmojiSkin,
     default as NimbleEmojiIndex,
-    EmojiEntry,
 } from './utils/emoji-index/nimble-emoji-index';
 
 export {

--- a/types/emoji-mart/dist-es/index.d.ts
+++ b/types/emoji-mart/dist-es/index.d.ts
@@ -17,20 +17,21 @@ export {
 export { default as emojiIndex } from './utils/emoji-index/emoji-index';
 
 export {
-    BaseEmoji,
-    CustomEmoji,
-    EmojiData,
-    EmojiSkin,
-    default as NimbleEmojiIndex,
+  BaseEmoji,
+  CustomEmoji,
+  EmojiData,
+  EmojiSkin,
+  default as NimbleEmojiIndex,
+  EmojiEntry,
 } from './utils/emoji-index/nimble-emoji-index';
 
 export {
-    Picker,
-    NimblePicker,
-    NimblePickerProps,
-    Emoji,
-    NimbleEmoji,
-    NimbleEmojiProps,
-    Category,
-    CategoryProps
+  Picker,
+  NimblePicker,
+  NimblePickerProps,
+  Emoji,
+  NimbleEmoji,
+  NimbleEmojiProps,
+  Category,
+  CategoryProps,
 } from './components';

--- a/types/emoji-mart/dist-es/index.d.ts
+++ b/types/emoji-mart/dist-es/index.d.ts
@@ -17,21 +17,21 @@ export {
 export { default as emojiIndex } from './utils/emoji-index/emoji-index';
 
 export {
-  BaseEmoji,
-  CustomEmoji,
-  EmojiData,
-  EmojiSkin,
-  default as NimbleEmojiIndex,
-  EmojiEntry,
+    BaseEmoji,
+    CustomEmoji,
+    EmojiData,
+    EmojiSkin,
+    default as NimbleEmojiIndex,
+    EmojiEntry,
 } from './utils/emoji-index/nimble-emoji-index';
 
 export {
-  Picker,
-  NimblePicker,
-  NimblePickerProps,
-  Emoji,
-  NimbleEmoji,
-  NimbleEmojiProps,
-  Category,
-  CategoryProps,
+    Picker,
+    NimblePicker,
+    NimblePickerProps,
+    Emoji,
+    NimbleEmoji,
+    NimbleEmojiProps,
+    Category,
+    CategoryProps,
 } from './components';

--- a/types/emoji-mart/dist-es/utils/emoji-index/emoji-index.d.ts
+++ b/types/emoji-mart/dist-es/utils/emoji-index/emoji-index.d.ts
@@ -2,13 +2,13 @@ import { EmojiData, EmojiEntry } from './nimble-emoji-index';
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-      search(query: ''): null;
-  search(query: string): EmojiData[] | null;
+    search(query: ''): null;
+    search(query: string): EmojiData[] | null;
 
     emojis: { [emoji: string]: EmojiEntry };
 
-  /** Mapping of string to keyof emojis */
-  emoticons: { [emoticon: string]: string };
+    /** Mapping of string to keyof emojis */
+    emoticons: { [emoticon: string]: string };
 };
 
 export { _default as default };

--- a/types/emoji-mart/dist-es/utils/emoji-index/emoji-index.d.ts
+++ b/types/emoji-mart/dist-es/utils/emoji-index/emoji-index.d.ts
@@ -1,14 +1,14 @@
-import { EmojiData } from './nimble-emoji-index';
+import { EmojiData, EmojiEntry } from './nimble-emoji-index';
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-    search(query: ''): null;
-    search(query: string): EmojiData|null;
+      search(query: ''): null;
+  search(query: string): EmojiData[] | null;
 
-    emojis: { [emoji: string]: EmojiData };
+    emojis: { [emoji: string]: EmojiEntry };
 
-    /** Mapping of string to keyof emojis */
-    emoticons: { [emoticon: string]: string };
+  /** Mapping of string to keyof emojis */
+  emoticons: { [emoticon: string]: string };
 };
 
 export { _default as default };

--- a/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
+++ b/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
@@ -32,10 +32,10 @@ export type EmojiData = BaseEmoji | CustomEmoji;
 export type EmojiEntry = EmojiData | { [variant: number]: EmojiData }; // emoji with skin tones will return
 
 export default class NimbleEmojiIndex {
-                 constructor(data: Data);
-                 search(query: ''): null;
-                 search(query: string): EmojiData[] | null;
-                 emojis: { [emoji: string]: EmojiData };
-                 /** Mapping of string to keyof emojis */
-                 emoticons: { [emoticon: string]: string };
-               }
+    constructor(data: Data);
+    search(query: ''): null;
+    search(query: string): EmojiData[] | null;
+    emojis: { [emoji: string]: EmojiData };
+    /** Mapping of string to keyof emojis */
+    emoticons: { [emoticon: string]: string };
+}

--- a/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
+++ b/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
@@ -1,4 +1,4 @@
-import { Data } from "../data";
+import { Data } from '../data';
 
 import { CategoryName } from '../shared-props';
 
@@ -29,12 +29,13 @@ export interface CustomEmoji {
 }
 
 export type EmojiData = BaseEmoji | CustomEmoji;
+export type EmojiEntry = EmojiData | { [variant: number]: EmojiData }; // emoji with skin tones will return
 
 export default class NimbleEmojiIndex {
-    constructor(data: Data);
-    search(query: ''): null;
-    search(query: string): EmojiData[]|null;
-    emojis: { [emoji: string]: EmojiData };
-    /** Mapping of string to keyof emojis */
-    emoticons: { [emoticon: string]: string };
-}
+                 constructor(data: Data);
+                 search(query: ''): null;
+                 search(query: string): EmojiData[] | null;
+                 emojis: { [emoji: string]: EmojiData };
+                 /** Mapping of string to keyof emojis */
+                 emoticons: { [emoticon: string]: string };
+               }

--- a/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
+++ b/types/emoji-mart/dist-es/utils/emoji-index/nimble-emoji-index.d.ts
@@ -29,7 +29,7 @@ export interface CustomEmoji {
 }
 
 export type EmojiData = BaseEmoji | CustomEmoji;
-export type EmojiEntry = EmojiData | { [variant: number]: EmojiData }; // emoji with skin tones will return
+export type EmojiEntry = EmojiData | { [variant in EmojiSkin]: EmojiData }; // emoji with skin tones will return
 
 export default class NimbleEmojiIndex {
     constructor(data: Data);

--- a/types/emoji-mart/dist-es/utils/frequently.d.ts
+++ b/types/emoji-mart/dist-es/utils/frequently.d.ts
@@ -2,8 +2,8 @@ import { EmojiData } from '..';
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-    add(emoji: Pick<EmojiData, 'id'>): void
-    get(perLine: number): string[]
+  add(emoji: Pick<EmojiData, 'id'>): void;
+  get(perLine: number): string[];
 };
 
 export { _default as default };

--- a/types/emoji-mart/dist-es/utils/frequently.d.ts
+++ b/types/emoji-mart/dist-es/utils/frequently.d.ts
@@ -2,8 +2,8 @@ import { EmojiData } from '..';
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-  add(emoji: Pick<EmojiData, 'id'>): void;
-  get(perLine: number): string[];
+    add(emoji: Pick<EmojiData, 'id'>): void;
+    get(perLine: number): string[];
 };
 
 export { _default as default };

--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -32,7 +32,18 @@ export interface EmojiProps {
     /** data is omitted here as it should be used for NimbleEmoji only - not emoji */
 }
 
-export type CategoryName = 'search' | 'recent' | 'people' | 'nature' | 'foods' | 'activity' | 'places' | 'objects' | 'symbols' | 'flags' | 'custom';
+export type CategoryName =
+  | 'search'
+  | 'recent'
+  | 'people'
+  | 'nature'
+  | 'foods'
+  | 'activity'
+  | 'places'
+  | 'objects'
+  | 'symbols'
+  | 'flags'
+  | 'custom';
 
 // tslint:disable-next-line interface-name
 export interface I18n {

--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -33,17 +33,17 @@ export interface EmojiProps {
 }
 
 export type CategoryName =
-  | 'search'
-  | 'recent'
-  | 'people'
-  | 'nature'
-  | 'foods'
-  | 'activity'
-  | 'places'
-  | 'objects'
-  | 'symbols'
-  | 'flags'
-  | 'custom';
+    | 'search'
+    | 'recent'
+    | 'people'
+    | 'nature'
+    | 'foods'
+    | 'activity'
+    | 'places'
+    | 'objects'
+    | 'symbols'
+    | 'flags'
+    | 'custom';
 
 // tslint:disable-next-line interface-name
 export interface I18n {

--- a/types/emoji-mart/dist-es/utils/store.d.ts
+++ b/types/emoji-mart/dist-es/utils/store.d.ts
@@ -5,11 +5,11 @@ export interface StoreHandlers {
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-  setHandlers(handlers?: StoreHandlers): void;
-  setNamespace(namespace: string): void;
-  update(state: { [key: string]: any }): void;
-  set(key: string, value: any): void;
-  get(key: string): any;
+    setHandlers(handlers?: StoreHandlers): void;
+    setNamespace(namespace: string): void;
+    update(state: { [key: string]: any }): void;
+    set(key: string, value: any): void;
+    get(key: string): any;
 };
 
 export { _default as default };

--- a/types/emoji-mart/dist-es/utils/store.d.ts
+++ b/types/emoji-mart/dist-es/utils/store.d.ts
@@ -5,11 +5,11 @@ export interface StoreHandlers {
 
 // tslint:disable-next-line strict-export-declare-modifiers
 declare const _default: {
-    setHandlers(handlers?: StoreHandlers): void
-    setNamespace(namespace: string): void
-    update(state: {[key: string]: any}): void
-    set(key: string, value: any): void
-    get(key: string): any
+  setHandlers(handlers?: StoreHandlers): void;
+  setNamespace(namespace: string): void;
+  update(state: { [key: string]: any }): void;
+  set(key: string, value: any): void;
+  get(key: string): any;
 };
 
 export { _default as default };

--- a/types/emoji-mart/emoji-mart-tests.tsx
+++ b/types/emoji-mart/emoji-mart-tests.tsx
@@ -1,35 +1,46 @@
 // Port of https://github.com/missive/emoji-mart/blob/v2.8.0/stories/index.js
 
 import React = require('react');
+import { useState } from 'react';
 
-import { Picker, Emoji, EmojiProps, CustomEmoji, BaseEmoji, NimbleEmojiIndex } from 'emoji-mart';
+import {
+    Picker,
+    Emoji,
+    EmojiProps,
+    CustomEmoji,
+    BaseEmoji,
+    NimbleEmojiIndex,
+    emojiIndex,
+    EmojiData,
+    EmojiEntry,
+} from 'emoji-mart';
 
-declare var console: { log(...args: any[]): void; };
+declare var console: { log(...args: any[]): void };
 
 const CUSTOM_EMOJIS: CustomEmoji[] = [
-  {
-    name: 'Party Parrot',
-    short_names: ['parrot'],
-    keywords: ['party'],
-    imageUrl: 'http://cultofthepartyparrot.com/parrots/hd/parrot.gif'
-  },
-  {
-    name: 'Octocat',
-    short_names: ['octocat'],
-    keywords: ['github'],
-    imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/octocat.png?v7'
-  },
-  {
-    name: 'Squirrel',
-    short_names: ['shipit', 'squirrel'],
-    keywords: ['github'],
-    imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/shipit.png?v7'
-  },
+    {
+        name: 'Party Parrot',
+        short_names: ['parrot'],
+        keywords: ['party'],
+        imageUrl: 'http://cultofthepartyparrot.com/parrots/hd/parrot.gif',
+    },
+    {
+        name: 'Octocat',
+        short_names: ['octocat'],
+        keywords: ['github'],
+        imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/octocat.png?v7',
+    },
+    {
+        name: 'Squirrel',
+        short_names: ['shipit', 'squirrel'],
+        keywords: ['github'],
+        imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/shipit.png?v7',
+    },
 ];
 
 interface State {
     native: boolean;
-    set: EmojiProps['set']|'native';
+    set: EmojiProps['set'] | 'native';
     emoji: string;
     title: string;
     custom: CustomEmoji[];
@@ -41,53 +52,92 @@ class Example extends React.Component<{}, State> {
         set: 'apple',
         emoji: 'point_up',
         title: 'Pick your emoji…',
-        custom: CUSTOM_EMOJIS
+        custom: CUSTOM_EMOJIS,
     };
-  render() {
+    render() {
+        return (
+            <div>
+                <div className="row">
+                    <h1>Emoji Mart 🏬</h1>
+                </div>
+
+                <div className="row">
+                    {(['native', 'apple', 'google', 'twitter', 'emojione', 'messenger', 'facebook'] as Array<
+                        EmojiProps['set'] | 'native'
+                    >).map(set => {
+                        const props = { disabled: !this.state.native && set === this.state.set };
+
+                        if (set === 'native' && this.state.native) {
+                            props.disabled = true;
+                        }
+
+                        return (
+                            <button
+                                key={set}
+                                value={set}
+                                onClick={() => {
+                                    if (set === 'native') {
+                                        this.setState({ native: true });
+                                    } else {
+                                        this.setState({ set, native: false });
+                                    }
+                                }}
+                                {...props}
+                            >
+                                {set}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                <div className="row">
+                    <Picker
+                        {...this.state}
+                        // NOTE: The original code passes the this.state directly, which includes a potential
+                        // invalid 'set' value. The value of 'set' happens to be ignored if native is true, but no
+                        // good way to represent it in the typings.
+                        set={this.state.set === 'native' ? undefined : this.state.set}
+                        onClick={console.log}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+const AutoCompleteExample: React.FC = () => {
+    const [search, setSearch] = useState('');
+    const changed = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const target = e.target as { value: any };
+        setSearch(target.value);
+    };
+
+    const match = search.match(/:([a-z_]+)(:)?/);
+    let suggestions: ReturnType<typeof emojiIndex.search> = [];
+    if (match && match[2]) {
+        // smiley is closed
+        let emoji = emojiIndex.emojis[match[1]];
+        const isSingleEmoji = (e: EmojiEntry): e is EmojiData => {
+            return 'name' in e;
+        };
+        const isNativeEmoji = (e: EmojiData): e is BaseEmoji => {
+            return 'native' in e;
+        };
+        if (!isSingleEmoji(emoji)) {
+            emoji = emoji[1];
+        }
+        const native = isNativeEmoji(emoji) && emoji.native || '';
+        setSearch(search.replace(match[0], native));
+    } else if (match && match[1].length > 2) {
+        suggestions = emojiIndex.search(match[1]) || [];
+    }
     return (
         <div>
-            <div className="row">
-                <h1>Emoji Mart 🏬</h1>
-            </div>
-
-            <div className="row">
-                {(['native', 'apple', 'google', 'twitter', 'emojione', 'messenger', 'facebook'] as Array<EmojiProps['set']|'native'>).map((set) => {
-                    const props = { disabled: !this.state.native && set === this.state.set };
-
-                    if (set === 'native' && this.state.native) {
-                        props.disabled = true;
-                    }
-
-                    return (
-                        <button
-                            key={set}
-                            value={set}
-                            onClick={() => {
-                                if (set === 'native') {
-                                    this.setState({ native: true });
-                                } else {
-                                    this.setState({ set, native: false });
-                                }
-                            }}
-                            {...props}
-                        >
-                            {set}
-                        </button>
-                    );
-                })}
-            </div>
-
-            <div className="row">
-                <Picker
-                    {...this.state}
-                    // NOTE: The original code passes the this.state directly, which includes a potential
-                    // invalid 'set' value. The value of 'set' happens to be ignored if native is true, but no
-                    // good way to represent it in the typings.
-                    set={this.state.set === 'native' ? undefined : this.state.set}
-                    onClick={console.log}
-                />
-            </div>
+            {suggestions.map(emoji => {
+                return 'native' in emoji && <span>{emoji.native}</span>;
+            })}
+            {match && <div>{match[0]}</div>}
+            <input type="text" onInput={changed} placeholder="enter a message..." value={search} />
         </div>
     );
-  }
-}
+};

--- a/types/emoji-mart/emoji-mart-tests.tsx
+++ b/types/emoji-mart/emoji-mart-tests.tsx
@@ -126,7 +126,7 @@ const AutoCompleteExample: React.FC = () => {
         if (!isSingleEmoji(emoji)) {
             emoji = emoji[1];
         }
-        const native = isNativeEmoji(emoji) && emoji.native || '';
+        const native = (isNativeEmoji(emoji) && emoji.native) || '';
         setSearch(search.replace(match[0], native));
     } else if (match && match[1].length > 2) {
         suggestions = emojiIndex.search(match[1]) || [];

--- a/types/emoji-mart/index.d.ts
+++ b/types/emoji-mart/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for emoji-mart 2.8
+// Type definitions for emoji-mart 2.11
 // Project: https://github.com/missive/emoji-mart
 // Definitions by: Jessica Franco <https://github.com/Jessidhia>
 //                 Nick Winans <https://github.com/Nicell>
+//                 Elvis Wolcott <https://github.com/elvis-wolcott>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/emoji-mart/index.d.ts
+++ b/types/emoji-mart/index.d.ts
@@ -4,6 +4,6 @@
 //                 Nick Winans <https://github.com/Nicell>
 //                 Elvis Wolcott <https://github.com/elvis-wolcott>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 export * from './dist-es';

--- a/types/emoji-mart/tsconfig.json
+++ b/types/emoji-mart/tsconfig.json
@@ -1,17 +1,13 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://github.com/missive/emoji-mart#headless-search
Documentation showing that `emojiIndex.search()` returns an array of emoji
* https://github.com/missive/emoji-mart/blob/master/src/utils/emoji-index/nimble-emoji-index.js#L39-L50
Source showing that the `emojiIndex.emojis` returns an object of `EmojiData` when multiple skin tones exist.
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
