### PR TITLE
feat(aria-query): Add types

### DIFF
--- a/types/aria-query/aria-query-tests.ts
+++ b/types/aria-query/aria-query-tests.ts
@@ -27,3 +27,6 @@ function prettyRoleRelation(relation: ARIARoleRelation) {
         );
     }
 }
+
+const [selectElement] = Array.from(roleElements.get('combobox')!);
+const selectRoles: string[] = Array.from(elementRoles.get(selectElement)!);

--- a/types/aria-query/aria-query-tests.ts
+++ b/types/aria-query/aria-query-tests.ts
@@ -1,0 +1,26 @@
+import { elementRoles, roleElements, roles, ARIARoleDefintionKey } from 'aria-query';
+
+function prettRole(roleName: ARIARoleDefintionKey) {
+    let role = roles.get(roleName)!;
+    console.log(`required props: ${role.requiredProps.join(', ')}`);
+    console.log(`props: ${role.props.join(', ')}`);
+    console.log(`Is ${role.abstract === false ? 'not abstract' : 'abstract'}`);
+    console.log(`Is ${role.interactive === false ? 'not interactive' : 'interactive'}`);
+    console.log(
+        `${
+            role.childrenPresentational === true
+                ? 'Has Child Presentational characteristics'
+                : 'No special cahracteristics'
+        }`,
+    );
+    console.log('baseConcepts:');
+    console.log(role.baseConcepts.forEach(prettyRoleRelation));
+    console.log('relatedConcepts:');
+    console.log(role.relatedConcepts.forEach(prettyRoleRelation));
+}
+
+function prettyRoleRelation(relation: ARIARoleRelation) {
+    console.log(`module: ${relation.module}`);
+    console.log(`concept: ${relation.concept.name}`);
+    console.log(`attributes: ${relation.concept.attributes.map(({ name, value }) => `name=${value}`).join(', ')}`);
+}

