### PR TITLE
Add channelgroup type definitions to pubnub types

### DIFF
--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -33,25 +33,30 @@ declare class Pubnub {
 
   publish(
     params: Pubnub.PublishParameters,
-    callback: (status: Pubnub.PublishStatus, response: Pubnub.PublishResponse) => void
+    callback: (
+      status: Pubnub.PublishStatus,
+      response: Pubnub.PublishResponse,
+    ) => void,
   ): void;
 
-  publish(
-    params: Pubnub.PublishParameters
-  ): Promise<Pubnub.PublishResponse>;
+  publish(params: Pubnub.PublishParameters): Promise<Pubnub.PublishResponse>;
 
   fire(
     params: Pubnub.FireParameters,
-    callback: (status: Pubnub.PublishStatus, response: Pubnub.PublishResponse) => void
+    callback: (
+      status: Pubnub.PublishStatus,
+      response: Pubnub.PublishResponse,
+    ) => void,
   ): void;
 
-  fire(
-    params: Pubnub.FireParameters
-  ): Promise<Pubnub.PublishResponse>;
+  fire(params: Pubnub.FireParameters): Promise<Pubnub.PublishResponse>;
 
   history(
     params: Pubnub.HistoryParameters,
-    callback: (status: Pubnub.HistoryStatus, response: Pubnub.HistoryResponse) => void
+    callback: (
+      status: Pubnub.HistoryStatus,
+      response: Pubnub.HistoryResponse,
+    ) => void,
   ): void;
 
   subscribe(params: Pubnub.SubscribeParameters): void;
@@ -68,48 +73,50 @@ declare class Pubnub {
 
   hereNow(
     params: Pubnub.HereNowParameters,
-    callback: (status: Pubnub.HereNowStatus, response: Pubnub.HereNowResponse) => void
+    callback: (
+      status: Pubnub.HereNowStatus,
+      response: Pubnub.HereNowResponse,
+    ) => void,
   ): void;
 
-  hereNow(
-    params: Pubnub.HereNowParameters
-  ): Promise<Pubnub.HereNowResponse>;
+  hereNow(params: Pubnub.HereNowParameters): Promise<Pubnub.HereNowResponse>;
 
   whereNow(
     params: Pubnub.WhereNowParameters,
-    callback: (status: Pubnub.WhereNowStatus, response: Pubnub.WhereNowResponse) => void
+    callback: (
+      status: Pubnub.WhereNowStatus,
+      response: Pubnub.WhereNowResponse,
+    ) => void,
   ): void;
 
-  whereNow(
-    params: Pubnub.WhereNowParameters
-  ): Promise<Pubnub.WhereNowResponse>;
+  whereNow(params: Pubnub.WhereNowParameters): Promise<Pubnub.WhereNowResponse>;
 
   getState(
     params: Pubnub.GetStateParameters,
-    callback: (status: Pubnub.GetStateStatus, state: Pubnub.GetStateResponse) => void
+    callback: (
+      status: Pubnub.GetStateStatus,
+      state: Pubnub.GetStateResponse,
+    ) => void,
   ): void;
 
-  getState(
-    params: Pubnub.GetStateParameters
-  ): Promise<Pubnub.GetStateResponse>;
+  getState(params: Pubnub.GetStateParameters): Promise<Pubnub.GetStateResponse>;
 
   setState(
     params: Pubnub.SetStateParameters,
-    callback: (status: Pubnub.SetStateStatus, state: Pubnub.SetStateResponse) => void
+    callback: (
+      status: Pubnub.SetStateStatus,
+      state: Pubnub.SetStateResponse,
+    ) => void,
   ): void;
 
-  setState(
-    params: Pubnub.SetStateParameters
-  ): Promise<Pubnub.SetStateResponse>;
+  setState(params: Pubnub.SetStateParameters): Promise<Pubnub.SetStateResponse>;
 
   grant(
     params: Pubnub.GrantParameters,
-    callback: (status: Pubnub.GrantStatus, response: {}) => void
+    callback: (status: Pubnub.GrantStatus, response: {}) => void,
   ): void;
 
-  grant(
-    params: Pubnub.GrantParameters
-  ): Promise<{}>;
+  grant(params: Pubnub.GrantParameters): Promise<{}>;
 
   encrypt(
     data: string,
@@ -120,7 +127,7 @@ declare class Pubnub {
   decrypt(
     data: string | object,
     customCipherKey?: string,
-    options?: Pubnub.CryptoParameters
+    options?: Pubnub.CryptoParameters,
   ): any;
 
   time(): Promise<Pubnub.FetchTimeResponse>;

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -19,6 +19,8 @@ declare class Pubnub {
 
   static generateUUID(): string;
 
+  channelGroups: Pubnub.ChannelGroups;
+
   setUUID(uuid: string): void;
 
   getUUID(): string;
@@ -120,6 +122,8 @@ declare class Pubnub {
     customCipherKey?: string,
     options?: Pubnub.CryptoParameters
   ): any;
+
+  time(): Promise<Pubnub.FetchTimeResponse>;
 }
 
 declare namespace Pubnub {
@@ -269,6 +273,84 @@ declare namespace Pubnub {
     channelGroups?: string[];
   }
 
+  // channelGroups
+  interface ChannelGroups {
+    addChannels(
+      params: AddChannelParameters,
+      callback: (status: ChannelGroupStatus) => void
+    ): void;
+
+    addChannels(
+      params: AddChannelParameters
+    ): Promise<{}>;
+
+    removeChannels(
+      params: RemoveChannelParameters,
+      callback: (status: ChannelGroupStatus) => void
+    ): void;
+
+    removeChannels(
+      params: RemoveChannelParameters
+    ): Promise<{}>;
+
+    listChannels(
+      params: ListChannelsParameters,
+      callback: (status: ChannelGroupStatus, response: ListChannelsResponse) => void
+    ): void;
+
+    listChannels(
+      params: ListChannelsParameters
+    ): Promise<ListChannelsResponse>;
+
+    listGroups(
+      callback: (status: ChannelGroupStatus, response: ListAllGroupsResponse) => void
+    ): void;
+
+    listGroups(): Promise<ListAllGroupsResponse>;
+
+    deleteGroup(
+      params: DeleteGroupParameters,
+      callback: (status: ChannelGroupStatus) => void
+    ): void;
+
+    deleteGroup(
+      params: DeleteGroupParameters
+    ): Promise<{}>;
+  }
+
+  interface AddChannelParameters {
+    channels: string[];
+    channelGroup: string;
+  }
+
+  interface RemoveChannelParameters {
+    channels: string[];
+    channelGroup: string;
+  }
+
+  interface ListChannelsParameters {
+    channelGroup: string;
+  }
+
+  interface DeleteGroupParameters {
+    channelGroup: string;
+  }
+
+  interface ListAllGroupsResponse {
+    groups: string[];
+  }
+
+  interface ListChannelsResponse {
+    channels: string[];
+  }
+
+  interface ChannelGroupStatus {
+    error: boolean;
+    errorData?: Error;
+    operation: string; // see Pubnub.Operations
+    statusCode?: number;
+  }
+
   // addListener
   interface ListenerParameters {
     status?(statusEvent: StatusEvent): void;
@@ -381,6 +463,11 @@ declare namespace Pubnub {
     keyEncoding?: string;
     keyLength?: number;
     mode?: string;
+  }
+
+  // fetch time
+  interface FetchTimeResponse {
+    timetoken: number;
   }
 
   interface Categories {

--- a/types/pubnub/pubnub-tests.ts
+++ b/types/pubnub/pubnub-tests.ts
@@ -115,3 +115,47 @@ const mySecret = {
 pubnub.decrypt(mySecret, undefined, cryptoOptions);
 pubnub.decrypt('mySecretString', undefined, cryptoOptions);
 pubnub.encrypt('egrah5rwgrehwqh5eh3hwfwef', undefined, cryptoOptions);
+
+pubnub.time().then(response => console.log(response));
+
+const channelGroup = 'channel-group-1';
+const channels = [ 'channel-1' ];
+
+pubnub.channelGroups.addChannels({ channelGroup, channels })
+  .then(response => console.log(response));
+
+pubnub.channelGroups.listChannels({ channelGroup })
+  .then(response => console.log(response));
+
+pubnub.channelGroups.listGroups().then(response => console.log(response));
+
+pubnub.channelGroups.removeChannels({ channelGroup, channels })
+  .then(response => console.log(response));
+
+pubnub.channelGroups.deleteGroup({ channelGroup })
+  .then(response => console.log(response));
+
+pubnub.channelGroups.addChannels(
+  { channelGroup, channels },
+  status => console.log(status)
+);
+
+pubnub.channelGroups.listChannels(
+  { channelGroup },
+  (status, response) => {
+    console.log(status);
+    console.log(response);
+  }
+);
+
+pubnub.channelGroups.listGroups((status, response) => {
+  console.log(status);
+  console.log(response);
+});
+
+pubnub.channelGroups.removeChannels(
+  { channelGroup, channels },
+  status => console.log(status)
+);
+
+pubnub.channelGroups.deleteGroup({ channelGroup }, status => console.log(status));

--- a/types/pubnub/pubnub-tests.ts
+++ b/types/pubnub/pubnub-tests.ts
@@ -119,43 +119,44 @@ pubnub.encrypt('egrah5rwgrehwqh5eh3hwfwef', undefined, cryptoOptions);
 pubnub.time().then(response => console.log(response));
 
 const channelGroup = 'channel-group-1';
-const channels = [ 'channel-1' ];
+const channels = ['channel-1'];
 
-pubnub.channelGroups.addChannels({ channelGroup, channels })
+pubnub.channelGroups
+  .addChannels({ channelGroup, channels })
   .then(response => console.log(response));
 
-pubnub.channelGroups.listChannels({ channelGroup })
+pubnub.channelGroups
+  .listChannels({ channelGroup })
   .then(response => console.log(response));
 
 pubnub.channelGroups.listGroups().then(response => console.log(response));
 
-pubnub.channelGroups.removeChannels({ channelGroup, channels })
+pubnub.channelGroups
+  .removeChannels({ channelGroup, channels })
   .then(response => console.log(response));
 
-pubnub.channelGroups.deleteGroup({ channelGroup })
+pubnub.channelGroups
+  .deleteGroup({ channelGroup })
   .then(response => console.log(response));
 
-pubnub.channelGroups.addChannels(
-  { channelGroup, channels },
-  status => console.log(status)
+pubnub.channelGroups.addChannels({ channelGroup, channels }, status =>
+  console.log(status),
 );
 
-pubnub.channelGroups.listChannels(
-  { channelGroup },
-  (status, response) => {
-    console.log(status);
-    console.log(response);
-  }
-);
+pubnub.channelGroups.listChannels({ channelGroup }, (status, response) => {
+  console.log(status);
+  console.log(response);
+});
 
 pubnub.channelGroups.listGroups((status, response) => {
   console.log(status);
   console.log(response);
 });
 
-pubnub.channelGroups.removeChannels(
-  { channelGroup, channels },
-  status => console.log(status)
+pubnub.channelGroups.removeChannels({ channelGroup, channels }, status =>
+  console.log(status),
 );
 
-pubnub.channelGroups.deleteGroup({ channelGroup }, status => console.log(status));
+pubnub.channelGroups.deleteGroup({ channelGroup }, status =>
+  console.log(status),
+);


### PR DESCRIPTION
I started to use the pubnub type definitions, but I needed to call the set of methods I have added. I've had a forked copy of this file in my codebase for a few months, so I wanted to merge it in here so I can remove the file from my code. I was referencing pubnub@4.25.2, which is the latest version. I don't know if there are other things still missing from the types here, but I only focused on adding the ones I needed.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pubnub/javascript/blob/master/src/core/pubnub-common.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (I was referencing 4.25.2, but I'm only adding the parts I need and not checking everything.)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
