### PR TITLE
Fix Lodash's _.memoize return type in TS3.1

### DIFF
--- a/types/lodash/ts3.1/common/function.d.ts
+++ b/types/lodash/ts3.1/common/function.d.ts
@@ -497,7 +497,7 @@ declare module "../index" {
          * @return Returns the new memoizing function.
          */
         memoize: {
-            <T extends (...args: any) => any>(func: T, resolver?: (...args: any[]) => any): T & MemoizedFunction;
+            <T extends (...args: any) => any>(func: T, resolver?: (...args: any[]) => any): ((...args: Parameters<T>) => ReturnType<T>)  & MemoizedFunction;
             Cache: MapCacheConstructor;
         };
     }

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -3526,14 +3526,8 @@ fp.now(); // $ExpectType number
     memoizedFn.cache = new WeakMap();
     memoizedFn.cache = new Map();
 
-    {
-        type MemoizedResultFn = (a1: string, a2: number) => boolean;
-        let beforeMemoize: MemoizedResultFn & {otherKey: number};
-        let result: MemoizedResultFn;
-
-        beforeMemoize = _.assign(memoizeFn, {otherKey: 1});
-        result = _.memoize(beforeMemoize);
-    }
+    const beforeMemoize = _.assign((a1: string, a2: number): boolean => true, {otherKey: 1}); // $ExpectType ((a1: string, a2: number) => boolean) & { otherKey: number; }
+    const afterMemoize = _.memoize(beforeMemoize); // $ExpectType ((a1: string, a2: number) => boolean) & MemoizedFunction
 }
 
 // _.overArgs

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -3525,6 +3525,15 @@ fp.now(); // $ExpectType number
     const memoizedFn = _.memoize(memoizeFn);
     memoizedFn.cache = new WeakMap();
     memoizedFn.cache = new Map();
+
+    {
+        type MemoizedResultFn = (a1: string, a2: number) => boolean;
+        let beforeMemoize: MemoizedResultFn & {otherKey: number};
+        let result: MemoizedResultFn;
+
+        beforeMemoize = _.assign(memoizeFn, {otherKey: 1});
+        result = _.memoize(beforeMemoize);
+    }
 }
 
 // _.overArgs


### PR DESCRIPTION
Fix incorrect typing of `_.memoize()`:
Since memoize wraps the original function and do not return it,
the return type cannot be `T` because it won't have the properties defined on the passed function,
e.g:
```typescript
type AnyFunction = (...args: any[]) => any
type CreateFunction = () => AnyFunction & {otherValue: number}
const f = createFunction()
const memoized = _.memoize(f) 
// memoized.otherValue is undefined even though it's type is number
```