### PR TITLE
fix @types/googlemaps uses of MapTypeId | string

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -49,7 +49,7 @@ declare namespace google.maps {
         getCenter(): LatLng;
         getDiv(): Element;
         getHeading(): number;
-        getMapTypeId(): MapTypeId | string;
+        getMapTypeId(): MapTypeId;
         getProjection(): Projection | null;
         getStreetView(): StreetViewPanorama;
         getTilt(): number;
@@ -149,7 +149,7 @@ declare namespace google.maps {
         /** The initial display options for the Map type control. */
         mapTypeControlOptions?: MapTypeControlOptions;
         /** The initial Map mapTypeId. Defaults to ROADMAP. */
-        mapTypeId?: MapTypeId;
+        mapTypeId?: MapTypeId | string;
         /**
          * The maximum zoom level which will be displayed on the map. If omitted, or
          * set to null, the maximum zoom from the current map type is used instead.


### PR DESCRIPTION
MapTypeId as of #38084 is defined as a string enum, but all uses of MapTypeId were accidentally left as ``MapTypeId | string`` which looses type information.

I updated returns to be strictly MapTypeId, but input still seems to need to be ``MapTypeId | string`` because the TypeScript compiler seems to not recognize that a string with the proper value is a MapTypeId without casting it as such. Changing this would break all consumers and does not seem to make sense to do.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/maps/documentation/javascript/reference/map#MapTypeId>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.