### PR TITLE
add array of objects as possible type for presetColors in @types/react-color

### DIFF
--- a/types/react-color/lib/components/sketch/Sketch.d.ts
+++ b/types/react-color/lib/components/sketch/Sketch.d.ts
@@ -3,7 +3,7 @@ import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface SketchPickerProps extends ColorPickerProps<SketchPicker> {
     disableAlpha?: boolean;
-    presetColors?: string[];
+    presetColors?: string[] | { color: string; title: string; }[];
     width?: string;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }


### PR DESCRIPTION


http://casesandberg.github.io/react-color/#api-individual  

 presetColors type doesn't currently let have an "array of objects with color and title properties: [{ color: '#f00', title: 'red' }] or a combination of both"

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x  ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: http://casesandberg.github.io/react-color/#api-individual  
