### PR TITLE
Add types for draftjs-to-html

### DIFF
--- a/types/draftjs-to-html/draftjs-to-html-tests.ts
+++ b/types/draftjs-to-html/draftjs-to-html-tests.ts
@@ -19,4 +19,3 @@ const editorContent = {
 
 // $ExpectType string
 draftToHtml(editorContent);
-

--- a/types/draftjs-to-html/draftjs-to-html-tests.ts
+++ b/types/draftjs-to-html/draftjs-to-html-tests.ts
@@ -1,0 +1,22 @@
+import draftToHtml from 'draftjs-to-html';
+
+const editorContent = {
+  blocks: [
+    {
+      key: '355iu',
+      text: 'test',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {
+        'text-align': 'center',
+      },
+    },
+  ],
+  entityMap: {},
+};
+
+// $ExpectType string
+draftToHtml(editorContent);
+

--- a/types/draftjs-to-html/index.d.ts
+++ b/types/draftjs-to-html/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for draftjs-to-html 0.8
+// Project: https://github.com/jpuri/draftjs-to-html#readme
+// Definitions by: Ivan Zverev <https://github.com/1cheese>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import { RawDraftContentState } from 'draft-js';
+
+export interface HashtagConfig {
+    trigger?: string;
+    separator?: string;
+}
+
+export default function draftToHtml(
+    editorContent: RawDraftContentState,
+    hashtagConfig?: HashtagConfig,
+    directional?: boolean,
+    customEntityTransform?: (...args: any[]) => any,
+): string;

--- a/types/draftjs-to-html/index.d.ts
+++ b/types/draftjs-to-html/index.d.ts
@@ -6,14 +6,16 @@
 
 import { RawDraftContentState } from 'draft-js';
 
-export interface HashtagConfig {
+interface HashtagConfig {
     trigger?: string;
     separator?: string;
 }
 
-export default function draftToHtml(
+declare function draftToHtml(
     editorContent: RawDraftContentState,
     hashtagConfig?: HashtagConfig,
     directional?: boolean,
     customEntityTransform?: (...args: any[]) => any,
 ): string;
+
+export = draftToHtml;

--- a/types/draftjs-to-html/tsconfig.json
+++ b/types/draftjs-to-html/tsconfig.json
@@ -16,7 +16,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/draftjs-to-html/tsconfig.json
+++ b/types/draftjs-to-html/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "draftjs-to-html-tests.ts"
+    ]
+}

--- a/types/draftjs-to-html/tslint.json
+++ b/types/draftjs-to-html/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
