### PR TITLE
[angular-file-saver] add module name export

### DIFF
--- a/types/angular-file-saver/index.d.ts
+++ b/types/angular-file-saver/index.d.ts
@@ -5,6 +5,10 @@
 // TypeScript Version: 2.3
 
 import * as angular from 'angular';
+
+declare const moduleName: 'ngFileSaver';
+export = moduleName;
+
 declare module 'angular' {
     /**
      * A core Angular factory proving FileSaver functionality.


### PR DESCRIPTION
Starting from version 1.0.3, `angular-file-saver` exports module name: https://github.com/alferov/angular-file-saver/commit/da6ae5c2555795f466d646f86ef73aae56aa1ba6

cc @deenairn