### PR TITLE
[semver] fix: support semver.inc() with 3 args

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -31,6 +31,11 @@ export function clean(version: string, optionsOrLoose?: boolean | Options): stri
  * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
  */
 export function inc(v: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
+export function inc(
+  v: string | SemVer,
+  release: ReleaseType,
+  identifier?: string,
+): string | null;
 /**
  * Return the major version number.
  */

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -38,6 +38,7 @@ strn = semver.inc(str, "patch", loose);
 strn = semver.inc(str, "prepatch", loose);
 strn = semver.inc(str, "prerelease", loose);
 strn = semver.inc(str, "prerelease", loose, "alpha");
+strn = semver.inc(str, 'prerelease', 'beta');
 num = semver.major(str, loose);
 num = semver.minor(str, loose);
 num = semver.patch(str, loose);


### PR DESCRIPTION
From the docs:

```ts
semver.inc('1.2.3', 'prerelease', 'beta')
// '1.2.4-beta.0'
```

P.S. Code formatting is looking a bit weird to me, but it was auto-formatted like that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-semver#prerelease-identifiers