### PR TITLE
[pino-http] Add new autoLogging flag from v4.3.0

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-http 4.0
+// Type definitions for pino-http 4.3
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for pino-http 4.0
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
+//                 Jeremy Forsythe <https://github.com/jdforsythe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -15,11 +16,17 @@ declare function PinoHttp(stream?: DestinationStream): PinoHttp.HttpLogger;
 declare namespace PinoHttp {
     type HttpLogger = (req: IncomingMessage, res: ServerResponse) => void;
 
+    /**
+     * Options for pino-http
+     *
+     * See https://github.com/pinojs/pino-http#pinohttpopts-stream
+     */
     interface Options extends LoggerOptions {
         logger?: Logger;
         genReqId?: GenReqId;
         useLevel?: Level;
         stream?: DestinationStream;
+        autoLogging?: boolean;
         customLogLevel?: (res: ServerResponse, error: Error) => Level;
     }
 

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -17,5 +17,6 @@ pinoHttp({ genReqId: (req) => 'foo' });
 pinoHttp({ genReqId: (req) => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
 pinoHttp({ prettyPrint: true });
+pinoHttp({ autoLogging: false });
 pinoHttp(new Writable());
 pinoHttp({ customLogLevel(req, res) { return 'info'; } });


### PR DESCRIPTION
See https://github.com/pinojs/pino-http/pull/70
See https://github.com/pinojs/pino-http/releases/tag/v4.3.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: pinojs/pino-http#70 [docs](https://github.com/pinojs/pino-http#pinohttpopts-stream)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
