### PR TITLE
license-checker-webpack-plugin: Fix outputWriter type

### DIFF
--- a/types/license-checker-webpack-plugin/index.d.ts
+++ b/types/license-checker-webpack-plugin/index.d.ts
@@ -19,6 +19,12 @@ declare namespace LicenseCheckerWebpackPlugin {
         licenseText: string;
     }
 
+    interface OutputWriterArgs {
+        dependencies: Dependency[];
+    }
+
+    type OutputWriter = (args: OutputWriterArgs) => string;
+
     interface Options {
         /**
          * Regular expression that matches the file paths of dependencies to check.
@@ -59,7 +65,7 @@ declare namespace LicenseCheckerWebpackPlugin {
          * Path to a `.ejs` template, or function that will generate the contents
          * of the third-party notices file.
          */
-        outputWriter: string | ((dependencies: Dependency[]) => string);
+        outputWriter: string | OutputWriter;
 
         /**
          * Name of the third-party notices file with all licensing information.

--- a/types/license-checker-webpack-plugin/license-checker-webpack-plugin-tests.ts
+++ b/types/license-checker-webpack-plugin/license-checker-webpack-plugin-tests.ts
@@ -18,7 +18,8 @@ new LicenseCheckerWebpackPlugin({
 // $ExpectType LicenseCheckerWebpackPlugin
 new LicenseCheckerWebpackPlugin({
     filter: /.*/,
-    outputWriter: (dependencies) => {
+    outputWriter: ({ dependencies }) => {
+        dependencies; // $ExpectType Dependency[]
         return dependencies.map(d => `${d.name} ${d.licenseName}`).join('\n');
     },
 });


### PR DESCRIPTION
The function is passed an object containing a dependencies array, not the array
itself.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/license-checker-webpack-plugin/blob/31d268685ff102f443033a0f6190ed18684124a2/src/licenseUtils.js#L125
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.