### PR TITLE
react-helmet: exported and renamed tags interface

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -10,7 +10,7 @@ type LinkProps = JSX.IntrinsicElements['link'];
 
 type MetaProps = JSX.IntrinsicElements['meta'];
 
-interface TagUpdates {
+export interface HelmetTags {
     baseTag: Array<any>;
     linkTags: Array<HTMLLinkElement>;
     metaTags: Array<HTMLMetaElement>;
@@ -27,7 +27,11 @@ export interface HelmetProps {
     defer?: boolean;
     encodeSpecialCharacters?: boolean;
     htmlAttributes?: any;
-    onChangeClientState?: (newState: any, addedTags: TagUpdates, removedTags: TagUpdates) => void;
+    onChangeClientState?: (
+        newState: any,
+        addedTags: HelmetTags,
+        removedTags: HelmetTags,
+    ) => void;
     link?: LinkProps[];
     meta?: MetaProps[];
     noscript?: Array<any>;


### PR DESCRIPTION
## What was done:
* Renamed the `TagUpdates` interface to `HelmetTags` in order to follow a common naming convention in the file (since it wasn't exported before it should not lead to any problems)
* Exported this interface in order to be able to import and use it when defining the handler function

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
