### PR TITLE
[parse] Avoid errors for generic use of Parse.Object.fromJSON()

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -301,7 +301,7 @@ declare namespace Parse {
         static fetchAll<T extends Object>(list: T[], options: Object.FetchAllOptions): Promise<T[]>;
         static fetchAllIfNeeded<T extends Object>(list: T[], options: Object.FetchAllOptions): Promise<T[]>;
         static fetchAllWithInclude<T extends Object>(list: T[], keys: string | Array<string | Array<string>>, options: RequestOptions): Promise<T[]>;
-        static fromJSON(json: any, override?: boolean): Object;
+        static fromJSON<T extends Object>(json: any, override?: boolean): T;
         static pinAll(objects: Object[]): Promise<void>;
         static pinAllWithName(name: string, objects: Object[]): Promise<void>;
         static registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -235,6 +235,9 @@ function test_user() {
     user.set("password", "my pass");
     user.set("email", "email@example.com");
     user.signUp(null, { useMasterKey: true });
+
+    const anotherUser: Parse.User = Parse.User.fromJSON({})
+    anotherUser.set('email', "email@example.com")
 }
 
 async function test_user_currentAsync() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/parse-community/Parse-SDK-JS/blob/master/src/ParseUser.js#L35

The test case exposes the next error:
```bash
# npx tsc -p ./types/parse/tsconfig.json
types/parse/parse-tests.ts:239:11 - error TS2740: Type 'Object' is missing the following properties from type 'User': signUp, logIn, authenticated, isCurrent, and 8 more.

239     const anotherUser: Parse.User = Parse.User.fromJSON({})
```

The error is fixed by allowing to specify the shape of result for `forJSON` method.