### PR TITLE
rebass: add Emotion CSSObject

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -13,6 +13,7 @@ import { ResponsiveStyleValue, SystemStyleObject } from '@styled-system/css';
 import * as React from "react";
 import * as StyledComponents from "styled-components";
 import * as StyledSystem from "styled-system";
+import { CSSObject } from '@emotion/serialize'
 
 export {};
 
@@ -21,6 +22,7 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export interface BaseProps extends React.RefAttributes<any> {
     as?: React.ElementType;
     css?:
+        | CSSObject
         | StyledComponents.CSSObject
         | StyledComponents.FlattenSimpleInterpolation
         | string;

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -13,7 +13,7 @@ import { ResponsiveStyleValue, SystemStyleObject } from '@styled-system/css';
 import * as React from "react";
 import * as StyledComponents from "styled-components";
 import * as StyledSystem from "styled-system";
-import { InterpolationWithTheme } from '@emotion/core'
+import { InterpolationWithTheme } from '@emotion/core';
 
 export {};
 

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -13,7 +13,7 @@ import { ResponsiveStyleValue, SystemStyleObject } from '@styled-system/css';
 import * as React from "react";
 import * as StyledComponents from "styled-components";
 import * as StyledSystem from "styled-system";
-import { CSSObject } from '@emotion/serialize'
+import { InterpolationWithTheme } from '@emotion/core'
 
 export {};
 
@@ -22,7 +22,7 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export interface BaseProps extends React.RefAttributes<any> {
     as?: React.ElementType;
     css?:
-        | CSSObject
+        | InterpolationWithTheme<any>
         | StyledComponents.CSSObject
         | StyledComponents.FlattenSimpleInterpolation
         | string;

--- a/types/rebass/package.json
+++ b/types/rebass/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@emotion/core": "^10.0.17"
+        "@emotion/core": "*"
     }
 }

--- a/types/rebass/package.json
+++ b/types/rebass/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@emotion/core": "^10.0.17"
+    }
+}

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import styled, { css } from "styled-components";
+import { css as emotionCss } from '@emotion/core'
 import { Box, Flex, Text, Heading, Button, Link, Image, Card, BoxProps } from "rebass";
 import "styled-components/macro";
 
@@ -23,7 +24,13 @@ const boxCss = css`
     color: white;
 `;
 
+const emotionCss = css`
+    background: purple;
+    color: white;
+`;
+
 const CssBox = () => <Box css={boxCss} />;
+const EmotionCssBox = () => <Box css={emotionCss} />;
 
 export default () => (
     <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em">
@@ -77,6 +84,7 @@ export default () => (
             </Box>
 
             <CssBox />
+            <EmotionCssBox/>
         </Flex>
     </Box>
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
-  [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rebassjs/rebass/issues/664

This adds the CSSObject from Emotion to the global css object definition on `BaseProps`. Rebass is using Emotion by default, so the user should expect to be able to use `css` prop from Emotion.