### PR TITLE
react-helmet: remove default export

### DIFF
--- a/types/react-helmet-async/index.d.ts
+++ b/types/react-helmet-async/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/staylor/react-helmet-async#readme
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-helmet-async/index.d.ts
+++ b/types/react-helmet-async/index.d.ts
@@ -1,14 +1,14 @@
-// Type definitions for react-helmet-async 1.0
-// Project: https://github.com/staylor/react-helmet-async, https://github.com/nytimes/react-helmet-async
+// Type definitions for react-helmet-async 0.0
+// Project: https://github.com/staylor/react-helmet-async#readme
 // Definitions by: forabi <https://github.com/forabi>
-//                 Daniel Perez Alvarez <https://github.com/unindented>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.6
 
-import * as React from "react";
-import { HelmetData } from "react-helmet";
+import * as React from 'react';
 
-export { default as Helmet } from "react-helmet";
+import { Helmet, HelmetData } from 'react-helmet';
+
+export { Helmet, HelmetData };
 
 export interface PopulatedContext {
     helmet: HelmetData;

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -81,4 +81,3 @@ export const peek: () => HelmetData;
 export const rewind: () => HelmetData;
 export const renderStatic: () => HelmetData;
 export const canUseDOM: boolean;
-export default Helmet;


### PR DESCRIPTION
This package does not have a default export.


```
> typeof require('react-helmet').Helmet
'function'
> typeof require('react-helmet').default
'undefined'
```
