### PR TITLE
@types/leaflet: extracted L.DivOverlay abstract class definition

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1163,6 +1163,20 @@ export interface DivOverlayOptions {
     pane?: string;
 }
 
+export abstract class DivOverlay extends Layer {
+    getLatLng(): LatLng | undefined;
+    setLatLng(latlng: LatLngExpression): this;
+    getContent(): Content | ((source: Layer) => Content) | undefined;
+    setContent(htmlContent: ((source: Layer) => Content) | Content): this;
+    getElement(): HTMLElement | undefined;
+    update(): void;
+    isOpen(): boolean;
+    bringToFront(): this;
+    bringToBack(): this;
+
+    options: DivOverlayOptions;
+}
+
 export interface PopupOptions extends DivOverlayOptions {
     maxWidth?: number;
     minWidth?: number;
@@ -1180,17 +1194,8 @@ export interface PopupOptions extends DivOverlayOptions {
 
 export type Content = string | HTMLElement;
 
-export class Popup extends Layer {
+export class Popup extends DivOverlay {
     constructor(options?: PopupOptions, source?: Layer);
-    getLatLng(): LatLng | undefined;
-    setLatLng(latlng: LatLngExpression): this;
-    getContent(): Content | ((source: Layer) => Content) | undefined;
-    setContent(htmlContent: ((source: Layer) => Content) | Content): this;
-    getElement(): HTMLElement | undefined;
-    update(): void;
-    isOpen(): boolean;
-    bringToFront(): this;
-    bringToBack(): this;
     openOn(map: Map): this;
 
     options: PopupOptions;
@@ -1210,18 +1215,8 @@ export interface TooltipOptions extends DivOverlayOptions {
     opacity?: number;
 }
 
-export class Tooltip extends Layer {
+export class Tooltip extends DivOverlay {
     constructor(options?: TooltipOptions, source?: Layer);
-    setOpacity(val: number): void;
-    getLatLng(): LatLng | undefined;
-    setLatLng(latlng: LatLngExpression): this;
-    getContent(): Content | undefined;
-    setContent(htmlContent: ((source: Layer) => Content) | Content): this;
-    getElement(): HTMLElement | undefined;
-    update(): void;
-    isOpen(): boolean;
-    bringToFront(): this;
-    bringToBack(): this;
 
     options: TooltipOptions;
 }

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1164,6 +1164,7 @@ export interface DivOverlayOptions {
 }
 
 export abstract class DivOverlay extends Layer {
+    constructor(options?: DivOverlayOptions, source?: Layer);
     getLatLng(): LatLng | undefined;
     setLatLng(latlng: LatLngExpression): this;
     getContent(): Content | ((source: Layer) => Content) | undefined;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1217,6 +1217,7 @@ export interface TooltipOptions extends DivOverlayOptions {
 
 export class Tooltip extends DivOverlay {
     constructor(options?: TooltipOptions, source?: Layer);
+    setOpacity(val: number): void;
 
     options: TooltipOptions;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.5.0.html#divoverlay

---

Rationale:
In general (without this) it is hard to make L.Popup/L.Tooltip-like implementations cause L.DivOverlay superclass is not exposed by typings.

Cheers!