### PR TITLE
prosemirror-view: upgrade api to 1.11.3

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.9
+// Type definitions for prosemirror-view 1.11
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -234,6 +234,10 @@ export class EditorView<S extends Schema = any> {
    * should not directly interfere with its content.)
    */
   dom: Element;
+  /**
+   * Indicates whether the editor is currently [editable](#view.EditorProps.editable).
+   */
+   editable: boolean;
   /**
    * When editor content is being dragged, this object contains
    * information about the dragged slice and whether it is being
@@ -546,7 +550,7 @@ export interface EditorProps<S extends Schema = any> {
     [name: string]: (
       node: ProsemirrorNode<S>,
       view: EditorView<S>,
-      getPos: () => number,
+      getPos: (() => number) | boolean,
       decorations: Decoration[]
     ) => NodeView<S>;
   } | null;
@@ -683,11 +687,17 @@ export interface NodeView<S extends Schema = any> {
   /**
    * Called when a DOM
    * [mutation](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
-   * happens within the view. Return false if the editor should
+   * or a selection change happens within the view. When the change is
+   * a selection change, the record will have a `type` property of
+   * `"selection"` (which doesn't occur for native mutation records).
+   * Return false if the editor should re-read the selection or
    * re-parse the range around the mutation, true if it can safely be
    * ignored.
    */
-  ignoreMutation?: ((p: MutationRecord) => boolean) | null;
+  ignoreMutation?: ((p: MutationRecord | {
+    type: 'selection';
+    target: Element;
+  }) => boolean) | null;
   /**
    * Called when the node view is removed from the editor or the whole
    * editor is destroyed.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/ProseMirror/prosemirror-view/blob/master/CHANGELOG.md#1110-2019-09-16>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
