### PR TITLE
updates typings for the 'vorpal' package

### DIFF
--- a/types/vorpal/index.d.ts
+++ b/types/vorpal/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for vorpal 1.11
+// Type definitions for vorpal 1.12
 // Project: https://github.com/dthree/vorpal
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+//                 Gheorghe Avram <https://github.com/sweethuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.5
 
 declare class Vorpal {
     parse(argv: ReadonlyArray<string>): this;
@@ -32,6 +33,10 @@ declare namespace Vorpal {
         options: {
             [key: string]: any;
         };
+    }
+
+    interface PromptObject {
+        [key: string]: any;
     }
 
     type Action = (args: Args) => Promise<void>;
@@ -74,7 +79,7 @@ declare namespace Vorpal {
 
     class CommandInstance {
         log(value: string, ...values: string[]): void;
-        prompt(prompt: object | ReadonlyArray<object>): Promise<object>;
+        prompt(prompt: object | ReadonlyArray<object>): Promise<PromptObject>;
         delimiter(value: string): void;
     }
 }

--- a/types/vorpal/vorpal-tests.ts
+++ b/types/vorpal/vorpal-tests.ts
@@ -10,6 +10,18 @@ vorpal
         vorpal.log('bar');
         return Promise.resolve();
     });
+vorpal
+    .command('input', 'Test Prompt Function')
+    .action(async (action) => {
+       const promptInput =  await vorpal.activeCommand.prompt([
+            {
+                type: 'input',
+                name: 'exampleInput',
+                message: 'Please Input Something',
+            }
+        ]);
+       vorpal.log(promptInput.exampleInput);
+    });
 
 vorpal
     .delimiter('myapp$')


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dthree/vorpal/wiki/API-%7C-CommandInstance#commandinstancepromptobject-callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
