### PR TITLE
added types for katex sub module katex2tex

### DIFF
--- a/types/katex/contrib/index.d.ts
+++ b/types/katex/contrib/index.d.ts
@@ -1,1 +1,2 @@
 /// <reference path="auto-render.d.ts" />
+/// <reference path="katex2tex.d.ts" />

--- a/types/katex/contrib/katex2tex.d.ts
+++ b/types/katex/contrib/katex2tex.d.ts
@@ -2,7 +2,7 @@ declare module 'katex/contrib/copy-tex/katex2tex' {
     /**
      * Set these to how you want inline and display math to be delimited.
      */
-    interface ICopyDelimiters {
+    export interface CopyDelimiters {
         inline: ['$', '$'] | ['(', ')'];
         display: ['$$', '$$'] | ['[', ']'];
     }
@@ -15,9 +15,6 @@ declare module 'katex/contrib/copy-tex/katex2tex' {
      */
     export default function katexReplaceWithTex(
         fragment: DocumentFragment,
-        copyDelimiters?: ICopyDelimiters,
+        copyDelimiters?: CopyDelimiters,
     ): DocumentFragment;
 }
-
-
-

--- a/types/katex/contrib/katex2tex.d.ts
+++ b/types/katex/contrib/katex2tex.d.ts
@@ -1,0 +1,23 @@
+declare module 'katex/contrib/copy-tex/katex2tex' {
+    /**
+     * Set these to how you want inline and display math to be delimited.
+     */
+    interface ICopyDelimiters {
+        inline: ['$', '$'] | ['(', ')'];
+        display: ['$$', '$$'] | ['[', ']'];
+    }
+    /**
+     * Replace .katex elements with their TeX source (<annotation> element).
+     * Modifies fragment in-place.  Useful for writing your own 'copy' handler,
+     * as in https://github.com/KaTeX/KaTeX/blob/master/contrib/copy-tex/copy-tex.js.
+     * @param fragment Selected fragment of the DOM.
+     * @param copyDelimiters Delimiters for inline and display math.
+     */
+    export default function katexReplaceWithTex(
+        fragment: DocumentFragment,
+        copyDelimiters?: ICopyDelimiters,
+    ): DocumentFragment;
+}
+
+
+

--- a/types/katex/index.d.ts
+++ b/types/katex/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Michael Randolph <https://github.com/mrand01>
 //                 Kevin Nguyen <https://github.com/knguyen0125>
 //                 bLue <https://github.com/dreamerblue>
+//                 Sebastian Weigand <https://github.com/s-weigand>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/katex/katex-tests.ts
+++ b/types/katex/katex-tests.ts
@@ -3,40 +3,40 @@ import renderMathInElement, { RenderMathInElementOptions } from 'katex/dist/cont
 import katexReplaceWithTex from 'katex/contrib/copy-tex/katex2tex';
 
 class KatexTest {
-  constructor() {
-    katexLib.render('My Latex String', document.createElement('div'));
+    constructor() {
+        katexLib.render('My Latex String', document.createElement('div'));
 
-    try {
-      let options: katexLib.KatexOptions = {
-        throwOnError: true,
-      };
-      let value: string = katexLib.renderToString('My Latex String', options);
-    } catch (error) {
-      if (error instanceof katexLib.ParseError) {
-        //do something with this error
-      }
+        try {
+            let options: katexLib.KatexOptions = {
+                throwOnError: true,
+            };
+            let value: string = katexLib.renderToString('My Latex String', options);
+        } catch (error) {
+            if (error instanceof katexLib.ParseError) {
+                //do something with this error
+            }
+        }
+
+        const renderMathInElementOptions: RenderMathInElementOptions = {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '\\[', right: '\\]', display: true },
+                { left: '$', right: '$', display: false },
+                { left: '\\(', right: '\\)', display: false },
+            ],
+            errorCallback(msg: string, err: Error): void {
+                console.error(msg, err);
+                //do something with this error
+            },
+        };
+        const container = document.createElement('div');
+        container.innerText = 'LaTeX string $c = \\pm\\sqrt{a^2 + b^2}$';
+        renderMathInElement(container, renderMathInElementOptions);
+
+        // testing katexReplaceWithTex
+        const range = document.createRange();
+        range.selectNode(container);
+        const fragment = range.cloneContents();
+        katexReplaceWithTex(fragment).textContent;
     }
-
-    const renderMathInElementOptions: RenderMathInElementOptions = {
-      delimiters: [
-        { left: '$$', right: '$$', display: true },
-        { left: '\\[', right: '\\]', display: true },
-        { left: '$', right: '$', display: false },
-        { left: '\\(', right: '\\)', display: false },
-      ],
-      errorCallback(msg: string, err: Error): void {
-        console.error(msg, err);
-        //do something with this error
-      },
-    };
-    const container = document.createElement('div');
-    container.innerText = 'LaTeX string $c = \\pm\\sqrt{a^2 + b^2}$';
-    renderMathInElement(container, renderMathInElementOptions);
-
-    // testing katexReplaceWithTex
-    const range = document.createRange();
-    range.selectNode(container);
-    const fragment = range.cloneContents();
-    katexReplaceWithTex(fragment).textContent;
-  }
 }

--- a/types/katex/katex-tests.ts
+++ b/types/katex/katex-tests.ts
@@ -37,6 +37,21 @@ class KatexTest {
         const range = document.createRange();
         range.selectNode(container);
         const fragment = range.cloneContents();
-        katexReplaceWithTex(fragment).textContent;
+        katexReplaceWithTex(fragment, {
+            inline: ['$', '$'],
+            display: ['$$', '$$'],
+        }).textContent;
+        katexReplaceWithTex(fragment, {
+            inline: ['(', ')'],
+            display: ['[', ']'],
+        }).textContent;
+        katexReplaceWithTex(fragment, {
+            inline: ['$', '$'],
+            display: ['[', ']'],
+        }).textContent;
+        katexReplaceWithTex(fragment, {
+            inline: ['(', ')'],
+            display: ['$$', '$$'],
+        }).textContent;
     }
 }

