### PR TITLE
Added types for html-webpack-tags-plugin

### DIFF
--- a/types/html-webpack-tags-plugin/html-webpack-tags-plugin-tests.ts
+++ b/types/html-webpack-tags-plugin/html-webpack-tags-plugin-tests.ts
@@ -1,0 +1,19 @@
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+import * as tags from 'html-webpack-tags-plugin';
+
+const optionsArray: tags.Options[] = [
+    {
+        tags: 'tag'
+    },
+    {
+        tags: ['tags', 'hugs'],
+        files: 'readme.txt'
+    },
+    {
+        tags: ['tags', 'hugs'],
+        files: 'readme.txt',
+        append: true
+    }
+];
+
+const plugins: HtmlWebpackPlugin[] = optionsArray.map(options => new HtmlWebpackPlugin(options));

--- a/types/html-webpack-tags-plugin/index.d.ts
+++ b/types/html-webpack-tags-plugin/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for html-webpack-tags-plugin 2.0
 // Project: https://github.com/jharris4/html-webpack-tags-plugin
-// Definitions by: // Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions by: 贺师俊 <https://github.com/hax>
+//                 Vladimir Grenaderov <https://github.com/VladimirGrenaderov>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/html-webpack-tags-plugin/index.d.ts
+++ b/types/html-webpack-tags-plugin/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for html-webpack-tags-plugin 2.0
+// Project: https://github.com/jharris4/html-webpack-tags-plugin
+// Definitions by: // Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack';
+
+export interface Options {
+    tags: string | string[];
+    files?: string | string[];
+    append?: boolean;
+}
+
+export default class HtmlWebpackTagsPlugin extends Plugin {
+    constructor(options: Options);
+}

--- a/types/html-webpack-tags-plugin/index.d.ts
+++ b/types/html-webpack-tags-plugin/index.d.ts
@@ -8,12 +8,16 @@
 
 import { Plugin } from 'webpack';
 
-export interface Options {
-    tags: string | string[];
-    files?: string | string[];
-    append?: boolean;
+declare namespace HtmlWebpackTagsPlugin {
+    interface Options {
+        tags: string | string[];
+        files?: string | string[];
+        append?: boolean;
+    }
+} 
+
+declare class HtmlWebpackTagsPlugin extends Plugin {
+    constructor(options: HtmlWebpackTagsPlugin.Options);
 }
 
-export default class HtmlWebpackTagsPlugin extends Plugin {
-    constructor(options: Options);
-}
+export = HtmlWebpackTagsPlugin;

--- a/types/html-webpack-tags-plugin/index.d.ts
+++ b/types/html-webpack-tags-plugin/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jharris4/html-webpack-tags-plugin
 // Definitions by: // Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import { Plugin } from 'webpack';
 

--- a/types/html-webpack-tags-plugin/index.d.ts
+++ b/types/html-webpack-tags-plugin/index.d.ts
@@ -14,7 +14,7 @@ declare namespace HtmlWebpackTagsPlugin {
         files?: string | string[];
         append?: boolean;
     }
-} 
+}
 
 declare class HtmlWebpackTagsPlugin extends Plugin {
     constructor(options: HtmlWebpackTagsPlugin.Options);

--- a/types/html-webpack-tags-plugin/tsconfig.json
+++ b/types/html-webpack-tags-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-webpack-tags-plugin-tests.ts"
+    ]
+}

--- a/types/html-webpack-tags-plugin/tslint.json
+++ b/types/html-webpack-tags-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
