### PR TITLE
Added type definitions for use-combined-reducers

### DIFF
--- a/types/use-combined-reducers/index.d.ts
+++ b/types/use-combined-reducers/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/the-road-to-learn-react/use-combined-reducers#readme
 // Definitions by: kwdowik <https://github.com/kwdowik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/use-combined-reducers/index.d.ts
+++ b/types/use-combined-reducers/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for use-combined-reducers 1.0
+// Project: https://github.com/the-road-to-learn-react/use-combined-reducers
+// Definitions by: Kacper Wdowik https://github.com/kwdowik/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'React';
+
+declare module "use-combined-reducers" {
+    function useCombinedReducers<T, A>(combinedReducers: Record<keyof T, [T[keyof T], React.Dispatch<A>]>): [T, (action: A) => void];
+
+    export default useCombinedReducers;
+}
+

--- a/types/use-combined-reducers/index.d.ts
+++ b/types/use-combined-reducers/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/the-road-to-learn-react/use-combined-reducers#readme
 // Definitions by: kwdowik <https://github.com/kwdowik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 import * as React from 'react';
 

--- a/types/use-combined-reducers/index.d.ts
+++ b/types/use-combined-reducers/index.d.ts
@@ -1,13 +1,9 @@
 // Type definitions for use-combined-reducers 1.0
-// Project: https://github.com/the-road-to-learn-react/use-combined-reducers
-// Definitions by: Kacper Wdowik https://github.com/kwdowik/>
+// Project: https://github.com/the-road-to-learn-react/use-combined-reducers#readme
+// Definitions by: kwdowik <https://github.com/kwdowik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as React from 'React';
 
-declare module "use-combined-reducers" {
-    function useCombinedReducers<T, A>(combinedReducers: Record<keyof T, [T[keyof T], React.Dispatch<A>]>): [T, (action: A) => void];
-
-    export default useCombinedReducers;
-}
-
+export default function useCombinedReducers<T, A>(combinedReducers: Record<keyof T, [T[keyof T], React.Dispatch<A>]>): [T, (action: A) => void];

--- a/types/use-combined-reducers/index.d.ts
+++ b/types/use-combined-reducers/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import * as React from 'React';
+import * as React from 'react';
 
 export default function useCombinedReducers<T, A>(combinedReducers: Record<keyof T, [T[keyof T], React.Dispatch<A>]>): [T, (action: A) => void];

--- a/types/use-combined-reducers/tsconfig.json
+++ b/types/use-combined-reducers/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "preserve"
+    },
+    "files": [
+        "index.d.ts",
+        "use-combined-reducers-test.ts"
+    ]
+}

--- a/types/use-combined-reducers/tsconfig.json
+++ b/types/use-combined-reducers/tsconfig.json
@@ -6,19 +6,18 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "jsx": "preserve"
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",
-        "use-combined-reducers-test.ts"
+        "use-combined-reducers-tests.ts"
     ]
 }

--- a/types/use-combined-reducers/tslint.json
+++ b/types/use-combined-reducers/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/use-combined-reducers/tslint.json
+++ b/types/use-combined-reducers/tslint.json
@@ -1,3 +1,1 @@
-{
-    "extends": "dtslint/dt.json"
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/use-combined-reducers/use-combined-reducers-test.ts
+++ b/types/use-combined-reducers/use-combined-reducers-test.ts
@@ -1,0 +1,6 @@
+import useCombinedReducers from 'use-combined-reducers';
+
+useCombinedReducers<{ a: number, b: any }, () => {}>({
+    a: ['', () => { }],
+    b: ['', () => { }],
+});

--- a/types/use-combined-reducers/use-combined-reducers-tests.ts
+++ b/types/use-combined-reducers/use-combined-reducers-tests.ts
@@ -1,6 +1,6 @@
 import useCombinedReducers from 'use-combined-reducers';
 
-useCombinedReducers<{ a: number, b: any }, () => {}>({
+useCombinedReducers<{ a: number; b: any }, () => {}>({
     a: ['', () => { }],
     b: ['', () => { }],
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
