### PR TITLE
Add types for pull-stream

### DIFF
--- a/types/pull-stream/index.d.ts
+++ b/types/pull-stream/index.d.ts
@@ -1,0 +1,147 @@
+// Type definitions for pull-stream 3.6
+// Project: https://pull-stream.github.io
+// Definitions by: Michael de Wit <https://github.com/mjwwit>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+import { count as countImport, empty as emptyImport, error as errorImport, infinite as infiniteImport, keys as keysImport, once as onceImport, values as valuesImport } from './sources';
+import {
+    asyncMap as asyncMapImport,
+    filterNot as filterNotImport,
+    filter as filterImport,
+    flatten as flattenImport,
+    map as mapImport,
+    nonUnique as nonUniqueImport,
+    take as takeImport,
+    through as throughImport,
+    unique as uniqueImport
+} from './throughs';
+import { collect as collectImport, concat as concatImport, drain as drainImport, find as findImport, log as logImport, onEnd as onEndImport, reduce as reduceImport } from './sinks';
+
+/**
+ * Pipe data through a number of `pull-stream`s
+ */
+declare function pull(): undefined;
+declare function pull<InOut>(source: pull.Source<InOut>, sink: pull.Sink<InOut>): undefined;
+declare function pull<In, Out>(source: pull.Source<In>, t1: pull.Through<In, Out>, sink: pull.Sink<Out>): undefined;
+declare function pull<In, P1, Out>(source: pull.Source<In>, t1: pull.Through<In, P1>, t2: pull.Through<P1, Out>, sink: pull.Sink<Out>): undefined;
+declare function pull<In, P1, P2, Out>(source: pull.Source<In>, t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, Out>, sink: pull.Sink<Out>): undefined;
+declare function pull<In, P1, P2, P3, Out>(
+    source: pull.Source<In>,
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, Out>,
+    sink: pull.Sink<Out>
+): undefined;
+declare function pull<In, P1, P2, P3, P4, Out>(
+    source: pull.Source<In>,
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, Out>,
+    sink: pull.Sink<Out>
+): undefined;
+
+declare function pull<In>(sink: pull.Sink<In>): pull.Sink<In>;
+declare function pull<In, Out>(t1: pull.Through<In, Out>, sink: pull.Sink<Out>): pull.Sink<In>;
+declare function pull<In, P1, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, Out>, sink: pull.Sink<Out>): pull.Sink<In>;
+declare function pull<In, P1, P2, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, Out>, sink: pull.Sink<Out>): pull.Sink<In>;
+declare function pull<In, P1, P2, P3, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, P3>, t4: pull.Through<P3, Out>, sink: pull.Sink<Out>): pull.Sink<In>;
+declare function pull<In, P1, P2, P3, P4, Out>(
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, Out>,
+    sink: pull.Sink<Out>
+): pull.Sink<In>;
+declare function pull<In, P1, P2, P3, P4, P5, Out>(
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, P5>,
+    t6: pull.Through<P5, Out>,
+    sink: pull.Sink<Out>
+): pull.Sink<In>;
+
+declare function pull<Out>(source: pull.Source<Out>): pull.Source<Out>;
+declare function pull<In, Out>(source: pull.Source<In>, t1: pull.Through<In, Out>): pull.Source<Out>;
+declare function pull<In, P1, Out>(source: pull.Source<In>, t1: pull.Through<In, P1>, t2: pull.Through<P1, Out>): pull.Source<Out>;
+declare function pull<In, P1, P2, Out>(source: pull.Source<In>, t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, Out>): pull.Source<Out>;
+declare function pull<In, P1, P2, P3, Out>(source: pull.Source<In>, t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, P3>, t4: pull.Through<P3, Out>): pull.Source<Out>;
+declare function pull<In, P1, P2, P3, P4, Out>(
+    source: pull.Source<In>,
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, Out>
+): pull.Source<Out>;
+declare function pull<In, P1, P2, P3, P4, P5, Out>(
+    source: pull.Source<In>,
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, P5>,
+    t6: pull.Through<P5, Out>
+): pull.Source<Out>;
+
+declare function pull<In, Out>(t1: pull.Through<In, Out>): pull.Through<In, Out>;
+declare function pull<In, P1, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, Out>): pull.Through<In, Out>;
+declare function pull<In, P1, P2, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, Out>): pull.Through<In, Out>;
+declare function pull<In, P1, P2, P3, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, P2>, t3: pull.Through<P2, P3>, t4: pull.Through<P3, Out>): pull.Through<In, Out>;
+declare function pull<In, P1, P2, P3, P4, Out>(
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, Out>
+): pull.Through<In, Out>;
+declare function pull<In, P1, P2, P3, P4, P5, Out>(
+    t1: pull.Through<In, P1>,
+    t2: pull.Through<P1, P2>,
+    t3: pull.Through<P2, P3>,
+    t4: pull.Through<P3, P4>,
+    t5: pull.Through<P4, P5>,
+    t6: pull.Through<P5, Out>
+): pull.Through<In, Out>;
+
+declare function pull(...pullStreams: ReadonlyArray<(pull.Source<any> | pull.Sink<any> | pull.Through<any, any>)>): pull.Source<any> | pull.Sink<any> | pull.Through<any, any> | undefined;
+
+declare namespace pull {
+    type Source<T> = (endOrError: Error | boolean | null, cb: (endOrError: Error | boolean | null, data: T) => any) => undefined;
+    type Sink<T> = (source: Source<T>) => undefined;
+    type Through<T, U> = (source: Source<T>) => Source<U>;
+
+    const count: typeof countImport;
+    const empty: typeof emptyImport;
+    const error: typeof errorImport;
+    const infinite: typeof infiniteImport;
+    const keys: typeof keysImport;
+    const once: typeof onceImport;
+    const values: typeof valuesImport;
+
+    const asyncMap: typeof asyncMapImport;
+    const filterNot: typeof filterNotImport;
+    const filter: typeof filterImport;
+    const flatten: typeof flattenImport;
+    const map: typeof mapImport;
+    const nonUnique: typeof nonUniqueImport;
+    const take: typeof takeImport;
+    const through: typeof throughImport;
+    const unique: typeof uniqueImport;
+
+    const collect: typeof collectImport;
+    const concat: typeof concatImport;
+    const drain: typeof drainImport;
+    const find: typeof findImport;
+    const log: typeof logImport;
+    const onEnd: typeof onEndImport;
+    const reduce: typeof reduceImport;
+}
+
+export = pull;

