### PR TITLE
Fix node http.ClientRequest  aborted property type to boolean

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -173,7 +173,7 @@ declare module "http" {
     class ClientRequest extends OutgoingMessage {
         connection: Socket;
         socket: Socket;
-        aborted: number;
+        aborted: boolean;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -108,6 +108,9 @@ import * as net from 'net';
     // abort
     req.abort();
 
+    // aborted
+    const aborted: boolean = req.aborted;
+
     // connection
     req.connection.on('pause', () => { });
 

--- a/types/node/v11/http.d.ts
+++ b/types/node/v11/http.d.ts
@@ -162,7 +162,7 @@ declare module "http" {
     class ClientRequest extends OutgoingMessage {
         connection: Socket;
         socket: Socket;
-        aborted: number;
+        aborted: boolean;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 

--- a/types/node/v11/test/http.ts
+++ b/types/node/v11/test/http.ts
@@ -108,6 +108,9 @@ import * as net from 'net';
     // abort
     req.abort();
 
+    // aborted
+    const aborted: boolean = req.aborted;
+
     // connection
     req.connection.on('pause', () => { });
 


### PR DESCRIPTION
Hi,
In Node.js V11.0.0 and above, the type of the aborted property of http.ClientRequest has been changed to boolean from number.
So, I changed the type of properties in those versions.

reference
https://nodejs.org/api/http.html#http_request_aborted

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.