--- a/types/aria-query/aria-query-tests.ts
+++ b/types/aria-query/aria-query-tests.ts
@@ -1,11 +1,10 @@
-import { elementRoles, roleElements, roles, ARIARoleDefintionKey } from 'aria-query';
+import { elementRoles, roleElements, roles, ARIARoleDefintionKey, ARIARoleRelation } from 'aria-query';
 
 function prettRole(roleName: ARIARoleDefintionKey) {
-    let role = roles.get(roleName)!;
-    console.log(`required props: ${role.requiredProps.join(', ')}`);
-    console.log(`props: ${role.props.join(', ')}`);
+    const role = roles.get(roleName)!;
+    console.log(`required props: ${Object.keys(role.requiredProps).join(', ')}`);
+    console.log(`props: ${Object.keys(role.props).join(', ')}`);
     console.log(`Is ${role.abstract === false ? 'not abstract' : 'abstract'}`);
-    console.log(`Is ${role.interactive === false ? 'not interactive' : 'interactive'}`);
     console.log(
         `${
             role.childrenPresentational === true
@@ -21,6 +20,10 @@ function prettRole(roleName: ARIARoleDefintionKey) {
 
 function prettyRoleRelation(relation: ARIARoleRelation) {
     console.log(`module: ${relation.module}`);
-    console.log(`concept: ${relation.concept.name}`);
-    console.log(`attributes: ${relation.concept.attributes.map(({ name, value }) => `name=${value}`).join(', ')}`);
+    console.log(`concept: ${relation.concept !== undefined ? relation.concept.name : 'none'}`);
+    if (relation.concept !== undefined) {
+        console.log(
+            `attributes: ${(relation.concept.attributes || []).map(({ name, value }) => `name=${value}`).join(', ')}`,
+        );
+    }
 }

--- a/types/aria-query/aria-query-tests.ts
+++ b/types/aria-query/aria-query-tests.ts
@@ -4,21 +4,17 @@ function prettRole(roleName: ARIARoleDefintionKey) {
     const role = roles.get(roleName)!;
     console.log(`required props: ${Object.keys(role.requiredProps).join(', ')}`);
     console.log(`props: ${Object.keys(role.props).join(', ')}`);
-    console.log(`Is ${role.abstract === false ? 'not abstract' : 'abstract'}`);
+    console.log(`Is ${!role.abstract ? 'not abstract' : 'abstract'}`);
     console.log(
-        `${
-            role.childrenPresentational === true
-                ? 'Has Child Presentational characteristics'
-                : 'No special cahracteristics'
-        }`,
+        `${role.childrenPresentational ? 'Has Child Presentational characteristics' : 'No special cahracteristics'}`,
     );
     console.log('baseConcepts:');
-    console.log(role.baseConcepts.forEach(prettyRoleRelation));
+    role.baseConcepts.forEach(prettyRoleRelation);
     console.log('relatedConcepts:');
-    console.log(role.relatedConcepts.forEach(prettyRoleRelation));
+    role.relatedConcepts.forEach(prettyRoleRelation);
 }
 
-function prettyRoleRelation(relation: ARIARoleRelation) {
+function prettyRoleRelation(relation: ARIARoleRelation): void {
     console.log(`module: ${relation.module}`);
     console.log(`concept: ${relation.concept !== undefined ? relation.concept.name : 'none'}`);
     if (relation.concept !== undefined) {

--- a/types/aria-query/index.d.ts
+++ b/types/aria-query/index.d.ts
@@ -156,14 +156,14 @@ export interface ARIARoleDefinition {
     /* Abstract roles may not be used in HTML. */
     abstract: boolean;
     /* The concepts in related domains that inform behavior mappings. */
-    baseConcepts: Array<ARIARoleRelation>;
+    baseConcepts: ARIARoleRelation[];
     /* Child presentational roles strip child nodes of roles and flatten the
      * content to text. */
     childrenPresentational: boolean;
     /* aria-* properties and states allowed on this role. */
     props: ARIAPropertyMap;
     /* The concepts in related domains that inform behavior mappings. */
-    relatedConcepts: Array<ARIARoleRelation>;
+    relatedConcepts: ARIARoleRelation[];
     /* aria-* properties and states required on this role. */
     requiredProps: ARIAPropertyMap;
     /* An array or super class "stacks." Each stack contains a LIFO list of
@@ -244,7 +244,7 @@ export interface ARIAPropertyMap {
     'aria-colindex'?: unknown;
     'aria-colspan'?: unknown;
     'aria-controls'?: unknown;
-    'aria-current'?: ARIAPropertyCurrent | undefined | null;
+    'aria-current'?: ARIAPropertyCurrent | null;
     'aria-describedat'?: unknown;
     'aria-describedby'?: unknown;
     'aria-details'?: unknown;
@@ -297,7 +297,7 @@ export interface ARIARoleRelation {
  * and ARIA to name a few. */
 export interface ARIARoleRelationConcept {
     name: string;
-    attributes?: Array<ARIARoleRelationConceptAttribute>;
+    attributes?: ARIARoleRelationConceptAttribute[];
 }
 
 export interface ARIARoleRelationConceptAttribute {

--- a/types/aria-query/index.d.ts
+++ b/types/aria-query/index.d.ts
@@ -1,0 +1,306 @@
+// Type definitions for aria-query 3.0
+// Project: https://github.com/A11yance/aria-query#readme
+// Definitions by: Sebastian Silbermann <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+// index.js
+export type ARIARoleDefintionKey = ARIAAbstractRole | ARIARole | ARIADPubRole;
+
+export const aria: Map<ARIAProperty, ARIAPropertyDefinition>;
+export interface DOMDefinition {
+    reserved?: boolean;
+    interactive?: boolean;
+}
+export const dom: Map<string, DOMDefinition>;
+export const elementRoles: Map<ARIARoleRelationConcept, Set<ARIARoleDefintionKey>>;
+export const roles: Map<ARIARoleDefintionKey, ARIARoleDefinition>;
+export const roleElements: Map<ARIARoleDefintionKey, Set<ARIARoleRelationConcept>>;
+
+// types
+export type ARIAAbstractRole =
+    | 'command'
+    | 'composite'
+    | 'input'
+    | 'landmark'
+    | 'range'
+    | 'roletype'
+    | 'section'
+    | 'sectionhead'
+    | 'select'
+    | 'structure'
+    | 'widget'
+    | 'window';
+
+export type ARIAWidgetRole =
+    | 'alert'
+    | 'alertdialog'
+    | 'button'
+    | 'checkbox'
+    | 'dialog'
+    | 'gridcell'
+    | 'link'
+    | 'log'
+    | 'marquee'
+    | 'menuitem'
+    | 'menuitemcheckbox'
+    | 'menuitemradio'
+    | 'option'
+    | 'progressbar'
+    | 'radio'
+    | 'scrollbar'
+    | 'searchbox'
+    | 'slider'
+    | 'spinbutton'
+    | 'status'
+    | 'switch'
+    | 'tab'
+    | 'tabpanel'
+    | 'textbox'
+    | 'timer'
+    | 'tooltip'
+    | 'treeitem';
+
+export type ARIACompositeWidgetRole =
+    | 'combobox'
+    | 'grid'
+    | 'listbox'
+    | 'menu'
+    | 'menubar'
+    | 'radiogroup'
+    | 'tablist'
+    | 'tree'
+    | 'treegrid';
+
+export type ARIADocumentStructureRole =
+    | 'article'
+    | 'cell'
+    | 'columnheader'
+    | 'definition'
+    | 'directory'
+    | 'document'
+    | 'feed'
+    | 'figure'
+    | 'group'
+    | 'heading'
+    | 'img'
+    | 'list'
+    | 'listitem'
+    | 'math'
+    | 'none'
+    | 'note'
+    | 'presentation'
+    | 'region'
+    | 'row'
+    | 'rowgroup'
+    | 'rowheader'
+    | 'separator'
+    | 'table'
+    | 'term'
+    | 'toolbar';
+
+export type ARIALandmarkRole =
+    | 'application'
+    | 'banner'
+    | 'complementary'
+    | 'contentinfo'
+    | 'form'
+    | 'main'
+    | 'navigation'
+    | 'search';
+
+export type ARIADPubRole =
+    | 'doc-abstract'
+    | 'doc-acknowledgments'
+    | 'doc-afterword'
+    | 'doc-appendix'
+    | 'doc-backlink'
+    | 'doc-biblioentry'
+    | 'doc-bibliography'
+    | 'doc-biblioref'
+    | 'doc-chapter'
+    | 'doc-colophon'
+    | 'doc-conclusion'
+    | 'doc-cover'
+    | 'doc-credit'
+    | 'doc-credits'
+    | 'doc-dedication'
+    | 'doc-endnote'
+    | 'doc-endnotes'
+    | 'doc-epigraph'
+    | 'doc-epilogue'
+    | 'doc-errata'
+    | 'doc-example'
+    | 'doc-footnote'
+    | 'doc-foreword'
+    | 'doc-glossary'
+    | 'doc-glossref'
+    | 'doc-index'
+    | 'doc-introduction'
+    | 'doc-noteref'
+    | 'doc-notice'
+    | 'doc-pagebreak'
+    | 'doc-pagelist'
+    | 'doc-part'
+    | 'doc-preface'
+    | 'doc-prologue'
+    | 'doc-pullquote'
+    | 'doc-qna'
+    | 'doc-subtitle'
+    | 'doc-tip'
+    | 'doc-toc';
+
+export type ARIARole = ARIAWidgetRole | ARIACompositeWidgetRole | ARIADocumentStructureRole | ARIALandmarkRole;
+
+export interface ARIARoleDefinition {
+    /* Abstract roles may not be used in HTML. */
+    abstract: boolean;
+    /* The concepts in related domains that inform behavior mappings. */
+    baseConcepts: Array<ARIARoleRelation>;
+    /* Child presentational roles strip child nodes of roles and flatten the
+     * content to text. */
+    childrenPresentational: boolean;
+    /* aria-* properties and states allowed on this role. */
+    props: ARIAPropertyMap;
+    /* The concepts in related domains that inform behavior mappings. */
+    relatedConcepts: Array<ARIARoleRelation>;
+    /* aria-* properties and states required on this role. */
+    requiredProps: ARIAPropertyMap;
+    /* An array or super class "stacks." Each stack contains a LIFO list of
+     * strings correspond to a super class in the inheritance chain of this
+     * role. Roles may have more than one inheritance chain, which is why
+     * this property is an array of arrays and not a single array. */
+    superClass: Array<Array<ARIAAbstractRole | ARIARole | ARIADPubRole>>;
+}
+
+export type ARIAState =
+    | 'aria-busy'
+    | 'aria-checked'
+    | 'aria-disabled'
+    | 'aria-expanded'
+    | 'aria-grabbed'
+    | 'aria-hidden'
+    | 'aria-invalid'
+    | 'aria-pressed'
+    | 'aria-selected';
+
+export type ARIAProperty =
+    | 'aria-activedescendant'
+    | 'aria-atomic'
+    | 'aria-autocomplete'
+    | 'aria-colcount'
+    | 'aria-colindex'
+    | 'aria-colspan'
+    | 'aria-controls'
+    | 'aria-current'
+    | 'aria-describedat'
+    | 'aria-describedby'
+    | 'aria-details'
+    | 'aria-dropeffect'
+    | 'aria-errormessage'
+    | 'aria-flowto'
+    | 'aria-haspopup'
+    | 'aria-keyshortcuts'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'aria-level'
+    | 'aria-live'
+    | 'aria-modal'
+    | 'aria-multiline'
+    | 'aria-multiselectable'
+    | 'aria-orientation'
+    | 'aria-owns'
+    | 'aria-placeholder'
+    | 'aria-posinset'
+    | 'aria-readonly'
+    | 'aria-relevant'
+    | 'aria-required'
+    | 'aria-roledescription'
+    | 'aria-rowcount'
+    | 'aria-rowindex'
+    | 'aria-rowspan'
+    | 'aria-setsize'
+    | 'aria-sort'
+    | 'aria-valuemax'
+    | 'aria-valuemin'
+    | 'aria-valuenow'
+    | 'aria-valuetext'
+    | ARIAState;
+
+export interface ARIAPropertyMap {
+    'aria-busy'?: unknown;
+    'aria-checked'?: unknown;
+    'aria-disabled'?: unknown;
+    'aria-expanded'?: unknown;
+    'aria-grabbed'?: unknown;
+    'aria-hidden'?: unknown;
+    'aria-invalid'?: unknown;
+    'aria-pressed'?: unknown;
+    'aria-selected'?: unknown;
+    'aria-activedescendant'?: unknown;
+    'aria-atomic'?: unknown;
+    'aria-autocomplete'?: unknown;
+    'aria-colcount'?: unknown;
+    'aria-colindex'?: unknown;
+    'aria-colspan'?: unknown;
+    'aria-controls'?: unknown;
+    'aria-current'?: ARIAPropertyCurrent | undefined | null;
+    'aria-describedat'?: unknown;
+    'aria-describedby'?: unknown;
+    'aria-details'?: unknown;
+    'aria-dropeffect'?: unknown;
+    'aria-errormessage'?: unknown;
+    'aria-flowto'?: unknown;
+    'aria-haspopup'?: unknown;
+    'aria-keyshortcuts'?: unknown;
+    'aria-label'?: unknown;
+    'aria-labelledby'?: unknown;
+    'aria-level'?: unknown;
+    'aria-live'?: unknown;
+    'aria-modal'?: unknown;
+    'aria-multiline'?: unknown;
+    'aria-multiselectable'?: unknown;
+    'aria-orientation'?: unknown;
+    'aria-owns'?: unknown;
+    'aria-placeholder'?: unknown;
+    'aria-posinset'?: unknown;
+    'aria-readonly'?: unknown;
+    'aria-relevant'?: unknown;
+    'aria-required'?: unknown;
+    'aria-roledescription'?: unknown;
+    'aria-rowcount'?: unknown;
+    'aria-rowindex'?: unknown;
+    'aria-rowspan'?: unknown;
+    'aria-setsize'?: unknown;
+    'aria-sort'?: unknown;
+    'aria-valuemax'?: unknown;
+    'aria-valuemin'?: unknown;
+    'aria-valuenow'?: unknown;
+    'aria-valuetext'?: unknown;
+}
+
+export interface ARIAPropertyDefinition {
+    type: 'string' | 'id' | 'idlist' | 'integer' | 'number' | 'boolean' | 'token' | 'tokenlist' | 'tristate';
+    value?: Array<string | boolean>;
+    allowundefined?: boolean;
+}
+
+export type ARIAPropertyCurrent = 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false' | true | false;
+
+export interface ARIARoleRelation {
+    module?: string;
+    concept?: ARIARoleRelationConcept;
+}
+
+/* The concept in a related domain that informs behavior mappings.
+ * Related domains include: HTML, "Device Independence Delivery Unit", XForms,
+ * and ARIA to name a few. */
+export interface ARIARoleRelationConcept {
+    name: string;
+    attributes?: Array<ARIARoleRelationConceptAttribute>;
+}
+
+export interface ARIARoleRelationConceptAttribute {
+    name: string;
+    value?: string;
+}

--- a/types/aria-query/tsconfig.json
+++ b/types/aria-query/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "aria-query-tests.ts"
+    ]
+}

--- a/types/aria-query/tslint.json
+++ b/types/aria-query/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Based on https://github.com/A11yance/aria-query/blob/v3.0.0/src/index.js
Mostly copied and adjusted for DT from the flow types under https://github.com/A11yance/aria-query/blob/v3.0.0/flow/aria.js
