### PR TITLE
mui-datatables: add searchPlaceholder property in MUIDataTableOptions

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -194,6 +194,7 @@ export interface MUIDataTableOptions {
     rowsExpanded?: any[];
     rowsSelected?: any[];
     search?: boolean;
+    searchPlaceholder?: string;
     searchText?: string;
     selectableRows?: SelectableRows;
     selectableRowsOnClick?: boolean;


### PR DESCRIPTION
table option was merged in release 2.10.0
https://github.com/gregnb/mui-datatables/pull/852

This merge adds the missing searchPlaceholder property to the MUIDataTableOptions interface.

Please fill in this template.

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ -- ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ X ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ -- ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
