### PR TITLE
[react-datepicker@2.9.4] formatWeekday parameter is a string, not a date object

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -50,7 +50,7 @@ export interface ReactDatePickerProps {
 	filterDate?(date: Date): boolean;
 	fixedHeight?: boolean;
 	forceShowMonthNavigation?: boolean;
-	formatWeekDay?(date: Date): string;
+	formatWeekDay?(formattedDate: string): string;
 	formatWeekNumber?(date: Date): string | number;
 	highlightDates?: Array<HighlightDates|Date>;
 	id?: string;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -33,7 +33,7 @@ const defaultLocale = getDefaultLocale();
 	filterDate={date => true}
 	fixedHeight
 	forceShowMonthNavigation
-	formatWeekDay={date => ''}
+	formatWeekDay={formattedDate => formattedDate[0]}
 	formatWeekNumber={date => 0}
 	highlightDates={[{ someClassName: [new Date()]}]}
 	id=""


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/blob/de392f68bb08f63676edbbb0f28f17f0595c44a7/src/date_utils.js#L346
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
