### PR TITLE
Ensures that prettier has the same settings as editorconfig

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/prettierrc",
     "singleQuote": true,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "printWidth": 120
 }
-


### PR DESCRIPTION
When you read the notice about editorconfig support in prettier - it says it [only works by default](https://prettier.io/blog/2017/12/05/1.9.0.html#add-editorconfig-support-3255-https-githubcom-prettier-prettier-pull-3255-by-josephfrazier-https-githubcom-josephfrazier) in the CLI, and not the API. 

Because the post-hook uses a different CLI to apply partial diffs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37400 then the post-hooks don't actually work with the same values. This duplicates the settings across the both configs and should mean they are consistent.