### PR TITLE
chromecast-caf-receiver: Convert cast.framework.events.EventType from union type to enum

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -139,7 +139,7 @@ export class QueueBase {
     fetchItems(
         itemId: number,
         nextCount: number,
-        prevCount: number
+        prevCount: number,
     ): messages.QueueItem[] | Promise<messages.QueueItem[]>;
 
     /**
@@ -189,9 +189,284 @@ export class PlayerManager {
     constructor(params?: any);
 
     /**
-     * Adds an event listener for player event.
+     * Adds an event listener for events proxied from the @see{@link events.MediaElementEvent}.
+     * See {@link https://dev.w3.org/html5/spec-preview/media-elements.html#mediaevents} for more information.
      */
-    addEventListener: (eventType: events.EventType | events.EventType[], eventListener: EventHandler) => void;
+    addEventListener(
+        eventType:
+            | events.EventType.ABORT
+            | events.EventType.ABORT[]
+            | events.EventType.CAN_PLAY
+            | events.EventType.CAN_PLAY[]
+            | events.EventType.CAN_PLAY_THROUGH
+            | events.EventType.CAN_PLAY_THROUGH[]
+            | events.EventType.DURATION_CHANGE
+            | events.EventType.DURATION_CHANGE[]
+            | events.EventType.EMPTIED
+            | events.EventType.EMPTIED[]
+            | events.EventType.ENDED
+            | events.EventType.ENDED[]
+            | events.EventType.LOADED_DATA
+            | events.EventType.LOADED_DATA[]
+            | events.EventType.LOADED_METADATA
+            | events.EventType.LOADED_METADATA[]
+            | events.EventType.LOAD_START
+            | events.EventType.LOAD_START[]
+            | events.EventType.PLAY
+            | events.EventType.PLAY[]
+            | events.EventType.PLAYING
+            | events.EventType.PLAYING[]
+            | events.EventType.PROGRESS
+            | events.EventType.PROGRESS[]
+            | events.EventType.RATE_CHANGE
+            | events.EventType.RATE_CHANGE[]
+            | events.EventType.SEEKED
+            | events.EventType.SEEKED[]
+            | events.EventType.SEEKING
+            | events.EventType.SEEKING[]
+            | events.EventType.STALLED
+            | events.EventType.STALLED[]
+            | events.EventType.TIME_UPDATE
+            | events.EventType.TIME_UPDATE[]
+            | events.EventType.SUSPEND
+            | events.EventType.SUSPEND[]
+            | events.EventType.WAITING
+            | events.EventType.WAITING[],
+        eventListener: MediaElementEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the pause player event. Fired when playback is paused. This event is forwarded from the MediaElement.
+     */
+    addEventListener(
+        eventType: events.EventType.PAUSE | events.EventType.PAUSE[],
+        eventListener: PauseEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the bitrate changed player event.
+     * Fired when the bitrate of the playing media changes
+     * (such as when an active track is changed,
+     * or when a different bitrate is chosen in response to network conditions).
+     */
+    addEventListener(
+        eventType: events.EventType.BITRATE_CHANGED | events.EventType.BITRATE_CHANGED[],
+        eventListener: BitrateChangedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for events related to breaks.
+     */
+    addEventListener(
+        eventType:
+            | events.EventType.BREAK_STARTED
+            | events.EventType.BREAK_STARTED[]
+            | events.EventType.BREAK_ENDED
+            | events.EventType.BREAK_ENDED[]
+            | events.EventType.BREAK_CLIP_LOADING
+            | events.EventType.BREAK_CLIP_LOADING[]
+            | events.EventType.BREAK_CLIP_STARTED
+            | events.EventType.BREAK_CLIP_STARTED[]
+            | events.EventType.BREAK_CLIP_ENDED
+            | events.EventType.BREAK_CLIP_ENDED[],
+        eventListener: BreaksEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the buffering player event. Fired when playback has either stopped due to buffering, or started again after buffering has finished.
+     */
+    addEventListener(
+        eventType: events.EventType.BUFFERING | events.EventType.BUFFERING[],
+        eventListener: BufferingEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the cache loaded player event. Fired when content pre-cached by fastplay has finished loading.
+     */
+    addEventListener(
+        eventType: events.EventType.CACHE_LOADED | events.EventType.CACHE_LOADED[],
+        eventListener: CacheLoadedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the cache hit and cache inserted player events.
+     */
+    addEventListener(
+        eventType:
+            | events.EventType.CACHE_HIT
+            | events.EventType.CACHE_HIT[]
+            | events.EventType.CACHE_INSERTED
+            | events.EventType.CACHE_INSERTED[],
+        eventListener: CacheItemEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the clip ended player event. Fired when any clip ends.
+     * This includes break clips and main content clips between break clips.
+     * If you want to see when a break clip ends, you should use @see{@link events.EventType.BREAK_CLIP_ENDED}.
+     * If you want to see when the media is completely done playing, you should use @see{@link events.EventType.MEDIA_FINISHED}.
+     */
+    addEventListener(
+        eventType: events.EventType.CLIP_ENDED | events.EventType.CLIP_ENDED[],
+        eventListener: ClipEndedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the EMSG player event. Fired when an emsg is found in a segment. This will only be fired for DASH content
+     */
+    addEventListener(eventType: events.EventType.EMSG | events.EventType.EMSG[], eventListener: EmsgEventHandler): void;
+
+    /**
+     * Adds an event listener for the pause player event. Fired when an error occurs.
+     */
+    addEventListener(
+        eventType: events.EventType.ERROR | events.EventType.ERROR[],
+        eventListener: ErrorEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the ID3 player event. Fired when an ID3 tag is encountered. This will only be fired for HLS content.
+     */
+    addEventListener(eventType: events.EventType.ID3 | events.EventType.ID3[], eventListener: Id3EventHandler): void;
+
+    /**
+     * Adds an event listener for the media status player event. Fired before an outgoing message is sent containing current media status.
+     */
+    addEventListener(
+        eventType: events.EventType.MEDIA_STATUS | events.EventType.MEDIA_STATUS[],
+        eventListener: MediaStatusEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the custom state player event. Fired when an outgoing custom state message is sent.
+     */
+    addEventListener(
+        eventType: events.EventType.CUSTOM_STATE | events.EventType.CUSTOM_STATE[],
+        eventListener: CustomStateEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the media information changed player event. Fired if the media information is changed during playback.
+     * For example when playing a live radio and the track metadata changed.
+     */
+    addEventListener(
+        eventType: events.EventType.MEDIA_INFORMATION_CHANGED | events.EventType.MEDIA_INFORMATION_CHANGED[],
+        eventListener: MediaInformationChangedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the media finished player event. Fired when the media has completely finished playing.
+     * This includes the following cases: there is nothing left in the stream to play, user has requested a stop, or an error has occurred.
+     * When queueing is used, this event will trigger once for each queue item that finishes.
+     */
+    addEventListener(
+        eventType: events.EventType.MEDIA_FINISHED | events.EventType.MEDIA_FINISHED[],
+        eventListener: MediaFinishedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for loading player events.
+     */
+    addEventListener(
+        eventType:
+            | events.EventType.PLAYER_PRELOADING
+            | events.EventType.PLAYER_PRELOADING[]
+            | events.EventType.PLAYER_PRELOADING_CANCELLED
+            | events.EventType.PLAYER_PRELOADING_CANCELLED[]
+            | events.EventType.PLAYER_LOAD_COMPLETE
+            | events.EventType.PLAYER_LOAD_COMPLETE[]
+            | events.EventType.PLAYER_LOADING
+            | events.EventType.PLAYER_LOADING[],
+        eventListener: LoadEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the media finished player event. Fired when the media has completely finished playing.
+     * This includes the following cases: there is nothing left in the stream to play, user has requested a stop, or an error has occurred.
+     * When queueing is used, this event will trigger once for each queue item that finishes.
+     */
+    addEventListener(
+        eventType: events.EventType.SEGMENT_DOWNLOADED | events.EventType.SEGMENT_DOWNLOADED[],
+        eventListener: SegmentDownloadedEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for request events made to the receiver.
+     */
+    addEventListener(
+        eventType:
+            | events.EventType.REQUEST_SEEK
+            | events.EventType.REQUEST_SEEK[]
+            | events.EventType.REQUEST_LOAD
+            | events.EventType.REQUEST_LOAD[]
+            | events.EventType.REQUEST_STOP
+            | events.EventType.REQUEST_STOP[]
+            | events.EventType.REQUEST_PAUSE
+            | events.EventType.REQUEST_PAUSE[]
+            | events.EventType.REQUEST_PRECACHE
+            | events.EventType.REQUEST_PRECACHE[]
+            | events.EventType.REQUEST_PLAY
+            | events.EventType.REQUEST_PLAY[]
+            | events.EventType.REQUEST_SKIP_AD
+            | events.EventType.REQUEST_SKIP_AD[]
+            | events.EventType.REQUEST_PLAY_AGAIN
+            | events.EventType.REQUEST_PLAY_AGAIN[]
+            | events.EventType.REQUEST_PLAYBACK_RATE_CHANGE
+            | events.EventType.REQUEST_PLAYBACK_RATE_CHANGE[]
+            | events.EventType.REQUEST_VOLUME_CHANGE
+            | events.EventType.REQUEST_VOLUME_CHANGE[]
+            | events.EventType.REQUEST_EDIT_TRACKS_INFO
+            | events.EventType.REQUEST_EDIT_TRACKS_INFO[]
+            | events.EventType.REQUEST_EDIT_AUDIO_TRACKS
+            | events.EventType.REQUEST_EDIT_AUDIO_TRACKS[]
+            | events.EventType.REQUEST_SET_CREDENTIALS
+            | events.EventType.REQUEST_SET_CREDENTIALS[]
+            | events.EventType.REQUEST_LOAD_BY_ENTITY
+            | events.EventType.REQUEST_LOAD_BY_ENTITY[]
+            | events.EventType.REQUEST_USER_ACTION
+            | events.EventType.REQUEST_USER_ACTION[]
+            | events.EventType.REQUEST_DISPLAY_STATUS
+            | events.EventType.REQUEST_DISPLAY_STATUS[]
+            | events.EventType.REQUEST_CUSTOM_COMMAND
+            | events.EventType.REQUEST_CUSTOM_COMMAND[]
+            | events.EventType.REQUEST_FOCUS_STATE
+            | events.EventType.REQUEST_FOCUS_STATE[]
+            | events.EventType.REQUEST_QUEUE_LOAD
+            | events.EventType.REQUEST_QUEUE_LOAD[]
+            | events.EventType.REQUEST_QUEUE_INSERT
+            | events.EventType.REQUEST_QUEUE_INSERT[]
+            | events.EventType.REQUEST_QUEUE_UPDATE
+            | events.EventType.REQUEST_QUEUE_UPDATE[]
+            | events.EventType.REQUEST_QUEUE_REMOVE
+            | events.EventType.REQUEST_QUEUE_REMOVE[]
+            | events.EventType.REQUEST_QUEUE_REORDER
+            | events.EventType.REQUEST_QUEUE_REORDER[]
+            | events.EventType.REQUEST_QUEUE_GET_ITEM_RANGE
+            | events.EventType.REQUEST_QUEUE_GET_ITEM_RANGE[]
+            | events.EventType.REQUEST_QUEUE_GET_ITEMS
+            | events.EventType.REQUEST_QUEUE_GET_ITEMS[]
+            | events.EventType.REQUEST_QUEUE_GET_ITEM_IDS
+            | events.EventType.REQUEST_QUEUE_GET_ITEM_IDS[],
+        eventListener: RequestEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for the live player events.
+     */
+    addEventListener(
+        eventType:
+            | events.EventType.LIVE_IS_MOVING_WINDOW_CHANGED
+            | events.EventType.LIVE_IS_MOVING_WINDOW_CHANGED[]
+            | events.EventType.LIVE_ENDED
+            | events.EventType.LIVE_ENDED[],
+        eventListener: LiveStatusEventHandler,
+    ): void;
+
+    /**
+     * Adds an event listener for player events that get the base @see{@link events.Event} in the callback.
+     * Includes ALL and CLIP_STARTED
+     */
+    addEventListener(eventType: events.EventType | events.EventType[], eventListener: EventHandler): void;
 
     /**
      * Sends a media status message to all senders (broadcast). Applications use this to send a custom state change.
@@ -316,7 +591,7 @@ export class PlayerManager {
         requestId: number,
         type: messages.ErrorType,
         reason?: messages.ErrorReason,
-        customData?: any
+        customData?: any,
     ): void;
 
     /**
@@ -332,7 +607,7 @@ export class PlayerManager {
         requestId: number,
         includeMedia?: boolean,
         customData?: any,
-        includeQueueItems?: boolean
+        includeQueueItems?: boolean,
     ): void;
 
     /**
@@ -359,7 +634,7 @@ export class PlayerManager {
      *  or null to prevent the media from playing. The return value can be a promise to allow waiting for data from the server.
      */
     setMediaPlaybackInfoHandler(
-        handler: (loadRequestData: messages.LoadRequestData, playbackConfig: PlaybackConfig) => void
+        handler: (loadRequestData: messages.LoadRequestData, playbackConfig: PlaybackConfig) => void,
     ): void;
 
     /**
@@ -377,7 +652,7 @@ export class PlayerManager {
      */
     setMessageInterceptor(
         type: messages.MessageType,
-        interceptor: (requestData: messages.RequestData) => Promise<any>
+        interceptor: (requestData: messages.RequestData) => Promise<any>,
     ): void;
 
     /**

--- a/types/chromecast-caf-receiver/cast.framework.events.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.d.ts
@@ -1,79 +1,89 @@
-import { RequestData, MediaInformation, Track, MediaStatus } from './cast.framework.messages';
+import { RequestData, MediaInformation, Track, MediaStatus, LiveSeekableRange } from './cast.framework.messages';
 import * as category from './cast.framework.events.category';
 
 export import category = category;
 
 export as namespace events;
-export type EventType =
-    | 'ALL'
-    | 'ABORT'
-    | 'CAN_PLAY'
-    | 'CAN_PLAY_THROUGH'
-    | 'DURATION_CHANGE'
-    | 'EMPTIED'
-    | 'ENDED'
-    | 'LOADED_DATA'
-    | 'LOADED_METADATA'
-    | 'LOAD_START'
-    | 'PAUSE'
-    | 'PLAY'
-    | 'PLAYING'
-    | 'PROGRESS'
-    | 'RATE_CHANGE'
-    | 'SEEKED'
-    | 'SEEKING'
-    | 'STALLED'
-    | 'TIME_UPDATE'
-    | 'SUSPEND'
-    | 'WAITING'
-    | 'BITRATE_CHANGED'
-    | 'BREAK_STARTED'
-    | 'BREAK_ENDED'
-    | 'BREAK_CLIP_LOADING'
-    | 'BREAK_CLIP_STARTED'
-    | 'BREAK_CLIP_ENDED'
-    | 'BUFFERING'
-    | 'CACHE_LOADED'
-    | 'CACHE_HIT'
-    | 'CACHE_INSERTED'
-    | 'CLIP_STARTED'
-    | 'CLIP_ENDED'
-    | 'EMSG'
-    | 'ERROR'
-    | 'ID3'
-    | 'MEDIA_STATUS'
-    | 'MEDIA_FINISHED'
-    | 'PLAYER_PRELOADING'
-    | 'PLAYER_PRELOADING_CANCELLED'
-    | 'PLAYER_LOAD_COMPLETE'
-    | 'PLAYER_LOADING'
-    | 'SEGMENT_DOWNLOADED'
-    | 'REQUEST_SEEK'
-    | 'REQUEST_LOAD'
-    | 'REQUEST_STOP'
-    | 'REQUEST_PAUSE'
-    | 'REQUEST_PLAY'
-    | 'REQUEST_PLAY_AGAIN'
-    | 'REQUEST_PLAYBACK_RATE_CHANGE'
-    | 'REQUEST_SKIP_AD'
-    | 'REQUEST_VOLUME_CHANGE'
-    | 'REQUEST_EDIT_TRACKS_INFO'
-    | 'REQUEST_EDIT_AUDIO_TRACKS'
-    | 'REQUEST_SET_CREDENTIALS'
-    | 'REQUEST_LOAD_BY_ENTITY'
-    | 'REQUEST_USER_ACTION'
-    | 'REQUEST_DISPLAY_STATUS'
-    | 'REQUEST_CUSTOM_COMMAND'
-    | 'REQUEST_FOCUS_STATE'
-    | 'REQUEST_QUEUE_LOAD'
-    | 'REQUEST_QUEUE_INSERT'
-    | 'REQUEST_QUEUE_UPDATE'
-    | 'REQUEST_QUEUE_REMOVE'
-    | 'REQUEST_QUEUE_REORDER'
-    | 'REQUEST_QUEUE_GET_ITEM_RANGE'
-    | 'REQUEST_QUEUE_GET_ITEMS'
-    | 'REQUEST_QUEUE_GET_ITEM_IDS'
-    | 'REQUEST_PRECACHE';
+
+/**
+ * Player event types for @see{@link framework.PlayerManager}.
+ * https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events#.EventType
+ */
+export enum EventType {
+    ALL = '*',
+    ABORT = 'ABORT',
+    CAN_PLAY = 'CAN_PLAY',
+    CAN_PLAY_THROUGH = 'CAN_PLAY_THROUGH',
+    DURATION_CHANGE = 'DURATION_CHANGE',
+    EMPTIED = 'EMPTIED',
+    ENDED = 'ENDED',
+    LOADED_DATA = 'LOADED_DATA',
+    LOADED_METADATA = 'LOADED_METADATA',
+    LOAD_START = 'LOAD_START',
+    PAUSE = 'PAUSE',
+    PLAY = 'PLAY',
+    PLAYING = 'PLAYING',
+    PROGRESS = 'PROGRESS',
+    RATE_CHANGE = 'RATE_CHANGE',
+    SEEKED = 'SEEKED',
+    SEEKING = 'SEEKING',
+    STALLED = 'STALLED',
+    TIME_UPDATE = 'TIME_UPDATE',
+    SUSPEND = 'SUSPEND',
+    WAITING = 'WAITING',
+    BITRATE_CHANGED = 'BITRATE_CHANGED',
+    BREAK_STARTED = 'BREAK_STARTED',
+    BREAK_ENDED = 'BREAK_ENDED',
+    BREAK_CLIP_LOADING = 'BREAK_CLIP_LOADING',
+    BREAK_CLIP_STARTED = 'BREAK_CLIP_STARTED',
+    BREAK_CLIP_ENDED = 'BREAK_CLIP_ENDED',
+    BUFFERING = 'BUFFERING',
+    CACHE_LOADED = 'CACHE_LOADED',
+    CACHE_HIT = 'CACHE_HIT',
+    CACHE_INSERTED = 'CACHE_INSERTED',
+    CLIP_STARTED = 'CLIP_STARTED',
+    CLIP_ENDED = 'CLIP_ENDED',
+    EMSG = 'EMSG',
+    ERROR = 'ERROR',
+    ID3 = 'ID3',
+    MEDIA_STATUS = 'MEDIA_STATUS',
+    CUSTOM_STATE = 'CUSTOM_STATE',
+    MEDIA_INFORMATION_CHANGED = 'MEDIA_INFORMATION_CHANGED',
+    MEDIA_FINISHED = 'MEDIA_FINISHED',
+    PLAYER_PRELOADING = 'PLAYER_PRELOADING',
+    PLAYER_PRELOADING_CANCELLED = 'PLAYER_PRELOADING_CANCELLED',
+    PLAYER_LOAD_COMPLETE = 'PLAYER_LOAD_COMPLETE',
+    PLAYER_LOADING = 'PLAYER_LOADING',
+    SEGMENT_DOWNLOADED = 'SEGMENT_DOWNLOADED',
+    REQUEST_SEEK = 'REQUEST_SEEK',
+    REQUEST_LOAD = 'REQUEST_LOAD',
+    REQUEST_STOP = 'REQUEST_STOP',
+    REQUEST_PAUSE = 'REQUEST_PAUSE',
+    REQUEST_PLAY = 'REQUEST_PLAY',
+    REQUEST_PLAY_AGAIN = 'REQUEST_PLAY_AGAIN',
+    REQUEST_PLAYBACK_RATE_CHANGE = 'REQUEST_PLAYBACK_RATE_CHANGE',
+    REQUEST_SKIP_AD = 'REQUEST_SKIP_AD',
+    REQUEST_VOLUME_CHANGE = 'REQUEST_VOLUME_CHANGE',
+    REQUEST_EDIT_TRACKS_INFO = 'REQUEST_EDIT_TRACKS_INFO',
+    REQUEST_EDIT_AUDIO_TRACKS = 'REQUEST_EDIT_AUDIO_TRACKS',
+    REQUEST_SET_CREDENTIALS = 'REQUEST_SET_CREDENTIALS',
+    REQUEST_LOAD_BY_ENTITY = 'REQUEST_LOAD_BY_ENTITY',
+    REQUEST_USER_ACTION = 'REQUEST_USER_ACTION',
+    REQUEST_DISPLAY_STATUS = 'REQUEST_DISPLAY_STATUS',
+    REQUEST_CUSTOM_COMMAND = 'REQUEST_CUSTOM_COMMAND',
+    REQUEST_FOCUS_STATE = 'REQUEST_FOCUS_STATE',
+    REQUEST_QUEUE_LOAD = 'REQUEST_QUEUE_LOAD',
+    REQUEST_QUEUE_INSERT = 'REQUEST_QUEUE_INSERT',
+    REQUEST_QUEUE_UPDATE = 'REQUEST_QUEUE_UPDATE',
+    REQUEST_QUEUE_REMOVE = 'REQUEST_QUEUE_REMOVE',
+    REQUEST_QUEUE_REORDER = 'REQUEST_QUEUE_REORDER',
+    REQUEST_QUEUE_GET_ITEM_RANGE = 'REQUEST_QUEUE_GET_ITEM_RANGE',
+    REQUEST_QUEUE_GET_ITEMS = 'REQUEST_QUEUE_GET_ITEMS',
+    REQUEST_QUEUE_GET_ITEM_IDS = 'REQUEST_QUEUE_GET_ITEM_IDS',
+    REQUEST_PRECACHE = 'REQUEST_PRECACHE',
+    LIVE_IS_MOVING_WINDOW_CHANGED = 'LIVE_IS_MOVING_WINDOW_CHANGED',
+    LIVE_ENDED = 'LIVE_ENDED',
+}
 
 export type DetailedErrorCode =
     | 'MEDIA_UNKNOWN'
@@ -236,12 +246,17 @@ export class InbandTrackAddedEvent {
 
 /** Event data for @see{@link EventType.ID3} event. */
 export class Id3Event extends Event {
-    constructor(segmentData: Uint8Array);
+    constructor(segmentData: Uint8Array, timestamp: number);
 
     /**
      * The segment data.
      */
     segmentData: Uint8Array;
+
+    /**
+     * The timestamp in seconds.
+     */
+    timestamp: number;
 }
 /**
  * Event data for @see{@link EventType.EMSG} event.
@@ -404,9 +419,54 @@ export class BitrateChangedEvent {
     totalBitrate: number;
 }
 
+/**
+ * Event data for @see{@link EventType.ERROR} event.
+ */
 export class ErrorEvent extends Event {
-    constructor(detailedErrorCode: DetailedErrorCode, error?: any);
+    constructor(detailedErrorCode?: DetailedErrorCode, error?: any, reason?: cast.framework.messages.ErrorReason);
 
-    detailedErrorCode: DetailedErrorCode;
+    /**
+     * An error code representing the cause of the error.
+     */
+    detailedErrorCode?: DetailedErrorCode;
+
+    /**
+     * The error object. This could be an Error object (e.g., if an Error was thrown in an event handler) or an object with error information (e.g., if the receiver received an invalid command).
+     */
     error?: any;
+
+    /**
+     * Optional error reason.
+     */
+    reason?: cast.framework.messages.ErrorReason;
+}
+
+/**
+ * Event data for @see{@link EventType.CUSTOM_STATE} event.
+ */
+export class CustomStateEvent extends Event {
+    constructor(state: any);
+
+    state: any;
+}
+
+/**
+ * Event data for @see{@link EventType.MEDIA_INFORMATION_CHANGED} event.
+ */
+export class MediaInformationChangedEvent extends Event {
+    constructor(media?: MediaInformation);
+
+    media?: MediaInformation;
+}
+
+/**
+ * Event data for @see{@link EventType.LIVE_ENDED} and @see{@link EventType.LIVE_IS_MOVING_WINDOW_CHANGED} events.
+ */
+export class LiveStatusEvent extends Event {
+    constructor(type: EventType, liveSeekableRange: LiveSeekableRange);
+
+    /**
+     * Updated live status.
+     */
+    liveSeekableRange: LiveSeekableRange;
 }

--- a/types/chromecast-caf-receiver/cast.framework.system.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.system.d.ts
@@ -1,4 +1,4 @@
-import { EventType } from './cast.framework.events';
+import * as events from './cast.framework.events';
 
 export as namespace system;
 export enum EventType {

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -1,5 +1,6 @@
 import { MediaMetadata } from 'chromecast-caf-receiver/cast.framework.messages';
 import { CastReceiverContext } from 'chromecast-caf-receiver/cast.framework';
+import { EventType } from 'chromecast-caf-receiver/cast.framework.events';
 
 // The following test showcases how you can import individual types directly from the namespace:
 
@@ -11,7 +12,7 @@ mediaMetadata.metadataType = cast.framework.messages.MetadataType.TV_SHOW;
 // conforms exactly to the CAF documentation.
 
 // tslint:disable-next-line
-const breaksEvent = new cast.framework.events.BreaksEvent('BREAK_STARTED');
+const breaksEvent = new cast.framework.events.BreaksEvent(EventType.BREAK_STARTED);
 breaksEvent.breakId = 'some-break-id';
 breaksEvent.breakClipId = 'some-break-clip-id';
 
@@ -22,18 +23,18 @@ const breakClip = new cast.framework.messages.BreakClip('id');
 // tslint:disable-next-line
 const adBreak = new cast.framework.messages.Break('id', ['id'], 1);
 // tslint:disable-next-line
-const rEvent = new cast.framework.events.RequestEvent('BITRATE_CHANGED', {
+const rEvent = new cast.framework.events.RequestEvent(EventType.BITRATE_CHANGED, {
     requestId: 2,
 });
 // tslint:disable-next-line
 const pManager = new cast.framework.PlayerManager();
-pManager.addEventListener('STALLED', () => {});
+pManager.addEventListener(EventType.STALLED, () => {});
 pManager.addEventListener(cast.framework.events.category.CORE, () => {});
 pManager.addEventListener(cast.framework.events.category.DEBUG, () => {});
 pManager.addEventListener(cast.framework.events.category.FINE, () => {});
 pManager.addEventListener(cast.framework.events.category.REQUEST, () => {});
 pManager.addEventListener(
-  'MEDIA_FINISHED',
+  EventType.MEDIA_FINISHED,
   (event: cast.framework.events.MediaFinishedEvent) =>
     `${event.currentMediaTime} ${event.endedReason}`,
 );

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/googlecast
 // Definitions by: Sergio Arbeo <https://github.com/Serabe>
 //                 Craig Bruce <https://github.com/craigrbruce>
+//                 Brandon Risell <https://github.com/brandonrisell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -12,9 +13,30 @@
 /// <reference path="./cast.framework.system.d.ts" />
 /// <reference path="./cast.framework.ui.d.ts" />
 
-import * as framework from "./cast.framework";
-import { PlayerDataChangedEvent } from "./cast.framework.ui";
-import { Event } from "./cast.framework.events";
+import * as framework from './cast.framework';
+import { PlayerDataChangedEvent } from './cast.framework.ui';
+import {
+    Event,
+    Id3Event,
+    ErrorEvent,
+    MediaElementEvent,
+    MediaPauseEvent,
+    BitrateChangedEvent,
+    BreaksEvent,
+    BufferingEvent,
+    CacheItemEvent,
+    CacheLoadedEvent,
+    ClipEndedEvent,
+    EmsgEvent,
+    MediaStatusEvent,
+    CustomStateEvent,
+    MediaInformationChangedEvent,
+    MediaFinishedEvent,
+    LoadEvent,
+    SegmentDownloadedEvent,
+    RequestEvent,
+    LiveStatusEvent,
+} from './cast.framework.events';
 
 export as namespace cast;
 export { framework };
@@ -23,9 +45,26 @@ declare global {
     const cast: { framework: typeof framework };
 
     type EventHandler = (event: Event) => void;
-    type PlayerDataChangedEventHandler = (
-        event: PlayerDataChangedEvent
-    ) => void;
+    type Id3EventHandler = (event: Id3Event) => void;
+    type ErrorEventHandler = (event: ErrorEvent) => void;
+    type MediaElementEventHandler = (event: MediaElementEvent) => void;
+    type PauseEventHandler = (event: MediaPauseEvent) => void;
+    type BitrateChangedEventHandler = (event: BitrateChangedEvent) => void;
+    type BreaksEventHandler = (event: BreaksEvent) => void;
+    type BufferingEventHandler = (event: BufferingEvent) => void;
+    type CacheLoadedEventHandler = (event: CacheLoadedEvent) => void;
+    type CacheItemEventHandler = (event: CacheItemEvent) => void;
+    type ClipEndedEventHandler = (event: ClipEndedEvent) => void;
+    type EmsgEventHandler = (event: EmsgEvent) => void;
+    type MediaStatusEventHandler = (event: MediaStatusEvent) => void;
+    type CustomStateEventHandler = (event: CustomStateEvent) => void;
+    type MediaInformationChangedEventHandler = (event: MediaInformationChangedEvent) => void;
+    type MediaFinishedEventHandler = (event: MediaFinishedEvent) => void;
+    type LoadEventHandler = (event: LoadEvent) => void;
+    type SegmentDownloadedEventHandler = (event: SegmentDownloadedEvent) => void;
+    type RequestEventHandler = (event: RequestEvent) => void;
+    type LiveStatusEventHandler = (event: LiveStatusEvent) => void;
+    type PlayerDataChangedEventHandler = (event: PlayerDataChangedEvent) => void;
     type RequestHandler = (request: framework.NetworkRequestInfo) => void;
     type BinaryHandler = (data: Uint8Array) => Uint8Array;
 }


### PR DESCRIPTION
- Convert cast.framework.events.EventType from union type to enum
- Overload PlayerManager.addEventListener with the specific event handler parameters that will be used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events#.EventType>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.