### PR TITLE
[Promise-ftp] Update list, listSafe return types

### DIFF
--- a/types/promise-ftp/index.d.ts
+++ b/types/promise-ftp/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for promise-ftp 1.3
 // Project: https://github.com/realtymaps/promise-ftp
 // Definitions by: coolreader18 <https://github.com/coolreader18>
+//                 Rolands Jegorovs <https://github.com/Rolandisimo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -88,8 +89,8 @@ declare class PromiseFtp {
      * @param useCompression - defaults to false.
      * @returns the contents of the specified directory
      */
-    list(path?: string, useCompression?: boolean): Promise<FtpClient.ListingElement[]>;
-    list(useCompression: boolean): Promise<FtpClient.ListingElement[]>;
+    list(path?: string, useCompression?: boolean): Promise<Array<FtpClient.ListingElement | string>>;
+    list(useCompression: boolean): Promise<Array<FtpClient.ListingElement | string>>;
 
     /**
      * Optional "standard" commands (RFC 959)
@@ -106,8 +107,8 @@ declare class PromiseFtp {
     listSafe(
         path?: string,
         useCompression?: boolean
-    ): FtpClient.ListingElement[];
-    listSafe(useCompression: boolean): Promise<FtpClient.ListingElement[]>;
+    ): Promise<Array<FtpClient.ListingElement | string>>;
+    listSafe(useCompression: boolean): Promise<Array<FtpClient.ListingElement | string>>;
 
     /**
      * Retrieve a file at path from the server.


### PR DESCRIPTION
Update return types of list, listSafe to return an array of strings.
This case is possible depending on FTP server configuration and OS. An issue regarding this was created a long time ago.

Related issues:
- https://github.com/mscdex/node-ftp/issues/188
- https://github.com/realtymaps/promise-ftp/issues/41

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/realtymaps/promise-ftp/blob/master/lib/promiseFtp.coffee#L15