### PR TITLE
[svgo] added path and info to OptimizedSvg interface

### DIFF
--- a/types/svgo/index.d.ts
+++ b/types/svgo/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for svgo 1.2
+// Type definitions for svgo 1.3
 // Project: https://github.com/svg/svgo
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 Gilad Gray <https://github.com/giladgray>
 //                 Aankhen <https://github.com/Aankhen>
 //                 Jan Karres <https://github.com/jankarres>
+//                 Gavin Gregory <https://github.com/gavingregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -201,7 +202,11 @@ interface SvgInfo {
 
 interface OptimizedSvg {
     data: string;
-    info: object;
+    info: {
+        width: string;
+        height: string;
+    };
+    path?: string;
 }
 
 declare class SVGO {

--- a/types/svgo/svgo-tests.ts
+++ b/types/svgo/svgo-tests.ts
@@ -27,5 +27,16 @@ const options: SVGO.Options = {
 svgo = new SVGO(options);
 
 // SVGO instance methods
-svgo.optimize(`<?xml version="1.0" encoding="utf-8"?><svg></svg>`, { path: "filepath" })
-    .then(result => result.data, error => error);
+svgo
+  .optimize(`<?xml version="1.0" encoding="utf-8"?><svg></svg>`, {
+    path: 'filepath',
+  })
+  .then(
+    result => {
+      result.data;
+      result.info.height;
+      result.info.width;
+      result.path;
+    },
+    error => error,
+  );


### PR DESCRIPTION
extended the OptimizedSvg interface to include:
* path (it exists in the OptimizedSvg type if provided in the optimize call).
* `info` changed to `{ width: string, height: string }` and height to add more specific type information, previously just defined as `object`.

https://github.com/svg/svgo/blob/master/lib/svgo.js#L49 - illustrates that the `path` property is conditionally present on the OptimizedSvg return object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
