### PR TITLE
fix: update type of eureka-js-client config obj

### DIFF
--- a/types/eureka-js-client/index.d.ts
+++ b/types/eureka-js-client/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for eureka-js-client 4.4
+// Type definitions for eureka-js-client 4.5
 // Project: https://github.com/jquatier/eureka-js-client
 // Definitions by: Ilko Hoffmann <https://github.com/Schnillz>
 //                 Karl O. <https://github.com/karl-run>
 //                 Tom Barton <https://github.com/tombarton>
 //                 Josh Sullivan <https://github.com/jpsullivan>
+//                 WayJam So <https://github.com/imsuwj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class Eureka {
@@ -23,6 +24,13 @@ export namespace EurekaClient {
         requestMiddleware?: EurekaMiddlewareConfig;
         instance: EurekaInstanceConfig;
         eureka: EurekaClientConfig;
+        shouldUseDelta?: boolean;
+        logger?: {
+            warn: (...args: any[]) => void;
+            info: (...args: any[]) => void;
+            debug: (...args: any[]) => void;
+            error: (...args: any[]) => void;
+        };
     }
     interface EurekaInstanceConfig {
         app: string;
@@ -70,13 +78,6 @@ export namespace EurekaClient {
         registerWithEureka?: boolean;
         useLocalMetadata?: boolean;
         preferIpAddress?: boolean;
-        shouldUseDelta?: boolean;
-        logger?: {
-            warn: (...args: any[]) => void;
-            info: (...args: any[]) => void;
-            debug: (...args: any[]) => void;
-            error: (...args: any[]) => void;
-        };
     }
     interface EurekaYmlConfig {
         cwd: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jquatier/eureka-js-client/blob/master/src/EurekaClient.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

