### PR TITLE
[@types/tabulator-tables] copyToClipboard should accept 'selected' in…

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1604,7 +1604,7 @@ declare class Tabulator {
     The first argument is the copy selector, you can choose from any of the built in options or pass a function in to the argument, that must return the selected row components.
 
     If you leave this argument undefined, Tabulator will use the value of the clipboardCopySelector property, which has a default value of table */
-    copyToClipboard: (type: 'selection' | 'table') => void;
+    copyToClipboard: (type?: 'selected' | 'table' | 'active') => void;
 
     /** With history enabled you can use the undo function to automatically undo a user action, the more times you call the function, the further up the history log you go. */
     undo: () => boolean;

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -3,7 +3,7 @@
 
 // constructor
 let table = new Tabulator('#test');
-table.copyToClipboard('selection');
+table.copyToClipboard('selected');
 table.searchRows('name', '<', 3);
 table.setFilter('name', '<=', 3);
 table.setFilter([


### PR DESCRIPTION
…stead of 'selection', as well as undefined

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* 'selected' selector: https://github.com/olifolkerd/tabulator/blob/cb39652ac7fcc0063eb23cecfe303a439f8ca4e4/dist/js/modules/clipboard.js#L863
* 'undefined' parameter for copyToClipboard: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/13ad568eaaa359a9f4586b695229a1738ed8a189/types/tabulator-tables/index.d.ts#L1606
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
