### PR TITLE
react-scrollspy: componentTag can take components

### DIFF
--- a/types/react-scrollspy/index.d.ts
+++ b/types/react-scrollspy/index.d.ts
@@ -17,7 +17,7 @@ export interface ScrollspyProps {
     scrolledPastClassName?: string;
 
     // HTML tag for Scrollspy component if you want to use other than ul
-    componentTag?: string;
+    componentTag?: string | React.ComponentType;
 
     // Style attribute to be passed to the generated <ul /> element
     style?: React.CSSProperties;


### PR DESCRIPTION
Its proptypes defintion is:
 `componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])`
But it's used like:
  `<componentTag className={ itemClass } style={ style }>`
Which makes it a component not any old function.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [-not done- existing tests don't cover this ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [-no- existing failure in the react package - can't find module csstype ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/makotot/react-scrollspy/blob/master/src/js/lib/scrollspy.js#L251 and also line 284 where it is used
- [n/a ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [not making substantial changes ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.