### PR TITLE
[@types/fabric] Allow passing HTMLVideoElement to the Image class.

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -2259,23 +2259,23 @@ interface Image extends Object, IImageOptions { }
 export class Image {
 	/**
 	 * Constructor
-	 * @param element Image element
+	 * @param element Image or Video element
 	 * @param [options] Options object
 	 */
-	constructor(element?: string | HTMLImageElement, options?: IImageOptions);
+	constructor(element?: string | HTMLImageElement | HTMLVideoElement, options?: IImageOptions);
 	/**
-	 * Returns image element which this instance if based on
-	 * @return Image element
+	 * Returns image or video element which this instance is based on
+	 * @return Image or Video element
 	 */
-	getElement(): HTMLImageElement;
+	getElement(): HTMLImageElement | HTMLVideoElement;
 	/**
-	 * Sets image element for this instance to a specified one.
+	 * Sets image or video element for this instance to a specified one.
 	 * If filters defined they are applied to new image.
 	 * You might need to call `canvas.renderAll` and `object.setCoords` after replacing, to render new image and update controls area.
 	 * @param element image element
 	 * @param [options] Options object
 	 */
-	setElement(element: HTMLImageElement, options?: IImageOptions): Image;
+	setElement(element: HTMLImageElement | HTMLVideoElement, options?: IImageOptions): Image;
 	/**
 	 * Delete a single texture if in webgl mode
 	 */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://fabricjs.com/video-element

fabric.js supports passing a HTMLVideoElement to the Image class. This is shown as an example in the [documentation](http://fabricjs.com/video-element). The type definition  however, allowed just for HTMLImageElements.
