### PR TITLE
[node-geocoder] Allow for discrimination on options for specific geocoder providers

### DIFF
--- a/types/node-geocoder/index.d.ts
+++ b/types/node-geocoder/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-geocoder 3.24.0
+// Type definitions for node-geocoder 3.24
 // Project: https://github.com/nchaulet/node-geocoder#readme
 // Definitions by: Krzysztof Rosinski <https://github.com/rosek86>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/node-geocoder/index.d.ts
+++ b/types/node-geocoder/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-geocoder 3.19
+// Type definitions for node-geocoder 3.24.0
 // Project: https://github.com/nchaulet/node-geocoder#readme
 // Definitions by: Krzysztof Rosinski <https://github.com/rosek86>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,36 +7,76 @@
 
 declare namespace node_geocoder {
     type Providers =
-        'google' | 'here' | 'freegeoip' |
-        'datasciencetoolkit' | 'openstreetmap' |
+        'freegeoip' | 'datasciencetoolkit' |
         'locationiq' | 'mapquest' | 'openmapquest' |
-        'agol' | 'tomtom' | 'nominatimmapquest' |
-        'opencage' | 'smartyStreet' | 'geocodio' |
-        'yandex' | 'teleport' | 'opendatafrance' |
-        'pickpoint';
+        'tomtom' | 'nominatimmapquest' |
+        'opencage' | 'geocodio' |
+        'yandex' | 'teleport' | 'pickpoint';
 
-    interface Options {
-        provider: Providers;
+    interface BaseOptions {
+        provider: string;
         httpAdapter?: 'https' | 'http' | 'request';
-        clientId?: string;
-        apiKey?: string;
-        language?: string;
-        region?: string;
-        appId?: string;
-        appCode?: string;
-        politicalView?: string;
-        country?: string;
-        state?: string;
-        host?: string;
-        email?: string;
-        client_id?: string;
-        client_secret?: string;
-        auth_id?: string;
-        auth_token?: string;
         timeout?: number;
         formatterPattern?: string;
         formatter?: any;
     }
+
+    interface HereOptions {
+        provider: 'here';
+        appId: string;
+        appCode: string;
+        language?: string;
+        politicalView?: string;
+        country?: string;
+        state?: string;
+        production?: boolean;
+    }
+
+    interface OpenStreetMapOptions {
+        provider: 'openstreetmap';
+        language?: string;
+        email?: string;
+        apiKey?: string;
+        osmServer?: string;
+    }
+
+    interface OpenDataFranceOptions {
+        provider: 'opendatafrance';
+        language?: string;
+        email?: string;
+        apiKey?: string;
+    }
+
+    interface AgolOptions {
+        provider: 'agol';
+        client_id?: string;
+        client_secret?: string;
+    }
+
+    interface SmartyStreetsOptions {
+        provider: 'smartyStreet';
+        auth_id: string;
+        auth_token: string;
+    }
+
+    interface GoogleOptions {
+        provider: 'google';
+        clientId?: string;
+        apiKey?: string;
+        language?: string;
+        region?: string;
+        excludePartialMatches?: boolean;
+        channel?: string;
+    }
+
+    interface GenericOptions {
+        provider: Providers;
+        apiKey?: string;
+        language?: string;
+        host?: string;
+    }
+
+    type Options = BaseOptions & (GenericOptions | HereOptions | OpenStreetMapOptions | OpenDataFranceOptions | AgolOptions | SmartyStreetsOptions | GoogleOptions);
 
     interface Location {
         lat: number;


### PR DESCRIPTION
This allows for clearer identification of which options are required for which provider, including which parameters are mandatory. I only covered the most distinct providers (here, ism, odf, agol, smartystreets, google) as the others are more generic

This also adds the `production` option used in HERE

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nchaulet/node-geocoder/blob/6b1957617215a831777daf864e71113a84ba82b5/lib/geocoder/heregeocoder.js#L10
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.