### PR TITLE
[react-big-calendar] Correct type for `views`

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -27,11 +27,11 @@ export type stringOrDate = string | Date;
 export type ViewKey = 'MONTH' | 'WEEK' | 'WORK_WEEK' | 'DAY' | 'AGENDA';
 export type View = 'month' | 'week' | 'work_week' | 'day' | 'agenda';
 export type ViewsProps = View[] | {
-    work_week?: boolean | React.SFC | React.Component,
-    day?: boolean | React.SFC | React.Component,
-    agenda?: boolean | React.SFC | React.Component,
-    month?: boolean | React.SFC | React.Component,
-    week?: boolean | React.SFC | React.Component
+    work_week?: boolean | React.ComponentType<any> & ViewStatic,
+    day?: boolean | React.ComponentType<any> & ViewStatic,
+    agenda?: boolean | React.ComponentType<any> & ViewStatic,
+    month?: boolean | React.ComponentType<any> & ViewStatic,
+    week?: boolean | React.ComponentType<any> & ViewStatic
 };
 export type NavigateAction = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 export interface Event {
@@ -309,8 +309,15 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onShowMore?: (events: TEvent[], date: Date) => void;
 }
 
+export interface TitleOptions {
+    formats: DateFormat[];
+    culture?: string;
+    [propName: string]: any;
+}
+
 export interface ViewStatic {
     navigate(date: Date, action: NavigateAction, props: any): Date;
+    title(date: Date, options: TitleOptions): string;
 }
 
 export interface MoveOptions {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -119,13 +119,24 @@ class CalendarResource {
 
 // overriding 'views' props
 {
-    const DaySFC: React.SFC = () => null;
+    interface DayProps {
+        random: string;
+    }
+    class DayComponent extends React.Component<DayProps> {
+        static title() {
+            return 'title';
+        }
+
+        static navigate() {
+            return new Date();
+        }
+    }
     // supplying object to 'views' prop with only some of the supported views.
-    // A view can be a boolean or an SFC
+    // A view can be a boolean or implement title() and navigate()
     ReactDOM.render(<Calendar
                         localizer={momentLocalizer(moment)}
                         views={{
-                            day: DaySFC,
+                            day: DayComponent,
                             work_week: true
                         }}
     />, document.body);


### PR DESCRIPTION
Per the documentation, `views` accepts an object hash of either booleans
or React components that implement static `title` and `navigate`
functions.

This corrects the types to match.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://intljusticemission.github.io/react-big-calendar/examples/index.html#prop-views
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~