--- a/types/pull-stream/pull-stream-tests.ts
+++ b/types/pull-stream/pull-stream-tests.ts
@@ -1,0 +1,167 @@
+import pull = require('pull-stream');
+
+/********
+ * pull *
+ ********/
+
+let source: pull.Source<string> = (end, cb) => undefined;
+let through: pull.Through<string, string> = (source) => source;
+let sink: pull.Sink<string> = (source) => undefined;
+
+// Start with source and end with sink
+let nothing: undefined;
+nothing = pull();
+nothing = pull(source, sink);
+nothing = pull(source, through, sink);
+nothing = pull(source, through, through, sink);
+
+// End with sink
+sink = pull(sink);
+sink = pull(through, sink);
+sink = pull(through, through, sink);
+
+// Start with source
+source = pull(source);
+source = pull(source, through);
+source = pull(source, through, through);
+
+// Through only
+through = pull(through);
+through = pull(through, through);
+through = pull(through, through, through);
+
+const numberSource: pull.Source<number> = (end, cb) => undefined;
+const parseNumber: pull.Through<string, number> = (source) => numberSource;
+const numberSink: pull.Sink<number> = (source) => undefined;
+
+// Strictly typed pipe
+nothing = pull(source, through, parseNumber, numberSink);
+
+// Long pipe
+let result: pull.Source<any> | pull.Sink<any> | pull.Through<any, any> | undefined;
+result = pull(source, through, through, through, through, through, through, through, through, sink);
+
+/***********
+ * sources *
+ ***********/
+
+// count
+nothing = pull(pull.count(), numberSink);
+nothing = pull(pull.count(5), numberSink);
+nothing = pull(pull.count(5, (err) => { if (err) err.stack; }), numberSink);
+
+// empty
+nothing = pull(pull.empty(), sink);
+
+// error
+nothing = pull(pull.error(), sink);
+
+// infinite
+nothing = pull(pull.infinite(), numberSink);
+nothing = pull(pull.infinite(() => 'value'), sink);
+nothing = pull(pull.infinite(() => 'value', (err) => { if (err) err.stack; }), sink);
+
+// keys
+nothing = pull(pull.keys({ hello: 'world' }), sink);
+nothing = pull(pull.keys([]), sink);
+nothing = pull(pull.keys([], (err) => { if (err) err.stack; }), sink);
+
+// once
+nothing = pull(pull.once('value'), sink);
+nothing = pull(pull.once(1), numberSink);
+nothing = pull(pull.once(1, (err) => { if (err) err.stack; }), numberSink);
+
+// values
+nothing = pull(pull.values(['hello', 'world']), sink);
+nothing = pull(pull.values([1, 2]), numberSink);
+nothing = pull(pull.values([1, 2], (err) => { if (err) err.stack; }), numberSink);
+
+/************
+ * throughs *
+ ************/
+
+// asyncMap
+nothing = pull(source, pull.asyncMap((data, cb) => { cb(null, Number(data)); }), numberSink);
+
+// filterNot
+nothing = pull(source, pull.filterNot((data) => data === 'hello'), sink);
+
+// filter
+nothing = pull(source, pull.filter((data) => data === 'hello'), sink);
+nothing = pull(source, pull.filter((data): data is 'hello' => data === 'hello'), sink as pull.Sink<'hello'>);
+
+// flatten
+const streamOfArrays: pull.Source<string[]> = (end, cb) => undefined;
+const streamOfStreams: pull.Source<Array<pull.Source<string>>> = (end, cb) => undefined;
+const throughToStreams: pull.Through<
+  any,
+  Array<pull.Source<string>>
+> = streamOfStreams => streamOfStreams;
+nothing = pull(streamOfArrays, pull.flatten(), sink);
+nothing = pull(streamOfStreams, pull.flatten(), sink);
+sink = pull(throughToStreams, pull.flatten(), sink);
+
+// map
+nothing = pull(source, pull.map(Number), numberSink);
+
+// nonUnique
+nothing = pull(source, pull.nonUnique(), sink);
+nothing = pull(source, pull.nonUnique(Number), sink);
+nothing = pull(source, pull.nonUnique('length'), sink);
+
+// take
+nothing = pull(source, pull.take(1), sink);
+nothing = pull(source, pull.take(s => !!s), sink);
+nothing = pull(source, pull.take(s => !!s, { last: true }), sink);
+
+// through
+nothing = pull(source, pull.through(), sink);
+nothing = pull(source, pull.through(Number), sink);
+nothing = pull(source, pull.through(Number, (err) => { if (err) err.stack; }), sink);
+
+// unique
+nothing = pull(source, pull.unique(), sink);
+nothing = pull(source, pull.unique(Number), sink);
+nothing = pull(source, pull.unique('length'), sink);
+
+/*********
+ * sinks *
+ *********/
+
+// collect
+nothing = pull(source, pull.collect((err, results) => {
+    if (err) err.stack;
+    const check: string[] = results;
+}));
+
+// concat
+nothing = pull(source, pull.concat((err, result) => {
+    if (err) err.stack;
+    const check: string = result;
+}));
+
+// drain
+nothing = pull(source, pull.drain(Number));
+nothing = pull(source, pull.drain(Number, (err) => { if (err) err.stack; }));
+
+// find
+nothing = pull(source, pull.find());
+nothing = pull(source, pull.find((err) => { if (err) err.stack; }));
+nothing = pull(source, pull.find(Boolean, (err) => { if (err) err.stack; }));
+nothing = pull(source, pull.find('length', (err) => { if (err) err.stack; }));
+
+// log
+nothing = pull(source, pull.log());
+
+// onEnd
+nothing = pull(source, pull.onEnd((err) => { if (err) err.stack; }));
+
+// reduce
+nothing = pull(source, pull.reduce<string, number>((acc, data) => (acc || 0) + Number(data), (err, result) => {
+    if (err) err.stack;
+    const check: number = result;
+}));
+nothing = pull(source, pull.reduce((acc, data) => acc + Number(data), 0, (err, result) => {
+    if (err) err.stack;
+    const check: number = result;
+}));

