### PR TITLE
fix(node-hid): The HID class derives from the EventEmitter

### DIFF
--- a/types/node-hid/index.d.ts
+++ b/types/node-hid/index.d.ts
@@ -5,6 +5,10 @@
 //                 Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+
 export interface Device {
     vendorId: number;
     productId: number;
@@ -18,7 +22,7 @@ export interface Device {
     usage?: number;
 }
 
-export class HID {
+export class HID extends EventEmitter {
     constructor(path: string);
     constructor(vid: number, pid: number);
     close(): void;
@@ -29,10 +33,6 @@ export class HID {
     sendFeatureReport(data: number[]): number;
     getFeatureReport(report_id: number, report_length: number): number[];
     resume(): void;
-    on(event: string, handler: (value: any) => void): void;
-    once(event: string, handler: (value: any) => void): void;
-    removeListener(event: string, handler: (value: any) => void): void;
-    removeAllListeners(event: string): void;
     write(values: number[]): number;
     setNonBlocking(no_block: boolean): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-hid/node-hid/blob/67fa185f43ef52e33943b427f71d52cd556dce42/nodehid.js#L33
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
