### PR TITLE
React-filepond: Add FilePondBaseProps.files and export FilePondProps subinterfaces 

### DIFF
--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -193,7 +193,7 @@ type FetchServerConfigFunction = (
     headers: (headersString: string) => void,
 ) => void;
 
-interface FilePondServerConfigProps {
+export interface FilePondServerConfigProps {
     instantUpload?: boolean;
     server?: string | {
         process?: string | ServerUrl | ProcessServerConfigFunction;
@@ -204,7 +204,7 @@ interface FilePondServerConfigProps {
     };
 }
 
-interface FilePondDragDropProps {
+export interface FilePondDragDropProps {
     /** FilePond will catch all files dropped on the webpage */
     dropOnPage?: boolean;
     /** Require drop on the FilePond element itself to catch the file. */
@@ -221,7 +221,7 @@ interface FilePondDragDropProps {
     ignoredFiles?: string[];
 }
 
-interface FilePondLabelProps {
+export interface FilePondLabelProps {
     /**
      * The decimal separator used to render numbers.
      * By default this is determined automatically.
@@ -276,7 +276,7 @@ interface FilePondLabelProps {
     labelButtonProcessItem?: string;
 }
 
-interface FilePondSvgIconProps {
+export interface FilePondSvgIconProps {
     iconRemove?: string;
     iconProcess?: string;
     iconRetry?: string;
@@ -293,7 +293,7 @@ interface FilePondErrorDescription {
  * always give the error as the second prop, with the file as
  * the first prop.    This is contradictory to the current docs.
  */
-interface FilePondCallbackProps {
+export interface FilePondCallbackProps {
     /** FilePond instance has been created and is ready. */
     oninit?: () => void;
     /**
@@ -336,11 +336,11 @@ interface FilePondCallbackProps {
     onupdatefiles?: (fileItems: File[]) => void;
 }
 
-interface FilePondHookProps {
+export interface FilePondHookProps {
     beforeRemoveFile?: (file: File) => boolean;
 }
 
-interface FilePondBaseProps {
+export interface FilePondBaseProps {
     children?: React.ReactElement<File> | Array<React.ReactElement<File>>;
     id?: string;
     name?: string;
@@ -368,6 +368,8 @@ interface FilePondBaseProps {
     maxFiles?: number;
     /** The maximum number of files that can be uploaded in parallel */
     maxParallelUploads?: number;
+    /** List of files for controlled usage */
+    files?: File[];
     acceptedFileTypes?: string[];
     metadata?: {[key: string]: any};
 }

--- a/types/react-filepond/react-filepond-tests.tsx
+++ b/types/react-filepond/react-filepond-tests.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as filepond from 'react-filepond';
 
 interface AppState {
-    files: File[];
+    files: filepond.File[];
     filenames: string[];
 }
 

--- a/types/react-filepond/react-filepond-tests.tsx
+++ b/types/react-filepond/react-filepond-tests.tsx
@@ -41,7 +41,7 @@ class App extends React.Component<{}, AppState> {
                         fetch: (url, load, error, progress, abort, headers) => {},
                     }}
                     oninit={() => this.handleInit() }
-                    files={this.files}
+                    files={this.state.files}
                     onupdatefiles={(fileItems) => {
                         // Set current file objects to this.state
                         this.setState({

--- a/types/react-filepond/react-filepond-tests.tsx
+++ b/types/react-filepond/react-filepond-tests.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as filepond from 'react-filepond';
 
 interface AppState {
+    files: File[];
     filenames: string[];
 }
 
@@ -15,7 +16,8 @@ class App extends React.Component<{}, AppState> {
 
         this.state = {
             // Set initial files
-            filenames: ['index.html']
+            filenames: ['index.html'],
+            files: [],
         };
     }
 
@@ -39,10 +41,12 @@ class App extends React.Component<{}, AppState> {
                         fetch: (url, load, error, progress, abort, headers) => {},
                     }}
                     oninit={() => this.handleInit() }
+                    files={this.files}
                     onupdatefiles={(fileItems) => {
                         // Set current file objects to this.state
                         this.setState({
-                            filenames: fileItems.map(fileItem => fileItem.file.name)
+                            files: fileItems,
+                            filenames: fileItems.map(fileItem => fileItem.file.name),
                         });
                     }}
                 >


### PR DESCRIPTION
The `files` property was missing from `FilePondProps`.
Related: pqina/react-filepond#103

Also export all interfaces which `FilePondProps` is extended from so consumers can partially construct them as needed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pqina.nl/filepond/docs/patterns/frameworks/react/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
