### PR TITLE
[use-subscription] Add types

### DIFF
--- a/types/use-subscription/index.d.ts
+++ b/types/use-subscription/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for use-subscription 1.0
+// Project: https://github.com/facebook/react/
+// Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+export type Unsubscribe = () => void;
+
+export interface Subscription<T> {
+    /**
+     * (Synchronously) returns the current value of our subscription.
+     */
+    getCurrentValue: () => T;
+    /**
+     * This function is passed an event handler to attach to the subscription.
+     * It must return an unsubscribe function that removes the handler.
+     */
+    subscribe: (callback: () => void) => Unsubscribe;
+}
+
+export function useSubscription<T>(subscription: Subscription<T>): T;

--- a/types/use-subscription/tsconfig.json
+++ b/types/use-subscription/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "use-subscription-tests.ts"
+    ]
+}

--- a/types/use-subscription/tslint.json
+++ b/types/use-subscription/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/use-subscription/use-subscription-tests.ts
+++ b/types/use-subscription/use-subscription-tests.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useSubscription, Subscription } from 'use-subscription';
+
+// https://github.com/facebook/react/tree/d96f478f8a79da3125f6842c16efbc2ae8bcd3bf/packages/use-subscription#subscribing-to-event-dispatchers
+function EventDispatcherExample({ input }: { input: HTMLInputElement }) {
+    const subscription = useMemo(
+        (): Subscription<string> => ({
+            getCurrentValue: () => input.value,
+            subscribe: callback => {
+                input.addEventListener('change', callback);
+                return () => input.removeEventListener('change', callback);
+            },
+        }),
+
+        [input],
+    );
+
+    // $ExpectType string
+    const value = useSubscription(subscription);
+
+    // Your rendered output goes here ...
+}


### PR DESCRIPTION
Adds types for [`use-subscription`](https://github.com/facebook/react/blob/d96f478f8a79da3125f6842c16efbc2ae8bcd3bf/packages/use-subscription/src/useSubscription.js)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
