### PR TITLE
[@types/react-jsonschema-form] fix SchemaField export

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -256,16 +256,19 @@ declare module 'react-jsonschema-form/lib/components/fields/SchemaField' {
     import { JSONSchema6 } from 'json-schema';
     import { FieldProps, UiSchema, IdSchema, FormValidation } from 'react-jsonschema-form';
 
-    export interface SchemaFieldProps<T = any> {
-      schema: JSONSchema6;
-      uiSchema: UiSchema;
-      idSchema: IdSchema;
-      formData: T;
-      errorSchema: FormValidation;
-      registry: FieldProps['registry'];
-    }
+    export type SchemaFieldProps<T = any> = Pick<
+      FieldProps<T>,
+      | 'schema'
+      | 'uiSchema'
+      | 'idSchema'
+      | 'formData'
+      | 'errorSchema'
+      | 'registry'
+    >;
 
-    export class SchemaField<T> extends React.Component<SchemaFieldProps<T>> {}
+    export default class SchemaField extends React.Component<
+      SchemaFieldProps
+    > {}
 }
 
 declare module 'react-jsonschema-form/lib/utils' {

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -6,8 +6,7 @@ import Form, {
   ErrorSchema,
   withTheme,
 } from 'react-jsonschema-form';
-import {
-  SchemaField,
+import SchemaField, {
   SchemaFieldProps,
 } from 'react-jsonschema-form/lib/components/fields/SchemaField';
 import { JSONSchema6 } from "json-schema";


### PR DESCRIPTION
Fixing issue in #38281 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/#custom-schemafield
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
