### PR TITLE
[serverless] extend plugin types

### DIFF
--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -1,11 +1,11 @@
 import Serverless = require('../index');
 
-declare abstract class Plugin {
-    hooks: {
+declare namespace Plugin {
+    interface Hooks {
         [event: string]: (...rest: any[]) => any;
-    };
+    }
 
-    commands?: {
+    interface Commands {
         [command: string]: {
             usage?: string;
             lifecycleEvents?: string[];
@@ -18,7 +18,13 @@ declare abstract class Plugin {
                 };
             };
         };
-    };
+    }
+}
+
+declare abstract class Plugin {
+    hooks: Plugin.Hooks;
+
+    commands?: Plugin.Commands;
 
     constructor(serverless: Serverless, options: Serverless.Options);
 }

--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -1,11 +1,26 @@
-import Serverless = require("../index");
+import Serverless = require('../index');
 
 declare abstract class Plugin {
     hooks: {
-        [event: string]: Promise<any>;
+        [event: string]: (...rest: any[]) => any;
     };
 
-    constructor(serverless: Serverless, options: Serverless.Options)
+    commands?: {
+        [command: string]: {
+            usage?: string;
+            lifecycleEvents?: string[];
+            commands?: { [command: string]: {} };
+            options?: {
+                [option: string]: {
+                    usage?: string;
+                    required?: boolean;
+                    shortcut?: string;
+                };
+            };
+        };
+    };
+
+    constructor(serverless: Serverless, options: Serverless.Options);
 }
 
 export = Plugin;

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -2,14 +2,15 @@
 // Project: https://github.com/serverless/serverless#readme
 // Definitions by: Hassan Khan <https://github.com/hassankhan>
 //                 Jonathan M. Wilbur <https://github.com/JonathanWilbur>
+//                 Alex Pavlenko <https://github.com/a-pavlenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Service = require("./classes/Service");
-import Plugin = require("./classes/Plugin");
-import PluginManager = require("./classes/PluginManager");
-import Utils = require("./classes/Utils");
-import YamlParser = require("./classes/YamlParser");
-import AwsProvider = require("./plugins/aws/provider/awsProvider");
+import Service = require('./classes/Service');
+import Plugin = require('./classes/Plugin');
+import PluginManager = require('./classes/PluginManager');
+import Utils = require('./classes/Utils');
+import YamlParser = require('./classes/YamlParser');
+import AwsProvider = require('./plugins/aws/provider/awsProvider');
 
 declare namespace Serverless {
     interface Options {
@@ -32,7 +33,7 @@ declare namespace Serverless {
         handler: string;
         timeout?: number;
         memorySize?: number;
-        environment?: { [ name: string ]: string };
+        environment?: { [name: string]: string };
     }
 
     interface Event {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -2,36 +2,36 @@ import Serverless from 'serverless';
 import Plugin from 'serverless/classes/Plugin';
 
 const options: Serverless.Options = {
-  noDeploy: false,
-  stage: null,
-  region: '',
+    noDeploy: false,
+    stage: null,
+    region: '',
 };
 
 const serverless = new Serverless();
 
 class CustomPlugin extends Plugin {
-  commands = {
-    command: {
-      usage: 'description',
-      lifecycleEvents: ['start'],
-      options: {
-        option: {
-          usage: `description`,
-          required: true,
-          shortcut: 'o',
+    commands = {
+        command: {
+            usage: 'description',
+            lifecycleEvents: ['start'],
+            options: {
+                option: {
+                    usage: `description`,
+                    required: true,
+                    shortcut: 'o',
+                },
+            },
         },
-      },
-    },
-  };
-
-  customProp = {};
-
-  hooks: Plugin.Hooks;
-
-  constructor(serverless: Serverless, options: Serverless.Options) {
-    super(serverless, options);
-    this.hooks = {
-      'command:start': () => {},
     };
-  }
+
+    customProp = {};
+
+    hooks: Plugin.Hooks;
+
+    constructor(serverless: Serverless, options: Serverless.Options) {
+        super(serverless, options);
+        this.hooks = {
+            'command:start': () => {},
+        };
+    }
 }

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -2,36 +2,36 @@ import Serverless from 'serverless';
 import Plugin from 'serverless/classes/Plugin';
 
 const options: Serverless.Options = {
-    noDeploy: false,
-    stage: null,
-    region: '',
+  noDeploy: false,
+  stage: null,
+  region: '',
 };
 
 const serverless = new Serverless();
 
 class CustomPlugin extends Plugin {
-    commands = {
-        command: {
-            usage: 'description',
-            lifecycleEvents: ['start'],
-            options: {
-                option: {
-                    usage: `description`,
-                    required: true,
-                    shortcut: 'o',
-                },
-            },
+  commands = {
+    command: {
+      usage: 'description',
+      lifecycleEvents: ['start'],
+      options: {
+        option: {
+          usage: `description`,
+          required: true,
+          shortcut: 'o',
         },
+      },
+    },
+  };
+
+  customProp = {};
+
+  hooks: Plugin.Hooks;
+
+  constructor(serverless: Serverless, options: Serverless.Options) {
+    super(serverless, options);
+    this.hooks = {
+      'command:start': () => {},
     };
-
-    customProp = {};
-
-    hooks: Plugin.Hooks;
-
-    constructor(serverless: Serverless, options: Serverless.Options) {
-        super(serverless, options);
-        this.hooks = {
-            'command:start': () => {},
-        };
-    }
+  }
 }

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -1,9 +1,37 @@
 import Serverless from 'serverless';
+import Plugin from 'serverless/classes/Plugin';
 
 const options: Serverless.Options = {
     noDeploy: false,
     stage: null,
-    region: ''
+    region: '',
 };
 
 const serverless = new Serverless();
+
+class CustomPlugin extends Plugin {
+    commands = {
+        command: {
+            usage: 'description',
+            lifecycleEvents: ['start'],
+            options: {
+                option: {
+                    usage: `description`,
+                    required: true,
+                    shortcut: 'o',
+                },
+            },
+        },
+    };
+
+    customProp = {};
+
+    hooks: Plugin.Hooks;
+
+    constructor(serverless: Serverless, options: Serverless.Options) {
+        super(serverless, options);
+        this.hooks = {
+            'command:start': () => {},
+        };
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://serverless.com/framework/docs/providers/aws/guide/plugins/>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
