### PR TITLE
chore(hapi): update hapi ecosystem to ts 3.x

### DIFF
--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /// <reference types='node' />
 

--- a/types/hapi__accept/index.d.ts
+++ b/types/hapi__accept/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: feinoujc <https://github.com/feinoujc>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.1
 
 export function charset(charsetHeader?: string, preferences?: string[]): string;
 export function charsets(charsetHeader?: string): string[];

--- a/types/hapi__basic/hapi__basic-tests.ts
+++ b/types/hapi__basic/hapi__basic-tests.ts
@@ -37,7 +37,7 @@ const validate: Basic.Validate = async (request, username, password, h) => {
 server.register(Basic).then(() => {
 
     server.auth.strategy('simple', 'basic', { validate });
-	server.auth.default('simple');
+    server.auth.default('simple');
 
     server.route({ method: 'GET', path: '/', options: { auth: 'simple' } });
 });

--- a/types/hapi__basic/index.d.ts
+++ b/types/hapi__basic/index.d.ts
@@ -4,18 +4,18 @@
 //                 Rodrigo Saboya <https://github.com/saboya>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
-import { Plugin, Request, ResponseToolkit } from '@hapi/hapi';
+import { Plugin, Request, ResponseToolkit, Lifecycle } from '@hapi/hapi';
 
 declare namespace Basic {
     interface ValidateCustomResponse {
-        response: any,
+        response: Lifecycle.ReturnValue;
     }
 
     interface ValidateResponse {
-        isValid: boolean,
-        credentials?: any,
+        isValid: boolean;
+        credentials?: unknown;
     }
 
     interface Validate {
@@ -23,6 +23,6 @@ declare namespace Basic {
     }
 }
 
-declare var Basic: Plugin<{}>;
+declare var Basic: Plugin;
 
 export = Basic;

--- a/types/hapi__bell/index.d.ts
+++ b/types/hapi__bell/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { Server, Request, Plugin, AuthCredentials } from '@hapi/hapi';
 

--- a/types/hapi__boom/hapi__boom-tests.ts
+++ b/types/hapi__boom/hapi__boom-tests.ts
@@ -148,7 +148,7 @@ const isBoomError = new Boom('test');
 
 Boom.isBoom(isBoomError);
 
-const maybeBoom = <any> new Boom('test');
+const maybeBoom = <unknown> new Boom('test');
 if (Boom.isBoom(maybeBoom)) {
     // isBoom is a type guard that allows accessing these properties:
     maybeBoom.output.headers;

--- a/types/hapi__boom/index.d.ts
+++ b/types/hapi__boom/index.d.ts
@@ -7,14 +7,14 @@
 //                 Daniel Machado <https://github.com/danielmachado>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.1
 
  export = Boom;
 /**
  * boom provides a set of utilities for returning HTTP errors. Each utility returns a Boom error response object (instance of Error) which includes the following properties:
  * @see {@link https://github.com/hapijs/boom#boom}
  */
-declare class Boom<Data = any> extends Error {
+declare class Boom<Data = unknown> extends Error {
     /** Creates a new Boom object using the provided message and then calling boomify() to decorate the error with the Boom properties. */
     constructor(message?: string | Error, options?: Boom.Options<Data>);
     /** isBoom - if true, indicates this is a Boom object instance. */
@@ -45,7 +45,7 @@ declare namespace Boom {
         /** decorate - an option with extra properties to set on the error object. */
         decorate?: object;
         /** ctor - constructor reference used to crop the exception call stack output. */
-        ctor?: any;
+        ctor?: unknown;
         /** message - error message string. If the error already has a message, the provided message is added as a prefix. Defaults to no message. */
         message?: string;
         /**
@@ -84,9 +84,10 @@ declare namespace Boom {
          * "Every key/value pair will be included ... in the response payload under the attributes key."
          * [see docs](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes)
          */
-        attributes?: any;
+        attributes?: string | {
+            [key: string]: unknown;
+        };
         // Excluded this to aid typing of the other values.  See tests for example casting to a custom interface to manipulate the payload
-        // [anyContent: string]: any;
     }
 
     /**
@@ -101,7 +102,7 @@ declare namespace Boom {
      * Identifies whether an error is a Boom object. Same as calling instanceof Boom.
      * @param error the error object to identify.
      */
-    function isBoom(error: Error): error is Boom;
+    function isBoom(error: unknown): error is Boom;
 
     // 4xx
     /**

--- a/types/hapi__catbox-memory/index.d.ts
+++ b/types/hapi__catbox-memory/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { ClientApi, ClientOptions } from '@hapi/catbox';
 

--- a/types/hapi__catbox-redis/index.d.ts
+++ b/types/hapi__catbox-redis/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 // tslint:disable-next-line
 declare module '@hapi/catbox-redis' {

--- a/types/hapi__catbox/index.d.ts
+++ b/types/hapi__catbox/index.d.ts
@@ -5,7 +5,7 @@
 //                 Rodrigo Saboya <https://github.com/saboya>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /**
  * Client
@@ -48,7 +48,7 @@ export class Client<T> implements ClientApi<T> {
     validateSegmentName(segment: string): null | Error;
 }
 
-export type EnginePrototypeOrObject = EnginePrototype<any> | ClientApi<any>;
+export type EnginePrototypeOrObject = EnginePrototype<unknown> | ClientApi<unknown>;
 
 /**
  * A prototype CatBox engine function

--- a/types/hapi__code/index.d.ts
+++ b/types/hapi__code/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Prashant Tiwari <https://github.com/prashaantt>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+
+import { DeepEqualOptions } from '@hapi/hoek';
 
 /** Generates an assertion object. */
 export function expect<T>(value: T | T[], prefix?: string): AssertionChain<T>;
@@ -79,7 +82,7 @@ export interface Types<T> {
     /** Asserts that the reference value is a Date. */
     date(): AssertionChain<T>;
     /** Asserts that the reference value is an error. */
-    error(type?: any, message?: string | RegExp): AssertionChain<T>;
+    error(type?: unknown, message?: string | RegExp): AssertionChain<T>;
     /** Asserts that the reference value is a function. */
     function(): AssertionChain<T>;
     /** Asserts that the reference value is a number. */
@@ -126,9 +129,9 @@ export interface Values<T> {
     /** Asserts that the reference value has a length property matching the provided size or an object with the specified number of keys. */
     length(size: number): AssertionChain<T>;
     /** Asserts that the reference value equals the provided value. */
-    equal(value: T | T[], options?: any): AssertionChain<T>;
+    equal(value: T | T[], options?: DeepEqualOptions): AssertionChain<T>;
     /** Asserts that the reference value equals the provided value. */
-    equals(value: T | T[], options?: any): AssertionChain<T>;
+    equals(value: T | T[], options?: DeepEqualOptions): AssertionChain<T>;
     /** Asserts that the reference value is greater than (>) the provided value. */
     above(value: T): AssertionChain<T>;
     /** Asserts that the reference value is greater than (>) the provided value. */
@@ -154,25 +157,25 @@ export interface Values<T> {
     /** Asserts that the reference value is about the provided value within a delta margin of difference. */
     about(value: number, delta: number): AssertionChain<T>;
     /** Asserts that the reference value has the provided instanceof value. */
-    instanceof(type: any): AssertionChain<T>;
+    instanceof(type: unknown): AssertionChain<T>;
     /** Asserts that the reference value has the provided instanceof value. */
-    instanceOf(type: any): AssertionChain<T>;
+    instanceOf(type: unknown): AssertionChain<T>;
     /** Asserts that the reference value's toString() representation matches the provided regular expression. */
     match(regex: RegExp): AssertionChain<T>;
     /** Asserts that the reference value's toString() representation matches the provided regular expression. */
     matches(regex: RegExp): AssertionChain<T>;
     /** Asserts that the Promise reference value rejects with an exception when called */
-    reject(type?: any, message?: string | RegExp): AssertionChain<T>;
+    reject(type?: unknown, message?: string | RegExp): AssertionChain<T>;
     /** Asserts that the Promise reference value rejects with an exception when called */
-    rejects(type?: any, message?: string | RegExp): AssertionChain<T>;
+    rejects(type?: unknown, message?: string | RegExp): AssertionChain<T>;
     /** Asserts that the reference value satisfies the provided validator function. */
     satisfy(validator: (value: T) => boolean): AssertionChain<T>;
     /** Asserts that the reference value satisfies the provided validator function. */
     satisfies(validator: (value: T) => boolean): AssertionChain<T>;
     /** Asserts that the function reference value throws an exception when called. */
-    throw(type?: any, message?: string | RegExp): AssertionChain<T>;
+    throw(type?: unknown, message?: string | RegExp): AssertionChain<T>;
     /** Asserts that the function reference value throws an exception when called. */
-    throws(type?: any, message?: string | RegExp): AssertionChain<T>;
+    throws(type?: unknown, message?: string | RegExp): AssertionChain<T>;
 }
 
 export interface Settings {

--- a/types/hapi__code/tsconfig.json
+++ b/types/hapi__code/tsconfig.json
@@ -15,6 +15,9 @@
         "paths": {
             "@hapi/code": [
                 "hapi__code"
+            ],
+            "@hapi/hoek": [
+                "hapi__hoek"
             ]
         },
         "types": [],

--- a/types/hapi__cookie/index.d.ts
+++ b/types/hapi__cookie/index.d.ts
@@ -4,7 +4,7 @@
 //                 Simon Schick <https://github.com/SimonSchick>
 //                 Matt Erickson <https://github.com/Mutmatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { Request, ResponseObject, Plugin, ResponseToolkit, AuthCredentials, ServerStateCookieOptions } from '@hapi/hapi';
 
@@ -82,6 +82,6 @@ declare namespace hapiAuthCookie {
     }
 }
 
-declare const hapiAuthCookie: Plugin<void>;
+declare const hapiAuthCookie: Plugin;
 
 export = hapiAuthCookie;

--- a/types/hapi__crumb/index.d.ts
+++ b/types/hapi__crumb/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Silas Rech <https://github.com/lenovouser>
 //                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { Request, Plugin, ResponseToolkit, ServerStateCookieOptions } from '@hapi/hapi';
 

--- a/types/hapi__cryptiles/index.d.ts
+++ b/types/hapi__cryptiles/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Alex Wendland <https://github.com/awendland>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
 
 /**
  * Returns a cryptographically strong pseudo-random data string. Takes a size argument for the length of the string.

--- a/types/hapi__glue/index.d.ts
+++ b/types/hapi__glue/index.d.ts
@@ -3,14 +3,14 @@
 // Definitions by: Gareth Parker <https://github.com/garfty>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import { Server, ServerOptions } from "@hapi/hapi";
 
 export interface Options {
   relativeTo: string;
-  preConnections?: (Server: Server, next: (err: any) => void) => void;
-  preRegister?: (Server: Server, next: (err: any) => void) => void;
+  preConnections?: (Server: Server, next: (err: unknown) => void) => void;
+  preRegister?: (Server: Server, next: (err: unknown) => void) => void;
 }
 
 export interface Plugin {

--- a/types/hapi__h2o2/hapi__h2o2-tests.ts
+++ b/types/hapi__h2o2/hapi__h2o2-tests.ts
@@ -83,7 +83,7 @@ async function main() {
 
                 async onResponse(err, res, request, h, settings, ttl) {
                     console.log('receiving the response from the upstream.');
-                    const payload = await wreck.read(res, { json: true });
+                    const payload = <object>await wreck.read(res, { json: true });
 
                     console.log('some payload manipulation if you want to.')
                     let response = h.response(payload);

--- a/types/hapi__h2o2/index.d.ts
+++ b/types/hapi__h2o2/index.d.ts
@@ -5,7 +5,7 @@
 //                 Garth Kidd <https://github.com/garthk>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /// <reference types="node" />
 

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -6,17 +6,7 @@
 //                 Rodrigo Saboya <https://github.com/saboya>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
-
-/* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
- +                                                                           +
- +                                                                           +
- +                                                                           +
- +                      WARNING: BACKWARDS INCOMPATIBLE                      +
- +                                                                           +
- +                                                                           +
- +                                                                           +
- + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + */
+// TypeScript Version: 3.1
 
 /// <reference types='node' />
 
@@ -97,28 +87,6 @@ export interface PluginsStates {
 export interface PluginSpecificConfiguration {
 }
 
-export interface PluginNameVersion {
-    /**
-     * (required) the plugin name string. The name is used as a unique key. Published plugins (e.g. published in the npm
-     * registry) should use the same name as the name field in their 'package.json' file. Names must be
-     * unique within each application.
-     */
-    name: string;
-
-    /**
-     * optional plugin version. The version is only used informatively to enable other plugins to find out the versions loaded. The version should be the same as the one specified in the plugin's
-     * 'package.json' file.
-     */
-    version?: string;
-}
-
-export interface PluginPackage {
-    /**
-     * Alternatively, the name and version can be included via the pkg property containing the 'package.json' file for the module which already has the name and version included
-     */
-    pkg: any;
-}
-
 /**
  * Plugins provide a way to organize application code by splitting the server logic into smaller components. Each
  * plugin can manipulate the server through the standard server interface, but with the added ability to sandbox
@@ -128,7 +96,7 @@ export interface PluginPackage {
  *
  * The type T is the type of the plugin options.
  */
-export interface PluginBase<T> {
+export interface Plugin<T = void> {
     /**
      * (required) the registration function with the signature async function(server, options) where:
      * * server - the server object with a plugin-specific server.realm.
@@ -153,9 +121,20 @@ export interface PluginBase<T> {
 
     /** once - (optional) if true, will only register the plugin once per server. If set, overrides the once option passed to server.register(). Defaults to no override. */
     once?: boolean;
-}
 
-export type Plugin<T> = PluginBase<T> & (PluginNameVersion | PluginPackage);
+    /**
+     * (required) the plugin name string. The name is used as a unique key. Published plugins (e.g. published in the npm
+     * registry) should use the same name as the name field in their 'package.json' file. Names must be
+     * unique within each application.
+     */
+    name: string;
+
+    /**
+     * optional plugin version. The version is only used informatively to enable other plugins to find out the versions loaded. The version should be the same as the one specified in the plugin's
+     * 'package.json' file.
+     */
+    version?: string;
+}
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +
@@ -503,7 +482,7 @@ export interface Request extends Podium {
      * An object where each key is the name assigned by a route pre-handler methods function. The values are the raw values provided to the continuation function as argument. For the wrapped response
      * object, use responses.
      */
-    readonly pre: Util.Dictionary<any>;
+    readonly pre: Util.Dictionary<unknown>;
 
     /**
      * Access: read / write (see limitations below).
@@ -516,7 +495,7 @@ export interface Request extends Podium {
     /**
      * Same as pre but represented as the response object created by the pre method.
      */
-    readonly preResponses: Util.Dictionary<any>;
+    readonly preResponses: Util.Dictionary<unknown>;
 
     /**
      * By default the object outputted from node's URL parse() method.
@@ -549,7 +528,7 @@ export interface Request extends Podium {
     /**
      * An object containing parsed HTTP state information (cookies) where each key is the cookie name and value is the matching cookie content after processing using any registered cookie definition.
      */
-    readonly state: Util.Dictionary<any>;
+    readonly state: Util.Dictionary<unknown>;
 
     /**
      * The parsed request URI.
@@ -1004,7 +983,7 @@ export interface ResponseToolkit {
      * A response symbol. Provides access to the route or server context set via the route [bind](https://github.com/hapijs/hapi/blob/master/API.md#route.options.bind)
      * option or [server.bind()](https://github.com/hapijs/hapi/blob/master/API.md#server.bind()).
      */
-    readonly context: any;
+    readonly context: unknown;
 
     /**
      * A response symbol. When returned by a lifecycle method, the request lifecycle continues without changing the response.
@@ -2748,7 +2727,7 @@ export interface ServerInjectResponse extends Shot.ResponseObject {
  * * * ttl - 0 if result is valid but cannot be cached. Defaults to cache policy.
  * For reference [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermethodname-method-options)
  */
-export type ServerMethod = (...args: any[]) => any;
+export type ServerMethod = (...args: unknown[]) => unknown;
 
 /**
  * The same cache configuration used in server.cache().
@@ -2785,7 +2764,7 @@ export interface ServerMethodOptions {
      * unique key if the function's arguments are all of types 'string', 'number', or 'boolean'. However if the method uses other types of arguments, a key generation function must be provided which
      * takes the same arguments as the function and returns a unique string (or null if no key can be generated).
      */
-    generateKey?(...args: any[]): string | null;
+    generateKey?(...args: unknown[]): string | null;
 }
 
 /**
@@ -2810,8 +2789,8 @@ export interface ServerMethodConfigurationObject {
     options?: ServerMethodOptions;
 }
 
-export type CacheProvider<T extends ClientOptions = ClientOptions> = EnginePrototype<any> | {
-    constructor: EnginePrototype<any>;
+export type CacheProvider<T extends ClientOptions = ClientOptions> = EnginePrototype<unknown> | {
+    constructor: EnginePrototype<unknown>;
     options?: T;
 };
 
@@ -2820,9 +2799,9 @@ export type CacheProvider<T extends ClientOptions = ClientOptions> = EngineProto
  * MongoDB, Memcached, Riak, among others). Caching is only utilized if methods and plugins explicitly store their state in the cache.
  * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-cache)
  */
-export interface ServerOptionsCache extends PolicyOptions<any> {
+export interface ServerOptionsCache extends PolicyOptions<unknown> {
     /** catbox engine object. */
-    engine?: ClientApi<any>;
+    engine?: ClientApi<unknown>;
 
     /**
      * a class or a prototype function
@@ -2842,7 +2821,7 @@ export interface ServerOptionsCache extends PolicyOptions<any> {
     partition?: string;
 
     /** other options passed to the catbox strategy used. Other options are only passed to catbox when engine above is a class or function and ignored if engine is a catbox engine object). */
-    [s: string]: any;
+    [s: string]: unknown;
 }
 
 export interface ServerOptionsCompression {
@@ -3059,7 +3038,7 @@ export interface ServerOptions {
          * the method must return an object where each key is a parameter and matching value is the parameter value.
          * If the method throws, the error is used as the response or returned when `request.setUrl` is called.
          */
-        parser(raw: Util.Dictionary<string>): Util.Dictionary<any>;
+        parser(raw: Util.Dictionary<string>): Util.Dictionary<unknown>;
     };
 }
 
@@ -3156,23 +3135,6 @@ export interface ServerRegisterPluginObject<T> extends ServerRegisterOptions {
      * options passed to the plugin during registration.
      */
     options?: T;
-}
-
-export interface ServerRegisterPluginObjectArray<T, U, V, W, X, Y, Z> extends Array<ServerRegisterPluginObject<T>
-                                                                                    | ServerRegisterPluginObject<U>
-                                                                                    | ServerRegisterPluginObject<V>
-                                                                                    | ServerRegisterPluginObject<W>
-                                                                                    | ServerRegisterPluginObject<X>
-                                                                                    | ServerRegisterPluginObject<Y>
-                                                                                    | ServerRegisterPluginObject<Z>
-                                                                                    | undefined> {
-    0: ServerRegisterPluginObject<T>;
-    1?: ServerRegisterPluginObject<U>;
-    2?: ServerRegisterPluginObject<V>;
-    3?: ServerRegisterPluginObject<W>;
-    4?: ServerRegisterPluginObject<X>;
-    5?: ServerRegisterPluginObject<Y>;
-    6?: ServerRegisterPluginObject<Z>;
 }
 
 /* tslint:disable-next-line:no-empty-interface */
@@ -3292,7 +3254,7 @@ export interface ServerStateCookieOptions {
     /** if false, allows any cookie value including values in violation of RFC 6265. Defaults to true. */
     strictHeader?: boolean;
     /** used by proxy plugins (e.g. h2o2). */
-    passThrough?: any;
+    passThrough?: unknown;
 }
 
 /**
@@ -3368,14 +3330,14 @@ export interface ServerState {
  * If the property is set to a function, the function uses the signature function(method) and returns the route default configuration.
  */
 export interface HandlerDecorationMethod {
-    (route: RouteOptions, options: any): Lifecycle.Method;
-    defaults?: RouteOptions | ((method: any) => RouteOptions);
+    (route: RouteOptions, options: unknown): Lifecycle.Method;
+    defaults?: RouteOptions | ((method: HandlerDecorationMethod) => RouteOptions);
 }
 
 /**
  * The general case for decorators added via server.decorate.
  */
-export type DecorationMethod<T> = (this: T, ...args: any[]) => any;
+export type DecorationMethod<T> = (this: T, ...args: unknown[]) => unknown;
 
 /**
  * An empty interface to allow typings of custom plugin properties.
@@ -3385,6 +3347,12 @@ export interface PluginProperties {
 }
 
 export type DecorateName = string | symbol;
+
+export interface Mimes {
+    path(fileName: string): {
+        type: string;
+    };
+}
 
 /**
  * The server object is the main application container. The server manages all incoming requests along with all
@@ -3541,7 +3509,7 @@ export class Server {
      * modified directly but only through the [mime](https://github.com/hapijs/hapi/blob/master/API.md#server.options.mime) server setting.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermime)
      */
-    mime: any;
+    mime: Mimes;
 
     /**
      * An object containing the values exposed by each registered plugin where each key is a plugin name and the values
@@ -3640,12 +3608,17 @@ export class Server {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverdecoratetype-property-method-options)
      */
     decorate(type: 'handler', property: DecorateName, method: HandlerDecorationMethod, options?: {apply?: boolean, extend?: boolean}): void;
-    decorate(type: 'request', property: DecorateName, method: (existing: ((...args: any[]) => any)) => (request: Request) => DecorationMethod<Request>, options: {apply: true, extend: true}): void;
+    decorate(
+        type: 'request',
+        property: DecorateName,
+        method: (existing: ((...args: unknown[]) => unknown)) => (request: Request) => DecorationMethod<Request>,
+        options: {apply: true, extend: true}
+    ): void;
     decorate(type: 'request', property: DecorateName, method: (request: Request) => DecorationMethod<Request>, options: {apply: true, extend?: boolean}): void;
     decorate(type: 'request', property: DecorateName, method: DecorationMethod<Request>, options?: {apply?: boolean, extend?: boolean}): void;
-    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<ResponseToolkit>, options: {apply?: boolean, extend: true}): void;
+    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: unknown[]) => unknown)) => DecorationMethod<ResponseToolkit>, options: {apply?: boolean, extend: true}): void;
     decorate(type: 'toolkit', property: DecorateName, method: DecorationMethod<ResponseToolkit>, options?: {apply?: boolean, extend?: boolean}): void;
-    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<Server>, options: {apply?: boolean, extend: true}): void;
+    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: unknown[]) => unknown)) => DecorationMethod<Server>, options: {apply?: boolean, extend: true}): void;
     decorate(type: 'server', property: DecorateName, method: DecorationMethod<Server>, options?: {apply?: boolean, extend?: boolean}): void;
 
     /**
@@ -3679,7 +3652,7 @@ export class Server {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverexposekey-value)
      */
