### PR TITLE
Add types for rox-browser

### DIFF
--- a/types/rox-browser/index.d.ts
+++ b/types/rox-browser/index.d.ts
@@ -1,0 +1,273 @@
+// Type definitions for rox-browser 4.8
+// Project: https://rollout.io
+// Definitions by: g-guirado <https://github.com/g-guirado>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/**
+ *
+ * Official documentation for rox-browser is available here:
+ * https://support.rollout.io/docs/javascript-browser-api
+ *
+ */
+
+export {};
+
+export interface RoxContainer {
+  [key: string]: Flag | Configuration<any> | Variant;
+}
+
+/**
+ * The register function should be called before the call to Rox.setup()
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section-register
+ */
+export function register(namespace: string, roxContainer: RoxContainer): void;
+
+/**
+ * Set Global Context.
+ * You can think of Global Context as a default context
+ *
+ * https://support.rollout.io/docs/context#section-global-context
+ */
+export function setContext(globalContext: unknown): void;
+
+/**
+ * Initiate connection with Rox servers for the application identified by the application key.
+ * The registered containers will be synced and Rox entities will get the appropriate values.
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section-setup
+ */
+export function setup(apiKey: string, options?: RoxSetupOptions): Promise<unknown>;
+
+export interface RoxSetupOptions {
+  version?: string;
+  // https://support.rollout.io/docs/javascript-browser-api#section-configurationfetchedhandler
+  configurationFetchedHandler?(fetcherResult: RoxFetcherResult): void;
+  debugLevel?: 'verbose';
+  // https://support.rollout.io/docs/javascript-browser-api#section-using-the-impressionhandler-option
+  impressionHandler?(reporting: RoxReporting, experiment: RoxExperiment, context: unknown): void;
+  platform?: string;
+  freeze?: RoxFlagFreezeLevel;
+  disableNetworkFetch?: boolean;
+  devModeSecret?: string;
+}
+
+export enum RoxFetcherStatus {
+  AppliedFromEmbedded = 'APPLIED_FROM_EMBEDDED',
+  AppliedFromCache = 'APPLIED_FROM_CACHE',
+  AppliedFromNetwork = 'APPLIED_FROM_NETWORK',
+  ErrorFetchFailed = 'ERROR_FETCH_FAILED'
+}
+
+export interface RoxFetcherResult {
+  fetcherStatus: RoxFetcherStatus;
+  creationDate: Date;
+  hasChanges: boolean;
+  errorDetails?: string;
+}
+
+export interface RoxReporting {
+  name: string;
+  value: string;
+}
+
+export interface RoxExperiment {
+  identifier: string; //  experiment id
+  name: string;
+  isArchived: boolean;
+  labels: string[]; // experiment's labels. assigned from dashboard
+}
+
+/**
+ * Note that you might have to call unfreeze after setting custom properties such as email after login
+ * https://support.rollout.io/docs/custom-properties
+ */
+export function setCustomNumberProperty(name: string, value: number | (() => number)): void;
+export function setCustomStringProperty(name: string, value: string | (() => string)): void;
+export function setCustomBooleanProperty(name: string, value: boolean | (() => boolean)): void;
+export function setDynamicCustomPropertyRule(
+  handler: (propName: string, context: unknown) => number | string | boolean
+): void;
+
+/**
+ * Unfreeze the state of all flags in code
+ * Calling this function will unfreeze all flags, and using a flag will return it’s most updated value
+ *
+ * https://support.rollout.io/docs/flags-update-flow#section-flag-unfreeze
+ * https://support.rollout.io/docs/javascript-browser-api#section-unfreeze
+ */
+export function unfreeze(namespace?: string): void;
+
+/**
+ * Pulls the latest configuration and flag values down from the Rollout servers
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section-fetch
+ */
+export function fetch(): Promise<unknown>;
+
+/**
+ * Opens the flag override view, providing a debug UI for the application's set of feature flags.
+ * https://support.rollout.io/docs/javascript-browser-api#section-showoverrides
+ */
+export function showOverrides(position?: RoxOverridesPosition): void;
+
+export enum RoxOverridesPosition {
+  TopLeft = 'top left',
+  TopRight = 'top right',
+  BottomLeft = 'bottom left',
+  BottomRight = 'bottom right'
+}
+
+/**
+ * Default is untilForeground
+ *
+ * https://support.rollout.io/docs/flags-update-flow#section-flag-freeze-level
+ */
+export enum RoxFlagFreezeLevel {
+  None = 'none',
+  UntilForeground = 'untilForeground',
+  UntilLaunch = 'untilLaunch'
+}
+
+export interface RoxFlagOptions {
+  freeze?: RoxFlagFreezeLevel;
+}
+
+/**
+ * Creates a new Flag
+ * https://support.rollout.io/docs/javascript-browser-api#section--rox-flag-
+ */
+export class Flag {
+  constructor(defaultValue?: boolean, options?: RoxFlagOptions);
+
+  // The name of the Flag
+  readonly name: string;
+
+  // Default value of the Flag
+  readonly defaultValue: boolean;
+
+  // Returns true when the flag is enabled
+  isEnabled(): boolean;
+
+  // Unlock the Flag value from changes from the last time it was freezed
+  unfreeze(): void;
+}
+
+/**
+ * Used to create and manage Rollout feature flags that determine different predefined values
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section--rox-variant-
+ */
+export class Variant<T extends string = string> {
+  constructor(defaultValue: T, options: ReadonlyArray<T>, name?: string);
+
+  // The name of the Variant
+  readonly name: string;
+
+  // Default value of the Variant
+  readonly defaultValue: BasicType<T>;
+
+  // Returns the current value of the Variant, accounting for value overrides
+  getValue(): BasicType<T>;
+
+  // Unlock the Variant value from changes from the last time it was freezed
+  unfreeze(): void;
+}
+
+/**
+ * manages a remote configuration setting with a value of type string, boolean, or number.
+ * The constructor sets the default value for the remote configuration setting
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section--rox-configuration-
+ */
+export class Configuration<T extends number | boolean | string> {
+  constructor(defaultValue: T);
+
+  // The name of the Configuration
+  readonly name: string;
+
+  // Default value of the Configuration
+  readonly defaultValue: BasicType<T>;
+
+  // Returns the current value of the Configuration, accounting for value overrides
+  getValue(): BasicType<T>;
+
+  // Unlock the Configuration value from changes from the last time it was freezed
+  unfreeze(): void;
+}
+
+/**
+ * Ensure that TypeScript properly types things with a basic type.
+ * For example, if T is true, returnedtype shall be boolean, not true
+ */
+type BasicType<T> = T extends boolean ? boolean : T extends number ? number : T extends string ? string : never;
+
+/**
+ * Override: Should only be used for development purposes (QA - Feature dev - e2e)
+ *
+ * When you override an existing flag value using the Rox.overrides.setOverride method,
+ * the SDK will disregard existing configuration coming from the dashboard and will
+ * serialize the override on disk this value will be loaded and override the flag
+ * right after you call Rox.setup. To clear the override from the cache you need to
+ * call the Rox.overrides.clearOverride method
+ *
+ * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-
+ */
+export interface RoxOverrides {
+  /**
+   * Sets an override value on a specific flag, this function accepts two parameters flag name (
+   * full flag name including namespace) and desired value (from type String).
+   * This function also saves the override value on the local device disk,
+   * so it is "remembered" for the next the SDK is loaded to production.
+   *
+   * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-setoverride-
+   *
+   * Note that for boolean flag we still give the value as a string.
+   */
+  setOverride(nameSpacedFlagName: string, value: string): void;
+
+  /**
+   * Clears the override value from the flag (and the disk).
+   *
+   * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-clearoverride-
+   */
+  clearOverride(nameSpacedFlagName: string): void;
+
+  /**
+   * Clears all override values
+   */
+  clearAllOverrides(): void;
+
+  getOriginalValue(nameSpacedFlagName: string): string;
+
+  /**
+   * full flag name including namespace
+   *
+   * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-hasoverride-
+   */
+  hasOverride(nameSpacedFlagName: string): boolean;
+}
+
+export const overrides: RoxOverrides;
+
+/**
+ * Dynamic API is an alternative to Rollout static API for defining flags on the
+ * different container objects and accessing them from that container object.
+ * https://support.rollout.io/docs/dynamic-api
+ */
+export class DynamicApi {
+  /**
+   * Getting boolean value of a flag
+   */
+  isEnabled(nameSpacedFlagName: string, defaultValue: boolean, context?: unknown): boolean;
+
+  /**
+   * Getting string value of a Variant flag
+   */
+  value(nameSpacedFlagName: string, defaultValue: string, context?: unknown): string;
+}
+
+export const dynamicApi: DynamicApi;
+
+export const flags: ReadonlyArray<Flag>;

