### PR TITLE
[passport-jwt] Fix return type of jwt extractor

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -42,7 +42,7 @@ export interface VerifiedCallback {
 }
 
 export interface JwtFromRequestFunction {
-    (req: Request): string;
+    (req: Request): string | null;
 }
 
 export declare namespace ExtractJwt {

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -5,6 +5,7 @@
 //                 David Ng <https://github.com/davidNHK/>
 //                 Carlos Eduardo Scheffer <https://github.com/carlosscheffer/>
 //                 Byungjin Kim <https://github.com/jindev>
+//                 Svyatoslav Bychkov <https://github.com/stbychkov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [passport-jwt](https://github.com/mikenicholson/passport-jwt/blob/master/lib/extract_jwt.js#L18)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
