### PR TITLE
add destroyed flag as of node 8 https://nodejs.org/api/stream.html#stream_writable_destroyed

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -750,6 +750,7 @@ declare namespace NodeJS {
         cork(): void;
         uncork(): void;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
     interface ReadStream extends Socket {
         readonly readableHighWaterMark: number;
@@ -760,6 +761,7 @@ declare namespace NodeJS {
         _destroy(err: Error | null, callback: (err?: null | Error) => void): void;
         push(chunk: any, encoding?: string): boolean;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
 
     interface HRTime {

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -39,7 +39,7 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -133,7 +133,7 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -684,6 +684,7 @@ declare namespace NodeJS {
         cork(): void;
         uncork(): void;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
     interface ReadStream extends Socket {
         readonly readableHighWaterMark: number;
@@ -694,6 +695,7 @@ declare namespace NodeJS {
         _destroy(err: Error | null, callback: Function): void;
         push(chunk: any, encoding?: string): boolean;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
 
     interface HRTime {

--- a/types/node/v10/stream.d.ts
+++ b/types/node/v10/stream.d.ts
@@ -33,7 +33,7 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error: Error | null) => void): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -123,7 +123,7 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -717,6 +717,7 @@ declare namespace NodeJS {
         cork(): void;
         uncork(): void;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
     interface ReadStream extends Socket {
         readonly readableHighWaterMark: number;
@@ -727,6 +728,7 @@ declare namespace NodeJS {
         _destroy(err: Error | null, callback: (err?: null | Error) => void): void;
         push(chunk: any, encoding?: string): boolean;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
 
     interface HRTime {

--- a/types/node/v11/stream.d.ts
+++ b/types/node/v11/stream.d.ts
@@ -34,7 +34,7 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -127,7 +127,7 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -518,6 +518,7 @@ declare namespace NodeJS {
         cork(): void;
         uncork(): void;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
     export interface ReadStream extends Socket {
         readonly readableHighWaterMark: number;
@@ -527,6 +528,7 @@ declare namespace NodeJS {
         _destroy(err: Error | undefined, callback: Function): void;
         push(chunk: any, encoding?: string): boolean;
         destroy(error?: Error): void;
+        destroyed: boolean;
     }
 
     export interface Process extends EventEmitter {
@@ -3106,7 +3108,7 @@ declare module "fs" {
         destroy(): void;
         bytesRead: number;
         path: string | Buffer;
-
+        destroyed: boolean;
         /**
          * events.EventEmitter
          *   1. open
@@ -5424,7 +5426,7 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error) => void): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -5511,7 +5513,7 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -3513,7 +3513,6 @@ declare module "fs" {
         destroy(): void;
         bytesRead: number;
         path: string | Buffer;
-        destroyed: boolean;
 
         /**
          * events.EventEmitter
@@ -3545,7 +3544,6 @@ declare module "fs" {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;
-        destroyed: boolean;
 
         /**
          * events.EventEmitter
@@ -5829,7 +5827,6 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error) => void): void;
             destroy(error?: Error): void;
-            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -5917,7 +5914,6 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -3513,6 +3513,7 @@ declare module "fs" {
         destroy(): void;
         bytesRead: number;
         path: string | Buffer;
+        destroyed: boolean;
 
         /**
          * events.EventEmitter
@@ -3544,6 +3545,7 @@ declare module "fs" {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;
+        destroyed: boolean;
 
         /**
          * events.EventEmitter
@@ -5827,7 +5829,7 @@ declare module "stream" {
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error) => void): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -5915,7 +5917,7 @@ declare module "stream" {
             cork(): void;
             uncork(): void;
             destroy(error?: Error): void;
-
+            destroyed: boolean;
             /**
              * Event emitter
              * The defined events on documents including:


### PR DESCRIPTION
Adding destroyed flag to ReadableStream and WriteableStream as per the node documentation from v8 onwards. 

If changing an existing definition:
- [1 ] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_writable_destroyed
