### PR TITLE
[@types/matter-js] Fix bounds min/max properties

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1082,17 +1082,16 @@ declare namespace Matter {
 
     }
 
-    export interface IBound {
-        min: { x: number, y: number }
-        max: { x: number, y: number }
-    }
-
     /**
     * The `Matter.Bounds` module contains methods for creating and manipulating axis-aligned bounding boxes (AABB).
     *
     * @class Bounds
     */
     export class Bounds {
+
+        min: Vector;
+        max: Vector;
+
         /**
          * Creates a new axis-aligned bounding box (AABB) for the given vertices.
          * @method create

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -7,7 +7,8 @@ var Engine = Matter.Engine,
 	Constraint = Matter.Constraint,
 	Events = Matter.Events,
 	Query = Matter.Query,
-    Plugin = Matter.Plugin;
+    Plugin = Matter.Plugin,
+    Render = Matter.Render;
     
 
 Matter.use('matter-attractors');
@@ -59,3 +60,18 @@ Events.on(engine, "beforeTick", (e:Matter.IEventTimestamped<Matter.Engine>)=>{
 
 
 Engine.run(engine);
+
+//Renderer
+var render = Render.create({
+	engine: engine,
+	bounds: {
+		min: {
+			x: -500,
+			y: -500
+		},
+		max: {
+			x: 500,
+			y: 500
+		}
+	}
+})


### PR DESCRIPTION
The `IBound` type does not appear to be used anywhere in the code, yet the `Bounds` type which *is* used is missing its `min`/`max` properties.

Remove the unused type and add the missing properties as `Vector`s.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liabru/matter-js/blob/master/src/render/Render.js#L92
