### PR TITLE
feat: Add `webidl‑conversions`

### DIFF
--- a/types/webidl-conversions/.editorconfig
+++ b/types/webidl-conversions/.editorconfig
@@ -1,0 +1,3 @@
+# This package uses tabs
+[*]
+indent_style = tab

--- a/types/webidl-conversions/index.d.ts
+++ b/types/webidl-conversions/index.d.ts
@@ -34,19 +34,19 @@ declare const WebIDLConversions: {
 	octet(V: any, opts?: WebIDLConversions.IntegerOptions): number;
 
 	short(V: any, opts?: WebIDLConversions.IntegerOptions): number;
-	["unsigned short"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	['unsigned short'](V: any, opts?: WebIDLConversions.IntegerOptions): number;
 
 	long(V: any, opts?: WebIDLConversions.IntegerOptions): number;
-	["unsigned long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	['unsigned long'](V: any, opts?: WebIDLConversions.IntegerOptions): number;
 
-	["long long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
-	["unsigned long long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	['long long'](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	['unsigned long long'](V: any, opts?: WebIDLConversions.IntegerOptions): number;
 
 	double(V: any, opts?: WebIDLConversions.Options): number;
-	["unrestricted double"](V: any, opts?: WebIDLConversions.Options): number;
+	['unrestricted double'](V: any, opts?: WebIDLConversions.Options): number;
 
 	float(V: any, opts?: WebIDLConversions.Options): number;
-	["unrestricted float"](V: any, opts?: WebIDLConversions.Options): number;
+	['unrestricted float'](V: any, opts?: WebIDLConversions.Options): number;
 
 	DOMString(V: any, opts?: WebIDLConversions.StringOptions): string;
 	ByteString(V: any, opts?: WebIDLConversions.StringOptions): string;
@@ -76,7 +76,10 @@ declare const WebIDLConversions: {
 	DOMTimeStamp(V: any, opts?: WebIDLConversions.Options): number;
 	// tslint:disable:ban-types
 	Function<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any[]) => any) ? V : Function;
-	VoidFunction<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any[]) => any) ? (...args: Parameters<V>) => void : Function;
+	VoidFunction<V>(
+		V: V,
+		opts?: WebIDLConversions.Options,
+	): V extends ((...args: any[]) => any) ? (...args: Parameters<V>) => void : Function;
 };
 
 // This can't use ES6 style exports, as those can't have spaces in export names.

--- a/types/webidl-conversions/index.d.ts
+++ b/types/webidl-conversions/index.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for webidl-conversions 4.0
+// Project: https://github.com/jsdom/webidl-conversions#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare type Identity<T> = {} & { [K in keyof T]: T[K] };
+
+declare namespace WebIDLConversions {
+	interface Options {
+		context?: string;
+	}
+
+	interface IntegerOptions extends Options {
+		enforceRange?: boolean;
+		clamp?: boolean;
+	}
+
+	interface StringOptions extends Options {
+		treatNullAsEmptyString?: boolean;
+	}
+
+	type IntegerConversion = (V: any, opts?: IntegerOptions) => number;
+	type StringConversion = (V: any, opts?: StringOptions) => string;
+	type NumberConversion = (V: any, opts?: Options) => number;
+}
+
+declare const WebIDLConversions: {
+	any<V>(V: V, opts?: WebIDLConversions.Options): V;
+	void(V?: any, opts?: WebIDLConversions.Options): void;
+	boolean(V: any, opts?: WebIDLConversions.Options): boolean;
+
+	byte(V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	octet(V: any, opts?: WebIDLConversions.IntegerOptions): number;
+
+	short(V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	["unsigned short"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+
+	long(V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	["unsigned long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+
+	["long long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+	["unsigned long long"](V: any, opts?: WebIDLConversions.IntegerOptions): number;
+
+	double(V: any, opts?: WebIDLConversions.Options): number;
+	["unrestricted double"](V: any, opts?: WebIDLConversions.Options): number;
+
+	float(V: any, opts?: WebIDLConversions.Options): number;
+	["unrestricted float"](V: any, opts?: WebIDLConversions.Options): number;
+
+	DOMString(V: any, opts?: WebIDLConversions.StringOptions): string;
+	ByteString(V: any, opts?: WebIDLConversions.StringOptions): string;
+	USVString(V: any, opts?: WebIDLConversions.StringOptions): string;
+
+	object(V: any, opts?: WebIDLConversions.Options): object;
+	Error(V: any, opts?: WebIDLConversions.Options): Error;
+
+	ArrayBuffer(V: any, opts?: WebIDLConversions.Options): ArrayBuffer;
+	DataView(V: any, opts?: WebIDLConversions.Options): DataView;
+
+	Int8Array(V: any, opts?: WebIDLConversions.Options): Int8Array;
+	Int16Array(V: any, opts?: WebIDLConversions.Options): Int16Array;
+	Int32Array(V: any, opts?: WebIDLConversions.Options): Int32Array;
+
+	Uint8Array(V: any, opts?: WebIDLConversions.Options): Uint8Array;
+	Uint16Array(V: any, opts?: WebIDLConversions.Options): Uint16Array;
+	Uint32Array(V: any, opts?: WebIDLConversions.Options): Uint32Array;
+	Uint8ClampedArray(V: any, opts?: WebIDLConversions.Options): Uint8ClampedArray;
+
+	Float32Array(V: any, opts?: WebIDLConversions.Options): Float32Array;
+	Float64Array(V: any, opts?: WebIDLConversions.Options): Float64Array;
+
+	ArrayBufferView(V: any, opts?: WebIDLConversions.Options): ArrayBufferView;
+	BufferSource(V: any, opts?: WebIDLConversions.Options): ArrayBuffer | ArrayBufferView;
+
+	DOMTimeStamp(V: any, opts?: WebIDLConversions.Options): number;
+	Function<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any) => any) ? V : Function;
+	VoidFunction<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any) => any) ? (...args: Parameters<V>) => void : Function;
+};
+
+// This can't use ES6 style exports, as those can't have spaces in export names.
+export = WebIDLConversions;

--- a/types/webidl-conversions/index.d.ts
+++ b/types/webidl-conversions/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/jsdom/webidl-conversions#readme
 // Definitions by: ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
-declare type Identity<T> = {} & { [K in keyof T]: T[K] };
+type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
 
 declare namespace WebIDLConversions {
 	interface Options {
@@ -73,8 +74,9 @@ declare const WebIDLConversions: {
 	BufferSource(V: any, opts?: WebIDLConversions.Options): ArrayBuffer | ArrayBufferView;
 
 	DOMTimeStamp(V: any, opts?: WebIDLConversions.Options): number;
-	Function<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any) => any) ? V : Function;
-	VoidFunction<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any) => any) ? (...args: Parameters<V>) => void : Function;
+	// tslint:disable:ban-types
+	Function<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any[]) => any) ? V : Function;
+	VoidFunction<V>(V: V, opts?: WebIDLConversions.Options): V extends ((...args: any[]) => any) ? (...args: Parameters<V>) => void : Function;
 };
 
 // This can't use ES6 style exports, as those can't have spaces in export names.

