### PR TITLE
Reference the toplevel index.d.ts from the extensions.

### DIFF
--- a/types/cometd/AckExtension/index.d.ts
+++ b/types/cometd/AckExtension/index.d.ts
@@ -1,4 +1,4 @@
-import * as m from '..';
+import * as m from '../index';
 
 declare class AckExtension implements m.Extension {
     constructor();

--- a/types/cometd/BinaryExtension/index.d.ts
+++ b/types/cometd/BinaryExtension/index.d.ts
@@ -1,4 +1,4 @@
-import * as m from '..';
+import * as m from '../index';
 
 declare class BinaryExtension implements m.Extension {
     constructor();

--- a/types/cometd/TimeSyncExtension/index.d.ts
+++ b/types/cometd/TimeSyncExtension/index.d.ts
@@ -1,4 +1,4 @@
-import * as m from '..';
+import * as m from '../index';
 
 declare class TimeSyncExtension implements m.Extension {
     constructor();


### PR DESCRIPTION
cometd: fix imports of the extensions 

When using an extension in code the old 'import ..' does not work. Other modules explicitly import ../index which is what should be used here, too.