### PR TITLE
Improve typing for the jasmine library

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -19,13 +19,10 @@
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
-type ImplementationCallback = (() => PromiseLike<any>) | (() => void) | ((done: DoneFn) => void);
-type Fn = (...args: any[]) => any;
-// Use trick with prototype to allow abstract classes.
-// More info: https://stackoverflow.com/a/38642922/2009373
-type Constructor = Function & { prototype: any };
-
-type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
+/**
+ * @deprecated Use {@link jasmine.ImplementationCallback} instead.
+ */
+type ImplementationCallback = jasmine.ImplementationCallback;
 
 /**
  * Create a group of specs (often called a suite).
@@ -55,7 +52,7 @@ declare function xdescribe(description: string, specDefinitions: () => void): vo
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function it(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function it(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A focused `it`. If suites or specs are focused, only those that are focused will be executed.
@@ -63,7 +60,7 @@ declare function it(expectation: string, assertion?: ImplementationCallback, tim
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function fit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function fit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A temporarily disabled `it`. The spec will report as pending and will not be executed.
@@ -71,7 +68,7 @@ declare function fit(expectation: string, assertion?: ImplementationCallback, ti
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function xit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function xit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Mark a spec as pending, expectation results will be ignored.
@@ -85,14 +82,14 @@ declare function pending(reason?: string): void;
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeEach.
  */
-declare function beforeEach(action: ImplementationCallback, timeout?: number): void;
+declare function beforeEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown after each of the specs in the describe in which it is called.
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterEach.
  */
