### PR TITLE
Add types for multivariate-normal

### DIFF
--- a/types/multivariate-normal/index.d.ts
+++ b/types/multivariate-normal/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Distribution {
-    sample(): number[];
-    getMean(): ReadonlyArray<number>;
-    setMean(newMean: number[]): Distribution;
-    getCov(): ReadonlyArray<ReadonlyArray<number>>;
-    setCov(newCov: number[][]): Distribution;
+  sample(): number[];
+  getMean(): ReadonlyArray<number>;
+  setMean(newMean: ReadonlyArray<number>): Distribution;
+  getCov(): ReadonlyArray<ReadonlyArray<number>>;
+  setCov(newCov: ReadonlyArray<ReadonlyArray<number>>): Distribution;
 }
 
 export default function MultivariateNormal(

--- a/types/multivariate-normal/index.d.ts
+++ b/types/multivariate-normal/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for multivariate-normal 0.1
+// Type definitions for multivariate-normal 0.1.2
 // Project: https://github.com/tulip/multivariate-normal-js#readme
-// Definitions by: Ben Weissmann <https://github.com/me>
+// Definitions by: Ben Weissmann <https://github.com/benweissmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Distribution {

--- a/types/multivariate-normal/index.d.ts
+++ b/types/multivariate-normal/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for multivariate-normal 0.1.2
+// Type definitions for multivariate-normal 0.1
 // Project: https://github.com/tulip/multivariate-normal-js#readme
 // Definitions by: Ben Weissmann <https://github.com/benweissmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/multivariate-normal/index.d.ts
+++ b/types/multivariate-normal/index.d.ts
@@ -11,4 +11,7 @@ export interface Distribution {
     setCov(newCov: number[][]): Distribution;
 }
 
-export default function MultivariateNormal(mean: number[], cov: number[][]): Distribution;
+export default function MultivariateNormal(
+  mean: ReadonlyArray<number>,
+  cov: ReadonlyArray<ReadonlyArray<number>>,
+): Distribution;

--- a/types/multivariate-normal/index.d.ts
+++ b/types/multivariate-normal/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for multivariate-normal 0.1
+// Project: https://github.com/tulip/multivariate-normal-js#readme
+// Definitions by: Ben Weissmann <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Distribution {
+    sample(): number[];
+    getMean(): ReadonlyArray<number>;
+    setMean(newMean: number[]): Distribution;
+    getCov(): ReadonlyArray<ReadonlyArray<number>>;
+    setCov(newCov: number[][]): Distribution;
+}
+
+export default function MultivariateNormal(mean: number[], cov: number[][]): Distribution;

--- a/types/multivariate-normal/multivariate-normal-tests.ts
+++ b/types/multivariate-normal/multivariate-normal-tests.ts
@@ -1,11 +1,15 @@
 import MultivariateNormal from 'multivariate-normal';
 
-const dist = MultivariateNormal([1, 2, 3], [[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
+// Test constructing using mutable arrays
+const mutArray: number[] = [1, 2, 3];
+const dist = MultivariateNormal(mutArray, [[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
 
+// Test methods for creating a new distribution from an existing one
 const newDist = dist
   .setMean([4, 5, 6])
   .setCov([[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
 
+// Test accessors
 const newMean: ReadonlyArray<number> = newDist.getMean();
 const newCov: ReadonlyArray<ReadonlyArray<number>> = newDist.getCov();
 
@@ -23,3 +27,6 @@ newDist.getCov()[0][0] = 10;
 // Samples are mutable
 const sample: number[] = newDist.sample();
 sample[0] = 123;
+
+// Check that we can pass immutable arrays into the constructor
+MultivariateNormal(newDist.getMean(), newDist.getCov());

--- a/types/multivariate-normal/multivariate-normal-tests.ts
+++ b/types/multivariate-normal/multivariate-normal-tests.ts
@@ -1,0 +1,25 @@
+import MultivariateNormal from 'multivariate-normal';
+
+const dist = MultivariateNormal([1, 2, 3], [[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
+
+const newDist = dist
+  .setMean([4, 5, 6])
+  .setCov([[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
+
+const newMean: ReadonlyArray<number> = newDist.getMean();
+const newCov: ReadonlyArray<ReadonlyArray<number>> = newDist.getCov();
+
+// Mean and covariance are immutable
+
+// $ExpectError
+newDist.getMean()[0] = 10;
+
+// $ExpectError
+newDist.getCov()[0] = [1, 2, 3];
+
+// $ExpectError
+newDist.getCov()[0][0] = 10;
+
+// Samples are mutable
+const sample: number[] = newDist.sample();
+sample[0] = 123;

--- a/types/multivariate-normal/multivariate-normal-tests.ts
+++ b/types/multivariate-normal/multivariate-normal-tests.ts
@@ -1,13 +1,13 @@
 import MultivariateNormal from 'multivariate-normal';
 
-// Test constructing using mutable arrays
+// Test constructing using mutable and literal arrays
 const mutArray: number[] = [1, 2, 3];
 const dist = MultivariateNormal(mutArray, [[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
 
-// Test methods for creating a new distribution from an existing one
-const newDist = dist
-  .setMean([4, 5, 6])
-  .setCov([[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
+// Test methods for creating a new distribution from an existing one using
+// mutable and literal arrays
+const mutArray2: number[] = [4, 5, 6];
+const newDist = dist.setMean(mutArray2).setCov([[0, 0, 1], [0, 1, 0], [1, 0, 0]]);
 
 // Test accessors
 const newMean: ReadonlyArray<number> = newDist.getMean();
@@ -28,5 +28,8 @@ newDist.getCov()[0][0] = 10;
 const sample: number[] = newDist.sample();
 sample[0] = 123;
 
-// Check that we can pass immutable arrays into the constructor
+// Check that we can pass immutable arrays into the constructor or mutators
 MultivariateNormal(newDist.getMean(), newDist.getCov());
+
+newDist.setCov(dist.getCov());
+newDist.setMean(dist.getMean());

--- a/types/multivariate-normal/tsconfig.json
+++ b/types/multivariate-normal/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "multivariate-normal-tests.ts"
+    ]
+}

--- a/types/multivariate-normal/tslint.json
+++ b/types/multivariate-normal/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
