### PR TITLE
[prop-types] Do not consider null without undefined as optional

### DIFF
--- a/types/airbnb-prop-types/airbnb-prop-types-tests.ts
+++ b/types/airbnb-prop-types/airbnb-prop-types-tests.ts
@@ -12,9 +12,9 @@ function FuncComp() {
     return null;
 }
 
-// $ExpectType Requireable<number | null>
+// $ExpectType Requireable<number | null | undefined>
 AirbnbPropTypes.and([PropTypes.number]);
-// $ExpectType Requireable<number | null>
+// $ExpectType Requireable<number | null | undefined>
 AirbnbPropTypes.and([PropTypes.number, AirbnbPropTypes.nonNegativeInteger]);
 // $ExpectType Validator<number>
 AirbnbPropTypes.and([PropTypes.number, AirbnbPropTypes.integer()], 'foo').isRequired;
@@ -87,7 +87,7 @@ interface ForbidShape {
     baz?: boolean | null;
 }
 
-// $ExpectType ValidationMap<{ foo: string | null; bar: number; baz: boolean | null; }>
+// $ExpectType ValidationMap<{ foo: string | null | undefined; bar: number; baz: boolean | null | undefined; }>
 AirbnbPropTypes.forbidExtraProps({
     foo: PropTypes.string,
     bar: PropTypes.number.isRequired,
@@ -155,7 +155,7 @@ AirbnbPropTypes.range<5>(0, 10);
 // $ExpectType Requireable<ReactLegacyRefLike<HTMLElement>>
 AirbnbPropTypes.ref();
 
-// $ExpectType Requireable<string | null>
+// $ExpectType Requireable<string | null | undefined>
 AirbnbPropTypes.requiredBy('foo', PropTypes.string);
 // $ExpectType Validator<number>
 AirbnbPropTypes.requiredBy('bar', PropTypes.number, 42).isRequired;
@@ -177,11 +177,11 @@ interface ShapeShape {
     bar?: number | null;
 }
 
-// $ExpectType Requireable<{ foo: string | null; }>
+// $ExpectType Requireable<{ foo: string | null | undefined; }>
 AirbnbPropTypes.shape({
     foo: PropTypes.string,
 });
-// $ExpectType Requireable<{ foo: string | null; bar: number | null; }>
+// $ExpectType Requireable<{ foo: string | null | undefined; bar: number | null | undefined; }>
 AirbnbPropTypes.shape({
     foo: PropTypes.string,
     bar: PropTypes.number,
@@ -200,5 +200,5 @@ AirbnbPropTypes.uniqueArray();
 // $ExpectType Requireable<string[]>
 AirbnbPropTypes.uniqueArray<string>();
 
-// $ExpectType Requireable<{ [key: string]: number | null; }>
+// $ExpectType Requireable<{ [key: string]: number | null | undefined; }>
 AirbnbPropTypes.valuesOf(PropTypes.number);

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -30,7 +30,6 @@ export type ReactNodeLike =
     | undefined;
 
 export const nominalTypeHack: unique symbol;
-export const nominalOptionalHack: unique symbol;
 
 export type IsOptional<T> = undefined extends T ? true : false;
 
@@ -40,8 +39,9 @@ export type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]>; };
 
 export interface Validator<T> {
     (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
-    [nominalTypeHack]?: T;
-    [nominalOptionalHack]?: T extends undefined ? true : false;
+    [nominalTypeHack]?: {
+        type: T;
+    };
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -30,6 +30,7 @@ export type ReactNodeLike =
     | undefined;
 
 export const nominalTypeHack: unique symbol;
+export const nominalOptionalHack: unique symbol;
 
 export type IsOptional<T> = undefined extends T ? true : false;
 
@@ -40,6 +41,7 @@ export type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]>; };
 export interface Validator<T> {
     (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
     [nominalTypeHack]?: T;
+    [nominalOptionalHack]?: T extends undefined ? true : false;
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -31,7 +31,7 @@ export type ReactNodeLike =
 
 export const nominalTypeHack: unique symbol;
 
-export type IsOptional<T> = undefined | null extends T ? true : undefined extends T ? true : null extends T ? true : false;
+export type IsOptional<T> = undefined extends T ? true : false;
 
 export type RequiredKeys<V> = { [K in keyof V]-?: Exclude<V[K], undefined> extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -33,6 +33,8 @@ interface Props {
         baz?: any;
     };
     optionalNumber?: number | null;
+    nullableNumber: number | null,
+    undefinableNumber?: number;
     customProp?: typeof uniqueType;
     component: PropTypes.ReactComponentLike;
 }
@@ -75,6 +77,8 @@ const propTypes: PropTypesMap = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
+    nullableNumber: (() => null) as PropTypes.Validator<number | null>,
+    undefinableNumber: (() => null) as PropTypes.Validator<number | undefined>,
     customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>,
     component: PropTypes.elementType.isRequired
 };
@@ -102,6 +106,8 @@ const propTypesWithoutAnnotation = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
+    nullableNumber: (() => null) as PropTypes.Validator<number | null>,
+    undefinableNumber: (() => null) as PropTypes.Validator<number | undefined>,
     customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>,
     component: PropTypes.elementType.isRequired
 };

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -33,7 +33,7 @@ interface Props {
         baz?: any;
     };
     optionalNumber?: number | null;
-    nullableNumber: number | null,
+    nullableNumber: number | null;
     undefinableNumber?: number;
     customProp?: typeof uniqueType;
     component: PropTypes.ReactComponentLike;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -20,7 +20,7 @@ interface Props {
     instanceOf: TestClass;
     oneOf: 'a' | 'b' | 'c';
     oneOfType: string | boolean | {
-        foo?: string;
+        foo?: string | null;
         bar: number;
     };
     numberOrFalse: false | number;
@@ -29,8 +29,8 @@ interface Props {
     objectOf: { [K: string]: number };
     shape: {
         foo: string;
-        bar?: boolean;
-        baz?: any
+        bar?: boolean | null;
+        baz?: any;
     };
     optionalNumber?: number | null;
     customProp?: typeof uniqueType;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  - some failing tests remain in `airbnb-prop-types`; should I fix those in the same PR?
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37999
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Authors: @DovydasNavickas @ferdaber @eps1lon

---

<s>This change works fine with my own code, though due to a bug (?) in the react types I haven't been able to run the formal test suite on my machine. "Error: Errors in typescript@next for external dependencies: ../react/index.d.ts(28,22): error TS2307: Cannot find module 'csstype'.". Hopefully the PR process will run tests on a CI machine without this issue.</s>

This both simplifies the `IsOptional` check and makes it behave better. Since the `Validator` type already includes `null | undefined` anyway, this won't make any difference to the built-in validators (they will still be considered optional unless marked as `isRequired`), but custom validators which consider `null` and `undefined` separately are now inferred correctly by `shape`.

<s>I would like to add a test for this use-case as well, but since I can't run the tests myself and I'm not familiar with this testing framework, I want the first commit to just ensure the existing tests do not break.</s>