### PR TITLE
console-ui now uses Readable/WritableStream from node

### DIFF
--- a/types/console-ui/index.d.ts
+++ b/types/console-ui/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
-import { Readable, Writable } from 'stream';
 import { QuestionCollection } from 'inquirer';
 
 type WriteLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
@@ -18,9 +17,9 @@ export = UI;
  */
 declare class UI {
     constructor(options?: {
-        inputStream?: Readable;
-        outputStream?: Writable;
-        errorStream?: Writable;
+        inputStream?: NodeJS.ReadableStream;
+        outputStream?: NodeJS.WritableStream;
+        errorStream?: NodeJS.WritableStream;
         writeLevel?: WriteLevel;
         ci?: boolean;
     });


### PR DESCRIPTION
Previously, it used process.Readable/Writeable. But its tests show that the constructor is meant to take process.stdin, which is a ReadStream. Until
recently, the two types were mistakenly assignable. Now that they are not, I think the type should be ReadableStream, which is a common
supertype of process.Readable and ReadStream.