### PR TITLE
[node-polyglot] Add types for new options and static methods from latest release

### DIFF
--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/airbnb/polyglot.js
 // Definitions by: Tim Jackson-Kiely <https://github.com/timjk>
 //                 Liam Ross <https://github.com/liamross>
+//                 Michael Mok <https://github.com/pmmmwh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Polyglot {

--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-polyglot v0.4.3
+// Type definitions for node-polyglot v0.4.4
 // Project: https://github.com/airbnb/polyglot.js
 // Definitions by: Tim Jackson-Kiely <https://github.com/timjk>
 //                 Liam Ross <https://github.com/liamross>
@@ -12,18 +12,27 @@ declare namespace Polyglot {
         [interpolationKey: string]: any;
     }
 
+    interface InterpolationTokenOptions {
+        prefix?: string;
+        suffix?: string;
+    }
+
     interface PolyglotOptions {
         phrases?: any;
         locale?: string;
         allowMissing?: boolean;
         onMissingKey?: (key: string, options?: Polyglot.InterpolationOptions, locale?: string) => string;
+        warn?: (message: string) => void;
+        interpolation?: InterpolationTokenOptions;
     }
+
+    function transformPhrase(phrase: string, options?: number | Polyglot.InterpolationOptions, locale?: string): string;
 }
 
 declare class Polyglot {
     constructor(options?: Polyglot.PolyglotOptions);
 
-    extend(phrases: any): void;
+    extend(phrases: any, prefix?: string): void;
 
     t(phrase: string, options?: number | Polyglot.InterpolationOptions): string;
 
@@ -34,6 +43,8 @@ declare class Polyglot {
     locale(locale?: string): string;
 
     has(phrase: string): boolean;
+
+    unset(phrases: any, prefix?: string): void;
 }
 
 export = Polyglot;

--- a/types/node-polyglot/node-polyglot-tests.ts
+++ b/types/node-polyglot/node-polyglot-tests.ts
@@ -21,6 +21,17 @@ function instantiatePolyglot(): void {
 			return 'ouups!';
 		}
 	});
+    var warnPolyglot = new Polyglot({
+        warn: (message: string): void => {
+            return;
+        }
+    });
+    var interpolationPrefixPolyglot = new Polyglot({
+        interpolation: {prefix: "$["}
+    });
+    var interpolationSuffixPolyglot = new Polyglot(
+        {interpolation: {suffix: "]"}
+    });
 }
 
 function translate(): void {
@@ -36,6 +47,10 @@ function translate(): void {
 		},
 		"num_cars": "%{smart_count} car |||| %{smart_count} cars"
 	});
+    polyglot.extend({
+        "hello": "Hello",
+        "hello_name": "Hola, %{name}."
+    }, "nested");
 
 	polyglot.t("hello");
 	polyglot.t("hello_name");
@@ -47,7 +62,7 @@ function translate(): void {
 		_: "I like to write in %{language}.",
 		language: "Javascript"
 	});
-  
+
 	polyglot.has("hello");
 	polyglot.has("world");
 
@@ -60,11 +75,28 @@ function translate(): void {
 		}
 	});
 
+    polyglot.unset("hello");
+    polyglot.unset({
+        "hello_name": "Hola, %{name}."
+    });
+    polyglot.unset("hello", "nested");
+    polyglot.unset({
+        "hello_name": "Hola, %{name}."
+    }, "nested");
+
 	polyglot.clear();
 
 	if (polyglot.locale("fr")) {
     };
-    
+
 	if (polyglot.locale()) {
     };
+}
+
+function transform(): void {
+    Polyglot.transformPhrase("Hello");
+    Polyglot.transformPhrase("Hola, %{name}.", {name: "Spike"});
+    Polyglot.transformPhrase("%{smart_count} car |||| %{smart_count} cars", 0);
+    Polyglot.transformPhrase("%{smart_count} car |||| %{smart_count} cars", {smart_count: 0});
+    Polyglot.transformPhrase("Bonjour", undefined, "fr");
 }

