### PR TITLE
[react-datepicker] Update dependency on date-fns

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 2.8
+// Type definitions for react-datepicker 2.9
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>,
 //                 Andrey Balokha <https://github.com/andrewBalekha>,

--- a/types/react-datepicker/package.json
+++ b/types/react-datepicker/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "popper.js": "^1.14.1",
-        "date-fns": "^2.0.0-beta.1"
+        "date-fns": "^2.0.1"
     }
 }


### PR DESCRIPTION
Now that `date-fns` has release version `2.0.0` and `react-datepicker`
has updated to depend on the released version, this library should
not require an older version of `date-fns` any more.
