### PR TITLE
Added typing for xml-c14n

### DIFF
--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-declare module xml_c14n {
+declare namespace xml_c14n {
     type canonicaliseCb = (err: any, data: string) => void;
 
     interface Options {
@@ -26,4 +26,6 @@ declare module xml_c14n {
     }
 }
 
-export default function c14n(): xml_c14n.CanonizationFactory;
+declare function c14n(): xml_c14n.CanonizationFactory;
+
+export = c14n;

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -26,6 +26,6 @@ declare namespace xml_c14n {
     }
 }
 
-declare function c14n(): xml_c14n.CanonizationFactory;
+declare function xml_c14n(): xml_c14n.CanonizationFactory;
 
-export = c14n;
+export = xml_c14n;

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -28,4 +28,4 @@ declare namespace xml_c14n {
 
 declare function c14n(): xml_c14n.CanonizationFactory;
 
-export default c14n;
+export = c14n;

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for xml-c14n 0.0.6
+// Type definitions for xml-c14n 0.0
 // Project: https://github.com/deoxxa/xml-c14n
 // Definitions by: Konstantin Yuriev <https://github.com/gallowsmaker>
 //                 Max Boguslavskiy <https://github.com/maxbogus>

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Konstantin Yuriev <https://github.com/gallowsmaker>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.7
 
 declare namespace xml_c14n {
     type canonicaliseCb = (err: any, data: string) => void;
@@ -28,4 +28,4 @@ declare namespace xml_c14n {
 
 declare function c14n(): xml_c14n.CanonizationFactory;
 
-export = c14n;
+export default c14n;

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -1,0 +1,22 @@
+declare module xml_c14n {
+    type canonicaliseCb = (err: any, data: string) => void;
+
+    interface Options {
+        includeComments?: boolean;
+        inclusiveNamespaces?: boolean;
+    }
+
+    interface Canonicalize {
+        name(): string;
+        _processInner(node: Node): string;
+        canonicalise(node: Node, cb: canonicaliseCb): void;
+    }
+
+    interface CanonizationFactory {
+        createCanonicaliser(kind: string, options?: Options): Canonicalize;
+        getAlgorithm(uri: string): any;
+        registerAlgorithm(uri: string, implementation: any): any;
+    }
+}
+
+export default function c14n(): xml_c14n.CanonizationFactory;

--- a/types/xml-c14n/index.d.ts
+++ b/types/xml-c14n/index.d.ts
@@ -1,3 +1,10 @@
+// Type definitions for xml-c14n 0.0.6
+// Project: https://github.com/deoxxa/xml-c14n
+// Definitions by: Konstantin Yuriev <https://github.com/gallowsmaker>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
 declare module xml_c14n {
     type canonicaliseCb = (err: any, data: string) => void;
 

--- a/types/xml-c14n/package.json
+++ b/types/xml-c14n/package.json
@@ -2,5 +2,8 @@
     "private": true,
     "dependencies": {
         "xml-c14n": "0.0.6"
+    },
+    "scripts": {
+        "test": "node ../../node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed"
     }
 }

--- a/types/xml-c14n/package.json
+++ b/types/xml-c14n/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "xml-c14n": "0.0.6"
+    }
+}

--- a/types/xml-c14n/package.json
+++ b/types/xml-c14n/package.json
@@ -1,9 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "xml-c14n": "0.0.6"
-    },
-    "scripts": {
-        "test": "node ../../node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed"
-    }
-}

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "esModuleInterop": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -5,11 +5,7 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "esModuleInterop": true,
-        "strictFunctionTypes": true,
-        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -7,6 +7,9 @@
         ],
         "esModuleInterop": true,
         "noImplicitAny": false,
+        "noImplicitThis": false,
+        "strictNullChecks": false,
+        "strictFunctionTypes": false,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -6,10 +6,10 @@
             "dom"
         ],
         "esModuleInterop": true,
-        "noImplicitAny": false,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
-        "strictFunctionTypes": false,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "xml-c14n-tests.ts"
+    ]
+}

--- a/types/xml-c14n/tsconfig.json
+++ b/types/xml-c14n/tsconfig.json
@@ -6,6 +6,7 @@
             "dom"
         ],
         "esModuleInterop": true,
+        "noImplicitAny": false,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/xml-c14n/tslint.json
+++ b/types/xml-c14n/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/xml-c14n/xml-c14n-tests.ts
+++ b/types/xml-c14n/xml-c14n-tests.ts
@@ -1,5 +1,5 @@
 import c14n from 'xml-c14n';
 
-var canonizer = c14n().createCanonicaliser(
+const canonizer = c14n().createCanonicaliser(
   'http://www.w3.org/2001/10/xml-exc-c14n#',
 );

--- a/types/xml-c14n/xml-c14n-tests.ts
+++ b/types/xml-c14n/xml-c14n-tests.ts
@@ -1,3 +1,5 @@
 import c14n from 'xml-c14n';
 
-var canonizer = c14n().createCanonicaliser('http://www.w3.org/2001/10/xml-exc-c14n#');
+var canonizer = c14n().createCanonicaliser(
+  'http://www.w3.org/2001/10/xml-exc-c14n#',
+);

--- a/types/xml-c14n/xml-c14n-tests.ts
+++ b/types/xml-c14n/xml-c14n-tests.ts
@@ -1,0 +1,4 @@
+import c14n from 'xml-c14n';
+
+c14n().createCanonicaliser('http://www.w3.org/2001/10/xml-exc-c14n#');
+

--- a/types/xml-c14n/xml-c14n-tests.ts
+++ b/types/xml-c14n/xml-c14n-tests.ts
@@ -1,4 +1,3 @@
 import c14n from 'xml-c14n';
 
-c14n().createCanonicaliser('http://www.w3.org/2001/10/xml-exc-c14n#');
-
+var canonizer = c14n().createCanonicaliser('http://www.w3.org/2001/10/xml-exc-c14n#');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