--- a/types/node-polyglot/node-polyglot-tests.ts
+++ b/types/node-polyglot/node-polyglot-tests.ts
@@ -1,102 +1,105 @@
-
-import Polyglot = require("node-polyglot");
+import Polyglot = require('node-polyglot');
 
 function instantiatePolyglot(): void {
-	var polyglot = new Polyglot();
-	var phrasedPolyglot = new Polyglot({phrases: {"hello": "Hello"}});
-	var localePolyglot = new Polyglot({locale: "fr"});
-	var allowMissingPolyglot = new Polyglot({
-		phrases: {"hello": "Hello"},
-		allowMissing: true
-	});
-	var onMissingKeySimplePolyglot = new Polyglot({
-		phrases: {"hello": "Hello"},
-		onMissingKey: (key: string): string => {
-			return 'ouups!';
-		}
-	});
-	var onMissingKeyComplexPolyglot = new Polyglot({
-		phrases: {"hello": "Hello"},
-		onMissingKey: (key: string, options: Polyglot.InterpolationOptions, locale: string): string => {
-			return 'ouups!';
-		}
-	});
+    var polyglot = new Polyglot();
+    var phrasedPolyglot = new Polyglot({ phrases: { hello: 'Hello' } });
+    var localePolyglot = new Polyglot({ locale: 'fr' });
+    var allowMissingPolyglot = new Polyglot({
+        phrases: { hello: 'Hello' },
+        allowMissing: true,
+    });
+    var onMissingKeySimplePolyglot = new Polyglot({
+        phrases: { hello: 'Hello' },
+        onMissingKey: (key: string): string => {
+            return 'ouups!';
+        },
+    });
+    var onMissingKeyComplexPolyglot = new Polyglot({
+        phrases: { hello: 'Hello' },
+        onMissingKey: (key: string, options: Polyglot.InterpolationOptions, locale: string): string => {
+            return 'ouups!';
+        },
+    });
     var warnPolyglot = new Polyglot({
         warn: (message: string): void => {
             return;
-        }
+        },
     });
     var interpolationPrefixPolyglot = new Polyglot({
-        interpolation: {prefix: "$["}
+        interpolation: { prefix: '$[' },
     });
-    var interpolationSuffixPolyglot = new Polyglot(
-        {interpolation: {suffix: "]"}
-    });
+    var interpolationSuffixPolyglot = new Polyglot({ interpolation: { suffix: ']' } });
 }
 
 function translate(): void {
-	var polyglot = new Polyglot();
+    var polyglot = new Polyglot();
 
-	polyglot.extend({
-		"hello": "Hello",
-		"hello_name": "Hola, %{name}.",
-		"nav": {
-			"sidebar": {
-				"welcome": "Welcome"
-			}
-		},
-		"num_cars": "%{smart_count} car |||| %{smart_count} cars"
-	});
     polyglot.extend({
-        "hello": "Hello",
-        "hello_name": "Hola, %{name}."
-    }, "nested");
-
-	polyglot.t("hello");
-	polyglot.t("hello_name");
-	polyglot.t("nav.sidebar.welcome");
-	polyglot.t("num_cars", {smart_count: 0});
-	polyglot.t("num_cars", 0);
-	polyglot.t("hello_name", {name: "Spike"});
-	polyglot.t("i_like_to_write_in_language", {
-		_: "I like to write in %{language}.",
-		language: "Javascript"
-	});
-
-	polyglot.has("hello");
-	polyglot.has("world");
-
-	polyglot.replace({
-		"hello": "hey",
-		"nav": {
-			"sidebar": {
-				"welcome": "Greetings"
-			}
-		}
-	});
-
-    polyglot.unset("hello");
-    polyglot.unset({
-        "hello_name": "Hola, %{name}."
+        hello: 'Hello',
+        hello_name: 'Hola, %{name}.',
+        nav: {
+            sidebar: {
+                welcome: 'Welcome',
+            },
+        },
+        num_cars: '%{smart_count} car |||| %{smart_count} cars',
     });
-    polyglot.unset("hello", "nested");
+    polyglot.extend(
+        {
+            hello: 'Hello',
+            hello_name: 'Hola, %{name}.',
+        },
+        'nested',
+    );
+
+    polyglot.t('hello');
+    polyglot.t('hello_name');
+    polyglot.t('nav.sidebar.welcome');
+    polyglot.t('num_cars', { smart_count: 0 });
+    polyglot.t('num_cars', 0);
+    polyglot.t('hello_name', { name: 'Spike' });
+    polyglot.t('i_like_to_write_in_language', {
+        _: 'I like to write in %{language}.',
+        language: 'Javascript',
+    });
+
+    polyglot.has('hello');
+    polyglot.has('world');
+
+    polyglot.replace({
+        hello: 'hey',
+        nav: {
+            sidebar: {
+                welcome: 'Greetings',
+            },
+        },
+    });
+
+    polyglot.unset('hello');
     polyglot.unset({
-        "hello_name": "Hola, %{name}."
-    }, "nested");
+        hello_name: 'Hola, %{name}.',
+    });
+    polyglot.unset('hello', 'nested');
+    polyglot.unset(
+        {
+            hello_name: 'Hola, %{name}.',
+        },
+        'nested',
+    );
 
