### PR TITLE
Update type definitions for "react-copy-to-clipboard"

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -13,8 +13,9 @@ export = CopyToClipboard;
 
 declare namespace CopyToClipboard {
   interface Options {
-    debug: boolean;
-    message: string;
+    debug?: boolean;
+    format?: "text/html" | "text/plain";
+    message?: string;
   }
 
   interface Props {

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -19,7 +19,7 @@ declare namespace CopyToClipboard {
 
   interface Props {
     text: string;
-    onCopy?(a: string, b: boolean): void;
+    onCopy?(text: string, result: boolean): void;
     options?: Options;
     children: React.ReactNode
   }

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -21,6 +21,7 @@ declare namespace CopyToClipboard {
     text: string;
     onCopy?(a: string, b: boolean): void;
     options?: Options;
+    children: React.ReactNode
   }
 }
 

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for react-copy-to-clipboard 4.2
+// Type definitions for react-copy-to-clipboard 4.3
 // Project: https://github.com/nkbt/react-copy-to-clipboard
 // Definitions by: Meno Abels <https://github.com/mabels>
 //                 Bernabe <https://github.com/BernabeFelix>
+//                 Ward Delabastita <https://github.com/wdlb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -18,10 +18,10 @@ declare namespace CopyToClipboard {
   }
 
   interface Props {
+    children: React.ReactNode;
     text: string;
     onCopy?(text: string, result: boolean): void;
     options?: Options;
-    children: React.ReactNode
   }
 }
 

--- a/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -1,11 +1,22 @@
 import * as React from "react";
 import CopyToClipboard = require("react-copy-to-clipboard");
 
-export class Test extends React.Component {
+export class OnlyRequiredProps extends React.Component {
+    render() {
+        return (
+          <CopyToClipboard text={"Hello World"}>
+              <button>Copy to clipboard with button</button>
+          </CopyToClipboard>
+        );
+    }
+}
+
+export class AllProps extends React.Component {
     render() {
         return (
           <CopyToClipboard text={"Hello World"}
-            onCopy={() => {}}>
+                onCopy={() => {}}
+                options={{debug: true, message: "message", format: "text/plain"}}>
             <span>Copy to clipboard with span</span>
           </CopyToClipboard>
         );


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nkbt/react-copy-to-clipboard/blob/master/README.md#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
