### PR TITLE
fix(node‑fetch): `fetch(…)` supports `URL`‑like objects

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -17,7 +17,7 @@ import { URLSearchParams, URL } from "url";
 import { AbortSignal } from "./externals";
 
 export class Request extends Body {
-    constructor(input: string | { href: string } | Request, init?: RequestInit);
+    constructor(input: RequestInfo, init?: RequestInit);
     clone(): Request;
     context: RequestContext;
     headers: Headers;
@@ -187,6 +187,10 @@ export interface ResponseInit {
     url?: string;
 }
 
+interface URLLike {
+    href: string;
+}
+
 export type HeadersInit = Headers | string[][] | { [key: string]: string };
 // HeaderInit is exported to support backwards compatibility. See PR #34382
 export type HeaderInit = HeadersInit;
@@ -196,7 +200,7 @@ export type BodyInit =
     | NodeJS.ReadableStream
     | string
     | URLSearchParams;
-export type RequestInfo = string | Request;
+export type RequestInfo = string | URLLike | Request;
 
 declare function fetch(
     url: RequestInfo,

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -80,6 +80,44 @@ function test_fetchUrlWithRequestObject() {
     handlePromise(fetch(request));
 }
 
+function test_fetchUrlObject() {
+    handlePromise(fetch(new URL("https://example.org")));
+}
+
+function test_fetchUrlObjectWithRequestObject() {
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        signal: {
+            aborted: false,
+
+            addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean,
+                once?: boolean,
+                passive?: boolean
+            }) => undefined,
+
+            removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean
+            }) => undefined,
+
+            dispatchEvent: (event: any) => false
+        }
+    };
+    const request: Request = new Request(
+        new URL("https://example.org"),
+        requestOptions
+    );
+    const timeout: number = request.timeout;
+    const size: number = request.size;
+    const agent: Agent | ((parsedUrl: URL) => Agent) | undefined = request.agent;
+    const protocol: string = request.protocol;
+
+    handlePromise(fetch(request));
+}
+
 function test_globalFetchVar() {
     fetch("http://test.com", {}).then(response => {
         // for test only


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ~~<https://github.com/liangxingchen/node-fetch-unix/blob/8ae665a16eecb7e0e2eeccc34e5b5cbb6a62055d/src/request.js#L70-L74>~~ <https://github.com/bitinn/node-fetch/blob/5535c2ed478d418969ecfd60c16453462de2a53f/src/request.js#L58-L62>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - Note that the currently published version should be for 2.6, because support for lazily‑evaluated Node HTTP `agent`s was only added in v2.6.0
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.