### PR TITLE
fix(expect-puppeteer): update return type for toMatchElement

### DIFF
--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -59,7 +59,7 @@ declare global {
             toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
             toFillForm(selector: string, value: { [key: string]: any}, options?: ExpectTimingActions): Promise<void>;
             toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
-            toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
+            toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<ElementHandle>;
             toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
             toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
         }


### PR DESCRIPTION
This change aligns with [`toMatchElement`s API](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer#expectinstancetomatchelementselector-options) which resolves an `ElementHandle`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

