### PR TITLE
react: Fix test failure from merge conflict.

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -402,7 +402,13 @@ const ForwardingRefComponent = React.forwardRef((props: {}, ref: React.Ref<RefCo
     return React.createElement(RefComponent, { ref });
 });
 
-const ForwardingRefComponentPropTypes: React.WeakValidationMap<Props> = {};
+interface AttributeProps extends React.Attributes {
+    hello: string;
+    world?: string | null;
+    foo: number;
+}
+
+const ForwardingRefComponentPropTypes: React.WeakValidationMap<AttributeProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 
 function RefCarryingComponent() {


### PR DESCRIPTION
A test written in #38337 on 12 Sep was merged on 24 Sep. In between in #38352, the Props definition it used changed so that the new test was an error.

This PR just clones the original Props type and gives it a new name. This fixes the error.