### PR TITLE
[librato-node] Add types for librato-node

### DIFF
--- a/types/librato-node/index.d.ts
+++ b/types/librato-node/index.d.ts
@@ -26,10 +26,11 @@ export interface LibratoConfig {
     prefix?: string;
     source?: string;
     requestOptions?: LibratoRequestOptions;
+    simulate?: false;
 }
 
 export interface LibratoSimulate {
-    simulate: boolean;
+    simulate: true;
 }
 
 export function configure(config: LibratoConfig | LibratoSimulate): void;

--- a/types/librato-node/index.d.ts
+++ b/types/librato-node/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for librato-node 5.0
+// Project: https://github.com/goodeggs/librato-node
+// Definitions by: Jim Geurts <https://github.com/jgeurts>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+/// <reference types="node" />
+
+export interface CustomSource {
+    source: string;
+}
+
+export interface LibratoRequestOptions {
+    method?: string;
+    uri?: string;
+    headers?: { [index: string]: string };
+    maxAttempts?: number;
+    retryDelay?: number;
+    delayStrategy?: () => number;
+    authorization?: string;
+    'user-agent'?: string;
+}
+
+export interface LibratoConfig {
+    email: string;
+    token: string;
+    prefix?: string;
+    source?: string;
+    requestOptions?: LibratoRequestOptions;
+}
+
+export interface LibratoSimulate {
+    simulate: boolean;
+}
+
+export function configure(config: LibratoConfig | LibratoSimulate): void;
+export function increment(name: string, value?: number, opts?: CustomSource): void;
+export function measure(name: string, value: number, opts?: CustomSource): void;
+export function timing(name: string, fn: (done: () => void) => void, cb: ((err?: Error | null) => void)): void;
+export function timing(name: string, fn: (done: () => void) => void, opts?: CustomSource, cb?: ((err?: Error | null) => void)): void;
+export function timing<T>(name: string, fn: (done: (err: Error | null | undefined, result: T) => T) => void, cb: ((err?: Error | null) => void)): T;
+export function timing<T>(name: string, fn: (done: (err: Error | null | undefined, result: T) => T) => void, opts?: CustomSource, cb?: ((err?: Error | null) => void)): T;
+export function start(): void;
+export function stop(cb?: (err?: Error) => void): void;
+export function flush(cb?: (err?: Error) => void): void;
+export function middleware(config?: {
+    requestCountKey?: string;
+    responseTimeKey?: string;
+    statusCodeKey?: string;
+}): (req: object, res: object, next: () => void | Promise<void>) => void;
+
+export function on(event: 'error', handler: (err: Error) => void): void;
+export function on(event: 'SIGINT', handler: () => void): void;

--- a/types/librato-node/librato-node-tests.ts
+++ b/types/librato-node/librato-node-tests.ts
@@ -1,0 +1,88 @@
+import * as librato from 'librato-node';
+
+let str = '';
+const num = 0;
+const error  = new Error();
+const optionalErrorCallback = (err?: Error | null) => {
+    throw err;
+};
+const errorCallback = (err: Error) => {
+    throw err;
+};
+
+librato.configure({
+    simulate: true,
+});
+librato.configure({
+    email: 'foo@bar.com',
+    token: 'foobar',
+});
+librato.configure({
+    email: 'foo@bar.com',
+    token: 'foobar',
+    prefix: 'foo.',
+    source: 'bar',
+    requestOptions: {
+        method: 'POST',
+        uri: 'https://foo.com',
+    }
+});
+
+librato.increment(str);
+librato.increment(str, num);
+librato.increment(str, num, {
+    source: 'foo',
+});
+librato.measure(str, num);
+librato.measure(str, num, {
+    source: 'foo',
+});
+librato.timing(str, () => {});
+librato.timing(str, () => {}, optionalErrorCallback);
+librato.timing(str, (done: () => void) => {
+    done();
+});
+librato.timing(str, (done: () => void) => {
+    done();
+}, {
+    source: str,
+}, optionalErrorCallback);
+librato.timing(str, (done: () => void) => {
+    done();
+}, optionalErrorCallback);
+librato.timing(str, (done: (err: Error) => void) => {
+    done(error);
+});
+librato.timing(str, (done: (err: Error) => void) => {
+    done(error);
+}, {
+    source: str,
+}, optionalErrorCallback);
+librato.timing(str, (done: (err: Error) => void) => {
+    done(error);
+}, optionalErrorCallback);
+str = librato.timing('key', (done: (err: Error, result: string) => string) => {
+    return done(error, 'result string');
+});
+str = librato.timing('key', (done: (err: Error, result: string) => string) => {
+    return done(error, 'result string');
+}, {
+    source: 'foobar source',
+}, optionalErrorCallback);
+str = librato.timing('key', (done: (err: Error, result: string) => string) => {
+    return done(error, 'result string');
+}, optionalErrorCallback);
+librato.start();
+librato.stop();
+librato.stop(optionalErrorCallback);
+librato.flush();
+librato.flush(optionalErrorCallback);
+librato.middleware();
+librato.middleware({
+    requestCountKey: str,
+    responseTimeKey: str,
+    statusCodeKey: str,
+});
+
+librato.on('error', errorCallback);
+librato.on('SIGINT', () => {});

--- a/types/librato-node/librato-node-tests.ts
+++ b/types/librato-node/librato-node-tests.ts
@@ -25,7 +25,8 @@ librato.configure({
     requestOptions: {
         method: 'POST',
         uri: 'https://foo.com',
-    }
+    },
+    simulate: false,
 });
 
 librato.increment(str);

--- a/types/librato-node/tsconfig.json
+++ b/types/librato-node/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noUnusedParameters": true,
+
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "librato-node-tests.ts"
+    ]
+}

--- a/types/librato-node/tslint.json
+++ b/types/librato-node/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldnt have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
