### PR TITLE
[chart.js] Update type of `borderWidth` in `ChartDataSets`.

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -1,4 +1,4 @@
-import { Chart, ChartData, Point, ChartColor } from 'chart.js';
+import { BorderWidth, Chart, ChartData, Point, ChartColor } from 'chart.js';
 
 // alternative:
 // import chartjs = require('chart.js');
@@ -14,7 +14,7 @@ const chart: Chart = new Chart(ctx, {
     type: 'bar',
     plugins: [plugin, plugin],
     data: {
-        labels: ['group 1'],
+        labels: ['group 1', 'group 2'],
         datasets: [
             {
                 backgroundColor: '#000000',
@@ -24,6 +24,12 @@ const chart: Chart = new Chart(ctx, {
                 label: 'test',
                 data: [1, null, 3],
             },
+            {
+                backgroundColor: '#ff0000',
+                borderWidth: { top: 1, right: 1, bottom: 0, left: 1 },
+                label: 'test',
+                data: [1, 3, 5],
+            }
         ],
     },
     options: {
@@ -197,6 +203,12 @@ const chartWithScriptedOptions = new Chart(new CanvasRenderingContext2D(), {
                     return "black";
                 }
                 return value > 3 ? "red" : "green";
+            },
+            borderWidth: ({ dataset, dataIndex }): BorderWidth => {
+                if (dataset === undefined || dataset.data === undefined || dataIndex === undefined) {
+                    return 1;
+                }
+                return { top: 1, right: 1, bottom: 0, left: 1 };
             }
         }],
     }

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -138,6 +138,8 @@ declare namespace Chart {
 
     type BorderAlignment = 'center' | 'inner';
 
+    type BorderWidth = number | { [key in PositionType]?: number };
+
     interface ChartArea {
         top: number;
         right: number;
@@ -218,9 +220,9 @@ declare namespace Chart {
         datasets?: ChartDataSets[];
     }
 
-	interface RadialChartOptions extends ChartOptions {
-		scale?: RadialLinearScale;
-	}
+    interface RadialChartOptions extends ChartOptions {
+        scale?: RadialLinearScale;
+    }
 
     interface ChartSize {
         height: number;
@@ -537,7 +539,7 @@ declare namespace Chart {
         cubicInterpolationMode?: 'default' | 'monotone';
         backgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         borderAlign?: BorderAlignment | BorderAlignment[] | Scriptable<BorderAlignment>;
-        borderWidth?: number | number[] | Scriptable<number>;
+        borderWidth?: BorderWidth | BorderWidth[] | Scriptable<BorderWidth>;
         borderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         borderCapStyle?: 'butt' | 'round' | 'square';
         borderDash?: number[];

--- a/types/chart.js/tslint.json
+++ b/types/chart.js/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "ban-types": false
+        "ban-types": false,
+        "indent": [true, "spaces", 4]
     }
 }


### PR DESCRIPTION
Chart.js 2.8 allows for configuration of `borderWidth` as object.

This is related to the changes in PR https://github.com/chartjs/Chart.js/pull/6077

Documentation: https://github.com/chartjs/Chart.js/blob/master/docs/charts/bar.md#borderwidth

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chartjs/Chart.js/blob/master/docs/charts/bar.md#borderwidth
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