--- a/types/pull-stream/sinks/collect.d.ts
+++ b/types/pull-stream/sinks/collect.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Read the stream into an array, then call `cb`.
+ */
+declare function collect<T>(cb?: (err: Error | null, results: T[]) => unknown): pull.Sink<T>;
+export = collect;

--- a/types/pull-stream/sinks/concat.d.ts
+++ b/types/pull-stream/sinks/concat.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Concat stream of strings into single string, then call `cb`.
+ */
+declare function concat(cb?: (err: Error | null, result: string) => unknown): pull.Sink<string>;
+export = concat;

--- a/types/pull-stream/sinks/drain.d.ts
+++ b/types/pull-stream/sinks/drain.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Drain the stream, calling op on each `data`. Call `done` when stream is finished. If `op` returns `=== false`, abort the stream.
+ */
+declare function drain<T>(op?: (data: T) => unknown, cb?: (err: Error | null) => unknown): pull.Sink<T>;
+export = drain;

--- a/types/pull-stream/sinks/find.d.ts
+++ b/types/pull-stream/sinks/find.d.ts
@@ -1,0 +1,5 @@
+import pull = require('..');
+
+declare function find<T>(cb?: (err: Error | null, results: T[]) => unknown): pull.Sink<T>;
+declare function find<T>(test: ((data: T) => boolean) | keyof T, cb?: (err: Error | null, result: T) => unknown): pull.Sink<T>;
+export = find;

