### PR TITLE
use-global-hook Adds type support for subset declaration

### DIFF
--- a/types/use-global-hook/index.d.ts
+++ b/types/use-global-hook/index.d.ts
@@ -23,4 +23,4 @@ export default function useStore<S, A>(
     inititalState: S,
     actions: object,
     initializers?: InitializerFunction<S, A>,
-): () => [S, A];
+): <NS, NA>(stateFunc?: (state: S) => NS, actionsFunc?: (state: A) => NA) => [NS, NA];

--- a/types/use-global-hook/use-global-hook-tests.ts
+++ b/types/use-global-hook/use-global-hook-tests.ts
@@ -1,13 +1,28 @@
 import useStore, { Store, InitializerFunction } from 'use-global-hook';
 import React = require('react');
 
-interface state { value: string; }
-interface associatedActions { setValue(value: string): void; }
-const initializer: InitializerFunction<state, associatedActions> = (store: Store<state, associatedActions>) => {
-    store.actions.setValue("");
+interface stateType {
+  value: string;
+}
+
+type setFunc = (value: string) => void;
+
+interface associatedActionsType {
+  setValue: setFunc;
+}
+
+const initializer: InitializerFunction<stateType, associatedActionsType> = (store: Store<stateType, associatedActionsType>) => {
+    store.actions.setValue('');
     store.state.value;
-    store.setState({ value: "string" });
+    store.setState({ value: 'string' });
 };
 
-useStore<state, associatedActions>(React, { value: "" }, {}, initializer); // $ExpectType () => [state, associatedActions]
-useStore<state, associatedActions>(React, { value: "" }, {}); // $ExpectType () => [state, associatedActions]
+const store = useStore<stateType, associatedActionsType>(React, { value: '' }, {}, initializer);
+
+store(); // $ExpectType [unknown, unknown]
+store<stateType, associatedActionsType>(); // $ExpectType [stateType, associatedActionsType]
+store<string, associatedActionsType>((state: stateType) => state.value); // $ExpectType [string, associatedActionsType]
+store<stateType, setFunc>(undefined, (action: associatedActionsType) => action.setValue); // $ExpectType [stateType, setFunc]
+store<string, setFunc>((state: stateType) => state.value, (actions: associatedActionsType) => actions.setValue); // $ExpectType [string, setFunc]
+
+useStore<stateType, associatedActionsType>(React, { value: '' }, {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [code that is supported](https://github.com/andregardi/use-global-hook/blob/master/index.js#L9), [example usage](https://codesandbox.io/s/several-counters-pdbsy)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.