### PR TITLE
test(react): Remove usage of React.Attributes

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -22,7 +22,7 @@ interface Console {
     log(...args: any[]): void;
 }
 
-interface Props extends React.Attributes {
+interface Props {
     hello: string;
     world?: string | null;
     foo: number;
@@ -132,8 +132,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
     static propTypes: React.ValidationMap<Props> = {
         hello: PropTypes.string.isRequired,
         world: PropTypes.string,
-        foo: PropTypes.number.isRequired,
-        key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]) as PropTypes.Validator<string | number | undefined>
+        foo: PropTypes.number.isRequired
     };
 
     static contextTypes: React.ValidationMap<Context> = {


### PR DESCRIPTION
Spotted this during review and it kind of threw me off. `React.Attributes` only includes `key` with which you'll never deal in props validation nor see in your component implementation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
