### PR TITLE
Add types for electron-prompt

### DIFF
--- a/types/electron-prompt/electron-prompt-tests.ts
+++ b/types/electron-prompt/electron-prompt-tests.ts
@@ -1,0 +1,15 @@
+import prompt = require('electron-prompt');
+import { BrowserWindow } from 'electron';
+
+prompt({
+    inputAttrs: {
+        type: 'url',
+    },
+    label: 'URL:',
+    title: 'Prompt example',
+    value: 'http://example.org',
+}).then(r => {
+    r; // $ExpectType string | null
+});
+
+prompt({}, new BrowserWindow());

--- a/types/electron-prompt/index.d.ts
+++ b/types/electron-prompt/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for electron-prompt 1.3
+// Project: https://github.com/p-sam/electron-prompt#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+import { BrowserWindow } from 'electron';
+
+declare namespace prompt {
+    interface Options {
+        /**
+         * The local path of a CSS file to stylize the prompt window.
+         * Defaults to `null`.
+         */
+        customStylesheet?: string | null;
+        /** The height of the prompt window. Defaults to `130`. */
+        height?: number;
+        /**
+         * The path to an icon image to use in the title bar. Defaults to `null`
+         * and uses electron's icon.
+         */
+        icon?: string | null;
+        /**
+         * The attributes of the input field, analagous to the HTML attributes:
+         * `{type: 'text', required: true}` -> `<input type="text" required>`.
+         * Used if the type is `'input'`.
+         */
+        inputAttrs?: Record<string, any>;
+        /**
+         * The label which appears on the prompt for the input field. Defaults
+         * to `'Please input a value:'`.
+         */
+        label?: string;
+        /**
+         * Whether the prompt window can be resized or not. Defaults to
+         * `false`.
+         */
+        resizable?: boolean;
+        /**
+         * The items for the select dropdown if using the `'select'` type in the
+         * format `'value'`: `'display text'`, where the value is what will be
+         * given to the then block and the display text is what the user will
+         * see.
+         */
+        selectOptions?: object;
+        /** The title of the prompt window. Defaults to `'Prompt'`. */
+        title?: string;
+        /**
+         * The type of input field, either `'input'` for a standard text input
+         * field or 'select' for a dropdown type input. Defaults to `'input'`.
+         */
+        type?: `'input'` | 'select';
+        /**
+         * Whether the label should be interpreted as HTML or not. Defaults to
+         * `false`.
+         */
+        useHtmlLabel?: boolean;
+        /** The default value for the input field. Defaults to `null`. */
+        value?: string | null;
+        /** The width of the prompt window. Defaults to `370`. */
+        width?: number;
+    }
+}
+
+declare function prompt(options?: prompt.Options, parentBrowserWindow?: BrowserWindow): Promise<string | null>;
+
+export = prompt;

--- a/types/electron-prompt/package.json
+++ b/types/electron-prompt/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+      "electron": "latest"
+  }
+}

--- a/types/electron-prompt/tsconfig.json
+++ b/types/electron-prompt/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "electron-prompt-tests.ts"
+    ]
+}

--- a/types/electron-prompt/tslint.json
+++ b/types/electron-prompt/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
