### PR TITLE
Fix MenuLinkProps `as` prop

### DIFF
--- a/types/reach__menu-button/index.d.ts
+++ b/types/reach__menu-button/index.d.ts
@@ -52,7 +52,7 @@ export type ResolvedMenuLinkComponent<T> = T extends keyof JSX.IntrinsicElements
 export type MenuLinkProps<
   T extends SupportedMenuLinkComponent
 > = ResolvedMenuLinkProps<T> & {
-  as?: string;
+  as?: ResolvedMenuLinkComponent<T>;
   to?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;

--- a/types/reach__menu-button/index.d.ts
+++ b/types/reach__menu-button/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @reach/menu-button 0.1
 // Project: https://github.com/reach/reach-ui
 // Definitions by: Harry Hedger <https://github.com/hedgerh>
+//                 Guillaume Amat <https://github.com/GuillaumeAmat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/reach__menu-button/index.d.ts
+++ b/types/reach__menu-button/index.d.ts
@@ -45,9 +45,9 @@ export type ResolvedMenuLinkProps<T> = T extends keyof JSX.IntrinsicElements
   ? JSX.IntrinsicElements[T]
   : T;
 
-export type ResolvedMenuLinkComponent<T> = T extends keyof JSX.IntrinsicElements
-  ? T
-  : React.ComponentType<T>;
+export type ResolvedMenuLinkComponent<T> =
+  | keyof JSX.IntrinsicElements
+  | React.ComponentType<T>;
 
 export type MenuLinkProps<
   T extends SupportedMenuLinkComponent

--- a/types/reach__menu-button/reach__menu-button-tests.tsx
+++ b/types/reach__menu-button/reach__menu-button-tests.tsx
@@ -3,21 +3,26 @@ import { Menu, MenuButton, MenuList, MenuItem, MenuLink } from '@reach/menu-butt
 import * as React from 'react';
 import { render } from 'react-dom';
 
+const CustomComponent = ({ ...props }) => <a {...props} />;
+
 const Example = () => (
-    <Menu>
-        <MenuButton>
-            Actions <span aria-hidden>▾</span>
-        </MenuButton>
-        <MenuList>
-            <MenuItem onSelect={() => alert('Download')}>Download</MenuItem>
-            <MenuItem onSelect={() => alert('Copy')}>Create a Copy</MenuItem>
-            <MenuItem onSelect={() => alert('Mark as Draft')}>Mark as Draft</MenuItem>
-            <MenuItem onSelect={() => alert('Delete')}>Delete</MenuItem>
-            <MenuLink as="a" to="https://reach.tech/workshops">
-                Attend a Workshop
-            </MenuLink>
-        </MenuList>
-    </Menu>
+  <Menu>
+    <MenuButton>
+      Actions <span aria-hidden>▾</span>
+    </MenuButton>
+    <MenuList>
+      <MenuItem onSelect={() => alert('Download')}>Download</MenuItem>
+      <MenuItem onSelect={() => alert('Copy')}>Create a Copy</MenuItem>
+      <MenuItem onSelect={() => alert('Mark as Draft')}>Mark as Draft</MenuItem>
+      <MenuItem onSelect={() => alert('Delete')}>Delete</MenuItem>
+      <MenuLink as="a" to="https://reach.tech/workshops">
+        Attend a Workshop
+      </MenuLink>
+      <MenuLink as={CustomComponent} to="https://reach.tech/workshops">
+        Attend a Workshop
+      </MenuLink>
+    </MenuList>
+  </Menu>
 );
 
 render(<Example />, document.getElementById('app'));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

The `as` prop accepts any component, not just strings.

cc @hedgerh 