### PR TITLE
Update types for `glob-parent` to version `5.1`

### DIFF
--- a/types/glob-parent/glob-parent-tests.ts
+++ b/types/glob-parent/glob-parent-tests.ts
@@ -2,3 +2,10 @@ import globParent = require('glob-parent');
 
 // $ExpectType string
 globParent('*.js');
+
+globParent('*.js', {});
+globParent('*.js', { flipBackslashes: false });
+
+const options: globParent.Options = {
+    flipBackslashes: false
+};

--- a/types/glob-parent/index.d.ts
+++ b/types/glob-parent/index.d.ts
@@ -1,8 +1,14 @@
-// Type definitions for glob-parent 3.1
+// Type definitions for glob-parent 5.1
 // Project: https://github.com/gulpjs/glob-parent
 // Definitions by: mrmlnc <https://github.com/mrmlnc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function globParent(pattern: string): string;
+declare function globParent(pattern: string, options?: globParent.Options): string;
+
+declare namespace globParent {
+    interface Options {
+        flipBackslashes?: boolean;
+    }
+}
 
 export = globParent;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gulpjs/glob-parent/commit/92974fe1a17721aa3e4601054fd76a71cb3d2bde
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.