### PR TITLE
fix(react-router): Failing with strictFunctionTypes

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -143,12 +143,8 @@ export interface WithRouterStatics<C extends React.ComponentType<any>> {
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<C extends React.ComponentType<RouteComponentProps>>(
-  component: C,
-): React.ComponentClass<
-  Omit<React.ComponentProps<C>, keyof RouteComponentProps> & WithRouterProps<C>,
-  never
-> &
-  WithRouterStatics<C>;
+export function withRouter<P extends RouteComponentProps<any>, C extends React.ComponentType<P>>(
+  component: C & React.ComponentType<P>,
+): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
 
 export const __RouterContext: React.Context<RouteComponentProps>;

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -13,8 +13,6 @@ const FunctionComponent: React.FunctionComponent<TOwnProps> = props => (
   <h2>Welcome {props.username}</h2>
 );
 
-declare const Component: React.ComponentType<TOwnProps>;
-
 class ComponentClass extends React.Component<TOwnProps> {
     render() {
         return <h2>Welcome {this.props.username}</h2>;
@@ -23,9 +21,14 @@ class ComponentClass extends React.Component<TOwnProps> {
 
 const WithRouterComponentFunction = withRouter(ComponentFunction);
 const WithRouterFunctionComponent = withRouter(FunctionComponent);
-const WithRouterComponent = withRouter(Component);
 const WithRouterComponentClass = withRouter(ComponentClass);
 WithRouterComponentClass.WrappedComponent; // $ExpectType typeof ComponentClass
+
+// Fix introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38326
+// caused more common use cases with `strictFunctionTypes` to fail
+// declare const Component: React.ComponentType<TOwnProps>;
+// $ExpectError ^3.6.3
+// const WithRouterComponent = withRouter(Component);
 
 const WithRouterTestFunction = () => (
     <WithRouterComponentFunction username="John" />


### PR DESCRIPTION
Resolves issues reported in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38271#issuecomment-532428873 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38326#issuecomment-532328360

I'll try to make sense of the current issue later in this text but TL;DR: The introduced bug reports have more upvotes than the fixed bug reports so we revert until we figure out what's happening.

I tried to fiddle around with the `withRouter` declaration but anything I tried created an error in a different version of TS with strictFunctionTypes.

The current issue is a result of `C & ComponentType<P>` which resolves (in the removed test case) to `FunctionComponent<P> | (Functioncomponent<P> & ComponentClass<P>)` which is probably a result of the intermediate distribution of `&` to `(FunctionComponent<P> & FunctionComponent<P>) | (FunctionComponent<P> & ComponentClass<P>) | (ComponentClass<P> & FunctionComponent<P>) | (FunctionComponent<P> & ComponentClass<P>)` which should be simplified to `FunctionComponent<P> | ComponentClass<P> | (FunctionComponent<P> | ComponentClass<P>)` but for some reason the `ComponentClass<P>` is dropped. Maybe TypeScript is using only the first part of the union and resolves the `C` in `C & ComponentType<P>` to `FunctionComponent<P> & ComponentType<P>` which would explain the result.