### PR TITLE
[nodegit] Fix Tree#getEntry return type

### DIFF
--- a/types/nodegit/index.d.ts
+++ b/types/nodegit/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>,
 //                 Tobias Nießen <https://github.com/tniessen>,
 //                 Pierre Vigier <https://github.com/pvigier>
+//                 Jibril Saffi <https://github.com/IGI-111>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export { AnnotatedCommit } from './annotated-commit';

--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -14,6 +14,9 @@ const ref = new Git.Reference();
 const tree = new Git.Tree();
 
 tree.walk().start();
+tree.getEntry("/").then(entry => {
+    // Use entry
+});
 
 // AnnotatedCommit Tests
 

--- a/types/nodegit/tree.d.ts
+++ b/types/nodegit/tree.d.ts
@@ -50,7 +50,7 @@ export class Tree {
     /**
      * Get an entry at a path. Unlike by name, this takes a fully qualified path, like /foo/bar/baz.javascript
      */
-    getEntry(filePath: string): TreeEntry;
+    getEntry(filePath: string): Promise<TreeEntry>;
     /**
      * Return an array of the entries in this tree (excluding its children).
      */


### PR DESCRIPTION
As per the documentation, Tree#getEntry is an async function and thus
returns a Promise.
See: https://www.nodegit.org/api/tree/#getEntry

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.nodegit.org/api/tree/#getEntry
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.