### PR TITLE
google-protobuf: adjust Message.clone[Message]()

### DIFF
--- a/types/google-protobuf/google-protobuf-tests.ts
+++ b/types/google-protobuf/google-protobuf-tests.ts
@@ -534,3 +534,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 15) != null;
   }
 };
+
+// ensures messages are cloneable without a redundant cast
+const myMessage: MySimple = new MySimple();
+const myClonedMessage: MySimple = myMessage.clone();
+const myClonedMessage2: MySimple = myMessage.cloneMessage()

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/google/google-protobuf
 // Definitions by: Marcus Longmuir <https://github.com/marcuslongmuir>
 //                 Chaitanya Kamatham <https://github.com/kamthamc>
+//                 Austin Bonander <https://github.com/abonander>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 type ByteSource = ArrayBuffer | Uint8Array | number[] | string;
@@ -110,8 +111,8 @@ export abstract class Message {
   static equals(m1: Message, m2: Message): boolean;
   static compareExtensions(extension1: {}, extension2: {}): boolean;
   static compareFields(field1: any, field2: any): boolean;
-  cloneMessage(): Message;
-  clone(): Message;
+  cloneMessage(): this;
+  clone(): this;
   static clone<T extends Message>(msg: T): T;
   static cloneMessage<T extends Message>(msg: T): T;
   static copyInto(fromMessage: Message, toMessage: Message): void;


### PR DESCRIPTION
Returning [the polymorphic `this` type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#polymorphic-this-types) ensures calling `.clone()` or `.cloneMessage()` on a subclass instance doesn't require a redundant cast.

These methods actually return the same type as the method receiver, because the implementation uses the constructor from `this` to make a new object: https://github.com/protocolbuffers/protobuf/blob/3.7.x/js/message.js#L1672

This should be a mostly backwards-compatible change, although this is a breaking change for subclasses that override these methods with the old signature or a signature that was otherwise compatible with the old one. 

----
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)
- [ ] (N/A) ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [ ] (N/A) ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~