### PR TITLE
[cookies] Fix Cookies.set signature for omitting`value` 

### DIFF
--- a/types/cookies/cookies-tests.ts
+++ b/types/cookies/cookies-tests.ts
@@ -26,6 +26,9 @@ const server = http.createServer((req, res) => {
             .set("tampered", "baz")
             .set("tampered.sig", "bogus")
 
+            // delete cookie but pass options
+            .set("removed", { signed: true })
+
             // sameSite option
             .set("samesite", "same", {sameSite: 'lax'})
             .set("samesite", "same", {sameSite: 'strict'})

--- a/types/cookies/index.d.ts
+++ b/types/cookies/index.d.ts
@@ -29,7 +29,8 @@ interface Cookies {
      * the current context to allow chaining.If the value is omitted,
      * an outbound header with an expired date is used to delete the cookie.
      */
-    set(name: string, value?: string, opts?: Cookies.SetOption): this;
+    set(name: string, value: string, opts?: Cookies.SetOption): this;
+    set(name: string, opts?: Cookies.SetOption): this;
 }
 
 declare namespace Cookies {


### PR DESCRIPTION
When omitting the `value` parameter the signature assumes you have omitted the `opts` parameter and causes an error because the types don't match

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/cookies#cookiesset-name--value---options--
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed..~
