### PR TITLE
add: type definitions for isstream

### DIFF
--- a/types/isstream/index.d.ts
+++ b/types/isstream/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for isstream 0.1
+// Project: https://github.com/rvagg/isstream
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const isStream: {
+    (obj: any): boolean;
+    isReadable(obj: any): boolean;
+    isWritable(obj: any): boolean;
+    isDuplex(obj: any): boolean;
+};
+
+export = isStream;

--- a/types/isstream/index.d.ts
+++ b/types/isstream/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Matthew Peveler <https://github.com/MasterOdin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const isStream: {
-    (obj: any): boolean;
-    isReadable(obj: any): boolean;
-    isWritable(obj: any): boolean;
-    isDuplex(obj: any): boolean;
-};
+declare function isStream(obj: any): boolean;
+declare namespace isStream {
+    function isReadable(obj: any): boolean;
+    function isWritable(obj: any): boolean;
+    function isDuplex(obj: any): boolean;
+}
 
 export = isStream;

--- a/types/isstream/isstream-tests.ts
+++ b/types/isstream/isstream-tests.ts
@@ -1,0 +1,42 @@
+/// <reference types="node" />
+
+import isStream = require('isstream');
+import { isDuplex, isReadable, isWritable } from 'isstream';
+import { Stream, Readable, Writable, Duplex } from 'stream';
+
+const objs = [
+    new Stream(),
+    new Readable(),
+    new Writable(),
+    new Duplex(),
+    'string',
+    10
+];
+
+for (let i = 0; i < objs.length; i++) {
+    let type = 'not a stream';
+    if (isStream.isDuplex(objs[i])) {
+        type = 'duplex';
+    } else if (isStream.isWritable(objs[i])) {
+        type = 'writable';
+    } else if (isStream.isReadable(objs[i])) {
+        type = 'readable';
+    } else if (isStream(objs[i])) {
+        type = 'stream';
+    }
+    console.log(`${i}. ${type}`);
+}
+
+for (let i = 0; i < objs.length; i++) {
+    let type = 'not a stream';
+    if (isDuplex(objs[i])) {
+        type = 'duplex';
+    } else if (isWritable(objs[i])) {
+        type = 'writable';
+    } else if (isReadable(objs[i])) {
+        type = 'readable';
+    } else if (isStream(objs[i])) {
+        type = 'stream';
+    }
+    console.log(`${i}. ${type}`);
+}

--- a/types/isstream/tsconfig.json
+++ b/types/isstream/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "isstream-tests.ts"
+    ]
+}

--- a/types/isstream/tslint.json
+++ b/types/isstream/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.