### PR TITLE
[xml-crypto] add types for `references`

### DIFF
--- a/types/xml-crypto/index.d.ts
+++ b/types/xml-crypto/index.d.ts
@@ -12,6 +12,16 @@ export class HashAlgorithm {
     getHash(xml: string): string;
 }
 
+export interface Reference {
+    xpath: string;
+    transforms?: ReadonlyArray<string>;
+    digestAlgorithm?: string;
+    uri?: string;
+    digestValue?: string;
+    inclusiveNamespacesPrefixList?: string;
+    isEmptyUri?: boolean;
+}
+
 export class SignatureAlgorithm {
     getAlgorithmName(): string;
     getSignature(signedInfo: Node, signingKey: Buffer): string;
@@ -28,6 +38,7 @@ export class SignedXml {
     static SignatureAlgorithms: {[uri: string]: new () => SignatureAlgorithm};
     canonicalizationAlgorithm: string;
     keyInfoProvider: FileKeyInfo;
+    references: Reference[];
     signatureAlgorithm: string;
     signingKey: Buffer | string;
     validationErrors: string[];

--- a/types/xml-crypto/index.d.ts
+++ b/types/xml-crypto/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for xml-crypto 1.4
 // Project: https://github.com/yaronn/xml-crypto#readme
 // Definitions by: Eric Heikes <https://github.com/eheikes>
+//                 Max Chehab <https://github.com/maxchehab>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
The `SignedXML` class contains a `references` array of crypto references. This PR adds an interface to describe the shape of a `Reference` and adds an array of `Reference`s to the `SignedXML` class as a property.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/yaronn/xml-crypto/blob/master/lib/signed-xml.js#L291>