### PR TITLE
In the '@types/meteor' package, allow passing a string as value for the `$unset` modifier.

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -107,7 +107,7 @@ declare module Mongo {
         $rename?: PartialMapTo<T, string> & Dictionary<string>,
         $set?: Partial<T> & Dictionary<any>,
         $setOnInsert?: Partial<T> & Dictionary<any>,
-        $unset?: PartialMapTo<T, boolean | 1 | 0> & Dictionary<any>,
+        $unset?: PartialMapTo<T, string | boolean | 1 | 0> & Dictionary<any>,
         $addToSet?: ArraysOrEach<T> & Dictionary<any>,
         $push?: PushModifier<T> & Dictionary<any>,
         $pull?: ElementsOf<T> & Dictionary<any>,

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -12,6 +12,7 @@
 //                 Arthur Gunn <https://github.com/gunn>
 //                 alesn <https://github.com/alesn>
 //                 Per Bergland <https://github.com/perbergland>
+//                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -108,7 +108,7 @@ declare module "meteor/mongo" {
             $rename?: PartialMapTo<T, string> & Dictionary<string>,
             $set?: Partial<T> & Dictionary<any>,
             $setOnInsert?: Partial<T> & Dictionary<any>,
-            $unset?: PartialMapTo<T, boolean | 1 | 0> & Dictionary<any>,
+            $unset?: PartialMapTo<T, string | boolean | 1 | 0> & Dictionary<any>,
             $addToSet?: ArraysOrEach<T> & Dictionary<any>,
             $push?: PushModifier<T> & Dictionary<any>,
             $pull?: ElementsOf<T> & Dictionary<any>,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/operator/update/unset/#up._S_unset

As per documentation: 
> The specified value in the $unset expression (i.e. "") does not impact the operation.

A common approach is using empty strings as the value for the `$unset` modifier. Even the example in the official mongo documentation use an empty string.