### PR TITLE
Mongoose type fixes: Mongoose.prototype.STATES and Schema.post('insertMany')

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -777,6 +777,21 @@ declare module "mongoose" {
      * @param method name of the method to hook
      * @param fn callback
      */
+    post<T extends Document>(method: 'insertMany', fn: (
+      this: Model<Document>,
+      error: mongodb.MongoError, docs: T[], next: (err?: NativeError) => void
+    ) => void): this;
+
+    post<T extends Document>(method: 'insertMany', fn: (
+      this: Model<Document>,
+      docs: T[], next: (err?: NativeError) => void
+    ) => void): this;
+
+    post<T extends Document>(method: 'insertMany', fn: (
+      this: Model<Document>,
+      docs: T[], next: (err?: NativeError) => Promise<any>
+    ) => void): this;
+
     post<T extends Document>(method: string | RegExp, fn: (
       doc: T, next: (err?: NativeError) => void
     ) => void): this;

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -31,6 +31,7 @@
 //                 Simon Driscoll <https://github.com/dinodeSimon>
 //                 Anton Kenikh <https://github.com/anthony-kenikh>
 //                 Chathu Vishwajith <https://github.com/iamchathu>
+//                 Tom Yam <https://github.com/tomyam1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -97,7 +98,7 @@ declare module "mongoose" {
   export var SchemaTypes: typeof Schema.Types;
 
   /** Expose connection states for user-land */
-  export var STATES: ConnectionStates;
+  export var STATES: typeof ConnectionStates;
   /** The default connection of the mongoose module. */
   export var connection: Connection;
   /** An array containing all connections associated with this Mongoose instance. */
@@ -309,7 +310,7 @@ declare module "mongoose" {
     readyState: number;
 
     /** mapping of ready states */
-    states: ConnectionStates;
+    states: typeof ConnectionStates;
   }
 
   /**
@@ -411,7 +412,7 @@ declare module "mongoose" {
     startSession(options?: mongodb.SessionOptions, cb?: (err: any, session: mongodb.ClientSession) => void): Promise<mongodb.ClientSession>;
 
     /** Expose the possible connection states. */
-    static STATES: ConnectionStates;
+    static STATES: typeof ConnectionStates;
   }
 
   export enum ConnectionStates {

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -503,6 +503,22 @@ schema
 .post('save', function (doc: mongoose.Document) {
   doc.model;
 });
+
+schema.post('insertMany', function(docs: mongoose.Document[], next: () => void) {
+    const isDefaultType: mongoose.Model<mongoose.Document> = this;
+    next();
+});
+
+schema.post('insertMany', function(error, docs: mongoose.Document[], next) {
+    const isDefaultType: mongoose.Model<mongoose.Document> = this;
+    next();
+});
+
+schema.post('insertMany', async function(docs: mongoose.Document[]): Promise<void> {
+    const isDefaultType: mongoose.Model<mongoose.Document> = this;
+    return;
+});
+
 schema.queue('m1', [1, 2, 3]).queue('m2', [[]]);
 schema.remove('path');
 schema.remove(['path1', 'path2', 'path3']);

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -65,6 +65,9 @@ mongoose.plugin(cb, {}).connect('');
 mongoose.set('test', 'value');
 mongoose.set('debug', function(collectionName: any, methodName: any, arg1: any, arg2: any) {});
 mongoose.STATES.hasOwnProperty('');
+mongoose.STATES.disconnected === 0;
+mongoose.STATES.connected === 1;
+
 mongoose.connection.on('error', cb);
 new mongoose.mongo.MongoError('error').stack;
 mongoose.SchemaTypes.String;
@@ -146,6 +149,9 @@ conn1.collections['coll'].$format(999);
 conn1.readyState.toFixed();
 conn1.useDb('myDb').useDb('');
 mongoose.Connection.STATES.hasOwnProperty('');
+mongoose.Connection.STATES.disconnected === 0;
+mongoose.Connection.STATES.connected === 1;
+
 /* inherited properties */
 conn1.on('data', cb);
 conn1.addListener('close', cb);
@@ -2068,6 +2074,9 @@ mongoose.connection.createCollection('foo', {wtimeout: 5}, (err: Error, coll): v
 
 const db = mongoose.connection;
 const User = mongoose.model('User', new mongoose.Schema({ name: String }));
+
+db.states.disconnected === 0;
+db.states.connected === 1;
 
 let session: mongoose.ClientSession;
 mongoose.connection.createCollection('users').


### PR DESCRIPTION
This PR fixes two issues with the current typings.

## fix typing for `Mongoose.prototype.STATES` and its aliases

4ef82c9 added the `STATES` object that is shared on:

1. `Mongoose.prototype.STATES`
https://mongoosejs.com/docs/api.html#mongoose_Mongoose-STATES

2. `Connection.prototype.STATES` (undocumented)
https://github.com/Automattic/mongoose/blob/5.6.11/lib/connection.js#L1082

3. `connection.states` (undocumented)
https://github.com/Automattic/mongoose/blob/5.6.11/lib/connection.js#L58

`STATES` maps connection state names to numbers (also undocumented)
https://github.com/Automattic/mongoose/blob/5.6.11/lib/connectionstate.js#L22

(it also numbers back to strings but I don't think it's critical to support this)

Before the commit - you'd get
`TS2339: Property 'connected' does not exist on type 'ConnectionStates'` if you try to
do `connection.states.connected` (or any other state)

This commit allows it

## Add typings for Schema.post('insertMany')

insertMany is different from other middlewares

1. Since it's a "Model middleware":

"Model middleware is supported for the following model functions.
In model middleware functions, this refers to the model."

From https://mongoosejs.com/docs/middleware.html#types-of-middleware

2. It's arguments include the created documents

Undocumented but found in the specs:
https://github.com/Automattic/mongoose/blob/5.6.11/test/model.test.js#L4853

This commit add typings for the normal and error post insertMany handlers



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>