### PR TITLE
Adding ticks to scale-attribute on ChartOptions

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -246,7 +246,7 @@ declare namespace Chart {
         animation?: ChartAnimationOptions;
         elements?: ChartElementsOptions;
         layout?: ChartLayoutOptions;
-        scale?: { display?: boolean };
+        scale?: ChartScale;
         scales?: ChartScales;
         showLines?: boolean;
         spanGaps?: boolean;
@@ -576,6 +576,11 @@ declare namespace Chart {
         showLine?: boolean;
         stack?: string;
         spanGaps?: boolean;
+    }
+
+    interface ChartScale {
+        display?: boolean;
+        ticks?: TickOptions;
     }
 
     interface ChartScales {


### PR DESCRIPTION
Adding the ticks-property to the single scale property to ChartOptions. Please see https://www.chartjs.org/docs/latest/axes/radial/linear.html?h=scale%3A
This is needed in the radar-chart to set min and max values.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chartjs.org/docs/latest/axes/radial/linear.html?h=scale%3A
