### PR TITLE
[urijs] Bugfix: URI.expand is sometimes undefined

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -203,7 +203,12 @@ declare namespace uri {
         encode(str: string): string;
         encodeQuery(qry: string): string;
         encodeReserved(str: string): string;
-        expand(template: string, vals: object): URI;
+
+        /**
+         * @description Wrapper for `URITemplate#expand`. Only present after
+         *              importing `urijs/src/URITemplate` explicitly.
+         */
+        expand?: (template: string, vals: object) => URI;
 
         iso8859(): void;
 

--- a/types/urijs/test/urijs-dom.test.ts
+++ b/types/urijs/test/urijs-dom.test.ts
@@ -69,11 +69,11 @@ const withDuplicates = URI("?bar=1&bar=1")
  ```
  */
 URI('http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag').equals(
-    URI.expand('http://user:pass@example.org:80{/p*}{?q*}{#h}', {
-        p: ["foo", "bar.html"],
-        q: {foo: "bar", bar: "baz"},
-        h: "frag"
-    })
+  URI.expand!('http://user:pass@example.org:80{/p*}{?q*}{#h}', {
+    p: ['foo', 'bar.html'],
+    q: { foo: 'bar', bar: 'baz' },
+    h: 'frag',
+  }),
 );
 
 // Basic URITemplate type usage

--- a/types/urijs/test/urijs-nodejs.test.ts
+++ b/types/urijs/test/urijs-nodejs.test.ts
@@ -65,12 +65,14 @@ declare var $: (arg?: any) => JQuery;
     void URITemplate;
     ```
     */
-    URI('http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag').equals(
-        URI.expand('http://user:pass@example.org:80{/p*}{?q*}{#h}', {
-            p: ['foo', 'bar.html'],
-            q: { foo: 'bar', bar: 'baz' },
-            h: 'frag',
-        })
+    URI(
+      'http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag',
+    ).equals(
+      URI.expand!('http://user:pass@example.org:80{/p*}{?q*}{#h}', {
+        p: ['foo', 'bar.html'],
+        q: { foo: 'bar', bar: 'baz' },
+        h: 'frag',
+      }),
     );
 
     // Basic URITemplate type usage


### PR DESCRIPTION
`URI.expand` will only be set if you do `import "urijs/src/URITemplate"` first (it is set [here](https://github.com/medialize/URI.js/blob/gh-pages/src/URITemplate.js#L507-L513)).

I had to update the test files to use `URI.expand!`.  Looks like the linter made some additional minor changes in those files.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/medialize/URI.js/blob/gh-pages/src/URITemplate.js#L507-L513
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
