### PR TITLE
[koa-generic-session] Add a sameSite attribute to SessionOptions

### DIFF
--- a/types/koa-generic-session/index.d.ts
+++ b/types/koa-generic-session/index.d.ts
@@ -37,6 +37,7 @@ declare namespace koaSession {
             maxAge?: number;
             secure?: boolean;
             httpOnly?: boolean;
+            sameSite?: string;
         };
         allowEmpty?: boolean;
         defer?: boolean;

--- a/types/koa-generic-session/index.d.ts
+++ b/types/koa-generic-session/index.d.ts
@@ -37,7 +37,7 @@ declare namespace koaSession {
             maxAge?: number;
             secure?: boolean;
             httpOnly?: boolean;
-            sameSite?: string;
+            sameSite?: boolean | "lax" | "none" | "strict";
         };
         allowEmpty?: boolean;
         defer?: boolean;


### PR DESCRIPTION
Seems like koa-generic-session has started supporting SameSite, but the definitions do not contain it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## Changing an existing definition
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/cookie#samesite
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ This is not a result of a version change, the `cookie` package upon which this is based supports this option.
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~ Not making a substantial change.