### PR TITLE
@rails/actioncable: create version 6

### DIFF
--- a/types/rails__actioncable/index.d.ts
+++ b/types/rails__actioncable/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for ActionCable 6.0
+// Project: https://github.com/rails/rails/tree/master/actioncable/
+// Definitions by: Vincent Zhu <https://github.com/zhu1230>
+//                 Jared Szechy <https://github.com/szechyjs>
+//                 Renaud Chaput <https://github.com/renchap>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module ActionCable {
+    interface Channel {
+        unsubscribe(): void;
+        perform(action: string, data: {}): void;
+        send(data: any): boolean;
+    }
+
+    interface Subscriptions {
+        create(channel: string | ChannelNameWithParams, obj: CreateMixin): Channel;
+    }
+
+    interface Cable {
+        subscriptions: Subscriptions;
+        send(data: any): void;
+        connect(): void;
+        disconnect(): void;
+        ensureActiveConnection(): void;
+    }
+
+    interface CreateMixin {
+        connected(): void;
+        disconnected(): void;
+        received(obj: any): void;
+        [key: string]: Function;
+    }
+
+    interface ChannelNameWithParams {
+        channel: string;
+        [key: string]: any;
+    }
+
+    function createConsumer(): Cable;
+    function createConsumer(url: string): Cable;
+}
+
+declare interface AppInterface {
+    cable?: ActionCable.Cable;
+    network?: ActionCable.Channel;
+}
+
+declare var App: AppInterface;
+
+declare module '@rails/actioncable' {
+    export = ActionCable;
+}

--- a/types/rails__actioncable/rails__actioncable-tests.ts
+++ b/types/rails__actioncable/rails__actioncable-tests.ts
@@ -1,0 +1,41 @@
+interface HelloChannel extends ActionCable.Channel {
+    hello(world: string, name?: string): void;
+}
+
+App = {};
+App.cable = ActionCable.createConsumer();
+const helloChannel = App.cable.subscriptions.create('NetworkChannel', {
+    connected(): void {
+        console.log('connected');
+    },
+    disconnected(): void {
+        console.log('disconnected');
+    },
+    received(obj: Object): void {
+        console.log(obj);
+    },
+    hello(world: string, name: string = 'John Doe'): void {
+        console.log(`Hello, ${world}! name[${name}]`);
+    },
+}) as HelloChannel;
+
+helloChannel.hello('World');
+
+const channelParams: ActionCable.ChannelNameWithParams = {
+    channel: 'NetworkChannel',
+    token: 'foo',
+    data: {
+        bar: 'baz',
+    },
+};
+const channelWithParams = App.cable.subscriptions.create(channelParams, {
+    connected(): void {
+        console.log('connected');
+    },
+    disconnected(): void {
+        console.log('disconnected');
+    },
+    received(obj: Object): void {
+        console.log(obj);
+    },
+});

--- a/types/rails__actioncable/tsconfig.json
+++ b/types/rails__actioncable/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "rails__actioncable-tests.ts"]
+}

--- a/types/rails__actioncable/tslint.json
+++ b/types/rails__actioncable/tslint.json
@@ -1,0 +1,11 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false,
+        "no-internal-module": false,
+        "no-outside-dependencies": false,
+        "no-single-declare-module": false,
+        "strict-export-declare-modifiers": false,
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
This is a copy of the `actioncable` type definitions. It as been renamed to `@rails/actioncable` with Rails 6. As per [the changelog](https://github.com/rails/rails/blob/6-0-stable/actioncable/CHANGELOG.md), the public API did not change.

I cleaned up a bit the `tsconfig.json`. `tslint.json` also now only disables the rules that are triggered by this type definition (the previous version disabled a lot of other rules).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.