### PR TITLE
ramda: better mergeDeepRight / mergeDeepLeft types

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -551,8 +551,14 @@ declare namespace R {
     type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 
     type CommonKeys<T1, T2> = keyof T1 & keyof T2;
+
+    type PropsThatAreArrays<T, K extends keyof T> = K extends keyof T ? T[K] extends ReadonlyArray<any> ? K : never : never;
+    type PropsThatAreObjectsButNotArrays<T, K extends keyof T> = K extends keyof T ? T[K] extends ReadonlyArray<any> ? never : T[K] extends object ? K : never : never;
     type PropsThatAreObjects<T, K extends keyof T> = K extends keyof T ? T[K] extends object ? K : never : never;
+
+    type CommonPropsThatAreArrays<T1, T2> = PropsThatAreArrays<T1, keyof T1> & PropsThatAreArrays<T2, keyof T2>;
     type CommonPropsThatAreObjects<T1, T2> = PropsThatAreObjects<T1, keyof T1> & PropsThatAreObjects<T2, keyof T2>;
+    type CommonPropsThatAreObjectsButNotArrays<T1, T2> = PropsThatAreObjectsButNotArrays<T1, keyof T1> & PropsThatAreObjectsButNotArrays<T2, keyof T2>;
 
     type Ord = number | string | boolean | Date;
 
@@ -782,7 +788,9 @@ declare namespace R {
     ];
 
     type Merge<Primary, Secondary> = { [K in keyof Primary]: Primary[K] } & { [K in Exclude<keyof Secondary, CommonKeys<Primary, Secondary>>]: Secondary[K] };
-    type MergeDeep<Primary, Secondary> = { [K in CommonPropsThatAreObjects<Primary, Secondary>]: MergeDeep<Primary[K], Secondary[K]> } &
+    type MergeDeep<Primary, Secondary> =
+        { [K in CommonPropsThatAreArrays<Primary, Secondary>]: Secondary[K] } &
+        { [K in CommonPropsThatAreObjectsButNotArrays<Primary, Secondary>]: MergeDeep<Primary[K], Secondary[K]> } &
         { [K in Exclude<keyof Primary, CommonPropsThatAreObjects<Primary, Secondary>>]: Primary[K] } &
         { [K in Exclude<keyof Secondary, CommonKeys<Primary, Secondary>>]: Secondary[K] };
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1424,11 +1424,19 @@ class Rectangle {
 };
 
 () => {
-    const a = R.mergeDeepLeft({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: {bar: 1}}
+  const a = R.mergeDeepLeft({ foo: { bar: 1 } }, { foo: { bar: 2 } }); // => {foo: {bar: 1}}
+  const b: { foo: { bar: number; baz: number[] } } = R.mergeDeepLeft(
+    { foo: { bar: 1, baz: [1, 2] } },
+    { foo: { bar: 2, baz: [3, 4] } },
+  ); // => {foo: {bar: 2, baz: [1, 2]}}
 };
 
 () => {
-    const a = R.mergeDeepRight({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foor: bar: 2}}
+  const a = R.mergeDeepRight({ foo: { bar: 1 } }, { foo: { bar: 2 } }); // => {foo: {bar: 2}}
+  const b: { foo: { bar: number; baz: number[] } } = R.mergeDeepRight(
+    { foo: { bar: 1, baz: [1, 2] } },
+    { foo: { bar: 2, baz: [3, 4] } },
+  ); // => {foo: {bar: 2, baz: [3, 4]}}
 };
 
 () => {


### PR DESCRIPTION
`MergeDeep` doesn't type correctly for array members of to-be-merged objects, since arrays `extend object` too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ramda REPL](https://ramdajs.com/repl/?v=0.26.1#?R.mergeDeepRight%28%7B%20name%3A%20%27fred%27%2C%20age%3A%2010%2C%20contact%3A%20%7B%20email%3A%20%27moo%40example.com%27%20%7D%2C%20types%3A%20%5B2%2C%205%5D%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%20age%3A%2040%2C%20contact%3A%20%7B%20email%3A%20%27baa%40example.com%27%20%7D%2C%20types%3A%20%5B1%2C%204%5D%7D%29%3B%0A%2F%2F%3D%3E%20%7B%20name%3A%20%27fred%27%2C%20age%3A%2040%2C%20contact%3A%20%7B%20email%3A%20%27baa%40example.com%27%20%7D%7D)

