### PR TITLE
Unused files webpack plugin

### DIFF
--- a/types/unused-files-webpack-plugin/index.d.ts
+++ b/types/unused-files-webpack-plugin/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for unused-files-webpack-plugin 3.4
+// Project: https://github.com/tomchentw/unused-files-webpack-plugin
+// Definitions by: Vladimir Grenaderov <https://github.com/VladimirGrenaderov>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Plugin } from 'webpack';
+
+interface Options {
+    patterns?: string[];
+    failOnUnused: boolean;
+    globOptions?: {
+        ignore?: string | string[];
+    };
+    ignore?: string | string[];
+    cwd?: string;
+}
+
+declare class UnusedFilesWebpackPlugin extends Plugin {
+    constructor(options: Options);
+}
+
+export = UnusedFilesWebpackPlugin

--- a/types/unused-files-webpack-plugin/index.d.ts
+++ b/types/unused-files-webpack-plugin/index.d.ts
@@ -21,4 +21,4 @@ declare class UnusedFilesWebpackPlugin extends Plugin {
     constructor(options: Options);
 }
 
-export = UnusedFilesWebpackPlugin
+export = UnusedFilesWebpackPlugin;

--- a/types/unused-files-webpack-plugin/tsconfig.json
+++ b/types/unused-files-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "unused-files-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/unused-files-webpack-plugin/tslint.json
+++ b/types/unused-files-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
+++ b/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
@@ -1,0 +1,29 @@
+import * as webpack from 'webpack';
+import UnusedFilesWebpackPlugin = require('unused-files-webpack-plugin');
+
+const ignoredFiles = [""];
+const config: webpack.Configuration = {
+    plugins: [
+        new UnusedFilesWebpackPlugin({
+            failOnUnused: false,
+        }),
+        new UnusedFilesWebpackPlugin({
+            failOnUnused: true,
+            globOptions: {
+                ignore: ignoredFiles
+            }
+        }),
+        new UnusedFilesWebpackPlugin({
+            patterns: ["one", "two"],
+            failOnUnused: true,
+        }),
+        new UnusedFilesWebpackPlugin({
+            failOnUnused: false,
+            ignore: "no"
+        }),
+        new UnusedFilesWebpackPlugin({
+            failOnUnused: false,
+            cwd: "cwd"
+        })
+    ]
+};

--- a/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
+++ b/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
@@ -1,29 +1,29 @@
 import * as webpack from 'webpack';
 import UnusedFilesWebpackPlugin = require('unused-files-webpack-plugin');
 
-const ignoredFiles = [""];
+const ignoredFiles = [''];
 const config: webpack.Configuration = {
-    plugins: [
-        new UnusedFilesWebpackPlugin({
-            failOnUnused: false,
-        }),
-        new UnusedFilesWebpackPlugin({
-            failOnUnused: true,
-            globOptions: {
-                ignore: ignoredFiles
-            }
-        }),
-        new UnusedFilesWebpackPlugin({
-            patterns: ["one", "two"],
-            failOnUnused: true,
-        }),
-        new UnusedFilesWebpackPlugin({
-            failOnUnused: false,
-            ignore: "no"
-        }),
-        new UnusedFilesWebpackPlugin({
-            failOnUnused: false,
-            cwd: "cwd"
-        })
-    ]
+  plugins: [
+    new UnusedFilesWebpackPlugin({
+      failOnUnused: false,
+    }),
+    new UnusedFilesWebpackPlugin({
+      failOnUnused: true,
+      globOptions: {
+        ignore: ignoredFiles,
+      },
+    }),
+    new UnusedFilesWebpackPlugin({
+      patterns: ['one', 'two'],
+      failOnUnused: true,
+    }),
+    new UnusedFilesWebpackPlugin({
+      failOnUnused: false,
+      ignore: 'no',
+    }),
+    new UnusedFilesWebpackPlugin({
+      failOnUnused: false,
+      cwd: 'cwd',
+    }),
+  ],
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
