### PR TITLE
Add types for the @loadable/webpack-plugin package

### DIFF
--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/smooth-code/loadable-components
 // Definitions by: Spencer Miskoviak <https://github.com/skovy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as webpack from 'webpack';
 

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for @loadable/webpack-plugin 5.7
+// Project: https://github.com/smooth-code/loadable-components
+// Definitions by: Spencer Miskoviak <https://github.com/skovy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as webpack from 'webpack';
+
+interface PluginOptions {
+    /**
+     * The stats filename.
+     *
+     * @default loadable-stats.json
+     */
+    filename?: string;
+
+    /**
+     * Always write stats file to disk.
+     *
+     * @default false
+     */
+    writeToDisk?: boolean | { filename: string };
+
+    /**
+     * @default true
+     */
+    outputAsset?: boolean;
+}
+
+declare class LoadablePlugin extends webpack.Plugin {
+    constructor(options?: PluginOptions);
+}
+
+export default LoadablePlugin;

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,0 +1,20 @@
+import LoadablePlugin from '@loadable/webpack-plugin';
+import { Configuration } from 'webpack';
+
+let config: Configuration = {
+  plugins: [new LoadablePlugin()],
+};
+
+config = {
+  plugins: [
+    new LoadablePlugin({
+      filename: 'stats.json',
+      writeToDisk: true,
+      outputAsset: false,
+    }),
+  ],
+};
+
+config = {
+  plugins: [new LoadablePlugin({ writeToDisk: { filename: 'stats.json' } })],
+};

--- a/types/loadable__webpack-plugin/tsconfig.json
+++ b/types/loadable__webpack-plugin/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@loadable/webpack-plugin": [
+                "loadable__webpack-plugin"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "loadable__webpack-plugin-tests.ts"
+    ]
+}

--- a/types/loadable__webpack-plugin/tslint.json
+++ b/types/loadable__webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
