### PR TITLE
Create a type definition for npm module hark

### DIFF
--- a/types/hark/hark-tests.ts
+++ b/types/hark/hark-tests.ts
@@ -1,0 +1,22 @@
+import hark = require('hark');
+
+navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then(
+    (stream) => {
+        const option: hark.Option = {
+            smoothing: 0.1,
+            interval: 50,
+            history: 10,
+            threshold: -50
+        };
+        const h: hark.Harker = hark(stream, option);
+        h.stop();
+        h.resume();
+        h.on('speaking', () => {
+            console.log('speaking');
+        });
+
+        h.on('stopped_speaking', () => {
+            console.log('stop speaking');
+        });
+    }
+);

--- a/types/hark/index.d.ts
+++ b/types/hark/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for hark 1.2
+// Project: https://github.com/otalk/hark
+// Definitions by: baiyufei <https://github.com/baiyufei>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = hark;
+
+declare function hark(stream: HTMLAudioElement | HTMLVideoElement | MediaStream, option?: hark.Option): hark.Harker;
+
+declare namespace hark {
+    interface Option {
+        smoothing?: number;
+        interval?: number;
+        threshold?: number;
+        play?: boolean;
+        history?: number;
+    }
+
+    interface Harker {
+        speaking: boolean;
+        suspend(): Promise<void>;
+        resume(): Promise<void>;
+        readonly state: AudioContextState;
+        setThreshold(t: number): void;
+        setInterval(i: number): void;
+        stop(): void;
+        speakingHistory: number[];
+
+        on(event: 'speaking' | 'stopped_speaking', listener: () => void): void;
+        on(event: 'volume_change', listener: (currentVolume: number, threshold: number) => void): void;
+        on(event: 'state_change', listener: (state: AudioContextState) => void): void;
+    }
+}
+
+// TypeScript Version: 2.3

--- a/types/hark/index.d.ts
+++ b/types/hark/index.d.ts
@@ -31,5 +31,3 @@ declare namespace hark {
         on(event: 'state_change', listener: (state: AudioContextState) => void): void;
     }
 }
-
-// TypeScript Version: 2.3

--- a/types/hark/index.d.ts
+++ b/types/hark/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/otalk/hark
 // Definitions by: baiyufei <https://github.com/baiyufei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 export = hark;
 

--- a/types/hark/tsconfig.json
+++ b/types/hark/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6", "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "hark-tests.ts"
+    ]
+}

--- a/types/hark/tslint.json
+++ b/types/hark/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.