### PR TITLE
react-bootstrap: add restoreFocus prop to Modal

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -15,6 +15,7 @@
 //                 Andrew Makarov <https://github.com/r3nya>
 //                 Duong Tran <https://github.com/t49tran>
 //                 Erik Zivkovic <https://github.com/bes>
+//                 Collin Green <https://github.com/collingreen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-bootstrap/lib/Modal.d.ts
+++ b/types/react-bootstrap/lib/Modal.d.ts
@@ -26,6 +26,7 @@ declare namespace Modal {
         dialogComponent?: any; // TODO: Add more specific type
         dialogTransitionTimeout?: number;
         enforceFocus?: boolean;
+        restoreFocus?: boolean;
         keyboard?: boolean;
         onBackdropClick?: (node: HTMLElement) => any;
         onEscapeKeyDown?: (node: HTMLElement) => any;


### PR DESCRIPTION
Add `restoreFocus` prop for Modal - this has been in the react-bootstrap library for ~2 years but is not in the type definitions.

The `restoreFocus` prop was added to react-bootstrap in this commit from
2017 that was first released in v0.30.8.

https://github.com/react-bootstrap/react-bootstrap/commit/bd76a90d4780c834b4620c423e38b40c66a80882

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
  - The other non-required props don't have anything in the tests so this is consistent in that way. Looking for guidance on what to add to the tests for this property.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - commit where prop was added to react-bootstrap: https://github.com/react-bootstrap/react-bootstrap/commit/bd76a90d4780c834b4620c423e38b40c66a80882 
  - docs: https://5c507d49471426000887a6a7--react-bootstrap.netlify.com/components/modal/

