### PR TITLE
[bittorrent-protocol] Fixes typo in `setTimeout` definition

### DIFF
--- a/types/bittorrent-protocol/index.d.ts
+++ b/types/bittorrent-protocol/index.d.ts
@@ -48,7 +48,7 @@ declare namespace BittorrentProtocol {
 
         setKeepAlive(enable: boolean): void;
 
-        setTimeot(ms: number, unref?: boolean): void;
+        setTimeout(ms: number, unref?: boolean): void;
 
         destroy(): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L106-L117