-    expose(key: string, value: any): void;
+    expose(key: string, value: unknown): void;
 
     /**
      * Merges an object into to the existing content of server.plugins[name] where:
@@ -3786,7 +3759,7 @@ export class Server {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverlogtags-data-timestamp)
      */
-    log(tags: string | string[], data?: string | object | (() => any), timestamp?: number): void;
+    log(tags: string | string[], data?: string | object | (() => unknown), timestamp?: number): void;
 
     /**
      * Looks up a route configuration where:
@@ -3867,13 +3840,20 @@ export class Server {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-await-serverregisterplugins-options)
      */
-     /* tslint:disable-next-line:no-unnecessary-generics */
-    register<T>(plugin: ServerRegisterPluginObject<T>, options?: ServerRegisterOptions): Promise<void>;
-    /* tslint:disable-next-line:no-unnecessary-generics */
-    register<T, U, V, W, X, Y, Z>(plugins: ServerRegisterPluginObjectArray<T, U, V, W, X, Y, Z>, options?: ServerRegisterOptions): Promise<void>;
-    register(plugins: Array<ServerRegisterPluginObject<any>>, options?: ServerRegisterOptions): Promise<void>;
-    /* tslint:disable-next-line:unified-signatures */
-    register(plugins: Plugin<any> | Array<Plugin<any>>, options?: ServerRegisterOptions): Promise<void>;
+    register<T>(plugin: Plugin<T> | ServerRegisterPluginObject<T>, options?: ServerRegisterOptions): Promise<void>;
+    register(plugins: Array<ServerRegisterPluginObject<unknown>>, options?: ServerRegisterOptions): Promise<void>;
+    register<A, B, C, D, E, F, G, H, I, J>(
+        plugins: [
+            Plugin<A>, Plugin<B>?, Plugin<C>?, Plugin<D>?, Plugin<E>?,
+            Plugin<F>?, Plugin<G>?, Plugin<H>?, Plugin<I>?, Plugin<J>?
+        ] | [
+            ServerRegisterPluginObject<A>, ServerRegisterPluginObject<B>?, ServerRegisterPluginObject<C>?,
+            ServerRegisterPluginObject<D>?, ServerRegisterPluginObject<E>?, ServerRegisterPluginObject<F>?,
+            ServerRegisterPluginObject<G>?, ServerRegisterPluginObject<H>?, ServerRegisterPluginObject<I>?,
+            ServerRegisterPluginObject<J>?
+        ],
+        options?: ServerRegisterOptions
+    ): Promise<void>;
 
     /**
      * Adds a route where:
@@ -3995,7 +3975,7 @@ export namespace Json {
     /**
      * @see {@link https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter}
      */
