### PR TITLE
Adding a new package: jwk-to-pem

### DIFF
--- a/types/jwk-to-pem/index.d.ts
+++ b/types/jwk-to-pem/index.d.ts
@@ -3,7 +3,11 @@
 // Definitions by: Erik Silkensen <https://github.com/esilkensen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace jwkToPem {
+export = jwkToBuffer;
+
+declare function jwkToBuffer(jwk: jwkToBuffer.JWK, opts?: jwkToBuffer.Options): string;
+
+declare namespace jwkToBuffer {
     interface Options {
         private: boolean;
     }
@@ -36,9 +40,4 @@ declare namespace jwkToPem {
     }
 
     type JWK = EC | ECPrivate | RSA;
-
-    type jwkToBuffer = (jwk: JWK, opts?: Options) => string;
 }
-
-declare const jwkToPem: jwkToPem.jwkToBuffer;
-export = jwkToPem;

--- a/types/jwk-to-pem/index.d.ts
+++ b/types/jwk-to-pem/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for jwk-to-pem 2.0
+// Project: https://github.com/Brightspace/node-jwk-to-pem#readme
+// Definitions by: Erik Silkensen <https://github.com/esilkensen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace jwkToPem {
+    interface Options {
+        private: boolean;
+    }
+
+    interface EC {
+        kty: "EC";
+        crv: string;
+        x: string;
+        y: string;
+    }
+
+    interface ECPrivate {
+        kty: "EC";
+        crv: string;
+        d: string;
+        x?: string;
+        y?: string;
+    }
+
+    interface RSA {
+        kty: "RSA";
+        e: string;
+        n: string;
+        d?: string;
+        p?: string;
+        q?: string;
+        dp?: string;
+        dq?: string;
+        qi?: string;
+    }
+
+    type JWK = EC | ECPrivate | RSA;
+
+    type jwkToBuffer = (jwk: JWK, opts?: Options) => string;
+}
+
+declare const jwkToPem: jwkToPem.jwkToBuffer;
+export = jwkToPem;

--- a/types/jwk-to-pem/jwk-to-pem-tests.ts
+++ b/types/jwk-to-pem/jwk-to-pem-tests.ts
@@ -1,68 +1,68 @@
-import jwkToPem = require("jwk-to-pem");
+import jwkToPem = require('jwk-to-pem');
 
 const jwk: jwkToPem.JWK = { kty: 'EC', crv: 'P-256', x: '...', y: '...' };
 jwkToPem(jwk); // $ExpectType string
 
-jwkToPem("hi"); // $ExpectError
+jwkToPem('hi'); // $ExpectError
 jwkToPem(null); // $ExpectError
 jwkToPem({ kty: {} }); // $ExpectError
-jwkToPem({ kty: "foozleberries" }); // $ExpectError
+jwkToPem({ kty: 'foozleberries' }); // $ExpectError
 
 const ec1: jwkToPem.JWK = {
-  crv: 'P-256',
-  kty: 'EC',
-  x: 'gh9MmXjtmcHFesofqWZ6iuxSdAYgoPVvfJqpv1818lo',
-  y: '3BDZHsNvKUb5VbyGPqcAFf4FGuPhJ2Xy215oWDw_1jc',
+    crv: 'P-256',
+    kty: 'EC',
+    x: 'gh9MmXjtmcHFesofqWZ6iuxSdAYgoPVvfJqpv1818lo',
+    y: '3BDZHsNvKUb5VbyGPqcAFf4FGuPhJ2Xy215oWDw_1jc',
 };
 jwkToPem(ec1); // $ExpectType string
 
 const ec2: jwkToPem.JWK = {
-  kty: 'EC',
-  crv: 'P-256',
-  d: '870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE',
+    kty: 'EC',
+    crv: 'P-256',
+    d: '870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE',
 };
 jwkToPem(ec2); // $ExpectType string
 jwkToPem(ec2, { private: true }); // $ExpectType string
 jwkToPem(ec2, {}); // $ExpectError