-	polyglot.clear();
+    polyglot.clear();
 
-	if (polyglot.locale("fr")) {
-    };
+    if (polyglot.locale('fr')) {
+    }
 
-	if (polyglot.locale()) {
-    };
+    if (polyglot.locale()) {
+    }
 }
 
 function transform(): void {
-    Polyglot.transformPhrase("Hello");
-    Polyglot.transformPhrase("Hola, %{name}.", {name: "Spike"});
-    Polyglot.transformPhrase("%{smart_count} car |||| %{smart_count} cars", 0);
-    Polyglot.transformPhrase("%{smart_count} car |||| %{smart_count} cars", {smart_count: 0});
-    Polyglot.transformPhrase("Bonjour", undefined, "fr");
+    Polyglot.transformPhrase('Hello');
+    Polyglot.transformPhrase('Hola, %{name}.', { name: 'Spike' });
+    Polyglot.transformPhrase('%{smart_count} car |||| %{smart_count} cars', 0);
+    Polyglot.transformPhrase('%{smart_count} car |||| %{smart_count} cars', { smart_count: 0 });
+    Polyglot.transformPhrase('Bonjour', undefined, 'fr');
 }


### PR DESCRIPTION
# Background

Polyglot.js received a version update a year ago which allowed users to change the interpolation setting ([`v2.3.0`](https://github.com/airbnb/polyglot.js/blob/master/CHANGELOG.md#v230-july-2-2018)). Upon updating the types, I found that some other methods which have been altered, so I decided to also include them in this PR.

All terminology used in this PR follows the terminology used within the package.

**Question**:
Should I bump the version of the types to `v2.3.1` to better indicate that it is compatible with the latest release? I have never attempted such a big jump in versioning so I think it is worth asking before attempting it.

# PR Info

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `Polyglot.options.interpolation`: [here](https://github.com/airbnb/polyglot.js/blob/3ca7e08c3771e058155ff9e4c3f289988da1190a/index.js#L213) and [here](https://github.com/airbnb/polyglot.js/blob/3ca7e08c3771e058155ff9e4c3f289988da1190a/index.js#L136)
  - [`new Polyglot().extend`](https://github.com/airbnb/polyglot.js/blob/3ca7e08c3771e058155ff9e4c3f289988da1190a/index.js#L273)
  - [`new Polyglot().unset`](https://github.com/airbnb/polyglot.js/blob/3ca7e08c3771e058155ff9e4c3f289988da1190a/index.js#L295)
  - [`Polyglot.transformPhrase`](https://github.com/airbnb/polyglot.js/blob/3ca7e08c3771e058155ff9e4c3f289988da1190a/index.js#L384)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
