### PR TITLE
msgpack-lite - Typings for individual Decoder factory

### DIFF
--- a/types/msgpack-lite/index.d.ts
+++ b/types/msgpack-lite/index.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="node" />
 import * as stream from 'stream';
+import { EventEmitter } from 'events';
 
 /**
  * encode from JS Object to MessagePack
@@ -84,7 +85,9 @@ export interface Encoder {
   end(chunk: any): void;
 }
 
-export interface Decoder {
+export function Decoder(options?: DecoderOptions): Decoder;
+
+export interface Decoder extends EventEmitter {
   bufferish: any;
   offset: number;
   fetch(): void;

--- a/types/msgpack-lite/msgpack-lite-tests.ts
+++ b/types/msgpack-lite/msgpack-lite-tests.ts
@@ -84,3 +84,18 @@ function customExtensionTypes() {
     return new MyVector(array[0], array[1]); // return Object deserialized
   }
 }
+
+// https://github.com/kawanet/msgpack-lite#benchmarks
+// (this is not well documented, but in the test there is an example usage.)
+function standaloneDecoder() {
+  const decoder = msgpack.Decoder();
+  const object = { test: "Object" };
+  const encoded = msgpack.encode(object);
+  decoder.on('data', (obj) => {
+    if (object.test !== obj.test) {
+      throw Error();
+    }
+  });
+
+  decoder.push(encoded);
+}


### PR DESCRIPTION
Decoder can be built standalone (is part of the actual public interface
and part of the performance-test interface described in the README.md of
the project). Moreover, Decoder is an event emitter. The interface has
been update accordingly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kawanet/msgpack-lite#benchmarks (this is not really documented, but part of the test cases and part of the tests) https://github.com/kawanet/msgpack-lite/blob/master/test/13.decoder.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