-jwkToPem(ec2, { foo: "bar" }); // $ExpectError
-jwkToPem(ec2, "foo"); // $ExpectError
+jwkToPem(ec2, { foo: 'bar' }); // $ExpectError
+jwkToPem(ec2, 'foo'); // $ExpectError
 
 const ec5: jwkToPem.JWK = {
-  crv: 'P-384',
-  kty: 'EC',
-  x: 'QIRvRhN2MpnTQ4teO4Y_RYFaK2Qlvc2lbhC0vALwrFOy33kUihkNUvHiTaUsp2W3',
-  y: 'vSA1sCKKzT4UOavStUL2WpwcCflEyDshzy3dc1IZtACUngU2xMDDMsi0gDL9jLiU',
+    crv: 'P-384',
+    kty: 'EC',
+    x: 'QIRvRhN2MpnTQ4teO4Y_RYFaK2Qlvc2lbhC0vALwrFOy33kUihkNUvHiTaUsp2W3',
+    y: 'vSA1sCKKzT4UOavStUL2WpwcCflEyDshzy3dc1IZtACUngU2xMDDMsi0gDL9jLiU',
 };
 jwkToPem(ec5); // $ExpectType string
 
-jwkToPem({ kty: "EC", x: "foo", y: "bar" }); // $ExpectError
-jwkToPem({ kty: "EC", crv: {}, x: "foo", y: "bar" }); // $ExpectError
-jwkToPem({ kty: "EC", crv: "P-256", y: "bar" }); // $ExpectError
-jwkToPem({ kty: "EC", crv: "P-256", x: {}, y: "bar" }); // $ExpectError
-jwkToPem({ kty: "EC", crv: "P-256", x: "foo" }); // $ExpectError
-jwkToPem({ kty: "EC", crv: "P-256", x: "foo", y: {} }); // $ExpectError
+jwkToPem({ kty: 'EC', x: 'foo', y: 'bar' }); // $ExpectError
+jwkToPem({ kty: 'EC', crv: {}, x: 'foo', y: 'bar' }); // $ExpectError
+jwkToPem({ kty: 'EC', crv: 'P-256', y: 'bar' }); // $ExpectError
+jwkToPem({ kty: 'EC', crv: 'P-256', x: {}, y: 'bar' }); // $ExpectError
+jwkToPem({ kty: 'EC', crv: 'P-256', x: 'foo' }); // $ExpectError
+jwkToPem({ kty: 'EC', crv: 'P-256', x: 'foo', y: {} }); // $ExpectError
 
 const rsa1: jwkToPem.JWK = {
-  kty: 'RSA',
-  n: '...',
-  e: 'AQAB',
+    kty: 'RSA',
+    n: '...',
+    e: 'AQAB',
 };
 jwkToPem(rsa1); // $ExpectType string
 
 const rsa2: jwkToPem.JWK = {
-  kty: 'RSA',
-  n: '...',
-  e: 'AQAB',
-  d: '...',
-  p: '...',
-  q: '...',
-  dp: '...',
-  dq: '...',
-  qi: '...',
+    kty: 'RSA',
+    n: '...',
+    e: 'AQAB',
+    d: '...',
+    p: '...',
+    q: '...',
+    dp: '...',
+    dq: '...',
+    qi: '...',
 };
 jwkToPem(rsa2); // $ExpectType string
 
-jwkToPem({ kty: "RSA", e: "AQAB" }); // $ExpectError
-jwkToPem({ kty: "RSA", n: {}, e: "AQAB" }); // $ExpectError
-jwkToPem({ kty: "RSA", n: "foo" }); // $ExpectError
-jwkToPem({ kty: "RSA", n: "foo", e: {} }); // $ExpectError
+jwkToPem({ kty: 'RSA', e: 'AQAB' }); // $ExpectError
+jwkToPem({ kty: 'RSA', n: {}, e: 'AQAB' }); // $ExpectError
+jwkToPem({ kty: 'RSA', n: 'foo' }); // $ExpectError
+jwkToPem({ kty: 'RSA', n: 'foo', e: {} }); // $ExpectError