-    type StringifyReplacer = ((key: string, value: any) => any) | Array<(string | number)> | undefined;
+    type StringifyReplacer = ((key: string, value: unknown) => unknown) | Array<(string | number)> | undefined;
 
     /**
      * Any value greater than 10 is truncated.

--- a/types/hapi__hapi/test/server/server-bind.ts
+++ b/types/hapi__hapi/test/server/server-bind.ts
@@ -4,8 +4,13 @@ import { Lifecycle, Plugin, Request, ResponseToolkit, Server, ServerRegisterOpti
 const server = new Server({
     port: 8000,
 });
+
+interface MyContext {
+    message: string;
+}
+
 const handler: Lifecycle.Method = (request, h) => {
-    return h.context.message;    // Or h.context.message
+    return (<MyContext> h.context).message;    // Or h.context.message
 };
 
 const plugin: Plugin<any> = {

--- a/types/hapi__hapi/test/server/server-cache.ts
+++ b/types/hapi__hapi/test/server/server-cache.ts
@@ -1,6 +1,6 @@
 // https://github.com/hapijs/hapi/blob/master/API.md#-servercacheoptions
 import { Server, ServerOptionsCache } from "@hapi/hapi";
-import * as catbox from "@hapi/catbox";
+import { PolicyOptions } from '@hapi/catbox';
 
 const server = new Server({
     port: 8000,
@@ -10,7 +10,7 @@ const catboxOptions: ServerOptionsCache = {
     segment: 'countries',
     expiresIn: 60 * 60 * 1000
 };
-const cache = server.cache<string>(catboxOptions);
+const cache = server.cache<string>(<PolicyOptions<string>> catboxOptions);
 cache.set('norway', 'oslo', 10 * 1000).then(() => {});
 
 const value = cache.get('norway').then(() => {});

--- a/types/hapi__hapi/test/server/server-methods.ts
+++ b/types/hapi__hapi/test/server/server-methods.ts
@@ -6,6 +6,6 @@ const server = new Server({
 });
 server.start();
 
-server.method('add', (a, b) => (a + b));
+server.method('add', (a: number, b: number) => (a + b));
 const result = server.methods.add(1, 2);    // 3
 console.log(result);

--- a/types/hapi__hapi/tslint.json
+++ b/types/hapi__hapi/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "no-angle-bracket-type-assertion": false
+        "no-angle-bracket-type-assertion": false,
+        "no-unnecessary-generics": false
     }
 }

--- a/types/hapi__hoek/hapi__hoek-tests.ts
+++ b/types/hapi__hoek/hapi__hoek-tests.ts
@@ -8,7 +8,7 @@ import * as Hoek from "@hapi/hoek";
 
 // clone(obj)
 
-let nestedObj = {
+const nestedObj = {
     w: /^something$/ig,
     x: {
         a: [1, 2, 3],
@@ -19,28 +19,13 @@ let nestedObj = {
     z: new Date()
 };
 
-let copy = Hoek.clone(nestedObj);
+const copy = Hoek.clone(nestedObj);
 
 copy.x.b = 100;
 
 console.log(copy.y);        // results in 'y'
 console.log(nestedObj.x.b); // results in 123456
 console.log(copy.x.b);      // results in 100
-
-// cloneWithShallow(obj, keys)
-
-nestedObj = {
-    w: /^something$/ig,
-    x: {
-        a: [1, 2, 3],
-        b: 123456,
-        c: new Date()
-    },
-    y: 'y',
-    z: new Date()
-};
-
-copy = Hoek.cloneWithShallow(nestedObj, ['x']);
 
 copy.x.b = 100;
 
@@ -76,8 +61,6 @@ const options1 = { host: null, port: 8080 };
 
 config = Hoek.applyToDefaults(defaults, options1, true); // results in { host: null, port: 8080 }
 
-// applyToDefaultsWithShallow(defaults, options, keys)
-
 const defaults1 = {
     server: {
         host: "localhost",
@@ -87,8 +70,6 @@ const defaults1 = {
 };
 
 const options2 = { server: { port: 8080 } };
-
-const config1 = Hoek.applyToDefaultsWithShallow(defaults1, options2, ['server']); // results in { server: { port: 8080 }, name: 'example' }
 
 // deepEqual(b, a, [options])
 
@@ -102,17 +83,9 @@ let array = [1, 2, 2, 3, 3, 4, 5, 6];
 
 const newArray = Hoek.unique(array);    // results in [1,2,3,4,5,6]
 
-let array1 = [{ id: 1 }, { id: 1 }, { id: 2 }];
+const array1 = [{ id: 1 }, { id: 1 }, { id: 2 }];
 
 const newArray1 = Hoek.unique(array1, "id");  // results in [{id: 1}, {id: 2}]
-
-// mapToObject(array, key)
-
-array = [1, 2, 3];
-let newObject = Hoek.mapToObject(array);   // results in {"1": true, "2": true, "3": true}
-
-array1 = [{ id: 1 }, { id: 2 }];
-newObject = Hoek.mapToObject(array1, "id"); // results in {"1": true, "2": true}
 
 // intersect(array1, array2)
 
@@ -120,6 +93,7 @@ array = [1, 2, 3];
 const array2 = [1, 4, 5];
 
 const newArray2 = Hoek.intersect(array, array2); // results in [1]
+const common: number = Hoek.intersect(array, array2, { first: true });
 
 // contain(ref, values, [options])
 
@@ -169,52 +143,16 @@ const source1 = {
     state: 'CA'
 };
 
-let result = Hoek.transform(source1, {
-    'person.address.lineOne': 'address.one',
-    'person.address.lineTwo': 'address.two',
-    title: 'title',
-    'person.address.region': 'state'
-});
-// Results in
-// {
-//     person: {
-//         address: {
-//             lineOne: '123 main street',
-//             lineTwo: 'PO Box 1234',
-//             region: 'CA'
-//         }
-//     },
-//     title: 'Warehouse'
-// }
-
-// shallow(obj)
-
-const shallow = Hoek.shallow({ a: { b: 1 } });
-
 // stringify(obj)
 
 let a: any = {};
 a.b = a;
 Hoek.stringify(a);      // Returns '[Cannot display object: Converting circular structure to JSON]'
 
-// Timer
-
-const timerObj = new Hoek.Timer();
-console.log("Time is now: " + timerObj.ts);
-console.log(`Elapsed time from initialization: ${timerObj.elapsed()}milliseconds`);
-
 // Bench
 
 const benchObj = new Hoek.Bench();
 console.log(`Elapsed time from initialization: ${benchObj.elapsed()}milliseconds`);
-
-// base64urlEncode(value)
-
-Hoek.base64urlEncode("hoek");
-
-// base64urlDecode(value)
-
-Hoek.base64urlDecode("aG9law==");
 
 // escapeHtml(string)
 
@@ -242,35 +180,9 @@ Hoek.assert(x === y, new Error('x should equal y')); // Throws the given error o
 
 Hoek.abort("Error message");
 
-// displayStack(slice)
-
-const stack = Hoek.displayStack();
-console.log(stack);
-
-// callStack(slice)
-
-const stack2 = Hoek.callStack();
-console.log(stack2);
-
-// nextTick(fn)
-
-let myFn = () => {
-    console.log('Do this later');
-};
-
-const nextFn = Hoek.nextTick(myFn);
-
-nextFn();
-console.log('Do this first');
-
-// Results in:
-//
-// Do this first
-// Do this later
-
 // once(fn)
 
-myFn = () => {
+const myFn = () => {
     console.log('Ran myFn');
 };
 
@@ -282,10 +194,6 @@ onceFn(); // results in undefined
 
 Hoek.ignore();
 
-// uniqueFilename(path, extension)
+const waited: Promise<void> = Hoek.wait(123);
 
-const result1 = Hoek.uniqueFilename('./test/modules', 'txt'); // results in "full/path/test/modules/{random}.txt"
-
-// isInteger(value)
-
-result = Hoek.isInteger('23');
+const nevar: Promise<never> = Hoek.block();

--- a/types/hapi__hoek/index.d.ts
+++ b/types/hapi__hoek/index.d.ts
@@ -1,8 +1,10 @@
-// Type definitions for @hapi/hoek 6.2
+// Type definitions for @hapi/hoek 8.2
 // Project: https://github.com/hapijs/hoek
 // Definitions by: Prashant Tiwari <https://github.com/prashaantt>
 //                 Silas Rech <https://github.com/lenovouser>
+//                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
 
 export interface ContainOptions {
     /** Perform a deep comparison of the values? */
