### PR TITLE
Express: use generics for Request

### DIFF
--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,6 +1,6 @@
 import express = require('express');
 import * as http from 'http';
-import { RequestRanges, ParamsArray } from 'express-serve-static-core';
+import { Request, RequestRanges, ParamsArray } from 'express-serve-static-core';
 
 namespace express_tests {
     const app = express();
@@ -131,8 +131,32 @@ namespace express_tests {
         req.params.length; // $ExpectType number
     });
 
+    // Params can used as an array
+    router.get('/*', (req: Request<ParamsArray>) => {
+        req.params[0]; // $ExpectType string
+        req.params.length; // $ExpectType number
+    });
+
+    // Params can used as an array
+    router.get('/*', (req: express.Request<ParamsArray>) => {
+        req.params[0]; // $ExpectType string
+        req.params.length; // $ExpectType number
+    });
+
     // Params can be a custom type that conforms to constraint
     router.get<{ foo: string }>('/:foo', req => {
+        req.params.foo; // $ExpectType string
+        req.params.bar; // $ExpectError
+    });
+
+    // Params can be a custom type that conforms to constraint
+    router.get('/:foo', (req: Request<{ foo: string }>) => {
+        req.params.foo; // $ExpectType string
+        req.params.bar; // $ExpectError
+    });
+
+    // Params can be a custom type that conforms to constraint
+    router.get('/:foo', (req: express.Request<{ foo: string }>) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectError
     });

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -86,17 +86,17 @@ declare namespace e {
     interface Application extends core.Application { }
     interface CookieOptions extends core.CookieOptions { }
     interface Errback extends core.Errback { }
-    interface ErrorRequestHandler extends core.ErrorRequestHandler { }
+    interface ErrorRequestHandler<P extends core.Params = core.ParamsDictionary> extends core.ErrorRequestHandler<P> { }
     interface Express extends core.Express { }
     interface Handler extends core.Handler { }
     interface IRoute extends core.IRoute { }
-    interface IRouter<T> extends core.IRouter { }
+    interface IRouter extends core.IRouter { }
     interface IRouterHandler<T> extends core.IRouterHandler<T> { }
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
-    interface Request extends core.Request { }
-    interface RequestHandler extends core.RequestHandler { }
+    interface Request<P extends core.Params = core.ParamsDictionary> extends core.Request<P> { }
+    interface RequestHandler<P extends core.Params = core.ParamsDictionary> extends core.RequestHandler<P> { }
     interface RequestParamHandler extends core.RequestParamHandler { }
     export interface Response extends core.Response { }
     interface Router extends core.Router { }

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Express 4.17
 // Project: http://expressjs.com
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
+//                 China Medical University Hospital <https://github.com/CMUH>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -1,5 +1,6 @@
 import StorageBase, { Image, ReadOptions } from 'ghost-storage-base';
 import { Request, Response, NextFunction } from 'express';
+import { Params } from 'express-serve-static-core';
 
 class MyCustomAdapter extends StorageBase {
     constructor() {
@@ -15,7 +16,7 @@ class MyCustomAdapter extends StorageBase {
     }
 
     serve() {
-        return (req: Request, res: Response, next: NextFunction) => next();
+        return (req: Request<Params>, res: Response, next: NextFunction) => next();
     }
 
     async delete(fileName: string, targetDir?: string) {
@@ -41,5 +42,5 @@ storage.getSanitizedFileName('IMAGE.jpg'); // $ExpectType string
 
 storage.exists('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>
 storage.save(image, '/'); // $ExpectType Promise<string>
-storage.serve(); // $ExpectType (req: Request, res: Response, next: NextFunction) => void
+storage.serve(); // $ExpectType (req: Request<Params>, res: Response, next: NextFunction) => void
 storage.delete('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>

--- a/types/i18n-abide/i18n-abide-tests.ts
+++ b/types/i18n-abide/i18n-abide-tests.ts
@@ -11,9 +11,9 @@ const fullAbideOptions: i18n.AbideOptions = {
     logger: { warn(msg: string) {}, error(msg: string) {} },
 };
 
-i18n.abide(); // $ExpectType RequestHandler
-i18n.abide(emptyAbideOptions); // $ExpectType RequestHandler
-i18n.abide(fullAbideOptions); // $ExpectType RequestHandler
+i18n.abide(); // $ExpectType RequestHandler<Dictionary<string>>
+i18n.abide(emptyAbideOptions); // $ExpectType RequestHandler<Dictionary<string>>
+i18n.abide(fullAbideOptions); // $ExpectType RequestHandler<Dictionary<string>>
 
 i18n.parseAcceptLanguage(""); // $ExpectType { lang: string; quality: number; }[]
 

--- a/types/lasso/lasso-tests.ts
+++ b/types/lasso/lasso-tests.ts
@@ -199,10 +199,10 @@ transforms.createTransformer([], new LassoContext(), (err, result) => {});
 
 // Middleware tests
 
-// $ExpectType RequestHandler
+// $ExpectType RequestHandler<Dictionary<string>>
 serveStatic();
 
-// $ExpectType RequestHandler
+// $ExpectType RequestHandler<Dictionary<string>>
 serveStatic({
     lasso,
     sendOptions: {}


### PR DESCRIPTION
In #37718, that missed to export generics for Request, so we must use `Resuest` in `@type/express-serve-static-core` not `@type/express`.

This PR like a syntax sugar to use this easily.

``` typescript
// Example Code
import { Request } from 'express';
//import { Request } from 'express-serve-static-core';

app.get('/:id', (req: Request<{id: int}>) => {
    // do something here.
});
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (#37502)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. 

