### PR TITLE
Improve typings of reconnectingwebsocket

### DIFF
--- a/types/reconnectingwebsocket/index.d.ts
+++ b/types/reconnectingwebsocket/index.d.ts
@@ -1,46 +1,227 @@
 // Type definitions for reconnectingwebsocket 1.0
 // Project: https://github.com/joewalnes/reconnecting-websocket
 // Definitions by: Nicholas Guarracino <https://github.com/nguarracino>
+//                 AppLover69 <https://github.com/AppLover69>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace ReconnectingWebSocket {
     interface Options {
+        /**
+         * Whether or not the WebSocket should attempt to connect immediately upon instantiation.
+         * The socket can be manually opened or closed at any time using `open()` and `close()`.
+         * @default `true`
+         */
         automaticOpen?: boolean;
-        binaryType?: 'blob' | 'arraybuffer';
+        /**
+         * The binary type, possible values `'blob'` or `'arraybuffer'`.
+         * @default `'blob'`
+         */
+        binaryType?: globalThis.WebSocket['binaryType'];
+        /**
+         * Whether this instance should log debug messages.
+         * @default `false`
+         */
         debug?: boolean;
+        /**
+         * The maximum number of reconnection attempts to make. Unlimited if `null`.
+         * @default `null`
+         */
         maxReconnectAttempts?: number | null;
+        /**
+         * The maximum number of milliseconds to delay a reconnection attempt.
+         * Accepts integer.
+         * @default `30000`
+         */
         maxReconnectInterval?: number;
+        /**
+         * The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist.
+         * Accepts integer or float.
+         * @default `1.5`
+         */
         reconnectDecay?: number;
+        /**
+         * The number of milliseconds to delay before attempting to reconnect.
+         * Accepts integer.
+         * @default `1000`
+         */
         reconnectInterval?: number;
+        /**
+         * The maximum time in milliseconds to wait for a connection to succeed before closing and retrying.
+         * Accepts integer.
+         * @default `2000`
+         */
         timeoutInterval?: number;
+    }
+
+    interface OpenEvent extends CustomEvent<undefined> {
+        type: 'open';
+        isReconnect: boolean;
+    }
+
+    interface CloseEvent extends CustomEvent<undefined> {
+        type: 'close';
+    }
+
+    interface ConnectingEvent extends CustomEvent<undefined> {
+        type: 'connecting';
+        code: globalThis.CloseEvent['code'];
+        reason: globalThis.CloseEvent['reason'];
+        wasClean: globalThis.CloseEvent['wasClean'];
+    }
+
+    interface MessageEvent extends CustomEvent<undefined> {
+        type: 'message';
+        data: globalThis.MessageEvent['data'];
+    }
+
+    interface ErrorEvent extends CustomEvent<undefined> {
+        type: 'error';
+    }
+
+    interface EventMap {
+        'open': ReconnectingWebSocket.OpenEvent;
+        'close': ReconnectingWebSocket.CloseEvent;
+        'connecting': ReconnectingWebSocket.ConnectingEvent;
+        'message': ReconnectingWebSocket.MessageEvent;
+        'error': ReconnectingWebSocket.ErrorEvent;
     }
 }
 
