### PR TITLE
[@types/react-router] Make the useRouteMatch path argument optional to reflect implementation

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -156,5 +156,5 @@ export function useLocation<S = H.LocationState>(): H.Location<S>;
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: string };
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(
-    path: string | RouteProps,
+    path?: string | RouteProps,
 ): match<Params> | null;


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/hooks.js#L50