### PR TITLE
Add definitions for spectrogram@0.0.7

### DIFF
--- a/types/spectrogram/index.d.ts
+++ b/types/spectrogram/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for spectrogram 0.0
+// Project: https://github.com/miguelmota/spectrogram/
+// Definitions by: AppLover69 <https://github.com/AppLover69>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+interface SpectrogramOptions {
+    canvas?: {
+        width?: HTMLCanvasElement['width'] | (() => HTMLCanvasElement['width']);
+        height?: HTMLCanvasElement['height'] | (() => HTMLCanvasElement['height']);
+    };
+    audio?: {
+        enable?: boolean;
+    };
+    colors?: (steps: number) => Array<CanvasRenderingContext2D['fillStyle']>;
+}
+
+interface Spectrogram {
+    connectSource(audioBuffer: AudioBuffer, audioContext?: AudioContext): void;
+    connectSource(analyserNode: AnalyserNode, audioContext: AudioContext): void;
+    start(offset?: number): void;
+    stop(): void;
+    pause(): void;
+    resume(): void;
+    clear(canvasContext: CanvasRenderingContext2D): void;
+}
+
+interface SpectrogramConstructor {
+    (canvas: HTMLCanvasElement, options: SpectrogramOptions): Spectrogram;
+    new(canvas: HTMLCanvasElement, options: SpectrogramOptions): Spectrogram;
+}
+
+declare var Spectrogram: SpectrogramConstructor;
+export = Spectrogram;

--- a/types/spectrogram/spectrogram-tests.ts
+++ b/types/spectrogram/spectrogram-tests.ts
@@ -1,0 +1,73 @@
+import * as Spectrogram from "spectrogram";
+
+// XHR
+const canvas1 = document.createElement('canvas');
+const spectro1 = Spectrogram(canvas1, {
+    audio: {
+        enable: false,
+    },
+});
+const audioContext1 = new AudioContext();
+const request = new XMLHttpRequest();
+request.open('GET', 'audio.mp3', true);
+request.responseType = 'arraybuffer';
+
+request.onload = () => {
+    audioContext1.decodeAudioData(request.response, (buffer) => {
+        spectro1.connectSource(buffer, audioContext1);
+        spectro1.start();
+    });
+};
+
+request.send();
+
+// User media stream
+const canvas2 = document.createElement('canvas');
+const spectro2 = new Spectrogram(canvas2, {
+    canvas: {
+        width: 1280,
+        height: 720,
+    },
+    colors: (steps) => {
+        const frequency = Math.PI / steps;
+        const amplitude = 127;
+        const center = 128;
+        const slice = (Math.PI / 2) * 3.1;
+        const colors = [];
+
+        function toRGBString(v: number) {
+            return `rgba(${[v, v, v, 1].toString()})`;
+        }
+
+        for (let i = 0; i < steps; i++) {
+            const v = (Math.sin((frequency * i) + slice) * amplitude + center) >> 0;
+
+            colors.push(toRGBString(v));
+        }
+
+        return colors;
+    }
+});
+
+const audioContext2 = new AudioContext();
+navigator.getUserMedia(
+    {
+        video: false,
+        audio: true
+    },
+    (stream) => {
+        const input = audioContext2.createMediaStreamSource(stream);
+        const analyser = audioContext2.createAnalyser();
+
+        analyser.smoothingTimeConstant = 0;
+        analyser.fftSize = 2048;
+
+        input.connect(analyser);
+
+        spectro2.connectSource(analyser, audioContext2);
+        spectro2.start();
+    },
+    (error) => {
+        spectro2.stop();
+    },
+);

--- a/types/spectrogram/tsconfig.json
+++ b/types/spectrogram/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "spectrogram-tests.ts"
+    ]
+}

--- a/types/spectrogram/tslint.json
+++ b/types/spectrogram/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
