### PR TITLE
[relay-compiler] Add requirements for relay-compiler-language-typescript

### DIFF
--- a/types/relay-compiler/index.d.ts
+++ b/types/relay-compiler/index.d.ts
@@ -1,17 +1,66 @@
 // Type definitions for relay-compiler 6.0
 // Project: https://relay.dev
 // Definitions by: n1ru4l <https://github.com/n1ru4l>
+//                 Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import { GraphQLCompilerContext } from './lib/core/GraphQLCompilerContext';
 import * as ASTConvert from './lib/core/ASTConvert';
-
 import * as Parser from './lib/core/RelayParser';
 import * as Printer from './lib/core/GraphQLIRPrinter';
+import * as IRTransforms from './lib/core/RelayIRTransforms';
+import * as IRVisitor from './lib/core/GraphQLIRVisitor';
+import * as SchemaUtils from './lib/core/GraphQLSchemaUtils';
+
 import ConsoleReporter = require('./lib/reporters/GraphQLConsoleReporter');
 import MultiReporter = require('./lib/reporters/GraphQLMultiReporter');
 
 declare var transformASTSchema: typeof ASTConvert.transformASTSchema;
 
-export { GraphQLCompilerContext, ASTConvert, transformASTSchema, Parser, Printer, ConsoleReporter, MultiReporter };
+export {
+    ASTConvert,
+    ConsoleReporter,
+    IRTransforms,
+    IRVisitor,
+    MultiReporter,
+    Parser,
+    Printer,
+    SchemaUtils,
+    transformASTSchema,
+};
+
+export { main as relayCompiler } from './lib/bin/RelayCompilerMain';
+export { GraphQLCompilerContext } from './lib/core/GraphQLCompilerContext';
+export { FormatModule, TypeGenerator } from './lib/language/RelayLanguagePluginInterface';
+export {
+    Argument,
+    ArgumentDefinition,
+    ArgumentValue,
+    Condition,
+    Definition,
+    Directive,
+    Field,
+    Fragment,
+    FragmentSpread,
+    GeneratedDefinition,
+    Handle,
+    InlineFragment,
+    IR,
+    LinkedField,
+    ListValue,
+    Literal,
+    LocalArgumentDefinition,
+    ModuleImport,
+    Metadata,
+    Node,
+    ObjectFieldValue,
+    ObjectValue,
+    Request,
+    Root,
+    RootArgumentDefinition,
+    ScalarField,
+    ScalarFieldType,
+    Selection,
+    SplitOperation,
+    Variable,
+} from './lib/core/GraphQLIR';

--- a/types/relay-compiler/lib/bin/RelayCompilerMain.d.ts
+++ b/types/relay-compiler/lib/bin/RelayCompilerMain.d.ts
@@ -1,0 +1,25 @@
+import { PluginInitializer, PluginInterface } from '../language/RelayLanguagePluginInterface';
+import { ScalarTypeMapping } from '../language/javascript/RelayFlowTypeTransformers';
+
+export interface Config {
+    schema: string;
+    src: string;
+    extensions: Array<string>;
+    include: Array<string>;
+    exclude: Array<string>;
+    verbose: boolean;
+    watchman: boolean;
+    watch?: boolean | null;
+    validate: boolean;
+    quiet: boolean;
+    persistOutput?: string | null;
+    noFutureProofEnums: boolean;
+    language: string | PluginInitializer;
+    persistFunction?: string | ((text: string) => Promise<string>) | null;
+    artifactDirectory?: string | null;
+    customScalars?: ScalarTypeMapping;
+}
+
+export function getLanguagePlugin(language: string | PluginInitializer): PluginInterface;
+
+export function main(config: Config): Promise<void>;

