### PR TITLE
[yargs-parser] Add config options `strip-dashed` and `strip-aliased`

### DIFF
--- a/types/yargs-parser/index.d.ts
+++ b/types/yargs-parser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs-parser 13.1.0
+// Type definitions for yargs-parser 13.1
 // Project: https://github.com/yargs/yargs-parser#readme
 // Definitions by: Miles Johnson <https://github.com/milesj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/yargs-parser/index.d.ts
+++ b/types/yargs-parser/index.d.ts
@@ -52,6 +52,10 @@ declare namespace yargsParser {
         'set-placeholder-key': boolean;
         /** Should a group of short-options be treated as boolean flags? Default is `true` */
         'short-option-groups': boolean;
+        /** Should aliases be removed before returning results? Default is `false` */
+        'strip-aliased': boolean;
+        /** Should dashed keys be removed before returning results? This option has no effect if camel-case-expansion is disabled. Default is `false` */
+        'strip-dashed': boolean;
     }
 
     interface Options {

--- a/types/yargs-parser/index.d.ts
+++ b/types/yargs-parser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs-parser 13.0
+// Type definitions for yargs-parser 13.1.0
 // Project: https://github.com/yargs/yargs-parser#readme
 // Definitions by: Miles Johnson <https://github.com/milesj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
yargs-parser v.13.1.0 (2019-05-05) added the config options `strip-dashed` and `strip-aliased`
https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md#1310-2019-05-05 

The full list of configurations can be found: https://github.com/yargs/yargs-parser/blob/d3d9027f9c9235be8e7a650d0e33d4d55287e0e2/index.js#L28-L29

Please fill in this template.

- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] URL to documentation which provides context for the suggested changes: https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md#1310-2019-05-05
- [x] Update the version number in the header