### PR TITLE
Expose Trusted Types names in global scope

### DIFF
--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -6,67 +6,71 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-declare class TrustedHTML {
-    private readonly _brand: true; // To prevent structural typing.
-}
-
-declare class TrustedScript {
-    private readonly _brand: true; // To prevent structural typing.
-}
-
-declare class TrustedScriptURL {
-    private readonly _brand: true; // To prevent structural typing.
-}
-
-declare class TrustedURL {
-    private readonly _brand: true; // To prevent structural typing.
-}
-
-declare class TrustedTypePolicy {
-    readonly name: string;
-    createHTML(input: string): TrustedHTML;
-    createScript(input: string): TrustedScript;
-    createScriptURL(input: string): TrustedScriptURL;
-    createURL(input: string): TrustedURL;
-}
-
-interface TrustedTypePolicyOptions {
-    createHTML?: (input: string) => string;
-    createScript?: (input: string) => string;
-    createScriptURL?: (input: string) => string;
-    createURL?: (input: string) => string;
-}
-
-declare class TrustedTypePolicyFactory {
-    createPolicy<Keys extends keyof TrustedTypePolicyOptions>(
-        name: string,
-        policyOptions: Pick<TrustedTypePolicyOptions, Keys>,
-        expose?: boolean,
-        ): Pick<TrustedTypePolicy, 'name'|Keys>;
-    getPolicyNames(): string[];
-
-    isHTML(value: any): value is TrustedHTML;
-    isScript(value: any): value is TrustedScript;
-    isScriptURL(value: any): value is TrustedScriptURL;
-    isURL(value: any): value is TrustedURL;
-    getAttributeType(tagName: string, attrName: string, elemNs?: string, attrNs?: string): string|null;
-    getPropertyType(tagName: string, propName: string, elemNs?: string): string|null;
-    defaultPolicy?: TrustedTypePolicy;
-    emptyHTML: TrustedHTML;
-}
-
-declare const trustedTypes: TrustedTypePolicyFactory;
-
 declare global {
+    interface TrustedTypePolicyOptions {
+        createHTML?: (input: string) => string;
+        createScript?: (input: string) => string;
+        createScriptURL?: (input: string) => string;
+        createURL?: (input: string) => string;
+    }
+
+    class TrustedHTML {
+        private constructor(); // to prevent instantiting with 'new'.
+        private _brand: true; // To prevent structural typing.
+    }
+
+    class TrustedScript {
+        private constructor(); // to prevent instantiting with 'new'.
+        private _brand: true; // To prevent structural typing.
+    }
+
+    class TrustedScriptURL {
+        private constructor(); // to prevent instantiting with 'new'.
+        private _brand: true; // To prevent structural typing.
+    }
+
+    class TrustedURL {
+        private constructor(); // to prevent instantiting with 'new'.
+        private _brand: true; // To prevent structural typing.
+    }
+
+    interface TrustedTypePolicy {
+        readonly name: string;
+        createHTML(input: string): TrustedHTML;
+        createScript(input: string): TrustedScript;
+        createScriptURL(input: string): TrustedScriptURL;
+        createURL(input: string): TrustedURL;
+    }
+
+    interface TrustedTypePolicyFactory {
+        createPolicy<Keys extends keyof TrustedTypePolicyOptions>(
+            name: string,
+            policyOptions: Pick<TrustedTypePolicyOptions, Keys>,
+            expose?: boolean,
+            ): Pick<TrustedTypePolicy, 'name'|Keys>;
+        getPolicyNames(): string[];
+        isHTML(value: any): value is TrustedHTML;
+        isScript(value: any): value is TrustedScript;
+        isScriptURL(value: any): value is TrustedScriptURL;
+        isURL(value: any): value is TrustedURL;
+        getAttributeType(tagName: string, attrName: string, elemNs?: string, attrNs?: string): string | undefined;
+        getPropertyType(tagName: string, propName: string, elemNs?: string): string | undefined;
+        defaultPolicy?: TrustedTypePolicy;
+        emptyHTML: TrustedHTML;
+    }
+
     interface Window {
         trustedTypes: TrustedTypePolicyFactory;
         TrustedHTML: TrustedHTML;
         TrustedScript: TrustedScript;
         TrustedScriptURL: TrustedScriptURL;
         TrustedURL: TrustedURL;
-        TrustedTypePolicyOptions: TrustedTypePolicyOptions;
         TrustedTypePolicyFactory: TrustedTypePolicyFactory;
+        TrustedTypePolicy: TrustedTypePolicy;
     }
 }
+
+// this is not available in global scope. It's only used for the export.
+declare const trustedTypes: TrustedTypePolicyFactory;
 
 export default trustedTypes;

--- a/types/trusted-types/trusted-types-tests.ts
+++ b/types/trusted-types/trusted-types-tests.ts
@@ -3,6 +3,9 @@ import TT from 'trusted-types';
 // $ExpectType TrustedTypePolicyFactory
 TT;
 
+// $ExpectError
+trustedTypes;
+
 const rules = {
     createHTML: (s: string) => s,
     createScript: (s: string) => s,
@@ -48,3 +51,13 @@ window.trustedTypes.isScript(html);
 window.trustedTypes.isScriptURL(html);
 // $ExpectType boolean
 window.trustedTypes.isURL(html);
+
+// test that types are globaly available
+const trustedHTML: TrustedHTML = null as any;
+const trustedScript: TrustedScript = null as any;
+
+// $ExpectError
+trustedHTML = trustedScript;
+
+// $ExpectError
+new TrustedHTML();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.