### PR TITLE
typography: Add missing `headerLineHeight` option

### DIFF
--- a/types/typography/index.d.ts
+++ b/types/typography/index.d.ts
@@ -30,6 +30,7 @@ export interface TypographyOptions {
     scaleRatio?: number;
     googleFonts?: GoogleFont[];
     headerFontFamily?: string[];
+    headerLineHeight?: number;
     bodyFontFamily?: string[];
     headerColor?: string;
     bodyColor?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/KyleAMathews/typography.js/blob/master/packages/typography/src/index.js#L14
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