@@ -19,11 +21,44 @@ export interface ReachOptions {
     /** String to split chain path on. Defaults to ".". */
     separator?: string;
     /** Value to return if the path or value is not present. Default is undefined. */
-    default?: any;
+    default?: unknown;
     /** Throw an error on missing member? Default is false. */
     strict?: boolean;
     /** Allow traversing functions for properties? */
     functions?: boolean;
+}
+
+export interface DeepEqualOptions {
+    /**
+     * When true, function values are deep compared using their source code and object properties.
+     * @default false
+     */
+    deepFunction?: boolean;
+    /**
+     * When true, allows a partial match where some of b is present in a. Defaults to false.
+     * prototype - when false, prototype comparisons are skipped.
+     * @default true
+     */
+    part?: boolean;
+
+    /**
+     * When false, prototype comparisons are skipped.
+     * @default true
+     */
+    prototype?: boolean;
+
+    /**
+     * An array of key name strings to skip comparing.
+     * The keys can be found in any level of the object.
+     * Note that both values must contain the key - only the value comparison is skipped.
+     * Only applies to plain objects and deep functions (not to map, sets, etc.).
+     */
+    skip?: string[];
+    /**
+     * When false, symbol properties are ignored.
+     * @default true
+     */
+    symbols?: boolean;
 }
 
 // Object
