### PR TITLE
@types/react-map-gl: Update GeolocateControl typing with style attribute

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -335,6 +335,7 @@ export interface GeolocateControlProps extends BaseControlProps {
     showUserLocation?: boolean;
     onViewStateChange?: ViewStateChangeHandler;
     onViewportChange?: ViewportChangeHandler;
+    style?: React.CSSProperties;
 }
 
 export class GeolocateControl extends BaseControl<GeolocateControlProps, HTMLDivElement> {}

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -40,7 +40,7 @@ class MyMap extends React.Component<{}, State> {
                     ref={this.setRefInteractive}
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
-                    <GeolocateControl className="test-class" />
+                    <GeolocateControl className="test-class" style={{ marginTop: "8px" }} />
                     <CanvasOverlay
                         redraw={opts => {
                             const {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://uber.github.io/react-map-gl/#/Documentation/api-reference/geolocate-control?section=properties

I think the `GeolocateControl` typing was missing the optional `style` attribute, described [here](https://uber.github.io/react-map-gl/#/Documentation/api-reference/geolocate-control?section=properties) in the docs.