--- a/types/rox-browser/index.d.ts
+++ b/types/rox-browser/index.d.ts
@@ -11,8 +11,6 @@
  *
  */
 
-export {};
-
 export interface RoxContainer {
   [key: string]: Flag | Configuration<any> | Variant;
 }
@@ -201,7 +199,7 @@ export class Configuration<T extends number | boolean | string> {
  * Ensure that TypeScript properly types things with a basic type.
  * For example, if T is true, returnedtype shall be boolean, not true
  */
-type BasicType<T> = T extends boolean ? boolean : T extends number ? number : T extends string ? string : never;
+export type BasicType<T> = T extends boolean ? boolean : T extends number ? number : T extends string ? string : never;
 
 /**
  * Override: Should only be used for development purposes (QA - Feature dev - e2e)

--- a/types/rox-browser/index.d.ts
+++ b/types/rox-browser/index.d.ts
@@ -214,7 +214,7 @@ type BasicType<T> = T extends boolean ? boolean : T extends number ? number : T 
  *
  * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-
  */
-export interface RoxOverrides {
+export namespace overrides {
   /**
    * Sets an override value on a specific flag, this function accepts two parameters flag name (
    * full flag name including namespace) and desired value (from type String).
@@ -225,49 +225,45 @@ export interface RoxOverrides {
    *
    * Note that for boolean flag we still give the value as a string.
    */
-  setOverride(nameSpacedFlagName: string, value: string): void;
+  function setOverride(nameSpacedFlagName: string, value: string): void;
 
   /**
    * Clears the override value from the flag (and the disk).
    *
    * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-clearoverride-
    */
-  clearOverride(nameSpacedFlagName: string): void;
+  function clearOverride(nameSpacedFlagName: string): void;
 
   /**
    * Clears all override values
    */
-  clearAllOverrides(): void;
+  function clearAllOverrides(): void;
 
-  getOriginalValue(nameSpacedFlagName: string): string;
+  function getOriginalValue(nameSpacedFlagName: string): string;
 
   /**
    * full flag name including namespace
    *
    * https://support.rollout.io/docs/javascript-browser-api#section--rox-overrides-hasoverride-
    */
-  hasOverride(nameSpacedFlagName: string): boolean;
+  function hasOverride(nameSpacedFlagName: string): boolean;
 }
-
-export const overrides: RoxOverrides;
 
 /**
  * Dynamic API is an alternative to Rollout static API for defining flags on the
  * different container objects and accessing them from that container object.
  * https://support.rollout.io/docs/dynamic-api
  */
-export class DynamicApi {
+export namespace dynamicApi {
   /**
    * Getting boolean value of a flag
    */
-  isEnabled(nameSpacedFlagName: string, defaultValue: boolean, context?: unknown): boolean;
+  function isEnabled(nameSpacedFlagName: string, defaultValue: boolean, context?: unknown): boolean;
 
   /**
    * Getting string value of a Variant flag
    */
-  value(nameSpacedFlagName: string, defaultValue: string, context?: unknown): string;
+  function value(nameSpacedFlagName: string, defaultValue: string, context?: unknown): string;
 }
-
-export const dynamicApi: DynamicApi;
 
 export const flags: ReadonlyArray<Flag>;

--- a/types/rox-browser/rox-browser-tests.ts
+++ b/types/rox-browser/rox-browser-tests.ts
@@ -1,0 +1,65 @@
+import * as Rox from 'rox-browser';
+
+const flags = {
+  superFlag: new Rox.Flag(false, { freeze: Rox.RoxFlagFreezeLevel.None }),
+  superFlag2: new Rox.Flag(),
+};
+
+const variants = {
+  superVariant: new Rox.Variant('value1', ['value1', 'value2']),
+};
+
+const configurations = {
+  superConfiguration: new Rox.Configuration('☀️'),
+  superConfiguration2: new Rox.Configuration(true),
+};
+
+// The register function should be called before the call to Rox.setup()
+Rox.register('default', { ...configurations, ...variants, ...flags });
+Rox.setContext({ user: 'John Doe' });
+Rox.setup('ROLLOUT_IO_KEY', {
+  impressionHandler,
+  configurationFetchedHandler,
+}).then(linkTargetGroupAttributes);
+
+Rox.showOverrides(Rox.RoxOverridesPosition.BottomLeft);
+
+Rox.dynamicApi.isEnabled('system.repotAnalytics', false);
+Rox.dynamicApi.value('ui.textColor', 'red');
+
+Rox.flags[0].defaultValue;
+Rox.flags[0].name;
+
+configurations.superConfiguration.defaultValue;
+configurations.superConfiguration.name;
+
+variants.superVariant.defaultValue;
+variants.superVariant.name;
+
+Rox.unfreeze();
+flags.superFlag.unfreeze();
+
+function linkTargetGroupAttributes() {
+  Rox.setCustomStringProperty('id', 'someId');
+  Rox.setCustomBooleanProperty('thisIsATest', true);
+  Rox.setCustomNumberProperty('aNumberProperty', 17);
+  Rox.setDynamicCustomPropertyRule((propName: string, _context: unknown) => {
+    return propName === 'myPropName';
+  });
+}
+
+function impressionHandler(
+  _reporting: Rox.RoxReporting,
+  _experiment?: Rox.RoxExperiment,
+) {
+  // If there is no experiment it means that the user has not been enrolled
+  // or that the reporting is not used yet
+}
+
+function configurationFetchedHandler(fetcherResult: Rox.RoxFetcherResult) {
+  if (
+    fetcherResult.hasChanges &&
+    fetcherResult.fetcherStatus === Rox.RoxFetcherStatus.AppliedFromCache
+  ) {
+  }
+}

--- a/types/rox-browser/tsconfig.json
+++ b/types/rox-browser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "rox-browser-tests.ts"
+    ]
+}

--- a/types/rox-browser/tslint.json
+++ b/types/rox-browser/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "file-name-casing": [true, "kebab-case"]
+    }
+}


### PR DESCRIPTION
rox-browser is the Javascript browser SDK for our https://rollout.io/ service.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
