### PR TITLE
Updated AOS types with missing properties

### DIFF
--- a/types/aos/aos-tests.ts
+++ b/types/aos/aos-tests.ts
@@ -6,6 +6,9 @@ const options: Aos.AosOptions = {
     initClassName: "aos-init",
     animatedClassName: "aos-animate",
     useClassNames: false,
+    disableMutationObserver: false,
+    debounceDelay: 50,
+    throttleDelay: 99,
 
     offset: 120,
     delay: 0,

--- a/types/aos/index.d.ts
+++ b/types/aos/index.d.ts
@@ -83,6 +83,18 @@ declare namespace Aos {
          * If true, will add content of `data-aos` as classes on scroll
          */
         useClassNames?: boolean;
+        /**
+         * Disables automatic mutations' detections
+         */
+        disableMutationObserver?: boolean;
+        /**
+         * The delay on debounce used while resizing window
+         */
+        debounceDelay?: number;
+        /**
+         * The delay on throttle used while scrolling the page
+         */
+        throttleDelay?: number;
         // #endregion
 
         // #region Settings that can be overridden on per-element basis, by `data-aos-*` attributes

--- a/types/aos/index.d.ts
+++ b/types/aos/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for aos 3.0.0-beta.6
+// Type definitions for aos 3.0
 // Project: https://github.com/michalsnik/aos, https://michalsnik.github.io/aos
 // Definitions by: Rostislav Shermenyov <https://github.com/shermendev>, Matheus Grieger <https://github.com/matheusgrieger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/aos/index.d.ts
+++ b/types/aos/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for aos 3.0
+// Type definitions for aos 3.0.0-beta.6
 // Project: https://github.com/michalsnik/aos, https://michalsnik.github.io/aos
-// Definitions by: Rostislav Shermenyov <https://github.com/shermendev>
+// Definitions by: Rostislav Shermenyov <https://github.com/shermendev>, Matheus Grieger <https://github.com/matheusgrieger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/michalsnik/aos
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
