### PR TITLE
[@types/react-json-pretty] Add replacer, space, and themeClassName props for v1.7

### DIFF
--- a/types/react-json-pretty/index.d.ts
+++ b/types/react-json-pretty/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ComponentClass, HTMLAttributes } from "react";
+import { ComponentClass, HTMLAttributes } from 'react';
 
 export as namespace JSONPretty;
 

--- a/types/react-json-pretty/index.d.ts
+++ b/types/react-json-pretty/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for react-json-pretty 1.3
+// Type definitions for react-json-pretty 1.7
 // Project: https://github.com/chenckang/react-json-pretty
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ComponentClass, HTMLProps } from "react";
+import { ComponentClass, HTMLAttributes } from "react";
 
 export as namespace JSONPretty;
 
@@ -14,7 +14,10 @@ declare const JSONPretty: JSONPretty;
 type JSONPretty = ComponentClass<JSONPretty.JSONPrettyProps>;
 
 declare namespace JSONPretty {
-    interface JSONPrettyProps extends HTMLProps<JSONPretty> {
-        json: {} | string;
+    interface JSONPrettyProps extends HTMLAttributes<HTMLPreElement> {
+        json: any;
+        replacer?(this: any, key: string, value: any): any;
+        space?: number;
+        themeClassName?: string;
     }
 }

--- a/types/react-json-pretty/react-json-pretty-tests.tsx
+++ b/types/react-json-pretty/react-json-pretty-tests.tsx
@@ -7,10 +7,17 @@ export class Test extends React.Component {
             foo: "bar"
         };
 
+        const fn = (key: string, value: any) => {
+            return value;
+        };
+
         return (
             <div>
                 <JSONPretty json={ json } />
                 <JSONPretty json={ JSON.stringify(json) } />
+                <JSONPretty json={ json } replacer={ fn } />
+                <JSONPretty json={ json } space={ 1 } />
+                <JSONPretty json={ json } themeClassName="themeName" />
             </div>
         );
     }

--- a/types/react-json-pretty/react-json-pretty-tests.tsx
+++ b/types/react-json-pretty/react-json-pretty-tests.tsx
@@ -8,17 +8,17 @@ export class Test extends React.Component {
         };
 
         const fn = (key: string, value: any) => {
-            return value;
+          return value;
         };
 
         return (
-            <div>
-                <JSONPretty json={ json } />
-                <JSONPretty json={ JSON.stringify(json) } />
-                <JSONPretty json={ json } replacer={ fn } />
-                <JSONPretty json={ json } space={ 1 } />
-                <JSONPretty json={ json } themeClassName="themeName" />
-            </div>
+          <div>
+            <JSONPretty json={json} />
+            <JSONPretty json={JSON.stringify(json)} />
+            <JSONPretty json={json} replacer={fn} />
+            <JSONPretty json={json} space={1} />
+            <JSONPretty json={json} themeClassName="themeName" />
+          </div>
         );
     }
 }


### PR DESCRIPTION
See #25674 for additional context. This PR is similar, but also adds `space`, which [only accepts numbers](https://github.com/chenckang/react-json-pretty/blob/v1.7.9/src/JSONPretty.js#L41). Referred to the [JSON.stringify](https://github.com/microsoft/TypeScript/blob/master/src/lib/es5.d.ts#L1046) definition to pick the `replacer` type. (Switched `json` to any for the same reason.)

The only potentially breaking change is replacing `HTMLProps<JSONPretty>` with `HTMLAttributes<HTMLPreElement>`, but I think the latter is more accurate, since this component passes all unrecognized props to a `pre` element.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chenckang/react-json-pretty/blob/v1.7.9/src/JSONPretty.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.