### PR TITLE
Add type definitions for react-native-privacy-snapshot

### DIFF
--- a/types/react-native-privacy-snapshot/index.d.ts
+++ b/types/react-native-privacy-snapshot/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for react-native-privacy-snapshot 1.0
+// Project: https://github.com/kayla-tech/react-native-privacy-snapshot#readme
+// Definitions by: Matthew Bajorek <https://github.com/mattbajorek>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface PrivacySnapshot {
+    enabled: (isEnabled: boolean) => void;
+}
+
+declare const PrivacySnapshot: PrivacySnapshot;
+
+export default PrivacySnapshot;

--- a/types/react-native-privacy-snapshot/index.d.ts
+++ b/types/react-native-privacy-snapshot/index.d.ts
@@ -9,4 +9,4 @@ interface PrivacySnapshot {
 
 declare const PrivacySnapshot: PrivacySnapshot;
 
-export default PrivacySnapshot;
+export = PrivacySnapshot;

--- a/types/react-native-privacy-snapshot/index.d.ts
+++ b/types/react-native-privacy-snapshot/index.d.ts
@@ -3,10 +3,4 @@
 // Definitions by: Matthew Bajorek <https://github.com/mattbajorek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface PrivacySnapshot {
-    enabled: (isEnabled: boolean) => void;
-}
-
-declare const PrivacySnapshot: PrivacySnapshot;
-
-export = PrivacySnapshot;
+export function enabled(isEnabled: boolean): void;

--- a/types/react-native-privacy-snapshot/react-native-privacy-snapshot-tests.ts
+++ b/types/react-native-privacy-snapshot/react-native-privacy-snapshot-tests.ts
@@ -1,4 +1,4 @@
-import PrivacySnapshot from "react-native-privacy-snapshot";
+import PrivacySnapshot = require('react-native-privacy-snapshot');
 
 PrivacySnapshot.enabled(true);
 PrivacySnapshot.enabled(false);

--- a/types/react-native-privacy-snapshot/react-native-privacy-snapshot-tests.ts
+++ b/types/react-native-privacy-snapshot/react-native-privacy-snapshot-tests.ts
@@ -1,0 +1,4 @@
+import PrivacySnapshot from "react-native-privacy-snapshot";
+
+PrivacySnapshot.enabled(true);
+PrivacySnapshot.enabled(false);

--- a/types/react-native-privacy-snapshot/tsconfig.json
+++ b/types/react-native-privacy-snapshot/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true 
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/react-native-privacy-snapshot/tsconfig.json
+++ b/types/react-native-privacy-snapshot/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true 
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-privacy-snapshot-tests.ts"
+    ]
+}

--- a/types/react-native-privacy-snapshot/tslint.json
+++ b/types/react-native-privacy-snapshot/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
