### PR TITLE
fix(chai): typesafe `Assert#include` methods

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1588,35 +1588,39 @@ suite('assert', () => {
     });
 
     test('include', () => {
-      assert.include('foobar', 'bar');
-      assert.include([ 1, 2, 3 ], 3);
-      assert.include({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
-      assert.include(new Set([ 1, 2 ]), 2);
-      assert.include(new Map([[ 'a', 1 ], [ 'b', 2 ]]), 2);
+        assert.include('foobar', 'bar');
+        assert.include([ 1, 2, 3 ], 3);
+        assert.include({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
+        assert.include(new Set([ 1, 2 ]), 2);
+        assert.include(new Map([ [ 'a', 1 ], [ 'b', 2 ] ]), 2);
 
-      const a = {};
-      assert.include(new WeakSet([ {}, a ]), a);
+        const a = {};
+        assert.include(new WeakSet([ {}, a ]), a);
     });
 
     test('notInclude', () => {
         assert.notInclude('foobar', 'baz');
-        assert.notInclude([1, 2, 3], 4);
-        assert.notInclude('foobar', 'bar');
-        assert.notInclude(undefined, 'bar');
+        assert.notInclude([ 1, 2, 3 ], 4);
+        assert.notInclude({ a: 1, b: 2, c: 3 }, { a: 6, b: 2 });
+        assert.notInclude(new Set([ 1, 2 ]), 8);
+        assert.notInclude(new WeakSet([ {}, {} ]), {});
+        assert.notInclude(new Map([ [ 'a', 1 ], [ 'b', 2 ] ]), 8);
     });
 
     test('deepInclude', () => {
         assert.deepInclude('foobar', 'bar');
-        assert.deepInclude([1, 2, 3], 3);
-        assert.deepInclude('foobar', 'baz');
-        assert.deepInclude(undefined, 'bar');
+        assert.deepInclude([ 1, { a: 1 }, 3 ], { a: 1 });
+        assert.deepInclude({ a: 1, b: { d: 4 }, c: 3 }, { a: 1, b: { d: 4 } });
+        assert.deepInclude(new Set([ { a: 1 }, { a: 2 } ]), { a: 2 });
+        assert.deepInclude(new Map([ [ 'a', { a: 1 } ], [ 'b', { a: 2 } ] ]), { a: 1 });
     });
 
     test('notDeepInclude', () => {
         assert.notDeepInclude('foobar', 'baz');
-        assert.notDeepInclude([1, 2, 3], 4);
-        assert.notDeepInclude('foobar', 'bar');
-        assert.notDeepInclude(undefined, 'bar');
+        assert.notDeepInclude([ 1, { a: 1 }, 3 ], { a: 3 });
+        assert.notDeepInclude({ a: 1, b: { d: 4 }, c: 3 }, { a: 1, b: { d: 6 } });
+        assert.notDeepInclude(new Set([ { a: 1 }, { a: 2 } ]), { a: 3 });
+        assert.notDeepInclude(new Map([ [ 'a', { a: 1 } ], [ 'b', { a: 2 } ] ]), { a: 8 });
     });
 
     test('nestedInclude', () => {

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1588,10 +1588,14 @@ suite('assert', () => {
     });
 
     test('include', () => {
-        assert.include('foobar', 'bar');
-        assert.include([1, 2, 3], 3);
-        assert.include('foobar', 'baz');
-        assert.include(undefined, 'bar');
+      assert.include('foobar', 'bar');
+      assert.include([ 1, 2, 3 ], 3);
+      assert.include({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
+      assert.include(new Set([ 1, 2 ]), 2);
+      assert.include(new Map([[ 'a', 1 ], [ 'b', 2 ]]), 2);
+
+      const a = {};
+      assert.include(new WeakSet([ {}, a ]), a);
     });
 
     test('notInclude', () => {

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1612,6 +1612,8 @@ suite('assert', () => {
         assert.deepInclude([ 1, { a: 1 }, 3 ], { a: 1 });
         assert.deepInclude({ a: 1, b: { d: 4 }, c: 3 }, { a: 1, b: { d: 4 } });
         assert.deepInclude(new Set([ { a: 1 }, { a: 2 } ]), { a: 2 });
+        // deep include does not support ('cause)[https://github.com/chaijs/chai/blob/7ff12731428ab5d12f1e77e32d6a8d3eb967d082/lib/chai/core/assertions.js#L492]
+        // assert.deepInclude(new WeakSet([ {}, {} ]), {});
         assert.deepInclude(new Map([ [ 'a', { a: 1 } ], [ 'b', { a: 2 } ] ]), { a: 1 });
     });
 
@@ -1620,6 +1622,8 @@ suite('assert', () => {
         assert.notDeepInclude([ 1, { a: 1 }, 3 ], { a: 3 });
         assert.notDeepInclude({ a: 1, b: { d: 4 }, c: 3 }, { a: 1, b: { d: 6 } });
         assert.notDeepInclude(new Set([ { a: 1 }, { a: 2 } ]), { a: 3 });
+        // deep include does not support ('cause)[https://github.com/chaijs/chai/blob/7ff12731428ab5d12f1e77e32d6a8d3eb967d082/lib/chai/core/assertions.js#L492]
+        // assert.notDeepInclude(new WeakSet([ {}, {} ]), {});
         assert.notDeepInclude(new Map([ [ 'a', { a: 1 } ], [ 'b', { a: 2 } ] ]), { a: 8 });
     });
 

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -912,13 +912,35 @@ declare namespace Chai {
         deepInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
-         * Asserts that haystack does not include needle. Can be used to assert the absence of a value in an array or a subset of properties in an object. Deep equality is used.
+         * Asserts that haystack does not includes needle. Deep equality is used.
          *
-         * @param haystack   Container string or array.
-         * @param needle   Potential expected substring of haystack.
+         * @param haystack   Container string.
+         * @param needle   Potential substring of haystack.
+         * @param message   Message to display on error.
+         *
+         * @deprecated Does not have any effect on string. Use {@link Assert#notInclude} instead.
+         */
+        notDeepInclude(haystack: string, needle: string, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle. Deep equality is used.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container array, set or map.
+         * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
-        notDeepInclude(haystack: string | ReadonlyArray<any>, needle: any, message?: string): void;
+        notDeepInclude<T>(haystack: ReadonlyArray<T> | ReadonlySet<T> | ReadonlyMap<any, T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle. Deep equality is used.
+         *
+         * @type T   Type of haystack.
+         * @param haystack   Object.
+         * @param needle   Potential subset of the haystack's properties.
+         * @param message   Message to display on error.
+         */
+        notDeepInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
          * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -909,7 +909,7 @@ declare namespace Chai {
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
          */
-        deepInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
+        deepInclude<T>(haystack: T, needle: T extends WeakSet<any> ? never : Partial<T>, message?: string): void;
 
         /**
          * Asserts that haystack does not includes needle. Deep equality is used.
@@ -940,7 +940,7 @@ declare namespace Chai {
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
          */
-        notDeepInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
+        notDeepInclude<T>(haystack: T, needle: T extends WeakSet<any> ? never : Partial<T>, message?: string): void;
 
         /**
          * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -815,21 +815,11 @@ declare namespace Chai {
          * Asserts that haystack includes needle.
          *
          * @type T   Type of values in haystack.
-         * @param haystack   Container array.
+         * @param haystack   Container array, set or map.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
-        include<T>(haystack: ReadonlyArray<T>, needle: T, message?: string): void;
-
-        /**
-         * Asserts that haystack includes needle.
-         *
-         * @type T   Type of values in haystack.
-         * @param haystack   Container set.
-         * @param needle   Potential value contained in haystack.
-         * @param message   Message to display on error.
-         */
-        include<T>(haystack: ReadonlySet<T>, needle: T, message?: string): void;
+        include<T>(haystack: ReadonlyArray<T> | ReadonlySet<T> | ReadonlyMap<any, T>, needle: T, message?: string): void;
 
         /**
          * Asserts that haystack includes needle.
@@ -840,16 +830,6 @@ declare namespace Chai {
          * @param message   Message to display on error.
          */
         include<T extends object>(haystack: WeakSet<T>, needle: T, message?: string): void;
-
-        /**
-         * Asserts that haystack includes needle.
-         *
-         * @type T   Type of values in haystack.
-         * @param haystack   Container map.
-         * @param needle   Potential value contained in haystack.
-         * @param message   Message to display on error.
-         */
-        include<T>(haystack: ReadonlyMap<any, T>, needle: T, message?: string): void;
 
         /**
          * Asserts that haystack includes needle.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -881,22 +881,35 @@ declare namespace Chai {
         notInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
-         * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.
+         * Asserts that haystack includes needle. Deep equality is used.
          *
          * @param haystack   Container string.
-         * @param needle   Potential expected substring of haystack.
+         * @param needle   Potential substring of haystack.
          * @param message   Message to display on error.
+         *
+         * @deprecated Does not have any effect on string. Use {@link Assert#include} instead.
          */
         deepInclude(haystack: string, needle: string, message?: string): void;
 
         /**
-         * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.
+         * Asserts that haystack includes needle. Deep equality is used.
          *
-         * @param haystack
-         * @param needle
+         * @type T   Type of values in haystack.
+         * @param haystack   Container array, set or map.
+         * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
-        deepInclude<T>(haystack: any, needle: any, message?: string): void;
+        deepInclude<T>(haystack: ReadonlyArray<T> | ReadonlySet<T> | ReadonlyMap<any, T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle.
+         *
+         * @type T   Type of haystack.
+         * @param haystack   Object.
+         * @param needle   Potential subset of the haystack's properties.
+         * @param message   Message to display on error.
+         */
+        deepInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
          * Asserts that haystack does not include needle. Can be used to assert the absence of a value in an array or a subset of properties in an object. Deep equality is used.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -822,13 +822,53 @@ declare namespace Chai {
         include<T>(haystack: ReadonlyArray<T>, needle: T, message?: string): void;
 
         /**
+         * Asserts that haystack includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container set.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        include<T>(haystack: ReadonlySet<T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container WeakSet.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        include<T extends object>(haystack: WeakSet<T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container map.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        include<T>(haystack: ReadonlyMap<any, T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle.
+         *
+         * @type T   Type of haystack.
+         * @param haystack   Object.
+         * @param needle   Potential subset of the haystack's properties.
+         * @param message   Message to display on error.
+         */
+        include<T>(haystack: T, needle: Partial<T>, message?: string): void;
+
+        /**
          * Asserts that haystack does not include needle.
          *
          * @param haystack   Container string or array.
          * @param needle   Potential expected substring of haystack.
          * @param message   Message to display on error.
          */
-        notInclude(haystack: string | ReadonlyArray<any>, needle: any, message?: string): void;
+        notInclude(haystack: string | ReadonlyArray<any> | ReadonlySet<any> | WeakSet<any> | ReadonlyMap<any, any>, needle: any, message?: string): void;
 
         /**
          * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -806,7 +806,7 @@ declare namespace Chai {
          * Asserts that haystack includes needle.
          *
          * @param haystack   Container string.
-         * @param needle   Potential expected substring of haystack.
+         * @param needle   Potential substring of haystack.
          * @param message   Message to display on error.
          */
         include(haystack: string, needle: string, message?: string): void;
@@ -825,7 +825,7 @@ declare namespace Chai {
          * Asserts that haystack includes needle.
          *
          * @type T   Type of values in haystack.
-         * @param haystack   Container WeakSet.
+         * @param haystack   WeakSet container.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
@@ -842,13 +842,43 @@ declare namespace Chai {
         include<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
-         * Asserts that haystack does not include needle.
+         * Asserts that haystack does not includes needle.
          *
-         * @param haystack   Container string or array.
-         * @param needle   Potential expected substring of haystack.
+         * @param haystack   Container string.
+         * @param needle   Potential substring of haystack.
          * @param message   Message to display on error.
          */
-        notInclude(haystack: string | ReadonlyArray<any> | ReadonlySet<any> | WeakSet<any> | ReadonlyMap<any, any>, needle: any, message?: string): void;
+        notInclude(haystack: string, needle: string, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container array, set or map.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        notInclude<T>(haystack: ReadonlyArray<T> | ReadonlySet<T> | ReadonlyMap<any, T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   WeakSet container.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        notInclude<T extends object>(haystack: WeakSet<T>, needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack does not includes needle.
+         *
+         * @type T   Type of haystack.
+         * @param haystack   Object.
+         * @param needle   Potential subset of the haystack's properties.
+         * @param message   Message to display on error.
+         */
+        notInclude<T>(haystack: T, needle: Partial<T>, message?: string): void;
 
         /**
          * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chai/core/assertions.js](https://github.com/chaijs/chai/blob/7ff12731428ab5d12f1e77e32d6a8d3eb967d082/lib/chai/core/assertions.js#L471)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.