### PR TITLE
[filesize] Add support for localeOptions option, v4.2.0

### DIFF
--- a/types/filesize/index.d.ts
+++ b/types/filesize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for filesize 4.1
+// Type definitions for filesize 4.2
 // Project: https://github.com/avoidwork/filesize.js, https://filesizejs.com
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Renaud Chaput <https://github.com/renchap>
@@ -62,6 +62,10 @@ declare namespace Filesize {
          * BCP 47 language tag to specify a locale, or true to use default locale, default is ""
          */
         locale?: string | boolean;
+        /**
+         * ECMA-402 number format option overrides, default is "{}"
+         */
+        localeOptions?: Intl.NumberFormatOptions;
         /**
          * Output of function (array, exponent, object, or string), default is string
          */


### PR DESCRIPTION
Related to: https://github.com/avoidwork/filesize.js/pull/102

Updates the `Options` type to allow for an optional `localeOptions` object to be passed in. `NumberFormatOptions` is [provided by typescript](https://github.com/Microsoft/TypeScript/blob/master/src/lib/es5.d.ts#L4060).

Option documented here: https://github.com/avoidwork/filesize.js#localeoptions-overrides-separator-requires-string-for-locale-option

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/avoidwork/filesize.js#localeoptions-overrides-separator-requires-string-for-locale-option
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