--- a/types/webidl-conversions/tsconfig.json
+++ b/types/webidl-conversions/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"webidl-conversions-tests.ts"
+	]
+}

--- a/types/webidl-conversions/tsconfig.json
+++ b/types/webidl-conversions/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"lib": [
-			"es6"
+			"es2015"
 		],
 		"noImplicitAny": true,
 		"noImplicitThis": true,

--- a/types/webidl-conversions/tslint.json
+++ b/types/webidl-conversions/tslint.json
@@ -1,0 +1,6 @@
+{
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"indent": [true, "tabs"]
+	}
+}

--- a/types/webidl-conversions/tslint.json
+++ b/types/webidl-conversions/tslint.json
@@ -1,6 +1,1 @@
-{
-	"extends": "dtslint/dt.json",
-	"rules": {
-		"indent": [true, "tabs"]
-	}
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -2,7 +2,10 @@ import conversions = require("webidl-conversions");
 
 const any: any = void 0;
 const unknown: unknown = void 0;
-const options: conversions.Options = {}; // $ExpectType Options
+// $ExpectType Options
+const options: conversions.Options = ((): conversions.Options => {
+	return {};
+})();
 
 conversions.any(any); // $ExpectType any
 conversions.any(unknown); // $ExpectType unknown
@@ -62,6 +65,6 @@ conversions.Function(any, options); // $ExpectType any
 conversions.Function(unknown, options); // $ExpectType Function
 conversions.Function((arg: any) => true, options); // $ExpectType (arg: any) => true
 
-conversions.VoidFunction(any, options); // $ExpectType Function | ((arg: any) => void)
+conversions.VoidFunction(any, options); // $ExpectType Function | ((...args: unknown[]) => void)
 conversions.VoidFunction(unknown, options); // $ExpectType Function
 conversions.VoidFunction((arg: any) => true, options); // $ExpectType (arg: any) => void

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -1,0 +1,67 @@
+import conversions = require("webidl-conversions");
+
+const any: any = void 0;
+const unknown: unknown = void 0;
+const options: conversions.Options = {}; // $ExpectType Options
+
+conversions.any(any); // $ExpectType any
+conversions.any(unknown); // $ExpectType unknown
+conversions.any(options); // $ExpectType Options
+conversions.any(RegExp); // $ExpectType RegExpConstructor
+conversions.any(Symbol.toStringTag); // $ExpectType symbol
+
+conversions.void(); // $ExpectType void
+conversions.boolean(any); // $ExpectType boolean
+
+conversions.byte(any); // $ExpectType number
+conversions.octet(any); // $ExpectType number
+
+conversions.short(any); // $ExpectType number
+conversions["unsigned short"](any); // $ExpectType number
+
+conversions.long(any); // $ExpectType number
+conversions["unsigned long"](any); // $ExpectType number
+
+conversions["long long"](any); // $ExpectType number
+conversions["unsigned long long"](any); // $ExpectType number
+
+conversions.double(any); // $ExpectType number
+conversions["unrestricted double"](any); // $ExpectType number
+
+conversions.float(any); // $ExpectType number
+conversions["unrestricted float"](any); // $ExpectType number
+
+conversions.DOMString(any, options); // $ExpectType string
+conversions.ByteString(any, options); // $ExpectType string
+conversions.USVString(any, options); // $ExpectType string
+
+conversions.object(any, options); // $ExpectType object
+conversions.Error(any, options); // $ExpectType Error
+
+conversions.ArrayBuffer(any, options); // $ExpectType ArrayBuffer
+conversions.DataView(any, options); // $ExpectType DataView
+
+conversions.Int8Array(any, options); // $ExpectType Int8Array
+conversions.Int16Array(any, options); // $ExpectType Int16Array
+conversions.Int32Array(any, options); // $ExpectType Int32Array
+
+conversions.Uint8Array(any, options); // $ExpectType Uint8Array
+conversions.Uint16Array(any, options); // $ExpectType Uint16Array
+conversions.Uint32Array(any, options); // $ExpectType Uint32Array
+conversions.Uint8ClampedArray(any, options); // $ExpectType Uint8ClampedArray
+
+conversions.Float32Array(any, options); // $ExpectType Float32Array
+conversions.Float64Array(any, options); // $ExpectType Float64Array
+
+conversions.ArrayBufferView(any, options); // $ExpectType ArrayBufferView
+conversions.BufferSource(any, options); // $ExpectType ArrayBuffer | ArrayBufferView
+
+conversions.DOMTimeStamp(any, options); // $ExpectType number
+
+conversions.Function(any, options); // $ExpectType any
+conversions.Function(unknown, options); // $ExpectType Function
+conversions.Function((arg: any) => true, options); // $ExpectType (arg: any) => true
+
+conversions.VoidFunction(any, options); // $ExpectType Function | ((arg: any) => void)
+conversions.VoidFunction(unknown, options); // $ExpectType Function
+conversions.VoidFunction((arg: any) => true, options); // $ExpectType (arg: any) => void

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -1,4 +1,4 @@
-import conversions = require("webidl-conversions");
+import conversions = require('webidl-conversions');
 
 const any: any = void 0;
 const unknown: unknown = void 0;
@@ -20,19 +20,19 @@ conversions.byte(any); // $ExpectType number
 conversions.octet(any); // $ExpectType number
 
 conversions.short(any); // $ExpectType number
-conversions["unsigned short"](any); // $ExpectType number
+conversions['unsigned short'](any); // $ExpectType number
 
 conversions.long(any); // $ExpectType number
-conversions["unsigned long"](any); // $ExpectType number
+conversions['unsigned long'](any); // $ExpectType number
 
-conversions["long long"](any); // $ExpectType number
-conversions["unsigned long long"](any); // $ExpectType number
+conversions['long long'](any); // $ExpectType number
+conversions['unsigned long long'](any); // $ExpectType number
 
 conversions.double(any); // $ExpectType number
-conversions["unrestricted double"](any); // $ExpectType number
+conversions['unrestricted double'](any); // $ExpectType number
 
 conversions.float(any); // $ExpectType number
-conversions["unrestricted float"](any); // $ExpectType number
+conversions['unrestricted float'](any); // $ExpectType number
 
 conversions.DOMString(any, options); // $ExpectType string
 conversions.ByteString(any, options); // $ExpectType string


### PR DESCRIPTION
[webidl‑conversions](https://github.com/jsdom/webidl-conversions) is a JavaScript implementation of the [WebIDL ECMAScript type mapping](https://heycam.github.io/webidl/#es-type-mapping) algorithms, which is primarily used by [JSDOM](https://github.com/jsdom/jsdom) and [webidl2js](https://github.com/jsdom/webidl2js).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
  - @sandersn has&nbsp;allowed me&nbsp;to&nbsp;set&nbsp;`indent` in&nbsp;`dtslint.json`:&nbsp;https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33478#issuecomment-470728638.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