--- a/types/jwk-to-pem/jwk-to-pem-tests.ts
+++ b/types/jwk-to-pem/jwk-to-pem-tests.ts
@@ -1,0 +1,68 @@
+import jwkToPem = require("jwk-to-pem");
+
+const jwk: jwkToPem.JWK = { kty: 'EC', crv: 'P-256', x: '...', y: '...' };
+jwkToPem(jwk); // $ExpectType string
+
+jwkToPem("hi"); // $ExpectError
+jwkToPem(null); // $ExpectError
+jwkToPem({ kty: {} }); // $ExpectError
+jwkToPem({ kty: "foozleberries" }); // $ExpectError
+
+const ec1: jwkToPem.JWK = {
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'gh9MmXjtmcHFesofqWZ6iuxSdAYgoPVvfJqpv1818lo',
+  y: '3BDZHsNvKUb5VbyGPqcAFf4FGuPhJ2Xy215oWDw_1jc',
+};
+jwkToPem(ec1); // $ExpectType string
+
+const ec2: jwkToPem.JWK = {
+  kty: 'EC',
+  crv: 'P-256',
+  d: '870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE',
+};
+jwkToPem(ec2); // $ExpectType string
+jwkToPem(ec2, { private: true }); // $ExpectType string
+jwkToPem(ec2, {}); // $ExpectError
+jwkToPem(ec2, { foo: "bar" }); // $ExpectError
+jwkToPem(ec2, "foo"); // $ExpectError
+
+const ec5: jwkToPem.JWK = {
+  crv: 'P-384',
+  kty: 'EC',
+  x: 'QIRvRhN2MpnTQ4teO4Y_RYFaK2Qlvc2lbhC0vALwrFOy33kUihkNUvHiTaUsp2W3',
+  y: 'vSA1sCKKzT4UOavStUL2WpwcCflEyDshzy3dc1IZtACUngU2xMDDMsi0gDL9jLiU',
+};
+jwkToPem(ec5); // $ExpectType string
+
+jwkToPem({ kty: "EC", x: "foo", y: "bar" }); // $ExpectError
+jwkToPem({ kty: "EC", crv: {}, x: "foo", y: "bar" }); // $ExpectError
+jwkToPem({ kty: "EC", crv: "P-256", y: "bar" }); // $ExpectError
+jwkToPem({ kty: "EC", crv: "P-256", x: {}, y: "bar" }); // $ExpectError
+jwkToPem({ kty: "EC", crv: "P-256", x: "foo" }); // $ExpectError
+jwkToPem({ kty: "EC", crv: "P-256", x: "foo", y: {} }); // $ExpectError
+
+const rsa1: jwkToPem.JWK = {
+  kty: 'RSA',
+  n: '...',
+  e: 'AQAB',
+};
+jwkToPem(rsa1); // $ExpectType string
+
+const rsa2: jwkToPem.JWK = {
+  kty: 'RSA',
+  n: '...',
+  e: 'AQAB',
+  d: '...',
+  p: '...',
+  q: '...',
+  dp: '...',
+  dq: '...',
+  qi: '...',
+};
+jwkToPem(rsa2); // $ExpectType string
+
+jwkToPem({ kty: "RSA", e: "AQAB" }); // $ExpectError
+jwkToPem({ kty: "RSA", n: {}, e: "AQAB" }); // $ExpectError
+jwkToPem({ kty: "RSA", n: "foo" }); // $ExpectError
+jwkToPem({ kty: "RSA", n: "foo", e: {} }); // $ExpectError

--- a/types/jwk-to-pem/tsconfig.json
+++ b/types/jwk-to-pem/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jwk-to-pem-tests.ts"
+    ]
+}

--- a/types/jwk-to-pem/tslint.json
+++ b/types/jwk-to-pem/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
