### PR TITLE
Stripe: IBalanceTransaction.source_transfers is optional.

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1131,7 +1131,7 @@ declare namespace Stripe {
             /**
              * The transfers (if any) for which source is a source_transaction.
              */
-            source_transfers: IList<transfers.ITransfer>;
+            source_transfers?: IList<transfers.ITransfer>;
 
             /**
              * If the transaction's net funds are available in the Stripe balance yet. Either "available" or "pending".


### PR DESCRIPTION
I don't see `source_transfers` on my version of the REST API.  I also don't see it in the docs.

Here's an example dispute from a charge created with the `tok_createDispute` token:

```json
{
    "id": "dp_1FFl9bBCvBiGc7SdomkEXizS",
    "object": "dispute",
    "amount": 5000,
    "balance_transaction": "txn_1FFl9bBCvBiGc7SdhmTBWf2g",
    "balance_transactions": [
        {
            "id": "txn_1FFl9bBCvBiGc7SdhmTBWf2g",
            "object": "balance_transaction",
            "amount": -6481,
            "available_on": 1568332800,
            "created": 1567790603,
            "currency": "cad",
            "description": "Chargeback withdrawal for ch_1FFl9aBCvBiGc7SdOob5o8V2",
            "exchange_rate": null,
            "fee": 1500,
            "fee_details": [
                {
                    "amount": 1500,
                    "application": null,
                    "currency": "cad",
                    "description": "Dispute fee",
                    "type": "stripe_fee"
                }
            ],
            "net": -7981,
            "source": "dp_1FFl9bBCvBiGc7SdomkEXizS",
            "status": "pending",
            "type": "adjustment"
        }
    ],
    "charge": "ch_1FFl9aBCvBiGc7SdOob5o8V2",
    "created": 1567790603,
    "currency": "usd",
    "evidence": {
        "access_activity_log": null,
        "billing_address": null,
        "cancellation_policy": null,
        "cancellation_policy_disclosure": null,
        "cancellation_rebuttal": null,
        "customer_communication": null,
        "customer_email_address": null,
        "customer_name": null,
        "customer_purchase_ip": null,
        "customer_signature": null,
        "duplicate_charge_documentation": null,
        "duplicate_charge_explanation": null,
        "duplicate_charge_id": null,
        "product_description": null,
        "receipt": null,
        "refund_policy": null,
        "refund_policy_disclosure": null,
        "refund_refusal_explanation": null,
        "service_date": null,
        "service_documentation": null,
        "shipping_address": null,
        "shipping_carrier": null,
        "shipping_date": null,
        "shipping_documentation": null,
        "shipping_tracking_number": null,
        "uncategorized_file": null,
        "uncategorized_text": null
    },
    "evidence_details": {
        "due_by": 1568591999,
        "has_evidence": false,
        "past_due": false,
        "submission_count": 0
    },
    "is_charge_refundable": false,
    "livemode": false,
    "metadata": {
    },
    "reason": "fraudulent",
    "status": "needs_response"
}
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/api/balance_transactions/object>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.