### PR TITLE
Plotly.js: add support for colorscale and numeric colors

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -490,7 +490,8 @@ export type ErrorBar = Partial<ErrorOptions> & ({
 export type Dash = 'solid' | 'dot' | 'dash' | 'longdash' | 'dashdot' | 'longdashdot';
 
 export type Data = Partial<PlotData>;
-export type Color = string | Array<string | undefined | null> | Array<Array<string | undefined | null>>;
+export type Color = string | number | Array<string | number | undefined | null> | Array<Array<string | number | undefined | null>>;
+export type ColorScale = string | string[] | Array<[number, string]>;
 export type DataTransform = Partial<Transform>;
 export type ScatterData = PlotData;
 // Bar Scatter
@@ -557,7 +558,7 @@ export interface PlotData {
 	orientation: 'v' | 'h';
 	width: number | number[];
 	boxmean: boolean | 'sd';
-	colorscale: string | Array<[number, string]>;
+	colorscale: ColorScale;
 	zsmooth: 'fast' | 'best' | false;
 	ygap: number;
 	xgap: number;
@@ -663,7 +664,7 @@ export interface PlotMarker {
 	symbol: string | string[]; // Drawing.symbolList
 	color: Color | Color[];
 	colors: Color[];
-	colorscale: string | string[] | Array<Array<(string | number)>>;
+	colorscale: ColorScale;
 	cauto: boolean;
 	cmax: number;
 	cmin: number;
@@ -693,7 +694,7 @@ export type ScatterMarker = PlotMarker;
 export interface ScatterMarkerLine {
 	width: number | number[];
 	color: Color;
-	colorscale: string | string[];
+	colorscale: ColorScale;
 	cauto: boolean;
 	cmax: number;
 	cmin: number;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://plot.ly/javascript/reference/#scatter-marker-color, https://plot.ly/javascript/reference/#scatter-marker-colorscale
