### PR TITLE
Updates pnpapi to add extend process.versions

### DIFF
--- a/types/pnpapi/index.d.ts
+++ b/types/pnpapi/index.d.ts
@@ -4,38 +4,55 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export interface PhysicalPackageLocator {
-    name: string;
-    reference: string;
+declare namespace NodeJS {
+    interface ProcessVersions {
+        pnp?: string;
+    }
 }
 
-export interface TopLevelPackageLocator {
-    name: null;
-    reference: null;
+declare module 'pnpapi' {
+    export interface PhysicalPackageLocator {
+        name: string;
+        reference: string;
+    }
+
+    export interface TopLevelPackageLocator {
+      name: null;
+      reference: null;
+    }
+
+    export type PackageLocator =
+      | PhysicalPackageLocator
+      | TopLevelPackageLocator;
+
+    export interface PackageInformation {
+      packageLocation: string;
+      packageDependencies: Map<string, string | [string, string]>;
+    }
+
+    export const VERSIONS: { std: number; [key: string]: number };
+
+    export const topLevel: { name: null; reference: null };
+
+    export function getPackageInformation(
+      locator: PackageLocator,
+    ): PackageInformation;
+    export function findPackageLocator(location: string): PackageLocator | null;
+
+    export function resolveToUnqualified(
+      request: string,
+      issuer: string | null,
+      opts?: { considerBuiltins?: boolean },
+    ): string | null;
+    export function resolveUnqualified(
+      unqualified: string,
+      opts?: { extensions?: string[] },
+    ): string;
+    export function resolveRequest(
+      request: string,
+      issuer: string | null,
+      opts?: { considerBuiltins?: boolean; extensions?: string[] },
+    ): string | null;
+
+    export function setup(): void;
 }
-
-export type PackageLocator =
-    | PhysicalPackageLocator
-    | TopLevelPackageLocator;
-
-export interface PackageInformation {
-    packageLocation: string;
-    packageDependencies: Map<string, string | [string, string]>;
-}
-
-export const VERSIONS: {std: number, [key: string]: number};
-
-export const topLevel: {name: null, reference: null};
-
-export function getPackageInformation(locator: PackageLocator): PackageInformation;
-export function findPackageLocator(location: string): PackageLocator | null;
-
-export function resolveToUnqualified(request: string, issuer: string | null, opts?: {considerBuiltins?: boolean}): string | null;
-export function resolveUnqualified(unqualified: string, opts?: { extensions?: string[] }): string;
-export function resolveRequest(
-    request: string,
-    issuer: string | null,
-    opts?: { considerBuiltins?: boolean; extensions?: string[] }
-): string | null;
-
-export function setup(): void;

--- a/types/pnpapi/pnpapi-tests.ts
+++ b/types/pnpapi/pnpapi-tests.ts
@@ -1,15 +1,23 @@
 import * as pnp from 'pnpapi';
 
-const information = pnp.getPackageInformation(pnp.topLevel);
-
-const locator = pnp.findPackageLocator('/foo');
-if (locator !== null) {
+if (process.versions.pnp) {
+  const locator = pnp.findPackageLocator('/foo');
+  if (locator !== null) {
     pnp.getPackageInformation(locator).packageDependencies;
-}
+  }
 
-const resolution1 = pnp.resolveRequest('lodash', '/foo');
+  const resolution1 = pnp.resolveRequest('lodash', '/foo', {
+    considerBuiltins: false,
+    extensions: ['.ts', '.js'],
+  });
 
-let resolution2 = pnp.resolveToUnqualified('lodash', '/foo');
-if (resolution2 !== null) {
-    resolution2 = pnp.resolveUnqualified(resolution2);
+  let resolution2 = pnp.resolveToUnqualified('lodash', '/foo', {
+    considerBuiltins: false,
+  });
+
+  if (resolution2 !== null) {
+    resolution2 = pnp.resolveUnqualified(resolution2, {
+      extensions: ['.ts', '.js'],
+    });
+  }
 }

--- a/types/pnpapi/tsconfig.json
+++ b/types/pnpapi/tsconfig.json
@@ -12,7 +12,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": [],
+        "types": ["node"],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
The PnP hook adds a specific entry within `process.versions` to allow userland to detect whether the `pnpapi` package can be required or not. Since `process.versions` doesn't have an index (#37754), it needs to be extended.