### PR TITLE
[hapi__hapi] Improve types for RequestAuth

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -184,7 +184,7 @@ export interface AppCredentials {
 /**
  * User-extensible type for request.auth credentials.
  */
-export interface AuthCredentials {
+export interface AuthCredentials extends Record<string, any> {
     /**
      * The application scopes to be granted.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsauthaccessscope)
@@ -217,9 +217,9 @@ export type AuthMode = 'required' | 'optional' | 'try';
  */
 export interface RequestAuth {
     /** an artifact object received from the authentication strategy and used in authentication-related actions. */
-    artifacts: object;
+    artifacts: Record<string, any> | null;
     /** the credential object received during the authentication process. The presence of an object does not mean successful authentication. */
-    credentials: AuthCredentials;
+    credentials: AuthCredentials | null;
     /** the authentication error is failed and mode set to 'try'. */
     error: Error;
     /** true if the request has been successfully authenticated, otherwise false. */

--- a/types/hapi__hapi/test/request/auth.ts
+++ b/types/hapi__hapi/test/request/auth.ts
@@ -12,7 +12,7 @@ declare module '@hapi/hapi' {
 
 const req: Request = {} as any;
 const scope: string[] | undefined = req.auth.credentials ? req.auth.credentials.scope : undefined;
-const user = req.auth.credentials ? req.auth.credentials.user! : {};
+const user = req.auth.credentials ? req.auth.credentials.user! : { a: '' };
 console.log(user.a);
-const app = req.auth.credentials ? req.auth.credentials.app! : {};
+const app = req.auth.credentials ? req.auth.credentials.app! : { b: '' };
 console.log(app.b);

--- a/types/hapi__hapi/test/request/auth.ts
+++ b/types/hapi__hapi/test/request/auth.ts
@@ -11,8 +11,8 @@ declare module '@hapi/hapi' {
 }
 
 const req: Request = {} as any;
-const scope: string[] | undefined = req.auth.credentials.scope;
-const user = req.auth.credentials.user!;
+const scope: string[] | undefined = req.auth.credentials ? req.auth.credentials.scope : undefined;
+const user = req.auth.credentials ? req.auth.credentials.user! : {};
 console.log(user.a);
-const app = req.auth.credentials.app!;
+const app = req.auth.credentials ? req.auth.credentials.app! : {};
 console.log(app.b);

--- a/types/hapi__hapi/test/server/server-auth-default.ts
+++ b/types/hapi__hapi/test/server/server-auth-default.ts
@@ -34,6 +34,10 @@ server.route({
     method: 'GET',
     path: '/',
     handler(request, h) {
+        if (!request.auth.credentials) {
+            return 'not authed';
+        }
+
         return request.auth.credentials.user || 'not authed';
     }
 });


### PR DESCRIPTION
artifacts and credentials are null if the user is not authenticated.
Also the credentials could be any value, therefore I added the `extends Record<string, any>` to AuthCredentials.
This should be considered in the types correctly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/blob/master/lib/auth.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
