### PR TITLE
[ramda] split tests to separate modules - functions beginning with 'a'

### DIFF
--- a/types/ramda/README.md
+++ b/types/ramda/README.md
@@ -1,0 +1,39 @@
+# @types/ramda
+
+## Contributing
+
+`ramda` is a popular library with a plethora of functions that can be mixed and matched in thousands of ways. Because of this, it can be a challenge to make changes to its types without breaking something. While sometimes breaking-changes are appropriate, we hope to keep them to a minimum.
+
+**Please read this guide in its entirety.** Doing so helps ensure that the only breaking changes will be those that bring `@types/ramda` closer to representing the behavior of the underlying `ramda` package.
+
+### Tests
+
+Tests are located in the `test/` directory. Each ramda function has its own test file, named `<function>-tests.ts`. When editing types for a function, please update the corresponding tests to prove that the behavior you seek actually works. When adding a new function, add a corresponding test file with as many tests as you can to detail the function's behavior.
+
+As a rule, the goal of each test file is to prove that the corresponding function's input and output types are correct. As such, each test file should only test its corresponding function as the top-most call.
+
+For instance, the following:
+
+```ts
+R.pipe(
+  R.add(2),
+  R.add(3),
+  R.add(4),
+);
+```
+
+tests `R.pipe`, _not_ `R.add`. So it belongs in `test/pipe-tests.ts` rather than `test/map-tests.ts`.
+
+Use [`$ExpectType`](https://github.com/microsoft/dtslint/blob/43859c39/README.md#write-tests) comments to test that a function returns the correct type:
+
+```ts
+// $ExpectType string[]
+R.map((n: number) => n.toString(), [1, 2, 3]);
+```
+
+Use [`$ExpectError`](https://github.com/microsoft/dtslint/blob/43859c39/README.md#write-tests) comments to test that using a function a certain way should result in a compiler error:
+
+```ts
+// $ExpectError
+R.map((n: number) => n.toString(), ['1', '2', '3']);
+```

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -681,13 +681,6 @@ R.times(i, 5);
  * List category
  */
 () => {
-    const lessThan2 = R.flip(R.lt)(2);
-    const lessThan3 = R.flip(R.lt)(3);
-    R.all(lessThan2)([1, 2]); // => false
-    R.all(lessThan3)([1, 2]); // => true
-};
-
-() => {
     const lessThan0 = R.flip(R.lt)(0);
     const lessThan2 = R.flip(R.lt)(2);
     R.any(lessThan0)([1, 2]); // => false

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -616,7 +616,6 @@ R.times(i, 5);
 });
 
 (() => {
-    const a: number[]   = R.ap([R.multiply(2), R.add(3)], [1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
     const b: number[][] = R.of([1]); // => [[1]]
     const c: number[]   = R.of(1);
 });
@@ -2128,12 +2127,6 @@ class Rectangle {
 
 () => {
     const a: number[] = R.without([1, 2], [1, 2, 1, 3, 4]); // => [3, 4]
-};
-
-() => {
-    const x: number[] = R.ap([R.multiply(2), R.add(3)], [1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
-    const y: number[] = R.ap([R.multiply(2), R.add(3)])([1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
-    const z: string = R.ap<string, string, string>(R.concat, R.toUpper)('Ramda'); // => 'RamdaRAMDA'
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -582,10 +582,6 @@ R.times(i, 5);
 })();
 
 (() => {
-    const plus3 = R.add(3);
-})();
-
-(() => {
     const pairs = [["a", 1], ["b", 2], ["c", 3]];
 
     function flattenPairs(pair: [string, number], acc: Array<string|number>): Array<string|number> {
@@ -2503,13 +2499,6 @@ class Rectangle {
     R.startsWith(1)([1, 2, 3]);   // => true
     R.startsWith([1], [1, 2, 3]);   // => true
     R.startsWith([1])([1, 2, 3]);   // => true
-};
-
-() => {
-    R.add(2, 3);       // =>  5
-    R.add(7)(10);      // => 17
-    R.add("Hello", " World");  // =>  "Hello World"
-    R.add("Hello")(" World");  // =>  "Hello World"
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1533,20 +1533,6 @@ type Pair = KeyValuePair<string, number>;
 /*****************************************************************
  * Object category
  */
-() => {
-    interface ABC { a: number; b: number; c: number; }
-    const a: ABC = R.assoc("c", 3, {a: 1, b: 2}); // => {a: 1, b: 2, c: 3}
-    const b: ABC = R.assoc("c")(3, {a: 1, b: 2}); // => {a: 1, b: 2, c: 3}
-    const c: ABC = R.assoc("c", 3)({a: 1, b: 2}); // => {a: 1, b: 2, c: 3}
-    const d: ABC = R.assoc(R.__, 3, {a: 1, b: 2})("c"); // => {a: 1, b: 2, c: 3}
-    const e: ABC = R.assoc("c", R.__, {a: 1, b: 2})(3); // => {a: 1, b: 2, c: 3}
-};
-
-() => {
-    type ABC = Record<string, string>;
-    const b: ABC = R.compose(R.assoc, R.toString)(3)("c", {1: "a", 2: "b"}); // => {1: "a", 2: "b", 3: "c"}
-    const c: ABC = R.compose(R.assoc, R.toString)(3)("c")({1: "a", 2: "b"}); // => {1: "a", 2: "b", 3: "c"}
-};
 
 () => {
     const a1 = R.dissoc<{ a: number, c: number }>("b", {a: 1, b: 2, c: 3}); // => {a: 1, c: 3}

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -637,16 +637,8 @@ R.times(i, 5);
         return n % 2 === 0;
     }
 
-    const filterIndexed = R.addIndex(R.filter);
-
     R.filter(isEven, [1, 2, 3, 4]); // => [2, 4]
     R.filter(isEven, { a: 0, b: 1 }); // => { a: 0 }
-
-    function lastTwo(val: number, idx: number, list: number[]) {
-        return list.length - idx <= 2;
-    }
-
-    filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [0, 9]
 
     function isOdd(n: number) {
         return n % 2 === 1;
@@ -841,18 +833,6 @@ R.times(i, 5);
 };
 
 () => {
-    function lastTwo(val: number, idx: number, list: number[]) {
-        return list.length - idx <= 2;
-    }
-
-    const filterIndexed = R.addIndex(R.filter);
-
-    filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [0, 9]
-    const lastTwoFn = filterIndexed(lastTwo);
-    lastTwoFn([8, 6, 7, 5, 3, 0, 9]);
-};
-
-() => {
     const xs = [{a: 1}, {a: 2}, {a: 3}];
     R.find(R.propEq("a", 2))(xs); // => {a: 2}
     R.find(R.propEq("a", 4))(xs); // => undefined
@@ -953,14 +933,6 @@ interface Obj {
     // -> 6
     // -> 7
     // -> 8
-};
-
-() => {
-    function plusFive(num: number, idx: number, list: number[]) {
-        list[idx] = num + 5;
-    }
-
-    R.addIndex(R.forEach)(plusFive)([1, 2, 3]); // => [6, 7, 8]
 };
 
 () => {
@@ -1181,18 +1153,6 @@ interface Obj {
 };
 
 () => {
-    function squareEnds(elt: number, idx: number, list: number[]) {
-        if (idx === 0 || idx === list.length - 1) {
-            return elt * elt;
-        }
-        return elt;
-    }
-
-    R.addIndex(R.map)(squareEnds, [8, 5, 3, 0, 9]); // => [64, 5, 3, 0, 81]
-    R.addIndex(R.map)(squareEnds)([8, 5, 3, 0, 9]); // => [64, 5, 3, 0, 81]
-};
-
-() => {
     const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
 
     R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
@@ -1278,20 +1238,6 @@ interface Student {
     // }
 };
 
-() => {
-    const reduceIndexed = R.addIndex(R.reduce);
-    const letters       = ["a", "b", "c"];
-
-    function objectify(accObject: { [elem: string]: number }, elem: string, idx: number, list: string[]) {
-        accObject[elem] = idx;
-        return accObject;
-    }
-
-    reduceIndexed(objectify, {}, letters); // => { 'a': 0, 'b': 1, 'c': 2 }
-    reduceIndexed(objectify)({}, letters); // => { 'a': 0, 'b': 1, 'c': 2 }
-    reduceIndexed(objectify, {})(letters); // => { 'a': 0, 'b': 1, 'c': 2 }
-};
-
 interface KeyValuePair<K, V> extends Array<K | V> {
     0: K;
     1: V;
@@ -1341,16 +1287,6 @@ type Pair = KeyValuePair<string, number>;
 
     R.reject(isOdd, [1, 2, 3, 4]); // => [2, 4]
     R.reject(isOdd)([1, 2, 3, 4]); // => [2, 4]
-};
-
-() => {
-    function lastTwo(val: number, idx: number, list: number[]) {
-        return list.length - idx <= 2;
-    }
-
-    const rejectIndexed = R.addIndex(R.reject);
-    rejectIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [8, 6, 7, 5, 3]
-    rejectIndexed(lastTwo)([8, 6, 7, 5, 3, 0, 9]); // => [8, 6, 7, 5, 3]
 };
 
 () => {
@@ -2206,20 +2142,6 @@ class Rectangle {
 
 () => {
     const a: number[] = R.without([1, 2], [1, 2, 1, 3, 4]); // => [3, 4]
-};
-
-() => {
-    const mapIndexed = R.addIndex(R.map);
-    mapIndexed((val: string, idx: number) => `${idx}-${val}`)(["f", "o", "o", "b", "a", "r"]);
-    // => ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
-    mapIndexed((rectangle: Rectangle, idx: number): number => rectangle.area() * idx, [new Rectangle(1, 2), new Rectangle(4, 7)]);
-    // => [2, 56]
-};
-
-() => {
-    const reduceIndexed = R.addIndex(R.reduce);
-    reduceIndexed((acc: string, val: string, idx: number) => `${acc},${idx}-${val}`, "", ["f", "o", "o", "b", "a", "r"]);
-    // => ['0-f,1-o,2-o,3-b,4-a,5-r']
 };
 
 () => {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2681,19 +2681,6 @@ class Rectangle {
 /*****************************************************************
  * Logic category
  */
-() => {
-    function gt10(x: number) {
-        return x > 10;
-    }
-
-    function even(x: number) {
-        return x % 2 === 0;
-    }
-
-    const f = R.allPass([gt10, even]);
-    f(11); // => false
-    f(12); // => true
-};
 
 () => {
     R.and(false, true); // => false

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2678,21 +2678,6 @@ class Rectangle {
  */
 
 () => {
-    R.and(false, true); // => false
-    R.and(0, []); // => 0
-    R.and(0)([]); // => 0
-    R.and(null, ""); // => null
-    const Why: any = ((val: boolean) => {
-        const why = {} as any;
-        why.val = val;
-        why.and = function(x: boolean) { return this.val && x; };
-        return Why;
-    })(true);
-    const why      = new Why(true);
-    R.and(why, false); // false
-};
-
-() => {
     function gt10(x: number) {
         return x > 10;
     }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2114,12 +2114,6 @@ class Rectangle {
 };
 
 () => {
-    const nums = [1, 2, 3, -99, 42, 6, 7];
-    R.apply(Math.max, nums); // => 42
-    R.apply(Math.max)(nums); // => 42
-};
-
-() => {
     interface T { sum: number; nested: { mul: number; }; }
     const getMetrics = R.applySpec<T>({
         sum: R.add, nested: {mul: R.multiply}

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2138,11 +2138,6 @@ class Rectangle {
 };
 
 () => {
-    const t           = R.always("Tee");
-    const x: string = t(); // => 'Tee'
-};
-
-() => {
     const x: number[] = R.ap([R.multiply(2), R.add(3)], [1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
     const y: number[] = R.ap([R.multiply(2), R.add(3)])([1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
     const z: string = R.ap<string, string, string>(R.concat, R.toUpper)('Ramda'); // => 'RamdaRAMDA'

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2114,18 +2114,6 @@ class Rectangle {
 };
 
 () => {
-    interface T { sum: number; nested: { mul: number; }; }
-    const getMetrics = R.applySpec<T>({
-        sum: R.add, nested: {mul: R.multiply}
-    });
-    const result     = getMetrics(2, 4); // => { sum: 6, nested: { mul: 8 } }
-    const record: { s: string; n: number } = R.applySpec({
-        s: (s: string, n: number) => s,
-        n: (s: string, n: number) => n,
-    })('1', 2);
-};
-
-() => {
     function takesThreeArgs(a: number, b: number, c: number) {
         return [a, b, c];
     }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -680,16 +680,6 @@ R.times(i, 5);
  * List category
  */
 () => {
-    R.aperture(2, [1, 2, 3, 4, 5]); // => [[1, 2], [2, 3], [3, 4], [4, 5]]
-    R.aperture(3, [1, 2, 3, 4, 5]); // => [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
-    R.aperture(7, [1, 2, 3, 4, 5]); // => []
-    R.aperture(7)([1, 2, 3, 4, 5]); // => []
-
-    const res1: Array<[number, number]> = R.aperture(2, [1, 2, 3, 4, 5]);
-    const res2: number[][] = R.aperture(11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-};
-
-() => {
     R.append("tests", ["write", "more"]); // => ['write', 'more', 'tests']
     R.append("tests")(["write", "more"]); // => ['write', 'more', 'tests']
     R.append("tests", []); // => ['tests']

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1541,18 +1541,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const testPath = ["x", 0, "y"];
-    const testObj  = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
-
-    R.assocPath(R.__, 42, testObj)(testPath); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-    R.assocPath(testPath, R.__, testObj)(42); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-    R.assocPath(testPath, 42, testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-    R.assocPath(testPath, 42)(testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-    R.assocPath(testPath)(42)(testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-    R.assocPath(testPath)(42, testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
-};
-
-() => {
     const a1 = R.dissocPath(["a", "b", "c"], {a: {b: {c: 42}}}); // => {a: {b: {}}}
     // optionally specify return type
     const a2 = R.dissocPath<{ a: { b: number } }>(["a", "b", "c"], {a: {b: {c: 42}}}); // => {a: {b: {}}}

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -680,12 +680,6 @@ R.times(i, 5);
  * List category
  */
 () => {
-    R.append("tests", ["write", "more"]); // => ['write', 'more', 'tests']
-    R.append("tests")(["write", "more"]); // => ['write', 'more', 'tests']
-    R.append("tests", []); // => ['tests']
-};
-
-() => {
     function duplicate(n: number) {
         return [n, n];
     }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2679,23 +2679,6 @@ class Rectangle {
         return x % 2 === 0;
     }
 
-    const f = R.anyPass([gt10, even]);
-    f(11); // => true
-    f(8); // => true
-    f(9); // => false
-
-    const f2 = R.anyPass<number>([gt10, even]);
-};
-
-() => {
-    function gt10(x: number) {
-        return x > 10;
-    }
-
-    function even(x: number) {
-        return x % 2 === 0;
-    }
-
     const f = R.both(gt10, even);
     const g = R.both(gt10)(even);
     f(100); // => true

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -681,13 +681,6 @@ R.times(i, 5);
  * List category
  */
 () => {
-    const lessThan0 = R.flip(R.lt)(0);
-    const lessThan2 = R.flip(R.lt)(2);
-    R.any(lessThan0)([1, 2]); // => false
-    R.any(lessThan2)([1, 2]); // => true
-};
-
-() => {
     R.aperture(2, [1, 2, 3, 4, 5]); // => [[1, 2], [2, 3], [3, 4], [4, 5]]
     R.aperture(3, [1, 2, 3, 4, 5]); // => [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
     R.aperture(7, [1, 2, 3, 4, 5]); // => []

--- a/types/ramda/test/add-tests.ts
+++ b/types/ramda/test/add-tests.ts
@@ -1,0 +1,12 @@
+import * as R from 'ramda';
+
+(() => {
+  const plus3 = R.add(3);
+})();
+
+() => {
+  R.add(2, 3); // =>  5
+  R.add(7)(10); // => 17
+  R.add('Hello', ' World'); // =>  "Hello World"
+  R.add('Hello')(' World'); // =>  "Hello World"
+};

--- a/types/ramda/test/addIndex-tests.ts
+++ b/types/ramda/test/addIndex-tests.ts
@@ -1,0 +1,111 @@
+import * as R from 'ramda';
+
+class Rectangle {
+  constructor(public width: number, public height: number) {
+    this.width = width;
+    this.height = height;
+  }
+
+  area(): number {
+    return this.width * this.height;
+  }
+}
+
+() => {
+  const filterIndexed = R.addIndex(R.filter);
+
+  function lastTwo(val: number, idx: number, list: number[]) {
+    return list.length - idx <= 2;
+  }
+
+  filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [0, 9]
+};
+
+() => {
+  function lastTwo(val: number, idx: number, list: number[]) {
+    return list.length - idx <= 2;
+  }
+
+  const filterIndexed = R.addIndex(R.filter);
+
+  filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [0, 9]
+  const lastTwoFn = filterIndexed(lastTwo);
+  lastTwoFn([8, 6, 7, 5, 3, 0, 9]);
+};
+
+() => {
+  function plusFive(num: number, idx: number, list: number[]) {
+    list[idx] = num + 5;
+  }
+
+  R.addIndex(R.forEach)(plusFive)([1, 2, 3]); // => [6, 7, 8]
+};
+
+() => {
+  function squareEnds(elt: number, idx: number, list: number[]) {
+    if (idx === 0 || idx === list.length - 1) {
+      return elt * elt;
+    }
+    return elt;
+  }
+
+  R.addIndex(R.map)(squareEnds, [8, 5, 3, 0, 9]); // => [64, 5, 3, 0, 81]
+  R.addIndex(R.map)(squareEnds)([8, 5, 3, 0, 9]); // => [64, 5, 3, 0, 81]
+};
+
+() => {
+  const reduceIndexed = R.addIndex(R.reduce);
+  const letters = ['a', 'b', 'c'];
+
+  function objectify(
+    accObject: { [elem: string]: number },
+    elem: string,
+    idx: number,
+    list: string[],
+  ) {
+    accObject[elem] = idx;
+    return accObject;
+  }
+
+  reduceIndexed(objectify, {}, letters); // => { 'a': 0, 'b': 1, 'c': 2 }
+  reduceIndexed(objectify)({}, letters); // => { 'a': 0, 'b': 1, 'c': 2 }
+  reduceIndexed(objectify, {})(letters); // => { 'a': 0, 'b': 1, 'c': 2 }
+};
+
+() => {
+  function lastTwo(val: number, idx: number, list: number[]) {
+    return list.length - idx <= 2;
+  }
+
+  const rejectIndexed = R.addIndex(R.reject);
+  rejectIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); // => [8, 6, 7, 5, 3]
+  rejectIndexed(lastTwo)([8, 6, 7, 5, 3, 0, 9]); // => [8, 6, 7, 5, 3]
+};
+
+() => {
+  const mapIndexed = R.addIndex(R.map);
+  mapIndexed((val: string, idx: number) => `${idx}-${val}`)([
+    'f',
+    'o',
+    'o',
+    'b',
+    'a',
+    'r',
+  ]);
+  // => ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
+  mapIndexed(
+    (rectangle: Rectangle, idx: number): number => rectangle.area() * idx,
+    [new Rectangle(1, 2), new Rectangle(4, 7)],
+  );
+  // => [2, 56]
+};
+
+() => {
+  const reduceIndexed = R.addIndex(R.reduce);
+  reduceIndexed(
+    (acc: string, val: string, idx: number) => `${acc},${idx}-${val}`,
+    '',
+    ['f', 'o', 'o', 'b', 'a', 'r'],
+  );
+  // => ['0-f,1-o,2-o,3-b,4-a,5-r']
+};

--- a/types/ramda/test/all-tests.ts
+++ b/types/ramda/test/all-tests.ts
@@ -1,0 +1,8 @@
+import * as R from 'ramda';
+
+() => {
+  const lessThan2 = R.flip(R.lt)(2);
+  const lessThan3 = R.flip(R.lt)(3);
+  R.all(lessThan2)([1, 2]); // => false
+  R.all(lessThan3)([1, 2]); // => true
+};

--- a/types/ramda/test/allPass-tests.ts
+++ b/types/ramda/test/allPass-tests.ts
@@ -1,0 +1,15 @@
+import * as R from 'ramda';
+
+() => {
+  function gt10(x: number) {
+    return x > 10;
+  }
+
+  function even(x: number) {
+    return x % 2 === 0;
+  }
+
+  const f = R.allPass([gt10, even]);
+  f(11); // => false
+  f(12); // => true
+};

--- a/types/ramda/test/always-tests.ts
+++ b/types/ramda/test/always-tests.ts
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+() => {
+  const t = R.always('Tee');
+  const x: string = t(); // => 'Tee'
+};

--- a/types/ramda/test/and-tests.ts
+++ b/types/ramda/test/and-tests.ts
@@ -1,0 +1,18 @@
+import * as R from 'ramda';
+
+() => {
+  R.and(false, true); // => false
+  R.and(0, []); // => 0
+  R.and(0)([]); // => 0
+  R.and(null, ''); // => null
+  const Why: any = ((val: boolean) => {
+    const why = {} as any;
+    why.val = val;
+    why.and = function(x: boolean) {
+      return this.val && x;
+    };
+    return Why;
+  })(true);
+  const why = new Why(true);
+  R.and(why, false); // false
+};

--- a/types/ramda/test/any-tests.ts
+++ b/types/ramda/test/any-tests.ts
@@ -1,0 +1,8 @@
+import * as R from 'ramda';
+
+() => {
+  const lessThan0 = R.flip(R.lt)(0);
+  const lessThan2 = R.flip(R.lt)(2);
+  R.any(lessThan0)([1, 2]); // => false
+  R.any(lessThan2)([1, 2]); // => true
+};

--- a/types/ramda/test/anyPass-tests.ts
+++ b/types/ramda/test/anyPass-tests.ts
@@ -1,0 +1,18 @@
+import * as R from 'ramda';
+
+() => {
+  function gt10(x: number) {
+    return x > 10;
+  }
+
+  function even(x: number) {
+    return x % 2 === 0;
+  }
+
+  const f = R.anyPass([gt10, even]);
+  f(11); // => true
+  f(8); // => true
+  f(9); // => false
+
+  const f2 = R.anyPass<number>([gt10, even]);
+};

--- a/types/ramda/test/ap-tests.ts
+++ b/types/ramda/test/ap-tests.ts
@@ -1,0 +1,11 @@
+import * as R from 'ramda';
+
+() => {
+  const a: number[] = R.ap([R.multiply(2), R.add(3)], [1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
+};
+
+() => {
+  const x: number[] = R.ap([R.multiply(2), R.add(3)], [1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
+  const y: number[] = R.ap([R.multiply(2), R.add(3)])([1, 2, 3]); // => [2, 4, 6, 4, 5, 6]
+  const z: string = R.ap<string, string, string>(R.concat, R.toUpper)('Ramda'); // => 'RamdaRAMDA'
+};

--- a/types/ramda/test/aperture-tests.ts
+++ b/types/ramda/test/aperture-tests.ts
@@ -1,0 +1,14 @@
+import * as R from 'ramda';
+
+() => {
+  R.aperture(2, [1, 2, 3, 4, 5]); // => [[1, 2], [2, 3], [3, 4], [4, 5]]
+  R.aperture(3, [1, 2, 3, 4, 5]); // => [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+  R.aperture(7, [1, 2, 3, 4, 5]); // => []
+  R.aperture(7)([1, 2, 3, 4, 5]); // => []
+
+  const res1: Array<[number, number]> = R.aperture(2, [1, 2, 3, 4, 5]);
+  const res2: number[][] = R.aperture(
+    11,
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+  );
+};

--- a/types/ramda/test/append-tests.ts
+++ b/types/ramda/test/append-tests.ts
@@ -1,0 +1,7 @@
+import * as R from 'ramda';
+
+() => {
+  R.append('tests', ['write', 'more']); // => ['write', 'more', 'tests']
+  R.append('tests')(['write', 'more']); // => ['write', 'more', 'tests']
+  R.append('tests', []); // => ['tests']
+};

--- a/types/ramda/test/apply-tests.ts
+++ b/types/ramda/test/apply-tests.ts
@@ -1,0 +1,7 @@
+import * as R from 'ramda';
+
+() => {
+  const nums = [1, 2, 3, -99, 42, 6, 7];
+  R.apply(Math.max, nums); // => 42
+  R.apply(Math.max)(nums); // => 42
+};

--- a/types/ramda/test/applySpec-tests.ts
+++ b/types/ramda/test/applySpec-tests.ts
@@ -1,0 +1,17 @@
+import * as R from 'ramda';
+
+() => {
+  interface T {
+    sum: number;
+    nested: { mul: number };
+  }
+  const getMetrics = R.applySpec<T>({
+    sum: R.add,
+    nested: { mul: R.multiply },
+  });
+  const result = getMetrics(2, 4); // => { sum: 6, nested: { mul: 8 } }
+  const record: { s: string; n: number } = R.applySpec({
+    s: (s: string, n: number) => s,
+    n: (s: string, n: number) => n,
+  })('1', 2);
+};

--- a/types/ramda/test/assoc-tests.ts
+++ b/types/ramda/test/assoc-tests.ts
@@ -1,0 +1,26 @@
+import * as R from 'ramda';
+
+() => {
+  interface ABC {
+    a: number;
+    b: number;
+    c: number;
+  }
+  const a: ABC = R.assoc('c', 3, { a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
+  const b: ABC = R.assoc('c')(3, { a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
+  const c: ABC = R.assoc('c', 3)({ a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
+  const d: ABC = R.assoc(R.__, 3, { a: 1, b: 2 })('c'); // => {a: 1, b: 2, c: 3}
+  const e: ABC = R.assoc('c', R.__, { a: 1, b: 2 })(3); // => {a: 1, b: 2, c: 3}
+};
+
+() => {
+  type ABC = Record<string, string>;
+  const b: ABC = R.compose(
+    R.assoc,
+    R.toString,
+  )(3)('c', { 1: 'a', 2: 'b' }); // => {1: "a", 2: "b", 3: "c"}
+  const c: ABC = R.compose(
+    R.assoc,
+    R.toString,
+  )(3)('c')({ 1: 'a', 2: 'b' }); // => {1: "a", 2: "b", 3: "c"}
+};

--- a/types/ramda/test/assocPath-tests.ts
+++ b/types/ramda/test/assocPath-tests.ts
@@ -1,0 +1,13 @@
+import * as R from 'ramda';
+
+() => {
+  const testPath = ['x', 0, 'y'];
+  const testObj = { x: [{ y: 2, z: 3 }, { y: 4, z: 5 }] };
+
+  R.assocPath(R.__, 42, testObj)(testPath); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+  R.assocPath(testPath, R.__, testObj)(42); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+  R.assocPath(testPath, 42, testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+  R.assocPath(testPath, 42)(testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+  R.assocPath(testPath)(42)(testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+  R.assocPath(testPath)(42, testObj); // => {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+};

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -28,6 +28,7 @@
         "test/always-tests.ts",
         "test/and-tests.ts",
         "test/any-tests.ts",
-        "test/anyPass-tests.ts"
+        "test/anyPass-tests.ts",
+        "test/ap-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -30,6 +30,7 @@
         "test/any-tests.ts",
         "test/anyPass-tests.ts",
         "test/ap-tests.ts",
-        "test/aperture-tests.ts"
+        "test/aperture-tests.ts",
+        "test/append-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -32,6 +32,7 @@
         "test/ap-tests.ts",
         "test/aperture-tests.ts",
         "test/append-tests.ts",
-        "test/apply-tests.ts"
+        "test/apply-tests.ts",
+        "test/applySpec-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -31,6 +31,7 @@
         "test/anyPass-tests.ts",
         "test/ap-tests.ts",
         "test/aperture-tests.ts",
-        "test/append-tests.ts"
+        "test/append-tests.ts",
+        "test/apply-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -25,6 +25,7 @@
         "test/addIndex-tests.ts",
         "test/all-tests.ts",
         "test/allPass-tests.ts",
-        "test/always-tests.ts"
+        "test/always-tests.ts",
+        "test/and-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "tools.d.ts",
-        "ramda-tests.ts"
+        "ramda-tests.ts",
+        "test/add-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -21,6 +21,7 @@
         "index.d.ts",
         "tools.d.ts",
         "ramda-tests.ts",
-        "test/add-tests.ts"
+        "test/add-tests.ts",
+        "test/addIndex-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -27,6 +27,7 @@
         "test/allPass-tests.ts",
         "test/always-tests.ts",
         "test/and-tests.ts",
-        "test/any-tests.ts"
+        "test/any-tests.ts",
+        "test/anyPass-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -24,6 +24,7 @@
         "test/add-tests.ts",
         "test/addIndex-tests.ts",
         "test/all-tests.ts",
-        "test/allPass-tests.ts"
+        "test/allPass-tests.ts",
+        "test/always-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -33,6 +33,7 @@
         "test/aperture-tests.ts",
         "test/append-tests.ts",
         "test/apply-tests.ts",
-        "test/applySpec-tests.ts"
+        "test/applySpec-tests.ts",
+        "test/assoc-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -22,6 +22,7 @@
         "tools.d.ts",
         "ramda-tests.ts",
         "test/add-tests.ts",
-        "test/addIndex-tests.ts"
+        "test/addIndex-tests.ts",
+        "test/all-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -26,6 +26,7 @@
         "test/all-tests.ts",
         "test/allPass-tests.ts",
         "test/always-tests.ts",
-        "test/and-tests.ts"
+        "test/and-tests.ts",
+        "test/any-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -29,6 +29,7 @@
         "test/and-tests.ts",
         "test/any-tests.ts",
         "test/anyPass-tests.ts",
-        "test/ap-tests.ts"
+        "test/ap-tests.ts",
+        "test/aperture-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -23,6 +23,7 @@
         "ramda-tests.ts",
         "test/add-tests.ts",
         "test/addIndex-tests.ts",
-        "test/all-tests.ts"
+        "test/all-tests.ts",
+        "test/allPass-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -34,6 +34,7 @@
         "test/append-tests.ts",
         "test/apply-tests.ts",
         "test/applySpec-tests.ts",
-        "test/assoc-tests.ts"
+        "test/assoc-tests.ts",
+        "test/assocPath-tests.ts"
     ]
 }


### PR DESCRIPTION
This is an alternative to #37710, which itself is an alternative to #37636. This PR aims to be easier to review than #37710 by migrating only a small subset of the tests.

I recommend looking at each commit individually. The first commit is the README, which would be good to read to get a feel for why I broke up the tests the way I did. The remaining 15 commits are each fairly small and every line removed from `ramda-tests.ts` should show up in a separate file with the (possible) exception of some duplicate tests that I found along the way.

Unlike #37710, which migrated _all_ tests to separate files, this just migrates tests for ramda functions that begin with the letter 'a'. It also adds a `README.md` to guide contributors towards writing meaningful tests for the `@types/ramda` package.

Unlike #37636, no changes were made to `types/ramda/index.d.ts`, and no additional assertions were added to the tests, nor were existing tests modified beyond being moved to a separate file. This PR just splits out each functions' tests into separate files.

The added readme lays one ground rule for the tests: that each test file should only contain tests where the outermost function called is the one which shares the name of the file. For instance, the following:

```ts
// $ExpectType (x: number) => number
R.pipe(
  R.add(2),
  R.add(3),
  R.add(4),
);
```

tests `R.pipe`, _not_ `R.add`. So it belongs in `test/pipe-tests.ts` rather than `test/add-tests.ts`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