--- a/types/katex/katex-tests.ts
+++ b/types/katex/katex-tests.ts
@@ -1,33 +1,42 @@
 import katexLib = require('katex');
 import renderMathInElement, { RenderMathInElementOptions } from 'katex/dist/contrib/auto-render';
+import katexReplaceWithTex from 'katex/contrib/copy-tex/katex2tex';
 
 class KatexTest {
-    constructor() {
-        katexLib.render('My Latex String', document.createElement('div'));
+  constructor() {
+    katexLib.render('My Latex String', document.createElement('div'));
 
-        try {
-            let options: katexLib.KatexOptions = { throwOnError: true };
-            let value: string = katexLib.renderToString('My Latex String', options);
-        } catch (error) {
-            if (error instanceof katexLib.ParseError) {
-                //do something with this error
-            }
-        }
-
-        const renderMathInElementOptions: RenderMathInElementOptions = {
-            delimiters: [
-                { left: "$$", right: "$$", display: true },
-                { left: "\\[", right: "\\]", display: true },
-                { left: "$", right: "$", display: false },
-                { left: "\\(", right: "\\)", display: false },
-            ],
-            errorCallback(msg: string, err: Error): void {
-                console.error(msg, err);
-                //do something with this error
-            }
-        };
-        const container = document.createElement('div');
-        container.innerText = 'LaTeX string $c = \\pm\\sqrt{a^2 + b^2}$';
-        renderMathInElement(container, renderMathInElementOptions);
+    try {
+      let options: katexLib.KatexOptions = {
+        throwOnError: true,
+      };
+      let value: string = katexLib.renderToString('My Latex String', options);
+    } catch (error) {
+      if (error instanceof katexLib.ParseError) {
+        //do something with this error
+      }
     }
+
+    const renderMathInElementOptions: RenderMathInElementOptions = {
+      delimiters: [
+        { left: '$$', right: '$$', display: true },
+        { left: '\\[', right: '\\]', display: true },
+        { left: '$', right: '$', display: false },
+        { left: '\\(', right: '\\)', display: false },
+      ],
+      errorCallback(msg: string, err: Error): void {
+        console.error(msg, err);
+        //do something with this error
+      },
+    };
+    const container = document.createElement('div');
+    container.innerText = 'LaTeX string $c = \\pm\\sqrt{a^2 + b^2}$';
+    renderMathInElement(container, renderMathInElementOptions);
+
+    // testing katexReplaceWithTex
+    const range = document.createRange();
+    range.selectNode(container);
+    const fragment = range.cloneContents();
+    katexReplaceWithTex(fragment).textContent;
+  }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/KaTeX/KaTeX/blob/master/contrib/copy-tex/katex2tex.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Also**:
I wanted to mention that i had some problems with the prettier formating in the git hook. It kept reformating and added additional new lines, on windows. 
If I manually (vs-code prettier plugin) format the file (on ubuntu this time), `precise-commits` even breaks the code since it runs on changed lines only.
And it used 2 space indentation instead of 4 space indentation in `types/katex/katex-tests.ts`. Which can be fixed by adding `"tabWidth": 4,` back to `.prettierrc.json`, which was removed by #37400 .
