### PR TITLE
react-native: Fix commandArgs type for dispatchViewManagerCommand

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7879,7 +7879,7 @@ export interface UIManagerStatic {
      * commandID - Id of the native method that should be called.
      * commandArgs - Args of the native method that we can pass from JS to native.
      */
-    dispatchViewManagerCommand: (reactTag: number | null, commandID: number, commandArgs?: Array<any>) => void;
+    dispatchViewManagerCommand: (reactTag: number | null, commandID: number, commandArgs: Array<any> | undefined) => void;
 }
 
 export interface SwitchPropsIOS extends ViewProps {

--- a/types/react-native/test/ui-manager.tsx
+++ b/types/react-native/test/ui-manager.tsx
@@ -1,0 +1,4 @@
+import { UIManager } from 'react-native';
+
+UIManager.dispatchViewManagerCommand(1, 1, undefined);
+UIManager.dispatchViewManagerCommand(1, 1, ["foo", "bar", "baz", 1, 2, 3]);

--- a/types/react-native/tsconfig.json
+++ b/types/react-native/tsconfig.json
@@ -23,6 +23,7 @@
         "test/init-example.tsx",
         "test/ART.tsx",
         "test/legacy-properties.tsx",
-        "test/stylesheet-create.tsx"
+        "test/stylesheet-create.tsx",
+        "test/ui-manager.tsx"
     ]
 }


### PR DESCRIPTION
The `dispatchViewManagerCommand` method has a subtle but dangerous bug in the types. We define the last argument (`commandArgs`) as optional, but `react-native` is strict about argument count https://github.com/facebook/react-native/blob/84f5ebe4f941e752ba96b4d4a75dc6c6f5faa665/React/Base/RCTModuleMethod.mm#L512-L536. 

This means if you leave off the `undefined` your code will not work. This can be seen in practice here https://github.com/react-native-community/react-native-webview/pull/886 - where trusting the incorrect types caused a breaking change to sneak by.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I tried to run `npm run lint react-native` but got a bunch of errors that weren't caused by this change? 

```
./DefinitelyTyped/types/react-native/index.d.ts:1:1
ERROR: 1:1  npm-naming               d.ts file must have a matching npm package.
```

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/84f5ebe4f941e752ba96b4d4a75dc6c6f5faa665/React/Base/RCTModuleMethod.mm#L512-L536
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.