### PR TITLE
Add type declarations for [bristol] logger

### DIFF
--- a/types/bristol/bristol-tests.ts
+++ b/types/bristol/bristol-tests.ts
@@ -1,0 +1,19 @@
+import * as bristol from 'bristol';
+
+const log = new bristol.Bristol();
+
+log.addTarget('console');
+log.info('Things be working.', {});
+
+log.addTarget('console').withFormatter('human');
+log.debug('Hello, world', { code: 404 });
+
+const uhoh: bristol.LogData = {
+  code: 500,
+  error: {
+    message: 'Something broke',
+    reason: 'idk why though',
+  },
+};
+
+log.error('Something went wrong', uhoh);

--- a/types/bristol/bristol-tests.ts
+++ b/types/bristol/bristol-tests.ts
@@ -1,14 +1,12 @@
-import * as bristol from 'bristol';
+import bristol = require('bristol');
 
-const log = new bristol.Bristol();
+bristol.addTarget('console');
+bristol.info('Things be working.', {});
 
-log.addTarget('console');
-log.info('Things be working.', {});
+bristol.addTarget('console').withFormatter('human');
+bristol.debug('Hello, world', { code: 404 });
 
-log.addTarget('console').withFormatter('human');
-log.debug('Hello, world', { code: 404 });
-
-const uhoh: bristol.LogData = {
+const uhoh = {
   code: 500,
   error: {
     message: 'Something broke',
@@ -16,4 +14,4 @@ const uhoh: bristol.LogData = {
   },
 };
 
-log.error('Something went wrong', uhoh);
+bristol.error('Something went wrong', uhoh);

--- a/types/bristol/index.d.ts
+++ b/types/bristol/index.d.ts
@@ -4,13 +4,16 @@
 //                 Elliott Campbell <https://github.com/ElliottCampbellJHA>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface LogError {
+// Caveat: Currently, .d.ts files are unable to handle this package fully
+//         as it requires both class and namespace be exported.
+
+interface LogError {
     message?: string;
     reason?: any;
     stack?: any;
 }
 
-export interface LogData {
+interface LogData {
     code?: number;
     id?: string;
     path?: string;
@@ -18,12 +21,16 @@ export interface LogData {
     data?: any;
 }
 
-export class Bristol {
-    addTarget(target: any, opts?: any): any;
-    withFormatter(formatter: string): any;
-    withLowestSeverity(severity: string): any;
-    info(message: string, data: LogData): any;
-    warn(message: string, data: LogData): any;
-    error(message: string, data: LogData): any;
-    debug(message: string, data: LogData): any;
+declare class Bristol {
+  addTarget(target: any, opts?: any): any;
+  withFormatter(formatter: string): any;
+  withLowestSeverity(severity: string): any;
+  info(message: string, data: LogData): any;
+  warn(message: string, data: LogData): any;
+  error(message: string, data: LogData): any;
+  debug(message: string, data: LogData): any;
 }
+
+declare const bristol: Bristol;
+
+export = bristol;

--- a/types/bristol/index.d.ts
+++ b/types/bristol/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for bristol 0.4
+// Project: https://github.com/TomFrost/Bristol
+// Definitions by: Eric Heikes <https://github.com/eheikes>
+//                 Elliott Campbell <https://github.com/ElliottCampbellJHA>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface LogError {
+    message?: string;
+    reason?: any;
+    stack?: any;
+}
+
+export interface LogData {
+    code?: number;
+    id?: string;
+    path?: string;
+    error?: LogError;
+    data?: any;
+}
+
+export class Bristol {
+    addTarget(target: any, opts?: any): any;
+    withFormatter(formatter: string): any;
+    withLowestSeverity(severity: string): any;
+    info(message: string, data: LogData): any;
+    warn(message: string, data: LogData): any;
+    error(message: string, data: LogData): any;
+    debug(message: string, data: LogData): any;
+}

--- a/types/bristol/tsconfig.json
+++ b/types/bristol/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bristol-tests.ts"
+    ]
+}

--- a/types/bristol/tslint.json
+++ b/types/bristol/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