--- a/types/pull-stream/sinks/index.d.ts
+++ b/types/pull-stream/sinks/index.d.ts
@@ -1,0 +1,15 @@
+import collectImport = require('./collect');
+import concatImport = require('./concat');
+import drainImport = require('./drain');
+import findImport = require('./find');
+import logImport = require('./log');
+import onEndImport = require('./on-end');
+import reduceImport = require('./reduce');
+
+export const collect: typeof collectImport;
+export const concat: typeof concatImport;
+export const drain: typeof drainImport;
+export const find: typeof findImport;
+export const log: typeof logImport;
+export const onEnd: typeof onEndImport;
+export const reduce: typeof reduceImport;

--- a/types/pull-stream/sinks/log.d.ts
+++ b/types/pull-stream/sinks/log.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Output the stream to `console.log`.
+ */
+declare function log(): pull.Sink<any>;
+export = log;

--- a/types/pull-stream/sinks/on-end.d.ts
+++ b/types/pull-stream/sinks/on-end.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Drain the stream and then call `cb` when done.
+ */
+declare function onEnd(cb?: (err: Error | null) => unknown): pull.Sink<any>;
+export = onEnd;

--- a/types/pull-stream/sinks/reduce.d.ts
+++ b/types/pull-stream/sinks/reduce.d.ts
@@ -1,0 +1,8 @@
+import pull = require('..');
+
+/**
+ * Reduce stream into single value, then callback.
+ */
+declare function reduce<T, U>(reducer: (acc: U | null, data: T) => U, cb: (err: Error | null, result: U) => unknown): pull.Sink<T>;
+declare function reduce<T, U>(reducer: (acc: U, data: T) => U, initial: U, cb: (err: Error | null, result: U) => unknown): pull.Sink<T>;
+export = reduce;

--- a/types/pull-stream/sources/count.d.ts
+++ b/types/pull-stream/sources/count.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create a stream that outputs 0 ... `max`. By default, `max` = `Infinity`.
+ */
+declare function count(max?: number, onAbort?: (err?: Error | null) => unknown): pull.Source<number>;
+export = count;

