### PR TITLE
fast-shuffle: returns type based on argument

### DIFF
--- a/types/fast-shuffle/fast-shuffle-tests.ts
+++ b/types/fast-shuffle/fast-shuffle-tests.ts
@@ -2,8 +2,8 @@ import shuffle from 'fast-shuffle';
 
 {
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
-    const d2 = shuffle(d1);
-    const d3 = shuffle(d1, () => 0.42);
+    const d2: string[] = shuffle(d1);
+    const d3: string[] = shuffle(d1, () => 0.42);
 }
 
 {
@@ -12,6 +12,6 @@ import shuffle from 'fast-shuffle';
     { name: 'Betty', money: 20 },
     { name: 'Cindy', money: 15 }
   ];
-  const d2 = shuffle(d1);
-  const d3 = shuffle(d1, () => 0.42);
+  const d2: Array<{ name: string, money: number }> = shuffle(d1);
+  const d3: Array<{ name: string, money: number }> = shuffle(d1, () => 0.42);
 }

--- a/types/fast-shuffle/index.d.ts
+++ b/types/fast-shuffle/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: Piotr Roszatycki <https://github.com/dex4er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function shuffle(deck: ReadonlyArray<any>, random?: () => number): any[];
+export default function shuffle<T>(deck: ReadonlyArray<T>, random?: () => number): T[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This is a fix: now function returns a list of the same type as in argument.
