### PR TITLE
fix: Fix QueryRenderer props for Relay v6.x

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -105,10 +105,11 @@ export {
     requestSubscription,
 } from 'relay-runtime';
 
-export type DataFrom = 'NETWORK_ONLY' | 'STORE_THEN_NETWORK';
+export type FetchPolicy = 'store-and-network' | 'network-only';
+
 declare class ReactRelayQueryRenderer<TOperation extends OperationType> extends React.Component<{
     cacheConfig?: CacheConfig | null;
-    dataFrom?: DataFrom;
+    fetchPolicy?: FetchPolicy;
     environment: Environment;
     query: GraphQLTaggedNode | null | undefined;
     render: (renderProps: {

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-relay 5.0
+// Type definitions for react-relay 6.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Johannes Schickling <https://github.com/graphcool>
 //                 Matt Martin <https://github.com/voxmatt>

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -36,19 +36,19 @@ const modernEnvironment = new Environment({ network, store });
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
-type MyQueryRendererVariables = {
+type MyQueryVariables = {
     pageID: string;
 };
-type MyQueryRendererResponse = {
+type MyQueryResponse = {
     name: string;
 };
-type MyQueryRenderer = {
-    variables: MyQueryRendererVariables;
-    response: MyQueryRendererResponse;
+type MyQuery = {
+    variables: MyQueryVariables;
+    response: MyQueryResponse;
 };
 
 const MyQueryRenderer = (props: { name: string; show: boolean }) => (
-    <QueryRenderer<MyQueryRenderer>
+    <QueryRenderer<MyQuery>
         environment={modernEnvironment}
         query={
             props.show
@@ -61,6 +61,7 @@ const MyQueryRenderer = (props: { name: string; show: boolean }) => (
                   `
                 : null
         }
+        fetchPolicy="store-and-network"
         variables={{
             pageID: '110798995619330',
         }}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/69603436caf211c95322f3e9e1f4c259408a8c44/packages/react-relay/ReactRelayQueryRenderer.js#L59 https://github.com/facebook/relay/blob/69603436caf211c95322f3e9e1f4c259408a8c44/packages/react-relay/ReactRelayTypes.js#L64
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.