--- a/types/pull-stream/sources/empty.d.ts
+++ b/types/pull-stream/sources/empty.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create a stream with no contents (it just ends immediately).
+ */
+declare function empty(): pull.Source<never>;
+export = empty;

--- a/types/pull-stream/sources/error.d.ts
+++ b/types/pull-stream/sources/error.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create a stream with no contents (it just ends immediately).
+ */
+declare function error(): pull.Source<never>;
+export = error;

--- a/types/pull-stream/sources/index.d.ts
+++ b/types/pull-stream/sources/index.d.ts
@@ -1,0 +1,15 @@
+import countImport = require('./count');
+import emptyImport = require('./empty');
+import errorImport = require('./error');
+import infiniteImport = require('./infinite');
+import keysImport = require('./keys');
+import onceImport = require('./once');
+import valuesImport = require('./values');
+
+export const count: typeof countImport;
+export const empty: typeof emptyImport;
+export const error: typeof errorImport;
+export const infinite: typeof infiniteImport;
+export const keys: typeof keysImport;
+export const once: typeof onceImport;
+export const values: typeof valuesImport;

--- a/types/pull-stream/sources/infinite.d.ts
+++ b/types/pull-stream/sources/infinite.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create an unending stream by repeatedly calling a generator function (by default, `Math.random`).
+ */
+declare function infinite<T = number>(generator?: () => T, onAbort?: (err?: Error | null) => unknown): pull.Source<T>;
+export = infinite;

--- a/types/pull-stream/sources/keys.d.ts
+++ b/types/pull-stream/sources/keys.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Stream the key names from an object (or array).
+ */
+declare function keys(obj: object | ReadonlyArray<any>, onAbort?: (err?: Error | null) => unknown): pull.Source<string>;
+export = keys;

--- a/types/pull-stream/sources/once.d.ts
+++ b/types/pull-stream/sources/once.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create a stream with a single value.
+ */
+declare function once<T>(value?: T, onAbort?: (err?: Error | null) => unknown): pull.Source<T>;
+export = once;

--- a/types/pull-stream/sources/values.d.ts
+++ b/types/pull-stream/sources/values.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Create a SourceStream that reads the values from an array or object and then stops.
+ */
+declare function values<T>(arrayOrObject?: Record<any, T> | ReadonlyArray<T>, onAbort?: (err?: Error | null) => unknown): pull.Source<T>;
+export = values;

--- a/types/pull-stream/throughs/async-map.d.ts
+++ b/types/pull-stream/throughs/async-map.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Like `map` but the signature of `fn` must be `function (data, cb) { cb(null, data) }`.
+ */
+declare function asyncMap<In, Out>(fn: (data: In, cb: (err: Error | null, result: Out) => void) => any): pull.Through<In, Out>;
+export = asyncMap;

--- a/types/pull-stream/throughs/filter-not.d.ts
+++ b/types/pull-stream/throughs/filter-not.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Like `filter`, but remove items where the filter returns true.
+ */
+declare function filterNot<InOut>(test: (data: InOut) => boolean): pull.Through<InOut, InOut>;
+export = filterNot;

--- a/types/pull-stream/throughs/filter.d.ts
+++ b/types/pull-stream/throughs/filter.d.ts
@@ -1,0 +1,8 @@
+import pull = require('..');
+
+/**
+ * Like `[].filter(function (data) {return true || false})` only `data` where `test(data) == true` are let through to the next stream.
+ */
+declare function filter<In, Out extends In>(test: (data: In) => data is Out): pull.Through<In, Out>;
+declare function filter<InOut>(test: (data: InOut) => boolean): pull.Through<InOut, InOut>;
+export = filter;

--- a/types/pull-stream/throughs/flatten.d.ts
+++ b/types/pull-stream/throughs/flatten.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Turn a stream of streams or a stream of arrays into a stream of their items, (undoes group).
+ */
+declare function flatten<Out>(): pull.Through<ReadonlyArray<Out | pull.Source<Out> | pull.Through<any, Out>>, Out>;
+export = flatten;

