### PR TITLE
Add types for html-to-draftjs

### DIFF
--- a/types/html-to-draftjs/html-to-draftjs-tests.ts
+++ b/types/html-to-draftjs/html-to-draftjs-tests.ts
@@ -1,0 +1,9 @@
+import htmlToDraft from 'html-to-draftjs';
+import { ContentBlock } from 'draft-js';
+
+const blocksFromHtml = htmlToDraft('<p>test</p>');
+
+// $ExpectType ContentBlock[]
+const contentBlocks = blocksFromHtml.contentBlocks;
+// $ExpectType any
+const entityMap = blocksFromHtml.entityMap;

--- a/types/html-to-draftjs/index.d.ts
+++ b/types/html-to-draftjs/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for html-to-draftjs 1.4
+// Project: https://github.com/jpuri/html-to-draftjs#readme
+// Definitions by: Ivan Zverev <https://github.com/1cheese>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import { ContentBlock, RawDraftEntity } from 'draft-js';
+
+export default function htmlToDraft(
+    text: string,
+    customChunkRenderer?: (
+        nodeName: string, node: HTMLElement
+    ) => RawDraftEntity | undefined,
+): {
+    contentBlocks: ContentBlock[];
+    entityMap?: any;
+};

--- a/types/html-to-draftjs/tsconfig.json
+++ b/types/html-to-draftjs/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-to-draftjs-tests.ts"
+    ]
+}

--- a/types/html-to-draftjs/tslint.json
+++ b/types/html-to-draftjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.