### PR TITLE
Add types for validate-npm-package-name

### DIFF
--- a/types/validate-npm-package-name/index.d.ts
+++ b/types/validate-npm-package-name/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for validate-npm-package-name 3.0
+// Project: https://github.com/npm/validate-npm-package-name
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace validate {
+    let scopedPackagePattern: RegExp;
+
+    interface Result {
+        errors?: string[];
+        validForNewPackages: boolean;
+        validForOldPackages: boolean;
+        warnings?: string[];
+    }
+}
+
+declare function validate(name: string): validate.Result;
+
+export = validate;

--- a/types/validate-npm-package-name/tsconfig.json
+++ b/types/validate-npm-package-name/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "validate-npm-package-name-tests.ts"
+    ]
+}

--- a/types/validate-npm-package-name/tslint.json
+++ b/types/validate-npm-package-name/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/validate-npm-package-name/validate-npm-package-name-tests.ts
+++ b/types/validate-npm-package-name/validate-npm-package-name-tests.ts
@@ -1,0 +1,10 @@
+import validate = require('validate-npm-package-name');
+
+validate('some-package'); // $ExpectType Result
+validate('example.com'); // $ExpectType Result
+validate('under_score'); // $ExpectType Result
+validate('123numeric'); // $ExpectType Result
+validate('@npm/thingy'); // $ExpectType Result
+validate('@jane/foo.js'); // $ExpectType Result
+
+validate.scopedPackagePattern;  // $ExpectType RegExp


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
