### PR TITLE
[@types/lodash] returned object from defaults cannot be null/undefiend

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -858,7 +858,7 @@ declare module "../index" {
         defaults(
             object: any,
             ...sources: any[]
-        ): NonNullable<any>;
+        ): any;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -904,7 +904,7 @@ declare module "../index" {
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashImplicitWrapper<NonNullable<any>>;
+        defaults(...sources: any[]): LoDashImplicitWrapper<any>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -950,7 +950,7 @@ declare module "../index" {
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashExplicitWrapper<NonNullable<any>>;
+        defaults(...sources: any[]): LoDashExplicitWrapper<any>;
     }
 
     // defaultsDeep

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -867,7 +867,7 @@ declare module "../index" {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashImplicitWrapper<TSource & TValue>;
+        ): LoDashImplicitWrapper<NotNullable<TSource & TValue>>;
 
         /**
          * @see _.defaults
@@ -875,7 +875,7 @@ declare module "../index" {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitWrapper<TSource2 & TSource1 & TValue>;
+        ): LoDashImplicitWrapper<NotNullable<TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -884,7 +884,7 @@ declare module "../index" {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitWrapper<TSource3 & TSource2 & TSource1 & TValue>;
+        ): LoDashImplicitWrapper<NotNullable<TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -894,17 +894,17 @@ declare module "../index" {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitWrapper<TSource4 & TSource3 & TSource2 & TSource1 & TValue>;
+        ): LoDashImplicitWrapper<NotNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(): LoDashImplicitWrapper<TValue>;
+        defaults(): LoDashImplicitWrapper<NotNullable<TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashImplicitWrapper<any>;
+        defaults(...sources: any[]): LoDashImplicitWrapper<NotNullable<any>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -913,7 +913,7 @@ declare module "../index" {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashExplicitWrapper<TSource & TValue>;
+        ): LoDashExplicitWrapper<NotNullable<TSource & TValue>>;
 
         /**
          * @see _.defaults
@@ -921,7 +921,7 @@ declare module "../index" {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashExplicitWrapper<TSource2 & TSource1 & TValue>;
+        ): LoDashExplicitWrapper<NotNullable<TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -930,7 +930,7 @@ declare module "../index" {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashExplicitWrapper<TSource3 & TSource2 & TSource1 & TValue>;
+        ): LoDashExplicitWrapper<NotNullable<TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -940,17 +940,17 @@ declare module "../index" {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashExplicitWrapper<TSource4 & TSource3 & TSource2 & TSource1 & TValue>;
+        ): LoDashExplicitWrapper<NotNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(): LoDashExplicitWrapper<TValue>;
+        defaults(): LoDashExplicitWrapper<NotNullable<TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashExplicitWrapper<any>;
+        defaults(...sources: any[]): LoDashExplicitWrapper<NotNullable<any>>;
     }
 
     // defaultsDeep

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -815,7 +815,7 @@ declare module "../index" {
         defaults<TObject, TSource>(
             object: TObject,
             source: TSource
-        ): TSource & TObject;
+        ): NonNullable<TSource & TObject>;
 
         /**
          * @see _.defaults
@@ -824,7 +824,7 @@ declare module "../index" {
             object: TObject,
             source1: TSource1,
             source2: TSource2
-        ): TSource2 & TSource1 & TObject;
+        ): NonNullable<TSource2 & TSource1 & TObject>;
 
         /**
          * @see _.defaults
@@ -834,7 +834,7 @@ declare module "../index" {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): TSource3 & TSource2 & TSource1 & TObject;
+        ): NonNullable<TSource3 & TSource2 & TSource1 & TObject>;
 
         /**
          * @see _.defaults
@@ -845,12 +845,12 @@ declare module "../index" {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): TSource4 & TSource3 & TSource2 & TSource1 & TObject;
+        ): NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & TObject>;
 
         /**
          * @see _.defaults
          */
-        defaults<TObject>(object: TObject): TObject;
+        defaults<TObject>(object: TObject): NonNullable<TObject>;
 
         /**
          * @see _.defaults
@@ -858,7 +858,7 @@ declare module "../index" {
         defaults(
             object: any,
             ...sources: any[]
-        ): any;
+        ): NonNullable<any>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -867,7 +867,7 @@ declare module "../index" {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashImplicitWrapper<NotNullable<TSource & TValue>>;
+        ): LoDashImplicitWrapper<NonNullable<TSource & TValue>>;
 
         /**
          * @see _.defaults
@@ -875,7 +875,7 @@ declare module "../index" {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitWrapper<NotNullable<TSource2 & TSource1 & TValue>>;
+        ): LoDashImplicitWrapper<NonNullable<TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -884,7 +884,7 @@ declare module "../index" {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitWrapper<NotNullable<TSource3 & TSource2 & TSource1 & TValue>>;
+        ): LoDashImplicitWrapper<NonNullable<TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -894,17 +894,17 @@ declare module "../index" {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitWrapper<NotNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
+        ): LoDashImplicitWrapper<NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(): LoDashImplicitWrapper<NotNullable<TValue>>;
+        defaults(): LoDashImplicitWrapper<NonNullable<TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashImplicitWrapper<NotNullable<any>>;
+        defaults(...sources: any[]): LoDashImplicitWrapper<NonNullable<any>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -913,7 +913,7 @@ declare module "../index" {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashExplicitWrapper<NotNullable<TSource & TValue>>;
+        ): LoDashExplicitWrapper<NonNullable<TSource & TValue>>;
 
         /**
          * @see _.defaults
@@ -921,7 +921,7 @@ declare module "../index" {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashExplicitWrapper<NotNullable<TSource2 & TSource1 & TValue>>;
+        ): LoDashExplicitWrapper<NonNullable<TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -930,7 +930,7 @@ declare module "../index" {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashExplicitWrapper<NotNullable<TSource3 & TSource2 & TSource1 & TValue>>;
+        ): LoDashExplicitWrapper<NonNullable<TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
@@ -940,17 +940,17 @@ declare module "../index" {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashExplicitWrapper<NotNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
+        ): LoDashExplicitWrapper<NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(): LoDashExplicitWrapper<NotNullable<TValue>>;
+        defaults(): LoDashExplicitWrapper<NonNullable<TValue>>;
 
         /**
          * @see _.defaults
          */
-        defaults(...sources: any[]): LoDashExplicitWrapper<NotNullable<any>>;
+        defaults(...sources: any[]): LoDashExplicitWrapper<NonNullable<any>>;
     }
 
     // defaultsDeep

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -468,16 +468,16 @@ declare namespace _ {
     interface LodashDefaults {
         <TSource>(source: TSource): LodashDefaults1x1<TSource>;
         <TObject>(source: lodash.__, object: TObject): LodashDefaults1x2<TObject>;
-        <TObject, TSource>(source: TSource, object: TObject): TSource & TObject;
+        <TObject, TSource>(source: TSource, object: TObject): NonNullable<TSource & TObject>;
     }
-    type LodashDefaults1x1<TSource> = <TObject>(object: TObject) => TSource & TObject;
-    type LodashDefaults1x2<TObject> = <TSource>(source: TSource) => TSource & TObject;
+    type LodashDefaults1x1<TSource> = <TObject>(object: TObject) => NonNullable<TSource & TObject>;
+    type LodashDefaults1x2<TObject> = <TSource>(source: TSource) => NonNullable<TSource & TObject>;
     interface LodashDefaultsAll {
-        <TObject, TSource>(object: [TObject, TSource]): TSource & TObject;
-        <TObject, TSource1, TSource2>(object: [TObject, TSource1, TSource2]): TSource2 & TSource1 & TObject;
-        <TObject, TSource1, TSource2, TSource3>(object: [TObject, TSource1, TSource2, TSource3]): TSource3 & TSource2 & TSource1 & TObject;
-        <TObject, TSource1, TSource2, TSource3, TSource4>(object: [TObject, TSource1, TSource2, TSource3, TSource4]): TSource4 & TSource3 & TSource2 & TSource1 & TObject;
-        <TObject>(object: [TObject]): TObject;
+        <TObject, TSource>(object: [TObject, TSource]): NonNullable<TSource & TObject>;
+        <TObject, TSource1, TSource2>(object: [TObject, TSource1, TSource2]): NonNullable<TSource2 & TSource1 & TObject>;
+        <TObject, TSource1, TSource2, TSource3>(object: [TObject, TSource1, TSource2, TSource3]): NonNullable<TSource3 & TSource2 & TSource1 & TObject>;
+        <TObject, TSource1, TSource2, TSource3, TSource4>(object: [TObject, TSource1, TSource2, TSource3, TSource4]): NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & TObject>;
+        <TObject>(object: [TObject]): NonNullable<TObject>;
         (object: ReadonlyArray<any>): any;
     }
     interface LodashDefaultsDeep {

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -479,23 +479,23 @@ declare module "../index" {
          * @param sources The source objects.
          * @return The destination object.
          */
-        defaults<TObject, TSource>(object: TObject, source: TSource): TSource & TObject;
+        defaults<TObject, TSource>(object: TObject, source: TSource): NonNullable<TSource & TObject>;
         /**
          * @see _.defaults
          */
-        defaults<TObject, TSource1, TSource2>(object: TObject, source1: TSource1, source2: TSource2): TSource2 & TSource1 & TObject;
+        defaults<TObject, TSource1, TSource2>(object: TObject, source1: TSource1, source2: TSource2): NonNullable<TSource2 & TSource1 & TObject>;
         /**
          * @see _.defaults
          */
-        defaults<TObject, TSource1, TSource2, TSource3>(object: TObject, source1: TSource1, source2: TSource2, source3: TSource3): TSource3 & TSource2 & TSource1 & TObject;
+        defaults<TObject, TSource1, TSource2, TSource3>(object: TObject, source1: TSource1, source2: TSource2, source3: TSource3): NonNullable<TSource3 & TSource2 & TSource1 & TObject>;
         /**
          * @see _.defaults
          */
-        defaults<TObject, TSource1, TSource2, TSource3, TSource4>(object: TObject, source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): TSource4 & TSource3 & TSource2 & TSource1 & TObject;
+        defaults<TObject, TSource1, TSource2, TSource3, TSource4>(object: TObject, source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & TObject>;
         /**
          * @see _.defaults
          */
-        defaults<TObject>(object: TObject): TObject;
+        defaults<TObject>(object: TObject): NonNullable<TObject>;
         /**
          * @see _.defaults
          */
@@ -505,23 +505,23 @@ declare module "../index" {
         /**
          * @see _.defaults
          */
-        defaults<TSource>(source: TSource): Object<TSource & T>;
+        defaults<TSource>(source: TSource): Object<NonNullable<TSource & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2>(source1: TSource1, source2: TSource2): Object<TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2>(source1: TSource1, source2: TSource2): Object<NonNullable<TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2, TSource3>(source1: TSource1, source2: TSource2, source3: TSource3): Object<TSource3 & TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2, TSource3>(source1: TSource1, source2: TSource2, source3: TSource3): Object<NonNullable<TSource3 & TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2, TSource3, TSource4>(source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): Object<TSource4 & TSource3 & TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2, TSource3, TSource4>(source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): Object<NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults(): Object<T>;
+        defaults(): Object<NonNullable<T>>;
         /**
          * @see _.defaults
          */
@@ -531,23 +531,23 @@ declare module "../index" {
         /**
          * @see _.defaults
          */
-        defaults<TSource>(source: TSource): ObjectChain<TSource & T>;
+        defaults<TSource>(source: TSource): ObjectChain<NonNullable<TSource & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2>(source1: TSource1, source2: TSource2): ObjectChain<TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2>(source1: TSource1, source2: TSource2): ObjectChain<NonNullable<TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2, TSource3>(source1: TSource1, source2: TSource2, source3: TSource3): ObjectChain<TSource3 & TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2, TSource3>(source1: TSource1, source2: TSource2, source3: TSource3): ObjectChain<NonNullable<TSource3 & TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults<TSource1, TSource2, TSource3, TSource4>(source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): ObjectChain<TSource4 & TSource3 & TSource2 & TSource1 & T>;
+        defaults<TSource1, TSource2, TSource3, TSource4>(source1: TSource1, source2: TSource2, source3: TSource3, source4: TSource4): ObjectChain<NonNullable<TSource4 & TSource3 & TSource2 & TSource1 & T>>;
         /**
          * @see _.defaults
          */
-        defaults(): ObjectChain<T>;
+        defaults(): ObjectChain<NonNullable<T>>;
         /**
          * @see _.defaults
          */


### PR DESCRIPTION
According to the docs and the source code, the returned object from `defaults` is never going to be null or undefined.

I can see there are multiple lodash object definitions, but to be honest I'm not too sure which one I should change, so I changed them all