### PR TITLE
[@types/heremaps] Removes static keyword from H.mapevents.Pointer properties

### DIFF
--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4550,13 +4550,13 @@ declare namespace H {
              * @param opt_buttons {number=} - Indicates which pointer device buttons are being pressed, expressed as a bitmask. Uses the same values, as "buttons" in Pointer Events spec.
              */
             constructor(viewportX: number, viewportY: number, id: number, type: string, opt_button?: H.mapevents.Pointer.Button, opt_buttons?: H.math.BitMask);
-            static viewportX: number;
-            static viewportY: number;
-            static target: (H.map.Object | H.Map);
-            static id: number;
-            static type: string;
-            static dragTarget: (H.map.Object | H.Map);
-            static button: H.mapevents.Pointer.Button;
+            viewportX: number;
+            viewportY: number;
+            target: (H.map.Object | H.Map);
+            id: number;
+            type: string;
+            dragTarget: (H.map.Object | H.Map);
+            button: H.mapevents.Pointer.Button;
         }
 
         namespace Pointer {


### PR DESCRIPTION
Removed static keyword from H.mapevents.Pointer - the HERE documentation seems to be wrong.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [HERE Docs - H.mapevents.Pointer](https://developer.here.com/documentation/maps/topics_api/h-mapevents-pointer.html)
  - [jsfiddle - showing docs are wrong](http://jsfiddle.net/n9tvjfe8/1/)
  - [Twitter - Me to HERE Developers, asking for confirmation](https://twitter.com/andy_mepham/status/1169302068462587904)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

_Edit 1: Added tweet to HERE for them to confirm if the docs are wrong._