### PR TITLE
lodash: fix flattenDeep to correctly handle strings

### DIFF
--- a/types/lodash/ts3.1/common/array.d.ts
+++ b/types/lodash/ts3.1/common/array.d.ts
@@ -488,7 +488,7 @@ declare module "../index" {
          */
         flatten(): T extends Many<infer U> ? CollectionChain<U> : CollectionChain<T>;
     }
-    type Flat<T> = (T extends List<any> ? never : T);
+    type Flat<T> = T extends string ? T : (T extends List<any> ? never : T);
     interface LoDashStatic {
         /**
          * Recursively flattens a nested array.

--- a/types/lodash/ts3.1/common/array.d.ts
+++ b/types/lodash/ts3.1/common/array.d.ts
@@ -488,7 +488,9 @@ declare module "../index" {
          */
         flatten(): T extends Many<infer U> ? CollectionChain<U> : CollectionChain<T>;
     }
+
     type Flat<T> = T extends string ? T : (T extends List<any> ? never : T);
+
     interface LoDashStatic {
         /**
          * Recursively flattens a nested array.

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -496,9 +496,9 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.flattenDeep([[1, 2, 3]]); // $ExpectType number[]
     _.flattenDeep([1, [2, [3, [4, 5]]]]); // $ExpectType number[]
     _.flattenDeep({0: 1, 1: [2, [3, [4, 5]]], length: 2}); // $ExpectType number[]
-    
+
     _.flattenDeep(['x']); // $ExpectType string[]
-    _.flattenDeep(['x',['y']]); // $ExpectType string[]
+    _.flattenDeep(['x', ['y']]); // $ExpectType string[]
 
     _.flattenDeep<number>([1, 2, 3]); // $ExpectType number[]
     _.flattenDeep<number>([[1, 2, 3]]); // $ExpectType number[]

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -496,6 +496,9 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.flattenDeep([[1, 2, 3]]); // $ExpectType number[]
     _.flattenDeep([1, [2, [3, [4, 5]]]]); // $ExpectType number[]
     _.flattenDeep({0: 1, 1: [2, [3, [4, 5]]], length: 2}); // $ExpectType number[]
+    
+    _.flattenDeep(['x']); // $ExpectType string[]
+    _.flattenDeep(['x',['y']]); // $ExpectType string[]
 
     _.flattenDeep<number>([1, 2, 3]); // $ExpectType number[]
     _.flattenDeep<number>([[1, 2, 3]]); // $ExpectType number[]


### PR DESCRIPTION
This is the change that was discussed at the end of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37443

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#flattenDeep
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