-declare function afterEach(action: ImplementationCallback, timeout?: number): void;
+declare function afterEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared setup once before all of the specs in the describe are run.
@@ -100,7 +97,7 @@ declare function afterEach(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeAll.
  */
-declare function beforeAll(action: ImplementationCallback, timeout?: number): void;
+declare function beforeAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown once before all of the specs in the describe are run.
@@ -108,7 +105,7 @@ declare function beforeAll(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterAll
  */
-declare function afterAll(action: ImplementationCallback, timeout?: number): void;
+declare function afterAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Create an expectation for a spec.
@@ -188,6 +185,15 @@ declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, t
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
+    type ImplementationCallback = (() => PromiseLike<any>) | (() => void) | ((done: DoneFn) => void);
+
+    type Func = (...args: any[]) => any;
+    // Use trick with prototype to allow abstract classes.
+    // More info: https://stackoverflow.com/a/38642922/2009373
+    type Constructor = Function & { prototype: any };
+
+    type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
+
     type DeepMatch<T> =
         T
         | AsymmetricMatcher<T>
@@ -210,7 +216,7 @@ declare namespace jasmine {
     type SpyObjMethodNames<T = undefined> =
         T extends undefined ?
             (ReadonlyArray<string> | { [methodName: string]: any }) :
-            (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Fn ? ReturnType<T[P]> : any });
+            (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
 
     function clock(): Clock;
 
@@ -288,8 +294,7 @@ declare namespace jasmine {
     interface ArrayContaining<T> extends AsymmetricMatcher<ArrayLike<T>> { }
 
     /**
-     * @deprecated Use AsymmetricMatcher<any> instead.
-     * @see {AsymmetricMatcher<any>}
+     * @deprecated Use {@link AsymmetricMatcher<any>} instead.
      */
     type Any = AsymmetricMatcher<any>;
 
@@ -302,8 +307,7 @@ declare namespace jasmine {
         : never;
 
     /**
-     * @deprecated Use PartialObjectMatcher<T> instead.
-     * @see {PartialObjectMatcher<T>}
+     * @deprecated Use {@link PartialObjectMatcher<T>} instead.
      */
     interface ObjectContaining<T> extends AsymmetricMatcher<Partial<T>> { }
 

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -25,6 +25,8 @@ type Fn = (...args: any[]) => any;
 // More info: https://stackoverflow.com/a/38642922/2009373
 type Constructor = Function & { prototype: any };
 
+type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
+
 /**
  * Create a group of specs (often called a suite).
  * @param description Textual description of the group
@@ -188,11 +190,15 @@ declare function waits(timeout?: number): void;
 declare namespace jasmine {
     type DeepMatch<T> =
         T
-        | ObjectContaining<T>
-        | (T extends Array<infer TElement> ? ArrayContaining<TElement> : never)
         | AsymmetricMatcher<T>
+        | PartialObjectMatcher<DeepPartial<T>>
+        | (T extends ArrayLike<infer TElement> ? ArrayContainingDeepMatch<TElement> : never)
         | Spy
         | { [K in keyof T]: DeepMatch<T[K]>; };
+
+    // A trick to recursively use `DeepMatch<T>`.
+    // See detailed explanation here: https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540.
+    interface ArrayContainingDeepMatch<T> extends ArrayContaining<DeepMatch<T>> { }
 
     // Keep for backward compatibility - if somebody already uses this type, they will not be broken.
     // Should use DeepMatch instead as it better describes the purpose.
@@ -246,7 +252,7 @@ declare namespace jasmine {
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
-    function objectContaining<T>(sample: T): ObjectContaining<T>;
+    function objectContaining<T>(sample: T): PartialObjectMatcher<UnwrapAsymmetricMatchers<T>>;
     function createSpy(name?: string, originalFn?: Function): Spy;
 
     function createSpyObj(baseName: string, methodNames: SpyObjMethodNames): any;
@@ -268,7 +274,7 @@ declare namespace jasmine {
     function formatErrorMsg(domain: string, usage: string): (msg: string) => string;
 
     interface AsymmetricMatcher<TValue> {
-        asymmetricMatch(other: TValue): boolean;
+        asymmetricMatch(other: TValue, customTesters: CustomEqualityTester[]): boolean;
         // Mark it optional to support custom user matchers coming without describe function.
         jasmineToString?(): string;
     }
@@ -287,14 +293,28 @@ declare namespace jasmine {
      */
     type Any = AsymmetricMatcher<any>;
 
-    type UnwrapAsymmetricMatchers<T> = {
-        [K in keyof T]: T[K] extends AsymmetricMatcher<infer TMatching> ? TMatching : UnwrapAsymmetricMatchers<T[K]>
-    };
+    /**
+     * Util to recursively traverse the type and unwrap AsymmetricMatcher occurences with their inner type.
+     * It used to align two types and make them comparable.
+     */
+    type UnwrapAsymmetricMatchers<TUnion> = TUnion extends infer T ?
+        { [K in keyof T]: T[K] extends AsymmetricMatcher<infer TMatching> ? TMatching : UnwrapAsymmetricMatchers<T[K]> }
+        : never;
 
-    // Current matcher reports the compatible type (type it can match) via AsymmetricMatcher arg.
-    // If any our property is a matcher itself, we should unwrap it, so TS could verify
-    // whether corresponding object property can be actually matched by that matcher.
-    interface ObjectContaining<T> extends AsymmetricMatcher<UnwrapAsymmetricMatchers<T>> { }
+    /**
+     * @deprecated Use PartialObjectMatcher<T> instead.
+     * @see {PartialObjectMatcher<T>}
+     */
+    interface ObjectContaining<T> extends AsymmetricMatcher<Partial<T>> { }
+
+    // Create a separate class for this matcher to that this type has its own identity.
+    // This type doesn't perform a strong T match and let's object to match only partially.
+    // This behavior is supported by this matcher only, while other matchers require full T match.
+    class PartialObjectMatcher<T> implements AsymmetricMatcher<T> {
+        constructor(sample: T);
+        asymmetricMatch(other: T, customTesters: CustomEqualityTester[]): boolean;
+        jasmineToString(): string;
+    }
 
     interface Block {
         new (env: Env, func: SpecFunction, spec: Spec): any;

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -196,6 +196,20 @@ declare namespace jasmine {
 
     type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
 
+    /**
+     * Recursively traverses the type and normalizes some entities to later correctly compare type with matchers.
+     */
+    type NormalizedType<TUnion> = TUnion extends infer T
+        ? T extends string ? string // string is ArrayLike
+        : T extends ArrayLike<infer TElement> ? ArrayLikeNormalized<TElement>
+        : T extends object ? { [K in keyof T]: NormalizedType<T[K]> }
+        : T
+        : never;
+
+    // A trick to recursively use `DeepMatch<T>`.
+    // See detailed explanation here: https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540.
+    interface ArrayLikeNormalized<TElement> extends ArrayLike<NormalizedType<TElement>> { }
+
     type DeepMatch<T> =
         T
         | AsymmetricMatcher<T>
@@ -542,7 +556,7 @@ declare namespace jasmine {
          * @example
          * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
          */
-        toEqual(expected: DeepMatch<T>, expectationFailOutput?: any): boolean;
+        toEqual(expected: DeepMatch<NormalizedType<T>>, expectationFailOutput?: any): boolean;
 
         /**
          * Expect the actual value to match a regular expression.
@@ -596,7 +610,7 @@ declare namespace jasmine {
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {
-        toContain(expected: DeepMatch<T>, expectationFailOutput?: any): boolean;
+        toContain(expected: DeepMatch<NormalizedType<T>>, expectationFailOutput?: any): boolean;
 
         /**
          * Add some context for an expect.
@@ -610,7 +624,7 @@ declare namespace jasmine {
         not: ArrayLikeMatchers<T>;
     }
 
-    type DeepMatchArgs<Fn> = Fn extends (...args: infer P) => any ? { [K in keyof P]: DeepMatch<P[K]> } : never;
+    type DeepMatchArgs<Fn> = Fn extends (...args: infer P) => any ? { [K in keyof P]: DeepMatch<NormalizedType<P[K]>> } : never;
 
     interface FunctionMatchers<T extends Func> extends Matchers<any> {
         toHaveBeenCalled(): boolean;
@@ -651,13 +665,13 @@ declare namespace jasmine {
          * Expect a promise to be resolved to a value equal to the expected, using deep equality comparison.
          * @param expected - Value that the promise is expected to resolve to.
          */
-        toBeResolvedTo(expected: DeepMatch<T>): Promise<void>;
+        toBeResolvedTo(expected: DeepMatch<NormalizedType<T>>): Promise<void>;
 
         /**
          * Expect a promise to be rejected with a value equal to the expected, using deep equality comparison.
          * @param expected - Value that the promise is expected to be rejected with.
          */
-        toBeRejectedWith(expected: DeepMatch<U>): Promise<void>;
+        toBeRejectedWith(expected: DeepMatch<NormalizedType<U>>): Promise<void>;
 
         /**
          * Add some context for an expect.

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -15,13 +15,10 @@
 //                 Alex Povar <https://github.com/zvirja>
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
-type ImplementationCallback = (() => Promise<any>) | (() => void) | ((done: DoneFn) => void);
-type Func = (...args: any[]) => any;
-// Use trick with prototype to allow abstract classes.
-// More info: https://stackoverflow.com/a/38642922/2009373
-type Constructor = Function & { prototype: any };
-
-type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
+/**
+ * @deprecated Use {@link jasmine.ImplementationCallback} instead.
+ */
+type ImplementationCallback = jasmine.ImplementationCallback;
 
 /**
  * Create a group of specs (often called a suite).
@@ -51,7 +48,7 @@ declare function xdescribe(description: string, specDefinitions: () => void): vo
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function it(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function it(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A focused `it`. If suites or specs are focused, only those that are focused will be executed.
@@ -59,7 +56,7 @@ declare function it(expectation: string, assertion?: ImplementationCallback, tim
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function fit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function fit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A temporarily disabled `it`. The spec will report as pending and will not be executed.
@@ -67,7 +64,7 @@ declare function fit(expectation: string, assertion?: ImplementationCallback, ti
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function xit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function xit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Mark a spec as pending, expectation results will be ignored.
@@ -81,14 +78,14 @@ declare function pending(reason?: string): void;
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeEach.
  */
-declare function beforeEach(action: ImplementationCallback, timeout?: number): void;
+declare function beforeEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown after each of the specs in the describe in which it is called.
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterEach.
  */
-declare function afterEach(action: ImplementationCallback, timeout?: number): void;
+declare function afterEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared setup once before all of the specs in the describe are run.
@@ -96,7 +93,7 @@ declare function afterEach(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeAll.
  */
-declare function beforeAll(action: ImplementationCallback, timeout?: number): void;
+declare function beforeAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown once before all of the specs in the describe are run.
@@ -104,14 +101,14 @@ declare function beforeAll(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterAll
  */
-declare function afterAll(action: ImplementationCallback, timeout?: number): void;
+declare function afterAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Create an expectation for a spec.
  * @checkReturnValue see https://tsetse.info/check-return-value
  * @param spy
  */
-declare function expect<T extends Func>(spy: T | jasmine.Spy<T>): jasmine.FunctionMatchers<T>;
+declare function expect<T extends jasmine.Func>(spy: T | jasmine.Spy<T>): jasmine.FunctionMatchers<T>;
 
 /**
  * Create an expectation for a spec.
@@ -166,7 +163,7 @@ interface DoneFn extends Function {
 declare function spyOn<T, K extends keyof T = keyof T>(
     object: T, method: T[K] extends Function ? K : never,
 ): jasmine.Spy<
-    T[K] extends Func ? T[K] :
+    T[K] extends jasmine.Func ? T[K] :
     T[K] extends { new (...args: infer A): infer V } ? (...args: A) => V :
     never
 >;
@@ -190,6 +187,15 @@ declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, t
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
+    type ImplementationCallback = (() => Promise<any>) | (() => void) | ((done: DoneFn) => void);
+
+    type Func = (...args: any[]) => any;
+    // Use trick with prototype to allow abstract classes.
+    // More info: https://stackoverflow.com/a/38642922/2009373
+    type Constructor = Function & { prototype: any };
+
+    type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]>; } : T;
+
     type DeepMatch<T> =
         T
         | AsymmetricMatcher<T>
@@ -284,8 +290,7 @@ declare namespace jasmine {
     interface ArrayContaining<T> extends AsymmetricMatcher<ArrayLike<T>> { }
 
     /**
-     * @deprecated Use AsymmetricMatcher<any> instead.
-     * @see {AsymmetricMatcher<any>}
+     * @deprecated Use {@link AsymmetricMatcher<any>} instead.
      */
     type Any = AsymmetricMatcher<any>;
 
@@ -298,8 +303,7 @@ declare namespace jasmine {
         : never;
 
     /**
-     * @deprecated Use PartialObjectMatcher<T> instead.
-     * @see {PartialObjectMatcher<T>}
+     * @deprecated Use {@link PartialObjectMatcher<T>} instead.
      */
     interface ObjectContaining<T> extends AsymmetricMatcher<Partial<T>> { }
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -12,10 +12,14 @@
 //                 Moshe Kolodny <https://github.com/kolodny>
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Mochamad Arfin <https://github.com/ndunks>
+//                 Alex Povar <https://github.com/zvirja>
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
-type ImplementationCallback = (() => Promise<any>) | ((done: DoneFn) => void);
-type InferableFunction = (...args: any[]) => any;
+type ImplementationCallback = (() => Promise<any>) | (() => void) | ((done: DoneFn) => void);
+type Func = (...args: any[]) => any;
+// Use trick with prototype to allow abstract classes.
+// More info: https://stackoverflow.com/a/38642922/2009373
+type Constructor = Function & { prototype: any };
 
 /**
  * Create a group of specs (often called a suite).
@@ -105,7 +109,7 @@ declare function afterAll(action: ImplementationCallback, timeout?: number): voi
  * @checkReturnValue see https://tsetse.info/check-return-value
  * @param spy
  */
-declare function expect(spy: Function): jasmine.Matchers<any>;
+declare function expect<T extends Func>(spy: T | jasmine.Spy<T>): jasmine.FunctionMatchers<T>;
 
 /**
  * Create an expectation for a spec.
@@ -160,9 +164,9 @@ interface DoneFn extends Function {
 declare function spyOn<T, K extends keyof T = keyof T>(
     object: T, method: T[K] extends Function ? K : never,
 ): jasmine.Spy<
-    T[K] extends InferableFunction ? T[K] :
-    T[K] extends {new (...args: infer A): infer V} ? (...args: A) => V :
-    T[K] extends Function ? InferableFunction : never
+    T[K] extends Func ? T[K] :
+    T[K] extends { new (...args: infer A): infer V } ? (...args: A) => V :
+    never
 >;
 
 /**
@@ -177,72 +181,81 @@ declare function spyOnProperty<T>(object: T, property: keyof T, accessType?: 'ge
  * Installs spies on all writable and configurable properties of an object.
  * @param object The object upon which to install the `Spy`s.
  */
-declare function spyOnAllFunctions(object: object): jasmine.Spy;
+declare function spyOnAllFunctions<T>(object: T): jasmine.SpyObj<T>;
 
 declare function runs(asyncMethod: Function): void;
 declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
-    type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher | {
-        [K in keyof T]: ExpectedRecursive<T[K]> | Any;
-    };
-    type Expected<T> = T | ObjectContaining<T> | AsymmetricMatcher | Any | Spy | {
-        [K in keyof T]: ExpectedRecursive<T[K]>;
-    };
+    type DeepMatch<T> =
+        T
+        | ObjectContaining<T>
+        | (T extends Array<infer TElement> ? ArrayContaining<TElement> : never)
+        | AsymmetricMatcher<T>
+        | Spy
+        | { [K in keyof T]: DeepMatch<T[K]>; };
+
+    // Keep for backward compatibility - if somebody already uses this type, they will not be broken.
+    // Should use DeepMatch instead as it better describes the purpose.
+    /**
+     * @deprecated Use {@link DeepMatch} instead.
+     */
+    type Expected<T> = DeepMatch<T>;
+
     type SpyObjMethodNames<T = undefined> =
         T extends undefined ?
-            (ReadonlyArray<string> | {[methodName: string]: any}) :
-            (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends InferableFunction ? T[P] : any>});
-
-    type AnyMethods<T> = {
-        [K in {
-            [K in keyof T]: T[K] extends Function ? K : never
-        }[keyof T]]: InferableFunction
-    };
+            (ReadonlyArray<string> | { [methodName: string]: any }) :
+            (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
 
     function clock(): Clock;
 
     var matchersUtil: MatchersUtil;
 
-    function any(aclass: any): Any;
+    /**
+     * That will succeed if the actual value being compared is an instance of the specified class/constructor.
+     */
+    function any(aclass: Constructor | Symbol): AsymmetricMatcher<any>;
 
-    function anything(): Any;
+    /**
+     * That will succeed if the actual value being compared is not `null` and not `undefined`.
+     */
+    function anything(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is `true` or anything truthy.
      * @since 3.1.0
      */
-    function truthy(): Truthy;
+    function truthy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is  `null`, `undefined`, `0`, `false` or anything falsey.
      * @since 3.1.0
      */
-    function falsy(): Falsy;
+    function falsy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is empty.
      * @since 3.1.0
      */
-    function empty(): Empty;
+    function empty(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is not empty.
      * @since 3.1.0
      */
-    function notEmpty(): NotEmpty;
+    function notEmpty(): AsymmetricMatcher<any>;
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
-    function objectContaining<T>(sample: Partial<T>): ObjectContaining<T>;
-    function createSpy<Fun extends InferableFunction>(name?: string, originalFn?: Fun): Spy<Fun>;
+    function objectContaining<T>(sample: T): ObjectContaining<T>;
+    function createSpy<Fn extends Func>(name?: string, originalFn?: Fn): Spy<Fn>;
 
     function createSpyObj(baseName: string, methodNames: SpyObjMethodNames): any;
     function createSpyObj<T>(baseName: string, methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function createSpyObj(methodNames: SpyObjMethodNames): any;
-    function createSpyObj<T>(methodNames: SpyObjMethodNames): SpyObj<T>;
+    function createSpyObj<T>(methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function pp(value: any): string;
 
@@ -252,27 +265,15 @@ declare namespace jasmine {
 
     function addMatchers(matchers: CustomMatcherFactories): void;
 
-    function stringMatching(str: string | RegExp): Any;
+    function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
     function formatErrorMsg(domain: string, usage: string): (msg: string) => string;
 
-    interface Any {
-        (...params: any[]): any; // jasmine.Any can also be a function
-        new (expectedClass: any): any;
-
-        jasmineMatches(other: any): boolean;
-        jasmineToString(): string;
+    interface AsymmetricMatcher<TValue> {
+        asymmetricMatch(other: TValue): boolean;
+        // Mark it optional to support custom user matchers coming without describe function.
+        jasmineToString?(): string;
     }
-
-    interface AsymmetricMatcher<T extends string = string> {
-      asymmetricMatch(other: any): boolean;
-      jasmineToString?(): T;
-    }
-
-    interface Truthy extends AsymmetricMatcher<'<jasmine.truthy>'> { }
-    interface Falsy extends AsymmetricMatcher<'<jasmine.falsy>'> { }
-    interface Empty extends AsymmetricMatcher<'<jasmine.empty>'> { }
-    interface NotEmpty extends AsymmetricMatcher<'<jasmine.notEmpty>'> { }
 
     // taken from TypeScript lib.core.es6.d.ts, applicable to CustomMatchers.contains()
     interface ArrayLike<T> {
@@ -280,16 +281,22 @@ declare namespace jasmine {
         [n: number]: T;
     }
 
-    interface ArrayContaining<T> extends AsymmetricMatcher {
-        new?(sample: ArrayLike<T>): ArrayLike<T>;
-    }
+    interface ArrayContaining<T> extends AsymmetricMatcher<ArrayLike<T>> { }
 
-    interface ObjectContaining<T> {
-        new?(sample: {[K in keyof T]?: any}): {[K in keyof T]?: any};
+    /**
+     * @deprecated Use AsymmetricMatcher<any> instead.
+     * @see {AsymmetricMatcher<any>}
+     */
+    type Any = AsymmetricMatcher<any>;
 
-        jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
-        jasmineToString?(): string;
-    }
+    type UnwrapAsymmetricMatchers<T> = {
+        [K in keyof T]: T[K] extends AsymmetricMatcher<infer TMatching> ? TMatching : UnwrapAsymmetricMatchers<T[K]>
+    };
+
+    // Current matcher reports the compatible type (type it can match) via AsymmetricMatcher arg.
+    // If any our property is a matcher itself, we should unwrap it, so TS could verify
+    // whether corresponding object property can be actually matched by that matcher.
+    interface ObjectContaining<T> extends AsymmetricMatcher<UnwrapAsymmetricMatchers<T>> { }
 
     interface Block {
         new (env: Env, func: SpecFunction, spec: Spec): any;
@@ -501,29 +508,39 @@ declare namespace jasmine {
         message(): any;
 
         /**
+         * Expect the actual value to be `===` to the expected value.
          *
-         * @param expected the actual value to be === to the expected value.
+         * @param expected - The expected value to compare against.
          * @param expectationFailOutput
+         * @example
+         * expect(thing).toBe(realThing);
          */
-        toBe(expected: Expected<T>, expectationFailOutput?: any): boolean;
+        toBe(expected: T, expectationFailOutput?: any): boolean;
 
         /**
-         *
-         * @param expected the actual value to be equal to the expected, using deep equality comparison.
+         * Expect the actual value to be equal to the expected, using deep equality comparison.
+         * @param expected - Expected value.
          * @param expectationFailOutput
+         * @example
+         * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
          */
-        toEqual(expected: Expected<T>, expectationFailOutput?: any): boolean;
+        toEqual(expected: DeepMatch<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to match a regular expression.
+         * @param expected - Value to look for in the string.
+         * @example
+         * expect("my string").toMatch(/string$/);
+         * expect("other string").toMatch("her");
+         */
         toMatch(expected: string | RegExp, expectationFailOutput?: any): boolean;
+
         toBeDefined(expectationFailOutput?: any): boolean;
         toBeUndefined(expectationFailOutput?: any): boolean;
         toBeNull(expectationFailOutput?: any): boolean;
         toBeNaN(): boolean;
         toBeTruthy(expectationFailOutput?: any): boolean;
         toBeFalsy(expectationFailOutput?: any): boolean;
-        toHaveBeenCalled(): boolean;
-        toHaveBeenCalledBefore(expected: Spy): boolean;
-        toHaveBeenCalledWith(...params: any[]): boolean;
-        toHaveBeenCalledTimes(expected: number): boolean;
         toContain(expected: any, expectationFailOutput?: any): boolean;
         toBeLessThan(expected: number, expectationFailOutput?: any): boolean;
         toBeLessThanOrEqual(expected: number, expectationFailOutput?: any): boolean;
@@ -536,7 +553,17 @@ declare namespace jasmine {
         toThrowMatching(predicate: (thrown: any) => boolean): boolean;
         toBeNegativeInfinity(expectationFailOutput?: any): boolean;
         toBePositiveInfinity(expectationFailOutput?: any): boolean;
-        toHaveClass(expected: any, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to be a DOM element that has the expected class.
+         * @since 3.0.0
+         * @param expected - The class name to test for.
+         * @example
+         * var el = document.createElement('div');
+         * el.className = 'foo bar baz';
+         * expect(el).toHaveClass('bar');
+         */
+        toHaveClass(expected: string, expectationFailOutput?: any): boolean;
 
         /**
          * Add some context for an expect.
@@ -544,16 +571,45 @@ declare namespace jasmine {
          */
         withContext(message: string): Matchers<T>;
 
+        /**
+         * Invert the matcher following this expect.
+         */
         not: Matchers<T>;
-
-        Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {
-        toBe(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
-        toEqual(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
-        toContain(expected: Expected<T>, expectationFailOutput?: any): boolean;
+        toContain(expected: DeepMatch<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Add some context for an expect.
+         * @param message - Additional context to show when the matcher fails.
+         */
+        withContext(message: string): ArrayLikeMatchers<T>;
+
+        /**
+         * Invert the matcher following this expect.
+         */
         not: ArrayLikeMatchers<T>;
+    }
+
+    type DeepMatchArgs<Fn> = Fn extends (...args: infer P) => any ? { [K in keyof P]: DeepMatch<P[K]> } : never;
+
+    interface FunctionMatchers<T extends Func> extends Matchers<any> {
+        toHaveBeenCalled(): boolean;
+        toHaveBeenCalledBefore(expected: Func): boolean;
+        toHaveBeenCalledTimes(expected: number): boolean;
+        toHaveBeenCalledWith(...params: DeepMatchArgs<T>): boolean;
+
+        /**
+         * Add some context for an expect.
+         * @param message - Additional context to show when the matcher fails.
+         */
+        withContext(message: string): FunctionMatchers<T>;
+
+        /**
+         * Invert the matcher following this expect.
+         */
+        not: FunctionMatchers<T>;
     }
 
     interface NothingMatcher {
@@ -577,13 +633,13 @@ declare namespace jasmine {
          * Expect a promise to be resolved to a value equal to the expected, using deep equality comparison.
          * @param expected - Value that the promise is expected to resolve to.
          */
-        toBeResolvedTo(expected: Expected<T>): Promise<void>;
+        toBeResolvedTo(expected: DeepMatch<T>): Promise<void>;
 
         /**
          * Expect a promise to be rejected with a value equal to the expected, using deep equality comparison.
          * @param expected - Value that the promise is expected to be rejected with.
          */
-        toBeRejectedWith(expected: Expected<U>): Promise<void>;
+        toBeRejectedWith(expected: DeepMatch<U>): Promise<void>;
 
         /**
          * Add some context for an expect.
@@ -745,61 +801,67 @@ declare namespace jasmine {
         execute(): void;
     }
 
-    interface Spy<Fn extends InferableFunction = InferableFunction> {
-        (...params: any[]): any;
+    interface Spy<Fn extends Func = Func> {
+        (...params: Parameters<Fn>): ReturnType<Fn>;
 
         and: SpyAnd<Fn>;
         calls: Calls<Fn>;
-        withArgs(...args: any[]): Spy<Fn>;
+        withArgs(...args: Parameters<Fn>): Spy<Fn>;
     }
 
     type SpyObj<T> = T & {
-        [k in keyof T]: T[k] extends InferableFunction ? T[k] & Spy<T[k]> : T[k];
+        [k in keyof T]: T[k] extends Func ? T[k] & Spy<T[k]> : T[k];
     };
 
-    interface SpyAnd<Fun extends InferableFunction> {
+    /**
+     * It's like SpyObj, but doesn't verify argument/return types for functions.
+     * Useful if TS cannot correctly infer type for complex objects.
+     */
+    type NonTypedSpyObj<T> = SpyObj<{ [K in keyof T]: T[K] extends Func ? Func : T[K] }>;
+
+    interface SpyAnd<Fn extends Func> {
         identity: string;
 
         /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
-        callThrough(): Spy<Fun>;
+        callThrough(): Spy<Fn>;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */
-        returnValue(val: ReturnType<Fun>): Spy<Fun>;
+        returnValue(val: ReturnType<Fn>): Spy<Fn>;
         /** By chaining the spy with and.returnValues, all calls to the function will return specific values in order until it reaches the end of the return values list. */
-        returnValues(...values: Array<ReturnType<Fun>>): Spy<Fun>;
+        returnValues(...values: Array<ReturnType<Fn>>): Spy<Fn>;
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
-        callFake(fn: Fun): Spy<Fun>;
+        callFake(fn: Fn): Spy<Fn>;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
         throwError(msg: string): Spy;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */
         stub(): Spy;
     }
 
-    interface Calls<Fun extends InferableFunction> {
+    interface Calls<Fn extends Func> {
         /** By chaining the spy with calls.any(), will return false if the spy has not been called at all, and then true once at least one call happens. */
         any(): boolean;
         /** By chaining the spy with calls.count(), will return the number of times the spy was called */
         count(): number;
         /** By chaining the spy with calls.argsFor(), will return the arguments passed to call number index */
-        argsFor(index: number): Parameters<Fun>;
+        argsFor(index: number): Parameters<Fn>;
         /** By chaining the spy with calls.allArgs(), will return the arguments to all calls */
-        allArgs(): Array<Parameters<Fun>>;
+        allArgs(): Array<Parameters<Fn>>;
         /** By chaining the spy with calls.all(), will return the context (the this) and arguments passed all calls */
-        all(): Array<CallInfo<Fun>>;
+        all(): Array<CallInfo<Fn>>;
         /** By chaining the spy with calls.mostRecent(), will return the context (the this) and arguments for the most recent call */
-        mostRecent(): CallInfo<Fun>;
+        mostRecent(): CallInfo<Fn>;
         /** By chaining the spy with calls.first(), will return the context (the this) and arguments for the first call */
-        first(): CallInfo<Fun>;
+        first(): CallInfo<Fn>;
         /** By chaining the spy with calls.reset(), will clears all tracking for a spy */
         reset(): void;
     }
 
-    interface CallInfo<Fun extends InferableFunction> {
+    interface CallInfo<Fn extends Func> {
         /** The context (the this) for the call */
         object: any;
         /** All arguments passed to the call */
-        args: Parameters<Fun>;
+        args: Parameters<Fn>;
         /** The return value of the call */
-        returnValue: ReturnType<Fun>;
+        returnValue: ReturnType<Fn>;
     }
 
     interface Util {

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1007,14 +1007,11 @@ describe("jasmine.objectContaining", () => {
     it('should work when string value is used as a type ', () => {
         const foo: { bar: 'bar', baz: 'baz' } | undefined = {} as any;
 
-        // It requires type specification, as by type is generalized.
+        expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar', baz: 'baz' }));
+        expect(foo).toEqual(jasmine.objectContaining({ bar: '' }));
         // If it's TS 3.5+ you can use `as const` instead.
         expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar' as 'bar', baz: 'baz' as 'baz' }));
         expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar' as 'bar' }));
-
-        // This, unfortunately, fails due to type generalization.
-        expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar', baz: 'baz' })); // $ExpectError
-        expect(foo).toEqual(jasmine.objectContaining({ bar: '' })); // $ExpectError
     });
 
     describe("when used with a spy", () => {
@@ -1611,6 +1608,8 @@ describe('Deeply nested type with unions', () => {
 
     const obj: TestComplexType = {} as any;
     const arr: TestComplexType[] = [];
+    const spyObj: jasmine.Spy<(arg: TestComplexType) => void> = { } as any;
+    const spyArr: jasmine.Spy<(arg: TestComplexType[]) => void> = { } as any;
 
     it("jasmine.objectContaining()", () => {
         expect(obj).toEqual(jasmine.objectContaining({ a: "value" }));
@@ -1666,8 +1665,55 @@ describe('Deeply nested type with unions', () => {
         expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: true } })]));
         expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: jasmine.anything() } })]));
         expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: [true] })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining([42]) })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining([false]) })]));
 
         expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: 42 } })])); // $ExpectError
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining(["foo"]) })])); // $ExpectError
+    });
+
+    it("toContain", () => {
+        expect(arr).toContain(jasmine.objectContaining({ a: "foo" }));
+        expect(arr).toContain(jasmine.objectContaining({ b: "bar" }));
+        expect(arr).toContain(jasmine.objectContaining({ innerArray: jasmine.arrayContaining([true]) }));
+        expect(arr).toContain(jasmine.objectContaining({ innerArray: jasmine.arrayContaining([42]) }));
+        expect(arr).toContain(jasmine.objectContaining({ inner: { inner2: { z: 22 } } }));
+        expect(arr).toContain(jasmine.objectContaining({ inner: { inner2: { z: "twenty two" } } }));
+        expect(arr).toContain(jasmine.objectContaining({ innerArray: jasmine.arrayContaining(["foo"]) })); // $ExpectError
+        expect(arr).toContain(jasmine.objectContaining({ b: false })); // $ExpectError
+        expect(arr).toContain(jasmine.objectContaining({ inner: { inner2: { z: false } } })); // $ExpectError
+    });
+
+    it("spy", () => {
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ a: "value" }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ c: false }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ a: "forty-two" }) }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ b: 42 }) }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ c: true }) }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ c: "some value" }) }));
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: { a: "forty-two", b: jasmine.any(String) } }));
+        expect(spyObj).toHaveBeenCalledWith({ inner: jasmine.objectContaining({ b: false }) });
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ inner2: jasmine.objectContaining({ z: 42 }) })}));
+
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ a: 42 })); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: 42 })); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ b: "str" })})); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ z: "str" })})); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: { z: "blah"} })); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ unknownProp: 42 })); // $ExpectError
+        expect(spyObj).toHaveBeenCalledWith(jasmine.objectContaining({ inner: jasmine.objectContaining({ inner2: jasmine.objectContaining({ z: true }) })})); // $ExpectError
+
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([undefined]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ a: "some value" })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: true } })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: true } })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: jasmine.anything() } })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: [true] })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining([42]) })]));
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining([false]) })]));
+
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: 42 } })])); // $ExpectError
+        expect(spyArr).toHaveBeenCalledWith(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: jasmine.arrayContaining(["foo"]) })])); // $ExpectError
     });
 });
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -15,23 +15,29 @@ describe("A suite is just a function", () => {
     });
 });
 
