### PR TITLE
[@types/web3] Fix web3.eth.subscribe callback type

### DIFF
--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -47,24 +47,24 @@ export default interface Eth {
     subscribe(
         type: "logs",
         options?: Logs,
-        callback?: Callback<Subscribe<Log>>
+        callback?: Callback<Log>
     ): Promise<Subscribe<Log>>;
     subscribe(
         type: "syncing",
-        callback?: Callback<Subscribe<any>>
+        callback?: Callback<any>
     ): Promise<Subscribe<any>>;
     subscribe(
         type: "newBlockHeaders",
-        callback?: Callback<Subscribe<BlockHeader>>
+        callback?: Callback<BlockHeader>
     ): Promise<Subscribe<BlockHeader>>;
     subscribe(
         type: "pendingTransactions",
-        callback?: Callback<Subscribe<Transaction>>
+        callback?: Callback<Transaction>
     ): Promise<Subscribe<Transaction>>;
     subscribe(
         type: "pendingTransactions" | "newBlockHeaders" | "syncing" | "logs",
         options?: Logs,
-        callback?: Callback<Subscribe<any>>
+        callback?: Callback<any>
     ): Promise<Subscribe<any>>;
 
     unsubscribe(callBack: Callback<boolean>): void | boolean;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://web3js.readthedocs.io/en/v1.2.0/web3-eth-subscribe.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.