### PR TITLE
[@types/eslint]: add missing extends to override config definition

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -389,19 +389,23 @@ linter.verify(SOURCE, { rules: { 'no-unused-vars': [2, { vars: 'all' }] } }, 'te
 linter.verify(SOURCE, { rules: { 'no-console': 1 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 0 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'error' } }, 'test.js');
-linter.verify(SOURCE, {
-    rules: { 'no-console': 'error' },
-    overrides: [
-        {
-            extends: ['eslint-config-bad-guy'],
-            excludedFiles: ['*-test.js', '*.spec.js'],
-            files: ['*-test.js', '*.spec.js'],
-            rules: {
-                'no-unused-expressions': 'off'
-            }
-        }
-    ]
-}, 'test.js');
+linter.verify(
+    SOURCE,
+    {
+        rules: { 'no-console': 'error' },
+        overrides: [
+            {
+                extends: ['eslint-config-bad-guy'],
+                excludedFiles: ['*-test.js', '*.spec.js'],
+                files: ['*-test.js', '*.spec.js'],
+                rules: {
+                    'no-unused-expressions': 'off',
+                },
+            },
+        ],
+    },
+    'test.js',
+);
 linter.verify(SOURCE, { rules: { 'no-console': 'warn' } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'off' } }, 'test.js');
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -393,6 +393,7 @@ linter.verify(SOURCE, {
     rules: { 'no-console': 'error' },
     overrides: [
         {
+            extends: ['eslint-config-bad-guy'],
             excludedFiles: ['*-test.js', '*.spec.js'],
             files: ['*-test.js', '*.spec.js'],
             rules: {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -385,7 +385,7 @@ export namespace Linter {
     }
     interface HasRules {
         rules?: {
-            [name: string]: RuleLevel | RuleLevelAndOptions
+            [name: string]: RuleLevel | RuleLevelAndOptions;
         };
     }
 
@@ -453,11 +453,13 @@ export namespace Linter {
         messages: LintMessage[];
     }
 
-    type ParserModule = {
-        parse(text: string, options?: any): AST.Program;
-    } | {
-        parseForESLint(text: string, options?: any): ESLintParseResult;
-    };
+    type ParserModule =
+        | {
+              parse(text: string, options?: any): AST.Program;
+          }
+        | {
+              parseForESLint(text: string, options?: any): ESLintParseResult;
+          };
 
     interface ESLintParseResult {
         ast: AST.Program;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -390,6 +390,7 @@ export namespace Linter {
     }
 
     interface RuleOverride extends HasRules {
+        extends?: string | string[];
         excludedFiles?: string[];
         files?: string[];
     }

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -389,19 +389,23 @@ linter.verify(SOURCE, { rules: { 'no-unused-vars': [2, { vars: 'all' }] } }, 'te
 linter.verify(SOURCE, { rules: { 'no-console': 1 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 0 } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'error' } }, 'test.js');
-linter.verify(SOURCE, {
-    rules: { 'no-console': 'error' },
-    overrides: [
-        {
-            extends: ['eslint-config-bad-guy'],
-            excludedFiles: ['*-test.js', '*.spec.js'],
-            files: ['*-test.js', '*.spec.js'],
-            rules: {
-                'no-unused-expressions': 'off'
-            }
-        }
-    ]
-}, 'test.js');
+linter.verify(
+    SOURCE,
+    {
+        rules: { 'no-console': 'error' },
+        overrides: [
+            {
+                extends: ['eslint-config-bad-guy'],
+                excludedFiles: ['*-test.js', '*.spec.js'],
+                files: ['*-test.js', '*.spec.js'],
+                rules: {
+                    'no-unused-expressions': 'off',
+                },
+            },
+        ],
+    },
+    'test.js',
+);
 linter.verify(SOURCE, { rules: { 'no-console': 'warn' } }, 'test.js');
 linter.verify(SOURCE, { rules: { 'no-console': 'off' } }, 'test.js');
 

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -393,6 +393,7 @@ linter.verify(SOURCE, {
     rules: { 'no-console': 'error' },
     overrides: [
         {
+            extends: ['eslint-config-bad-guy'],
             excludedFiles: ['*-test.js', '*.spec.js'],
             files: ['*-test.js', '*.spec.js'],
             rules: {

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -386,6 +386,7 @@ export namespace Linter {
     }
 
     interface RuleOverride<Rules extends RulesRecord = RulesRecord> extends HasRules<Rules> {
+        extends?: string | string[];
         excludedFiles?: string[];
         files?: string[];
     }

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -449,11 +449,13 @@ export namespace Linter {
         messages: LintMessage[];
     }
 
-    type ParserModule = {
-        parse(text: string, options?: any): AST.Program;
-    } | {
-        parseForESLint(text: string, options?: any): ESLintParseResult;
-    };
+    type ParserModule =
+        | {
+              parse(text: string, options?: any): AST.Program;
+          }
+        | {
+              parseForESLint(text: string, options?: any): ESLintParseResult;
+          };
 
     interface ESLintParseResult {
         ast: AST.Program;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eslint/eslint/commit/54e6edaa2f881aab530fa14e63d92e5e0e2ca55c
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

cc @pmdartus @j-f1 @saadq @JasonHK