### PR TITLE
[pino-http] Add err to ServerResponse

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -39,4 +39,7 @@ declare module 'http' {
     interface IncomingMessage {
         log: Logger;
     }
+    interface ServerResponse {
+        err: Error;
+    }
 }

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -40,6 +40,6 @@ declare module 'http' {
         log: Logger;
     }
     interface ServerResponse {
-        err: Error;
+        err?: Error;
     }
 }

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -9,7 +9,7 @@ const httpLogger = pinoHttp();
 function handle(req: http.IncomingMessage, res: http.ServerResponse) {
   httpLogger(req, res);
   req.log.info('something else');
-  const err: Error = res.err;
+  const err: Error | undefined = res.err;
 }
 
 pinoHttp({ logger });

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -9,6 +9,7 @@ const httpLogger = pinoHttp();
 function handle(req: http.IncomingMessage, res: http.ServerResponse) {
   httpLogger(req, res);
   req.log.info('something else');
+  const err: Error = res.err;
 }
 
 pinoHttp({ logger });


### PR DESCRIPTION
[pino-http](https://github.com/pinojs/pino-http/blob/master/logger.js#L48) uses the `err` property on `ServerResponse` to pass errors to the error serializer. Without this definition, you cannot set `res.err = err;` to allow the error to be logged.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-http/blob/master/logger.js#L48
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.