### PR TITLE
[file-loader] introduce types

### DIFF
--- a/types/file-loader/file-loader-tests.ts
+++ b/types/file-loader/file-loader-tests.ts
@@ -1,0 +1,27 @@
+import * as FileLoader from 'file-loader';
+
+let fn: FileLoader.BuildResourcePathFn;
+
+fn = () => {}; // $ExpectError
+fn = () => 1; // $ExpectError
+fn = () => ''; // $ExpectType () => string
+fn = url => ''; // $ExpectType (url: string) => string
+fn = (url, resourcePath, context, forth) => ''; // $ExpectError
+
+let options: FileLoader.Options;
+
+options = {}; // $ExpectType {}
+options = { name: '' }; // $ExpectType { name: string; }
+options = { name: () => '' }; // $ExpectType { name: () => string; }
+options = { outputPath: '' }; // $ExpectType { outputPath: string; }
+options = { outputPath: () => '' }; // $ExpectType { outputPath: () => string; }
+options = { publicPath: '' }; // $ExpectType { publicPath: string; }
+options = { publicPath: () => '' }; // $ExpectType { publicPath: () => string; }
+options = { context: '' }; // $ExpectType { context: string; }
+options = { context: () => '' }; // $ExpectError
+options = { emitFile: true }; // $ExpectType { emitFile: true; }
+options = { emitFile: false }; // $ExpectType { emitFile: false; }
+options = { emitFile: () => true }; // $ExpectError
+options = { regExp: /regex/ }; // $ExpectType { regExp: RegExp; }
+options = { regExp: 'regex' }; // $ExpectError
+options = { postTransformPublicPath: '' }; // $ExpectError

