### PR TITLE
explicit `any` value for P in React.ReactElement on material-ui

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -559,8 +559,8 @@ declare namespace __MaterialUI {
         className?: string;
         iconClassNameLeft?: string;
         iconClassNameRight?: string;
-        iconElementLeft?: React.ReactElement;
-        iconElementRight?: React.ReactElement;
+        iconElementLeft?: React.ReactElement<any>;
+        iconElementRight?: React.ReactElement<any>;
         iconStyleRight?: React.CSSProperties;
         iconStyleLeft?: React.CSSProperties;
         onLeftIconButtonClick?: React.MouseEventHandler<{}>;
@@ -654,7 +654,7 @@ declare namespace __MaterialUI {
         backgroundColor?: string;
         className?: string;
         color?: string;
-        icon?: React.ReactElement;
+        icon?: React.ReactElement<any>;
         size?: number;
         src?: string;
         style?: React.CSSProperties;
@@ -1038,7 +1038,7 @@ declare namespace __MaterialUI {
         text: string;
     }
     export interface DialogProps extends React.DOMAttributes<{}>, React.Props<Dialog> {
-        actions?: Array<DialogAction | React.ReactElement>;
+        actions?: Array<DialogAction | React.ReactElement<any>>;
         /** @deprecated use a custom `actions` property instead */
         actionFocus?: string;
         actionsContainerClassName?: string;
@@ -1104,10 +1104,10 @@ declare namespace __MaterialUI {
         }
 
         export interface GridTileProps {
-            actionIcon?: React.ReactElement;
+            actionIcon?: React.ReactElement<any>;
             actionPosition?: "left" | "right";
             cols?: number;
-            containerElement?: string | React.ReactElement | React.ComponentClass<any>;
+            containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
             rows?: number;
             style?: React.CSSProperties;
             subtitle?: React.ReactNode;
@@ -1158,9 +1158,9 @@ declare namespace __MaterialUI {
             initiallyOpen?: boolean;
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;
-            leftAvatar?: React.ReactElement;
-            leftCheckbox?: React.ReactElement;
-            leftIcon?: React.ReactElement;
+            leftAvatar?: React.ReactElement<any>;
+            leftCheckbox?: React.ReactElement<any>;
+            leftIcon?: React.ReactElement<any>;
             nestedItems?: Array<React.ReactElement<ListItemProps>>;
             nestedLevel?: number;
             nestedListStyle?: React.CSSProperties;
@@ -1173,10 +1173,10 @@ declare namespace __MaterialUI {
             open?: boolean;
             primaryText?: React.ReactNode;
             primaryTogglesNestedList?: boolean;
-            rightAvatar?: React.ReactElement;
-            rightIcon?: React.ReactElement;
-            rightIconButton?: React.ReactElement;
-            rightToggle?: React.ReactElement;
+            rightAvatar?: React.ReactElement<any>;
+            rightIcon?: React.ReactElement<any>;
+            rightIconButton?: React.ReactElement<any>;
+            rightToggle?: React.ReactElement<any>;
             secondaryText?: React.ReactNode;
             secondaryTextLines?: number; // 1 or 2
             style?: React.CSSProperties;
@@ -1228,11 +1228,11 @@ declare namespace __MaterialUI {
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;
             label?: string | React.ReactNode;
-            leftIcon?: React.ReactElement;
+            leftIcon?: React.ReactElement<any>;
             menuItems?: React.ReactNode;
             onClick?: React.MouseEventHandler<{}>;
             primaryText?: React.ReactNode;
-            rightIcon?: React.ReactElement;
+            rightIcon?: React.ReactElement<any>;
             secondaryText?: React.ReactNode;
             style?: React.CSSProperties;
             containerElement?: React.ReactNode | string;
@@ -1504,7 +1504,7 @@ declare namespace __MaterialUI {
             rippleColor?: string;
             rippleStyle?: React.CSSProperties;
             style?: React.CSSProperties;
-            switchElement: React.ReactElement;
+            switchElement: React.ReactElement<any>;
             switched: boolean;
             thumbStyle?: React.CSSProperties;
             trackStyle?: React.CSSProperties;


### PR DESCRIPTION
Previous versions of React would set `any` as default value of `P` in `React.ReactElement` class. Newer versions do not have a default value for `P` and require an explicit value for it.

By replacing `React.ReactElement` with `React.ReactElement<any>` in `index.d.ts`, we can still use `material-ui` library with newer versions of React while keeping backwards compatibility with older versions.