### PR TITLE
<google__maps> update departure_time to accept 'now'

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -576,7 +576,7 @@ export interface DirectionsRequest {
      *    This option is only available if the request contains a valid API key, or a valid Google Maps APIs Premium Plan client ID
      *    and signature. The `departure_time` must be set to the current time or some time in the future. It cannot be in the past.
      */
-    departure_time?: Date | number;
+    departure_time?: Date | number | 'now';
     /**
      * Specifies the assumptions to use when calculating time in traffic.
      * This setting affects the value returned in the `duration_in_traffic` field in the response, which contains the predicted time

--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @google/maps 0.5
 // Project: https://github.com/googlemaps/google-maps-services-js
 // Definitions by: Indri Muska <https://github.com/indrimuska>
+//                 Gabe O'Leary <https://github.com/goleary>
 // Definitions: https://github.com/indrimuska/google-maps-api-typings
 // TypeScript Version: 2.3
 

--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for @google/maps 0.5
 // Project: https://github.com/googlemaps/google-maps-services-js
 // Definitions by: Indri Muska <https://github.com/indrimuska>
-//                 Gabe O'Leary <https://github.com/goleary>
 // Definitions: https://github.com/indrimuska/google-maps-api-typings
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/indrimuska/google-maps-api-typings/issues/9#issuecomment-527292693
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
