### PR TITLE
[jasmine] Improve various library types

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -185,6 +185,10 @@ declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, t
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
+    // Use trick with prototype to allow abstract classes.
+    // More info: https://stackoverflow.com/a/38642922/2009373
+    type Constructor = Function & { prototype: any };
+
     type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
 
     type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | {
@@ -202,9 +206,15 @@ declare namespace jasmine {
 
     var matchersUtil: MatchersUtil;
 
-    function any(aclass: any): Any;
+    /**
+     * That will succeed if the actual value being compared is an instance of the specified class/constructor.
+     */
+    function any(aclass: Constructor | Symbol): AsymmetricMatcher<any>;
 
-    function anything(): Any;
+    /**
+     * That will succeed if the actual value being compared is not `null` and not `undefined`.
+     */
+    function anything(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is `true` or anything truthy.

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -249,7 +249,7 @@ declare namespace jasmine {
     function createSpyObj<T>(baseName: string, methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function createSpyObj(methodNames: SpyObjMethodNames): any;
-    function createSpyObj<T>(methodNames: SpyObjMethodNames): SpyObj<T>;
+    function createSpyObj<T>(methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function pp(value: any): string;
 

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -185,6 +185,8 @@ declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, t
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
+    type Func = (...args: any[]) => any;
+
     // Use trick with prototype to allow abstract classes.
     // More info: https://stackoverflow.com/a/38642922/2009373
     type Constructor = Function & { prototype: any };
@@ -199,8 +201,8 @@ declare namespace jasmine {
     };
     type SpyObjMethodNames<T = undefined> =
         T extends undefined ?
-            (ReadonlyArray<string> | {[methodName: string]: any}) :
-            (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends (...args: any[]) => any ? T[P] : any>});
+            (ReadonlyArray<string> | { [methodName: string]: any }) :
+            (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
 
     function clock(): Clock;
 

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -187,10 +187,10 @@ declare function waits(timeout?: number): void;
 declare namespace jasmine {
     type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
 
-    type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher | {
+    type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | {
         [K in keyof T]: ExpectedRecursive<T[K]> | Any;
     };
-    type Expected<T> = T | ObjectContaining<T> | AsymmetricMatcher | Any | Spy | {
+    type Expected<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | Any | Spy | {
         [K in keyof T]: ExpectedRecursive<T[K]>;
     };
     type SpyObjMethodNames<T = undefined> =
@@ -210,25 +210,25 @@ declare namespace jasmine {
      * That will succeed if the actual value being compared is `true` or anything truthy.
      * @since 3.1.0
      */
-    function truthy(): Truthy;
+    function truthy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is  `null`, `undefined`, `0`, `false` or anything falsey.
      * @since 3.1.0
      */
-    function falsy(): Falsy;
+    function falsy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is empty.
      * @since 3.1.0
      */
-    function empty(): Empty;
+    function empty(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is not empty.
      * @since 3.1.0
      */
-    function notEmpty(): NotEmpty;
+    function notEmpty(): AsymmetricMatcher<any>;
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
@@ -249,11 +249,11 @@ declare namespace jasmine {
 
     function addMatchers(matchers: CustomMatcherFactories): void;
 
-    function stringMatching(str: string | RegExp): Any;
+    function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
     function formatErrorMsg(domain: string, usage: string): (msg: string) => string;
 
-    interface Any {
+    interface Any extends AsymmetricMatcher<any> {
         (...params: any[]): any; // jasmine.Any can also be a function
         new (expectedClass: any): any;
 
@@ -261,15 +261,10 @@ declare namespace jasmine {
         jasmineToString(): string;
     }
 
-    interface AsymmetricMatcher<T extends string = string> {
-        asymmetricMatch(other: any): boolean;
-        jasmineToString?(): T;
-      }
-
-    interface Truthy extends AsymmetricMatcher<'<jasmine.truthy>'> { }
-    interface Falsy extends AsymmetricMatcher<'<jasmine.falsy>'> { }
-    interface Empty extends AsymmetricMatcher<'<jasmine.empty>'> { }
-    interface NotEmpty extends AsymmetricMatcher<'<jasmine.notEmpty>'> { }
+    interface AsymmetricMatcher<TValue> {
+      asymmetricMatch(other: TValue, customTesters: ReadonlyArray<CustomEqualityTester>): boolean;
+      jasmineToString?(): string;
+    }
 
     // taken from TypeScript lib.core.es6.d.ts, applicable to CustomMatchers.contains()
     interface ArrayLike<T> {
@@ -277,11 +272,11 @@ declare namespace jasmine {
         [n: number]: T;
     }
 
-    interface ArrayContaining<T> extends AsymmetricMatcher {
+    interface ArrayContaining<T> extends AsymmetricMatcher<any> {
         new?(sample: ArrayLike<T>): ArrayLike<T>;
     }
 
-    interface ObjectContaining<T> {
+    interface ObjectContaining<T> extends AsymmetricMatcher<any> {
         new?(sample: {[K in keyof T]?: any}): {[K in keyof T]?: any};
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -178,7 +178,7 @@ declare function spyOnProperty<T>(object: T, property: keyof T, accessType?: 'ge
  * Installs spies on all writable and configurable properties of an object.
  * @param object The object upon which to install the `Spy`s.
  */
-declare function spyOnAllFunctions(object: object): jasmine.Spy;
+declare function spyOnAllFunctions<T>(object: T): jasmine.SpyObj<T>;
 
 declare function runs(asyncMethod: Function): void;
 declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -19,7 +19,10 @@
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
-type ImplementationCallback = (() => PromiseLike<any>) | (() => void) | ((done: DoneFn) => void);
+/**
+ * @deprecated Use {@link jasmine.ImplementationCallback} instead.
+ */
+type ImplementationCallback = jasmine.ImplementationCallback;
 
 /**
  * Create a group of specs (often called a suite).
@@ -49,7 +52,7 @@ declare function xdescribe(description: string, specDefinitions: () => void): vo
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function it(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function it(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A focused `it`. If suites or specs are focused, only those that are focused will be executed.
@@ -57,7 +60,7 @@ declare function it(expectation: string, assertion?: ImplementationCallback, tim
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function fit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function fit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A temporarily disabled `it`. The spec will report as pending and will not be executed.
@@ -65,7 +68,7 @@ declare function fit(expectation: string, assertion?: ImplementationCallback, ti
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function xit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function xit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Mark a spec as pending, expectation results will be ignored.
@@ -79,14 +82,14 @@ declare function pending(reason?: string): void;
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeEach.
  */
-declare function beforeEach(action: ImplementationCallback, timeout?: number): void;
+declare function beforeEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown after each of the specs in the describe in which it is called.
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterEach.
  */
-declare function afterEach(action: ImplementationCallback, timeout?: number): void;
+declare function afterEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared setup once before all of the specs in the describe are run.
@@ -94,7 +97,7 @@ declare function afterEach(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeAll.
  */
-declare function beforeAll(action: ImplementationCallback, timeout?: number): void;
+declare function beforeAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown once before all of the specs in the describe are run.
@@ -102,7 +105,7 @@ declare function beforeAll(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterAll
  */
-declare function afterAll(action: ImplementationCallback, timeout?: number): void;
+declare function afterAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Create an expectation for a spec.
@@ -182,6 +185,8 @@ declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, t
 declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
+    type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
+
     type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher | {
         [K in keyof T]: ExpectedRecursive<T[K]> | Any;
     };

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -14,6 +14,7 @@
 //                 Moshe Kolodny <https://github.com/kolodny>
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Mochamad Arfin <https://github.com/ndunks>
+//                 Alex Povar <https://github.com/zvirja>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
@@ -745,7 +746,7 @@ declare namespace jasmine {
     }
 
     type SpyObj<T> = T & {
-        [k in keyof T]: T[k] extends Function ? T[k] & Spy : T[k];
+        [K in keyof T]: T[K] extends Function ? T[K] & Spy : T[K];
     };
 
     interface SpyAnd {

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -493,19 +493,33 @@ declare namespace jasmine {
         message(): any;
 
         /**
+         * Expect the actual value to be `===` to the expected value.
          *
-         * @param expected the actual value to be === to the expected value.
+         * @param expected - The expected value to compare against.
          * @param expectationFailOutput
+         * @example
+         * expect(thing).toBe(realThing);
          */
         toBe(expected: Expected<T>, expectationFailOutput?: any): boolean;
 
         /**
-         *
-         * @param expected the actual value to be equal to the expected, using deep equality comparison.
+         * Expect the actual value to be equal to the expected, using deep equality comparison.
+         * @param expected - Expected value.
          * @param expectationFailOutput
+         * @example
+         * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
          */
         toEqual(expected: Expected<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to match a regular expression.
+         * @param expected - Value to look for in the string.
+         * @example
+         * expect("my string").toMatch(/string$/);
+         * expect("other string").toMatch("her");
+         */
         toMatch(expected: string | RegExp, expectationFailOutput?: any): boolean;
+
         toBeDefined(expectationFailOutput?: any): boolean;
         toBeUndefined(expectationFailOutput?: any): boolean;
         toBeNull(expectationFailOutput?: any): boolean;
@@ -528,7 +542,17 @@ declare namespace jasmine {
         toThrowMatching(predicate: (thrown: any) => boolean): boolean;
         toBeNegativeInfinity(expectationFailOutput?: any): boolean;
         toBePositiveInfinity(expectationFailOutput?: any): boolean;
-        toHaveClass(expected: any, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to be a DOM element that has the expected class.
+         * @since 3.0.0
+         * @param expected - The class name to test for.
+         * @example
+         * var el = document.createElement('div');
+         * el.className = 'foo bar baz';
+         * expect(el).toHaveClass('bar');
+         */
+        toHaveClass(expected: string, expectationFailOutput?: any): boolean;
 
         /**
          * Add some context for an expect.
@@ -536,15 +560,45 @@ declare namespace jasmine {
          */
         withContext(message: string): Matchers<T>;
 
+        /**
+         * Invert the matcher following this expect.
+         */
         not: Matchers<T>;
 
         Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {
+        /**
+         * Expect the actual value to be `===` to the expected value.
+         *
+         * @param expected - The expected value to compare against.
+         * @param expectationFailOutput
+         * @example
+         * expect(thing).toBe(realThing);
+         */
         toBe(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to be equal to the expected, using deep equality comparison.
+         * @param expected - Expected value.
+         * @param expectationFailOutput
+         * @example
+         * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
+         */
         toEqual(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
+
         toContain(expected: Expected<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Add some context for an expect.
+         * @param message - Additional context to show when the matcher fails.
+         */
+        withContext(message: string): ArrayLikeMatchers<T>;
+
+        /**
+         * Invert the matcher following this expect.
+         */
         not: ArrayLikeMatchers<T>;
     }
 

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -576,8 +576,6 @@ declare namespace jasmine {
          * Invert the matcher following this expect.
          */
         not: Matchers<T>;
-
-        Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -786,13 +786,19 @@ describe("multiple spies, when created with spyOnAllFunctions", () => {
             y: (a: number) => a,
         };
 
-        spyOnAllFunctions(obj);
+        const spy = spyOnAllFunctions(obj);
+
+        spy.x.and.returnValue(42);
+        spy.y.and.returnValue(24);
+        spy.z; // $ExpectError
 
         obj.x(0);
         obj.y(1);
 
         expect(obj.x).toHaveBeenCalled();
         expect(obj.y).toHaveBeenCalledWith(1);
+        expect(spy.y).toHaveBeenCalledWith(1);
+        expect(spy.y).toHaveBeenCalledWith("one");
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -15,23 +15,29 @@ describe("A suite is just a function", () => {
     });
 });
 
-describe("The 'toBe' matcher compares with ===", () => {
-    it("and has a positive case", () => {
-        expect(true).toBe(true);
-    });
-
-    it("and can have a negative case", () => {
-        expect(false).not.toBe(true);
-    });
-});
-
 describe("Included matchers:", () => {
-    it("The 'toBe' matcher compares with ===", () => {
-        const a = 12;
-        const b = a;
+    describe('toBe', () => {
+        it("and has a positive case", () => {
+            expect(true).toBe(true);
+        });
 
-        expect(a).toBe(b);
-        expect(a).not.toBe(24);
+        it("and can have a negative case", () => {
+            expect(false).not.toBe(true);
+        });
+
+        it("the 'toBe' matcher compares with ===", () => {
+            const a = 12;
+            const b = a;
+
+            expect(a).toBe(b);
+            expect(a).not.toBe(24);
+        });
+
+        it('should allow to accept any union type', () => {
+            const value: number | string = null as any;
+
+            expect(value).toBe(12);
+        });
     });
 
     describe("The 'toEqual' matcher", () => {
@@ -211,7 +217,9 @@ describe("toBePositiveInfinity", () => {
 });
 
 describe("toHaveClass", () => {
-    expect("").toHaveClass(Array);
+    const element: HTMLElement = null!;
+    expect(element).toHaveClass("some-class");
+    expect(element).toHaveClass(Element); // $ExpectError
 });
 
 describe("A spec", () => {
@@ -985,6 +993,15 @@ describe("jasmine.arrayContaining", () => {
 
         expect(foo).toBe(jasmine.arrayContaining([3, 1]));
         expect(foo).not.toBe(jasmine.arrayContaining([6]));
+    });
+
+    it("matches read-only array", () => {
+        const bar: ReadonlyArray<number> = [1, 2, 3, 4];
+
+        expect(bar).toEqual(jasmine.arrayContaining([3, 1]));
+        expect(bar).not.toEqual(jasmine.arrayContaining([6]));
+
+        expect(bar).toBe(jasmine.arrayContaining([3, 1]));
     });
 
     describe("when used with a spy", () => {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1360,16 +1360,6 @@ describe('better typed spys', () => {
             // $ExpectType (val: any) => Spy
             spyObj.method.and.returnValue;
         });
-
-        it('has a way to opt out of inferred function types', () => {
-            interface I {
-                f(): string;
-                f(x: any): number;
-              }
-
-            const spyObject = jasmine.createSpyObj<I>("spyObject", ["f"]);
-            spyObject.f.and.returnValue("a string - working");
-        });
     });
 });
 
@@ -1524,6 +1514,33 @@ describe('Static Matcher Test', function() {
             value: 'any value should ok',
           })
         );
+    });
+});
+
+describe("User scenarios", () => {
+    describe("https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34080", () => {
+        interface Test {
+            f(): string;
+            f(x: any): number;
+        }
+
+        it("has a way to opt out of inferred function types", () => {
+            const spyObject: jasmine.SpyObj<Test> = jasmine.createSpyObj<Test>("spyObject", ["f"]);
+            spyObject.f.and.returnValue("a string - working");
+
+            const spy2 = jasmine.createSpyObj<Test>(['f']);
+            spy2.f.and.returnValue("can return string" as any);
+        });
+
+        it("should be possible to opt out for spyOn", () => {
+            const obj: Test = null!;
+
+            const spy1: jasmine.Spy = spyOn(obj, "f");
+            spy1.and.returnValue("can return string");
+
+            const spy2 = spyOn(obj, "f");
+            spy2.and.returnValue("can return string" as any);
+        });
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -730,16 +730,23 @@ describe("A spy, when created manually", () => {
 });
 
 describe("Spy for generic method", () => {
+    interface Test {
+        method<T>(): Array<Box<T>>;
+    }
+
+    interface Box<T> {
+        value: T;
+    }
+
     it("should allow to configure generic method", () => {
-        interface Test {
-            method<T>(): Array<Box<T>>;
-        }
-
-        interface Box<T> {
-            value: T;
-        }
-
         const spy = jasmine.createSpyObj<Test>('test', ['method']);
+
+        spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
+    });
+
+    it("should allow to configure generic method with non-named spy", () => {
+        const spy = jasmine.createSpyObj<Test>(['method']);
+        jasmine.createSpyObj<Test>(['methodUnknown']); // $ExpectError
 
         spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
     });

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -398,22 +398,19 @@ describe("A spy, when configured to call through", () => {
 });
 
 describe("A spy, when configured to fake a return value", () => {
-    var foo: any, bar: any, fetchedBar: any;
+    var bar: number;
+    const foo = {
+        setBar: (value: number) => {
+            bar = value;
+        },
+        getBar: () => {
+            return bar;
+        }
+    };
 
-    beforeEach(() => {
-        foo = {
-            setBar: (value: any) => {
-                bar = value;
-            },
-            getBar: () => {
-                return bar;
-            }
-        };
-
+    it("verifies return value type", () => {
         spyOn(foo, "getBar").and.returnValue(745);
-
-        foo.setBar(123);
-        fetchedBar = foo.getBar();
+        spyOn(foo, "getBar").and.returnValue("42"); // Is an error with TS 3.1+ typings.
     });
 
     it("tracks that the spy was called", () => {
@@ -425,6 +422,8 @@ describe("A spy, when configured to fake a return value", () => {
     });
 
     it("when called returns the requested value", () => {
+        const fetchedBar = foo.getBar();
+
         expect(fetchedBar).toEqual(745);
     });
 });
@@ -722,6 +721,22 @@ describe("A spy, when created manually", () => {
     });
 });
 
+describe("Spy for generic method", () => {
+    it("should allow to configure generic method", () => {
+        interface Test {
+            method<T>(): Array<Box<T>>;
+        }
+
+        interface Box<T> {
+            value: T;
+        }
+
+        const spy = jasmine.createSpyObj<Test>('test', ['method']);
+
+        spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
+    });
+});
+
 describe("Multiple spies, when created manually", () => {
     class Tape {
         private rewindTo: number;
@@ -772,6 +787,12 @@ describe("Multiple spies, when created manually", () => {
 
     it("tracks all the arguments of its calls", () => {
         expect(tape.rewind).toHaveBeenCalledWith(0);
+        expect(tape.rewind).toHaveBeenCalledWith('42'); // Is an error with TS 3.1+ typings.
+        expect(tape.rewind).toHaveBeenCalledWith(jasmine.anything());
+        expect(tape.rewind).toHaveBeenCalledWith(jasmine.falsy());
+        expect(tape.rewind).not.toHaveBeenCalledWith(1);
+        expect(tape.rewind).not.toHaveBeenCalledWith('42'); // Is an error with TS 3.1+ typings.
+        expect(tape.rewind).not.toHaveBeenCalledWith(jasmine.truthy());
     });
 
     it("read isPlaying property", () => {
@@ -798,7 +819,7 @@ describe("multiple spies, when created with spyOnAllFunctions", () => {
         expect(obj.x).toHaveBeenCalled();
         expect(obj.y).toHaveBeenCalledWith(1);
         expect(spy.y).toHaveBeenCalledWith(1);
-        expect(spy.y).toHaveBeenCalledWith("one");
+        expect(spy.y).toHaveBeenCalledWith("one"); // Is an error with TS 3.1+ typings.
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -863,6 +863,15 @@ describe("jasmine.any", () => {
 
             expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
         });
+
+        it("is useful for comparing arguments for typed spy", () => {
+            const foo = jasmine.createSpy('foo');
+            foo(12, () => {
+                return true;
+            });
+
+            expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
+        });
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -841,6 +841,9 @@ describe("jasmine.any", () => {
     it("matches any value", () => {
         expect({}).toEqual(jasmine.any(Object));
         expect(12).toEqual(jasmine.any(Number));
+        expect(42).toEqual(jasmine.any(42)); // $ExpectError
+        expect({}).toEqual(jasmine.any({})); // $ExpectError
+        expect(() => null).toEqual(jasmine.any(Function));
     });
 
     it("matches any function", () => {
@@ -854,12 +857,35 @@ describe("jasmine.any", () => {
             fn2: (param1: number) => param1,
         };
 
-        const expected: Test = {
+        const expected = {
             fn1: jasmine.any(Function),
             fn2: jasmine.any(Function),
         };
 
         expect(a).toEqual(expected);
+    });
+
+    it("matches custom types", () => {
+        class Test { }
+
+        const obj = new Test();
+
+        expect(obj).toEqual(jasmine.any(Test));
+    });
+
+    it("matches base abstract class", () => {
+        abstract class TestClassBase { }
+        class TestClass extends TestClassBase { }
+        const obj = new TestClass();
+
+        expect(obj).toEqual(jasmine.any(TestClass));
+        expect(obj).toEqual(jasmine.any(TestClassBase));
+    });
+
+    it("matches symbols", () => {
+        const sym = Symbol('test symbol');
+
+        expect(sym).toEqual(jasmine.any(sym));
     });
 
     describe("when used with a spy", () => {

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -15,7 +15,10 @@
 //                 Alex Povar <https://github.com/zvirja>
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
-type ImplementationCallback = (() => Promise<any>) | ((done: DoneFn) => void);
+/**
+ * @deprecated Use {@link jasmine.ImplementationCallback} instead.
+ */
+type ImplementationCallback = jasmine.ImplementationCallback;
 
 /**
  * Create a group of specs (often called a suite).
@@ -45,7 +48,7 @@ declare function xdescribe(description: string, specDefinitions: () => void): vo
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function it(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function it(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A focused `it`. If suites or specs are focused, only those that are focused will be executed.
@@ -53,7 +56,7 @@ declare function it(expectation: string, assertion?: ImplementationCallback, tim
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function fit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function fit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * A temporarily disabled `it`. The spec will report as pending and will not be executed.
@@ -61,7 +64,7 @@ declare function fit(expectation: string, assertion?: ImplementationCallback, ti
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function xit(expectation: string, assertion?: ImplementationCallback, timeout?: number): void;
+declare function xit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Mark a spec as pending, expectation results will be ignored.
@@ -75,14 +78,14 @@ declare function pending(reason?: string): void;
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeEach.
  */
-declare function beforeEach(action: ImplementationCallback, timeout?: number): void;
+declare function beforeEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown after each of the specs in the describe in which it is called.
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterEach.
  */
-declare function afterEach(action: ImplementationCallback, timeout?: number): void;
+declare function afterEach(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared setup once before all of the specs in the describe are run.
@@ -90,7 +93,7 @@ declare function afterEach(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to setup your specs.
  * @param timeout Custom timeout for an async beforeAll.
  */
-declare function beforeAll(action: ImplementationCallback, timeout?: number): void;
+declare function beforeAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Run some shared teardown once before all of the specs in the describe are run.
@@ -98,7 +101,7 @@ declare function beforeAll(action: ImplementationCallback, timeout?: number): vo
  * @param action Function that contains the code to teardown your specs.
  * @param timeout Custom timeout for an async afterAll
  */
-declare function afterAll(action: ImplementationCallback, timeout?: number): void;
+declare function afterAll(action: jasmine.ImplementationCallback, timeout?: number): void;
 
 /**
  * Create an expectation for a spec.
@@ -185,6 +188,7 @@ declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
     type Func = (...args: any[]) => any;
+    type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
 
     type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher | {
         [K in keyof T]: ExpectedRecursive<T[K]> | Any;

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -203,8 +203,8 @@ declare namespace jasmine {
     };
     type SpyObjMethodNames<T = undefined> =
         T extends undefined ?
-            (ReadonlyArray<string> | {[methodName: string]: any}) :
-            (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends Func ? T[P] : any>});
+            (ReadonlyArray<string> | { [methodName: string]: any }) :
+            (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
 
     function clock(): Clock;
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -188,6 +188,11 @@ declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
     type Func = (...args: any[]) => any;
+
+    // Use trick with prototype to allow abstract classes.
+    // More info: https://stackoverflow.com/a/38642922/2009373
+    type Constructor = Function & { prototype: any };
+
     type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
 
     type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | {
@@ -211,9 +216,15 @@ declare namespace jasmine {
 
     var matchersUtil: MatchersUtil;
 
-    function any(aclass: any): Any;
+    /**
+     * That will succeed if the actual value being compared is an instance of the specified class/constructor.
+     */
+    function any(aclass: Constructor | Symbol): AsymmetricMatcher<any>;
 
-    function anything(): Any;
+    /**
+     * That will succeed if the actual value being compared is not `null` and not `undefined`.
+     */
+    function anything(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is `true` or anything truthy.

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -578,8 +578,6 @@ declare namespace jasmine {
          * Invert the matcher following this expect.
          */
         not: Matchers<T>;
-
-        Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -180,7 +180,7 @@ declare function spyOnProperty<T>(object: T, property: keyof T, accessType?: 'ge
  * Installs spies on all writable and configurable properties of an object.
  * @param object The object upon which to install the `Spy`s.
  */
-declare function spyOnAllFunctions(object: object): jasmine.Spy;
+declare function spyOnAllFunctions<T>(object: T): jasmine.SpyObj<T>;
 
 declare function runs(asyncMethod: Function): void;
 declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -206,12 +206,6 @@ declare namespace jasmine {
             (ReadonlyArray<string> | {[methodName: string]: any}) :
             (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends Func ? T[P] : any>});
 
-    type AnyMethods<T> = {
-        [K in {
-            [K in keyof T]: T[K] extends Function ? K : never
-        }[keyof T]]: Func
-    };
-
     function clock(): Clock;
 
     var matchersUtil: MatchersUtil;
@@ -842,6 +836,12 @@ declare namespace jasmine {
     type SpyObj<T> = T & {
         [K in keyof T]: T[K] extends Func ? T[K] & Spy<T[K]> : T[K];
     };
+
+    /**
+     * It's like SpyObj, but doesn't verify argument/return types for functions.
+     * Useful if TS cannot correctly infer type for complex objects.
+     */
+    type NonTypedSpyObj<T> = SpyObj<{ [K in keyof T]: T[K] extends Func ? Func : T[K] }>;
 
     interface SpyAnd<Fn extends Func> {
         identity: string;

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -259,7 +259,7 @@ declare namespace jasmine {
     function createSpyObj<T>(baseName: string, methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function createSpyObj(methodNames: SpyObjMethodNames): any;
-    function createSpyObj<T>(methodNames: SpyObjMethodNames): SpyObj<T>;
+    function createSpyObj<T>(methodNames: SpyObjMethodNames<T>): SpyObj<T>;
 
     function pp(value: any): string;
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -502,19 +502,33 @@ declare namespace jasmine {
         message(): any;
 
         /**
+         * Expect the actual value to be `===` to the expected value.
          *
-         * @param expected the actual value to be === to the expected value.
+         * @param expected - The expected value to compare against.
          * @param expectationFailOutput
+         * @example
+         * expect(thing).toBe(realThing);
          */
         toBe(expected: Expected<T>, expectationFailOutput?: any): boolean;
 
         /**
-         *
-         * @param expected the actual value to be equal to the expected, using deep equality comparison.
+         * Expect the actual value to be equal to the expected, using deep equality comparison.
+         * @param expected - Expected value.
          * @param expectationFailOutput
+         * @example
+         * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
          */
         toEqual(expected: Expected<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to match a regular expression.
+         * @param expected - Value to look for in the string.
+         * @example
+         * expect("my string").toMatch(/string$/);
+         * expect("other string").toMatch("her");
+         */
         toMatch(expected: string | RegExp, expectationFailOutput?: any): boolean;
+
         toBeDefined(expectationFailOutput?: any): boolean;
         toBeUndefined(expectationFailOutput?: any): boolean;
         toBeNull(expectationFailOutput?: any): boolean;
@@ -537,7 +551,17 @@ declare namespace jasmine {
         toThrowMatching(predicate: (thrown: any) => boolean): boolean;
         toBeNegativeInfinity(expectationFailOutput?: any): boolean;
         toBePositiveInfinity(expectationFailOutput?: any): boolean;
-        toHaveClass(expected: any, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to be a DOM element that has the expected class.
+         * @since 3.0.0
+         * @param expected - The class name to test for.
+         * @example
+         * var el = document.createElement('div');
+         * el.className = 'foo bar baz';
+         * expect(el).toHaveClass('bar');
+         */
+        toHaveClass(expected: string, expectationFailOutput?: any): boolean;
 
         /**
          * Add some context for an expect.
@@ -545,15 +569,45 @@ declare namespace jasmine {
          */
         withContext(message: string): Matchers<T>;
 
+        /**
+         * Invert the matcher following this expect.
+         */
         not: Matchers<T>;
 
         Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {
+        /**
+         * Expect the actual value to be `===` to the expected value.
+         *
+         * @param expected - The expected value to compare against.
+         * @param expectationFailOutput
+         * @example
+         * expect(thing).toBe(realThing);
+         */
         toBe(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Expect the actual value to be equal to the expected, using deep equality comparison.
+         * @param expected - Expected value.
+         * @param expectationFailOutput
+         * @example
+         * expect(bigObject).toEqual({ "foo": ['bar', 'baz'] });
+         */
         toEqual(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
+
         toContain(expected: Expected<T>, expectationFailOutput?: any): boolean;
+
+        /**
+         * Add some context for an expect.
+         * @param message - Additional context to show when the matcher fails.
+         */
+        withContext(message: string): ArrayLikeMatchers<T>;
+
+        /**
+         * Invert the matcher following this expect.
+         */
         not: ArrayLikeMatchers<T>;
     }
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -190,10 +190,10 @@ declare namespace jasmine {
     type Func = (...args: any[]) => any;
     type ImplementationCallback = (() => PromiseLike<any>) | ((done: DoneFn) => void);
 
-    type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher | {
+    type ExpectedRecursive<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | {
         [K in keyof T]: ExpectedRecursive<T[K]> | Any;
     };
-    type Expected<T> = T | ObjectContaining<T> | AsymmetricMatcher | Any | Spy | {
+    type Expected<T> = T | ObjectContaining<T> | AsymmetricMatcher<any> | Any | Spy | {
         [K in keyof T]: ExpectedRecursive<T[K]>;
     };
     type SpyObjMethodNames<T = undefined> =
@@ -219,25 +219,25 @@ declare namespace jasmine {
      * That will succeed if the actual value being compared is `true` or anything truthy.
      * @since 3.1.0
      */
-    function truthy(): Truthy;
+    function truthy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is  `null`, `undefined`, `0`, `false` or anything falsey.
      * @since 3.1.0
      */
-    function falsy(): Falsy;
+    function falsy(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is empty.
      * @since 3.1.0
      */
-    function empty(): Empty;
+    function empty(): AsymmetricMatcher<any>;
 
     /**
      * That will succeed if the actual value being compared is not empty.
      * @since 3.1.0
      */
-    function notEmpty(): NotEmpty;
+    function notEmpty(): AsymmetricMatcher<any>;
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
@@ -258,11 +258,11 @@ declare namespace jasmine {
 
     function addMatchers(matchers: CustomMatcherFactories): void;
 
-    function stringMatching(str: string | RegExp): Any;
+    function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
     function formatErrorMsg(domain: string, usage: string): (msg: string) => string;
 
-    interface Any {
+    interface Any extends AsymmetricMatcher<any> {
         (...params: any[]): any; // jasmine.Any can also be a function
         new (expectedClass: any): any;
 
@@ -270,15 +270,10 @@ declare namespace jasmine {
         jasmineToString(): string;
     }
 
-    interface AsymmetricMatcher<T extends string = string> {
-      asymmetricMatch(other: any): boolean;
-      jasmineToString?(): T;
+    interface AsymmetricMatcher<TValue> {
+      asymmetricMatch(other: TValue, customTesters: ReadonlyArray<CustomEqualityTester>): boolean;
+      jasmineToString?(): string;
     }
-
-    interface Truthy extends AsymmetricMatcher<'<jasmine.truthy>'> { }
-    interface Falsy extends AsymmetricMatcher<'<jasmine.falsy>'> { }
-    interface Empty extends AsymmetricMatcher<'<jasmine.empty>'> { }
-    interface NotEmpty extends AsymmetricMatcher<'<jasmine.notEmpty>'> { }
 
     // taken from TypeScript lib.core.es6.d.ts, applicable to CustomMatchers.contains()
     interface ArrayLike<T> {
@@ -286,11 +281,11 @@ declare namespace jasmine {
         [n: number]: T;
     }
 
-    interface ArrayContaining<T> extends AsymmetricMatcher {
+    interface ArrayContaining<T> extends AsymmetricMatcher<any> {
         new?(sample: ArrayLike<T>): ArrayLike<T>;
     }
 
-    interface ObjectContaining<T> {
+    interface ObjectContaining<T> extends AsymmetricMatcher<any> {
         new?(sample: {[K in keyof T]?: any}): {[K in keyof T]?: any};
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -398,22 +398,19 @@ describe("A spy, when configured to call through", () => {
 });
 
 describe("A spy, when configured to fake a return value", () => {
-    var foo: any, bar: any, fetchedBar: any;
+    var bar: number;
+    const foo = {
+        setBar: (value: number) => {
+            bar = value;
+        },
+        getBar: () => {
+            return bar;
+        }
+    };
 
-    beforeEach(() => {
-        foo = {
-            setBar: (value: any) => {
-                bar = value;
-            },
-            getBar: () => {
-                return bar;
-            }
-        };
-
+    it("verifies return value type", () => {
         spyOn(foo, "getBar").and.returnValue(745);
-
-        foo.setBar(123);
-        fetchedBar = foo.getBar();
+        spyOn(foo, "getBar").and.returnValue("42"); // $ExpectError
     });
 
     it("tracks that the spy was called", () => {
@@ -425,6 +422,8 @@ describe("A spy, when configured to fake a return value", () => {
     });
 
     it("when called returns the requested value", () => {
+        const fetchedBar = foo.getBar();
+
         expect(fetchedBar).toEqual(745);
     });
 });
@@ -722,6 +721,22 @@ describe("A spy, when created manually", () => {
     });
 });
 
+describe("Spy for generic method", () => {
+    it("should allow to configure generic method", () => {
+        interface Test {
+            method<T>(): Array<Box<T>>;
+        }
+
+        interface Box<T> {
+            value: T;
+        }
+
+        const spy = jasmine.createSpyObj<Test>('test', ['method']);
+
+        spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
+    });
+});
+
 describe("Multiple spies, when created manually", () => {
     class Tape {
         private rewindTo: number;
@@ -772,6 +787,12 @@ describe("Multiple spies, when created manually", () => {
 
     it("tracks all the arguments of its calls", () => {
         expect(tape.rewind).toHaveBeenCalledWith(0);
+        expect(tape.rewind).toHaveBeenCalledWith('42'); // $ExpectError
+        expect(tape.rewind).toHaveBeenCalledWith(jasmine.anything());
+        expect(tape.rewind).toHaveBeenCalledWith(jasmine.falsy());
+        expect(tape.rewind).not.toHaveBeenCalledWith(1);
+        expect(tape.rewind).not.toHaveBeenCalledWith('42'); // $ExpectError
+        expect(tape.rewind).not.toHaveBeenCalledWith(jasmine.truthy());
     });
 
     it("read isPlaying property", () => {
@@ -926,7 +947,7 @@ describe("jasmine.objectContaining", () => {
 
     describe("when used with a spy", () => {
         it("is useful for comparing arguments", () => {
-            const callback = jasmine.createSpy('callback');
+            const callback = jasmine.createSpy<(arg: { bar: string }) => void>('callback');
 
             callback({
                 bar: "baz"
@@ -959,7 +980,7 @@ describe("jasmine.arrayContaining", () => {
 
     describe("when used with a spy", () => {
         it("is useful when comparing arguments", () => {
-            const callback = jasmine.createSpy('callback');
+            const callback = jasmine.createSpy<(numbers: number[]) => void>('callback');
 
             callback([1, 2, 3, 4]);
 
@@ -986,7 +1007,7 @@ describe("jasmine.arrayWithExactContents", () => {
 
     describe("when used with a spy", () => {
         it("is useful when comparing arguments", () => {
-            const callback = jasmine.createSpy('callback');
+            const callback = jasmine.createSpy<(arg: number[]) => void>('callback');
 
             callback([1, 2, 3, 4]);
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1360,16 +1360,6 @@ describe('better typed spys', () => {
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
         });
-
-        it('has a way to opt out of inferred function types', () => {
-            interface I {
-                f(): string;
-                f(x: any): number;
-              }
-
-            const spyObject = jasmine.createSpyObj<jasmine.AnyMethods<I>>("spyObject", ["f"]);
-            spyObject.f.and.returnValue("a string - working");
-        });
     });
 });
 
@@ -1524,6 +1514,33 @@ describe('Static Matcher Test', function() {
             value: 'any value should ok',
           })
         );
+    });
+});
+
+describe("User scenarios", () => {
+    describe("https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34080", () => {
+        interface Test {
+            f(): string;
+            f(x: any): number;
+        }
+
+        it("has a way to opt out of inferred function types", () => {
+            const spyObject: jasmine.NonTypedSpyObj<Test> = jasmine.createSpyObj<Test>("spyObject", ["f"]);
+            spyObject.f.and.returnValue("a string - working");
+
+            const spy2 = jasmine.createSpyObj<Test>(['f']);
+            spy2.f.and.returnValue("can return string" as any);
+        });
+
+        it("should be possible to opt out for spyOn", () => {
+            const obj: Test = null!;
+
+            const spy1: jasmine.Spy = spyOn(obj, "f");
+            spy1.and.returnValue("can return string");
+
+            const spy2 = spyOn(obj, "f");
+            spy2.and.returnValue("can return string" as any);
+        });
     });
 });
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -15,23 +15,29 @@ describe("A suite is just a function", () => {
     });
 });
 
-describe("The 'toBe' matcher compares with ===", () => {
-    it("and has a positive case", () => {
-        expect(true).toBe(true);
-    });
-
-    it("and can have a negative case", () => {
-        expect(false).not.toBe(true);
-    });
-});
-
 describe("Included matchers:", () => {
-    it("The 'toBe' matcher compares with ===", () => {
-        const a = 12;
-        const b = a;
+    describe('toBe', () => {
+        it("and has a positive case", () => {
+            expect(true).toBe(true);
+        });
 
-        expect(a).toBe(b);
-        expect(a).not.toBe(24);
+        it("and can have a negative case", () => {
+            expect(false).not.toBe(true);
+        });
+
+        it("the 'toBe' matcher compares with ===", () => {
+            const a = 12;
+            const b = a;
+
+            expect(a).toBe(b);
+            expect(a).not.toBe(24);
+        });
+
+        it('should allow to accept any union type', () => {
+            const value: number | string = null as any;
+
+            expect(value).toBe(12);
+        });
     });
 
     describe("The 'toEqual' matcher", () => {
@@ -211,7 +217,9 @@ describe("toBePositiveInfinity", () => {
 });
 
 describe("toHaveClass", () => {
-    expect("").toHaveClass(Array);
+    const element: HTMLElement = null!;
+    expect(element).toHaveClass("some-class");
+    expect(element).toHaveClass(Element); // $ExpectError
 });
 
 describe("A spec", () => {
@@ -985,6 +993,15 @@ describe("jasmine.arrayContaining", () => {
 
         expect(foo).toBe(jasmine.arrayContaining([3, 1]));
         expect(foo).not.toBe(jasmine.arrayContaining([6]));
+    });
+
+    it("matches read-only array", () => {
+        const bar: ReadonlyArray<number> = [1, 2, 3, 4];
+
+        expect(bar).toEqual(jasmine.arrayContaining([3, 1]));
+        expect(bar).not.toEqual(jasmine.arrayContaining([6]));
+
+        expect(bar).toBe(jasmine.arrayContaining([3, 1]));
     });
 
     describe("when used with a spy", () => {

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -863,6 +863,15 @@ describe("jasmine.any", () => {
 
             expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
         });
+
+        it("is useful for comparing arguments for typed spy", () => {
+            const foo = jasmine.createSpy<(num: number, fn: () => boolean) => void>('foo');
+            foo(12, () => {
+                return true;
+            });
+
+            expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
+        });
     });
 });
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -786,13 +786,19 @@ describe("multiple spies, when created with spyOnAllFunctions", () => {
             y: (a: number) => a,
         };
 
-        spyOnAllFunctions(obj);
+        const spy = spyOnAllFunctions(obj);
+
+        spy.x.and.returnValue(42);
+        spy.y.and.returnValue(24);
+        spy.z; // $ExpectError
 
         obj.x(0);
         obj.y(1);
 
         expect(obj.x).toHaveBeenCalled();
         expect(obj.y).toHaveBeenCalledWith(1);
+        expect(spy.y).toHaveBeenCalledWith(1);
+        expect(spy.y).toHaveBeenCalledWith("one"); // $ExpectError
     });
 });
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -730,16 +730,23 @@ describe("A spy, when created manually", () => {
 });
 
 describe("Spy for generic method", () => {
+    interface Test {
+        method<T>(): Array<Box<T>>;
+    }
+
+    interface Box<T> {
+        value: T;
+    }
+
     it("should allow to configure generic method", () => {
-        interface Test {
-            method<T>(): Array<Box<T>>;
-        }
-
-        interface Box<T> {
-            value: T;
-        }
-
         const spy = jasmine.createSpyObj<Test>('test', ['method']);
+
+        spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
+    });
+
+    it("should allow to configure generic method with non-named spy", () => {
+        const spy = jasmine.createSpyObj<Test>(['method']);
+        jasmine.createSpyObj<Test>(['methodUnknown']); // $ExpectError
 
         spy.method.and.returnValue([{ value: 1 }, { value: 2 }]);
     });

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1439,7 +1439,7 @@ describe('Static Matcher Test', function() {
           })
         );
     });
-  });
+});
 
 (() => {
     // from boot.js

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -841,6 +841,9 @@ describe("jasmine.any", () => {
     it("matches any value", () => {
         expect({}).toEqual(jasmine.any(Object));
         expect(12).toEqual(jasmine.any(Number));
+        expect(42).toEqual(jasmine.any(42)); // $ExpectError
+        expect({}).toEqual(jasmine.any({})); // $ExpectError
+        expect(() => null).toEqual(jasmine.any(Function));
     });
 
     it("matches any function", () => {
@@ -854,12 +857,35 @@ describe("jasmine.any", () => {
             fn2: (param1: number) => param1,
         };
 
-        const expected: Test = {
+        const expected = {
             fn1: jasmine.any(Function),
             fn2: jasmine.any(Function),
         };
 
         expect(a).toEqual(expected);
+    });
+
+    it("matches custom types", () => {
+        class Test { }
+
+        const obj = new Test();
+
+        expect(obj).toEqual(jasmine.any(Test));
+    });
+
+    it("matches base abstract class", () => {
+        abstract class TestClassBase { }
+        class TestClass extends TestClassBase { }
+        const obj = new TestClass();
+
+        expect(obj).toEqual(jasmine.any(TestClass));
+        expect(obj).toEqual(jasmine.any(TestClassBase));
+    });
+
+    it("matches symbols", () => {
+        const sym = Symbol('test symbol');
+
+        expect(sym).toEqual(jasmine.any(sym));
     });
 
     describe("when used with a spy", () => {

--- a/types/jasminewd2/index.d.ts
+++ b/types/jasminewd2/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-/// <reference types="jasmine" />
+/// <reference types="jasmine/v2" />
 
 declare function it(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
 declare function fit(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;

--- a/types/saywhen/saywhen-tests.ts
+++ b/types/saywhen/saywhen-tests.ts
@@ -18,5 +18,5 @@ type Top = typeof top;
 declare function expectMatcherProxyTop(x: (arg: Top) => boolean): void;
 
 expectMatcherProxyTop(when.captor());
-when.captor(jasmine.any(Number));	// $ExpectType MatcherProxy<Any>
+when.captor(jasmine.any(Number));	// $ExpectType MatcherProxy<AsymmetricMatcher<any>>
 when.noConflict();	// $ExpectType void


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

# Motivation

Found a couple of typing gaps in the library and decided to fix those. Also slightly refactored the library typing to simplify project maintenance.

# Issues

Closes #30552
Closes #34080 

# Changes

The following enhancements has been done:

## Spy

- Added typings for `expect(spy).toHaveBeenCalledWith()`
- Fix missing typing for unnamed `createSpyObj`
- Fix typing for `spyOnAllFunctions`
- Move call assertions to a separate `FunctionMatchers` interface

## Matching

- Remove wrong deep equality from `toBe()`
- Allow `any` matcher to receive prototypes and symbols only
- Enhance types and doc for `toHaveClass` to avoid misuse

## Maintenance / other

- Move all helper types to the `jasmine` namespace to not pollute global namespace
- Remove `AnyMethods<>` in favor of `NonTypedSpyObj<T>` (see motivation [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34080#issuecomment-526913634))
- Remove undefined `Any` property from `Matchers<T>`
- Synchronize tests for default and 3.1+ projects
- Update jasminewd2 to depend on jasmine v2 types
