### PR TITLE
feat: add new typings for cloud-config-client

### DIFF
--- a/types/cloud-config-client/cloud-config-client-tests.ts
+++ b/types/cloud-config-client/cloud-config-client-tests.ts
@@ -1,0 +1,29 @@
+import client = require('cloud-config-client');
+
+client.load({
+    name: 'invoices'
+}).then(config => {
+    const conf = config; // $ExpectType Config
+    const value1 = config.get('this.is.a.key'); // $ExpectType any
+});
+
+// Async through IFFE
+
+(async () => {
+    const config = await client.load({name: 'invoices'}); // $ExpectType Config
+})();
+
+// With additional options
+
+client.load({
+    name: 'invoices',
+    profiles: ['profile1', 'profile2'],
+    label: 'label',
+    auth: {
+        pass: 'password',
+        user: 'admin',
+    }
+}).then(config => {
+    const conf = config; // $ExpectType Config
+    const value1 = config.get('this.is.a.key'); // $ExpectType any
+});

--- a/types/cloud-config-client/index.d.ts
+++ b/types/cloud-config-client/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for cloud-config-client 1.4
+// Project: https://github.com/victorherraiz/cloud-config-client#readme
+// Definitions by: Jeroen Claassens <https://github.com/favna>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+
+import http = require('http');
+import https = require('https');
+
+export function load(options: Options, callback?: LoadCallback): Promise<Config>;
+
+export abstract class Config {
+    constructor(data: ConfigData, context: { [key: string]: any });
+
+    properties(): { [key: string]: any };
+    raw(): { [key: string]: any };
+    get(keyParts: string): any;
+    forEach(callback: (property: string, value: string) => void, includeOverridden?: boolean): void;
+    toObject(): { [key: string]: any };
+    toString(spaces: number): string;
+}
+
+export interface ConfigFile {
+    name: string;
+    source: ConfigSource;
+}
+
+export interface ConfigSource {
+    [key: string]: any;
+}
+
+export interface ConfigData {
+    name: string;
+    profiles: string[];
+    label: string;
+    version: string;
+    propertySources: ConfigFile[];
+}
+
+export interface Auth {
+    user: string;
+    pass: string;
+}
+
+export interface Options {
+    endpoint?: string;
+    rejectUnauthorized?: boolean;
+
+    /** @deprecated use name */
+    application?: string;
+    name: string;
+    profiles?: string | string[];
+    label?: string;
+    auth?: Auth;
+    agent?: http.Agent | https.Agent;
+    context?: {
+        [key: string]: any
+    };
+}
+
+export interface LoadCallback {
+    (error: Error, config?: Config): void;
+}

--- a/types/cloud-config-client/tsconfig.json
+++ b/types/cloud-config-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cloud-config-client-tests.ts"
+    ]
+}

--- a/types/cloud-config-client/tslint.json
+++ b/types/cloud-config-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adding typings for the cloud-config-client library

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.