### PR TITLE
[pg] Add log to pg.PoolConfig

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -44,6 +44,7 @@ export interface PoolConfig extends ClientConfig {
     min?: number;
     connectionTimeoutMillis?: number;
     idleTimeoutMillis?: number;
+    log?: (...messages: any[]) => void;
 
     application_name?: string;
     Promise?: PromiseConstructorLike;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -137,6 +137,9 @@ const pool = new Pool({
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
   keepAlive: false,
+  log: (...args) => {
+    console.log.apply(console, args);
+  },
 });
 console.log(pool.totalCount);
 pool.connect((err, client, done) => {


### PR DESCRIPTION
The log attribute on PoolConfig allows you to attach a logger to debug
what's going in inside the pg-pool.

I did not use ReadonlyArray<any> as a rest-parameter must be of an array type before typescript@3.4.

It's available since `pg-pool` 2.0, but the PoolConfig type is defined in `pg`:
https://github.com/brianc/node-pg-pool/blob/master/index.js#L64


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-pg-pool/blob/master/index.js#L64
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
