### PR TITLE
Ensure tests of non-returning functions don't cause unreachability errors

### DIFF
--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -70,11 +70,11 @@ import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer, transcode, 
 
         assert.equal(3, "3", "uses == comparator");
 
-        assert.fail('stuff broke');
+        if (!!true) assert.fail('stuff broke');
 
-        assert.fail('actual', 'expected', 'message');
+        if (!!true) assert.fail('actual', 'expected', 'message');
 
-        assert.fail(1, 2, undefined, '>');
+        if (!!true) assert.fail(1, 2, undefined, '>');
 
         assert.ifError(0);
 

--- a/types/vfile/vfile-tests.ts
+++ b/types/vfile/vfile-tests.ts
@@ -40,7 +40,7 @@ file.message('test', {
 
 file.message('test', { start: 'invalid point' }); // $ExpectError
 
-file.fail('test');
+if (!!true) file.fail('test');
 
 const infoMessage: vfileMessage.VFileMessage = file.info('test');
 


### PR DESCRIPTION
Fixes issues resulting from unreachable code in `node/v10` and `vfile` following merge of https://github.com/microsoft/TypeScript/pull/32695.