### PR TITLE
[react-plotly.js] Use frame type from plotly.js so callbacks work

### DIFF
--- a/types/react-plotly.js/index.d.ts
+++ b/types/react-plotly.js/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jon Freedman <https://github.com/jonfreedman>
 //                 Mitchell Grice <https://github.com/gricey432>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// TypeScript Version: 2.8
 
 import * as Plotly from 'plotly.js';
 import * as React from 'react';

--- a/types/react-plotly.js/index.d.ts
+++ b/types/react-plotly.js/index.d.ts
@@ -1,27 +1,23 @@
 // Type definitions for react-plotly.js 2.2
 // Project: https://github.com/plotly/react-plotly.js#readme
 // Definitions by: Jon Freedman <https://github.com/jonfreedman>
+//                 Mitchell Grice <https://github.com/gricey432>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.4
 
 import * as Plotly from 'plotly.js';
 import * as React from 'react';
 
-export interface Frame {
-    name: string;
-    data: [{ x: Plotly.Datum, y: Plotly.Datum }];
-    group: 'lower' | 'upper';
-}
-
 export interface Figure {
     data: Plotly.Data[];
     layout: Partial<Plotly.Layout>;
+    frames: Plotly.Frame[] | null;
 }
 
 export interface PlotParams {
     data: Plotly.Data[];
     layout: Partial<Plotly.Layout>;
-    frames?: Frame[];
+    frames?: Plotly.Frame[];
     config?: Partial<Plotly.Config>;
     /**
      * When provided, causes the plot to update only when the revision is incremented.

--- a/types/react-plotly.js/react-plotly.js-tests.tsx
+++ b/types/react-plotly.js/react-plotly.js-tests.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as Plotly from 'plotly.js';
 import Plot from 'react-plotly.js';
 import createPlotlyComponent from 'react-plotly.js/factory';
 
@@ -19,6 +20,34 @@ export class SimpleChartComponent extends React.PureComponent<any> {
                     {type: 'bar', x: [1, 2, 3], y: [2, 5, 3]},
                 ]}
                 layout={ {width: 320, height: 240, title: 'A Fancy Plot'} }
+            />
+        );
+    }
+}
+
+/**
+ * based on https://github.com/plotly/react-plotly.js#state-management
+ */
+interface StateManagementChartComponentState {
+    data: Plotly.Data[];
+    layout: Partial<Plotly.Layout>;
+    frames: Plotly.Frame[] | null;
+}
+
+class StateManagementChartComponent extends React.Component<{}, StateManagementChartComponentState> {
+    constructor(props: {}) {
+        super(props);
+        this.state = { data: [], layout: {}, frames: [] };
+    }
+
+    render() {
+        return (
+            <Plot
+                data={this.state.data}
+                layout={this.state.layout}
+                frames={this.state.frames || undefined}
+                onInitialized={(figure) => this.setState(figure)}
+                onUpdate={(figure) => this.setState(figure)}
             />
         );
     }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See desc below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


Changed `Frame` type to be the one already present in Plotly, makes the types more inter-operable.
Added frames to the the `Figure` type, see https://github.com/plotly/react-plotly.js/blob/54bf0b25316079510d28fd3de2ccfcc080842146/src/factory.js#L175