### PR TITLE
[express-pino-logger]: add destination argument type

### DIFF
--- a/types/express-pino-logger/express-pino-logger-tests.ts
+++ b/types/express-pino-logger/express-pino-logger-tests.ts
@@ -4,18 +4,31 @@ import expressPinoLogger = require('express-pino-logger');
 
 const server = express();
 
-// no options
+// no arguments
 
 let middleware = expressPinoLogger();
 server.use(middleware);
 
-// pino own options
+// pino options only
 
 const pinoOptions: pino.LoggerOptions = {};
 middleware = expressPinoLogger(pinoOptions);
 server.use(middleware);
 
-// options with existing logger
+// pino destination only
+
+const pinoDestination: pino.DestinationStream = pino.destination('/log/path');
+middleware = expressPinoLogger(pinoDestination);
+server.use(middleware);
+
+// pino options and destination
+
+const pinoOpts: pino.LoggerOptions = {};
+const pinoDest: pino.DestinationStream = pino.destination('/log/path');
+middleware = expressPinoLogger(pinoOpts, pinoDest);
+server.use(middleware);
+
+// existing logger
 
 const logger = pino();
 const optionsWithLogger = { logger };

--- a/types/express-pino-logger/index.d.ts
+++ b/types/express-pino-logger/index.d.ts
@@ -5,9 +5,11 @@
 // TypeScript Version: 2.7
 
 import { Handler } from 'express';
-import { LoggerOptions, Logger } from 'pino';
+import { DestinationStream, LoggerOptions, Logger } from 'pino';
 
-declare function expressPinoLogger(options?: LoggerOptions | { logger?: Logger }): Handler;
+declare function expressPinoLogger(optionsOrStream?: LoggerOptions | DestinationStream | { logger: Logger }): Handler;
+
+declare function expressPinoLogger(options: LoggerOptions, stream: DestinationStream): Handler;
 
 export = expressPinoLogger;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/express-pino-logger#api and https://github.com/pinojs/pino/blob/HEAD/docs/api.md#pinooptions-destination--logger
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
