### PR TITLE
(koa-redis) Extend SessionStore interface to support client property

### DIFF
--- a/types/koa-redis/index.d.ts
+++ b/types/koa-redis/index.d.ts
@@ -12,7 +12,11 @@ declare namespace redisStore {
         duplicate?: boolean;
         client?: any;
     }
+
+    interface RedisSessionStore extends SessionStore {
+        client: any;
+    }
 }
 
-declare function redisStore(options: redisStore.RedisOptions): SessionStore;
+declare function redisStore(options: redisStore.RedisOptions): redisStore.RedisSessionStore;
 export = redisStore;


### PR DESCRIPTION
This fixes linter complaining about redisStore.client, which is useful to access in test to close the redis connection like redisStore.client.disconnect()