### PR TITLE
[react] Add propTypes to ForwardRefExoticComponent

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -725,6 +725,7 @@ declare namespace React {
     // but can be given its own specific name
     interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
         defaultProps?: Partial<P>;
+        propTypes?: WeakValidationMap<P>;
     }
 
     function forwardRef<T, P = {}>(Component: RefForwardingComponent<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -403,6 +403,9 @@ const ForwardingRefComponent = React.forwardRef((props: {}, ref: React.Ref<RefCo
     return React.createElement(RefComponent, { ref });
 });
 
+const ForwardingRefComponentPropTypes: React.WeakValidationMap<Props> = {};
+ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
+
 function RefCarryingComponent() {
     const ref: React.RefObject<RefComponent> = React.createRef();
     // Without the explicit type argument, TypeScript infers `{ref: React.RefObject<RefComponent>}`


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  - https://github.com/facebook/react/pull/12911
  - https://github.com/facebook/react/blob/v16.9.0/packages/react/src/__tests__/forwardRef-test.js#L77
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **(It doesn't)**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.  **(N/A)**
