### PR TITLE
Loosen type signature of treeify method asTree

### DIFF
--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -1,27 +1,23 @@
-// Type definitions for treeify 1.0
+// Type definitions for treeify 1.1
 // Project: https://github.com/notatestuser/treeify
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Arnesen <https://github.com/carnesen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
-
-export interface TreeObject {
-    [k: string]: TreeValue;
-}
-export type TreeValue = string | TreeObject;
+// TypeScript Version: 2.2
 
 export function asTree(
-    treeObj: TreeObject,
-    showValues: boolean,
-    hideFunctions: boolean
+    obj: object,
+    showValues?: boolean,
+    hideFunctions?: boolean
 ): string;
 
 export function asLines(
-    treeObj: TreeObject,
+    obj: object,
     showValues: boolean,
     lineCallback: (line: string) => void
 ): string;
 export function asLines(
-    treeObj: TreeObject,
+    obj: object,
     showValues: boolean,
     hideFunctions: boolean,
     lineCallback: (line: string) => void

--- a/types/treeify/index.d.ts
+++ b/types/treeify/index.d.ts
@@ -3,22 +3,22 @@
 // Definitions by: Mike North <https://github.com/mike-north>
 //                 Chris Arnesen <https://github.com/carnesen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.1
 
 export function asTree(
-    obj: object,
+    obj: any,
     showValues?: boolean,
     hideFunctions?: boolean
-): string;
+): string | undefined;
 
 export function asLines(
-    obj: object,
+    obj: any,
     showValues: boolean,
     lineCallback: (line: string) => void
-): string;
+): string | undefined;
 export function asLines(
-    obj: object,
+    obj: any,
     showValues: boolean,
     hideFunctions: boolean,
     lineCallback: (line: string) => void
-): string;
+): string | undefined;

--- a/types/treeify/treeify-tests.ts
+++ b/types/treeify/treeify-tests.ts
@@ -2,18 +2,21 @@ import * as treeify from 'treeify';
 
 function log(s: string): void {}
 
+// $ExpectType string
 treeify.asTree([0, { foo: 'bar' }, 2], true);
 // ├─ 0: 0
 // ├─ 1
 // │  └─ foo: bar
 // └─ 2: 2
 
+// $ExpectType string
 treeify.asTree([0, { foo: 'bar' }, 2]);
 // ├─ 0
 // ├─ 1
 // │  └─ foo
 // └─ 2
 
+// $ExpectType string
 treeify.asTree(
     {
         apples: 'gala', //      ├─ apples: gala
@@ -23,6 +26,7 @@ treeify.asTree(
     true
 );
 
+// $ExpectType string
 treeify.asLines(
     {
         apples: 'gala', //                       ├─ apples: gala
@@ -36,6 +40,7 @@ treeify.asLines(
     log
 );
 
+// $ExpectType string
 treeify.asLines(
     {
         apples: 'gala', //      ├─ apples: gala

--- a/types/treeify/treeify-tests.ts
+++ b/types/treeify/treeify-tests.ts
@@ -2,6 +2,18 @@ import * as treeify from 'treeify';
 
 function log(s: string): void {}
 
+treeify.asTree([0, { foo: 'bar' }, 2], true);
+// ├─ 0: 0
+// ├─ 1
+// │  └─ foo: bar
+// └─ 2: 2
+
+treeify.asTree([0, { foo: 'bar' }, 2]);
+// ├─ 0
+// ├─ 1
+// │  └─ foo
+// └─ 2
+
 treeify.asTree(
     {
         apples: 'gala', //      ├─ apples: gala

--- a/types/treeify/treeify-tests.ts
+++ b/types/treeify/treeify-tests.ts
@@ -1,23 +1,29 @@
-import * as treeify from 'treeify';
+import { asTree, asLines } from 'treeify';
 
 function log(s: string): void {}
 
-// $ExpectType string
-treeify.asTree([0, { foo: 'bar' }, 2], true);
+// $ExpectType string | undefined
+asTree(null);
+
+// $ExpectType string | undefined
+asTree(undefined);
+
+// $ExpectType string | undefined
+asTree([0, { foo: 'bar' }, 2], true);
 // ├─ 0: 0
 // ├─ 1
 // │  └─ foo: bar
 // └─ 2: 2
 
-// $ExpectType string
-treeify.asTree([0, { foo: 'bar' }, 2]);
+// $ExpectType string | undefined
+asTree([0, { foo: 'bar' }, 2]);
 // ├─ 0
 // ├─ 1
 // │  └─ foo
 // └─ 2
 
-// $ExpectType string
-treeify.asTree(
+// $ExpectType string | undefined
+asTree(
     {
         apples: 'gala', //      ├─ apples: gala
         oranges: 'mandarin' //  └─ oranges: mandarin
@@ -26,8 +32,8 @@ treeify.asTree(
     true
 );
 
-// $ExpectType string
-treeify.asLines(
+// $ExpectType string | undefined
+asLines(
     {
         apples: 'gala', //                       ├─ apples: gala
         oranges: 'mandarin', //                  ├─ oranges: mandarin
@@ -40,8 +46,8 @@ treeify.asLines(
     log
 );
 
-// $ExpectType string
-treeify.asLines(
+// $ExpectType string | undefined
+asLines(
     {
         apples: 'gala', //      ├─ apples: gala
         oranges: 'mandarin' //  └─ oranges: mandarin


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Note: `npm test` is failing but it does not seem related to any changed I made here)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/notatestuser/treeify/blob/master/treeify.js#L64
^^ Where showValues gets used (checks for truthiness only)
https://github.com/notatestuser/treeify/blob/master/treeify.js#L36
^^ Where hideFunctions gets used (checks for truthiness only)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
