### PR TITLE
[redux-api-middleware] Improve Dispatch call

### DIFF
--- a/types/redux-api-middleware/redux-api-middleware-tests.ts
+++ b/types/redux-api-middleware/redux-api-middleware-tests.ts
@@ -17,8 +17,7 @@ import {
     RSAASuccessTypeDescriptor,
     RSAAFailureTypeDescriptor,
     RSAARequestAction,
-    RSAASuccessAction,
-    RSAAFailureAction,
+    RSAAResultAction,
 } from 'redux-api-middleware';
 
 {
@@ -156,7 +155,7 @@ import {
 
 {
     const store: Store = createStore(() => undefined);
-    const action: RSAAAction = {
+    const action: RSAAAction<any, string, number> = {
         [RSAA]: {
             endpoint: '/test/endpoint',
             method: 'GET',
@@ -165,10 +164,21 @@ import {
     };
 
     store.dispatch(action);
-    store.dispatch(action).then((action: RSAASuccessAction) => Promise.resolve());
+    store.dispatch(action).then((action: RSAAResultAction<string, number>) => Promise.resolve());
     store.dispatch(action).then(() => Promise.resolve());
+    store
+        .dispatch(action)
+        .then(action => (action.error ? Promise.reject() : Promise.resolve(action.payload)))
+        .then((payload: string) => payload);
+    store
+        .dispatch(action)
+        .then(action => (action.error ? Promise.reject() : Promise.resolve(action.meta)))
+        .then((payload: number) => Promise.resolve());
+    store
+        .dispatch(action)
+        .then(action => (action.error ? Promise.reject() : Promise.resolve(action.payload)))
+        .then((payload: number) => Promise.resolve()); // $ExpectError
     store.dispatch(action).then((action: string) => Promise.resolve()); // $ExpectError
-    store.dispatch(action).catch((action: RSAAFailureAction) => Promise.reject());
 }
 
 {
@@ -222,18 +232,93 @@ import {
 }
 
 {
-    const requestAction0: RSAARequestAction<number, number> = {
-        type: ''
+    const requestActionSimple: RSAARequestAction = {
+        type: '',
     };
 
-    const successAction0: RSAASuccessAction<number, number> = {
+    const requestActionWithPayload: RSAARequestAction<number> = {
         type: '',
-        payload: 6
+        payload: 1,
     };
 
-    const failureAction0: RSAAFailureAction<number, number> = {
+    const requestActionWithIncorrectPayload: RSAARequestAction<number> = {
         type: '',
+        payload: '', // $ExpectError
+    };
+
+    const requestActionWithMeta: RSAARequestAction<never, number> = {
+        type: '',
+        meta: 1,
+    };
+
+    // $ExpectError
+    const requestActionWithMissingPayload: RSAARequestAction<number> = {
+        type: '',
+    };
+
+    const requestActionWithExtraneousMeta: RSAARequestAction<number> = {
+        type: '',
+        payload: 1,
+        meta: 1, // $ExpectError
+    };
+
+    const requestActionWithError: RSAARequestAction<number> = {
+        type: '',
+        error: true,
+        payload: new InvalidRSAA(['']),
+    };
+
+    const resultActionSimple: RSAAResultAction = {
+        type: '',
+    };
+
+    const resultActionWithPayload: RSAAResultAction<number> = {
+        type: '',
+        payload: 1,
+    };
+
+    const resultActionWithIncorrectPayload: RSAAResultAction<number> = {
+        type: '',
+        payload: '', // $ExpectError
+    };
+
+    const resultActionWithMeta: RSAAResultAction<never, number> = {
+        type: '',
+        meta: 1,
+    };
+
+    // $ExpectError
+    const resultActionWithMissingPayload: RSAAResultAction<number> = {
+        type: '',
+    };
+
+    const resultActionWithExtraneousMeta: RSAAResultAction<number> = {
+        type: '',
+        payload: 1,
+        meta: 1, // $ExpectError
+    };
+
+    const resultActionWithApiError: RSAAResultAction<number> = {
+        type: '',
+        error: true,
         payload: new ApiError(500, '', 1),
-        error: true
+    };
+
+    const resultActionWithInternalError: RSAAResultAction<number> = {
+        type: '',
+        error: true,
+        payload: new InternalError(''),
+    };
+
+    const resultActionWithRequestError: RSAAResultAction<number> = {
+        type: '',
+        error: true,
+        payload: new RequestError(''),
+    };
+
+    // $ExpectError
+    const resultActionWithMissingErrorPayload: RSAAResultAction<number> = {
+        type: '',
+        error: true,
     };
 }


### PR DESCRIPTION
Refactored the dispatched actions to be typed using Discriminated Union.
The promise results are now correctly typed and include payload type without needing explicit typing.

The `RSAARequestAction` changed default Payload and Meta types but the action shouldn't have been used outside the package anyway.
Kept `RSAASuccessAction` and `RSAAFailureAction` with current default Payload and Meta for backwards compatibility and deprecated them in favour of `RSAAResultAction` with stricter default typings.
Removed the `.catch` test since results aren't actually ever thrown from looking at the source code. It's also the reason I unified the success and failure actions since they aren't really that different and discriminated union takes care of differences.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agraboso/redux-api-middleware#lifecycle
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.