### PR TITLE
[@types/react] Declared functional components props as readonly.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -309,7 +309,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement|null);
+        (props: Readonly<P>): (ReactElement|null);
         readonly $$typeof: symbol;
     }
 
@@ -386,76 +386,81 @@ declare namespace React {
     // tslint:disable-next-line:no-empty-interface
     interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
     class Component<P, S> {
-        // tslint won't let me format the sample code in a way that vscode likes it :(
-        /**
-         * If set, `this.context` will be set at runtime to the current value of the given Context.
-         *
-         * Usage:
-         *
-         * ```ts
-         * type MyContext = number
-         * const Ctx = React.createContext<MyContext>(0)
-         *
-         * class Foo extends React.Component {
-         *   static contextType = Ctx
-         *   context!: React.ContextType<typeof Ctx>
-         *   render () {
-         *     return <>My context's value: {this.context}</>;
-         *   }
-         * }
-         * ```
-         *
-         * @see https://reactjs.org/docs/context.html#classcontexttype
-         */
-        static contextType?: Context<any>;
+      // tslint won't let me format the sample code in a way that vscode likes it :(
+      /**
+       * If set, `this.context` will be set at runtime to the current value of the given Context.
+       *
+       * Usage:
+       *
+       * ```ts
+       * type MyContext = number
+       * const Ctx = React.createContext<MyContext>(0)
+       *
+       * class Foo extends React.Component {
+       *   static contextType = Ctx
+       *   context!: React.ContextType<typeof Ctx>
+       *   render () {
+       *     return <>My context's value: {this.context}</>;
+       *   }
+       * }
+       * ```
+       *
+       * @see https://reactjs.org/docs/context.html#classcontexttype
+       */
+      static contextType?: Context<any>;
 
-        /**
-         * If using the new style context, re-declare this in your class to be the
-         * `React.ContextType` of your `static contextType`.
-         *
-         * ```ts
-         * static contextType = MyContext
-         * context!: React.ContextType<typeof MyContext>
-         * ```
-         *
-         * @deprecated if used without a type annotation, or without static contextType
-         * @see https://reactjs.org/docs/legacy-context.html
-         */
-        // TODO (TypeScript 3.0): unknown
-        context: any;
+      /**
+       * If using the new style context, re-declare this in your class to be the
+       * `React.ContextType` of your `static contextType`.
+       *
+       * ```ts
+       * static contextType = MyContext
+       * context!: React.ContextType<typeof MyContext>
+       * ```
+       *
+       * @deprecated if used without a type annotation, or without static contextType
+       * @see https://reactjs.org/docs/legacy-context.html
+       */
+      // TODO (TypeScript 3.0): unknown
+      context: any;
 
-        constructor(props: Readonly<P>);
-        /**
-         * @deprecated
-         * @see https://reactjs.org/docs/legacy-context.html
-         */
-        constructor(props: P, context?: any);
+      constructor(props: Readonly<P>);
+      /**
+       * @deprecated
+       * @see https://reactjs.org/docs/legacy-context.html
+       */
+      constructor(props: P, context?: any);
 
-        // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
-        // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
-        // Also, the ` | S` allows intellisense to not be dumbisense
-        setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
-            callback?: () => void
-        ): void;
+      // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+      // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+      // Also, the ` | S` allows intellisense to not be dumbisense
+      setState<K extends keyof S>(
+        state:
+          | ((
+              prevState: Readonly<S>,
+              props: Readonly<P>,
+            ) => Pick<S, K> | S | null)
+          | (Pick<S, K> | S | null),
+        callback?: () => void,
+      ): void;
 
-        forceUpdate(callback?: () => void): void;
-        render(): ReactNode;
+      forceUpdate(callback?: () => void): void;
+      render(): ReactNode;
 
-        // React.Props<T> is now deprecated, which means that the `children`
-        // property is not available on `P` by default, even though you can
-        // always pass children as variadic arguments to `createElement`.
-        // In the future, if we can define its call signature conditionally
-        // on the existence of `children` in `P`, then we should remove this.
-        readonly props: Readonly<P> & Readonly<{ children?: ReactNode }>;
-        state: Readonly<S>;
-        /**
-         * @deprecated
-         * https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
-         */
-        refs: {
-            [key: string]: ReactInstance
-        };
+      // React.Props<T> is now deprecated, which means that the `children`
+      // property is not available on `P` by default, even though you can
+      // always pass children as variadic arguments to `createElement`.
+      // In the future, if we can define its call signature conditionally
+      // on the existence of `children` in `P`, then we should remove this.
+      readonly props: ReadonlyPropsWithChildren<P>;
+      state: Readonly<S>;
+      /**
+       * @deprecated
+       * https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
+       */
+      refs: {
+        [key: string]: ReactInstance;
+      };
     }
 
     class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
@@ -493,7 +498,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: Readonly<PropsWithChildren<P>>, context?: any): ReactElement | null;
+        (props: ReadonlyPropsWithChildren<P>, context?: any): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -501,7 +506,7 @@ declare namespace React {
     }
 
     interface RefForwardingComponent<T, P = {}> {
-        (props: Readonly<PropsWithChildren<P>>, ref: Ref<T>): ReactElement | null;
+        (props: ReadonlyPropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -748,6 +753,7 @@ declare namespace React {
             : P;
 
     type PropsWithChildren<P> = P & { children?: ReactNode };
+    type ReadonlyPropsWithChildren<P> = Readonly<P> & { readonly children?: ReactNode };
 
     /**
      * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
@@ -774,7 +780,7 @@ declare namespace React {
 
     function memo<P extends object>(
         Component: SFC<P>,
-        propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean
+        propsAreEqual?: (prevProps: ReadonlyPropsWithChildren<P>, nextProps: ReadonlyPropsWithChildren<P>) => boolean
     ): NamedExoticComponent<P>;
     function memo<T extends ComponentType<any>>(
         Component: T,

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -493,7 +493,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: PropsWithChildren<P>, context?: any): ReactElement | null;
+        (props: Readonly<PropsWithChildren<P>>, context?: any): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -501,7 +501,7 @@ declare namespace React {
     }
 
     interface RefForwardingComponent<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
+        (props: Readonly<PropsWithChildren<P>>, ref: Ref<T>): ReactElement | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -213,7 +213,7 @@ function FunctionComponent(props: SCProps) {
 // tslint:disable-next-line:no-namespace
 namespace FunctionComponent {
     export const displayName = "FunctionComponent";
-    export const defaultProps = { foo: 42 };
+    export const defaultProps: Partial<SCProps> = { foo: 42 };
 }
 
 const FunctionComponent2: React.FunctionComponent<SCProps> =
@@ -244,6 +244,13 @@ const LegacyStatelessComponent3: React.SFC<SCProps> =
 
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
+
+// disallows prop mutation
+const FunctionComponent5: React.FunctionComponent<SCProps> = props => {
+    // $ExpectError
+    props.foo = 5;
+    return null;
+};
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =


### PR DESCRIPTION
## Description

Fixes #36729 

Props should be immutable inside of a component, for class components this was being correctly declared here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b6c6778/types/react/index.d.ts#L450

I followed the convention used by `React.memo` here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b6c6778/types/react/index.d.ts#L775-L778n 

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [React docs: Props are Read-Only](https://reactjs.org/docs/components-and-props.html#props-are-read-only)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
