### PR TITLE
npm-registry-fetch: Fix fetch.json return type

### DIFF
--- a/types/npm-registry-fetch/index.d.ts
+++ b/types/npm-registry-fetch/index.d.ts
@@ -29,7 +29,7 @@ declare namespace fetch {
      * response as JSON, and returns it as its final value. This is a utility
      * shorthand for `fetch(url).then(res => res.json())`.
      */
-    function json(url: string, opts?: Options): Record<string, unknown>;
+    function json(url: string, opts?: Options): Promise<Record<string, unknown>>;
 
     namespace json {
         /**

--- a/types/npm-registry-fetch/npm-registry-fetch-tests.ts
+++ b/types/npm-registry-fetch/npm-registry-fetch-tests.ts
@@ -73,8 +73,8 @@ const opts: fetch.Options = {
 
 fetch('/'); // $ExpectType Promise<Response>
 fetch('/', opts); // $ExpectType Promise<Response>
-fetch.json('/'); // $ExpectType Record<string, unknown>
-fetch.json('/', opts); // $ExpectType Record<string, unknown>
+fetch.json('/'); // $ExpectType Promise<Record<string, unknown>>
+fetch.json('/', opts); // $ExpectType Promise<Record<string, unknown>>
 fetch.json.stream('/-/user/zkat/package', '$*'); // $ExpectType ReadWriteStream
 fetch.json.stream('/-/user/zkat/package', '$*', opts); // $ExpectType ReadWriteStream
 fetch.pickRegistry('npm-registry-fetch@latest'); // $ExpectType string


### PR DESCRIPTION
`fetch.json()` should return a Promise, not the JSON object directly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/npm-registry-fetch#fetch-json
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