@@ -32,11 +67,6 @@ export interface ReachOptions {
  * Clone an object or an array.
  */
 export function clone<T>(obj: T): T;
-
-/**
- * Clone an object or array.
- */
-export function cloneWithShallow(obj: any, keys: string[]): any;
 
 /**
  * Merge all the properties of source into target.
@@ -49,14 +79,9 @@ export function merge<T1, T2>(target: T1, source: T2, isNullOverride?: boolean, 
 export function applyToDefaults<T1, T2>(defaults: T1, options: T2, isNullOverride?: boolean): T1 & T2;
 
 /**
- * Apply options to a copy of the defaults.
- */
-export function applyToDefaultsWithShallow<T1, T2>(defaults: T1, options: T2, keys?: string[]): T1 & T2;
-
-/**
  * Perform a deep comparison of the two values.
  */
-export function deepEqual<T>(b: T, a: T, options?: any): T;
+export function deepEqual<T>(b: T, a: T, options?: DeepEqualOptions): T;
 
 /**
  * Remove duplicate items from Array.
@@ -64,61 +89,37 @@ export function deepEqual<T>(b: T, a: T, options?: any): T;
 export function unique<T>(array: T[], key?: string): T[];
 
 /**
- * Convert an Array into an Object.
- */
-export function mapToObject(array: any[], key?: string): any;
-
-/**
  * Find the common unique items in two arrays.
  */
-export function intersect(array1: any[], array2: any[]): any;
+export function intersect<T>(array1: T[], array2: T[]): T[];
+export function intersect<T>(array1: T[], array2: T[], options: { first: true }): T;
+export function intersect<T>(array1: T[], array2: T[], options: { first: boolean }): T | T[];
 
 /**
  * Test if the reference value contains the provided values.
  */
-export function contain(ref: any, values: any, options?: ContainOptions): boolean;
+export function contain(ref: unknown[] | object, values: unknown | unknown[], options?: ContainOptions): boolean;
+export function contain(ref: string, values: string | string[], options?: ContainOptions): boolean;
 
 /**
  * Flatten an array.
  */
-export function flatten(array: any[], target?: any[]): any[];
+export function flatten(array: unknown[], target?: unknown[]): unknown[];
 
 /**
  * Convert an object key chain string to reference.
  */
-export function reach(obj: any, chain: any, options?: ReachOptions): any;
+export function reach(obj: unknown, chain: string | Array<string | number>, options?: ReachOptions): unknown;
 
 /**
  * Replace string parameters ({name}) with their corresponding object key values.
  */
-export function reachTemplate(obj: any, template: string, options?: ReachOptions): any;
-
-/**
- * Transform an existing object into a new one based on the supplied obj and transform map.
- */
-export function transform(obj: any, transform: any, options?: ReachOptions): any;
-
-/**
- * Perform a shallow copy by copying the references of all the top level children.
- */
-export function shallow(obj: any): any;
+export function reachTemplate(obj: unknown, template: string, options?: ReachOptions): unknown;
 
 /**
  * Convert an object to string. Any errors are caught and reported back in the form of the returned string.
  */
-export function stringify(obj: any): string;
-
-// Timer
-
-/**
- * A Timer object.
- */
-export class Timer {
-    /** The number of milliseconds elapsed since the epoch. */
-    ts: number;
-    /** The time (ms) elapsed since the timer was created. */
-    elapsed(): number;
-}
+export function stringify(obj: unknown): string;
 
 // Bench
 
@@ -131,18 +132,6 @@ export class Bench {
     /** The time (ms) elapsed since the timer was created. */
     elapsed(): number;
 }
-
-// Binary Encoding/Decoding
-
-/**
- * Encode value of string or buffer type in Base64 or URL encoding.
- */
-export function base64urlEncode(value: string): string;
-
-/**
- * Decode string into Base64 or URL encoding.
- */
-export function base64urlDecode(value: string): string;
 
 // Escaping Characters
 
@@ -173,41 +162,26 @@ export function assert(condition: boolean, message: string | Error): void | Erro
  */
 export function abort(message: string | Error): void;
 
-/**
- * Display the trace stack.
- */
-export function displayStack(slice?: any): string[];
-
-/**
- * Return a trace stack array.
- */
-export function callStack(slice?: any): any[];
-
 // Function
-
-/**
- * Wrap fn in process.nextTick.
- */
-export function nextTick(fn: () => void): () => void;
 
 /**
  * Make sure fn is only run once.
  */
-export function once(fn: () => void): () => void;
+export function once<TArgs extends unknown[]>(fn: (...args: TArgs) => unknown): (...args: TArgs) => void;
 
 /**
  * A simple no-op function.
  */
 export function ignore(): void;
 
-// Miscellaneous
+/**
+ * Resolve the promise after timeout.
+ * @param timeout In milliseconds
+ */
+export function wait(timeout: number): Promise<void>;
 
 /**
- * path to prepend to a randomly generated file name.
+ * A no-op Promise.
+ * Never resolves.
  */
-export function uniqueFilename(path: string, extension?: string): string;
-
-/**
- * Check value to see if it is an integer.
- */
-export function isInteger(value: any): boolean;
+export function block(): Promise<never>;

--- a/types/hapi__inert/index.d.ts
+++ b/types/hapi__inert/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alexander James Phillips <https://github.com/AJamesPhillips>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import {
     Plugin,

--- a/types/hapi__iron/index.d.ts
+++ b/types/hapi__iron/index.d.ts
@@ -4,7 +4,7 @@
 //                 Rafael Souza Fijalkowski <https://github.com/rafaelsouzaf>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.1
 
 /// <reference types="node" />
 

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -20,7 +20,7 @@
 //                 Anand Chowdhary <https://github.com/AnandChowdhary>
 //                 Miro Yovchev <https://github.com/myovchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.1
 
 // TODO express type of Schema in a type-parameter (.default, .valid, .example etc)
 

--- a/types/hapi__lab/hapi__lab-tests.ts
+++ b/types/hapi__lab/hapi__lab-tests.ts
@@ -1,8 +1,21 @@
 import { script, assertions } from "@hapi/lab";
 
 const { experiment, describe, suite, test, it, before, beforeEach, after, afterEach } = script();
-const expect = assertions.expect;
-const fail = assertions.fail;
+
+interface Chain {
+    to: Chain;
+    be: Chain;
+    equal(val: unknown): void;
+    true(): void;
+}
+
+interface Assertions {
+    expect(val: unknown): Chain;
+    fail(stuff: unknown): never;
+}
+
+const expect = (<Assertions>assertions).expect;
+const fail = (<Assertions>assertions).fail;
 
 experiment('math', () => {
 

--- a/types/hapi__lab/index.d.ts
+++ b/types/hapi__lab/index.d.ts
@@ -1,13 +1,14 @@
-// Type definitions for @hapi/lab 18.1
+// Type definitions for @hapi/lab 20.2
 // Project: https://github.com/hapijs/lab
 // Definitions by: Prashant Tiwari <https://github.com/prashaantt>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
 
 /** The test script. */
 export function script(options?: ScriptOptions): Lab & ExperimentAlt & TestAlt;
 /** Access the configured assertion library. */
-export const assertions: any;
+export const assertions: unknown;
 
 interface Lab {
     /** Organise tests into an experiment */
@@ -133,7 +134,9 @@ interface ScriptOptions {
     schedule?: boolean;
 
     /** Pass Lab CLI options */
-    cli?: any;
+    cli?: {
+        [key: string]: unknown;
+    };
 }
 
 interface ExperimentOptions {
@@ -173,11 +176,11 @@ type CleanupFunction = (func: (next: Function) => void) => void;
 
 type TestCallback = (done: DoneFunction & DoneNote, onCleanup?: CleanupFunction) => void;
 
-type TestPromise = () => Promise<any>;
+type TestPromise = () => Promise<unknown>;
 
 type AsyncCallback = (done: DoneFunction) => void;
 
-type AsyncPromise = () => Promise<any>;
+type AsyncPromise = () => Promise<unknown>;
 
 type ExperimentArgs = (desc: string, cb: EmptyCallback) => {};
 

--- a/types/hapi__mimos/index.d.ts
+++ b/types/hapi__mimos/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: AJP <https://github.com/AJamesPhillips>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.1
 
 import { DataStructure as MimeDbDataStructure } from 'mime-db';
 

--- a/types/hapi__nes/index.d.ts
+++ b/types/hapi__nes/index.d.ts
@@ -4,7 +4,7 @@
 //                 Rodrigo Saboya <https://github.com/saboya>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +
@@ -132,6 +132,6 @@ interface NesClassExports {
     };
 }
 
-declare var nes: NesClassExports & Plugin<{}>;
+declare var nes: NesClassExports & Plugin;
 
 export = nes;

--- a/types/hapi__podium/index.d.ts
+++ b/types/hapi__podium/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: AJP <https://github.com/AJamesPhillips>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.1
 
 /**
  * Podium
@@ -176,7 +176,7 @@ declare namespace Podium {
      * @see {@link https://github.com/hapijs/podium/blob/master/API.md#podiumoncriteria-listener}
      */
     export interface Listener {
-    (data: any, tags?: Tags, callback?: () => void): void;
+        (data: unknown, tags?: Tags, callback?: () => void): void;
     }
 
     export type Tags = {[tag: string]: boolean};

--- a/types/hapi__shot/index.d.ts
+++ b/types/hapi__shot/index.d.ts
@@ -4,7 +4,7 @@
 //                 Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.1
 
 /// <reference types="node" />
 
@@ -23,7 +23,7 @@ export function inject(dispatchFunc: Listener, options: RequestOptions): Promise
  * Checks if given object obj is a Shot Request object.
  * @see {@link https://github.com/hapijs/shot/blob/master/API.md#shotisinjectionobj}
  */
-export function isInjection(obj: any): boolean;
+export function isInjection(obj: unknown): boolean;
 
 /**
  * listener function. The same as you would pass to Http.createServer when making a node HTTP server. Has the signature function (req, res) where:
@@ -104,5 +104,5 @@ export interface ResponseObject {
     /** the raw payload as a Buffer. */
     rawPayload: Buffer;
     /** an object containing the response trailers. */
-    trailers: {[index: string]: any};
+    trailers: { [index: string]: unknown };
 }

--- a/types/hapi__sntp/index.d.ts
+++ b/types/hapi__sntp/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/hapijs/sntp
 // Definitions by: Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 export interface Options {
     host?: string;

--- a/types/hapi__topo/index.d.ts
+++ b/types/hapi__topo/index.d.ts
@@ -3,14 +3,14 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 export = Topo;
 
 /**
  * The Topo object is the container for topologically sorting a list of nodes with non-circular interdependencies.
  */
-declare class Topo<TNode = any, TGroup = string> {
+declare class Topo<TNode = unknown, TGroup = string> {
     /**
      * An array of the topologically sorted nodes. This list is renewed upon each call to `topo.add()`.
      */

--- a/types/hapi__vision/index.d.ts
+++ b/types/hapi__vision/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alexander James Phillips <https://github.com/AJamesPhillips>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import {
     Plugin,
@@ -131,7 +131,7 @@ declare namespace vision {
 
     type ServerViewCompile = ServerViewCompileSync | ServerViewCompileAsync;
 
-    type ServerViewCompileNext = (err: Error | null, compiled: (context: any, options: any, callback: (err: null | Error, rendered: string | null) => void) => void) => void;
+    type ServerViewCompileNext = (err: Error | null, compiled: (context: unknown, options: unknown, callback: (err: null | Error, rendered: string | null) => void) => void) => void;
 
     /**
      * The npm module used for rendering the templates. The module object must contain the compile() function
@@ -156,7 +156,7 @@ declare namespace vision {
          * Registers a helper for use during template rendering.
          * The name is the name that templates should use to reference the helper and helper is the function that will be invoked when the helper is called.
          */
-        registerHelper?(name: string, helper: (...args: any[]) => any): void;
+        registerHelper?(name: string, helper: (...args: unknown[]) => unknown): void;
     }
 
     type EngineConfigurationObject = object;
@@ -182,7 +182,7 @@ declare namespace vision {
          * @param helper
          * @see {@link https://github.com/hapijs/vision/blob/master/API.md#managerregisterhelpername-helper}
          */
-        registerHelper(name: string, helper: (...args: any[]) => any): void;
+        registerHelper(name: string, helper: (...args: unknown[]) => unknown): void;
         /**
          * Renders a template. This is typically not needed and it is usually more convenient to use server.render().
          * @see {@link https://github.com/hapijs/vision/blob/master/API.md#managerrendertemplate-context-options-callback}
@@ -249,7 +249,7 @@ declare module '@hapi/hapi' {
          *                 Cannot override isCached, partialsPath, or helpersPath which are only loaded at initialization.
          * @see {@link https://github.com/hapijs/vision/blob/master/API.md#replyviewtemplate-context-options}
          */
-        view(templatePath: string, context?: any, options?: vision.ViewHandlerOrReplyOptions): ResponseObject;
+        view(templatePath: string, context?: object, options?: vision.ViewHandlerOrReplyOptions): ResponseObject;
         /**
          * Returns the closest views manager to your realm (either on your realm or inherited from an ancestor realm)
          *

--- a/types/hapi__wreck/index.d.ts
+++ b/types/hapi__wreck/index.d.ts
@@ -5,7 +5,7 @@
 //                 Silas Rech <https://github.com/lenovouser>
 //                 Geoff Goodman <https://github.com/ggoodman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.1
 
 /// <reference types="node" />
 
@@ -19,16 +19,16 @@ import * as Url from "url";
 interface RequestOptions {
     baseUrl?: string;
     socketPath? : string;
-    payload?: any;
-    headers?: { [key: string]: any };
+    payload?: string | Buffer | stream.Readable | object;
+    headers?: { [key: string]: string | number };
     redirects?: number;
     redirect303?: boolean;
-    beforeRedirect?: (redirectMethod: string, statusCode: number, location: string, resHeaders: { [key: string]: any }, redirectOptions: any, next: () => {}) => void;
+    beforeRedirect?: (redirectMethod: string, statusCode: number, location: string, resHeaders: { [key: string]: unknown }, redirectOptions: RequestOptions, next: () => {}) => void;
     redirected?: (statusCode: number, location: string, req: http.ClientRequest) => void;
     timeout?: number;
     maxBytes?: number;
     rejectUnauthorized?: boolean;
-    downstreamRes?: any;
+    downstreamRes?: http.ServerResponse;
     agent?: http.Agent | false;
     secureProtocol?: string;
     ciphers?: string;
@@ -43,11 +43,11 @@ interface ReadOptions {
 }
 
 interface RequestResponse {
-    res: http.IncomingMessage,
-    payload: any,
+    res: http.IncomingMessage;
+    payload: Buffer | object;
 }
 
-declare type RequestCallback = (uri: string, options: RequestOptions & { payload?: any }) => void;
+declare type RequestCallback = (uri: string, options: RequestOptions & { payload?: Buffer | object }) => void;
 declare type ResponseCallback = (err: Boom | undefined, details: { req: http.ClientRequest, res: http.IncomingMessage | undefined, start: number, url: Url.URL }) => void;
 
 declare class WreckEventEmitter extends events.EventEmitter {
@@ -60,7 +60,7 @@ interface WreckObject {
 
     request: (method: string, uri: string, options: RequestOptions) => Promise<http.IncomingMessage> & { req: http.ClientRequest };
 
-    read: (response: http.IncomingMessage, options: ReadOptions) => Promise<any>;
+    read: (response: http.IncomingMessage, options: ReadOptions) => Promise<unknown>;
 
     get: (uri: string, options: RequestOptions & ReadOptions) => Promise<RequestResponse>;
     post: (uri: string, options: RequestOptions & ReadOptions) => Promise<RequestResponse>;
@@ -68,9 +68,9 @@ interface WreckObject {
     put: (uri: string, options: RequestOptions & ReadOptions) => Promise<RequestResponse>;
     delete: (uri: string, options: RequestOptions & ReadOptions) => Promise<RequestResponse>;
 
-    toReadableStream: (payload: any, encoding?: string) => stream.Readable;
+    toReadableStream: (payload: string | Buffer, encoding?: string) => stream.Readable;
 
-    parseCacheControl: (field: string) => any;
+    parseCacheControl: (field: string) => { [key: string]: string };
 
     agents: {
         http: http.Agent,

--- a/types/hapi__yar/index.d.ts
+++ b/types/hapi__yar/index.d.ts
@@ -3,8 +3,7 @@
 // Definitions by: Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
-// From https://github.com/hapijs/yar/blob/master/API.md
+// TypeScript Version: 3.1
 
 import {
     Server,
@@ -44,7 +43,7 @@ declare namespace yar {
         /**
          * hapi cache options which includes (among other options):
          */
-        cache?: CachePolicyOptions<any>;
+        cache?: CachePolicyOptions<unknown>;
 
         /**
          * the configuration for cookie-specific features:
@@ -124,14 +123,14 @@ declare namespace yar {
          */
         set<T>(key: string, value: T): T;
         /**
-         *  assigns values to multiple keys using each 'keysObject' top-level property. Returns the keysObject.
+         * Assigns values to multiple keys using each 'keysObject' top-level property. Returns the keysObject.
          */
-        set<T extends { [key: string]: any }>(keysObject: T): T;
+        set<T extends { [key: string]: unknown }>(keysObject: T): T;
 
         /**
          * retrieve value using a key. If 'clear' is 'true', key is cleared on return.
          */
-        get(key: string, clear?: boolean): any;
+        get(key: string, clear?: boolean): unknown;
         /**
          * clears key.
          */
@@ -149,7 +148,7 @@ declare namespace yar {
          * 'isOverride' used to indicate that the message provided should replace
          * any existing value instead of being appended to it (defaults to false).
          */
-        flash(type: string, message?: any, isOverride?: boolean): any[];
+        flash(type: string, message?: unknown, isOverride?: boolean): unknown[];
 
         /**
          * if set to 'true', enables lazy mode.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hoek/blob/master/API.md https://github.com/hapijs/wreck
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This touched a few packages across the @hapi namespace to improve type safety.
Core changes are in hapi and hoek.