### PR TITLE
[jsonwebtoken] change verify to return unknown

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -89,7 +89,7 @@ export type VerifyErrors =
     | TokenExpiredError;
 export type VerifyCallback = (
     err: VerifyErrors,
-    decoded: object | string,
+    decoded: unknown,
 ) => void;
 
 export type SignCallback = (
@@ -163,7 +163,7 @@ export function verify(
     token: string,
     secretOrPublicKey: string | Buffer,
     options?: VerifyOptions,
-): object | string;
+): unknown;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -6,7 +6,8 @@
 //                 Veli-Pekka Kestilä <https://github.com/vpk>,
 //                 Daniel Parker <https://github.com/rlgod>,
 //                 Kjell Dießel <https://github.com/kettil>,
-//                 Robert Gajda <https://github.com/RunAge>
+//                 Robert Gajda <https://github.com/RunAge>,
+//                 Lautaro Dragan <https://github.com/lautarodragan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -8,7 +8,7 @@
 //                 Kjell Dießel <https://github.com/kettil>,
 //                 Robert Gajda <https://github.com/RunAge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -14,6 +14,8 @@ interface TestObject {
     foo: string;
 }
 
+const isTestObject = (x: any): x is TestObject => x && typeof x.foo === 'string'
+
 const testObject = { foo: "bar" };
 
 /**
@@ -58,16 +60,18 @@ jwt.sign(testObject, cert, { algorithm: "RS256" }, (
  */
 // verify a token symmetric
 jwt.verify(token, "shhhhh", (err, decoded) => {
-    const result = decoded as TestObject;
+    if (!isTestObject(decoded))
+        throw new Error('Decoded object is un unexpected format')
 
-    console.log(result.foo); // bar
+    console.log(decoded.foo); // bar
 });
 
 // use external time for verifying
 jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
-    const result = decoded as TestObject;
+    if (!isTestObject(decoded))
+        throw new Error('Decoded object is un unexpected format')
 
-    console.log(result.foo); // bar
+    console.log(decoded.foo); // bar
 });
 
 // invalid token
@@ -79,9 +83,10 @@ jwt.verify(token, "wrong-secret", (err, decoded) => {
 // verify a token asymmetric
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {
-    const result = decoded as TestObject;
+    if (!isTestObject(decoded))
+        throw new Error('Decoded object is un unexpected format')
 
-    console.log(result.foo); // bar
+    console.log(decoded.foo); // bar
 });
 
 // verify a token assymetric with async key fetch function
@@ -92,9 +97,10 @@ function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
 }
 
 jwt.verify(token, getKey, (err, decoded) => {
-    const result = decoded as TestObject;
+    if (!isTestObject(decoded))
+        throw new Error('Decoded object is un unexpected format')
 
-    console.log(result.foo); // bar
+    console.log(decoded.foo); // bar
 });
 
 // verify audience

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -14,9 +14,11 @@ interface TestObject {
     foo: string;
 }
 
-const isTestObject = (x: any): x is TestObject => x && typeof x.foo === 'string'
+const isTestObject = (x: any): x is TestObject => x && typeof x.foo === 'string';
 
 const testObject = { foo: "bar" };
+
+const unexpectedFormatErrorString = 'Decoded object is an unexpected format';
 
 /**
  * jwt.sign
@@ -61,7 +63,7 @@ jwt.sign(testObject, cert, { algorithm: "RS256" }, (
 // verify a token symmetric
 jwt.verify(token, "shhhhh", (err, decoded) => {
     if (!isTestObject(decoded))
-        throw new Error('Decoded object is un unexpected format')
+        throw new Error(unexpectedFormatErrorString);
 
     console.log(decoded.foo); // bar
 });
@@ -69,7 +71,7 @@ jwt.verify(token, "shhhhh", (err, decoded) => {
 // use external time for verifying
 jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
     if (!isTestObject(decoded))
-        throw new Error('Decoded object is un unexpected format')
+        throw new Error(unexpectedFormatErrorString);
 
     console.log(decoded.foo); // bar
 });
@@ -84,7 +86,7 @@ jwt.verify(token, "wrong-secret", (err, decoded) => {
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {
     if (!isTestObject(decoded))
-        throw new Error('Decoded object is un unexpected format')
+        throw new Error(unexpectedFormatErrorString);
 
     console.log(decoded.foo); // bar
 });
@@ -98,7 +100,7 @@ function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
 
 jwt.verify(token, getKey, (err, decoded) => {
     if (!isTestObject(decoded))
-        throw new Error('Decoded object is un unexpected format')
+        throw new Error(unexpectedFormatErrorString);
 
     console.log(decoded.foo); // bar
 });


### PR DESCRIPTION
WIP.

[The jsonwebtoken docs](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback) aren't super clear on this, but `verify` and `decode` [return the payload passed by the user](https://github.com/auth0/node-jsonwebtoken/blob/v8.3.0/verify.js#L196) to `sign` in the first place, which can't be known by the library.

A type guard by the user of the library is always necessary.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Reminder to self: do [this](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#i-want-to-use-features-from-typescript-31-or-above)
