### PR TITLE
Create a type definition for npm module ssdeep

### DIFF
--- a/types/ssdeep/index.d.ts
+++ b/types/ssdeep/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for ssdeep 0.1
+// Project: https://github.com/pchaigno/node-ssdeep
+// Definitions by: Arne Schubert <https://github.com/atd-schubert>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function compare(hash1: string, hash2: string): number;
+
+export function hash(content: string): string;
+
+export function hash_from_file(path: string): string;

--- a/types/ssdeep/ssdeep-tests.ts
+++ b/types/ssdeep/ssdeep-tests.ts
@@ -1,0 +1,8 @@
+import { compare, hash, hash_from_file } from 'ssdeep';
+
+let str = 'string';
+let num = 123;
+
+num = compare(str, str);
+str = hash(str);
+str = hash_from_file(str);

--- a/types/ssdeep/tsconfig.json
+++ b/types/ssdeep/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ssdeep-tests.ts"
+    ]
+}

--- a/types/ssdeep/tslint.json
+++ b/types/ssdeep/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