--- a/types/pull-stream/throughs/index.d.ts
+++ b/types/pull-stream/throughs/index.d.ts
@@ -1,0 +1,19 @@
+import asyncMapImport = require('./async-map');
+import filterNotImport = require('./filter-not');
+import filterImport = require('./filter');
+import flattenImport = require('./flatten');
+import mapImport = require('./map');
+import nonUniqueImport = require('./non-unique');
+import takeImport = require('./take');
+import throughImport = require('./through');
+import uniqueImport = require('./unique');
+
+export const asyncMap: typeof asyncMapImport;
+export const filterNot: typeof filterNotImport;
+export const filter: typeof filterImport;
+export const flatten: typeof flattenImport;
+export const map: typeof mapImport;
+export const nonUnique: typeof nonUniqueImport;
+export const take: typeof takeImport;
+export const through: typeof throughImport;
+export const unique: typeof uniqueImport;

--- a/types/pull-stream/throughs/map.d.ts
+++ b/types/pull-stream/throughs/map.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Returns a through stream that calls the given `fn` for each chunk of incoming data and outputs the return value, in the same order as before.
+ */
+declare function map<In, Out>(fn: (data: In) => Out): pull.Through<In, Out>;
+export = map;

--- a/types/pull-stream/throughs/non-unique.d.ts
+++ b/types/pull-stream/throughs/non-unique.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Filter unique items -- get the duplicates. The inverse of `unique`.
+ */
+declare function nonUnique<InOut>(prop?: ((data: InOut) => unknown) | keyof InOut): pull.Through<InOut, InOut>;
+export = nonUnique;

--- a/types/pull-stream/throughs/take.d.ts
+++ b/types/pull-stream/throughs/take.d.ts
@@ -1,0 +1,12 @@
+import pull = require('..');
+
+/**
+ * `take` has 2 valid signatures:
+ * 1. A single positive integer `n`. `take` pulls `n` values from the source and then closes the stream. This is really useful for limiting how much you pull.
+ * 2. A `testFn` function and optional `opts`. Read data from the source stream and forward it downstream until `testFn(data)` returns false, then close the stream.
+ *
+ *    `opts` is an optional Object of form `{ last: Boolean }`, where `opts.last` determines whether the last value tested (before closing the stream) is included or excluded (default).
+ */
+declare function take<InOut>(n: number): pull.Through<InOut, InOut>;
+declare function take<InOut>(testFn: (data: InOut) => boolean, opts?: { last: boolean }): pull.Through<InOut, InOut>;
+export = take;

--- a/types/pull-stream/throughs/through.d.ts
+++ b/types/pull-stream/throughs/through.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Returns a pass through stream that doesn't change the value.
+ */
+declare function through<InOut>(op?: (data: InOut) => unknown, onEnd?: (err: Error | null) => unknown): pull.Through<InOut, InOut>;
+export = through;

--- a/types/pull-stream/throughs/unique.d.ts
+++ b/types/pull-stream/throughs/unique.d.ts
@@ -1,0 +1,7 @@
+import pull = require('..');
+
+/**
+ * Filter items that have a repeated value for `prop()`, by default, `prop = function (it) {return it }`, if `prop` is a string, it will filter nodes which have repeated values for that property.
+ */
+declare function unique<InOut>(prop?: ((data: InOut) => unknown) | keyof InOut): pull.Through<InOut, InOut>;
+export = unique;

--- a/types/pull-stream/tsconfig.json
+++ b/types/pull-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pull-stream-tests.ts"
+    ]
+}

--- a/types/pull-stream/tslint.json
+++ b/types/pull-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Something that may need to be improved in the future: the `Source` and `Sink` types currently return `undefined`, when `void` would probably be nicer. However, currently `void` causes TypeScript to mix up the `Sink` and `Through` types when using `pull`.
If anyone knows of a way around this I'd be happy to improve the current approach.