### PR TITLE
feat(parse): add missing Parse.Cloud job functions

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -32,6 +32,11 @@ declare namespace Parse {
         batchSize?: number;
     }
 
+    interface CascadeSaveOption {
+        /** If `false`, nested objects will not be saved (default is `true`). */
+        cascadeSave?: boolean;
+    }
+
     interface SuccessOption {
         success?: Function;
     }
@@ -370,10 +375,7 @@ declare namespace Parse {
 
         interface FetchOptions extends SuccessFailureOptions, ScopeOptions { }
 
-        interface SaveOptions extends SuccessFailureOptions, SilentOption, ScopeOptions, WaitOption {
-            /** If `false`, nested objects will not be saved (default is `true`). */
-            cascadeSave?: boolean;
-        }
+        interface SaveOptions extends CascadeSaveOption, SuccessFailureOptions, SilentOption, ScopeOptions, WaitOption { }
 
         interface SaveAllOptions extends BatchSizeOption, ScopeOptions { }
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -347,7 +347,6 @@ declare namespace Parse {
         remove(attr: string, item: any): this | false;
         removeAll(attr: string, items: any): this | false;
         revert(): void;
-        revert(keys: string): void;
         revert(...keys: string[]): void;
         save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<this>;
         save(key: string, value: any, options?: Object.SaveOptions): Promise<this>;
@@ -840,13 +839,13 @@ subscription.on('close', () => {});
          * Gets data for the current set of cloud jobs.
          * @returns A promise that will be resolved with the result of the function.
          */
-        function getJobsData(): Promise<any>;
+        function getJobsData(): Promise<Object>;
         /**
          * Gets job status by Id
          * @param jobStatusId The Id of Job Status.
          * @returns Status of Job.
          */
-        function getJobStatus(jobStatusId: string): Promise<any>;
+        function getJobStatus(jobStatusId: string): Promise<Object>;
         function httpRequest(options: HTTPOptions): Promise<HttpResponse>;
         function job(name: string, func?: (request: JobRequest) => Promise<void> | void): HttpResponse;
         function run(name: string, data?: any, options?: RunOptions): Promise<any>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -13,6 +13,7 @@
 //                  Julien Quere <https://github.com/jlnquere>
 //                  Yago Tomé <https://github.com/yagotome>
 //                  Thibault MOCELLIN <https://github.com/tybi>
+//                  Raschid JF Rafaelly <https://github.com/RaschidJFR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -346,6 +347,8 @@ declare namespace Parse {
         remove(attr: string, item: any): this | false;
         removeAll(attr: string, items: any): this | false;
         revert(): void;
+        revert(keys: string): void;
+        revert(...keys: string[]): void;
         save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<this>;
         save(key: string, value: any, options?: Object.SaveOptions): Promise<this>;
         save(attrs: object, options?: Object.SaveOptions): Promise<this>;
@@ -368,7 +371,10 @@ declare namespace Parse {
 
         interface FetchOptions extends SuccessFailureOptions, ScopeOptions { }
 
-        interface SaveOptions extends SuccessFailureOptions, SilentOption, ScopeOptions, WaitOption { }
+        interface SaveOptions extends SuccessFailureOptions, SilentOption, ScopeOptions, WaitOption {
+            /** If `false`, nested objects will not be saved (default is `true`). */
+            cascadeSave?: boolean;
+        }
 
         interface SaveAllOptions extends BatchSizeOption, ScopeOptions { }
 
@@ -830,10 +836,30 @@ subscription.on('close', () => {});
         function beforeFind(arg1: any, func?: (request: BeforeFindRequest) => Promise<Query> | Query): void;
         function afterFind(arg1: any, func?: (request: AfterFindRequest) => Promise<any> | any): void;
         function define(name: string, func?: (request: FunctionRequest) => Promise<any> | any): void;
+        /**
+         * Gets data for the current set of cloud jobs.
+         * @returns A promise that will be resolved with the result of the function.
+         */
+        function getJobsData(): Promise<any>;
+        /**
+         * Gets job status by Id
+         * @param jobStatusId The Id of Job Status.
+         * @returns Status of Job.
+         */
+        function getJobStatus(jobStatusId: string): Promise<any>;
         function httpRequest(options: HTTPOptions): Promise<HttpResponse>;
         function job(name: string, func?: (request: JobRequest) => Promise<void> | void): HttpResponse;
         function run(name: string, data?: any, options?: RunOptions): Promise<any>;
+        /**
+          * Starts a given cloud job, which will process asynchronously.
+          * @param jobName The function name.
+          * @param data The parameters to send to the cloud function.
+          * @returns A promise that will be resolved with the jobStatusId of the job.
+          */
+        function startJob(jobName: string, data: any): Promise<string>;
         function useMasterKey(): void;
+
+
 
         interface RunOptions extends SuccessFailureOptions, ScopeOptions { }
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse 2.2.1
+// Type definitions for parse 2.2.9
 // Project: https://parseplatform.org/
 // Definitions by:  Ullisen Media Group <http://ullisenmedia.com>
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -22,6 +22,13 @@ function test_object() {
 
     const game = new Game();
 
+    game.save(null, {
+        useMasterKey: true,
+        sessionToken: 'sometoken',
+        cascadeSave: false,
+      })
+      .then(result => result);
+
     if (!game.isNew()) {
         console.error("Game should be new");
     }

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -286,6 +286,8 @@ function test_user_acl_roles() {
     game.save({ score: '10' }, { useMasterKey: true }).then(function (game) {
         // Update game then revert it to the last saved state.
         game.set("score", '20');
+        game.revert('score');
+        game.revert('score', 'ACL');
         game.revert();
     }, function (error) {
         // The save failed
@@ -396,7 +398,7 @@ function test_cloud_functions() {
     const CUSTOM_ERROR_IMMUTABLE_FIELD = 1002
 
     Parse.Cloud.beforeSave('MyCustomClass', async (request: Parse.Cloud.BeforeSaveRequest) => {
-        
+
             if (request.object.isNew()) {
                 if (!request.object.has('immutable')) throw new Error('Field immutable is required')
             } else {
@@ -452,6 +454,12 @@ function test_cloud_functions() {
     Parse.Cloud.job('AJob', (request: Parse.Cloud.JobRequest) => {
         request.message('Message to associate with this job run');
     });
+
+    Parse.Cloud.startJob('AJob', {}).then(v => v);
+
+    Parse.Cloud.getJobStatus('AJob').then(v => v);
+
+    Parse.Cloud.getJobsData().then(v => v);
 }
 
 class PlaceObject extends Parse.Object { }


### PR DESCRIPTION
* Added functions [`startJob()`](https://parseplatform.org/Parse-SDK-JS/api/2.7.0/Parse.Cloud.html#.startJob), [`getJobsData()`](https://parseplatform.org/Parse-SDK-JS/api/2.7.0/Parse.Cloud.html#.getJobsData) and [`getJobStatus()`](https://parseplatform.org/Parse-SDK-JS/api/2.7.0/Parse.Cloud.html#.getJobStatus) in `Parse.Cloud`
* Added prop `Parse.Object.Saveoptions.cascadeSave` for [`Parse.Object.svae()`](https://parseplatform.org/Parse-SDK-JS/api/2.7.0/Parse.Object.html#save)
* Added params for [`Parse.Object.revert()`](https://parseplatform.org/Parse-SDK-JS/api/2.7.0/Parse.Object.html#revert)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://parseplatform.org/Parse-SDK-JS/api/2.7.0/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
