### PR TITLE
Add typings for react-with-direction

### DIFF
--- a/types/react-with-direction/dist/AutoDirectionProvider.d.ts
+++ b/types/react-with-direction/dist/AutoDirectionProvider.d.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Direction } from 'react-with-direction/dist/constants';
+
+type AutoDirectionProviderProps = {
+  children: React.ReactNode;
+  inline?: boolean | null;
+  text: string;
+};
+
+declare const AutoDirectionProvider: React.ComponentType<
+  AutoDirectionProviderProps
+>;
+
+export default AutoDirectionProvider;
+export { AutoDirectionProviderProps };

--- a/types/react-with-direction/dist/DirectionProvider.d.ts
+++ b/types/react-with-direction/dist/DirectionProvider.d.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { Direction, DIRECTIONS } from 'react-with-direction/dist/constants';
+
+type DirectionProviderProps = {
+  children: React.ReactNode;
+  direction: Direction;
+  inline?: boolean | null;
+};
+
+const DirectionProvider: React.ComponentType<DirectionProviderProps>;
+
+export default DirectionProvider;
+export { DIRECTIONS };

--- a/types/react-with-direction/dist/constants.d.ts
+++ b/types/react-with-direction/dist/constants.d.ts
@@ -1,0 +1,10 @@
+declare const CHANNEL: '__direction__';
+
+declare const DIRECTIONS: {
+  LTR: 'ltr';
+  RTL: 'rtl';
+};
+
+type Direction = typeof DIRECTIONS.LTR | typeof DIRECTIONS.RTL;
+
+export { CHANNEL, DIRECTIONS, Direction };

--- a/types/react-with-direction/dist/proptypes/direction.d.ts
+++ b/types/react-with-direction/dist/proptypes/direction.d.ts
@@ -1,0 +1,6 @@
+import * as PropTypes from 'prop-types';
+import { Direction } from 'react-with-direction/dist/constants';
+
+const directionPropType: PropTypes.Requireable<Direction>;
+
+export default directionPropType;

--- a/types/react-with-direction/index.d.ts
+++ b/types/react-with-direction/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for react-with-direction 1.3.0
+// Project: https://github.com/airbnb/react-with-direction
+// Definitions by: Mohsen Azimi <https://github.com/mohsen1>
+//                 Brie Bunge <https://github.com/brieb>
+//                 Joe Lencioni <https://github.com/lencioni>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+import { Direction, DIRECTIONS } from 'react-with-direction/dist/constants';
+import directionPropType from 'react-with-direction/dist/proptypes/direction';
+
+declare const withDirectionPropTypes: {
+    direction: typeof directionPropType.isRequired;
+};
+
+type WithDirectionProps = {
+    direction: Direction;
+};
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+type ComponentClassProps<C> = C extends new (props: infer P, context?: any) => any ? P : never;
+type SFCProps<C> = C extends (
+    props: infer P & { children?: React.ReactNode },
+    context?: any
+) => any
+    ? P
+    : never;
+type ElementProps<C> = C extends React.ComponentClass<any>
+    ? ComponentClassProps<C>
+    : C extends React.SFC<any> ? SFCProps<C> : never;
+type ElementConfig<C> = JSX.LibraryManagedAttributes<C, ElementProps<C>>;
+
+declare function withDirection<C extends React.ComponentType<any>>(
+    WrappedComponent: C
+): React.ComponentClass<Omit<ElementConfig<C>, keyof WithDirectionProps>>;
+
+export default withDirection;
+export { withDirectionPropTypes, WithDirectionProps, Direction, DIRECTIONS };
+  
+  
+

--- a/types/react-with-direction/react-with-direction-tests.ts
+++ b/types/react-with-direction/react-with-direction-tests.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import withDirection, { WithDirectionProps } from 'react-with-direction';
+
+const Component: React.FC<WithDirectionProps> = ({ direction }) =>
+  React.createElement('div', { dir: direction });
+
+withDirection(Component);

--- a/types/react-with-direction/tsconfig.json
+++ b/types/react-with-direction/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "dist/proptypes/direction.d.ts",
+        "dist/AutoDirectionProvider.d.ts",
+        "dist/DirectionProvider.d.ts",
+        "dist/constants.d.ts",
+        "index.d.ts",
+        "react-with-direction-tests.ts"
+    ]
+}

--- a/types/react-with-direction/tslint.json
+++ b/types/react-with-direction/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
