### PR TITLE
update version matcher for openpgp version 3.2

### DIFF
--- a/types/openpgp/package.json
+++ b/types/openpgp/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "types": "index",
     "typesVersions": {
-        ">=3.2.0-0": {
+        "<=3.2.0-0": {
             "*": [
                 "ts3.2/*"
             ]


### PR DESCRIPTION
fix the version matcher. 
this breaks if the version is 4