### PR TITLE
[puppeteer] Update definitions to 1.20.0

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for puppeteer 1.19
+// Type definitions for puppeteer 1.20
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Christopher Deutsch <https://github.com/cdeutsch>
 //                 Konstantin Simon Maria Möllers <https://github.com/ksm2>
 //                 Simon Schick <https://github.com/SimonSchick>
 //                 Serban Ghita <https://github.com/SerbanGhita>
+//                 Dave Cardwell <https://github.com/davecardwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -220,7 +221,7 @@ export interface Evalable {
   ): Promise<WrapElementHandle<R>>;
 }
 
-export interface JSEvalable {
+export interface JSEvalable<A = any> {
     /**
      * Evaluates a function in the browser context.
      * If the function, passed to the frame.evaluate, returns a Promise, then frame.evaluate would wait for the promise to resolve and return its value.
@@ -228,7 +229,7 @@ export interface JSEvalable {
      * @param fn Function to be evaluated in browser context
      * @param args Arguments to pass to `fn`
      */
-    evaluate<T extends EvaluateFn>(
+    evaluate<T extends EvaluateFn<A>>(
       pageFunction: T,
       ...args: SerializableOrJSHandle[],
     ): Promise<EvaluateFnReturnType<T>>;
@@ -240,7 +241,7 @@ export interface JSEvalable {
      * @param args Arguments to pass to `fn`
      */
     evaluateHandle(
-      pageFunction: (...args: any[]) => any,
+      pageFunction: (arg1: A, ...args: any[]) => any,
       ...args: SerializableOrJSHandle[],
     ): Promise<JSHandle>;
   }
@@ -516,7 +517,7 @@ export interface EmulateOptions {
   userAgent?: string;
 }
 
-export type EvaluateFn = string | ((...args: any[]) => any);
+export type EvaluateFn<T = any> = string | ((arg1: T, ...args: any[]) => any);
 export type EvaluateFnReturnType<T extends EvaluateFn> = T extends ((...args: any[]) => infer R) ? R : any;
 
 export type LoadEvent =
@@ -759,7 +760,7 @@ export interface Worker extends JSEvalable {
 /**
  * Represents an in-page DOM element. ElementHandles can be created with the page.$ method.
  */
-export interface ElementHandle<E extends Element = Element> extends JSHandle, Evalable {
+export interface ElementHandle<E extends Element = Element> extends JSHandle<E>, Evalable {
   /**
    * The method runs element.querySelector within the page.
    * If no element matches the selector, the return value resolve to null.
@@ -829,6 +830,14 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle, Ev
   screenshot(options?: BinaryScreenShotOptions): Promise<Buffer>;
   screenshot(options?: ScreenshotOptions): Promise<string | Buffer>;
   /**
+   * Triggers a change and input event once all the provided options have been selected. If there's no <select> element
+   * matching selector, the method throws an error.
+   * @param values Values of options to select. If the <select> has the multiple attribute, all values are considered, otherwise only the first one is taken into account.
+   * @returns An array of option values that have been successfully selected.
+   * @since 1.12.0
+   */
+  select(...values: string[]): Promise<string[]>;
+  /**
    * This method scrolls element into view if needed, and then uses touchscreen.tap to tap in the center of the element.
    * If the element is detached from DOM, the method throws an error.
    */
@@ -853,7 +862,7 @@ export interface ExecutionContext extends JSEvalable {
 }
 
 /** JSHandle represents an in-page JavaScript object. */
-export interface JSHandle {
+export interface JSHandle<T = any> extends JSEvalable<T> {
   /**
    * Returns a ElementHandle
    */

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -663,3 +663,23 @@ puppeteer.launch().then(async browser => {
   const isMultiple: boolean = fileChooser.isMultiple();
   await fileChooser.accept(['/foo/bar']);
 });
+
+// .evaluate and .evaluateHandle on ElementHandle and JSHandle, and elementHandle.select
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  const elementHandle = (await page.$('.something')) as puppeteer.ElementHandle<HTMLDivElement>;
+  elementHandle.evaluate(element => {
+    element; // $ExpectType HTMLDivElement
+  });
+  elementHandle.evaluateHandle(element => {
+    element; // $ExpectType HTMLDivElement
+  });
+
+  const jsHandle = await page.evaluateHandle(() => 'something');
+  jsHandle.evaluate(obj => {});
+  jsHandle.evaluateHandle(handle => {});
+
+  const selected: string[] = await elementHandle.select('a', 'b', 'c');
+})();


### PR DESCRIPTION
Definitions updated for v1.20.0. Modified the existing `JSEvalable`/`EvaluateFn` definitions to support a first argument with a known type.

When I run `npm run lint puppeteer` I do get an error:
> ERROR: 1:1  npm-naming  d.ts file must have a matching npm package.

However, I can’t see anything wrong with my definition and I see the same error on master before my changes, so… 🤷‍♂️

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/releases/tag/v1.20.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.