### PR TITLE
[redux-form]: fix type discrepancies

### DIFF
--- a/types/redux-form/lib/actions.d.ts
+++ b/types/redux-form/lib/actions.d.ts
@@ -75,6 +75,7 @@ declare const actions: {
     initialize: typeof initialize,
     registerField: typeof registerField,
     reset: typeof reset,
+    resetSection: typeof resetSection,
     startAsyncValidation: typeof startAsyncValidation,
     startSubmit: typeof startSubmit,
     stopAsyncValidation: typeof stopAsyncValidation,

--- a/types/redux-form/lib/reducer.d.ts
+++ b/types/redux-form/lib/reducer.d.ts
@@ -32,6 +32,7 @@ export interface FormState {
 export interface RegisteredFieldState {
     name: string;
     type: FieldType;
+    count: number;
 }
 
 export interface FieldState {

--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -18,13 +18,13 @@ import {
 } from "../index";
 
 export type FormSubmitHandler<FormData = {}, P = {}, ErrorType = string> =
-    (values: FormData, dispatch: Dispatch<any>, props: P) => void | FormErrors<FormData, ErrorType> | Promise<any>;
+    (values: FormData, dispatch: Dispatch<any>, props: DecoratedFormProps<FormData, P, ErrorType>) => void | FormErrors<FormData, ErrorType> | Promise<any>;
 
 export type GetFormState = (state: any) => FormStateMap;
 export interface SubmitHandler<FormData = {}, P = {}, ErrorType = string> {
     (
         submit: FormSubmitHandler<FormData, P, ErrorType>,
-        props?: InjectedFormProps<FormData, P, ErrorType>,
+        props?: DecoratedFormProps<FormData, P, ErrorType>,
         valid?: boolean,
         asyncValidate?: any,
         fields?: string[]
@@ -34,8 +34,8 @@ export interface SubmitHandler<FormData = {}, P = {}, ErrorType = string> {
 
 export interface ValidateCallback<FormData, P, ErrorType> {
     values: FormData;
-    nextProps: P & InjectedFormProps<FormData, P, ErrorType>;
-    props: P & InjectedFormProps<FormData, P, ErrorType>;
+    nextProps: DecoratedFormProps<FormData, P, ErrorType>;
+    props: DecoratedFormProps<FormData, P, ErrorType>;
     initialRender: boolean;
     structure: any;
 }
@@ -77,6 +77,7 @@ export interface InjectedFormProps<FormData = {}, P = {}, ErrorType = string> {
     blur(field: string, value: any): void;
     change(field: string, value: any): void;
     clearAsyncError(field: string): void;
+    clearSubmit(): void;
     destroy(): void;
     dirty: boolean;
     error: ErrorType;
@@ -95,14 +96,13 @@ export interface InjectedFormProps<FormData = {}, P = {}, ErrorType = string> {
     untouch(...field: string[]): void;
     valid: boolean;
     warning: any;
-    registeredFields: { [name: string]: RegisteredField };
 }
 
 export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     form: string;
     asyncBlurFields?: string[];
     asyncChangeFields?: string[];
-    asyncValidate?(values: FormData, dispatch: Dispatch<any>, props: P & InjectedFormProps<FormData, P, ErrorType>, blurredField: string): Promise<any>;
+    asyncValidate?(values: FormData, dispatch: Dispatch<any>, props: DecoratedFormProps<FormData, P, ErrorType>, blurredField: string): Promise<any>;
     destroyOnUnmount?: boolean;
     enableReinitialize?: boolean;
     forceUnregisterOnUnmount?: boolean;
@@ -111,15 +111,15 @@ export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     initialValues?: Partial<FormData>;
     keepDirtyOnReinitialize?: boolean;
     updateUnregisteredFields?: boolean;
-    onChange?(values: Partial<FormData>, dispatch: Dispatch<any>, props: P & InjectedFormProps<FormData, P, ErrorType>, previousValues: Partial<FormData>): void;
-    onSubmit?: FormSubmitHandler<FormData, P & InjectedFormProps<FormData, P, ErrorType>, ErrorType> | SubmitHandler<FormData, P & InjectedFormProps<FormData, P, ErrorType>, ErrorType>;
+    onChange?(values: Partial<FormData>, dispatch: Dispatch<any>, props: DecoratedFormProps<FormData, P, ErrorType>, previousValues: Partial<FormData>): void;
+    onSubmit?: FormSubmitHandler<FormData, P, ErrorType> | SubmitHandler<FormData, P, ErrorType>;
     onSubmitFail?(
         errors: FormErrors<FormData, ErrorType> | undefined,
         dispatch: Dispatch<any>,
         submitError: any,
-        props: P & InjectedFormProps<FormData, P, ErrorType>
+        props: DecoratedFormProps<FormData, P, ErrorType>
     ): void;
-    onSubmitSuccess?(result: any, dispatch: Dispatch<any>, props: P & InjectedFormProps<FormData, P, ErrorType>): void;
+    onSubmitSuccess?(result: any, dispatch: Dispatch<any>, props: DecoratedFormProps<FormData, P, ErrorType>): void;
     propNamespace?: string;
     pure?: boolean;
     shouldValidate?(params: ValidateCallback<FormData, P, ErrorType>): boolean;
@@ -129,11 +129,11 @@ export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     touchOnBlur?: boolean;
     touchOnChange?: boolean;
     persistentSubmitErrors?: boolean;
-    validate?(values: FormData, props: P & InjectedFormProps<FormData, P, ErrorType>): FormErrors<FormData, ErrorType>;
-    warn?(values: FormData, props: P & InjectedFormProps<FormData, P, ErrorType>): FormWarnings<FormData>;
+    validate?(values: FormData, props: DecoratedFormProps<FormData, P, ErrorType>): FormErrors<FormData, ErrorType>;
+    warn?(values: FormData, props: DecoratedFormProps<FormData, P, ErrorType>): FormWarnings<FormData>;
 }
 
-export interface FormInstance<FormData, P, ErrorType> extends Component<P> {
+export interface FormInstance<FormData, P> extends Component<P> {
     dirty: boolean;
     invalid: boolean;
     pristine: boolean;
@@ -143,22 +143,26 @@ export interface FormInstance<FormData, P, ErrorType> extends Component<P> {
     submit(): Promise<any>;
     valid: boolean;
     values: Partial<FormData>;
-    wrappedInstance: ReactElement<P & InjectedFormProps<FormData, P, ErrorType>>;
+    wrappedInstance?: HTMLElement;
 }
 
-export interface DecoratedComponentClass<FormData, P, ErrorType> {
-    new(props?: P, context?: any): FormInstance<FormData, P, ErrorType>;
+export type DecoratedFormProps<
+  FormData = {},
+  P = {},
+  ErrorType = string
+> = P & Partial<ConfigProps<FormData, P, ErrorType>> & { [key: string]: any };
+
+export interface DecoratedComponentClass<FormData, P> {
+    new(props?: P, context?: any): FormInstance<FormData, P>;
 }
 
-export type FormDecorator<FormData, P, Config, ErrorType = string> =
-    (component: ComponentType<P & InjectedFormProps<FormData, P, ErrorType>>) => DecoratedComponentClass<FormData, P & Config, ErrorType>;
+export type FormDecorator<FormData, P, ErrorType = string> =
+    (component: ComponentType<P & InjectedFormProps<FormData, P, ErrorType>>) => DecoratedComponentClass<FormData, DecoratedFormProps<FormData, P, ErrorType>>;
 
 export declare function reduxForm<FormData = {}, P = {}, ErrorType = string>(
-    config: ConfigProps<FormData, P, ErrorType>
-): FormDecorator<FormData, P, Partial<ConfigProps<FormData, P, ErrorType>>, ErrorType>;
-
-export declare function reduxForm<FormData = {}, P = {}, ErrorType = string>(
-    config: Partial<ConfigProps<FormData, P, ErrorType>>
-): FormDecorator<FormData, P, ConfigProps<FormData, P, ErrorType>, ErrorType>;
+  config:
+    | ConfigProps<FormData, P, ErrorType>
+    | Partial<ConfigProps<FormData, P, ErrorType>>,
+): FormDecorator<FormData, P, ErrorType>;
 
 export default reduxForm;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -24,8 +24,9 @@ import {
     actionTypes,
     submit,
     SubmissionError,
-    FieldArrayFieldsProps
-} from "redux-form";
+    FieldArrayFieldsProps,
+    DecoratedFormProps,
+} from 'redux-form';
 
 import {
     Field as ImmutableField,
@@ -233,10 +234,11 @@ const testFormWithInitialValuesAndValidationDecorator = reduxForm<MultivalueForm
 });
 
 const testFormWithChangeFunctionDecorator = reduxForm<TestFormData, TestFormComponentProps>({
-    form: "testWithValidation",
-    onChange: (values: Partial<TestFormData>,
+    form: 'testWithValidation',
+    onChange: (
+        values: Partial<TestFormData>,
         dispatch: Dispatch<any>,
-        props: TestFormComponentProps & InjectedFormProps<TestFormData, TestFormComponentProps>,
+        props: DecoratedFormProps<TestFormData, TestFormComponentProps>,
         previousValues: Partial<TestFormData>) => {}
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/erikras/redux-form/blob/master/src/createReduxForm.js#L290
The type in the link is what is being passed to the callbacks provided in `ConfigProps` (ex. `onChange`), note that this does not contain the injected form props, which are currently in the type definitions for the callbacks (`P & InjectedFormProps`). This issue is addressed by this PR.
https://github.com/erikras/redux-form/blob/master/src/createReduxForm.js#L1160 <-- This type has also been fixed.
