### PR TITLE
Fixes #35572, and the problem that using useRef with ref={} currently yields error

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -20,6 +20,7 @@
 //                 Saransh Kataria <https://github.com/saranshkataria>
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Staffan Eketorp <https://github.com/staeke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -77,7 +78,7 @@ declare namespace React {
     type Key = string | number;
 
     interface RefObject<T> {
-        readonly current: T | null;
+        readonly current: T | null | undefined;
     }
 
     type Ref<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"] | RefObject<T> | null;

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -63,11 +63,11 @@ export function App() {
     const birthdayRef = React.useRef<FancyButton>(null);
 
     React.useLayoutEffect(() => {
-        if (birthdayRef.current !== null) {
+        if (birthdayRef.current != null) {
             birthdayRef.current.fancyClick();
         } else {
             // this looks redundant but it ensures the type actually has "null" in it instead of "never"
-            // $ExpectType null
+            // $ExpectType null | undefined
             birthdayRef.current;
         }
     });


### PR DESCRIPTION
Fixes #35572, and the problem that using 

```jsx
const a = useRef<HTMLDivElement>(); 
return <div ref={a}/>
```

currently yields error

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/hooks-reference.html#useref