### PR TITLE
[angular-material] Create types for mdMenuCtrl

### DIFF
--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for angular-material 1.1
 // Project: https://github.com/angular/material, https://material.angularjs.org
-// Definitions by: Blake Bigelow <https://github.com/blbigelow>, Peter Hajdu <https://github.com/PeterHajdu>, Davide Donadello <https://github.com/Dona278>, Geert Jansen <https://github.com/geertjansen>, Edward Knowles <https://github.com/eknowles>
+// Definitions by: Blake Bigelow <https://github.com/blbigelow>
+//                 Peter Hajdu <https://github.com/PeterHajdu>
+//                 Davide Donadello <https://github.com/Dona278>
+//                 Geert Jansen <https://github.com/geertjansen>
+//                 Edward Knowles <https://github.com/eknowles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -5,6 +5,7 @@
 //                 Davide Donadello <https://github.com/Dona278>
 //                 Geert Jansen <https://github.com/geertjansen>
 //                 Edward Knowles <https://github.com/eknowles>
+//                 Chives <https://github.com/chivesrs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -524,5 +524,10 @@ declare module 'angular' {
             debounce<T extends Function>(func: T, wait?: number, scope?: any, invokeApply?: boolean): T;
             enableScrolling(): void;
         }
+
+        interface IMenuController {
+            close(skipFocus?: boolean, closeOpts?: {}): void;
+            open(event?: Event): void;
+        }
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular/material/blob/master/src/components/menu/js/menuController.js (see below for more details)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`mdMenuCtrl` is used by the `mdMenu` (or `md-menu` in `.ng` files) directive. Right now, I'm only concerned with the `open`/`close` functions, as that's what my code uses,

`open` takes in one parameter, `ev`, an optional event. See line 120.
`close` takes in two parameters, `skipFocus`, an optional boolean, and `closeOpts`, an optional configuration object. See line 179. I wasn't able to find more detailed information on what the parameters do beyond cursory inspection of the code.