### PR TITLE
[sharedb] Add Agent class and extraDbs option for ShareDB constructor, loosen query params to any

### DIFF
--- a/types/sharedb/lib/agent.d.ts
+++ b/types/sharedb/lib/agent.d.ts
@@ -1,0 +1,47 @@
+import { Duplex } from 'stream';
+import { JSONObject } from './sharedb';
+import ShareDbBackend = require('..');
+
+export = Agent;
+
+/**
+ * An `Agent` is the representation of a client's `Connection` state on the
+ * server. If the `Connection` was created through `backend.connect` (i.e. the
+ * client is running in the same Node process as the server), then the `Agent`
+ * associated with a `Connection` can be accessed through `connection.agent`.
+ *
+ * The `Agent` will be made available in all middleware requests. The
+ * `agent.custom` field is an object that can be used for storing arbitrary
+ * information for use in middleware.
+ *
+ * @see https://github.com/share/sharedb#class-sharedbagent
+ */
+declare class Agent {
+    backend: ShareDbBackend;
+    stream: Duplex & {
+        /**
+         * `true` if this is agent is handling a ShareDB client in the same
+         * Node process.
+         */
+        isServer?: boolean;
+    };
+    /**
+     * Object for custom use in middleware to store app-specific state for a
+     * given client session. It is in memory only as long as the session is
+     * active, and it is passed to each middleware call.
+     */
+    custom: Agent.Custom;
+
+    /**
+     * Sends a JSON-compatible message to the client for this agent.
+     *
+     * @param message
+     */
+    send(message: JSONObject): void;
+}
+
+declare namespace Agent {
+    interface Custom {
+        [key: string]: unknown;
+    }
+}

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -5,8 +5,8 @@ import * as ShareDB from './sharedb';
 export class Connection {
     constructor(ws: WebSocket | WS);
     get(collectionName: string, documentID: string): Doc;
-    createFetchQuery(collectionName: string, query: string, options: {results?: Query[]}, callback: (err: Error, results: any) => any): Query;
-    createSubscribeQuery(collectionName: string, query: string, options: {results?: Query[]}, callback: (err: Error, results: any) => any): Query;
+    createFetchQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;
+    createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;
 }
 export type Doc = ShareDB.Doc;
 export type Query = ShareDB.Query;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -201,4 +201,12 @@ function startClient(callback) {
         doc.submitOp([{p: ['numClicks'], na: 1}]);
         callback();
     });
+    // sharedb-mongo query object
+    connection.createSubscribeQuery('examples', {numClicks: {$gte: 5}}, null, (err, results) => {
+        console.log(err, results);
+    });
+    // SQL-ish query adapter that takes a string query condition
+    connection.createSubscribeQuery('examples', 'numClicks >= 5', null, (err, results) => {
+        console.log(err, results);
+    });
 }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -29,15 +29,37 @@ class WebSocketJSONStream extends Duplex {
     }
 }
 
-const backend = new ShareDB();
+class CustomExtraDb {
+    query(collection: string, query: any, fields: unknown, options: {customDbOption: boolean}, callback: ShareDB.DBQueryCallback) {
+        callback(null, [], {});
+    }
+    close() {}
+}
+
+const backend = new ShareDB({
+    extraDbs: {myDb: new CustomExtraDb()}
+});
+console.log(backend.db);
+console.log(backend.pubsub);
+console.log(backend.extraDbs);
 
 backend.addProjection('notes_minimal', 'notes', {title: true, creator: true, lastUpdateTime: true});
 
+// Test module augmentation to attach custom typed properties to `agent.custom`.
+import _ShareDbAgent = require('sharedb/lib/agent');
+declare module 'sharedb/lib/agent' {
+    interface Custom {
+        user?: {id: string};
+    }
+}
 // Exercise middleware (backend.use)
 type SubmitRelatedActions = 'afterSubmit' | 'apply' | 'commit' | 'submit';
 const submitRelatedActions: SubmitRelatedActions[] = ['afterSubmit', 'apply', 'commit', 'submit'];
 for (const action of submitRelatedActions) {
     backend.use(action, (request, callback) => {
+        if (request.agent.custom.user) {
+            console.log(request.agent.custom.user.id);
+        }
         console.log(
             request.action,
             request.agent,
@@ -56,9 +78,16 @@ for (const action of submitRelatedActions) {
     });
 }
 backend.use('connect', (context, callback) => {
+    // `context.req` is the HTTP / websocket request.
+    // This assumes that some request middleware has handled auth and popuplated `req.userId`.
+    if (context.req.userId) {
+        context.agent.custom.user = {id: context.req.userId};
+    }
     console.log(
         context.action,
         context.agent,
+        context.agent.backend === context.backend,
+        context.agent.stream.isServer,
         context.backend,
         context.stream,
         context.req,


### PR DESCRIPTION
## Changes

### Additions

* Add type definition for the [Agent class](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/agent.js)
  * For now, I've only added properties that are typically used by consumers of ShareDB.
* Add [`extraDbs` option](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/backend.js#L27) for the ShareDB constructor.
* Add public fields on ShareDB class: [`db`, `pubsub`, `extraDbs`](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/backend.js#L24-L27)

### Modifications

* These definitions now require TypeScript 3.0 for usage of `unknown`, up from 2.2.
* Types of a few no-result callbacks are now tightened to `(error?: Error) => void`.
* The `query` parameter to `DB#query`, `DB#queryPoll`, and `DB#queryPollDoc` is loosened to `any`.
  * It used to be `sharedb.Query`, which is incorrect - [the `query` parameter is an adapter-dependent object](https://github.com/share/sharedb/blob/v1.0.0-beta.23/README.md#class-sharedbconnection), e.g. a JSON object for sharedb-mongo or a string for sharedb-postgres.
* The callback to `DB#query` is tightened to `type DBQueryCallback = (err: Error | null, snapshots: ShareDB.Snapshot[], extra?: any) => void`.
  * **This is technically a breaking change** - the previous callback type was an extremely loose `(...args: any[]) => any`.
  * This brings the callback's types in line with the implementation's [invocation of the callback](https://github.com/share/sharedb/blob/v1.0.0-beta.23/lib/backend.js#L587-L590). See the README for [the types of `results` and `extra`](https://github.com/share/sharedb/blob/v1.0.0-beta.23/README.md#class-sharedbquery).
* The `query` parameter to `Connection#createFetchQuery` and `Connection#createSubscribeQuery` is loosened to `any` from `string`, for the same reason, and the callback's second parameter is slightly tightened to `results: any[]`, from `results: any`.
  * The implementation guarantees that `results` is always an array in the callback - here's the test for the no-results case producing an empty array: https://github.com/share/sharedb/blob/v1.0.0-beta.23/test/client/query.js#L14-L19

## Checklist

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes - Linked from each bullet point in the Changes section above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A, this just updates types
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. - N/A, tslint.json already exists
