### PR TITLE
Seamless Immutable: Add Optional Arguments to Array Map Callback

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -108,7 +108,7 @@ declare namespace SeamlessImmutable {
         /** Custom implementation of the array functions, which return Immutable. */
         interface Overrides<T> {
             forEach(callbackfn: (value: Immutable<T>, index: number, array: Immutable<T[]>) => void, thisArg?: any): void;
-            map<TTarget>(mapFuction: (item: Immutable<T>) => TTarget): Immutable<TTarget[]>;
+            map<TTarget>(mapFuction: (item: Immutable<T>, index: number, array: Immutable<T[]>) => TTarget): Immutable<TTarget[]>;
             filter(filterFunction: (item: Immutable<T>) => boolean): Immutable<T[]>;
             slice(start?: number, end?: number): Immutable<T[]>;
             concat(...arr: Array<T|T[]|Immutable<T>|Array<Immutable<T>>|Immutable<T[]>>): Immutable<T[]>;

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -124,6 +124,14 @@ interface NonDeepMutableExtendedUser {
     // map. Call the mutable array's 'map' with the same function to ensure compatability. Make sure the output array is immutable.
     interface FirstName { firstNameOnly: string; }
     array.asMutable().map((value: User) => ({ firstNameOnly: value.firstName }));
+    array
+      .asMutable()
+      .map((value: User, index) => ({ firstNameOnly: value.firstName, index }));
+    array.asMutable().map((value: User, index, allUsers: User[]) => ({
+      firstNameOnly: value.firstName,
+      index,
+      allUsers,
+    }));
     const map: Immutable.Immutable<FirstName[]> = array.map((value: User) => ({ firstNameOnly: value.firstName }));
     map.asMutable();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Parameters
- N/A If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- N/A If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

--- 

Example Code:

```js
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
> const SI = require('seamless-immutable')
> SI.from(['zero', 'one', 'two']).map((word, index,arr) => `${index}: ${word}, ${arr.join('-')}`)
[ '0: zero, zero-one-two',
  '1: one, zero-one-two',
  '2: two, zero-one-two' ]
```