### PR TITLE
Match `@types/ink-spinner` to `ink-spinner@3.0.1`, following Ink 2 component spec

### DIFF
--- a/types/ink-spinner/index.d.ts
+++ b/types/ink-spinner/index.d.ts
@@ -6,7 +6,7 @@
 
 import { Chalk } from 'chalk';
 import * as cliSpinners from 'cli-spinners';
-import { Component } from 'ink';
+import { Component } from 'react';
 
 type StringifyPartial<T> = {
     [P in keyof T]?: string;


### PR DESCRIPTION
These current types follow the prior spec where Ink exported its own "Component" type.  I modified these types in my own installation, just importing Component from 'react' gets the job done!

**Update Details for Reviewers:**
`ink` used to provide its own `Component` type prior to v2, whereas now it just leverages the built-in React option.  You can see the [old Ink component back in v0.5.1](https://github.com/vadimdemedes/ink/blob/890120254ba705399d736c4407194a77069f0a8b/lib/component.js), and compare that there's [no matching option in the most recent version](https://github.com/vadimdemedes/ink/tree/master/src/components).