### PR TITLE
[chrome] add the missing content_scripts::match_about_blank

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5689,6 +5689,7 @@ declare namespace chrome.runtime {
             js?: string[];
             run_at?: string;
             all_frames?: boolean;
+            match_about_blank?: boolean;
             include_globs?: string[];
             exclude_globs?: string[];
         }[];


### PR DESCRIPTION
This is a trivial change, just one missing property was added.  
No tests needed but I did test it in IDE and observed the change successfully as expected.

URL to documentation or source code:
https://developer.chrome.com/extensions/content_scripts#match_about_blank