### PR TITLE
algoliasearch: SecuredApiOptions can contain any search parameter

### DIFF
--- a/types/algoliasearch/algoliasearch-tests.ts
+++ b/types/algoliasearch/algoliasearch-tests.ts
@@ -62,6 +62,15 @@ let _algoliaSecuredApiOptions: SecuredApiOptions = {
     userToken: '',
 };
 
+let _algoliaSecuredApiOptionsAdvanced: SecuredApiOptions = {
+  filters: '',
+  validUntil: 0,
+  restrictIndices: ['', ''],
+  userToken: '',
+  attributesToRetrieve: ['foo', 'bar'],
+  restrictSearchableAttributes: [''],
+};
+
 let _algoliaIndexSettings: IndexSettings = {
     attributesToIndex: [''],
     attributesForFaceting: [''],

--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -12,6 +12,7 @@
 //                 Peter Esenwa <https://github.com/PeterEsenwa>
 //                 Samuel Bodin <https://github.com/bodinsamuel>
 //                 Richard Scotten <https://github.com/rscotten>
+//                 Chris Moyer <https://github.com/kopertio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -998,8 +999,10 @@ declare namespace algoliasearch {
   }
   /**
    * Describes the options used when generating new api keys
+   * 
+   * @see https://www.algolia.com/doc/api-reference/api-methods/generate-secured-api-key/
    */
-  interface SecuredApiOptions {
+  interface SecuredApiOptions extends QueryParameters {
     /**
      * Filter the query with numeric, facet or/and tag filters
      * default: ""
@@ -1012,7 +1015,7 @@ declare namespace algoliasearch {
     /**
      * Restricts the key to a list of index names allowed for the secured API key
      */
-    restrictIndices?: string;
+    restrictIndices?: string | string[];
     /**
      * Allows you to restrict a single user to performing a maximum of N API calls per hour
      */


### PR DESCRIPTION
And restrictIndexes can be an array of strings, rather than just a
single string

See https://www.algolia.com/doc/api-reference/api-methods/generate-secured-api-key/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.algolia.com/doc/api-reference/api-methods/generate-secured-api-key/>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