--- a/types/relay-compiler/lib/bin/RelayCompilerMain.d.ts
+++ b/types/relay-compiler/lib/bin/RelayCompilerMain.d.ts
@@ -4,9 +4,9 @@ import { ScalarTypeMapping } from '../language/javascript/RelayFlowTypeTransform
 export interface Config {
     schema: string;
     src: string;
-    extensions: Array<string>;
-    include: Array<string>;
-    exclude: Array<string>;
+    extensions: string[];
+    include: string[];
+    exclude: string[];
     verbose: boolean;
     watchman: boolean;
     watch?: boolean | null;

--- a/types/relay-compiler/lib/core/GraphQLIR.d.ts
+++ b/types/relay-compiler/lib/core/GraphQLIR.d.ts
@@ -1,341 +1,334 @@
 import {
-  Source,
-  GraphQLInputType,
-  GraphQLOutputType,
-  GraphQLCompositeType,
-  GraphQLLeafType,
-  GraphQLList,
-  GraphQLNonNull,
+    Source,
+    GraphQLInputType,
+    GraphQLOutputType,
+    GraphQLCompositeType,
+    GraphQLLeafType,
+    GraphQLList,
+    GraphQLNonNull,
 } from 'graphql';
 
 export type Metadata = { [key: string]: unknown } | undefined;
 
 export interface SourceLocation {
-  kind: 'Source';
-  start: number;
-  end: number;
-  source: Source;
+    kind: 'Source';
+    start: number;
+    end: number;
+    source: Source;
 }
 
 export interface GeneratedLocation {
-  kind: 'Generated';
+    kind: 'Generated';
 }
 
 export interface DerivedLocation {
-  kind: 'Derived';
-  source: Location;
+    kind: 'Derived';
+    source: Location;
 }
 export interface UnknownLocation {
-  kind: 'Unknown';
+    kind: 'Unknown';
 }
 
-export type Location =
-  | SourceLocation
-  | GeneratedLocation
-  | DerivedLocation
-  | UnknownLocation;
+export type Location = SourceLocation | GeneratedLocation | DerivedLocation | UnknownLocation;
 
 export interface Argument {
-  kind: 'Argument';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  type?: GraphQLInputType;
-  value: ArgumentValue;
+    kind: 'Argument';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    type?: GraphQLInputType;
+    value: ArgumentValue;
 }
 
-export type ArgumentDefinition =
-  | LocalArgumentDefinition
-  | RootArgumentDefinition;
+export type ArgumentDefinition = LocalArgumentDefinition | RootArgumentDefinition;
 
 export type ArgumentValue = ListValue | Literal | ObjectValue | Variable;
 
 export interface Condition {
-  condition: Literal | Variable;
-  kind: 'Condition';
-  loc: Location;
-  metadata: Metadata;
-  passingValue: boolean;
-  selections: ReadonlyArray<Selection>;
+    condition: Literal | Variable;
+    kind: 'Condition';
+    loc: Location;
+    metadata: Metadata;
+    passingValue: boolean;
+    selections: ReadonlyArray<Selection>;
 }
 
 export interface Directive {
-  args: ReadonlyArray<Argument>;
-  kind: 'Directive';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
+    args: ReadonlyArray<Argument>;
+    kind: 'Directive';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
 }
 
 export type Field = LinkedField | ScalarField | ConnectionField;
 
 export interface Fragment {
-  argumentDefinitions: ReadonlyArray<ArgumentDefinition>;
-  directives: ReadonlyArray<Directive>;
-  kind: 'Fragment';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  selections: ReadonlyArray<Selection>;
-  type: GraphQLCompositeType;
+    argumentDefinitions: ReadonlyArray<ArgumentDefinition>;
+    directives: ReadonlyArray<Directive>;
+    kind: 'Fragment';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    selections: ReadonlyArray<Selection>;
+    type: GraphQLCompositeType;
 }
 
 export interface FragmentSpread {
-  args: ReadonlyArray<Argument>;
-  directives: ReadonlyArray<Directive>;
-  kind: 'FragmentSpread';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
+    args: ReadonlyArray<Argument>;
+    directives: ReadonlyArray<Directive>;
+    kind: 'FragmentSpread';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
 }
 
 export interface Defer {
-  kind: 'Defer';
-  loc: Location;
-  metadata: Metadata;
-  selections: ReadonlyArray<Selection>;
-  label: string;
-  if: ArgumentValue | null;
+    kind: 'Defer';
+    loc: Location;
+    metadata: Metadata;
+    selections: ReadonlyArray<Selection>;
+    label: string;
+    if: ArgumentValue | null;
 }
 
 export interface Stream {
-  kind: 'Stream';
-  loc: Location;
-  metadata: Metadata;
-  selections: ReadonlyArray<Selection>;
-  label: string;
-  if: ArgumentValue | null;
-  initialCount: ArgumentValue;
+    kind: 'Stream';
+    loc: Location;
+    metadata: Metadata;
+    selections: ReadonlyArray<Selection>;
+    label: string;
+    if: ArgumentValue | null;
+    initialCount: ArgumentValue;
 }
 
 export interface InlineDataFragmentSpread {
-  kind: 'InlineDataFragmentSpread';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  selections: ReadonlyArray<Selection>;
+    kind: 'InlineDataFragmentSpread';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    selections: ReadonlyArray<Selection>;
 }
 
 export type IR =
-  | Argument
-  | ClientExtension
-  | Condition
-  | Defer
-  | ConnectionField
-  | Directive
-  | Fragment
-  | FragmentSpread
-  | InlineFragment
-  | LinkedField
-  | ListValue
-  | Literal
-  | LocalArgumentDefinition
-  | ModuleImport
-  | ObjectFieldValue
-  | ObjectValue
-  | Request
-  | Root
-  | RootArgumentDefinition
-  | ScalarField
-  | SplitOperation
-  | Stream
-  | InlineDataFragmentSpread
-  | Variable;
+    | Argument
+    | ClientExtension
+    | Condition
+    | Defer
+    | ConnectionField
+    | Directive
+    | Fragment
+    | FragmentSpread
+    | InlineFragment
+    | LinkedField
+    | ListValue
+    | Literal
+    | LocalArgumentDefinition
+    | ModuleImport
+    | ObjectFieldValue
+    | ObjectValue
+    | Request
+    | Root
+    | RootArgumentDefinition
+    | ScalarField
+    | SplitOperation
+    | Stream
+    | InlineDataFragmentSpread
+    | Variable;
 
 export interface RootArgumentDefinition {
-  kind: 'RootArgumentDefinition';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  type: GraphQLInputType;
+    kind: 'RootArgumentDefinition';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    type: GraphQLInputType;
 }
 
 export interface InlineFragment {
-  directives: ReadonlyArray<Directive>;
-  kind: 'InlineFragment';
-  loc: Location;
-  metadata: Metadata;
-  selections: ReadonlyArray<Selection>;
-  typeCondition: GraphQLCompositeType;
+    directives: ReadonlyArray<Directive>;
+    kind: 'InlineFragment';
+    loc: Location;
+    metadata: Metadata;
+    selections: ReadonlyArray<Selection>;
+    typeCondition: GraphQLCompositeType;
 }
 
 export interface Handle {
-  name: string;
-  key: string;
-  dynamicKey: Variable | null;
-  filters?: Readonly<string>;
+    name: string;
+    key: string;
+    dynamicKey: Variable | null;
+    filters?: Readonly<string>;
 }
 
 export interface ClientExtension {
-  kind: 'ClientExtension';
-  loc: Location;
-  metadata: Metadata;
-  selections: ReadonlyArray<Selection>;
+    kind: 'ClientExtension';
+    loc: Location;
+    metadata: Metadata;
+    selections: ReadonlyArray<Selection>;
 }
 
 export interface ConnectionField {
-  alias: string;
-  args: ReadonlyArray<Argument>;
-  directives: ReadonlyArray<Directive>;
-  kind: 'ConnectionField';
-  label: string;
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  resolver: string;
-  selections: ReadonlyArray<Selection>;
-  type: GraphQLOutputType;
+    alias: string;
+    args: ReadonlyArray<Argument>;
+    directives: ReadonlyArray<Directive>;
+    kind: 'ConnectionField';
+    label: string;
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    resolver: string;
+    selections: ReadonlyArray<Selection>;
+    type: GraphQLOutputType;
 }
 
 export interface LinkedField {
-  alias: string;
-  args: ReadonlyArray<Argument>;
-  directives: ReadonlyArray<Directive>;
-  handles?: ReadonlyArray<Handle>;
-  kind: 'LinkedField';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  selections: ReadonlyArray<Selection>;
-  type: GraphQLOutputType;
+    alias: string;
+    args: ReadonlyArray<Argument>;
+    directives: ReadonlyArray<Directive>;
+    handles?: ReadonlyArray<Handle>;
+    kind: 'LinkedField';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    selections: ReadonlyArray<Selection>;
+    type: GraphQLOutputType;
 }
 
 export interface ListValue {
-  kind: 'ListValue';
-  items: ReadonlyArray<ArgumentValue>;
-  loc: Location;
-  metadata: Metadata;
+    kind: 'ListValue';
+    items: ReadonlyArray<ArgumentValue>;
+    loc: Location;
+    metadata: Metadata;
 }
 
 export interface Literal {
-  kind: 'Literal';
-  loc: Location;
-  metadata: Metadata;
-  value: unknown;
+    kind: 'Literal';
+    loc: Location;
+    metadata: Metadata;
+    value: unknown;
 }
 
 export interface LocalArgumentDefinition {
-  defaultValue: unknown;
-  kind: 'LocalArgumentDefinition';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  type: GraphQLInputType;
+    defaultValue: unknown;
+    kind: 'LocalArgumentDefinition';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    type: GraphQLInputType;
 }
 
 export interface ModuleImport {
-  kind: 'ModuleImport';
-  loc: Location;
-  documentName: string;
-  module: string;
-  id: string;
-  name: string;
-  selections: ReadonlyArray<Selection>;
+    kind: 'ModuleImport';
+    loc: Location;
+    documentName: string;
+    module: string;
+    id: string;
+    name: string;
+    selections: ReadonlyArray<Selection>;
 }
 
 export type Node =
-  | ClientExtension
-  | Condition
-  | Defer
-  | ConnectionField
-  | Fragment
-  | InlineDataFragmentSpread
-  | InlineFragment
-  | LinkedField
-  | ModuleImport
-  | Root
-  | SplitOperation
-  | Stream;
+    | ClientExtension
+    | Condition
+    | Defer
+    | ConnectionField
+    | Fragment
+    | InlineDataFragmentSpread
+    | InlineFragment
+    | LinkedField
+    | ModuleImport
+    | Root
+    | SplitOperation
+    | Stream;
 
 export interface ObjectFieldValue {
-  kind: 'ObjectFieldValue';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  value: ArgumentValue;
+    kind: 'ObjectFieldValue';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    value: ArgumentValue;
 }
 
 export interface ObjectValue {
-  kind: 'ObjectValue';
-  fields: ReadonlyArray<ObjectFieldValue>;
-  loc: Location;
-  metadata: Metadata;
+    kind: 'ObjectValue';
+    fields: ReadonlyArray<ObjectFieldValue>;
+    loc: Location;
+    metadata: Metadata;
 }
 
 export interface Request {
-  kind: 'Request';
-  fragment: Fragment;
-  id?: string;
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  root: Root;
-  text?: string;
+    kind: 'Request';
+    fragment: Fragment;
+    id?: string;
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    root: Root;
+    text?: string;
 }
 
 export interface Root {
-  argumentDefinitions: Readonly<LocalArgumentDefinition>;
-  directives: Readonly<Directive>;
-  kind: 'Root';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  operation: 'query' | 'mutation' | 'subscription';
-  selections: Readonly<Selection>;
-  type: GraphQLCompositeType;
+    argumentDefinitions: ReadonlyArray<LocalArgumentDefinition>;
+    directives: ReadonlyArray<Directive>;
+    kind: 'Root';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    operation: 'query' | 'mutation' | 'subscription';
+    selections: Readonly<Selection>;
+    type: GraphQLCompositeType;
 }
 
 // workaround for circular reference
 // tslint:disable-next-line:no-empty-interface
-export interface ScalarFieldTypeGraphQLList
-  extends GraphQLList<ScalarFieldType> {}
+export interface ScalarFieldTypeGraphQLList extends GraphQLList<ScalarFieldType> {}
 
 export type ScalarFieldType =
-  | GraphQLLeafType
-  | ScalarFieldTypeGraphQLList
-  | GraphQLNonNull<GraphQLLeafType | ScalarFieldTypeGraphQLList>;
+    | GraphQLLeafType
+    | ScalarFieldTypeGraphQLList
+    | GraphQLNonNull<GraphQLLeafType | ScalarFieldTypeGraphQLList>;
 
 export interface ScalarField {
-  alias: string;
-  args: ReadonlyArray<Argument>;
-  directives: ReadonlyArray<Directive>;
-  handles?: ReadonlyArray<Handle>;
-  kind: 'ScalarField';
-  loc: Location;
-  metadata: Metadata;
-  name: string;
-  type: ScalarFieldType;
+    alias: string;
+    args: ReadonlyArray<Argument>;
+    directives: ReadonlyArray<Directive>;
+    handles?: ReadonlyArray<Handle>;
+    kind: 'ScalarField';
+    loc: Location;
+    metadata: Metadata;
+    name: string;
+    type: ScalarFieldType;
 }
 
 export type Selection =
-  | ClientExtension
-  | Condition
-  | Defer
-  | ConnectionField
-  | FragmentSpread
-  | InlineFragment
-  | LinkedField
-  | ModuleImport
-  | ScalarField
-  | InlineDataFragmentSpread
-  | Stream;
+    | ClientExtension
+    | Condition
+    | Defer
+    | ConnectionField
+    | FragmentSpread
+    | InlineFragment
+    | LinkedField
+    | ModuleImport
+    | ScalarField
+    | InlineDataFragmentSpread
+    | Stream;
 
 export type Definition = Fragment | Root | SplitOperation;
 export type GeneratedDefinition = Fragment | Request | SplitOperation;
 
 export interface SplitOperation {
-  kind: 'SplitOperation';
-  name: string;
-  selections: ReadonlyArray<Selection>;
-  loc: Location;
-  metadata: Metadata;
-  type: GraphQLCompositeType;
+    kind: 'SplitOperation';
+    name: string;
+    selections: ReadonlyArray<Selection>;
+    loc: Location;
+    metadata: Metadata;
+    type: GraphQLCompositeType;
 }
 
 export interface Variable {
-  kind: 'Variable';
-  loc: Location;
-  metadata: Metadata;
-  variableName: string;
-  type?: GraphQLInputType;
+    kind: 'Variable';
+    loc: Location;
+    metadata: Metadata;
+    variableName: string;
+    type?: GraphQLInputType;
 }

--- a/types/relay-compiler/lib/core/GraphQLIRVisitor.d.ts
+++ b/types/relay-compiler/lib/core/GraphQLIRVisitor.d.ts
@@ -45,14 +45,17 @@ export type VisitNode =
     | Stream
     | Variable;
 
-type EnterLeave<T> = { readonly enter?: T; readonly leave?: T };
+export interface EnterLeave<T> {
+    readonly enter?: T;
+    readonly leave?: T;
+}
 
 export type VisitFn<T extends VisitNode> = (
     node: T, // node we're visiting
     key?: any, // index/key to node from parent array/object
-    parent?: null | VisitNode | Array<VisitNode>, // Object immediately above node
-    path?: Array<any>, // keys to get from root: [keyForChild, ..., keyForParent]
-    ancestors?: Array<VisitNode | Array<VisitNode>>, // [root, child1, ..., grandparent]
+    parent?: null | VisitNode | VisitNode[], // Object immediately above node
+    path?: any[], // keys to get from root: [keyForChild, ..., keyForParent]
+    ancestors?: Array<VisitNode | VisitNode[]>, // [root, child1, ..., grandparent]
 ) => // Note: ancestors includes arrays which contain the visited node
 // These correspond to array indices in `path`.
 any;

--- a/types/relay-compiler/lib/core/GraphQLIRVisitor.d.ts
+++ b/types/relay-compiler/lib/core/GraphQLIRVisitor.d.ts
@@ -1,0 +1,109 @@
+import {
+    Argument,
+    ClientExtension,
+    Condition,
+    Defer,
+    ConnectionField,
+    Directive,
+    Fragment,
+    FragmentSpread,
+    InlineDataFragmentSpread,
+    InlineFragment,
+    LinkedField,
+    Literal,
+    LocalArgumentDefinition,
+    ModuleImport,
+    Request,
+    Root,
+    RootArgumentDefinition,
+    ScalarField,
+    SplitOperation,
+    Stream,
+    Variable,
+} from './GraphQLIR';
+
+export type VisitNode =
+    | Argument
+    | ClientExtension
+    | Condition
+    | Defer
+    | ConnectionField
+    | Directive
+    | Fragment
+    | FragmentSpread
+    | InlineDataFragmentSpread
+    | InlineFragment
+    | LinkedField
+    | Literal
+    | LocalArgumentDefinition
+    | ModuleImport
+    | Request
+    | Root
+    | RootArgumentDefinition
+    | ScalarField
+    | SplitOperation
+    | Stream
+    | Variable;
+
+type EnterLeave<T> = { readonly enter?: T; readonly leave?: T };
+
+export type VisitFn<T extends VisitNode> = (
+    node: T, // node we're visiting
+    key?: any, // index/key to node from parent array/object
+    parent?: null | VisitNode | Array<VisitNode>, // Object immediately above node
+    path?: Array<any>, // keys to get from root: [keyForChild, ..., keyForParent]
+    ancestors?: Array<VisitNode | Array<VisitNode>>, // [root, child1, ..., grandparent]
+) => // Note: ancestors includes arrays which contain the visited node
+// These correspond to array indices in `path`.
+any;
+
+export type NodeVisitorObject<T extends VisitNode> = EnterLeave<VisitFn<T>> | VisitFn<T>;
+
+export type NodeVisitor =
+    | EnterLeave<{
+          Argument?: VisitFn<Argument>;
+          ClientExtension?: VisitFn<ClientExtension>;
+          Condition?: VisitFn<Condition>;
+          Defer?: VisitFn<Defer>;
+          ConnectionField?: VisitFn<ConnectionField>;
+          Directive?: VisitFn<Directive>;
+          Fragment?: VisitFn<Fragment>;
+          FragmentSpread?: VisitFn<FragmentSpread>;
+          InlineFragment?: VisitFn<InlineFragment>;
+          LinkedField?: VisitFn<LinkedField>;
+          Literal?: VisitFn<Literal>;
+          LocalArgumentDefinition?: VisitFn<LocalArgumentDefinition>;
+          ModuleImport?: VisitFn<ModuleImport>;
+          Request?: VisitFn<Request>;
+          Root?: VisitFn<Root>;
+          RootArgumentDefinition?: VisitFn<RootArgumentDefinition>;
+          ScalarField?: VisitFn<ScalarField>;
+          SplitOperation?: VisitFn<SplitOperation>;
+          Stream?: VisitFn<Stream>;
+          Variable?: VisitFn<Variable>;
+      }>
+    | {
+          Argument?: NodeVisitorObject<Argument>;
+          ClientExtension?: VisitFn<ClientExtension>;
+          Condition?: NodeVisitorObject<Condition>;
+          Defer?: NodeVisitorObject<Defer>;
+          ConnectionField?: NodeVisitorObject<ConnectionField>;
+          Directive?: NodeVisitorObject<Directive>;
+          Fragment?: NodeVisitorObject<Fragment>;
+          FragmentSpread?: NodeVisitorObject<FragmentSpread>;
+          InlineDataFragmentSpread?: NodeVisitorObject<InlineDataFragmentSpread>;
+          InlineFragment?: NodeVisitorObject<InlineFragment>;
+          LinkedField?: NodeVisitorObject<LinkedField>;
+          Literal?: NodeVisitorObject<Literal>;
+          LocalArgumentDefinition?: NodeVisitorObject<LocalArgumentDefinition>;
+          ModuleImport?: NodeVisitorObject<ModuleImport>;
+          Request?: NodeVisitorObject<Request>;
+          Root?: NodeVisitorObject<Root>;
+          RootArgumentDefinition?: NodeVisitorObject<RootArgumentDefinition>;
+          ScalarField?: NodeVisitorObject<ScalarField>;
+          SplitOperation?: NodeVisitorObject<SplitOperation>;
+          Stream?: NodeVisitorObject<Stream>;
+          Variable?: NodeVisitorObject<Variable>;
+      };
+
+export function visit(root: VisitNode, visitor: NodeVisitor): any;

--- a/types/relay-compiler/lib/core/GraphQLSchemaUtils.d.ts
+++ b/types/relay-compiler/lib/core/GraphQLSchemaUtils.d.ts
@@ -1,0 +1,10 @@
+import { GraphQLUnionType, GraphQLType, GraphQLInterfaceType } from 'graphql';
+
+/**
+ * Determine if a type is abstract (not concrete).
+ *
+ * Note: This is used in place of the `graphql` version of the function in order
+ * to not break `instanceof` checks with Jest. This version also unwraps
+ * non-null/list wrapper types.
+ */
+export function isAbstractType(type: GraphQLType): type is GraphQLInterfaceType | GraphQLUnionType;

--- a/types/relay-compiler/lib/core/RelayIRTransforms.d.ts
+++ b/types/relay-compiler/lib/core/RelayIRTransforms.d.ts
@@ -1,0 +1,8 @@
+import { IRTransform } from './GraphQLCompilerContext';
+
+export const commonTransforms: IRTransform[];
+export const codegenTransforms: IRTransform[];
+export const fragmentTransforms: IRTransform[];
+export const printTransforms: IRTransform[];
+export const queryTransforms: IRTransform[];
+export const schemaExtensions: string[];

--- a/types/relay-compiler/lib/language/RelayLanguagePluginInterface.d.ts
+++ b/types/relay-compiler/lib/language/RelayLanguagePluginInterface.d.ts
@@ -1,0 +1,247 @@
+import { Root, Fragment, GeneratedDefinition } from '../core/GraphQLIR';
+import { IRTransform } from '../core/GraphQLCompilerContext';
+import { GeneratedNode, RelayConcreteNode } from 'relay-runtime';
+import { ScalarTypeMapping } from './javascript/RelayFlowTypeTransformers';
+
+/**
+ * A language plugin allows relay-compiler to both read and write files for any
+ * language.
+ *
+ * When reading, the plugin is expected to parse and return GraphQL tags; and
+ * when writing the plugin is responsible for generating type information about
+ * the GraphQL selections made as well as generating the contents of the
+ * artifact file.
+ *
+ * This interface describes the details relay-compiler requires to be able to
+ * use the plugin and is expected to be returned by a {PluginInitializer}.
+ */
+export type PluginInterface = {
+    inputExtensions: string[];
+    outputExtension: string;
+    findGraphQLTags: GraphQLTagFinder;
+    formatModule: FormatModule;
+    typeGenerator: TypeGenerator;
+};
+
+/**
+ * The plugin is expected to have as its main default export a function that
+ * returns an object conforming to the plugin interface.
+ *
+ * For now a plugin doesn’t take any arguments, but may do so in the future.
+ */
+export type PluginInitializer = () => PluginInterface;
+
+export type GraphQLTag = {
+    /**
+     * Should hold the string content of the `graphql` tagged template literal,
+     * which is either an operation or fragment.
+     *
+     * @example
+     *
+     *  grapqhl`query MyQuery { … }`
+     *  grapqhl`fragment MyFragment on MyType { … }`
+     */
+    template: string;
+
+    /**
+     * In the case this tag was part of a fragment container and it used a node
+     * map as fragment spec, rather than a single tagged node, this should hold
+     * the prop key to which the node is assigned.
+     *
+     * @example
+     *
+     *  createFragmentContainer(
+     *    MyComponent,
+     *    {
+     *      keyName: graphql`fragment MyComponent_keyName { … }`
+     *    }
+     *  )
+     *
+     */
+    keyName: null | string;
+
+    /**
+     * The location in the source file that the tag is placed at.
+     */
+    sourceLocationOffset: {
+        /**
+         * The line in the source file that the tag is placed on.
+         *
+         * Lines use 1-based indexing.
+         */
+        line: number;
+
+        /**
+         * The column in the source file that the tag starts on.
+         *
+         * Columns use 1-based indexing.
+         */
+        column: number;
+    };
+};
+
+/**
+ * This function is responsible for extracting `GraphQLTag` objects from source
+ * files.
+ *
+ * @param  {string} text       The source file contents.
+ * @param  {string} filePath   The path to the source file on disk.
+ * @return {Array<GraphQLTag>} All extracted `GraphQLTag` objects.
+ *
+ * @see {@link javascript/FindGraphQLTags.js}
+ */
+export type GraphQLTagFinder = (text: string, filePath: string) => ReadonlyArray<GraphQLTag>;
+
+/**
+ * The function that is responsible for generating the contents of the artifact
+ * file.
+ *
+ * @see {@link javascript/formatGeneratedModule.js}
+ */
+export type FormatModule = (options: {
+    /**
+     * The filename of the module.
+     */
+    moduleName: string;
+
+    /**
+     * The type of artifact that this module represents.
+     *
+     * @todo Document when this can be `empty`.
+     */
+    documentType: typeof RelayConcreteNode.FRAGMENT | typeof RelayConcreteNode.REQUEST | null;
+
+    /**
+     * The actual document that this module represents.
+     */
+    docText: null | string;
+
+    /**
+     * The IR for the document that this module represents.
+     */
+    concreteText: string;
+
+    /**
+     * The type information generated for the GraphQL selections made.
+     */
+    typeText: string;
+
+    /**
+     * A hash of the concrete node including the query text.
+     *
+     * @todo Document how this is different from `sourceHash`.
+     */
+    hash: null | string;
+
+    /**
+     * The 'kind' of the generated node.
+     */
+    kind: string;
+
+    /**
+     * The IR node from which the generated node is derived.
+     */
+    definition: GeneratedDefinition;
+
+    /**
+     * A hash of the document, which is used by relay-compiler to know if it needs
+     * to write a new version of the artifact.
+     *
+     * @todo Is this correct? And document how this is different from `hash`.
+     */
+    sourceHash: string;
+
+    /**
+     * The generated node being written.
+     */
+    node: GeneratedNode;
+}) => string;
+
+/**
+ * The options that will be passed to the `generate` function of your plugin’s
+ * type generator.
+ */
+export type TypeGeneratorOptions = {
+    /**
+     * A map of custom scalars to scalars that the plugin knows about and emits
+     * type information for.
+     *
+     * @example
+     *
+     *  // The URL custom scalar is essentially a string and should be treated as
+     *  // such by the language’s type system.
+     *  { URL: 'String' }
+     */
+    readonly customScalars: ScalarTypeMapping;
+
+    /**
+     * Lists all other fragments relay-compiler knows about. Use this to know when
+     * to import/reference other artifacts.
+     */
+    readonly existingFragmentNames: Set<string>;
+
+    /**
+     * Whether or not relay-compiler will store artifacts next to the module that
+     * they originate from or all together in a single directory.
+     *
+     * Storing all artifacts in a single directory makes it easy to import and
+     * reference fragments defined in other artifacts without needing to use the
+     * Haste module system.
+     *
+     * This defaults to `false`.
+     */
+    readonly useSingleArtifactDirectory: boolean;
+
+    /**
+     * This option controls whether or not a catch-all entry is added to enum type
+     * definitions for values that may be added in the future. Enabling this means
+     * you will have to update your application whenever the GraphQL server schema
+     * adds new enum values to prevent it from breaking.
+     *
+     * This defaults to `false`.
+     */
+    readonly noFutureProofEnums: boolean;
+
+    /**
+     * @todo Document this.
+     */
+    readonly optionalInputFields: ReadonlyArray<string>;
+
+    /**
+     * Whether or not the Haste module system is being used. This will currently
+     * always be `false` for OSS users.
+     */
+    readonly useHaste: boolean;
+
+    /**
+     * Import flow types from the Haste-style global module name or per-enum
+     * global module name given by the function variant.
+     */
+    readonly enumsHasteModule?: string | ((enumName: string) => string);
+
+    /**
+     * Optional normalization IR for generating raw response
+     */
+    readonly normalizationIR?: Root;
+};
+
+/**
+ * This object should hold the implementation required to generate types for the
+ * GraphQL selections made.
+ *
+ * @see {@link javascript/RelayFlowGenerator.js}
+ */
+export type TypeGenerator = {
+    /**
+     * Transforms that should be applied to the intermediate representation of the
+     * GraphQL document before passing to the `generate` function.
+     */
+    transforms: ReadonlyArray<IRTransform>;
+
+    /**
+     * Given GraphQL document IR, this function should generate type information
+     * for e.g. the selections made. It can, however, also generate any other
+     * content such as importing other files, including other artifacts.
+     */
+    generate: (node: Root | Fragment, options: TypeGeneratorOptions) => string;
+};

--- a/types/relay-compiler/lib/language/RelayLanguagePluginInterface.d.ts
+++ b/types/relay-compiler/lib/language/RelayLanguagePluginInterface.d.ts
@@ -15,13 +15,13 @@ import { ScalarTypeMapping } from './javascript/RelayFlowTypeTransformers';
  * This interface describes the details relay-compiler requires to be able to
  * use the plugin and is expected to be returned by a {PluginInitializer}.
  */
-export type PluginInterface = {
+export interface PluginInterface {
     inputExtensions: string[];
     outputExtension: string;
     findGraphQLTags: GraphQLTagFinder;
     formatModule: FormatModule;
     typeGenerator: TypeGenerator;
-};
+}
 
 /**
  * The plugin is expected to have as its main default export a function that
@@ -31,7 +31,7 @@ export type PluginInterface = {
  */
 export type PluginInitializer = () => PluginInterface;
 
-export type GraphQLTag = {
+export interface GraphQLTag {
     /**
      * Should hold the string content of the `graphql` tagged template literal,
      * which is either an operation or fragment.
@@ -78,15 +78,15 @@ export type GraphQLTag = {
          */
         column: number;
     };
-};
+}
 
 /**
  * This function is responsible for extracting `GraphQLTag` objects from source
  * files.
  *
- * @param  {string} text       The source file contents.
- * @param  {string} filePath   The path to the source file on disk.
- * @return {Array<GraphQLTag>} All extracted `GraphQLTag` objects.
+ * @param  text       The source file contents.
+ * @param  filePath   The path to the source file on disk.
+ * @return All extracted `GraphQLTag` objects.
  *
  * @see {@link javascript/FindGraphQLTags.js}
  */
