### PR TITLE
react-geosuggest: fix invalid types for Suggest.location

### DIFF
--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -81,6 +81,6 @@ export interface Fixture {
 export interface Suggest {
     gmaps?: google.maps.GeocoderResult;
     label: string;
-    location: {lat: string, lng: string};
+    location: {lat: number, lng: number};
     placeId: string;
 }


### PR DESCRIPTION
Changing definition for Suggest.location. lat and lng should be number, not string. Proper type for these properties (number) can be seen here:
https://github.com/ubilabs/react-geosuggest/blob/master/src/types/location.d.ts
