### PR TITLE
fix(node): replace reserved identifier in a function parameter

### DIFF
--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -127,7 +127,7 @@ declare module "readline" {
 
     function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
     function createInterface(options: ReadLineOptions): Interface;
-    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: Interface): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, readlineInterface?: Interface): void;
 
     type Direction = -1 | 0 | 1;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [--] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

In this PR, I replaced a parameter name `interface` occuring in `require('readline').emitKeypressEvents` to `readlineInterface`.
Since `interface` is a reserved keyword in JS strict mode, having it as a parameter name of `readline.emitKeypressEvents` can cause problems. For example, I use tsickle to convert the declaration files to Closure Compiler externs files, and having `interface` causes Closure Compiler to throw errors while parsing the generated externs file.