### PR TITLE
add authors mention helper to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,8 @@ If you know how to fix the issue, make a pull request instead.
 - [ ] I tried using the `@types/xxxx` package and had problems.
 - [ ] I tried using the latest stable version of tsc. https://www.npmjs.com/package/typescript
 - [ ] I have a question that is inappropriate for [StackOverflow](https://stackoverflow.com/).  (Please ask any appropriate questions there).
-- [ ] [Mention](https://github.com/blog/821-mention-somebody-they-re-notified) the authors (see `Definitions by:` in `index.d.ts`) so they can respond.
+- [ ] [Mention](https://github.com/blog/821-mention-somebody-they-re-notified) the authors (see `Definitions by:` in `index.d.ts`) so they can respond. 
+  <!-- You can use https://kerolloz.me/DefinitelyTypedAuthorMention/ to get all the authors mention -->
   - Authors: @....
 
 If you do not mention the authors the issue will be ignored.


### PR DESCRIPTION
add a link to a simple website that helps to mention all the authors of a package. very helpful when there are many authors. 