### PR TITLE
[react-native-vector-icons] fix: Icon style

### DIFF
--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -55,7 +55,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
    *
    * @default {marginRight: 10}
    */
-  iconStyle?: ViewStyle;
+  iconStyle?: TextStyle;
 
   /**
    * Style prop inherited from TextProps and TouchableWithoutFeedbackProperties

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 //                 Robert Ying <https://github.com/robertying>
+//                 Jesse Katsumata <https://github.com/Naturalclar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`create-icon-set.js` in `react-native-vector-icons` suggests that `Icon` Component is a `Text` Component, so the style should expect a `TextStyle` (With current definition, providing `color` results in TS error, because `color` is not part of `ViewStyle`).
It's true that default prop has a `marginRight: 10` , which is an invalid style for `TextStyle`, and I believe that is an error in `react-native-vector-icon`