-describe("The 'toBe' matcher compares with ===", () => {
-    it("and has a positive case", () => {
-        expect(true).toBe(true);
-    });
-
-    it("and can have a negative case", () => {
-        expect(false).not.toBe(true);
-    });
-});
-
 describe("Included matchers:", () => {
-    it("The 'toBe' matcher compares with ===", () => {
-        const a = 12;
-        const b = a;
+    describe('toBe', () => {
+        it("and has a positive case", () => {
+            expect(true).toBe(true);
+        });
 
-        expect(a).toBe(b);
-        expect(a).not.toBe(24);
+        it("and can have a negative case", () => {
+            expect(false).not.toBe(true);
+        });
+
+        it("the 'toBe' matcher compares with ===", () => {
+            const a = 12;
+            const b = a;
+
+            expect(a).toBe(b);
+            expect(a).not.toBe(24);
+        });
+
+        it('should allow to accept any union type', () => {
+            const value: number | string = null as any;
+
+            expect(value).toBe(12);
+        });
     });
 
     describe("The 'toEqual' matcher", () => {
@@ -734,7 +740,7 @@ describe("Spy for generic method", () => {
 
         const spy = jasmine.createSpyObj<Test>('test', ['method']);
 
-        spy.method.and.returnValue([{ value: 1}, { value: 2}]);
+        spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
     });
 });
 
@@ -910,12 +916,12 @@ describe('custom asymmetry', function() {
         },
     };
 
-    it('dives in deep', function() {
+    it('dives in deep', () => {
         expect('foo,bar,baz,quux').toEqual(tester);
         expect(123).not.toEqual(tester); // $ExpectError
     });
 
-    describe('when used with a spy', function() {
+    describe('when used with a spy', () => {
         it('is useful for comparing arguments', function() {
             const callback = jasmine.createSpy('callback');
 
@@ -996,6 +1002,19 @@ describe("jasmine.objectContaining", () => {
         expect(nestedFoo).toEqual({
             nested: jasmine.objectContaining({b: 2})
         });
+    });
+
+    it('should work when string value is used as a type ', () => {
+        const foo: { bar: 'bar', baz: 'baz' } | undefined = {} as any;
+
+        // It requires type specification, as by type is generalized.
+        // If it's TS 3.5+ you can use `as const` instead.
+        expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar' as 'bar', baz: 'baz' as 'baz' }));
+        expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar' as 'bar' }));
+
+        // This, unfortunately, fails due to type generalization.
+        expect(foo).toEqual(jasmine.objectContaining({ bar: 'bar', baz: 'baz' })); // $ExpectError
+        expect(foo).toEqual(jasmine.objectContaining({ bar: '' })); // $ExpectError
     });
 
     describe("when used with a spy", () => {
@@ -1574,6 +1593,84 @@ describe('Static Matcher Test', function() {
     });
 });
 
+describe('Deeply nested type with unions', () => {
+    type TestComplexType = { a: string; b: number | string } |
+                           { c: boolean } |
+                           {
+                               inner: { a: string; b: number | boolean } |
+                                      { c: boolean | string } |
+                                      {
+                                        inner2: {
+                                          a: number;
+                                          z: number | string
+                                        }
+                                      }
+                           } |
+                           { innerArray: Array<number | boolean>; } |
+                           undefined;
+
+    const obj: TestComplexType = {} as any;
+    const arr: TestComplexType[] = [];
+
+    it("jasmine.objectContaining()", () => {
+        expect(obj).toEqual(jasmine.objectContaining({ a: "value" }));
+        expect(obj).toEqual(jasmine.objectContaining({ c: false }));
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ a: "forty-two" }) }));
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ b: 42 }) }));
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ c: true }) }));
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ c: "some value" }) }));
+        expect(obj).toEqual(jasmine.objectContaining({ inner: { a: "forty-two", b: jasmine.any(String) } }));
+        expect(obj).toEqual({ inner: jasmine.objectContaining({ b: false }) });
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ inner2: jasmine.objectContaining({ z: 42 }) })}));
+
+        // Limitation - we don't prevent usage of unknown properties as long as any property is known.
+        expect(obj).toEqual(jasmine.objectContaining({ c: true, unknownProp: 42 }));
+        // But it still should fail if type is completely unkonwn.
+        expect(obj).toEqual(jasmine.objectContaining({ unknownProp: 42 })); // $ExpectError
+
+        expect(obj).toEqual(jasmine.objectContaining({ a: 42 })); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ inner: 42 })); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ b: "str" })})); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ z: "str" })})); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ inner: { z: "blah"} })); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ unknownProp: 42 })); // $ExpectError
+        expect(obj).toEqual(jasmine.objectContaining({ inner: jasmine.objectContaining({ inner2: jasmine.objectContaining({ z: true }) })})); // $ExpectError
+
+        expect(arr).toEqual([jasmine.objectContaining({ a: "forty-two" })]);
+    });
+
+    it("raw toEqual", () => {
+        expect(obj).toEqual({ a: "foo", b: "bar" });
+        expect(obj).toEqual({ a: "foo", b: 12 });
+        expect(obj).toEqual({ c: true });
+        expect(obj).toEqual(undefined);
+        expect(obj).toEqual({ inner: { a: "foo", b: 12 }});
+        expect(obj).toEqual({ inner: { a: "foo", b: false }});
+        expect(obj).toEqual({ inner: { c: true }});
+        expect(obj).toEqual({ inner: { c: "foo" }});
+        expect(obj).toEqual({ inner: { inner2: { a: 12, z: 21 } } });
+        expect(obj).toEqual({ inner: { inner2: { a: 12, z: "foo" } } });
+
+        expect(obj).toEqual({ a: "foo" }); // $ExpectError
+        expect(obj).toEqual({ a: "foo", b: false }); // $ExpectError
+        expect(obj).toEqual(null); // $ExpectError
+        expect(obj).toEqual({ inner: { a: "foo", b: "wrong" }}); // $ExpectError
+        expect(obj).toEqual({ inner: { inner2: { a: 12, z: false } } }); // $ExpectError
+        // expect(obj).toEqual({ a: "foo", b: "bar", c: "wrong-type" }); // Fails on TS 3.4+ only.
+    });
+
+    it("jasmine.arrayContaining()", () => {
+        expect(arr).toEqual(jasmine.arrayContaining([undefined]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ a: "some value" })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: true } })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: true } })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: jasmine.anything() } })]));
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ innerArray: [true] })]));
+
+        expect(arr).toEqual(jasmine.arrayContaining([jasmine.objectContaining({ inner: { c: 42 } })])); // $ExpectError
+    });
+});
+
 describe("User scenarios", () => {
     describe("https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36971", () => {
         it("should allow nested matchers", () => {
@@ -1581,10 +1678,6 @@ describe("User scenarios", () => {
 
             expect(elements).toEqual([
                 jasmine.objectContaining({ tagName: 'DIV', id: 'find-this' })]);
-
-            expect(elements).not.toEqual(
-                [jasmine.objectContaining({ tagName: 'DIV', id: 'find-this', unknownProp: 42 })] // $ExpectError
-            );
         });
     });
 

--- a/types/jasminewd2/index.d.ts
+++ b/types/jasminewd2/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-/// <reference types="jasmine" />
+/// <reference types="jasmine/v2" />
 
 declare function it(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
 declare function fit(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;

--- a/types/saywhen/saywhen-tests.ts
+++ b/types/saywhen/saywhen-tests.ts
@@ -18,5 +18,5 @@ type Top = typeof top;
 declare function expectMatcherProxyTop(x: (arg: Top) => boolean): void;
 
 expectMatcherProxyTop(when.captor());
-when.captor(jasmine.any(Number));	// $ExpectType MatcherProxy<Any>
+when.captor(jasmine.any(Number));	// $ExpectType MatcherProxy<AsymmetricMatcher<any>>
 when.noConflict();	// $ExpectType void


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

# Motivation

Found a couple of typing gaps in the library and decided to fix those. Also slightly refactored the library typing to simplify project maintenance.

# Issues

Fixes #36971
Closes #30552
Closes #34080 

# Changes

The following enhancements has been done:

## Spy

- Added typings for `expect(spy).toHaveBeenCalledWith()`
- Fix missing typing for unnamed `createSpyObj`
- Fix typing for spyOnAllFunctions
- Move call assertions to a separate `FunctionMatchers` interface

## Matching

- Remove wrong deep equality from `toBe()`
- Allow `any` matcher to receive prototypes and symbols only
- Enhance types and doc for `toHaveClass` to avoid misusage
- Fix invalid typing for Any and ArrayContaining types (remove constructors, as those are not returned)

## Maintenance / other

- Unify deep equality deep matchers support
- Rename `Expected<T>` to `DeepMatch<T>`, but still keep old type as an alias in case it's used.
- Remove `AnyMethods<>` in favor of `NonTypedSpyObj<T>` (see motivation [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34080#issuecomment-526913634))
- Remove undefined `Any` property from `Matchers<T>`
- Synchronize tests for default and 3.1+ projects
- Update jasminewd2 to depend on jasmine v2 types
