### PR TITLE
Add types for karma-coverage-istanbul-reporter

### DIFF
--- a/types/karma-coverage-istanbul-reporter/index.d.ts
+++ b/types/karma-coverage-istanbul-reporter/index.d.ts
@@ -1,0 +1,83 @@
+// Type definitions for karma-coverage-istanbul-reporter 2.1
+// Project: https://github.com/mattlewis92/karma-coverage-istanbul-reporter#readme
+// Definitions by: Dmitry Demensky <https://github.com/demensky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+export interface Threshold {
+    /** @default 0 */
+    readonly statements?: number;
+
+    /** @default 0 */
+    readonly lines?: number;
+
+    /** @default 0 */
+    readonly branches?: number;
+
+    /** @default 0 */
+    readonly functions?: number;
+}
+
+export interface ThresholdsEach extends Threshold {
+    /** @default {} */
+    readonly overrides?: { [key: string]: Threshold };
+}
+
+export interface ThresholdConfig {
+    /**
+     * Set to `true` to not fail the test command when thresholds are not met.
+     * @default false
+     */
+    readonly emitWarning?: boolean;
+
+    /** Thresholds for all files. */
+    readonly global?: Threshold;
+
+    /** Thresholds per file. */
+    readonly each?: ThresholdsEach;
+}
+
+/** @see {@link https://github.com/mattlewis92/karma-coverage-istanbul-reporter#configuration} */
+export interface CoverageIstanbulReporter {
+    /** Reports can be any that are listed {@link https://github.com/istanbuljs/istanbuljs/tree/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib here}. */
+    readonly reports?: string[];
+
+    /**
+     * Base output directory.
+     * If you include `%browser%` in the path it will be replaced with the karma browser name.
+     */
+    readonly dir?: string;
+
+    /** Combines coverage information from multiple browsers into one report rather than outputting a report for each browser */
+    readonly combineBrowserReports?: boolean;
+
+    /** if using webpack and pre-loaders, work around webpack breaking the source path. */
+    readonly fixWebpackSourcePaths?: boolean;
+
+    /** Omit files with no statements, no functions and no branches from the report. */
+    readonly skipFilesWithNoCoverage?: boolean;
+
+    // TODO: Add istanbul-api
+    /** Most reporters accept additional config options. You can pass these through the `report-config` option. */
+    readonly 'report-config'?: any;
+
+    /**
+     * Enforce percentage thresholds.
+     * Anything under these percentages will cause karma to fail with an exit code of 1 if not running in watch mode.
+     */
+    readonly thresholds?: ThresholdConfig;
+
+    /** Output config used by istanbul for debugging. */
+    readonly verbose?: boolean;
+
+    // TODO: Add istanbul-api
+    /** `instrumentation` is used to configure Istanbul API package. */
+    readonly instrumentation?: any;
+}
+
+declare module 'karma' {
+    interface ConfigOptions {
+        /** {@link https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-api/lib/config.js#L33-L39 Any of these options are valid}. */
+        readonly coverageIstanbulReporter?: CoverageIstanbulReporter;
+    }
+}

--- a/types/karma-coverage-istanbul-reporter/karma-coverage-istanbul-reporter-tests.ts
+++ b/types/karma-coverage-istanbul-reporter/karma-coverage-istanbul-reporter-tests.ts
@@ -1,0 +1,35 @@
+import { Config } from 'karma';
+import { join } from 'path';
+
+declare const config: Config;
+
+config.set({ coverageIstanbulReporter: {} });
+
+config.set({
+    coverageIstanbulReporter: {
+        reports: ['html', 'lcovonly', 'text-summary'],
+        dir: join(__dirname, 'coverage'),
+        combineBrowserReports: true,
+        fixWebpackSourcePaths: true,
+        skipFilesWithNoCoverage: true,
+        'report-config': { html: { subdir: 'html' } },
+        thresholds: {
+            emitWarning: false,
+            global: {
+                statements: 100,
+                lines: 100,
+                branches: 100,
+                functions: 100,
+            },
+            each: {
+                statements: 100,
+                lines: 100,
+                branches: 100,
+                functions: 100,
+                overrides: { 'baz/component/**/*.js': { statements: 98 } },
+            },
+        },
+        verbose: true,
+        instrumentation: { 'default-excludes': false },
+    },
+});

--- a/types/karma-coverage-istanbul-reporter/tsconfig.json
+++ b/types/karma-coverage-istanbul-reporter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "karma-coverage-istanbul-reporter-tests.ts"
+    ]
+}

--- a/types/karma-coverage-istanbul-reporter/tslint.json
+++ b/types/karma-coverage-istanbul-reporter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
