### PR TITLE
[Fix] rox-browser: custom properties allow an optional context parameter

### DIFF
--- a/types/rox-browser/index.d.ts
+++ b/types/rox-browser/index.d.ts
@@ -81,9 +81,9 @@ export interface RoxExperiment {
  * Note that you might have to call unfreeze after setting custom properties such as email after login
  * https://support.rollout.io/docs/custom-properties
  */
-export function setCustomNumberProperty(name: string, value: number | (() => number)): void;
-export function setCustomStringProperty(name: string, value: string | (() => string)): void;
-export function setCustomBooleanProperty(name: string, value: boolean | (() => boolean)): void;
+export function setCustomNumberProperty(name: string, value: number | ((context?: unknown) => number)): void;
+export function setCustomStringProperty(name: string, value: string | ((context?: unknown) => string)): void;
+export function setCustomBooleanProperty(name: string, value: boolean | ((context?: unknown) => boolean)): void;
 export function setDynamicCustomPropertyRule(
   handler: (propName: string, context: unknown) => number | string | boolean
 ): void;
@@ -146,7 +146,7 @@ export class Flag {
   readonly defaultValue: boolean;
 
   // Returns true when the flag is enabled
-  isEnabled(): boolean;
+  isEnabled(context?: unknown): boolean;
 
   // Unlock the Flag value from changes from the last time it was freezed
   unfreeze(): void;
@@ -167,7 +167,7 @@ export class Variant<T extends string = string> {
   readonly defaultValue: BasicType<T>;
 
   // Returns the current value of the Variant, accounting for value overrides
-  getValue(): BasicType<T>;
+  getValue(context?: unknown): BasicType<T>;
 
   // Unlock the Variant value from changes from the last time it was freezed
   unfreeze(): void;
@@ -189,7 +189,7 @@ export class Configuration<T extends number | boolean | string> {
   readonly defaultValue: BasicType<T>;
 
   // Returns the current value of the Configuration, accounting for value overrides
-  getValue(): BasicType<T>;
+  getValue(context?: unknown): BasicType<T>;
 
   // Unlock the Configuration value from changes from the last time it was freezed
   unfreeze(): void;

--- a/types/rox-browser/rox-browser-tests.ts
+++ b/types/rox-browser/rox-browser-tests.ts
@@ -30,19 +30,35 @@ Rox.dynamicApi.value('ui.textColor', 'red');
 Rox.flags[0].defaultValue;
 Rox.flags[0].name;
 
+flags.superFlag.isEnabled();
+flags.superFlag.isEnabled({ user: 'John' });
+
 configurations.superConfiguration.defaultValue;
 configurations.superConfiguration.name;
+configurations.superConfiguration.getValue();
+configurations.superConfiguration.getValue({ user: 'John' });
 
 variants.superVariant.defaultValue;
 variants.superVariant.name;
+variants.superVariant.getValue();
+variants.superVariant.getValue({ user: 'John' });
 
 Rox.unfreeze();
 flags.superFlag.unfreeze();
 
 function linkTargetGroupAttributes() {
   Rox.setCustomStringProperty('id', 'someId');
+  Rox.setCustomStringProperty('id', () => 'someId');
+  Rox.setCustomStringProperty('id', (context: any): string => context.id);
+
   Rox.setCustomBooleanProperty('thisIsATest', true);
+  Rox.setCustomBooleanProperty('thisIsATest', () => true);
+  Rox.setCustomBooleanProperty('thisIsATest', (context: any): boolean => context.value);
+
   Rox.setCustomNumberProperty('aNumberProperty', 17);
+  Rox.setCustomNumberProperty('aNumberProperty', () => 17);
+  Rox.setCustomNumberProperty('aNumberProperty', (context: any): number => context.value);
+
   Rox.setDynamicCustomPropertyRule((propName: string, _context: unknown) => {
     return propName === 'myPropName';
   });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://support.rollout.io/docs/custom-properties
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

