### PR TITLE
[express-ipfilter] added type declarations and tests

### DIFF
--- a/types/express-ipfilter/express-ipfilter-tests.ts
+++ b/types/express-ipfilter/express-ipfilter-tests.ts
@@ -1,0 +1,98 @@
+import express = require('express');
+import {
+    IpFilter,
+    IpDeniedError,
+    IpFilterOptions,
+} from 'express-ipfilter';
+
+const ip           = ['127.0.0.1'];
+const ipRange      = [['127.0.0.1', '127.0.0.10']];
+const cidrRange    = ['127.0.0.1/24'];
+const getIps       = () => ip;
+const getCidrRange = () => cidrRange;
+const getIpRange   = () => ipRange;
+
+const options: IpFilterOptions = { mode : 'allow' };
+
+// initialize express
+const app = express();
+
+// IPs
+app.use(IpFilter(ip));
+
+// IPs with options
+app.use(IpFilter(ip, options));
+
+// IP range
+app.use(IpFilter(ipRange));
+
+// IP range with options
+app.use(IpFilter(ipRange, options));
+
+// CIDR range
+app.use(IpFilter(cidrRange));
+
+// CIDR range with options
+app.use(IpFilter(cidrRange, options));
+
+// callback IPs
+app.use(IpFilter(getIps));
+
+// callback IPs with options
+app.use(IpFilter(getIps, options));
+
+// callback IP range
+app.use(IpFilter(getIpRange));
+
+// callback IP range with options
+app.use(IpFilter(getIpRange, options));
+
+// callback CIDR range
+app.use(IpFilter(getCidrRange));
+
+// callback CIDR range with options
+app.use(IpFilter(getCidrRange, options));
+
+// with `detectIp` option
+const customDetection = (req: express.Request) => {
+    if (req && req.connection && req.connection.remoteAddress) {
+        return req.connection.remoteAddress.replace(/\//g, '.');
+    }
+
+    // a `detectIp` function must return an IP
+    return '127.0.0.1';
+};
+IpFilter(getIps, { detectIp: customDetection });
+
+// IP range with all default options
+app.use(IpFilter(ipRange, {
+    mode       : 'allow',
+    log        : true,
+    logLevel   : 'all',
+    excluding  : [],
+    detectIp   : customDetection,
+    trustProxy : false,
+}));
+
+// IpDeniedError (taken from documentation)
+if (app.get('env') === 'development') {
+    app.use((
+        err: any,
+        req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+    ): any => {
+        console.log('Error handler', err);
+
+        if (err instanceof IpDeniedError) {
+            res.status(401);
+        } else {
+            res.status(err.status || 500);
+        }
+
+        res.render('error', {
+            message: 'You shall not pass',
+            error: err,
+        });
+    });
+}

--- a/types/express-ipfilter/index.d.ts
+++ b/types/express-ipfilter/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for express-ipfilter 1.0
+// Project: https://github.com/casz/express-ipfilter
+// Definitions by: Ravi S. Rāmphal <https://github.com/rramphal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import express = require('express');
+
+export type Ip              = string;
+export type CidrRange       = string;
+export type Route           = string;
+export type StartEndIpRange = Ip[];
+export type IpRange         = CidrRange | StartEndIpRange;
+export type IpList          = Array<Ip | IpRange>;
+
+export interface IpCallback {
+    (): IpList;
+}
+
+export interface IpFilterOptions {
+    detectIp?: (request: express.Request) => Ip;
+    excluding?: Route[];
+    log?: boolean;
+    logLevel?: 'all' | 'deny' | 'allow';
+    mode?: 'deny' | 'allow';
+    // `@types/proxy-addr` does not export the `trust` parameter type
+    trustProxy?: any;
+}
+
+export function IpFilter(
+    ips: IpList | IpCallback,
+    opts?: IpFilterOptions,
+): express.RequestHandler;
+
+export class IpDeniedError extends Error {
+    constructor(
+        message: string,
+        extra: any,
+    );
+}

--- a/types/express-ipfilter/tsconfig.json
+++ b/types/express-ipfilter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-ipfilter-tests.ts"
+    ]
+}

--- a/types/express-ipfilter/tslint.json
+++ b/types/express-ipfilter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
**Project:** https://github.com/casz/express-ipfilter (@casz)
**Original fork branch:** https://github.com/rramphal/DefinitelyTyped/tree/add-express-ipfilter

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

_**Note:** This is my first attempt at contributing to this repo, so I would appreciate any and all feedback and suggestions on how to do things more idiomatically._