### PR TITLE
[react-router-config] Enable array string type path in route config

### DIFF
--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -19,7 +19,7 @@ export interface RouteConfig {
     key?: React.Key;
     location?: Location;
     component?: React.ComponentType<RouteConfigComponentProps<any>> | React.ComponentType;
-    path?: string;
+    path?: string | string[];
     exact?: boolean;
     strict?: boolean;
     routes?: RouteConfig[];


### PR DESCRIPTION
react-router-config uses `matchPath` function in react-route. And matchPath function uses `RouteProps` type which has `path` with `string | string[]` type.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts
