### PR TITLE
WIP: Add types for undom 0.4

### DIFF
--- a/types/undom/index.d.ts
+++ b/types/undom/index.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for undom 0.4
+// Project: https://github.com/developit/undom
+// Definitions by: Jakub Jirutka <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference lib="dom" />
+
+export interface Attr {
+    ns: string | null;
+    key: string;
+    value: string;
+}
+
+export interface Event {
+    readonly type: string;
+    readonly bubbles: boolean;
+    readonly cancelable: boolean;
+
+    stopPropagation(): void;
+    stopImmediatePropagation(): void;
+    preventDefault(): void;
+}
+
+export interface Node {
+    readonly nextSibling: Node | undefined;
+    readonly previousSibling: Node | undefined;
+    readonly firstChild: Node | undefined;
+    readonly lastChild: Node | undefined;
+
+    appendChild(child: Node): Node;
+    insertBefore(child: Node, ref?: Node): Node;
+    replaceChild(child: Node, ref: Node): Node | undefined;
+    removeChild(child: Node): Node;
+    remove(): void;
+}
+
+export interface Text extends Node {
+    textContent: string;
+}
+
+export interface Element extends Node {
+    attributes: Attr[];
+    className: string | undefined;
+    readonly children: Element[];
+    cssText: string | undefined;
+    style: {[k: string]: string};
+
+    setAttribute(key: string, value: string): void;
+    getAttribute(key: string): string | undefined;
+    removeAttribute(key: string): void;
+    setAttributeNS(ns: string | null | undefined, name: string, value: string): void;
+    getAttributeNS(ns: string | null | undefined, name: string): string | undefined;
+    removeAttributeNS(ns: string | null | undefined, name: string): void;
+    addEventListener(type: string, handler: EventListenerOrEventListenerObject): void;
+    removeEventListener(type: string, handler: EventListenerOrEventListenerObject): void;
+    dispatchEvent(event: Event): boolean;
+}
+
+export interface Document extends Element {
+    createElement(type: string): Element;
+    createElementNS(ns: string | null, type: string): Element;
+    createTextNode(text: string): Text;
+}
+
+declare function createDocument(): Document;
+
+export default createDocument;

--- a/types/undom/tsconfig.json
+++ b/types/undom/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "undom-tests.ts"
+    ]
+}

--- a/types/undom/tslint.json
+++ b/types/undom/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/undom/undom-tests.ts
+++ b/types/undom/undom-tests.ts
@@ -1,0 +1,1 @@
+import undom from 'undom';


### PR DESCRIPTION
**I’ve eventually decided to use a different package, so I’m not planning to finish this PR myself.** I’ve opened it as Draft for anyone who would like to finish it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.