### PR TITLE
[@types/node-vagrant] Update typings for node-vagrant 1.4 and add missing function typing

### DIFF
--- a/types/node-vagrant/index.d.ts
+++ b/types/node-vagrant/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-vagrnat.js 1.3
+// Type definitions for node-vagrnat.js 1.4
 // Project: https://github.com/edin-m/node-vagrant
 // Definitions by: Matthew Peveler <https://github.com/MasterOdin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,7 @@ export type Callback = (err: ErrorArg, out?: string) => void;
 
 export interface Snapshots {
     push(cb?: Callback): void;
-    pop(args?: any, cb?: Callback): void;
+    pop(cb?: Callback): void;
     save(args?: string | string[], cb?: Callback): void;
     restore(args?: string | string[], cb?: Callback): void;
     list(cb?: Callback): void;
@@ -40,9 +40,10 @@ export interface Machine extends MachineEmitter {
     batch: Array<{command: string, cb: (err: ErrorArg, out?: any) => void}>;
     opts: {cwd: string, pwd: NodeJS.ProcessEnv};
 
-    init(image: string | string[], cb: Callback): void;
-    init(image: string | string[], config: any, cb: Callback): void;
+    init(args: string | string[], cb: Callback): void;
+    init(args: string | string[], config: any, cb: Callback): void;
     up(cb?: Callback): void;
+    up(args?: string | string[], cb?: Callback): void;
     status(cb: (err: ErrorArg, out?: Array<{status: string, provider: string}>) => void): void;
     sshConfig(cb: (err: ErrorArg, out?: {host: string | null, port: string | null, hostname: string | null, user: string | null, private_key: string | null}) => void): void;
     provision(cb?: Callback): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - Removing `args` from pop(): https://github.com/edin-m/node-vagrant/commit/af197b760892f5ea8af7b6599bf7953c59f0ade3
 - Function header for Machine.init: https://github.com/edin-m/node-vagrant/blob/master/src/machine.js#L163-L169
 - Function header for Machine.up: https://github.com/edin-m/node-vagrant/blob/master/src/machine.js#L93-L94
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.