### PR TITLE
[ioredis] Added typings for publishBuffer and zaddBuffer

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -226,6 +226,8 @@ declare namespace IORedis {
 
         zadd(key: KeyType, ...args: string[]): Promise<number | string>;
 
+        zaddBuffer(key: KeyType, score1: string, member1: Buffer): Promise<string | number>;
+
         zincrby(key: KeyType, increment: number, member: string, callback: (err: Error, res: any) => void): void;
         zincrby(key: KeyType, increment: number, member: string): Promise<any>;
 

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -226,7 +226,7 @@ declare namespace IORedis {
 
         zadd(key: KeyType, ...args: string[]): Promise<number | string>;
 
-        zaddBuffer(key: KeyType, score1: string, member1: Buffer): Promise<string | number>;
+        zaddBuffer(key: KeyType, score1: number, member1: Buffer): Promise<string | number>;
 
         zincrby(key: KeyType, increment: number, member: string, callback: (err: Error, res: any) => void): void;
         zincrby(key: KeyType, increment: number, member: string): Promise<any>;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -448,6 +448,8 @@ declare namespace IORedis {
         publish(channel: string, message: string, callback: (err: Error, res: number) => void): void;
         publish(channel: string, message: string): Promise<number>;
 
+        publishBuffer(channel: string, message: Buffer): Promise<number>;
+
         watch(...keys: KeyType[]): any;
 
         unwatch(callback: (err: Error, res: string) => void): void;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -273,6 +273,6 @@ const defineCommandResult = cluster.defineCommand('defineCommand', {
 console.log(defineCommandResult);
 cluster.sendCommand();
 
-redis.zaddBuffer('foo', 'fooScore1', Buffer.from('bar')).then(() => {
+redis.zaddBuffer('foo', 1, Buffer.from('bar')).then(() => {
     // sorted set 'foo' now has score 'foo1' containing barBuffer
 });

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -85,7 +85,7 @@ redis.subscribe('news', 'music', (err: any, count: any) => {
     // `count` represents the number of channels we are currently subscribed to.
 
     pub.publish('news', 'Hello world!');
-    pub.publish('music', 'Hello again!');
+    pub.publishBuffer('music', Buffer.from('Hello again!'));
 });
 
 redis.on('message', (channel: any, message: any) => {
@@ -272,3 +272,8 @@ const defineCommandResult = cluster.defineCommand('defineCommand', {
 });
 console.log(defineCommandResult);
 cluster.sendCommand();
+
+const barBuffer = Buffer.from('bar');
+redis.zaddBuffer('foo', 'foo1', barBuffer).then(() => {
+    // sorted set 'foo' now has score 'foo1' containing barBuffer
+});

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -273,7 +273,6 @@ const defineCommandResult = cluster.defineCommand('defineCommand', {
 console.log(defineCommandResult);
 cluster.sendCommand();
 
-const barBuffer = Buffer.from('bar');
-redis.zaddBuffer('foo', 'foo1', barBuffer).then(() => {
+redis.zaddBuffer('foo', 'fooScore1', Buffer.from('bar')).then(() => {
     // sorted set 'foo' now has score 'foo1' containing barBuffer
 });

--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -221,6 +221,8 @@ declare namespace IORedis {
 
         zadd(key: string, ...args: string[]): any;
 
+        zaddBuffer(key: string, score1: string, member1: Buffer): Promise<string | number>;
+
         zincrby(key: string, increment: number, member: string, callback: (err: Error, res: any) => void): void;
         zincrby(key: string, increment: number, member: string): Promise<any>;
 

--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -221,7 +221,7 @@ declare namespace IORedis {
 
         zadd(key: string, ...args: string[]): any;
 
-        zaddBuffer(key: string, score1: string, member1: Buffer): Promise<string | number>;
+        zaddBuffer(key: string, score1: number, member1: Buffer): Promise<string | number>;
 
         zincrby(key: string, increment: number, member: string, callback: (err: Error, res: any) => void): void;
         zincrby(key: string, increment: number, member: string): Promise<any>;

--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -439,6 +439,8 @@ declare namespace IORedis {
         publish(channel: string, message: string, callback: (err: Error, res: number) => void): void;
         publish(channel: string, message: string): Promise<number>;
 
+        publishBuffer(channel: string, message: Buffer): Promise<number>;
+
         watch(...keys: string[]): any;
 
         unwatch(callback: (err: Error, res: string) => void): void;

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -74,7 +74,7 @@ redis.subscribe('news', 'music', (err: any, count: any) => {
     // `count` represents the number of channels we are currently subscribed to.
 
     pub.publish('news', 'Hello world!');
-    pub.publish('music', 'Hello again!');
+    pub.publishBuffer('music', Buffer.from('Hello again!'));
 });
 
 redis.on('message', (channel: any, message: any) => {
@@ -179,4 +179,9 @@ new Redis.Cluster([], {
 
 new Redis.Cluster([], {
     clusterRetryStrategy: (times: number) => 1
+});
+
+const barBuffer = Buffer.from('bar');
+redis.zaddBuffer('foo', 'foo1', barBuffer).then(() => {
+    // sorted set 'foo' now has score 'foo1' containing barBuffer
 });

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -181,7 +181,6 @@ new Redis.Cluster([], {
     clusterRetryStrategy: (times: number) => 1
 });
 
-const barBuffer = Buffer.from('bar');
-redis.zaddBuffer('foo', 'foo1', barBuffer).then(() => {
+redis.zaddBuffer('foo', 'fooScore1', Buffer.from('bar')).then(() => {
     // sorted set 'foo' now has score 'foo1' containing barBuffer
 });

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -181,6 +181,6 @@ new Redis.Cluster([], {
     clusterRetryStrategy: (times: number) => 1
 });
 
-redis.zaddBuffer('foo', 'fooScore1', Buffer.from('bar')).then(() => {
+redis.zaddBuffer('foo', 1, Buffer.from('bar')).then(() => {
     // sorted set 'foo' now has score 'foo1' containing barBuffer
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
	* ❗ Running `npm test` gives me an error (similar to `npm run lint ioredis`)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
	* ❗ Running `npm run lint ioredis` errors `d.ts file must have a matching npm package.`. This error was already there for me on origin.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis#handle-binary-data
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
