### PR TITLE
[@types/carbon-components-react] Fix UIShell Link props. Fix HeaderMenuLink prop optionality.

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -9,7 +9,6 @@ import {
     TableRow,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
-import { ReactAnchorAttr } from './typings/shared';
 
 interface Row1 extends DataTableRow {
     rowProp: string;
@@ -142,17 +141,17 @@ const t4 = (
 );
 
 // UIShell - Link
-interface ITestComp1Props {
+interface TestCompProps {
     someProp: number,
 }
 
-class TestComp1 extends React.Component<ITestComp1Props> {
+class TestComp1 extends React.Component<TestCompProps> {
     render() {
         return (<div/>);
     }
 }
 
-const TestComp2 = (props: ITestComp1Props) => (<div/>);
+const TestComp2 = (props: TestCompProps) => (<div/>);
 
 const uisLinkT1 = (
     <Link href="#test">Test</Link>
@@ -161,8 +160,8 @@ const uisLinkT2 = (
     <Link<React.ImgHTMLAttributes<HTMLElement>> element="img" src="src"/>
 );
 const uisLinkT3 = (
-    <Link<ITestComp1Props> element={TestComp1} someProp={2}>ASDF</Link>
+    <Link<TestCompProps> element={TestComp1} someProp={2}>ASDF</Link>
 );
 const uisLinkT4 = (
-    <Link<ITestComp1Props> element={TestComp2} someProp={2}>ASDF</Link>
+    <Link<TestCompProps> element={TestComp2} someProp={2}>ASDF</Link>
 );

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -8,6 +8,8 @@ import {
     TableHeader,
     TableRow,
 } from 'carbon-components-react';
+import Link from 'carbon-components-react/lib/components/UIShell/Link';
+import { ReactAnchorAttr } from "./typings/shared";
 
 interface Row1 extends DataTableRow {
     rowProp: string;
@@ -137,4 +139,9 @@ const t4 = (
             return <div />;
         }}
     />
+);
+
+// UIShell - Link
+const uisLinkT1 = (
+    <Link href="#test">Test</Link>
 );

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -9,7 +9,7 @@ import {
     TableRow,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
-import { ReactAnchorAttr } from "./typings/shared";
+import { ReactAnchorAttr } from './typings/shared';
 
 interface Row1 extends DataTableRow {
     rowProp: string;
@@ -142,6 +142,27 @@ const t4 = (
 );
 
 // UIShell - Link
+interface ITestComp1Props {
+    someProp: number,
+}
+
+class TestComp1 extends React.Component<ITestComp1Props> {
+    render() {
+        return (<div/>);
+    }
+}
+
+const TestComp2 = (props: ITestComp1Props) => (<div/>);
+
 const uisLinkT1 = (
     <Link href="#test">Test</Link>
+);
+const uisLinkT2 = (
+    <Link<React.ImgHTMLAttributes<HTMLElement>> element="img" src="src"/>
+);
+const uisLinkT3 = (
+    <Link<ITestComp1Props> element={TestComp1} someProp={2}>ASDF</Link>
+);
+const uisLinkT4 = (
+    <Link<ITestComp1Props> element={TestComp2} someProp={2}>ASDF</Link>
 );

--- a/types/carbon-components-react/lib/components/UIShell/HeaderMenu.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/HeaderMenu.d.ts
@@ -10,7 +10,7 @@ interface InheritedProps {
 }
 
 export interface HeaderMenuProps extends InheritedProps {
-    menuLinkName: string,
+    menuLinkName?: string,
     renderMenuContent?: React.FC,
 }
 

--- a/types/carbon-components-react/lib/components/UIShell/Link.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/Link.d.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { ReactAnchorAttr, ShapeOf } from "../../../typings/shared";
 
+type InnerElementProps<P> = Omit<P, "element">;
 export interface LinkPropsBase<P = any> {
-    element?: string | React.JSXElementConstructor<P>, // required but has default value
+    element?: string | React.JSXElementConstructor<InnerElementProps<P>>, // required but has default value
 }
 
-export type LinkProps<P extends object = ReactAnchorAttr, IP = P> = ShapeOf<LinkPropsBase<Exclude<IP, "element">>, P>;
+export type LinkProps<P extends object = ReactAnchorAttr, IP = P> = ShapeOf<LinkPropsBase<IP>, P>;
 
 declare function Link<P extends object = ReactAnchorAttr>(
     props: React.PropsWithChildren<LinkProps<P>>,

--- a/types/carbon-components-react/lib/components/UIShell/Link.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/Link.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ReactAnchorAttr, ShapeOf } from "../../../typings/shared";
 
 type InnerElementProps<P> = Omit<P, "element">;
-export interface LinkPropsBase<P = any> {
+export interface LinkPropsBase<P = ReactAnchorAttr> {
     element?: string | React.JSXElementConstructor<InnerElementProps<P>>, // required but has default value
 }
 

--- a/types/carbon-components-react/lib/components/UIShell/Link.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/Link.d.ts
@@ -1,12 +1,15 @@
 import * as React from "react";
 import { ReactAnchorAttr, ShapeOf } from "../../../typings/shared";
 
-export interface LinkPropsBase {
-    element?: string, // required but has default value
+export interface LinkPropsBase<P = any> {
+    element?: string | React.JSXElementConstructor<P>, // required but has default value
 }
 
-export type LinkProps<E extends object = ReactAnchorAttr> = ShapeOf<LinkPropsBase, E>;
+export type LinkProps<P extends object = ReactAnchorAttr, IP = P> = ShapeOf<LinkPropsBase<Exclude<IP, "element">>, P>;
 
-declare function Link<E extends object = ReactAnchorAttr>(props: React.PropsWithChildren<LinkProps<E>>, ref: React.Ref<HTMLElement>): React.ReactElement;
+declare function Link<P extends object = ReactAnchorAttr>(
+    props: React.PropsWithChildren<LinkProps<P>>,
+    ref: React.Ref<HTMLElement>
+): React.ReactElement;
 
 export default Link;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/master/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.