### PR TITLE
Added missing insert overload for nedb

### DIFF
--- a/types/nedb/index.d.ts
+++ b/types/nedb/index.d.ts
@@ -77,10 +77,11 @@ declare class Nedb<G = any> extends EventEmitter {
     getCandidates(query: any): void;
 
     /**
-     * Insert a new document
+     * Insert one or more new documents
      * @param cb Optional callback, signature: err, insertedDoc
      */
     insert<T extends G>(newDoc: T, cb?: (err: Error, document: T) => void): void;
+    insert<T extends G>(newDocs: T[], cb?: (err: Error, documents: T[]) => void): void;
 
     /**
      * Count all documents matching the query


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/louischatriot/nedb#inserting-documents
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
