### PR TITLE
Fixed a compile error in c3 typings

### DIFF
--- a/types/c3/index.d.ts
+++ b/types/c3/index.d.ts
@@ -739,10 +739,6 @@ export interface YAxisConfigurationWithTime extends YAxisConfiguration {
 
 export interface TickConfiguration {
     /**
-     * A function to format tick value. Format string is also available for timeseries data.
-     */
-    format?: string | ((x: number | Date) => string | number);
-    /**
      * Show x axis outer tick.
      */
     outer?: boolean;
@@ -765,31 +761,38 @@ export interface TickConfiguration {
 }
 
 export interface XTickConfiguration extends TickConfiguration {
-    /**
-     * Centerise ticks on category axis
-     */
-    centered?: boolean;
-    /**
-     * Setting for culling ticks.
-     * If `true` is set, the ticks will be culled, then only limitted tick text will be shown. This option does not hide the tick lines. If `false` is set, all of ticks will be shown.
-     */
-    culling?: boolean | {
+  /**
+   * A function to format tick value. Format string is also available for timeseries data.
+   */
+  format?: string | ((x: number | Date) => string | number);
+
+  /**
+   * Centerise ticks on category axis
+   */
+  centered?: boolean;
+  /**
+   * Setting for culling ticks.
+   * If `true` is set, the ticks will be culled, then only limitted tick text will be shown. This option does not hide the tick lines. If `false` is set, all of ticks will be shown.
+   */
+  culling?:
+    | boolean
+    | {
         /**
          * The number of tick texts will be adjusted to less than this value.
          */
         max: number;
-    };
-    /**
-     * Fit x axis ticks.
-     * If `true` set, the ticks will be positioned nicely. If `false` set, the ticks will be positioned according to x value of the data points.
-     */
-    fit?: boolean;
-    /**
-     * Set width of x axis tick.
-     */
-    width?: number;
-    multiline?: boolean;
-    multilineMax?: number;
+      };
+  /**
+   * Fit x axis ticks.
+   * If `true` set, the ticks will be positioned nicely. If `false` set, the ticks will be positioned according to x value of the data points.
+   */
+  fit?: boolean;
+  /**
+   * Set width of x axis tick.
+   */
+  width?: number;
+  multiline?: boolean;
+  multilineMax?: number;
 }
 
 export interface YTickConfiguration extends TickConfiguration {

--- a/types/c3/index.d.ts
+++ b/types/c3/index.d.ts
@@ -761,42 +761,47 @@ export interface TickConfiguration {
 }
 
 export interface XTickConfiguration extends TickConfiguration {
-  /**
-   * A function to format tick value. Format string is also available for timeseries data.
-   */
-  format?: string | ((x: number | Date) => string | number);
+    /**
+     * A function to format x-axis tick values. A format string is also supported for timeseries data.
+     */
+    format?: string | ((x: number | Date) => string | number);
 
-  /**
-   * Centerise ticks on category axis
-   */
-  centered?: boolean;
-  /**
-   * Setting for culling ticks.
-   * If `true` is set, the ticks will be culled, then only limitted tick text will be shown. This option does not hide the tick lines. If `false` is set, all of ticks will be shown.
-   */
-  culling?:
-    | boolean
-    | {
-        /**
-         * The number of tick texts will be adjusted to less than this value.
-         */
-        max: number;
-      };
-  /**
-   * Fit x axis ticks.
-   * If `true` set, the ticks will be positioned nicely. If `false` set, the ticks will be positioned according to x value of the data points.
-   */
-  fit?: boolean;
-  /**
-   * Set width of x axis tick.
-   */
-  width?: number;
-  multiline?: boolean;
-  multilineMax?: number;
+    /**
+     * Centerise ticks on category axis
+     */
+    centered?: boolean;
+    /**
+     * Setting for culling ticks.
+     * If `true` is set, the ticks will be culled, then only limitted tick text will be shown.
+     * This option does not hide the tick lines. If `false` is set, all of ticks will be shown.
+     */
+    culling?:
+      | boolean
+      | {
+          /**
+           * The number of tick texts will be adjusted to less than this value.
+           */
+          max: number;
+        };
+    /**
+     * Fit x axis ticks.
+     * If `true` set, the ticks will be positioned nicely. If `false` set, the ticks will be positioned
+     * according to x value of the data points.
+     */
+    fit?: boolean;
+    /**
+     * Set width of x axis tick.
+     */
+    width?: number;
+    multiline?: boolean;
+    multilineMax?: number;
 }
 
 export interface YTickConfiguration extends TickConfiguration {
-    format: (x: number) => string;
+    /**
+     * A function to format y-axis tick values.
+     */
+    format?: (x: number) => string | number;
 }
 
 export interface YTickConfigurationWithTime extends YTickConfiguration {


### PR DESCRIPTION
Please fill in this template.

- [**x**] Test the change in your own code. (Compile and run.)
- [**N/A**] Add or edit tests to reflect the change. (Run with `npm test`.)
- [**x**] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A - compile failed for typings using typescript 3.6.3 - the PR is a bug fix that does not alter the typings any other way than fix this bug**
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.