### PR TITLE
[Sharepoint] Methods for "disableReturnValueCache"

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -2206,7 +2206,7 @@ declare namespace SP {
         set_formDigestHandlingEnabled(value: boolean): void;
         get_applicationName(): string;
         set_applicationName(value: string): void;
-        get_disableReturnValueCache(): boolean;        
+        get_disableReturnValueCache(): boolean;
         set_disableReturnValueCache(value: boolean): boolean;
         get_clientTag(): string;
         set_clientTag(value: string): void;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -2207,7 +2207,7 @@ declare namespace SP {
         get_applicationName(): string;
         set_applicationName(value: string): void;
         get_disableReturnValueCache(): boolean;        
-        set_disableReturnValueCache(value: boolean) :boolean;
+        set_disableReturnValueCache(value: boolean): boolean;
         get_clientTag(): string;
         set_clientTag(value: string): void;
         get_webRequestExecutorFactory(): SP.IWebRequestExecutorFactory;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -19,7 +19,7 @@ declare function ExecuteOrDelayUntilScriptLoaded(func: () => void, depScriptFile
 declare function ExecuteOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
 declare var Strings: any;
 declare const enum Sods {
-    missing =  1,
+    missing = 1,
     loading = 2,
     pending = 3,
     loaded = 4,
@@ -2206,6 +2206,8 @@ declare namespace SP {
         set_formDigestHandlingEnabled(value: boolean): void;
         get_applicationName(): string;
         set_applicationName(value: string): void;
+        get_disableReturnValueCache(): boolean;        
+        set_disableReturnValueCache(value: boolean) :boolean;
         get_clientTag(): string;
         set_clientTag(value: string): void;
         get_webRequestExecutorFactory(): SP.IWebRequestExecutorFactory;


### PR DESCRIPTION
I added methods to disable Caching of the Returnvalues. It is a default functionality like 

https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-csom/mt643132(v%3Doffice.15)

(the link is the C# Version, but it still applies to the JSOM-API, only the get- and set-methods are differently named)

