### PR TITLE
Add [bristol-sentry] type declarations

### DIFF
--- a/types/bristol-sentry/bristol-sentry-tests.ts
+++ b/types/bristol-sentry/bristol-sentry-tests.ts
@@ -1,0 +1,20 @@
+import bristolSentry = require('bristol-sentry');
+import * as raven from 'raven';
+
+let target = bristolSentry({
+    client: {
+        dsn: "wow.this.works"
+    }
+});
+
+const log = bristolSentry.formatter({}, 'error', new Date(), [
+    "hey",
+    "whaddup",
+    new Error("AHAHAHA"),
+    "cool.",
+    {message: "I'm a banana!"}]
+);
+
+target = bristolSentry({
+    client: new raven.Client("cool dsn")
+});

--- a/types/bristol-sentry/index.d.ts
+++ b/types/bristol-sentry/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for bristol-sentry 0.0
+// Project: https://github.com/jeffijoe/bristol-sentry#readme
+// Definitions by: Elliott Campbell <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as raven from 'raven';
+
+interface FormattedLog {
+    message: string;
+    extra: ReadonlyArray<object>;
+    error?: Error;
+}
+
+interface SentryConfig {
+    client?: {} | raven.Client;
+}
+
+export = makeSentryTarget;
+
+declare function makeSentryTarget(config: SentryConfig): () => void;
+
+declare namespace makeSentryTarget {
+    function formatter(opts: any, severity: string, date: Date, elems: ReadonlyArray<any>): FormattedLog;
+}

--- a/types/bristol-sentry/index.d.ts
+++ b/types/bristol-sentry/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for bristol-sentry 0.0
 // Project: https://github.com/jeffijoe/bristol-sentry#readme
-// Definitions by: Elliott Campbell <https://github.com/me>
+// Definitions by: Elliott Campbell <https://github.com/ElliottCampbellJHA>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/bristol-sentry/index.d.ts
+++ b/types/bristol-sentry/index.d.ts
@@ -21,5 +21,5 @@ export = makeSentryTarget;
 declare function makeSentryTarget(config: SentryConfig): () => void;
 
 declare namespace makeSentryTarget {
-    function formatter(opts: any, severity: string, date: Date, elems: ReadonlyArray<any>): FormattedLog;
+    function formatter(opts: object, severity: string, date: Date, elems: ReadonlyArray<any>): FormattedLog;
 }

--- a/types/bristol-sentry/tsconfig.json
+++ b/types/bristol-sentry/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bristol-sentry-tests.ts"
+    ]
+}

--- a/types/bristol-sentry/tslint.json
+++ b/types/bristol-sentry/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