@@ -161,7 +161,7 @@ export type FormatModule = (options: {
  * The options that will be passed to the `generate` function of your plugin’s
  * type generator.
  */
-export type TypeGeneratorOptions = {
+export interface TypeGeneratorOptions {
     /**
      * A map of custom scalars to scalars that the plugin knows about and emits
      * type information for.
@@ -223,7 +223,7 @@ export type TypeGeneratorOptions = {
      * Optional normalization IR for generating raw response
      */
     readonly normalizationIR?: Root;
-};
+}
 
 /**
  * This object should hold the implementation required to generate types for the
@@ -231,7 +231,7 @@ export type TypeGeneratorOptions = {
  *
  * @see {@link javascript/RelayFlowGenerator.js}
  */
-export type TypeGenerator = {
+export interface TypeGenerator {
     /**
      * Transforms that should be applied to the intermediate representation of the
      * GraphQL document before passing to the `generate` function.
@@ -244,4 +244,4 @@ export type TypeGenerator = {
      * content such as importing other files, including other artifacts.
      */
     generate: (node: Root | Fragment, options: TypeGeneratorOptions) => string;
-};
+}

--- a/types/relay-compiler/lib/language/javascript/RelayFlowTypeTransformers.d.ts
+++ b/types/relay-compiler/lib/language/javascript/RelayFlowTypeTransformers.d.ts
@@ -1,3 +1,3 @@
-export type ScalarTypeMapping = {
+export interface ScalarTypeMapping {
     [type: string]: string;
-};
+}

--- a/types/relay-compiler/lib/language/javascript/RelayFlowTypeTransformers.d.ts
+++ b/types/relay-compiler/lib/language/javascript/RelayFlowTypeTransformers.d.ts
@@ -1,0 +1,3 @@
+export type ScalarTypeMapping = {
+    [type: string]: string;
+};

--- a/types/relay-compiler/lib/transforms/ConnectionFieldTransform.d.ts
+++ b/types/relay-compiler/lib/transforms/ConnectionFieldTransform.d.ts
@@ -1,0 +1,9 @@
+import { GraphQLCompilerContext } from '../core/GraphQLCompilerContext';
+
+/**
+ * This transform rewrites LinkedField nodes with @connection_resolver and rewrites them
+ * into `ConnectionField` nodes.
+ */
+declare function connectionFieldTransform(context: GraphQLCompilerContext): GraphQLCompilerContext;
+
+export { connectionFieldTransform as transform };

--- a/types/relay-compiler/lib/transforms/RelayMaskTransform.d.ts
+++ b/types/relay-compiler/lib/transforms/RelayMaskTransform.d.ts
@@ -1,0 +1,9 @@
+import { GraphQLCompilerContext } from '../core/GraphQLCompilerContext';
+
+/**
+ * A transform that inlines fragment spreads with the @relay(mask: false)
+ * directive.
+ */
+declare function relayMaskTransform(context: GraphQLCompilerContext): GraphQLCompilerContext;
+
+export { relayMaskTransform as transform };

--- a/types/relay-compiler/lib/transforms/RelayMatchTransform.d.ts
+++ b/types/relay-compiler/lib/transforms/RelayMatchTransform.d.ts
@@ -1,0 +1,9 @@
+import { GraphQLCompilerContext } from '../core/GraphQLCompilerContext';
+
+/**
+ * This transform rewrites LinkedField nodes with @match and rewrites them
+ * into `LinkedField` nodes with a `supported` argument.
+ */
+declare function relayMatchTransform(context: GraphQLCompilerContext): GraphQLCompilerContext;
+
+export { relayMatchTransform as transform };

--- a/types/relay-compiler/lib/transforms/RelayRefetchableFragmentTransform.d.ts
+++ b/types/relay-compiler/lib/transforms/RelayRefetchableFragmentTransform.d.ts
@@ -1,0 +1,21 @@
+import { GraphQLCompilerContext } from '../core/GraphQLCompilerContext';
+
+/**
+ * This transform synthesizes "refetch" queries for fragments that
+ * are trivially refetchable. This is comprised of three main stages:
+ *
+ * 1. Validating that fragments marked with @refetchable qualify for
+ *    refetch query generation; mainly this means that the fragment
+ *    type is able to be refetched in some canonical way.
+ * 2. Determining the variable definitions to use for each generated
+ *    query. GraphQL does not have a notion of fragment-local variables
+ *    at all, and although Relay adds this concept developers are still
+ *    allowed to reference global variables. This necessitates a
+ *    visiting all reachable fragments for each @refetchable fragment,
+ *    and finding the union of all global variables expceted to be defined.
+ * 3. Building the refetch queries, a straightforward copying transform from
+ *    Fragment to Root IR nodes.
+ */
+declare function relayRefetchableFragmentTransform(context: GraphQLCompilerContext): GraphQLCompilerContext;
+
+export { relayRefetchableFragmentTransform as transform };

--- a/types/relay-compiler/lib/transforms/RelayRelayDirectiveTransform.d.ts
+++ b/types/relay-compiler/lib/transforms/RelayRelayDirectiveTransform.d.ts
@@ -1,0 +1,9 @@
+import { GraphQLCompilerContext } from '../core/GraphQLCompilerContext';
+
+/**
+ * A transform that extracts `@relay(plural: Boolean)` directives and converts
+ * them to metadata that can be accessed at runtime.
+ */
+declare function relayRelayDirectiveTransform(context: GraphQLCompilerContext): GraphQLCompilerContext;
+
+export { relayRelayDirectiveTransform as transform };

--- a/types/relay-compiler/relay-compiler-tests.ts
+++ b/types/relay-compiler/relay-compiler-tests.ts
@@ -1,35 +1,64 @@
 import {
-  GraphQLCompilerContext,
-  transformASTSchema,
-  Parser as RelayParser,
-  Printer as GraphQLIRPrinter,
+    GraphQLCompilerContext,
+    transformASTSchema,
+    Parser as RelayParser,
+    Printer as GraphQLIRPrinter,
 } from 'relay-compiler';
 
 import * as InlineFragmentsTransform from 'relay-compiler/lib/transforms/InlineFragmentsTransform';
 import * as SkipRedundantNodesTransform from 'relay-compiler/lib/transforms/SkipRedundantNodesTransform';
 import * as RelayApplyFragmentArgumentTransform from 'relay-compiler/lib/transforms/RelayApplyFragmentArgumentTransform';
 import * as FlattenTransform from 'relay-compiler/lib/transforms/FlattenTransform';
+import * as ConnectionFieldTransform from 'relay-compiler/lib/transforms/ConnectionFieldTransform';
+import { getLanguagePlugin } from 'relay-compiler/lib/bin/RelayCompilerMain';
 
 import { GraphQLSchema, DefinitionNode } from 'graphql';
+import { visit } from './lib/core/GraphQLIRVisitor';
 
 const documentAsts: DefinitionNode[] = [];
 const schema: GraphQLSchema = (undefined as any) as GraphQLSchema;
 
 const adjustedSchema = transformASTSchema(schema, [
-  /* GraphQL */ `
-    directive @connection(key: String!) on FIELD
-    directive @client on FIELD
-  `,
+    /* GraphQL */ `
+        directive @connection(key: String!) on FIELD
+        directive @client on FIELD
+    `,
 ]);
 
 const relayDocuments = RelayParser.transform(adjustedSchema, documentAsts);
 const queryCompilerContext = new GraphQLCompilerContext(adjustedSchema)
-  .addAll(relayDocuments)
-  .applyTransforms([
-    RelayApplyFragmentArgumentTransform.transform,
-    InlineFragmentsTransform.transform,
-    FlattenTransform.transformWithOptions({ flattenAbstractTypes: false }),
-    SkipRedundantNodesTransform.transform,
-  ]);
+    .addAll(relayDocuments)
+    .applyTransforms([
+        RelayApplyFragmentArgumentTransform.transform,
+        InlineFragmentsTransform.transform,
+        FlattenTransform.transformWithOptions({ flattenAbstractTypes: false }),
+        SkipRedundantNodesTransform.transform,
+        ConnectionFieldTransform.transform,
+    ]);
 
 queryCompilerContext.documents().map(doc => GraphQLIRPrinter.print(doc));
+
+getLanguagePlugin(() => ({
+    findGraphQLTags: (text, filePath) =>
+        text
+            .split(filePath)
+            .map(template => ({ template, keyName: filePath, sourceLocationOffset: { line: 24, column: 42 } })),
+    formatModule: options => options.docText || '',
+    inputExtensions: ['foo'],
+    outputExtension: 'bar',
+    typeGenerator: {
+        transforms: [RelayApplyFragmentArgumentTransform.transform],
+        generate: (node, options) => {
+            visit(node, {
+                Fragment(fragment) {
+                    return {
+                        ...fragment,
+                        name: 'BestFragmentName',
+                    };
+                },
+            });
+            return options.useSingleArtifactDirectory ? 'Some generated typings' : 'Some other generated typings';
+        },
+    },
+}));
+getLanguagePlugin('typescript').outputExtension;

--- a/types/relay-compiler/relay-compiler-tests.ts
+++ b/types/relay-compiler/relay-compiler-tests.ts
@@ -11,9 +11,9 @@ import * as RelayApplyFragmentArgumentTransform from 'relay-compiler/lib/transfo
 import * as FlattenTransform from 'relay-compiler/lib/transforms/FlattenTransform';
 import * as ConnectionFieldTransform from 'relay-compiler/lib/transforms/ConnectionFieldTransform';
 import { getLanguagePlugin } from 'relay-compiler/lib/bin/RelayCompilerMain';
+import { visit } from 'relay-compiler/lib/core/GraphQLIRVisitor';
 
 import { GraphQLSchema, DefinitionNode } from 'graphql';
-import { visit } from './lib/core/GraphQLIRVisitor';
 
 const documentAsts: DefinitionNode[] = [];
 const schema: GraphQLSchema = (undefined as any) as GraphQLSchema;

--- a/types/relay-compiler/tsconfig.json
+++ b/types/relay-compiler/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
+            "dom",
             "es6",
             "esnext.asynciterable"
         ],

--- a/types/relay-compiler/tsconfig.json
+++ b/types/relay-compiler/tsconfig.json
@@ -20,9 +20,14 @@
     "files": [
         "index.d.ts",
         "relay-compiler-tests.ts",
+        "lib/transforms/ConnectionFieldTransform.d.ts",
         "lib/transforms/FlattenTransform.d.ts",
         "lib/transforms/InlineFragmentsTransform.d.ts",
         "lib/transforms/RelayApplyFragmentArgumentTransform.d.ts",
-        "lib/transforms/SkipRedundantNodesTransform.d.ts"
+        "lib/transforms/SkipRedundantNodesTransform.d.ts",
+        "lib/transforms/RelayMaskTransform.d.ts",
+        "lib/transforms/RelayMatchTransform.d.ts",
+        "lib/transforms/RelayRefetchableFragmentTransform.d.ts",
+        "lib/transforms/RelayRelayDirectiveTransform.d.ts"
     ]
 }


### PR DESCRIPTION
Moves any missing types from https://github.com/relay-tools/relay-compiler-language-typescript/tree/83962d2b059d65a5dfd8a9bf7fa28be62fb7cbc3/types to here.

Also ran prettier.