### PR TITLE
rebass: add StyledSystem.LayoutProps to BoxKnownProps

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -49,8 +49,7 @@ export interface SxProps {
 interface BoxKnownProps
     extends BaseProps,
         StyledSystem.SpaceProps,
-        StyledSystem.WidthProps,
-        StyledSystem.HeightProps,
+        StyledSystem.LayoutProps,
         StyledSystem.FontSizeProps,
         StyledSystem.ColorProps,
         StyledSystem.FlexProps,

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -26,7 +26,7 @@ const boxCss = css`
 const CssBox = () => <Box css={boxCss} />;
 
 export default () => (
-    <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em">
+    <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em" display="block">
         <Flex width={1} alignItems="center" justifyContent="center">
             <Heading fontSize={5} fontWeight="bold">
                 Hi, I'm a heading.


### PR DESCRIPTION
This PR extends `BoxKnownProps` with `StyledSystem.LayoutProps` 

`StyledSystem.LayoutProps` contains props for  the  `<Box />` component that are missing right now ( `display`, `size`, `verticalAlign`, `minWidth`, `maxWidth`, `minHeight`, `maxHeight`). 

It also contains `width` and `height` props, so `StyledSystem.WidthProps` and `StyledSystem.HeightProps` are no longer needed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rebassjs/rebass/blob/master/packages/reflexbox/src/index.js#L40
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