--- a/types/file-loader/index.d.ts
+++ b/types/file-loader/index.d.ts
@@ -1,0 +1,232 @@
+// Type definitions for file-loader 4.2
+// Project: https://github.com/webpack-contrib/file-loader
+// Definitions by: Gareth Jones <https://github.com/g-rath>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { loader } from 'webpack';
+
+declare namespace FileLoader {
+    interface Options {
+        /**
+         * Specifies a custom filename template for the target file(s) using the query parameter name.
+         *
+         * By default the path and name you specify will output the file in that same directory,
+         * and will also use the same URI path to access the file.
+         *
+         * For example, to emit a file from your context directory into the output directory retaining the full
+         * directory structure, you might use:
+         *
+         * @example
+         * module.exports = {
+         *   module: {
+         *     rules: [
+         *       {
+         *         test: /\.(png|jpe?g|gif)$/i,
+         *         loader: 'file-loader',
+         *         options: {
+         *           name: '[path][name].[ext]',
+         *         },
+         *       },
+         *     ],
+         *   },
+         * };
+         *
+         * @example
+         * module.exports = {
+         *  module: {
+         *    rules: [
+         *      {
+         *        test: /\.(png|jpe?g|gif)$/i,
+         *        loader: 'file-loader',
+         *        options: {
+         *          name(file) {
+         *            if (process.env.NODE_ENV === 'development') {
+         *              return '[path][name].[ext]';
+         *            }
+         *
+         *            return '[contenthash].[ext]';
+         *          },
+         *        },
+         *      },
+         *    ],
+         *  },
+         * };
+         *
+         * @default '[contenthash].[ext]'
+         */
+        name?: string | ((file: string) => string);
+        /**
+         * Specify a filesystem path where the target file(s) will be placed.
+         *
+         * Function gets passes the original absolute path to the asset,
+         * as well as the directory where assets are stored.
+         *
+         * @example
+         * module.exports = {
+         *   module: {
+         *     rules: [
+         *       {
+         *         test: /\.(png|jpe?g|gif)$/i,
+         *         loader: 'file-loader',
+         *         options: {
+         *           outputPath: (url, resourcePath, context) => {
+         *             if (/my-custom-image\.png/.test(resourcePath)) {
+         *               return `other_output_path/${url}`;
+         *             }
+         *
+         *             if (/images/.test(context)) {
+         *               return `image_output_path/${url}`;
+         *             }
+         *
+         *             return `output_path/${url}`;
+         *           },
+         *         },
+         *       },
+         *     ],
+         *   },
+         * };
+         *
+         * @default undefined
+         */
+        outputPath?: string | BuildResourcePathFn;
+        /**
+         * Specifies a custom public path for the target file(s).
+         *
+         * Function gets passes the original absolute path to the asset,
+         * as well as the directory where assets are stored.
+         *
+         * @example
+         * module.exports = {
+         *  module: {
+         *    rules: [
+         *      {
+         *        test: /\.(png|jpe?g|gif)$/i,
+         *        loader: 'file-loader',
+         *        options: {
+         *          publicPath: (url, resourcePath, context) => {
+         *            if (/my-custom-image\.png/.test(resourcePath)) {
+         *              return `other_public_path/${url}`;
+         *            }
+         *
+         *            if (/images/.test(context)) {
+         *              return `image_output_path/${url}`;
+         *            }
+         *
+         *            return `public_path/${url}`;
+         *          },
+         *        },
+         *      },
+         *    ],
+         *  },
+         * };
+         *
+         * @default {@link https://webpack.js.org/api/module-variables/#__webpack_public_path__-webpack-specific __webpack_public_path__}
+         */
+        publicPath?: string | BuildResourcePathFn;
+        /**
+         * Specifies a custom function to post-process the generated public path.
+         *
+         * This can be used to prepend or append dynamic global variables that are only available at runtime, like
+         * `__webpack_public_path__`. This would not be possible with just publicPath, since it stringifies the values.
+         *
+         * @example
+         * module.exports = {
+         *   module: {
+         *     rules: [
+         *       {
+         *         test: /\.(png|jpg|gif)$/i,
+         *         loader: 'file-loader',
+         *         options: {
+         *           publicPath: '/some/path/',
+         *           postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
+         *         },
+         *       },
+         *     ],
+         *   },
+         * };
+         *
+         * @default undefined
+         */
+        postTransformPublicPath?: (p: string) => string;
+        /**
+         * Specifies a custom file context.
+         *
+         * @example
+         * module.exports = {
+         *   module: {
+         *     rules: [
+         *       {
+         *         test: /\.(png|jpe?g|gif)$/i,
+         *         use: [
+         *           {
+         *             loader: 'file-loader',
+         *             options: {
+         *               context: 'project',
+         *             },
+         *           },
+         *         ],
+         *       },
+         *     ],
+         *   },
+         * };
+         *
+         * @default {@link https://webpack.js.org/configuration/entry-context/#context context}
+         */
+        context?: string;
+        /**
+         * If `true`, emits a file (writes a file to the filesystem); otherwise, the loader will return a public URI
+         * but will not emit the file. It is often useful to disable this option for server-side packages.
+         *
+         * @default true
+         */
+        emitFile?: boolean;
+        /**
+         * Specifies a Regular Expression to one or many parts of the target file path.
+         * The capture groups can be reused in the name property using [N]
+         * {@link https://github.com/webpack-contrib/file-loader#placeholders placeholder}.
+         *
+         * If [0] is used, it will be replaced by the entire tested string,
+         * whereas [1] will contain the first capturing parenthesis of your regex and so on...
+         *
+         * @example
+         * // file.js
+         * import img from './customer01/file.png';
+         *
+         * // webpack.config.js
+         * module.exports = {
+         *   module: {
+         *     rules: [
+         *       {
+         *         test: /\.(png|jpe?g|gif)$/i,
+         *         use: [
+         *           {
+         *             loader: 'file-loader',
+         *             options: {
+         *               regExp: /\/([a-z0-9]+)\/[a-z0-9]+\.png$/i,
+         *               name: '[1]-[name].[ext]',
+         *             },
+         *           },
+         *         ],
+         *       },
+         *     ],
+         *   },
+         * };
+         *
+         * @default undefined
+         */
+        regExp?: RegExp;
+    }
+
+    /**
+     * @param url
+     * @param resourcePath original absolute path to the asset
+     * @param context directory where assets are stored (`rootContext`), or the value of the `context` option if set.
+     *
+     * @return the path to use for the asset
+     */
+    type BuildResourcePathFn = (url: string, resourcePath: string, context: string) => string;
+}
+
+declare const FileLoader: loader.Loader;
+export = FileLoader;

--- a/types/file-loader/tsconfig.json
+++ b/types/file-loader/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "file-loader-tests.ts"
+    ]
+}

--- a/types/file-loader/tslint.json
+++ b/types/file-loader/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are typings for [`file-loader`](https://github.com/webpack-contrib/file-loader), which is authored by @webpack-contrib

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.