-declare class ReconnectingWebSocket {
-    constructor(url: string, protocols?: string[], options?: ReconnectingWebSocket.Options);
+/**
+ * This behaves like a `WebSocket` in every way, except if it fails to connect,
+ * or it gets disconnected, it will repeatedly poll until it successfully connects
+ * again.
+ *
+ * It is API compatible, so when you have:
+ * ```ts
+ * ws = new WebSocket('ws://....');
+ * ```
+ * you can replace with:
+ * ```ts
+ * ws = new ReconnectingWebSocket('ws://....');
+ * ```
+ *
+ * The event stream will typically look like:
+ * - `onconnecting`
+ * - `onopen`
+ * - `onmessage`
+ * - `onmessage`
+ * - `onclose` // lost connection
+ * - `onconnecting`
+ * - `onopen`  // sometime later...
+ * - `onmessage`
+ * - `onmessage`
+ * - etc...
+ *
+ * It is API compatible with the standard WebSocket API, apart from the following members:
+ * - `bufferedAmount`
+ * - `extensions`
+ * - `binaryType`
+ */
+declare class ReconnectingWebSocket extends EventTarget {
+    /**
+     * @param url The url you are connecting to.
+     * @param protocols Optional string or array of protocols.
+     * @param options See `ReconnectingWebSocket.Options`
+     */
+    constructor(url: string, protocols?: string | string[], options?: ReconnectingWebSocket.Options);
 
+    /**
+     * Whether all instances of ReconnectingWebSocket should log debug messages.
+     * Setting this to true is the equivalent of setting all instances of ReconnectingWebSocket.debug to true.
+     */
     static debugAll: boolean;
 
-    static CONNECTING: number;
-    static OPEN: number;
-    static CLOSING: number;
-    static CLOSED: number;
+    static CONNECTING: globalThis.WebSocket['CONNECTING'];
+    static OPEN: globalThis.WebSocket['OPEN'];
+    static CLOSING: globalThis.WebSocket['CLOSING'];
+    static CLOSED: globalThis.WebSocket['CLOSED'];
 
-    onclose: (event: any) => void;
-    onconnecting: (event: any) => void;
-    onerror: (event: any) => void;
-    onmessage: (event: any) => void;
-    onopen: (event: any) => void;
+    /**
+     * An event listener to be called when the WebSocket connection's `readyState` changes to `OPEN`;
+     * this indicates that the connection is ready to send and receive data.
+     */
+    onopen: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.OpenEvent) => void;
+    /** An event listener to be called when the WebSocket connection's `readyState` changes to `CLOSED`. */
+    onclose: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.CloseEvent) => void;
+    /** An event listener to be called when a connection begins being attempted. */
+    onconnecting: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.ConnectingEvent) => void;
+    /** An event listener to be called when a message is received from the server. */
+    onmessage: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.MessageEvent) => void;
+    /** An event listener to be called when an error occurs. */
+    onerror: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.ErrorEvent) => void;
 
