### PR TITLE
[@types/hapi__joi] Add number type to ValidationErrorItem path property

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -186,11 +186,11 @@ validErrItem = {
 };
 
 validErrItem = {
-    message: str,
-    type: str,
-    path: [str, num, str],
-    options: validOpts,
-    context: obj
+  message: str,
+  type: str,
+  path: [str, num, str],
+  options: validOpts,
+  context: obj,
 };
 
 validErrFunc = errs => errs;

--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -6,6 +6,7 @@ let x: any = null;
 declare const value: any;
 let num = 0;
 let str = '';
+let strOrNum: string | number;
 declare const bool: boolean;
 declare const exp: RegExp;
 declare const obj: object;
@@ -180,6 +181,14 @@ validErrItem = {
     message: str,
     type: str,
     path: [str],
+    options: validOpts,
+    context: obj
+};
+
+validErrItem = {
+    message: str,
+    type: str,
+    path: [str, num, str],
     options: validOpts,
     context: obj
 };
@@ -940,7 +949,7 @@ schema = Joi.lazy(() => schema, { once: true });
         Joi.validate(value, schema, validOpts, (err, value) => {
             x = value;
             str = err.message;
-            str = err.details[0].path[0];
+            strOrNum = err.details[0].path[0];
             str = err.details[0].message;
             str = err.details[0].type;
         });

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -18,6 +18,7 @@
 //                 Alejandro Fernandez Haro <https://github.com/afharo>
 //                 Silas Rech <https://github.com/lenovouser>
 //                 Anand Chowdhary <https://github.com/AnandChowdhary>
+//                 Miro Yovchev <https://github.com/myovchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -283,7 +284,7 @@ export interface ValidationError extends Error, JoiObject {
 export interface ValidationErrorItem {
     message: string;
     type: string;
-    path: string[];
+    path: Array<string | number>;
     options?: ValidationOptions;
     context?: Context;
 }

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -282,11 +282,11 @@ export interface ValidationError extends Error, JoiObject {
 }
 
 export interface ValidationErrorItem {
-    message: string;
-    type: string;
-    path: Array<string | number>;
-    options?: ValidationOptions;
-    context?: Context;
+  message: string;
+  type: string;
+  path: Array<string | number>;
+  options?: ValidationOptions;
+  context?: Context;
 }
 
 export type ValidationErrorFunction = (errors: ValidationErrorItem[]) => string | ValidationErrorItem | ValidationErrorItem[] | Error;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://runkit.com/myovchev/hapi-joi-path-having-array-string-number-signature
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


`hapi` adds indexes to path when validating arrays: `[a, 0, b]` (showcased in the link above). The lack of number signature of paths would result in ts errors when one e.g. tries to build `lodash` compatible path from  `ValidationErrorItem` - `a[0].b`.
