### PR TITLE
@types/ssh2: Added shell() "env" option

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -494,7 +494,7 @@ export interface ExecOptions {
 }
 
 export interface ShellOptions {
-    /** An environment to use for the execution of the command. */
+    /** An environment to use for the execution of the shell. */
     env?: any;
     /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
     x11?: boolean | number | X11Options;

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -486,7 +486,7 @@ export interface ClientErrorExtensions {
 
 export interface ExecOptions {
     /** An environment to use for the execution of the command. */
-    env?: any;
+    env?: NodeJS.ProcessEnv;
     /** Set to `true` to allocate a pseudo-tty with defaults, or an object containing specific pseudo-tty settings. */
     pty?: true | PseudoTtyOptions;
     /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
@@ -495,7 +495,7 @@ export interface ExecOptions {
 
 export interface ShellOptions {
     /** An environment to use for the execution of the shell. */
-    env?: any;
+    env?: NodeJS.ProcessEnv;
     /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
     x11?: boolean | number | X11Options;
 }

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -494,6 +494,8 @@ export interface ExecOptions {
 }
 
 export interface ShellOptions {
+    /** An environment to use for the execution of the command. */
+    env?: any;
     /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
     x11?: boolean | number | X11Options;
 }


### PR DESCRIPTION
I copied the existing "env" definition from the `ExecOptions` interface into `ShellOptions`. I did not add any tests as the former was not tested either and I am new to TypeScript.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/master/lib/client.js#L823