### PR TITLE
Fix Pizzip.generate() return types

### DIFF
--- a/types/pizzip/index.d.ts
+++ b/types/pizzip/index.d.ts
@@ -14,7 +14,7 @@ declare class PizZip {
      * If the browser supports them, PizZip can take advantage of some "new" features : ArrayBuffer, Blob, Uint8Array.
      * To know if PizZip can use them, you can check the PizZip.support object.
      */
-     static support: {
+    static support: {
         /**
          * true if PizZip can read and generate ArrayBuffer, false otherwise.
          */
@@ -36,12 +36,12 @@ declare class PizZip {
     /**
      * the ZipObjects inside the zip with the name as key.
      */
-     files: { [key: string]: PizZip.ZipObject };
+    files: { [key: string]: PizZip.ZipObject };
 
     /**
      * the comment of the zip file.
      */
-     comment: string;
+    comment: string;
 
     constructor();
 
@@ -121,7 +121,11 @@ declare class PizZip {
      * see https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/support.md
      * @param options the options to generate the zip file
      */
-    generate(options: PizZip.GenerateOptions): PizZip.ZipObject;
+    generate(options?: PizZip.GenerateOptions & { type?: 'string' | 'base64' }): string;
+    generate(options: PizZip.GenerateOptions & { type: 'blob' }): Blob;
+    generate(options: PizZip.GenerateOptions & { type: 'nodebuffer' }): Buffer;
+    generate(options: PizZip.GenerateOptions & { type: 'arraybuffer' }): ArrayBuffer;
+    generate(options: PizZip.GenerateOptions & { type: 'uint8array' }): Uint8Array;
 
     /**
      * Delete a file or folder (recursively).
@@ -351,7 +355,7 @@ declare namespace PizZip {
          *
          * @default "base64"
          */
-        type: 'base64' | 'string' | 'uint8array' | 'arraybuffer' | 'blob' | 'nodebuffer';
+        type?: 'base64' | 'string' | 'uint8array' | 'arraybuffer' | 'blob' | 'nodebuffer';
         /**
          * The comment to use for the zip file.
          */

--- a/types/pizzip/pizzip-tests.ts
+++ b/types/pizzip/pizzip-tests.ts
@@ -25,8 +25,6 @@ zip.file('Hello.txt', 'Hello World\n')
     .remove('css');
 
 zip.load('content', { decodeFileName: bytes => 'encoding' });
-zip.generate({ type: 'uint8array', encodeFileName: string => new Buffer('') });
-zip.generate({ type: 'blob', mimeType: 'application/ods', compression: 'DEFLATE' });
 zip.file(/file/).map(z => z);
 zip.folder(/^vid/).map(z => z);
 zip.filter((relativePath, file) => true).map(z => z);
@@ -35,10 +33,19 @@ zip.folder('subfolder').load('data');
 const file = zip.file('');
 
 if (file) {
-    file.name.split('');
-    file.asText();
-    file.asArrayBuffer();
-    file.asUint8Array();
-    file.asNodeBuffer();
-    file.asText();
+    const nameTest: string = file.name;
+    const textTest: string = file.asText();
+    const binaryTest: string = file.asBinary();
+    const arrBufTest: ArrayBuffer = file.asArrayBuffer();
+    const uint8Test: Uint8Array = file.asUint8Array();
+    const bufTest: Buffer = file.asNodeBuffer();
 }
+
+const noOptionsTest: string = zip.generate();
+const noTypeTest: string = zip.generate({ base64: true });
+const b64Test: string = zip.generate({ type: 'base64', compression: 'DEFLATE' });
+const stringTest: string = zip.generate({ type: 'string', encodeFileName: s => new Buffer(s) });
+const arrBufTest: ArrayBuffer = zip.generate({ type: 'arraybuffer', mimeType: '' });
+const blobTest: Blob = zip.generate({ type: 'blob', compressionOptions: { level: 1 } });
+const bufTest: Buffer = zip.generate({ type: 'nodebuffer', platform: 'DOS' });
+const unit8Test: Uint8Array = zip.generate({ type: 'uint8array', base64: true });

--- a/types/pizzip/tsconfig.json
+++ b/types/pizzip/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [pizzip.generate(options)](https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Types were published today https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38527 - and I immediately saw I made a mistake :(

Fixing return types for [pizzip.generate(options)](https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)