### PR TITLE
[@babel/generator] Updated GeneratorOptions types for ^7.6.0.

### DIFF
--- a/types/babel__generator/babel__generator-tests.ts
+++ b/types/babel__generator/babel__generator-tests.ts
@@ -10,14 +10,20 @@ ast.loc!.start;
 
 const output = generate(ast, { /* options */ }, code);
 
-// Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-generator
-const result = generate(ast, {
+// Example (originally) from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-generator
+const result = generate(
+  ast,
+  {
     retainLines: false,
-    compact: "auto",
+    compact: 'auto',
     concise: false,
-    quotes: "double",
+    jsescOption: {
+      quotes: 'double',
+    },
     jsonCompatibleStrings: true,
     // ...
-}, code);
+  },
+  code,
+);
 result.code;
 result.map;

--- a/types/babel__generator/index.d.ts
+++ b/types/babel__generator/index.d.ts
@@ -1,12 +1,13 @@
-// Type definitions for @babel/generator 7.0
+// Type definitions for @babel/generator 7.6
 // Project: https://github.com/babel/babel/tree/master/packages/babel-generator, https://babeljs.io
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Johnny Estilles <https://github.com/johnnyestilles>
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
+//                 Cameron Yan <https://github.com/khell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import * as t from "@babel/types";
+import * as t from '@babel/types';
 
 export interface GeneratorOptions {
     /**
@@ -33,6 +34,12 @@ export interface GeneratorOptions {
     retainLines?: boolean;
 
     /**
+     * Retain parens around function expressions (could be used to change engine parsing behavior)
+     * Defaults to `false`.
+     */
+    retainFunctionParens?: boolean;
+
+    /**
      * Should comments be included in output? Defaults to `true`.
      */
     comments?: boolean;
@@ -40,7 +47,7 @@ export interface GeneratorOptions {
     /**
      * Set to true to avoid adding whitespace for formatting. Defaults to the value of `opts.minified`.
      */
-    compact?: boolean | "auto";
+    compact?: boolean | 'auto';
 
     /**
      * Should the output be minified. Defaults to `false`.
@@ -53,11 +60,6 @@ export interface GeneratorOptions {
     concise?: boolean;
 
     /**
-     * The type of quote to use in the output. If omitted, autodetects based on `ast.tokens`.
-     */
-    quotes?: "single" | "double";
-
-    /**
      * Used in warning messages
      */
     filename?: string;
@@ -66,11 +68,6 @@ export interface GeneratorOptions {
      * Enable generating source maps. Defaults to `false`.
      */
     sourceMaps?: boolean;
-
-    /**
-     * The filename of the generated code that the source map will be associated with.
-     */
-    sourceMapTarget?: string;
 
     /**
      * A root for all relative URLs in the source map.
@@ -87,6 +84,28 @@ export interface GeneratorOptions {
      * Set to true to run jsesc with "json": true to print "\u00A9" vs. "©";
      */
     jsonCompatibleStrings?: boolean;
+
+    /**
+     * Set to true to enable support for experimental decorators syntax before module exports.
+     * Defaults to `false`.
+     */
+    decoratorsBeforeExport?: boolean;
+
+    /**
+     * Options for outputting jsesc representation.
+     */
+    jsescOption?: {
+        /**
+         * The type of quote to use in the output. If omitted, autodetects based on `ast.tokens`.
+         */
+        quotes?: 'single' | 'double';
+
+        /**
+         * When enabled, the output is a valid JavaScript string literal wrapped in quotes. The type of quotes can be specified through the quotes setting.
+         * Defaults to `true`.
+         */
+        wrap?: boolean;
+    };
 }
 
 export class CodeGenerator {
@@ -101,7 +120,11 @@ export class CodeGenerator {
  * @param code - the original source code, used for source maps.
  * @returns - an object containing the output code and source map.
  */
-export default function generate(ast: t.Node, opts?: GeneratorOptions, code?: string | { [filename: string]: string; }): GeneratorResult;
+export default function generate(
+    ast: t.Node,
+    opts?: GeneratorOptions,
+    code?: string | { [filename: string]: string },
+): GeneratorResult;
 
 export interface GeneratorResult {
     code: string;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/master/packages/babel-generator/src/index.js#L38
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
