### PR TITLE
[dateFormat] Allow i18n to be changed.

### DIFF
--- a/types/dateformat/index.d.ts
+++ b/types/dateformat/index.d.ts
@@ -28,7 +28,7 @@ declare function dateFormat(mask?: string, utc?: boolean, gmt?: boolean): string
 
 declare namespace dateFormat {
     const masks: DateFormatMasks;
-    const i18n: DateFormatI18n;
+    let i18n: DateFormatI18n;
 
     /**
      * dateFormat.masks


### PR DESCRIPTION
The `i18n`-prop should be able to change, as it's described in the documentation as the way for changing the library language.
Since this is now defined as a const, Typescript indicates this as an invalid action.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://www.npmjs.com/package/dateformat#localization](https://www.npmjs.com/package/dateformat#localization)
