### PR TITLE
[mapbox-gl] line-dasharray, text-font, text-justify can be Expression's

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1548,7 +1548,7 @@ declare namespace mapboxgl {
         'line-offset-transition'?: Transition;
         'line-blur'?: number | StyleFunction | Expression;
         'line-blur-transition'?: Transition;
-        'line-dasharray'?: number[];
+        'line-dasharray'?: number[] | Expression;
         'line-dasharray-transition'?: Transition;
         'line-pattern'?: string | Expression;
         'line-pattern-transition'?: Transition;
@@ -1579,12 +1579,12 @@ declare namespace mapboxgl {
         'text-pitch-alignment'?: 'map' | 'viewport' | 'auto';
         'text-rotation-alignment'?: 'map' | 'viewport' | 'auto';
         'text-field'?: string | StyleFunction | Expression;
-        'text-font'?: string | string[];
+        'text-font'?: string | string[] | Expression;
         'text-size'?: number | StyleFunction | Expression;
         'text-max-width'?: number | Expression;
         'text-line-height'?: number | Expression;
         'text-letter-spacing'?: number | Expression;
-        'text-justify'?: 'left' | 'center' | 'right';
+        'text-justify'?: 'left' | 'center' | 'right' | Expression;
         'text-anchor'?: Anchor | StyleFunction | Expression;
         'text-max-angle'?: number | Expression;
         'text-rotate'?: number | StyleFunction | Expression;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -170,7 +170,28 @@ map.on('load', function() {
 		},
 		"paint": {
 			"line-color": "#888",
-			"line-width": 8
+			"line-width": 8,
+            "line-dasharray": [
+                "step",
+                [
+                    "zoom"
+                ],
+                [
+                    "literal",
+                    [
+                        1,
+                        0
+                    ]
+                ],
+                15,
+                [
+                    "literal",
+                    [
+                        1.75,
+                        1
+                    ]
+                ]
+            ]
 		}
 	});
 
@@ -399,7 +420,75 @@ var mapStyle = {
 			"layout": {
 				"text-transform": "uppercase",
 				"text-field": "{name_en}",
-				"text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                "text-font": [
+                    "step",
+                    [
+                        "zoom"
+                    ],
+                    [
+                        "literal",
+                        [
+                            "DIN Offc Pro Regular",
+                            "Arial Unicode MS Regular"
+                        ]
+                    ],
+                    8,
+                    [
+                        "step",
+                        [
+                            "get",
+                            "symbolrank"
+                        ],
+                        [
+                            "literal",
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        11,
+                        [
+                            "literal",
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                ],
+                "text-justify": [
+                    "step",
+                    [
+                        "zoom"
+                    ],
+                    [
+                        "match",
+                        [
+                            "get",
+                            "text_anchor"
+                        ],
+                        [
+                            "bottom",
+                            "top"
+                        ],
+                        "center",
+                        [
+                            "left",
+                            "bottom-left",
+                            "top-left"
+                        ],
+                        "left",
+                        [
+                            "right",
+                            "bottom-right",
+                            "top-right"
+                        ],
+                        "right",
+                        "center"
+                    ],
+                    8,
+                    "center"
+                ],
 				"text-letter-spacing": 0.15,
 				"text-max-width": 7,
 				"text-size": {"stops": [[4, 10], [6, 14]]}


### PR DESCRIPTION
I had a problem using an exported style from Mapbox studio. Apparently, line-dasharray, text-font and text-justify can be Expression's.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions