### PR TITLE
ramda: Add support for mapObjIndexed and string union key types

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1778,6 +1778,13 @@ declare namespace R {
         /**
          * Like mapObj, but but passes additional arguments to the predicate function.
          */
+        mapObjIndexed<T, TResult, TKey extends string>(
+            fn: (value: T, key: TKey, obj?: Record<TKey, T>) => TResult,
+            obj: Record<TKey, T>
+        ): Record<TKey, TResult>;
+        mapObjIndexed<T, TResult, TKey extends string>(
+            fn: (value: T, key: TKey, obj?: Record<TKey, T>) => TResult
+        ): (obj: Record<TKey, T>) =>  Record<TKey, TResult>;
         mapObjIndexed<T, TResult>(
             fn: (value: T, key: string, obj?: {
                 [key: string]: T

--- a/types/ramda/test/mapObjIndexed-tests.ts
+++ b/types/ramda/test/mapObjIndexed-tests.ts
@@ -11,14 +11,47 @@ import * as R from 'ramda';
 };
 
 () => {
-  const testObject: {
-    [key: string]: Error;
-  } = {
-    hello: new Error('hello'),
-  };
-  const errorMessages = R.mapObjIndexed(function test(value, key) {
-    // value should be inferred.
-    return value.message + String(key);
-  }, testObject);
-  console.log(errorMessages);
+    const testObject: {
+        [k: string]: Error;
+    } = {
+        hello: new Error('hello'),
+    };
+    const errorMessages = R.mapObjIndexed(function test(value, key) {
+        // value should be inferred.
+        const test = key.toLowerCase();
+        return value.message + String(key);
+    }, testObject);
+    console.log(errorMessages);
+};
+
+() => {
+    type TestKeys = 'hello' | 'test';
+    const testObject: Record<TestKeys, string> = {
+        hello: 'world',
+        test: '123',
+    };
+
+    const mapped = R.mapObjIndexed(function test(value, key) {
+        function unreachableCase(v: never): never {
+            throw new Error('not possible');
+        }
+
+        let returnValue: number;
+        // type of key should be inferred as `TestKeys` (not `string`).
+        if (key === 'hello') {
+            returnValue = 42;
+        } else if (key === 'test') {
+            returnValue = 13;
+        } else {
+            // make sure the type system knows that the key can't be anything other than 'hello' | 'test'
+            return unreachableCase(key);
+        }
+
+        const test1 = value.charAt(0);
+        return returnValue;
+    }, testObject);
+
+    // keys of testObject should be detected, and their values should be `number`.
+    const helloResult = mapped.hello.toFixed();
+    console.log(mapped, helloResult);
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- Provide a URL to documentation or source code which provides context for the suggested changes: *N/A, these are just better types for some scenarios*
