### PR TITLE
[yup] Allow optional type argument to be passed to string()

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -101,8 +101,8 @@ export interface MixedSchema<T = any> extends Schema<T> {
 }
 
 export interface StringSchemaConstructor {
-    <T extends string = string>(): StringSchema<T>;
-    new <T extends string = string>(): StringSchema<T>;
+    (): StringSchema;
+    new (): StringSchema;
 }
 
 export interface StringSchema<T extends string | null | undefined = string> extends Schema<T> {
@@ -228,7 +228,7 @@ export interface ArraySchema<T> extends BasicArraySchema<T[]> {
 }
 
 export type ObjectSchemaDefinition<T extends object | null | undefined> = {
-    [field in keyof T]: Schema<T[field]> | Ref;
+    [field in keyof T]: Schema<T[field] extends string ? string : T[field]> | Ref
 };
 
 /**

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -101,8 +101,8 @@ export interface MixedSchema<T = any> extends Schema<T> {
 }
 
 export interface StringSchemaConstructor {
-    (): StringSchema;
-    new (): StringSchema;
+    <T extends string = string>(): StringSchema<T>;
+    new <T extends string = string>(): StringSchema<T>;
 }
 
 export interface StringSchema<T extends string | null | undefined = string> extends Schema<T> {


### PR DESCRIPTION
Consider the following case:

```typescript
interface I {
    str: 'abc' | 'def';
}

const S = Yup.object().shape<I>({
  str: Yup.string(), //error: StringSchema<string> is not assignable to Schema<'abc' | 'def'>
})
```
If your interface specifies any string type which is narrower than `string`, you cannot match the interface to a yup object shape. This PR disregards the string literal type (as yup cannot validate this) and casts it as string.