### PR TITLE
sqlite3-promise type definitions

### DIFF
--- a/types/sqlite3-promise/index.d.ts
+++ b/types/sqlite3-promise/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-sqlite3-promise 1.0
+// Type definitions for sqlite3-promise 1.0
 // Project: https://github.com/Aminadav/node-sqlite3-promise
 // Definitions by: Jonathan Bredin <https://github.com/jonathanlb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/sqlite3-promise/index.d.ts
+++ b/types/sqlite3-promise/index.d.ts
@@ -1,39 +1,20 @@
-// Type definitions for node-sqlite3-promise 1.0
+// Type definitions for sqlite3-promise 1.0
 // Project: https://github.com/Aminadav/node-sqlite3-promise
 // Definitions by: Jonathan Bredin <https://github.com/jonathanlb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import sqlite3 = require('sqlite3');
+import * as sqlite3 from 'sqlite3';
+export * from 'sqlite3';
 
-export class Database extends sqlite3.Database {
-	allAsync(sql: string): Promise<any[]>;
-	closeAsync(): Promise<void>;
-	eachAsync(sql: string, cb?: (this: sqlite3.Statement, err: Error | null, row: any) => void): Promise<number>;
-	eachAsync(sql: string, params: any, cb?: (this: sqlite3.Statement, err: Error | null, row: any) => void): Promise<number>;
-	execAsync(sql: string): Promise<sqlite3.Statement>;
-	getAsync(sql: string): Promise<any>;
-	runAsync(sql: string): Promise<void>;
+declare module 'sqlite3' {
+    interface Database {
+        allAsync(sql: string): Promise<any[]>;
+        closeAsync(): Promise<void>;
+        eachAsync(sql: string, cb?: (this: Statement, err: Error | null, row: any) => void): Promise<number>;
+        eachAsync(sql: string, params: any, cb?: (this: Statement, err: Error | null, row: any) => void): Promise<number>;
+        execAsync(sql: string): Promise<Statement>;
+        getAsync(sql: string): Promise<any>;
+        runAsync(sql: string): Promise<void>;
+    }
 }
-
-export interface Sqlite3Promise {
-	Database: typeof Database;
-
-	OPEN_READWRITE: number;
-	OPEN_READONLY: number;
-	OPEN_CREATE: number;
-	OPEN_SHAREDCACHE: number;
-	OPEN_PRIVATECACHE: number;
-	OPEN_URI: number;
-
-	verbose: () => { type: Sqlite3Promise };
-}
-
-export const OPEN_READWRITE: number;
-export const OPEN_READONLY: number;
-export const OPEN_CREATE: number;
-export const OPEN_SHAREDCACHE: number;
-export const OPEN_PRIVATECACHE: number;
-export const OPEN_URI: number;
-
-export function verbose(): Sqlite3Promise;

--- a/types/sqlite3-promise/index.d.ts
+++ b/types/sqlite3-promise/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for node-sqlite3-promise 1.0
+// Project: https://github.com/Aminadav/node-sqlite3-promise
+// Definitions by: Jonathan Bredin <https://github.com/jonathanlb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import sqlite3 = require('sqlite3');
+
+export class Database extends sqlite3.Database {
+	allAsync(sql: string): Promise<any[]>;
+	closeAsync(): Promise<void>;
+	eachAsync(sql: string, cb?: (this: sqlite3.Statement, err: Error | null, row: any) => void): Promise<number>;
+	eachAsync(sql: string, params: any, cb?: (this: sqlite3.Statement, err: Error | null, row: any) => void): Promise<number>;
+	execAsync(sql: string): Promise<sqlite3.Statement>;
+	getAsync(sql: string): Promise<any>;
+	runAsync(sql: string): Promise<void>;
+}
+
+export interface Sqlite3Promise {
+	Database: typeof Database;
+
+	OPEN_READWRITE: number;
+	OPEN_READONLY: number;
+	OPEN_CREATE: number;
+	OPEN_SHAREDCACHE: number;
+	OPEN_PRIVATECACHE: number;
+	OPEN_URI: number;
+
+	verbose: () => { type: Sqlite3Promise };
+}
+
+export const OPEN_READWRITE: number;
+export const OPEN_READONLY: number;
+export const OPEN_CREATE: number;
+export const OPEN_SHAREDCACHE: number;
+export const OPEN_PRIVATECACHE: number;
+export const OPEN_URI: number;
+
+export function verbose(): Sqlite3Promise;

--- a/types/sqlite3-promise/sqlite3-promise-tests.ts
+++ b/types/sqlite3-promise/sqlite3-promise-tests.ts
@@ -1,0 +1,76 @@
+import * as sqlite3 from 'sqlite3-promise';
+
+runExamples();
+
+function createDb(): sqlite3.Database {
+	return new sqlite3.Database(
+		':memory:', sqlite3.OPEN_CREATE | sqlite3.OPEN_READWRITE);
+}
+
+async function runExamples() {
+	// Wraps all, get, and run
+	let db = createDb();
+	let query = 'CREATE TABLE rows (str TEXT, num INT)';
+	await db.runAsync(query);
+
+	query = 'INSERT INTO rows (str, num) VALUES (\'foo\', 11), (\'bar\', 19)';
+	await db.runAsync(query);
+
+	query = 'SELECT rowid, * FROM rows';
+	let result = await db.allAsync(query);
+	// expect(result.length).toBe(2);
+
+	query = 'SELECT str FROM rows WHERE num=19';
+	result = await db.allAsync(query);
+	// expect(result).toEqual([{str: 'bar'}]);
+
+	query = 'SELECT str FROM rows WHERE num=19';
+	const singleResult = await db.getAsync(query);
+	// expect(singleResult).toEqual({str: 'bar'});
+
+	await db.closeAsync();
+
+	// Wraps each
+	db = createDb();
+	db.serialize(() => {
+		db.run("CREATE TABLE lorem (info TEXT)");
+		const stmt = db.prepare("INSERT INTO lorem VALUES (?)");
+		for (let i = 0; i < 10; i++) {
+			stmt.run("Ipsum " + i);
+		}
+		stmt.finalize();
+	});
+
+	let sum = 0;
+	const eachResult = await db.eachAsync(
+		"SELECT rowid AS id, info FROM lorem",
+		(err, row) => { sum += row.id; });
+	// expect(result).toBe(10);
+	// expect(sum).toBe(55);
+	await db.closeAsync();
+
+	// Wraps exec
+	db = createDb();
+	query = `CREATE TABLE lorem (info TEXT);
+		INSERT INTO lorem VALUES ('foo')`;
+	const statement = await db.execAsync(query);
+
+	query = 'SELECT str FROM rows WHERE num=19';
+	result = await db.allAsync(query);
+	// expect(result).toEqual([{str: 'bar'}]);
+	await db.closeAsync();
+
+	// Wraps verbose
+	const verbose = sqlite3.verbose();
+	db = new verbose.Database(
+			':memory:', verbose.OPEN_CREATE | verbose.OPEN_READWRITE);
+	query = `CREATE TABLE rows (str TEXT, num INT);
+		INSERT INTO rows (str, num) VALUES ('foo', 11), ('bar', 19)`;
+	await db.execAsync(query);
+
+	query = 'SELECT str FROM rows WHERE num=19';
+	result = await db.allAsync(query);
+	// expect(result).toEqual([{str: 'bar'}]);
+
+	await db.closeAsync();
+}

--- a/types/sqlite3-promise/tsconfig.json
+++ b/types/sqlite3-promise/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sqlite3-promise-tests.ts"
+    ]
+}

--- a/types/sqlite3-promise/tslint.json
+++ b/types/sqlite3-promise/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.   The types/sqlite3/tsconfig.json file is copied, as the new package wraps sqlite3 with bluebird promises.
