### PR TITLE
[react-router] Fix #38271 (`withRouter` fails with `ComponentType` starting in 3.6.2)

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -143,8 +143,12 @@ export interface WithRouterStatics<C extends React.ComponentType<any>> {
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P extends RouteComponentProps<any>, C extends React.ComponentType<P>>(
-  component: C & React.ComponentType<P>,
-): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
+export function withRouter<C extends React.ComponentType<RouteComponentProps>>(
+  component: C,
+): React.ComponentClass<
+  Omit<React.ComponentProps<C>, keyof RouteComponentProps> & WithRouterProps<C>,
+  never
+> &
+  WithRouterStatics<C>;
 
 export const __RouterContext: React.Context<RouteComponentProps>;

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -9,6 +9,12 @@ const ComponentFunction = (props: TOwnProps) => (
     <h2>Welcome {props.username}</h2>
 );
 
+const FunctionComponent: React.FunctionComponent<TOwnProps> = props => (
+  <h2>Welcome {props.username}</h2>
+);
+
+declare const Component: React.ComponentType<TOwnProps>;
+
 class ComponentClass extends React.Component<TOwnProps> {
     render() {
         return <h2>Welcome {this.props.username}</h2>;
@@ -16,6 +22,8 @@ class ComponentClass extends React.Component<TOwnProps> {
 }
 
 const WithRouterComponentFunction = withRouter(ComponentFunction);
+const WithRouterFunctionComponent = withRouter(FunctionComponent);
+const WithRouterComponent = withRouter(Component);
 const WithRouterComponentClass = withRouter(ComponentClass);
 WithRouterComponentClass.WrappedComponent; // $ExpectType typeof ComponentClass
 


### PR DESCRIPTION
Fixes #38271.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

No substantial changes are made here. This PR fixes a type error uncovered by TypeScript 3.6.2 by using 1 type parameter instead of two. The second one is derived with `React.ComponentProps`.

> you should strive to have fewer type parameters in your function signatures

https://twitter.com/SeaRyanC/status/1118632999266861056