### PR TITLE
[ramda] split tests to separate modules: 'median' - 'none'

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,11 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    R.merge({name: "fred", age: 10}, {age: 40});
-    // => { 'name': 'fred', 'age': 40 }
-};
-
-() => {
     const a = R.mergeAll([{foo: 1}, {bar: 2}, {baz: 3}]); // => {foo:1,bar:2,baz:3}
     const b = R.mergeAll([{foo: 1}, {foo: 2}, {bar: 2}]); // => {foo:2,bar:2}
 };

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,14 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a = R.mergeDeepWith(
-        (a: number[], b: number[]) => a.concat(b),
-        {foo: {bar: [1, 2]}},
-        {foo: {bar: [3, 4]}},
-    ); // => {foo: {bar: [1,2,3,4]}}
-};
-
-() => {
     const a = R.mergeDeepWithKey(
         (k: string, a: number[], b: number[]) => k === 'bar' ? a.concat(b) : a,
         {foo: {bar: [1, 2], userIds: [42]}},

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,10 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a = R.mergeDeepRight({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: bar: 2}}
-};
-
-() => {
     const a = R.mergeDeepWith(
         (a: number[], b: number[]) => a.concat(b),
         {foo: {bar: [1, 2]}},

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1220,25 +1220,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    function cmp(obj: { x: R.Ord }) {
-        return obj.x;
-    }
-
-    const a = {x: 1};
-    const b = {x: 2};
-    const c = {x: 3};
-    const d = {x: "a"};
-    const e = {x: "z"};
-    const f = {x: new Date(0)};
-    const g = {x: new Date(60 * 1000)};
-    R.minBy(cmp, a, b); // => {x: 1}
-    R.minBy(cmp)(a, b); // => {x: 1}
-    R.minBy(cmp)(a)(c);
-    R.minBy(cmp, d, e);
-    R.minBy(cmp)(f)(g);
-};
-
-() => {
     R.modulo(17, 3); // => 2
     // JS behavior:
     R.modulo(-17, 3); // => -2

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,14 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a = R.mergeDeepWithKey(
-        (k: string, a: number[], b: number[]) => k === 'bar' ? a.concat(b) : a,
-        {foo: {bar: [1, 2], userIds: [42]}},
-        {foo: {bar: [3, 4], userIds: [34]}}
-    ); // => { foo: { bar: [ 1, 2, 3, 4 ], userIds: [42] } }
-};
-
-() => {
     R.mergeLeft({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: {bar: 1}}
     const curry1 = R.mergeLeft({foo: {bar: 1}});
     curry1({foo: {bar: 2}}); // => {foo: {bar: 1}}

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -44,9 +44,6 @@ class F2 {
 });
 
 () => {
-    function takesNoArg() {
-        return true;
-    }
     function takesOneArg(a: number) {
         return [a];
     }
@@ -56,12 +53,6 @@ class F2 {
     function takesThreeArgs(a: number, b: number, c: number) {
         return [a, b, c];
     }
-
-    R.nAry(0);
-    R.nAry(0, takesNoArg);
-    R.nAry(0, takesOneArg);
-    R.nAry(1, takesTwoArgs);
-    R.nAry(1, takesThreeArgs);
 
     const u1: (a: any) => any = R.unary(takesOneArg);
     const u2: (a: any) => any = R.unary(takesTwoArgs);

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1315,11 +1315,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a: number = R.median([7, 2, 10, 9]); // => 8
-    const b: number = R.median([]); // => NaN
-};
-
-() => {
     const x: number = R.min(9, 3); // => 3
     const y: string = R.min("a", "z"); // => 'a'
 };

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -487,23 +487,6 @@ interface Obj {
 };
 
 () => {
-    const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
-
-    R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-    R.move<string>(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
-
-    const moveCurried1 = R.move(0, 2);
-    moveCurried1<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-
-    const moveCurried2 = R.move(0);
-    moveCurried2<string>(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-
-    const moveCurried3 = R.move(0);
-    const moveCurried4 = moveCurried3(2);
-    moveCurried4<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
-};
-
-() => {
     R.none(R.isNaN, [1, 2, 3]); // => true
     R.none(R.isNaN, [1, 2, 3, NaN]); // => false
     R.none(R.isNaN)([1, 2, 3, NaN]); // => false

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -930,14 +930,6 @@ type Pair = KeyValuePair<string, number>;
     R.over(xyLens, R.negate, testObj);  // => {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
 };
 () => {
-    R.mergeRight({ name: 'fred', age: 10 }, { age: 40 });
-    // => { 'name': 'fred', 'age': 40 }
-
-    const withDefaults = R.mergeRight({x: 0, y: 0});
-    withDefaults({y: 2}); // => {x: 0, y: 2}
-};
-
-() => {
     const a = R.mergeWith(R.concat,
         {a: true, values: [10, 20]},
         {b: true, values: [15, 35]});

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1220,13 +1220,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    R.modulo(17, 3); // => 2
-    // JS behavior:
-    R.modulo(-17, 3); // => -2
-    R.modulo(17, -3); // => 2
-};
-
-() => {
     const double = R.multiply(2);
     const triple = R.multiply(3);
     double(3);       // =>  6

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,11 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a = R.mergeAll([{foo: 1}, {bar: 2}, {baz: 3}]); // => {foo:1,bar:2,baz:3}
-    const b = R.mergeAll([{foo: 1}, {foo: 2}, {bar: 2}]); // => {foo:2,bar:2}
-};
-
-() => {
     const a = R.mergeDeepLeft({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: {bar: 1}}
 };
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -930,13 +930,6 @@ type Pair = KeyValuePair<string, number>;
     R.over(xyLens, R.negate, testObj);  // => {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
 };
 () => {
-    const a = R.mergeWith(R.concat,
-        {a: true, values: [10, 20]},
-        {b: true, values: [15, 35]});
-    // => { a: true, b: true, values: [10, 20, 15, 35] }
-};
-
-() => {
     const concatValues = (k: string, l: string, r: string) => k === "values" ? R.concat(l, r) : r;
     R.mergeWithKey(concatValues,
         {a: true, thing: "foo", values: [10, 20]},

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1220,11 +1220,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const x: number = R.min(9, 3); // => 3
-    const y: string = R.min("a", "z"); // => 'a'
-};
-
-() => {
     function cmp(obj: { x: R.Ord }) {
         return obj.x;
     }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -478,12 +478,6 @@ interface Obj {
 };
 
 () => {
-    R.none(R.isNaN, [1, 2, 3]); // => true
-    R.none(R.isNaN, [1, 2, 3, NaN]); // => false
-    R.none(R.isNaN)([1, 2, 3, NaN]); // => false
-};
-
-() => {
     const list = ["foo", "bar", "baz", "quux"];
     R.nth(1, list); // => 'bar'
     R.nth(-1, list); // => 'quux'

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -298,36 +298,6 @@ R.times(i, 5);
 })();
 
 (() => {
-    interface Vector {
-      x: number;
-      y: number;
-    }
-
-    let numberOfCalls = 0;
-
-    function vectorSum(a: Vector, b: Vector): Vector {
-        numberOfCalls += 1;
-        return {
-            x: a.x + b.x,
-            y: a.y + b.y
-        };
-    }
-
-    const memoVectorSum = R.memoizeWith((a, b) => JSON.stringify([a, b]), vectorSum);
-
-    memoVectorSum({ x: 1, y: 1 }, { x: 2, y: 2 }); // => { x: 3, y: 3 }
-    numberOfCalls; // => 1
-    memoVectorSum({ x: 1, y: 1 }, { x: 2, y: 2 }); // => { x: 3, y: 3 }
-    numberOfCalls; // => 1
-    memoVectorSum({ x: 1, y: 2 }, { x: 2, y: 3 }); // => { x: 3, y: 5 }
-    numberOfCalls; // => 2
-
-    // Note that argument order matters
-    memoVectorSum({ x: 2, y: 3 }, { x: 1, y: 2 }); // => { x: 3, y: 5 }
-    numberOfCalls; // => 3
-})();
-
-(() => {
     const addOneOnce = R.once((x: number) => x + 1);
     addOneOnce(10); // => 11
     addOneOnce(addOneOnce(50)); // => 11

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1203,14 +1203,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const double = R.multiply(2);
-    const triple = R.multiply(3);
-    double(3);       // =>  6
-    triple(4);       // => 12
-    R.multiply(2, 5);  // => 10
-};
-
-() => {
     R.negate(42); // => -42
 };
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -930,15 +930,6 @@ type Pair = KeyValuePair<string, number>;
     R.over(xyLens, R.negate, testObj);  // => {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
 };
 () => {
-    const concatValues = (k: string, l: string, r: string) => k === "values" ? R.concat(l, r) : r;
-    R.mergeWithKey(concatValues,
-        {a: true, thing: "foo", values: [10, 20]},
-        {b: true, thing: "bar", values: [15, 35]});
-    const merge = R.mergeWithKey(concatValues);
-    merge({a: true, thing: "foo", values: [10, 20]}, {b: true, thing: "bar", values: [15, 35]});
-};
-
-() => {
     const orValue  = 11;
     const orValueStr = "str";
     const testPath = ["x", 0, "y"];

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1194,10 +1194,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    R.negate(42); // => -42
-};
-
-() => {
     R.product([2, 4, 6, 8, 100, 1]); // => 38400
 };
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -929,13 +929,6 @@ type Pair = KeyValuePair<string, number>;
     R.set(xyLens, 4, testObj);          // => {x: [{y: 4, z: 3}, {y: 4, z: 5}]}
     R.over(xyLens, R.negate, testObj);  // => {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
 };
-
-() => {
-    R.mergeLeft({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: {bar: 1}}
-    const curry1 = R.mergeLeft({foo: {bar: 1}});
-    curry1({foo: {bar: 2}}); // => {foo: {bar: 1}}
-};
-
 () => {
     R.mergeRight({ name: 'fred', age: 10 }, { age: 40 });
     // => { 'name': 'fred', 'age': 40 }

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -931,10 +931,6 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a = R.mergeDeepLeft({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: {bar: 1}}
-};
-
-() => {
     const a = R.mergeDeepRight({foo: {bar: 1}}, {foo: {bar: 2}}); // => {foo: bar: 2}}
 };
 

--- a/types/ramda/test/median-tests.ts
+++ b/types/ramda/test/median-tests.ts
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+() => {
+  const a: number = R.median([7, 2, 10, 9]); // => 8
+  const b: number = R.median([]); // => NaN
+};

--- a/types/ramda/test/memoizeWith-tests.ts
+++ b/types/ramda/test/memoizeWith-tests.ts
@@ -1,0 +1,34 @@
+import * as R from 'ramda';
+
+(() => {
+  interface Vector {
+    x: number;
+    y: number;
+  }
+
+  let numberOfCalls = 0;
+
+  function vectorSum(a: Vector, b: Vector): Vector {
+    numberOfCalls += 1;
+    return {
+      x: a.x + b.x,
+      y: a.y + b.y,
+    };
+  }
+
+  const memoVectorSum = R.memoizeWith(
+    (a, b) => JSON.stringify([a, b]),
+    vectorSum,
+  );
+
+  memoVectorSum({ x: 1, y: 1 }, { x: 2, y: 2 }); // => { x: 3, y: 3 }
+  numberOfCalls; // => 1
+  memoVectorSum({ x: 1, y: 1 }, { x: 2, y: 2 }); // => { x: 3, y: 3 }
+  numberOfCalls; // => 1
+  memoVectorSum({ x: 1, y: 2 }, { x: 2, y: 3 }); // => { x: 3, y: 5 }
+  numberOfCalls; // => 2
+
+  // Note that argument order matters
+  memoVectorSum({ x: 2, y: 3 }, { x: 1, y: 2 }); // => { x: 3, y: 5 }
+  numberOfCalls; // => 3
+})();

--- a/types/ramda/test/merge-tests.ts
+++ b/types/ramda/test/merge-tests.ts
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+() => {
+  R.merge({ name: 'fred', age: 10 }, { age: 40 });
+  // => { 'name': 'fred', 'age': 40 }
+};

--- a/types/ramda/test/mergeAll-tests.ts
+++ b/types/ramda/test/mergeAll-tests.ts
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeAll([{ foo: 1 }, { bar: 2 }, { baz: 3 }]); // => {foo:1,bar:2,baz:3}
+  const b = R.mergeAll([{ foo: 1 }, { foo: 2 }, { bar: 2 }]); // => {foo:2,bar:2}
+};

--- a/types/ramda/test/mergeDeepLeft-tests.ts
+++ b/types/ramda/test/mergeDeepLeft-tests.ts
@@ -1,0 +1,5 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeDeepLeft({ foo: { bar: 1 } }, { foo: { bar: 2 } }); // => {foo: {bar: 1}}
+};

--- a/types/ramda/test/mergeDeepRight-tests.ts
+++ b/types/ramda/test/mergeDeepRight-tests.ts
@@ -1,0 +1,5 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeDeepRight({ foo: { bar: 1 } }, { foo: { bar: 2 } }); // => {foo: bar: 2}}
+};

--- a/types/ramda/test/mergeDeepWith-tests.ts
+++ b/types/ramda/test/mergeDeepWith-tests.ts
@@ -1,0 +1,9 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeDeepWith(
+    (a: number[], b: number[]) => a.concat(b),
+    { foo: { bar: [1, 2] } },
+    { foo: { bar: [3, 4] } },
+  ); // => {foo: {bar: [1,2,3,4]}}
+};

--- a/types/ramda/test/mergeDeepWithKey-tests.ts
+++ b/types/ramda/test/mergeDeepWithKey-tests.ts
@@ -1,0 +1,9 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeDeepWithKey(
+    (k: string, a: number[], b: number[]) => (k === 'bar' ? a.concat(b) : a),
+    { foo: { bar: [1, 2], userIds: [42] } },
+    { foo: { bar: [3, 4], userIds: [34] } },
+  ); // => { foo: { bar: [ 1, 2, 3, 4 ], userIds: [42] } }
+};

--- a/types/ramda/test/mergeLeft-tests.ts
+++ b/types/ramda/test/mergeLeft-tests.ts
@@ -1,0 +1,7 @@
+import * as R from 'ramda';
+
+() => {
+  R.mergeLeft({ foo: { bar: 1 } }, { foo: { bar: 2 } }); // => {foo: {bar: 1}}
+  const curry1 = R.mergeLeft({ foo: { bar: 1 } });
+  curry1({ foo: { bar: 2 } }); // => {foo: {bar: 1}}
+};

--- a/types/ramda/test/mergeRight-tests.ts
+++ b/types/ramda/test/mergeRight-tests.ts
@@ -1,0 +1,9 @@
+import * as R from 'ramda';
+
+() => {
+  R.mergeRight({ name: 'fred', age: 10 }, { age: 40 });
+  // => { 'name': 'fred', 'age': 40 }
+
+  const withDefaults = R.mergeRight({ x: 0, y: 0 });
+  withDefaults({ y: 2 }); // => {x: 0, y: 2}
+};

--- a/types/ramda/test/mergeWith-tests.ts
+++ b/types/ramda/test/mergeWith-tests.ts
@@ -1,0 +1,10 @@
+import * as R from 'ramda';
+
+() => {
+  const a = R.mergeWith(
+    R.concat,
+    { a: true, values: [10, 20] },
+    { b: true, values: [15, 35] },
+  );
+  // => { a: true, b: true, values: [10, 20, 15, 35] }
+};

--- a/types/ramda/test/mergeWithKey-tests.ts
+++ b/types/ramda/test/mergeWithKey-tests.ts
@@ -1,0 +1,16 @@
+import * as R from 'ramda';
+
+() => {
+  const concatValues = (k: string, l: string, r: string) =>
+    k === 'values' ? R.concat(l, r) : r;
+  R.mergeWithKey(
+    concatValues,
+    { a: true, thing: 'foo', values: [10, 20] },
+    { b: true, thing: 'bar', values: [15, 35] },
+  );
+  const merge = R.mergeWithKey(concatValues);
+  merge(
+    { a: true, thing: 'foo', values: [10, 20] },
+    { b: true, thing: 'bar', values: [15, 35] },
+  );
+};

--- a/types/ramda/test/min-tests.ts
+++ b/types/ramda/test/min-tests.ts
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+() => {
+  const x: number = R.min(9, 3); // => 3
+  const y: string = R.min('a', 'z'); // => 'a'
+};

--- a/types/ramda/test/minBy-tests.ts
+++ b/types/ramda/test/minBy-tests.ts
@@ -1,0 +1,20 @@
+import * as R from 'ramda';
+
+() => {
+  function cmp(obj: { x: R.Ord }) {
+    return obj.x;
+  }
+
+  const a = { x: 1 };
+  const b = { x: 2 };
+  const c = { x: 3 };
+  const d = { x: 'a' };
+  const e = { x: 'z' };
+  const f = { x: new Date(0) };
+  const g = { x: new Date(60 * 1000) };
+  R.minBy(cmp, a, b); // => {x: 1}
+  R.minBy(cmp)(a, b); // => {x: 1}
+  R.minBy(cmp)(a)(c);
+  R.minBy(cmp, d, e);
+  R.minBy(cmp)(f)(g);
+};

--- a/types/ramda/test/modulo-tests.ts
+++ b/types/ramda/test/modulo-tests.ts
@@ -1,0 +1,8 @@
+import * as R from 'ramda';
+
+() => {
+  R.modulo(17, 3); // => 2
+  // JS behavior:
+  R.modulo(-17, 3); // => -2
+  R.modulo(17, -3); // => 2
+};

--- a/types/ramda/test/move-tests.ts
+++ b/types/ramda/test/move-tests.ts
@@ -1,0 +1,18 @@
+import * as R from 'ramda';
+
+() => {
+  const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+  R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+  R.move<string>(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
+
+  const moveCurried1 = R.move(0, 2);
+  moveCurried1<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+  const moveCurried2 = R.move(0);
+  moveCurried2<string>(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+  const moveCurried3 = R.move(0);
+  const moveCurried4 = moveCurried3(2);
+  moveCurried4<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+};

--- a/types/ramda/test/multiply-tests.ts
+++ b/types/ramda/test/multiply-tests.ts
@@ -1,0 +1,9 @@
+import * as R from 'ramda';
+
+() => {
+  const double = R.multiply(2);
+  const triple = R.multiply(3);
+  double(3); // =>  6
+  triple(4); // => 12
+  R.multiply(2, 5); // => 10
+};

--- a/types/ramda/test/nAry-tests.ts
+++ b/types/ramda/test/nAry-tests.ts
@@ -1,0 +1,22 @@
+import * as R from 'ramda';
+
+() => {
+  function takesNoArg() {
+    return true;
+  }
+  function takesOneArg(a: number) {
+    return [a];
+  }
+  function takesTwoArgs(a: number, b: number) {
+    return [a, b];
+  }
+  function takesThreeArgs(a: number, b: number, c: number) {
+    return [a, b, c];
+  }
+
+  R.nAry(0);
+  R.nAry(0, takesNoArg);
+  R.nAry(0, takesOneArg);
+  R.nAry(1, takesTwoArgs);
+  R.nAry(1, takesThreeArgs);
+};

--- a/types/ramda/test/negate-tests.ts
+++ b/types/ramda/test/negate-tests.ts
@@ -1,0 +1,5 @@
+import * as R from 'ramda';
+
+() => {
+  R.negate(42); // => -42
+};

--- a/types/ramda/test/none-tests.ts
+++ b/types/ramda/test/none-tests.ts
@@ -1,0 +1,7 @@
+import * as R from 'ramda';
+
+() => {
+  R.none(R.isNaN, [1, 2, 3]); // => true
+  R.none(R.isNaN, [1, 2, 3, NaN]); // => false
+  R.none(R.isNaN)([1, 2, 3, NaN]); // => false
+};

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -144,6 +144,7 @@
         "test/mergeLeft-tests.ts",
         "test/mergeRight-tests.ts",
         "test/mergeWith-tests.ts",
-        "test/mergeWithKey-tests.ts"
+        "test/mergeWithKey-tests.ts",
+        "test/min-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -138,6 +138,7 @@
         "test/merge-tests.ts",
         "test/mergeAll-tests.ts",
         "test/mergeDeepLeft-tests.ts",
-        "test/mergeDeepRight-tests.ts"
+        "test/mergeDeepRight-tests.ts",
+        "test/mergeDeepWith-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -137,6 +137,7 @@
         "test/memoizeWith-tests.ts",
         "test/merge-tests.ts",
         "test/mergeAll-tests.ts",
-        "test/mergeDeepLeft-tests.ts"
+        "test/mergeDeepLeft-tests.ts",
+        "test/mergeDeepRight-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -147,6 +147,7 @@
         "test/mergeWithKey-tests.ts",
         "test/min-tests.ts",
         "test/minBy-tests.ts",
-        "test/modulo-tests.ts"
+        "test/modulo-tests.ts",
+        "test/move-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -145,6 +145,7 @@
         "test/mergeRight-tests.ts",
         "test/mergeWith-tests.ts",
         "test/mergeWithKey-tests.ts",
-        "test/min-tests.ts"
+        "test/min-tests.ts",
+        "test/minBy-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -133,6 +133,7 @@
         "test/max-tests.ts",
         "test/maxBy-tests.ts",
         "test/mean-tests.ts",
-        "test/median-tests.ts"
+        "test/median-tests.ts",
+        "test/memoizeWith-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -149,6 +149,7 @@
         "test/minBy-tests.ts",
         "test/modulo-tests.ts",
         "test/move-tests.ts",
-        "test/multiply-tests.ts"
+        "test/multiply-tests.ts",
+        "test/nAry-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -143,6 +143,7 @@
         "test/mergeDeepWithKey-tests.ts",
         "test/mergeLeft-tests.ts",
         "test/mergeRight-tests.ts",
-        "test/mergeWith-tests.ts"
+        "test/mergeWith-tests.ts",
+        "test/mergeWithKey-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -150,6 +150,7 @@
         "test/modulo-tests.ts",
         "test/move-tests.ts",
         "test/multiply-tests.ts",
-        "test/nAry-tests.ts"
+        "test/nAry-tests.ts",
+        "test/negate-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -132,6 +132,7 @@
         "test/mathMod-tests.ts",
         "test/max-tests.ts",
         "test/maxBy-tests.ts",
-        "test/mean-tests.ts"
+        "test/mean-tests.ts",
+        "test/median-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -134,6 +134,7 @@
         "test/maxBy-tests.ts",
         "test/mean-tests.ts",
         "test/median-tests.ts",
-        "test/memoizeWith-tests.ts"
+        "test/memoizeWith-tests.ts",
+        "test/merge-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -141,6 +141,7 @@
         "test/mergeDeepRight-tests.ts",
         "test/mergeDeepWith-tests.ts",
         "test/mergeDeepWithKey-tests.ts",
-        "test/mergeLeft-tests.ts"
+        "test/mergeLeft-tests.ts",
+        "test/mergeRight-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -151,6 +151,7 @@
         "test/move-tests.ts",
         "test/multiply-tests.ts",
         "test/nAry-tests.ts",
-        "test/negate-tests.ts"
+        "test/negate-tests.ts",
+        "test/none-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -146,6 +146,7 @@
         "test/mergeWith-tests.ts",
         "test/mergeWithKey-tests.ts",
         "test/min-tests.ts",
-        "test/minBy-tests.ts"
+        "test/minBy-tests.ts",
+        "test/modulo-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -135,6 +135,7 @@
         "test/mean-tests.ts",
         "test/median-tests.ts",
         "test/memoizeWith-tests.ts",
-        "test/merge-tests.ts"
+        "test/merge-tests.ts",
+        "test/mergeAll-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -139,6 +139,7 @@
         "test/mergeAll-tests.ts",
         "test/mergeDeepLeft-tests.ts",
         "test/mergeDeepRight-tests.ts",
-        "test/mergeDeepWith-tests.ts"
+        "test/mergeDeepWith-tests.ts",
+        "test/mergeDeepWithKey-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -142,6 +142,7 @@
         "test/mergeDeepWith-tests.ts",
         "test/mergeDeepWithKey-tests.ts",
         "test/mergeLeft-tests.ts",
-        "test/mergeRight-tests.ts"
+        "test/mergeRight-tests.ts",
+        "test/mergeWith-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -148,6 +148,7 @@
         "test/min-tests.ts",
         "test/minBy-tests.ts",
         "test/modulo-tests.ts",
-        "test/move-tests.ts"
+        "test/move-tests.ts",
+        "test/multiply-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -140,6 +140,7 @@
         "test/mergeDeepLeft-tests.ts",
         "test/mergeDeepRight-tests.ts",
         "test/mergeDeepWith-tests.ts",
-        "test/mergeDeepWithKey-tests.ts"
+        "test/mergeDeepWithKey-tests.ts",
+        "test/mergeLeft-tests.ts"
     ]
 }

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -136,6 +136,7 @@
         "test/median-tests.ts",
         "test/memoizeWith-tests.ts",
         "test/merge-tests.ts",
-        "test/mergeAll-tests.ts"
+        "test/mergeAll-tests.ts",
+        "test/mergeDeepLeft-tests.ts"
     ]
 }


### PR DESCRIPTION
#37710 attempted to split the tests for `@types/ramda` into separate files per function, but the PR was too large to be approved on its own. This PR is part of a new piecemeal approach to migrating the tests.

I recommend stepping through the PR commit-by-commit to make it easier to check that no individual tests were dropped or changed substantively.

This PR is the next of many to move the functions over in a more piecemeal fashion. It continues from the following PRs:

* #38157 `[ramda] split tests to separate modules - functions beginning with 'a'`
* #38251 `[ramda] split tests to separate modules - functions beginning with 'b' - 'c'`
* #38274 `[ramda] split tests to separate modules - functions beginning with 'd' - 'e'`
* #38347 `[ramda] split tests to separate modules: 'filter' - 'head'`
* #38546 `[ramda] split tests to separate modules: 'identical' - 'isNaN'`
* #38570 `[ramda] split tests to separate modules: 'join' - 'mean'`

I'm splitting out the tests into separate files per function to make it easier to track what is and is not being tested. Please read the descriptions for #37710 and #38157 for more details.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~