### PR TITLE
[@types/react] Improve type of useState when storing functions

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -21,7 +21,7 @@
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.6
 
 /// <reference path="global.d.ts" />
 
@@ -796,7 +796,8 @@ declare namespace React {
     // based on the code in https://github.com/facebook/react/pull/13968
 
     // Unlike the class component setState, the updates are not allowed to be partial
-    type SetStateAction<S> = S | ((prevState: S) => S);
+    // tslint:disable-next-line:ban-types
+    type SetStateAction<S> = ((prevState: S) => S) | (S extends Function ? never : S);
     // this technically does accept a second argument, but it's already under a deprecation warning
     // and it's not even released so probably better to not define it.
     type Dispatch<A> = (value: A) => void;
@@ -833,7 +834,8 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    // tslint:disable-next-line:ban-types
+    function useState<S>(initialState: (() => S) | (S extends Function ? never : S)): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is ommitted
     /**
      * Returns a stateful value, and a function to update it.

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -208,6 +208,20 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // make sure setState accepts a function
     setToggle(r => !r);
 
+    // when storing a function in state, don't allow passing a function of such type as the initial value
+    // $ExpectError
+    React.useState<() => number>(() => 42);
+    // But do allow a higher-order function
+    React.useState<() => number>(() => () => 42);
+
+    // when storing a function in state, don't allow passing a function of such type to the state setter
+    const [, setFunction] = React.useState<() => number>(() => () => 42);
+    // $ExpectError
+    setFunction(() => 43);
+
+    // But do allow a higher-order function
+    setFunction(() => () => 43);
+
     // useReducer convenience overload
 
     return React.useCallback(() => didLayout.current, []);


### PR DESCRIPTION
We have a number of use cases of storing functions inside React state. React docs don't mention anywhere that this shouldn't be done under any circumstances. However, storing functions has the following pitfall when it comes to passing `initialState` to the `useState` hook or new state to the `setState` function (the one that comes from the hook): in both cases, React will execute the functions and store their return value instead. In order to store such functions in state, they need to be wrapped into a higher level function.

This PR makes corresponding changes to the type signature of `useState`, making sure that if the value stored inside state is a function, then the only way to update the state or provide the initial value is by using the functional variant of setState or initialState (that is, wrapping the function into another function).

**Help required!** I can't seem to make this work on TS < 3.6. Lower versions break down on conditional types, as they infer the type of primitives as their value instead of their actual type (e.g. the type of value stored inside `useState(true)` will be inferred as `true` instead of `boolean`).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/hooks-reference.html#functional-updates
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
