### PR TITLE
Fix link to Linter section in ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also see the [definitelytyped.org](http://definitelytyped.org) website, although
         * [Create a new package](#create-a-new-package)
         * [Common mistakes](#common-mistakes)
         * [Removing a package](#removing-a-package)
-        * [Linter](#lint)
+        * [Linter](#linter)
         * [Verifying](#verifying)
 * [FAQ](#faq)
 


### PR DESCRIPTION
This PR doesn't change any types.

Currently **Linter** entry in Table of contents has title that matches header, but link is `#lint` which doesn't navigate user to proper section of README