### PR TITLE
[@types/jscodeshift] Second (type) parameter for Collection.map should be optional

### DIFF
--- a/types/jscodeshift/src/Collection.d.ts
+++ b/types/jscodeshift/src/Collection.d.ts
@@ -64,7 +64,7 @@ export interface Collection<N>
             i: number,
             paths: Array<ASTPath<N>>
         ) => ASTPath<T> | Array<ASTPath<T>> | null | undefined,
-        type: recast.Type<any>
+        type?: recast.Type<any>
     ): Collection<T>;
 
     /** Returns the number of elements in this collection. */

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -10,6 +10,13 @@ function replaceWithFooTransform(fileInfo: FileInfo, api: API) {
         .toSource();
 }
 
+// Type-force parameter for .map is optional
+function mapSignature(fileInfo: FileInfo, api: API) {
+    return api.jscodeshift(fileInfo.source)
+        .map(p => p)
+        .toSource();
+}
+
 // Can define transform with arrow function, using `Transform` type.
 const reverseIdentifiersTransform: Transform = (file, api) => {
     const j = api.jscodeshift;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * Here is the code for .map, where the `types` parameter is forwarded on to `fromPaths`: https://github.com/facebook/jscodeshift/blob/master/src/Collection.js#L132
  * Here's the code that shows that that `types` parameter is optional: https://github.com/facebook/jscodeshift/blob/master/src/Collection.js#L302
  * Here are JSCodeShift's own tests for .map, which don't provide the second parameter: https://github.com/facebook/jscodeshift/blob/master/src/__tests__/Collection-test.js#L289
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