-    close(code?: number, reason?: string): void;
+    addEventListener<K extends keyof ReconnectingWebSocket.EventMap>(type: K, listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof ReconnectingWebSocket.EventMap>(type: K, listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+
+    /**
+     * Closes the WebSocket connection or connection attempt, if any.
+     * If the connection is already `CLOSED`, this method does nothing.
+     */
+    close: globalThis.WebSocket['close'];
     open(reconnectAttempt?: boolean): void;
+    /**
+     * Additional public API method to refresh the connection if still open (close, re-open).
+     * For example, if the app suspects bad data / missed heart beats, it can try to refresh.
+     */
     refresh(): void;
-    send(data: any): void;
+    /** Transmits data to the server over the WebSocket connection. */
+    send: globalThis.WebSocket['send'];
 
-    maxReconnectAttempts: number;
-    protocol: string | null;
-    readyState: number;
-    reconnectAttempts: number;
-    url: string;
+    /**
+     * Whether or not the WebSocket should attempt to connect immediately upon instantiation.
+     * The socket can be manually opened or closed at any time using `open()` and `close()`.
+     */
+    automaticOpen: NonNullable<ReconnectingWebSocket.Options['automaticOpen']>;
+    /**
+     * Whether this instance should log debug messages.
+     */
+    debug: NonNullable<ReconnectingWebSocket.Options['debug']>;
+    /** The maximum number of reconnection attempts to make. Unlimited if `null`. */
+    maxReconnectAttempts: NonNullable<ReconnectingWebSocket.Options['maxReconnectAttempts']> | null;
+    /**
+     * The maximum number of milliseconds to delay a reconnection attempt.
+     * Accepts integer.
+     */
+    maxReconnectInterval: NonNullable<ReconnectingWebSocket.Options['maxReconnectInterval']>;
+    /**
+     * The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist.
+     * Accepts integer or float.
+     */
+    reconnectDecay: NonNullable<ReconnectingWebSocket.Options['reconnectDecay']>;
+    /**
+     * The number of milliseconds to delay before attempting to reconnect.
+     * Accepts integer.
+     */
+    reconnectInterval: NonNullable<ReconnectingWebSocket.Options['reconnectInterval']>;
+    /**
+     * The maximum time in milliseconds to wait for a connection to succeed before closing and retrying.
+     * Accepts integer.
+     */
+    timeoutInterval: NonNullable<ReconnectingWebSocket.Options['timeoutInterval']>;
+    
+    /** The number of attempted reconnects since starting, or the last successful connection. */
+    readonly reconnectAttempts: number;
+    /**
+     * The binary type, possible values `'blob'` or `'arraybuffer'`.
+     */
+    readonly binaryType: globalThis.WebSocket['binaryType'];
+    /**
+     * The current state of the connection.
+     * Can be one of: `WebSocket.CONNECTING`, `WebSocket.OPEN`, `WebSocket.CLOSING`, `WebSocket.CLOSED`.
+     */
+    readonly readyState: globalThis.WebSocket['readyState'];
+    /**
+     * A string indicating the name of the sub-protocol the server selected; this will be one of
+     * the strings specified in the protocols parameter when creating the `WebSocket` object.
+     */
+    readonly protocol: globalThis.WebSocket['protocol'] | null;
+    /**
+     * The URL as resolved by the constructor. This is always an absolute URL.
+     */
+    readonly url: globalThis.WebSocket['url'];
 }
+
 export = ReconnectingWebSocket;

--- a/types/reconnectingwebsocket/index.d.ts
+++ b/types/reconnectingwebsocket/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Nicholas Guarracino <https://github.com/nguarracino>
 //                 AppLover69 <https://github.com/AppLover69>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+type GlobalMessageEvent = MessageEvent;
+type GlobalCloseEvent = CloseEvent;
 
 declare namespace ReconnectingWebSocket {
     interface Options {
@@ -16,7 +20,7 @@ declare namespace ReconnectingWebSocket {
          * The binary type, possible values `'blob'` or `'arraybuffer'`.
          * @default `'blob'`
          */
-        binaryType?: globalThis.WebSocket['binaryType'];
+        binaryType?: WebSocket['binaryType'];
         /**
          * Whether this instance should log debug messages.
          * @default `false`
@@ -53,37 +57,37 @@ declare namespace ReconnectingWebSocket {
         timeoutInterval?: number;
     }
 
-    interface OpenEvent extends CustomEvent<undefined> {
+    interface OpenEvent extends CustomEvent {
         type: 'open';
         isReconnect: boolean;
     }
 
-    interface CloseEvent extends CustomEvent<undefined> {
+    interface CloseEvent extends CustomEvent {
         type: 'close';
     }
 
-    interface ConnectingEvent extends CustomEvent<undefined> {
+    interface ConnectingEvent extends CustomEvent {
         type: 'connecting';
-        code: globalThis.CloseEvent['code'];
-        reason: globalThis.CloseEvent['reason'];
-        wasClean: globalThis.CloseEvent['wasClean'];
+        code: GlobalCloseEvent['code'];
+        reason: GlobalCloseEvent['reason'];
+        wasClean: GlobalCloseEvent['wasClean'];
     }
 
-    interface MessageEvent extends CustomEvent<undefined> {
+    interface MessageEvent extends CustomEvent {
         type: 'message';
-        data: globalThis.MessageEvent['data'];
+        data: GlobalMessageEvent['data'];
     }
 
-    interface ErrorEvent extends CustomEvent<undefined> {
+    interface ErrorEvent extends CustomEvent {
         type: 'error';
     }
 
     interface EventMap {
-        'open': ReconnectingWebSocket.OpenEvent;
-        'close': ReconnectingWebSocket.CloseEvent;
-        'connecting': ReconnectingWebSocket.ConnectingEvent;
-        'message': ReconnectingWebSocket.MessageEvent;
-        'error': ReconnectingWebSocket.ErrorEvent;
+        'open': OpenEvent;
+        'close': CloseEvent;
+        'connecting': ConnectingEvent;
+        'message': MessageEvent;
+        'error': ErrorEvent;
     }
 }
 
@@ -132,10 +136,10 @@ declare class ReconnectingWebSocket extends EventTarget {
      */
     static debugAll: boolean;
 
-    static CONNECTING: globalThis.WebSocket['CONNECTING'];
-    static OPEN: globalThis.WebSocket['OPEN'];
-    static CLOSING: globalThis.WebSocket['CLOSING'];
-    static CLOSED: globalThis.WebSocket['CLOSED'];
+    static CONNECTING: WebSocket['CONNECTING'];
+    static OPEN: WebSocket['OPEN'];
+    static CLOSING: WebSocket['CLOSING'];
+    static CLOSED: WebSocket['CLOSED'];
 
     /**
      * An event listener to be called when the WebSocket connection's `readyState` changes to `OPEN`;
@@ -151,16 +155,24 @@ declare class ReconnectingWebSocket extends EventTarget {
     /** An event listener to be called when an error occurs. */
     onerror: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.ErrorEvent) => void;
 
-    addEventListener<K extends keyof ReconnectingWebSocket.EventMap>(type: K, listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener<K extends keyof ReconnectingWebSocket.EventMap>(
+        type: K,
+        listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof ReconnectingWebSocket.EventMap>(type: K, listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener<K extends keyof ReconnectingWebSocket.EventMap>(
+        type: K,
+        listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     /**
      * Closes the WebSocket connection or connection attempt, if any.
      * If the connection is already `CLOSED`, this method does nothing.
      */
-    close: globalThis.WebSocket['close'];
+    close: WebSocket['close'];
     open(reconnectAttempt?: boolean): void;
     /**
      * Additional public API method to refresh the connection if still open (close, re-open).
@@ -168,7 +180,7 @@ declare class ReconnectingWebSocket extends EventTarget {
      */
     refresh(): void;
     /** Transmits data to the server over the WebSocket connection. */
-    send: globalThis.WebSocket['send'];
+    send: WebSocket['send'];
 
     /**
      * Whether or not the WebSocket should attempt to connect immediately upon instantiation.
@@ -201,27 +213,27 @@ declare class ReconnectingWebSocket extends EventTarget {
      * Accepts integer.
      */
     timeoutInterval: NonNullable<ReconnectingWebSocket.Options['timeoutInterval']>;
-    
+
     /** The number of attempted reconnects since starting, or the last successful connection. */
     readonly reconnectAttempts: number;
     /**
      * The binary type, possible values `'blob'` or `'arraybuffer'`.
      */
-    readonly binaryType: globalThis.WebSocket['binaryType'];
+    readonly binaryType: WebSocket['binaryType'];
     /**
      * The current state of the connection.
      * Can be one of: `WebSocket.CONNECTING`, `WebSocket.OPEN`, `WebSocket.CLOSING`, `WebSocket.CLOSED`.
      */
-    readonly readyState: globalThis.WebSocket['readyState'];
+    readonly readyState: WebSocket['readyState'];
     /**
      * A string indicating the name of the sub-protocol the server selected; this will be one of
      * the strings specified in the protocols parameter when creating the `WebSocket` object.
      */
-    readonly protocol: globalThis.WebSocket['protocol'] | null;
+    readonly protocol: WebSocket['protocol'] | null;
     /**
      * The URL as resolved by the constructor. This is always an absolute URL.
      */
-    readonly url: globalThis.WebSocket['url'];
+    readonly url: WebSocket['url'];
 }
 
 export = ReconnectingWebSocket;

--- a/types/reconnectingwebsocket/package.json
+++ b/types/reconnectingwebsocket/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        ">=3.4.0-0": { "*": ["ts3.4/*"] }
+    }
+}

--- a/types/reconnectingwebsocket/reconnectingwebsocket-tests.ts
+++ b/types/reconnectingwebsocket/reconnectingwebsocket-tests.ts
@@ -29,7 +29,7 @@ ws2.addEventListener('close', closeListener);
 ws2.removeEventListener('close', closeListener);
 
 ws2.onconnecting = (event) => {
-    console.log('Was clean?', event.wasClean);
+    console.log(event.type, 'was clean?', event.wasClean);
 };
 
 ws3.onerror = (event) => {
@@ -37,11 +37,11 @@ ws3.onerror = (event) => {
 };
 
 ws1.onmessage = (event: any) => {
-    console.log('Got data!', event.data);
+    console.log(event.type, event.data);
 };
 
 ws1.onopen = (event) => {
-    console.log('Is reconnect?', event.isReconnect);
+    console.log(event.type, 'is reconnect?', event.isReconnect);
 };
 
 ws1.open(true);
@@ -50,6 +50,6 @@ ws1.debug = true;
 
 ws1.refresh();
 
-ws1.send({});
+ws1.send(JSON.stringify({}));
 
 ws1.close();

--- a/types/reconnectingwebsocket/reconnectingwebsocket-tests.ts
+++ b/types/reconnectingwebsocket/reconnectingwebsocket-tests.ts
@@ -21,22 +21,32 @@ ReconnectingWebSocket.OPEN = WebSocket.OPEN;
 ReconnectingWebSocket.CLOSING = WebSocket.CLOSING;
 ReconnectingWebSocket.CLOSED = WebSocket.CLOSED;
 
-ws1.onclose = (event: any) => {
+const closeListener = (event: CustomEvent<undefined>) => {
+    console.log(event.type);
+};
+ws1.onclose = closeListener;
+ws2.addEventListener('close', closeListener);
+ws2.removeEventListener('close', closeListener);
+
+ws2.onconnecting = (event) => {
+    console.log('Was clean?', event.wasClean);
 };
 
-ws2.onconnecting = (event: any) => {
-};
-
-ws3.onerror = (event: any) => {
+ws3.onerror = (event) => {
+    console.log(event.type);
 };
 
 ws1.onmessage = (event: any) => {
+    console.log('Got data!', event.data);
 };
 
-ws1.onopen = (event: any) => {
+ws1.onopen = (event) => {
+    console.log('Is reconnect?', event.isReconnect);
 };
 
 ws1.open(true);
+
+ws1.debug = true;
 
 ws1.refresh();
 

--- a/types/reconnectingwebsocket/ts3.4/index.d.ts
+++ b/types/reconnectingwebsocket/ts3.4/index.d.ts
@@ -1,0 +1,229 @@
+declare namespace ReconnectingWebSocket {
+    interface Options {
+        /**
+         * Whether or not the WebSocket should attempt to connect immediately upon instantiation.
+         * The socket can be manually opened or closed at any time using `open()` and `close()`.
+         * @default `true`
+         */
+        automaticOpen?: boolean;
+        /**
+         * The binary type, possible values `'blob'` or `'arraybuffer'`.
+         * @default `'blob'`
+         */
+        binaryType?: globalThis.WebSocket['binaryType'];
+        /**
+         * Whether this instance should log debug messages.
+         * @default `false`
+         */
+        debug?: boolean;
+        /**
+         * The maximum number of reconnection attempts to make. Unlimited if `null`.
+         * @default `null`
+         */
+        maxReconnectAttempts?: number | null;
+        /**
+         * The maximum number of milliseconds to delay a reconnection attempt.
+         * Accepts integer.
+         * @default `30000`
+         */
+        maxReconnectInterval?: number;
+        /**
+         * The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist.
+         * Accepts integer or float.
+         * @default `1.5`
+         */
+        reconnectDecay?: number;
+        /**
+         * The number of milliseconds to delay before attempting to reconnect.
+         * Accepts integer.
+         * @default `1000`
+         */
+        reconnectInterval?: number;
+        /**
+         * The maximum time in milliseconds to wait for a connection to succeed before closing and retrying.
+         * Accepts integer.
+         * @default `2000`
+         */
+        timeoutInterval?: number;
+    }
+
+    interface OpenEvent extends CustomEvent<undefined> {
+        type: 'open';
+        isReconnect: boolean;
+    }
+
+    interface CloseEvent extends CustomEvent<undefined> {
+        type: 'close';
+    }
+
+    interface ConnectingEvent extends CustomEvent<undefined> {
+        type: 'connecting';
+        code: globalThis.CloseEvent['code'];
+        reason: globalThis.CloseEvent['reason'];
+        wasClean: globalThis.CloseEvent['wasClean'];
+    }
+
+    interface MessageEvent extends CustomEvent<undefined> {
+        type: 'message';
+        data: globalThis.MessageEvent['data'];
+    }
+
+    interface ErrorEvent extends CustomEvent<undefined> {
+        type: 'error';
+    }
+
+    interface EventMap {
+        'open': OpenEvent;
+        'close': CloseEvent;
+        'connecting': ConnectingEvent;
+        'message': MessageEvent;
+        'error': ErrorEvent;
+    }
+}
+
+/**
+ * This behaves like a `WebSocket` in every way, except if it fails to connect,
+ * or it gets disconnected, it will repeatedly poll until it successfully connects
+ * again.
+ *
+ * It is API compatible, so when you have:
+ * ```ts
+ * ws = new WebSocket('ws://....');
+ * ```
+ * you can replace with:
+ * ```ts
+ * ws = new ReconnectingWebSocket('ws://....');
+ * ```
+ *
+ * The event stream will typically look like:
+ * - `onconnecting`
+ * - `onopen`
+ * - `onmessage`
+ * - `onmessage`
+ * - `onclose` // lost connection
+ * - `onconnecting`
+ * - `onopen`  // sometime later...
+ * - `onmessage`
+ * - `onmessage`
+ * - etc...
+ *
+ * It is API compatible with the standard WebSocket API, apart from the following members:
+ * - `bufferedAmount`
+ * - `extensions`
+ * - `binaryType`
+ */
+declare class ReconnectingWebSocket extends EventTarget {
+    /**
+     * @param url The url you are connecting to.
+     * @param protocols Optional string or array of protocols.
+     * @param options See `ReconnectingWebSocket.Options`
+     */
+    constructor(url: string, protocols?: string | string[], options?: ReconnectingWebSocket.Options);
+
+    /**
+     * Whether all instances of ReconnectingWebSocket should log debug messages.
+     * Setting this to true is the equivalent of setting all instances of ReconnectingWebSocket.debug to true.
+     */
+    static debugAll: boolean;
+
+    static CONNECTING: globalThis.WebSocket['CONNECTING'];
+    static OPEN: globalThis.WebSocket['OPEN'];
+    static CLOSING: globalThis.WebSocket['CLOSING'];
+    static CLOSED: globalThis.WebSocket['CLOSED'];
+
+    /**
+     * An event listener to be called when the WebSocket connection's `readyState` changes to `OPEN`;
+     * this indicates that the connection is ready to send and receive data.
+     */
+    onopen: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.OpenEvent) => void;
+    /** An event listener to be called when the WebSocket connection's `readyState` changes to `CLOSED`. */
+    onclose: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.CloseEvent) => void;
+    /** An event listener to be called when a connection begins being attempted. */
+    onconnecting: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.ConnectingEvent) => void;
+    /** An event listener to be called when a message is received from the server. */
+    onmessage: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.MessageEvent) => void;
+    /** An event listener to be called when an error occurs. */
+    onerror: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.ErrorEvent) => void;
+
+    addEventListener<K extends keyof ReconnectingWebSocket.EventMap>(
+        type: K,
+        listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof ReconnectingWebSocket.EventMap>(
+        type: K,
+        listener: (this: ReconnectingWebSocket, event: ReconnectingWebSocket.EventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+
+    /**
+     * Closes the WebSocket connection or connection attempt, if any.
+     * If the connection is already `CLOSED`, this method does nothing.
+     */
+    close: globalThis.WebSocket['close'];
+    open(reconnectAttempt?: boolean): void;
+    /**
+     * Additional public API method to refresh the connection if still open (close, re-open).
+     * For example, if the app suspects bad data / missed heart beats, it can try to refresh.
+     */
+    refresh(): void;
+    /** Transmits data to the server over the WebSocket connection. */
+    send: globalThis.WebSocket['send'];
+
+    /**
+     * Whether or not the WebSocket should attempt to connect immediately upon instantiation.
+     * The socket can be manually opened or closed at any time using `open()` and `close()`.
+     */
+    automaticOpen: NonNullable<ReconnectingWebSocket.Options['automaticOpen']>;
+    /**
+     * Whether this instance should log debug messages.
+     */
+    debug: NonNullable<ReconnectingWebSocket.Options['debug']>;
+    /** The maximum number of reconnection attempts to make. Unlimited if `null`. */
+    maxReconnectAttempts: NonNullable<ReconnectingWebSocket.Options['maxReconnectAttempts']> | null;
+    /**
+     * The maximum number of milliseconds to delay a reconnection attempt.
+     * Accepts integer.
+     */
+    maxReconnectInterval: NonNullable<ReconnectingWebSocket.Options['maxReconnectInterval']>;
+    /**
+     * The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist.
+     * Accepts integer or float.
+     */
+    reconnectDecay: NonNullable<ReconnectingWebSocket.Options['reconnectDecay']>;
+    /**
+     * The number of milliseconds to delay before attempting to reconnect.
+     * Accepts integer.
+     */
+    reconnectInterval: NonNullable<ReconnectingWebSocket.Options['reconnectInterval']>;
+    /**
+     * The maximum time in milliseconds to wait for a connection to succeed before closing and retrying.
+     * Accepts integer.
+     */
+    timeoutInterval: NonNullable<ReconnectingWebSocket.Options['timeoutInterval']>;
+
+    /** The number of attempted reconnects since starting, or the last successful connection. */
+    readonly reconnectAttempts: number;
+    /**
+     * The binary type, possible values `'blob'` or `'arraybuffer'`.
+     */
+    readonly binaryType: globalThis.WebSocket['binaryType'];
+    /**
+     * The current state of the connection.
+     * Can be one of: `WebSocket.CONNECTING`, `WebSocket.OPEN`, `WebSocket.CLOSING`, `WebSocket.CLOSED`.
+     */
+    readonly readyState: globalThis.WebSocket['readyState'];
+    /**
+     * A string indicating the name of the sub-protocol the server selected; this will be one of
+     * the strings specified in the protocols parameter when creating the `WebSocket` object.
+     */
+    readonly protocol: globalThis.WebSocket['protocol'] | null;
+    /**
+     * The URL as resolved by the constructor. This is always an absolute URL.
+     */
+    readonly url: globalThis.WebSocket['url'];
+}
+
+export = ReconnectingWebSocket;

--- a/types/reconnectingwebsocket/ts3.4/reconnectingwebsocket-tests.ts
+++ b/types/reconnectingwebsocket/ts3.4/reconnectingwebsocket-tests.ts
@@ -1,0 +1,55 @@
+import ReconnectingWebSocket = require("reconnectingwebsocket");
+
+const options: ReconnectingWebSocket.Options = {
+    automaticOpen: false,
+    binaryType: "blob",
+    debug: false,
+    maxReconnectAttempts: 1,
+    maxReconnectInterval: 1000,
+    reconnectDecay: 1.5,
+    reconnectInterval: 1000,
+    timeoutInterval: 1000
+};
+
+const ws1: ReconnectingWebSocket = new ReconnectingWebSocket("url", ["protocol"], options);
+const ws2: ReconnectingWebSocket = new ReconnectingWebSocket("url", ["protocol"]);
+const ws3: ReconnectingWebSocket = new ReconnectingWebSocket("url");
+
+ReconnectingWebSocket.debugAll = true;
+ReconnectingWebSocket.CONNECTING = WebSocket.CONNECTING;
+ReconnectingWebSocket.OPEN = WebSocket.OPEN;
+ReconnectingWebSocket.CLOSING = WebSocket.CLOSING;
+ReconnectingWebSocket.CLOSED = WebSocket.CLOSED;
+
+const closeListener = (event: CustomEvent<undefined>) => {
+    console.log(event.type);
+};
+ws1.onclose = closeListener;
+ws2.addEventListener('close', closeListener);
+ws2.removeEventListener('close', closeListener);
+
+ws2.onconnecting = (event) => {
+    console.log(event.type, 'was clean?', event.wasClean);
+};
+
+ws3.onerror = (event) => {
+    console.log(event.type);
+};
+
+ws1.onmessage = (event: any) => {
+    console.log(event.type, event.data);
+};
+
+ws1.onopen = (event) => {
+    console.log(event.type, 'is reconnect?', event.isReconnect);
+};
+
+ws1.open(true);
+
+ws1.debug = true;
+
+ws1.refresh();
+
+ws1.send(JSON.stringify({}));
+
+ws1.close();

--- a/types/reconnectingwebsocket/ts3.4/tsconfig.json
+++ b/types/reconnectingwebsocket/ts3.4/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../../",
+        "typeRoots": ["../../"]
+    }
+}

--- a/types/reconnectingwebsocket/ts3.4/tsconfig.json
+++ b/types/reconnectingwebsocket/ts3.4/tsconfig.json
@@ -1,7 +1,19 @@
 {
     "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../../",
-        "typeRoots": ["../../"]
+        "typeRoots": ["../../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/reconnectingwebsocket/ts3.4/tsconfig.json
+++ b/types/reconnectingwebsocket/ts3.4/tsconfig.json
@@ -2,5 +2,9 @@
     "compilerOptions": {
         "baseUrl": "../../",
         "typeRoots": ["../../"]
-    }
+    },
+    "files": [
+        "index.d.ts",
+        "reconnectingwebsocket-tests.ts"
+    ]
 }

--- a/types/reconnectingwebsocket/ts3.4/tslint.json
+++ b/types/reconnectingwebsocket/ts3.4/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/joewalnes/reconnecting-websocket/blob/master/reconnecting-websocket.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
