### PR TITLE
[@types/react] Allow `null` in HTML element `style` attribute.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1645,7 +1645,7 @@ declare namespace React {
         placeholder?: string;
         slot?: string;
         spellCheck?: boolean;
-        style?: {[K in keyof CSSProperties]: CSSProperties[K] | null};
+        style?: {[K in keyof CSSProperties]: CSSProperties[K] | null} | null;
         tabIndex?: number;
         title?: string;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1645,7 +1645,7 @@ declare namespace React {
         placeholder?: string;
         slot?: string;
         spellCheck?: boolean;
-        style?: CSSProperties;
+        style?: {[K in keyof CSSProperties]: CSSProperties[K] | null};
         tabIndex?: number;
         title?: string;
 


### PR DESCRIPTION
React allows `null` in addition to `undefined` for CSS properties (see [`dangerousStyleValue()`](https://github.com/facebook/react/blob/21d79ce04066ade1098a7ae8990e596e01332a65/packages/react-dom/src/shared/dangerousStyleValue.js#L30)) but `csstype` properties are only optional.

I’m adding TypeScript to an untyped/Flow-typed codebase which uses `null` for style attributes a lot.