### PR TITLE
(koa-redis) Add interface RedisSessionStore containing client

### DIFF
--- a/types/koa-redis/index.d.ts
+++ b/types/koa-redis/index.d.ts
@@ -12,7 +12,11 @@ declare namespace redisStore {
         duplicate?: boolean;
         client?: any;
     }
+    
+    interface RedisSessionStore extends SessionStore {
+        client: any;
+    }
 }
 
-declare function redisStore(options: redisStore.RedisOptions): SessionStore;
+declare function redisStore(options: redisStore.RedisOptions): redisStore.RedisSessionStore;
 export = redisStore;


### PR DESCRIPTION
This PR fixes a type error when trying to access client property of a redisStore instance (useful to call store.client.disconnect() in tests)