### PR TITLE
wix-style-react: initial types

### DIFF
--- a/types/wix-style-react/Button.d.ts
+++ b/types/wix-style-react/Button.d.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+export interface ButtonProps {
+  as?: any;
+  className?: string;
+  skin?: ButtonSkin;
+  priority?: ButtonPriority;
+  size?: ButtonSize;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+  fullWidth?: boolean;
+  suffixIcon?: React.ReactElement;
+  prefixIcon?: React.ReactElement;
+  disabled?: boolean;
+  dataHook?: string;
+}
+
+export default class Button extends React.Component<ButtonProps> {}
+
+export type ButtonSkin =
+  | 'standard'
+  | 'inverted'
+  | 'destructive'
+  | 'premium'
+  | 'dark'
+  | 'light'
+  | 'transparent'
+  | 'premium-light';
+
+export type ButtonPriority = 'primary' | 'secondary';
+
+export type ButtonSize = 'tiny' | 'small' | 'medium' | 'large';

--- a/types/wix-style-react/Text.d.ts
+++ b/types/wix-style-react/Text.d.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+export interface TextProps {
+  showTooltip?: boolean;
+  ellipsed?: boolean;
+  tagName?: string;
+  className?: string;
+  size?: TextSize;
+  secondary?: boolean;
+  skin?: TextSkin;
+  light?: boolean;
+  weight?: TextWeight;
+}
+
+declare const Text: React.SFC<TextProps>;
+export default Text;
+
+export type TextSize = 'tiny' | 'small' | 'medium';
+
+export type TextSkin =
+  | 'standard'
+  | 'error'
+  | 'success'
+  | 'premium'
+  | 'disabled';
+
+export type TextWeight = 'thin' | 'normal' | 'bold';

--- a/types/wix-style-react/index.d.ts
+++ b/types/wix-style-react/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for wix-style-react 6.17
+// Project: https://github.com/wix/wix-style-react
+// Definitions by: Gilad Segal <https://github.com/giladsegal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`;
+// TypeScript Version: 3.5
+
+export { default as Button, ButtonProps } from './Button';
+export { default as Text, TextProps } from './Text';

--- a/types/wix-style-react/test/Button-tests.tsx
+++ b/types/wix-style-react/test/Button-tests.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Button from 'wix-style-react/Button';
+
+function ButtonWithMandatoryProps() {
+  return <Button />;
+}
+
+function ButtonWithAllProps() {
+  return (
+    <Button
+      as="button"
+      className="cls"
+      dataHook="hook"
+      disabled
+      fullWidth
+      onClick={e => undefined}
+      prefixIcon={<span />}
+      suffixIcon={<span />}
+      priority="primary"
+      size="medium"
+      skin="dark"
+    />
+  );
+}

--- a/types/wix-style-react/test/Text-tests.tsx
+++ b/types/wix-style-react/test/Text-tests.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Text from 'wix-style-react/Text';
+
+function TextWithMandatoryProps() {
+  return <Text />;
+}
+
+function TextWithAllProps() {
+  return (
+    <Text
+      className="cssssss"
+      size="tiny"
+      ellipsed
+      light
+      secondary
+      showTooltip
+      skin="standard"
+      tagName="marquee"
+      weight="thin"
+    />
+  );
+}

--- a/types/wix-style-react/tsconfig.json
+++ b/types/wix-style-react/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "wix-style-react-tests.ts",
+        "Text.d.ts",
+        "test/Text-tests.tsx",
+        "Button.d.ts",
+        "test/Button-tests.tsx"
+    ]
+}

--- a/types/wix-style-react/tslint.json
+++ b/types/wix-style-react/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wix-style-react/wix-style-react-tests.ts
+++ b/types/wix-style-react/wix-style-react-tests.ts
@@ -1,0 +1,3 @@
+// verify that all imports work
+
+import { Button, Text } from 'wix-style-react';


### PR DESCRIPTION
This is a very small subset of the components which exists in `wix-style-react`
I want to gradually add types as this library has a lot of consumers internally in Wix.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with npm test.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run npm run lint package-name (or tsc if no tslint.json is present).

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its .d.ts files generated via --declaration
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with dts-gen --dt, not by basing it on an existing project.
 Represents shape of module/library correctly
- [x] tslint.json should be present and it shouldn't have any additional or disabling of rules. Just content as { "extends": "dtslint/dt.json" }. If for reason the some rule need to be disabled, disable it for that line using // tslint:disable-next-line [ruleName] and not for whole package so that the need for disabling can be reviewed.
- [x] tsconfig.json should have noImplicitAny, noImplicitThis, strictNullChecks, and strictFunctionTypes set to true.