### PR TITLE
Add types for esrever

### DIFF
--- a/types/esrever/esrever-tests.ts
+++ b/types/esrever/esrever-tests.ts
@@ -1,0 +1,4 @@
+import * as esrever from "esrever";
+
+esrever.version;  // $ExpectType string
+esrever.reverse("abc");  // $ExpectType string

--- a/types/esrever/index.d.ts
+++ b/types/esrever/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for esrever 0.2
+// Project: https://github.com/mathiasbynens/esrever
+// Definitions by: Yuichiro Tsuchiya <https://github.com/tuttieee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace esrever;
+
+/**
+ * A string representing the semantic version number.
+ */
+export const version: string;
+
+/**
+ * This function takes a string and returns the reversed version of that string,
+ * correctly accounting for Unicode combining marks and astral symbols.
+ */
+export function reverse(text: string): string;

--- a/types/esrever/tsconfig.json
+++ b/types/esrever/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "esrever-tests.ts"
+    ]
+}

--- a/types/esrever/tslint.json
+++ b/types/esrever/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
