### PR TITLE
Add types for package-info

### DIFF
--- a/types/package-info/index.d.ts
+++ b/types/package-info/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for package-info 3.0
+// Project: https://github.com/AlessandroMinoccheri/package-info#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace info {
+    interface Package {
+        author: string;
+        description: string;
+        homepage: string;
+        license: string;
+        name: string;
+        version: string;
+    }
+}
+
+declare function info(name: string): Promise<info.Package>;
+
+export = info;

--- a/types/package-info/package-info-tests.ts
+++ b/types/package-info/package-info-tests.ts
@@ -1,0 +1,10 @@
+import info = require('package-info');
+
+info('package-info').then(data => {
+    data.author; // $ExpectType string
+    data.description; // $ExpectType string
+    data.homepage; // $ExpectType string
+    data.license; // $ExpectType string
+    data.name; // $ExpectType string
+    data.version; // $ExpectType string
+});

--- a/types/package-info/tsconfig.json
+++ b/types/package-info/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "package-info-tests.ts"
+    ]
+}

--- a/types/package-info/tslint.json
+++ b/types/package-info/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
