### PR TITLE
mongoose - Add AsyncIterator to DocumentQuery

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2225,6 +2225,13 @@ declare module "mongoose" {
     within(val?: any): this;
     within(coordinate: number[], ...coordinatePairs: number[][]): this;
 
+    /**
+     * Returns an asyncIterator for use with for/await/of loops
+     * This function only works for find() queries.
+     * You do not need to call this function explicitly, the JavaScript runtime will call it for you.
+     */
+    [Symbol.asyncIterator](): AsyncIterator<DocType>;
+
     /** Flag to opt out of using $geoWithin. */
     static use$geoWithin: boolean;
   }

--- a/types/mongoose/tsconfig.json
+++ b/types/mongoose/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "esnext"
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://mongoosejs.com/docs/api.html#query_Query-Symbol.asyncIterator>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.