### PR TITLE
[multer][update] move preservePath property to its parent object

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -43,9 +43,9 @@ declare namespace multer {
             parts?: number;
             /** For multipart forms, the max number of header key=> value pairs to parse Default: 2000(same as node's http). */
             headerPairs?: number;
-            /** Keep the full path of files instead of just the base name (Default: false) */
-            preservePath?: boolean;
         };
+        /** Keep the full path of files instead of just the base name (Default: false) */
+        preservePath?: boolean;
         /** A function to control which files to upload and which to skip. */
         fileFilter?(req: Express.Request, file: Express.Multer.File, callback: (error: Error | null, acceptFile: boolean) => void): void;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/multer#multeropts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Additional comment:

This property had been added two years ago (#17037) to the wrong object (`options.limits`) instead of the right one (`options`) as you can check in either the [README.md](https://github.com/expressjs/multer/blob/v1.3.0/README.md#multeropts) or its [implementation](https://github.com/expressjs/multer/blob/v1.3.0/lib/make-middleware.js#L26).

This change applies to both version 1.3.0 or greater and future releases.