### PR TITLE
[ramda] accurate merge types

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -542,17 +542,13 @@
 /// <reference path="./src/zipWith.d.ts" />
 /// <reference path="./src/includes.d.ts" />
 
-import { A, F, T } from "ts-toolbelt";
+import { A, F, T, O } from "ts-toolbelt";
 
 declare let R: R.Static;
 
 declare namespace R {
     import ValueOfRecord = Tools.ValueOfRecord;
     type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
-
-    type CommonKeys<T1, T2> = keyof T1 & keyof T2;
-    type PropsThatAreObjects<T, K extends keyof T> = K extends keyof T ? T[K] extends object ? K : never : never;
-    type CommonPropsThatAreObjects<T1, T2> = PropsThatAreObjects<T1, keyof T1> & PropsThatAreObjects<T2, keyof T2>;
 
     type Ord = number | string | boolean | Date;
 
@@ -780,11 +776,6 @@ declare namespace R {
         (x: any) => any,
         (x: V0) => any
     ];
-
-    type Merge<Primary, Secondary> = { [K in keyof Primary]: Primary[K] } & { [K in Exclude<keyof Secondary, CommonKeys<Primary, Secondary>>]: Secondary[K] };
-    type MergeDeep<Primary, Secondary> = { [K in CommonPropsThatAreObjects<Primary, Secondary>]: MergeDeep<Primary[K], Secondary[K]> } &
-        { [K in Exclude<keyof Primary, CommonPropsThatAreObjects<Primary, Secondary>>]: Primary[K] } &
-        { [K in Exclude<keyof Secondary, CommonKeys<Primary, Secondary>>]: Secondary[K] };
 
     interface AssocPartialOne<K extends keyof any> {
         <T>(val: T): <U>(obj: U) => Record<K, T> & U;
@@ -1854,10 +1845,10 @@ declare namespace R {
          *
          * @deprecated since 0.26 in favor of mergeRight
          */
-        merge<T2>(__: Placeholder, b: T2): <T1>(a: T1) => Merge<T2, T1>;
-        merge(__: Placeholder): <T1, T2>(b: T2, a: T1) => Merge<T2, T1>;
-        merge<T1, T2>(a: T1, b: T2): Merge<T2, T1>;
-        merge<T1>(a: T1): <T2>(b: T2) => Merge<T2, T1>;
+        merge<T2 extends object>(__: Placeholder, b: T2): <T1 extends object>(a: T1) => O.MergeUp<T2, T1>;
+        merge(__: Placeholder): <T1 extends object, T2 extends object>(b: T2, a: T1) => O.MergeUp<T2, T1>;
+        merge<T1 extends object, T2 extends object>(a: T1, b: T2): O.MergeUp<T2, T1>;
+        merge<T1 extends object>(a: T1): <T2 extends object>(b: T2) => O.MergeUp<T2, T1>;
 
         /**
          * Merges a list of objects together into one object.
@@ -1871,8 +1862,8 @@ declare namespace R {
          * and both values are objects, the two values will be recursively merged
          * otherwise the value from the first object will be used.
          */
-        mergeDeepLeft<T1, T2>(a: T1, b: T2): MergeDeep<T1, T2>;
-        mergeDeepLeft<T1>(a: T1): <T2>(b: T2) => MergeDeep<T1, T2>;
+        mergeDeepLeft<T1 extends object, T2 extends object>(a: T1, b: T2): O.MergeUp<T1, T2, 'deep'>;
+        mergeDeepLeft<T1 extends object>(a: T1): <T2 extends object>(b: T2) => O.MergeUp<T1, T2, 'deep'>;
 
         /**
          * Creates a new object with the own properties of the first object merged with the own properties of the second object.
@@ -1880,8 +1871,8 @@ declare namespace R {
          * and both values are objects, the two values will be recursively merged
          * otherwise the value from the second object will be used.
          */
-        mergeDeepRight<A, B>(a: A, b: B): MergeDeep<B, A>;
-        mergeDeepRight<A>(a: A): <B>(b: B) => MergeDeep<B, A>;
+        mergeDeepRight<A extends object, B extends object>(a: A, b: B): O.MergeUp<B, A>;
+        mergeDeepRight<A extends object>(a: A): <B extends object>(b: B) => O.MergeUp<B, A>;
 
         /**
          * Creates a new object with the own properties of the two provided objects. If a key exists in both objects:
@@ -1908,15 +1899,15 @@ declare namespace R {
          * Create a new object with the own properties of the first object merged with the own properties of the second object.
          * If a key exists in both objects, the value from the first object will be used.
          */
-        mergeLeft<T1, T2>(a: T1, b: T2): Merge<T1, T2>;
-        mergeLeft<T1>(a: T1): <T2>(b: T2) => Merge<T1, T2>;
+        mergeLeft<T1 extends object, T2 extends object>(a: T1, b: T2): O.MergeUp<T1, T2>;
+        mergeLeft<T1 extends object>(a: T1): <T2 extends object>(b: T2) => O.MergeUp<T1, T2>;
 
         /**
          * Create a new object with the own properties of the first object merged with the own properties of the second object.
          * If a key exists in both objects, the value from the second object will be used.
          */
-        mergeRight<T1, T2>(a: T1, b: T2): Merge<T2, T1>;
-        mergeRight<T1>(a: T1): <T2>(b: T2) => Merge<T2, T1>;
+        mergeRight<T1 extends object, T2 extends object>(a: T1, b: T2): O.MergeUp<T2, T1>;
+        mergeRight<T1 extends object>(a: T1): <T2 extends object>(b: T2) => O.MergeUp<T2, T1>;
 
         /**
          * Creates a new object with the own properties of the two provided objects. If a key exists in both objects,

--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "ts-toolbelt": "^3.8.75"
+        "ts-toolbelt": "^4.0.0"
     }
 }


### PR DESCRIPTION
This PR brings good comfort to the user by integrating a smarter `MergeUp` type that is able to handle optionals and preserve the type integrity. Here's an example:

```ts
const user: {
    name?: string
    age: number
    email: string
    extra: {
        ccn?: string
        cvv?: string
    }
} = {
    age  : 25,
    email: "jane@doe.com",
    extra: {}
};

const userUpdate: {
    name: string
    extra: {
        ccn: string
        cvv?: number
    }
} =  {
    name: "Jane Doe",
    extra: {
        ccn: "546545468745654",
        cvv: 123
    }
};

const userUpdated = R.mergeDeepLeft(user, userUpdate);

// this is what is computes now
type userUpdatedNew = {
    name: string;
    age: number;
    email: string;
    extra: {
        ccn: string;
        ccv?: string | number;
    };
}

// this is what it did before
type userUpdatedOld = {
    extra: {
        ccn: string | undefined;
        cvv: string | undefined;
    };
    name: string | undefined;
    age: number;
    email: string;
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
