### PR TITLE
libnpmsearch: Fix detailed score type

### DIFF
--- a/types/libnpmsearch/index.d.ts
+++ b/types/libnpmsearch/index.d.ts
@@ -28,9 +28,18 @@ declare namespace search {
         date?: Date;
     }
 
+    interface Score {
+        final: number;
+        detail: {
+            quality: number;
+            popularity: number;
+            maintenance: number;
+        };
+    }
+
     interface DetailedResult {
         package: Result;
-        score: number;
+        score: Score;
         searchScore: number;
     }
 


### PR DESCRIPTION
The score field was not well-documented on https://github.com/npm/libnpmsearch, but from looking at responses and reading https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search, it should be an object with a score breakdown, not a single number.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
