### PR TITLE
Update request-promise-native's `RequestPromise` for 2018 `Promise`

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/request/request-promise-native
 // Definitions by: Gustavo Henke <https://github.com/gustavohenke>
 //                 Matt R. Wilson <https://github.com/mastermatt>
+//                 Cory Reed <https://github.com/swashcap>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -9,9 +10,7 @@ import request = require('request');
 import http = require('http');
 
 declare namespace requestPromise {
-    interface RequestPromise<T = any> extends request.Request {
-        then: Promise<T>["then"];
-        catch: Promise<T>["catch"];
+    interface RequestPromise<T = any> extends request.Request, Promise<T> {
         promise(): Promise<T>;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

    This introduces a new method on `Promise`:
    
    https://github.com/microsoft/TypeScript/blob/1c20aa0b1abdfe60efa6cb08ad667f328daf74a8/lib/lib.es2018.promise.d.ts#L24-L32

    request-promise-native lacks this method. Here's a minimal reproduction:

    ```typescript
    import request from 'request-promise-native'

    interface Client {
      getData: () => Promise<{}>
    }

    const client: Client = {
      getData: () => request('http://httpbin.org/get')
    }
    ```

    This produces a compile error:

    ```shell
    src/index.ts:8:18 - error TS2739: Type 'RequestPromise<any>' is missing the following properties from type 'Promise<{}>': [Symbol.toStringTag], finally

    8   getData: () => request('http://httpbin.org/get')
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

      src/index.ts:4:12
        4   getData: () => Promise<{}>
                    ~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.


    Found 1 error.
    ```

    The 2018 `Promise` has a `finally` method. Making `RequestPromise` extend the built-in `Promise` ensures the type has the new method.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.