### PR TITLE
[@types/node] add `destroyed` property for Readable and Writable

### DIFF
--- a/types/derhuerst__cli-on-key/index.d.ts
+++ b/types/derhuerst__cli-on-key/index.d.ts
@@ -5,8 +5,6 @@
 
 /// <reference types="node" />
 
-import stream = require("stream");
-
 declare namespace listen {
     interface Key {
         name?: string;
@@ -23,7 +21,7 @@ declare namespace listen {
 }
 
 declare function listen(
-    stream: stream.Readable,
+    stream: NodeJS.ReadStream,
     callback: listen.Callback
 ): listen.OffKeyPress;
 

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -26,6 +26,7 @@ declare module "stream" {
             readable: boolean;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
+            destroyed: boolean;
             constructor(opts?: ReadableOptions);
             _read(size: number): void;
             read(size?: number): any;
@@ -119,6 +120,7 @@ declare module "stream" {
             readonly writableFinished: boolean;
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
+            destroyed: boolean;
             constructor(opts?: WritableOptions);
             _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             _writev?(chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;

--- a/types/node/test/global.ts
+++ b/types/node/test/global.ts
@@ -32,10 +32,21 @@ import { Readable, Writable } from 'stream';
 const a: NodeJS.TypedArray = new Buffer(123);
 
 {
-    const stdin: Readable = process.stdin;
     let writableFinished: boolean;
-    const stdout: Writable = process.stdout;
-    writableFinished = process.stdout.writableFinished;
-    const stderr: Writable = process.stderr;
-    writableFinished = process.stderr.writableFinished;
+    const readable: Readable = new Readable({
+        read() {
+            this.push('hello');
+            this.push('world');
+            this.push(null);
+        },
+    });
+    readable.destroyed;
+    const writable: Writable = new Writable({
+        write(chunk, _, cb) {
+            cb();
+        },
+    });
+    readable.pipe(writable);
+    writableFinished = writable.writableFinished;
+    writable.destroyed;
 }

--- a/types/yazl/index.d.ts
+++ b/types/yazl/index.d.ts
@@ -7,7 +7,6 @@
 
 /// <reference types="node" />
 
-import { Readable } from 'stream';
 import { Buffer } from 'buffer';
 
 export interface Options {
@@ -37,10 +36,10 @@ export interface DosDateTime {
 
 export class ZipFile {
     addFile(realPath: string, metadataPath: string, options?: Partial<Options>): void;
-    outputStream: Readable;
-    addReadStream(input: Readable, metadataPath: string, options?: Partial<ReadStreamOptions>): void;
+    outputStream: NodeJS.ReadableStream;
+    addReadStream(input: NodeJS.ReadableStream, metadataPath: string, options?: Partial<ReadStreamOptions>): void;
     addBuffer(buffer: Buffer, metadataPath: string, options?: Partial<Options>): void;
-    end(optoins?: EndOptions, finalSizeCallback?: () => void): void;
+    end(options?: EndOptions, finalSizeCallback?: () => void): void;
 
     addEmptyDirectory(metadataPath: string, options?: Partial<DirectoryOptions>): void;
     dateToDosDateTime(jsDate: Date): DosDateTime;

--- a/types/yazl/yazl-tests.ts
+++ b/types/yazl/yazl-tests.ts
@@ -1,5 +1,4 @@
 import { ZipFile } from "yazl";
-import { Readable } from "stream";
 import fs = require('fs');
 
 const zipfile = new ZipFile();
@@ -7,7 +6,7 @@ zipfile.addFile("file1.txt", "file1.txt");
 // (add only files, not directories)
 zipfile.addFile("path/to/file.txt", "path/in/zipfile.txt");
 // pipe() can be called any time after the constructor
-// $ExpectType Readable
+// $ExpectType ReadableStream
 zipfile.outputStream;
 zipfile.outputStream.pipe(fs.createWriteStream("output.zip")).on("close", () => {
 	console.log("done");


### PR DESCRIPTION
1. [readable.destroyed](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_readable_destroyed)
2. [writable.destroyed](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_writable_destroyed)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_readable_destroyed>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
