### PR TITLE
pdfkit - Add oblique attribute to TextOptions interface

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 //                 Erik Berreßem <https://github.com/she11sh0cked>
 //                 Jeroen Vervaeke <https://github.com/jeroenvervaeke/>
+//                 Thales Agapito <https://github.com/thalesagapito/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -141,14 +142,15 @@ declare namespace PDFKit.Mixins {
         underline?: boolean;
         /** whether to strike out the text */
         strike?: boolean;
-        /**whether the text segment will be followed immediately by another segment. Useful for changing styling in the middle of a paragraph. */
+        /** whether the text segment will be followed immediately by another segment. Useful for changing styling in the middle of a paragraph. */
         continued?: boolean;
-
+        /** whether to slant the text (angle in degrees or true) */
+        oblique?: boolean | number;
         /** the alignment of the text (center, justify, left, right) */
         //TODO check this
         align?: 'center' | 'justify' | 'left' | 'right' | string;
         /** the vertical alignment of the text with respect to its insertion point */
-        baseline?: number | "svg-middle" | "middle" | "svg-central" | "bottom" | "ideographic" | "alphabetic" | "mathematical" | "hanging" | "top"
+        baseline?: number | 'svg-middle' | 'middle' | 'svg-central' | 'bottom' | 'ideographic' | 'alphabetic' | 'mathematical' | 'hanging' | 'top';
     }
 
     interface PDFText<TDocument> {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](http://pdfkit.org/docs/text.html#text_styling)