### PR TITLE
Modify ramda tests to pass on typescript@next

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -966,7 +966,7 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const x: number = R.thunkify(R.identity)(42)();
+    const x: unknown = R.thunkify(R.identity)(42)();
     const y: number = R.thunkify((a: number, b: number) => a + b)(25, 17)();
     const z: number = R.thunkify((a: number, b: number) => a + b)(25)(17)();
 };


### PR DESCRIPTION
Contextual signature instantation now catches the fact that thunkify would have produced an `any` during execution and now produces `unknown` instead. This breaks a test that expects the result of `thunkify` to be
number. I changed the test to expect `unknown`, which is what `thunkify` produces when compiled with `typescript@next`.

@pirix-gh from commentary by @ahejlsberg it sounds like `thunkify` has a subtle failing to preserve generics. I expect this test can be restored by addressing that. https://github.com/microsoft/TypeScript/issues/33560