### PR TITLE
@types/meteor: Add imports in *.d.ts files so as to remove implicit imports from `/globals` folder.

### DIFF
--- a/types/meteor/accounts-base.d.ts
+++ b/types/meteor/accounts-base.d.ts
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 declare module "meteor/accounts-base" {
     interface URLS {
         resetPassword: (token: string) => string;

--- a/types/meteor/blaze.d.ts
+++ b/types/meteor/blaze.d.ts
@@ -1,3 +1,5 @@
+import { Tracker } from 'meteor/tracker';
+import { Meteor } from 'meteor/meteor';
 declare module "meteor/blaze" {
     module Blaze {
         var View: ViewStatic;

--- a/types/meteor/ddp.d.ts
+++ b/types/meteor/ddp.d.ts
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 declare module "meteor/ddp" {
     module DDP {
         interface DDPStatic {

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -1,3 +1,4 @@
+declare type global_Error = Error;
 declare module Meteor {
     /** Global props **/
     var isClient: boolean;

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -1,5 +1,9 @@
-type global_Error = Error;
+import { Mongo } from 'meteor/mongo';
+import { EJSONable, EJSONableProperty } from 'meteor/ejson';
+import { Blaze } from 'meteor/blaze';
+import { DDP } from 'meteor/ddp';
 declare module "meteor/meteor" {
+    type global_Error = Error;
     module Meteor {
         /** Global props **/
         var isClient: boolean;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 declare module "meteor/mongo" {
     module Mongo {
 

--- a/types/meteor/service-configuration.d.ts
+++ b/types/meteor/service-configuration.d.ts
@@ -1,3 +1,4 @@
+import { Mongo } from 'meteor/mongo';
 declare module "meteor/service-configuration" {
     interface Configuration {
         appId: string;

--- a/types/meteor/session.d.ts
+++ b/types/meteor/session.d.ts
@@ -1,3 +1,4 @@
+import { EJSONable } from 'meteor/ejson';
 declare module "meteor/session" {
     module Session {
         function equals(key: string, value: string | number | boolean | any): boolean;

--- a/types/meteor/templating.d.ts
+++ b/types/meteor/templating.d.ts
@@ -1,3 +1,4 @@
+import { Blaze } from 'meteor/blaze';
 declare module "meteor/templating" {
     var Template: TemplateStatic;
     interface TemplateStatic extends Blaze.TemplateStatic {

--- a/types/meteor/tools.d.ts
+++ b/types/meteor/tools.d.ts
@@ -1,3 +1,4 @@
+import { EJSON } from 'meteor/ejson';
 declare module "meteor/tools" {
     module App {
         function accessRule(pattern: string, options?: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36922

Using the `@types/meteor` package created a lot of errors of the form:
```
node_modules/@types/meteor/accounts-base.d.ts:235:39 - error TS2503: Cannot find namespace 'Meteor'.

235         function _checkPassword(user: Meteor.User, password: Password): { userId: string; error?: any };
```

Inside the DefinitelyTyped folder this wasn't an issue since the modules where imported implicitly from the `/globals` folder. The correct behavior is to the import the required modules directly (as the current PR does). The Issue [36922](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36922) should also be solved by this commit.
