### PR TITLE
[pdfkit] change all return type from 'TDocument' to 'this'. 

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -47,18 +47,18 @@ declare namespace PDFKit.Mixins {
         DA?: string;
     }
 
-    interface PDFAnnotation<TDocument> {
-        annotate(x: number, y: number, w: number, h: number, option: AnnotationOption): TDocument;
-        note(x: number, y: number, w: number, h: number, content: string, option?: AnnotationOption): TDocument;
-        goTo(x: number, y: number, w: number, h: number, name: string, options?: AnnotationOption): TDocument;
-        link(x: number, y: number, w: number, h: number, url: string, option?: AnnotationOption): TDocument;
-        highlight(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
-        underline(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
-        strike(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
-        lineAnnotation(x1: number, y1: number, x2: number, y2: number, option?: AnnotationOption): TDocument;
-        rectAnnotation(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
-        ellipseAnnotation(x: number, y: number, w: number, h: number, option?: AnnotationOption): TDocument;
-        textAnnotation(x: number, y: number, w: number, h: number, text: string, option?: AnnotationOption): TDocument;
+    interface PDFAnnotation {
+        annotate(x: number, y: number, w: number, h: number, option: AnnotationOption): this;
+        note(x: number, y: number, w: number, h: number, content: string, option?: AnnotationOption): this;
+        goTo(x: number, y: number, w: number, h: number, name: string, options?: AnnotationOption): this;
+        link(x: number, y: number, w: number, h: number, url: string, option?: AnnotationOption): this;
+        highlight(x: number, y: number, w: number, h: number, option?: AnnotationOption): this;
+        underline(x: number, y: number, w: number, h: number, option?: AnnotationOption): this;
+        strike(x: number, y: number, w: number, h: number, option?: AnnotationOption): this;
+        lineAnnotation(x1: number, y1: number, x2: number, y2: number, option?: AnnotationOption): this;
+        rectAnnotation(x: number, y: number, w: number, h: number, option?: AnnotationOption): this;
+        ellipseAnnotation(x: number, y: number, w: number, h: number, option?: AnnotationOption): this;
+        textAnnotation(x: number, y: number, w: number, h: number, text: string, option?: AnnotationOption): this;
     }
 
     // The color forms accepted by PDFKit:
@@ -68,22 +68,22 @@ declare namespace PDFKit.Mixins {
     // The winding / filling rule accepted by PDFKit:
     type RuleValue = 'even-odd' | 'evenodd' | 'non-zero' | 'nonzero';
 
-    interface PDFColor<TDocument> {
-        fillColor(color: ColorValue, opacity?: number): TDocument;
-        strokeColor(color: ColorValue, opacity?: number): TDocument;
-        opacity(opacity: number): TDocument;
-        fillOpacity(opacity: number): TDocument;
-        strokeOpacity(opacity: number): TDocument;
+    interface PDFColor {
+        fillColor(color: ColorValue, opacity?: number): this;
+        strokeColor(color: ColorValue, opacity?: number): this;
+        opacity(opacity: number): this;
+        fillOpacity(opacity: number): this;
+        strokeOpacity(opacity: number): this;
         linearGradient(x1: number, y1: number, x2: number, y2: number): PDFLinearGradient;
         radialGradient(x1: number, y1: number, r1: number, x2: number, y2: number, r2: number): PDFRadialGradient;
     }
 
-    interface PDFFont<TDocument> {
-        font(buffer: Buffer): TDocument;
-        font(src: string, family?: string, size?: number): TDocument;
-        fontSize(size: number): TDocument;
+    interface PDFFont {
+        font(buffer: Buffer): this;
+        font(src: string, family?: string, size?: number): this;
+        fontSize(size: number): this;
         currentLineHeight(includeGap?: boolean): number;
-        registerFont(name: string, src?: string, family?: string): TDocument;
+        registerFont(name: string, src?: string, family?: string): this;
     }
 
     interface ImageOption {
@@ -101,12 +101,12 @@ declare namespace PDFKit.Mixins {
         destination?: string;
     }
 
-    interface PDFImage<TDocument> {
+    interface PDFImage {
         /**
          * Draw an image in PDFKit document.
          */
-        image(src: any, x?: number, y?: number, options?: ImageOption): TDocument;
-        image(src: any, options?: ImageOption): TDocument;
+        image(src: any, x?: number, y?: number, options?: ImageOption): this;
+        image(src: any, options?: ImageOption): this;
     }
 
     interface TextOptions {
@@ -153,49 +153,49 @@ declare namespace PDFKit.Mixins {
         baseline?: number | 'svg-middle' | 'middle' | 'svg-central' | 'bottom' | 'ideographic' | 'alphabetic' | 'mathematical' | 'hanging' | 'top';
     }
 
-    interface PDFText<TDocument> {
-        lineGap(lineGap: number): TDocument;
-        moveDown(line?: number): TDocument;
-        moveUp(line?: number): TDocument;
-        text(text: string, x?: number, y?: number, options?: TextOptions): TDocument;
-        text(text: string, options?: TextOptions): TDocument;
+    interface PDFText {
+        lineGap(lineGap: number): this;
+        moveDown(line?: number): this;
+        moveUp(line?: number): this;
+        text(text: string, x?: number, y?: number, options?: TextOptions): this;
+        text(text: string, options?: TextOptions): this;
         widthOfString(text: string, options?: TextOptions): number;
         heightOfString(text: string, options?: TextOptions): number;
-        list(list: Array<string | any>, x?: number, y?: number, options?: TextOptions): TDocument;
-        list(list: Array<string | any>, options?: TextOptions): TDocument;
+        list(list: Array<string | any>, x?: number, y?: number, options?: TextOptions): this;
+        list(list: Array<string | any>, options?: TextOptions): this;
     }
 
-    interface PDFVector<TDocument> {
-        save(): TDocument;
-        restore(): TDocument;
-        closePath(): TDocument;
-        lineWidth(w: number): TDocument;
-        lineCap(c: string): TDocument;
-        lineJoin(j: string): TDocument;
-        miterLimit(m: any): TDocument;
-        dash(length: number, option: any): TDocument;
-        undash(): TDocument;
-        moveTo(x: number, y: number): TDocument;
-        lineTo(x: number, y: number): TDocument;
-        bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): TDocument;
-        quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): TDocument;
-        rect(x: number, y: number, w: number, h: number): TDocument;
-        roundedRect(x: number, y: number, w: number, h: number, r?: number): TDocument;
-        ellipse(x: number, y: number, r1: number, r2?: number): TDocument;
-        circle(x: number, y: number, raduis: number): TDocument;
-        polygon(...points: number[][]): TDocument;
-        path(path: string): TDocument;
-        fill(color?: ColorValue, rule?: RuleValue): TDocument;
-        fill(rule: RuleValue): TDocument;
-        stroke(color?: ColorValue): TDocument;
-        fillAndStroke(fillColor?: ColorValue, strokeColor?: ColorValue, rule?: RuleValue): TDocument;
-        fillAndStroke(fillColor: ColorValue, rule?: RuleValue): TDocument;
-        fillAndStroke(rule: RuleValue): TDocument;
-        clip(rule?: RuleValue): TDocument;
-        transform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): TDocument;
-        translate(x: number, y: number): TDocument;
-        rotate(angle: number, options?: { origin?: number[] }): TDocument;
-        scale(xFactor: number, yFactor?: number, options?: { origin?: number[] }): TDocument;
+    interface PDFVector {
+        save(): this;
+        restore(): this;
+        closePath(): this;
+        lineWidth(w: number): this;
+        lineCap(c: string): this;
+        lineJoin(j: string): this;
+        miterLimit(m: any): this;
+        dash(length: number, option: any): this;
+        undash(): this;
+        moveTo(x: number, y: number): this;
+        lineTo(x: number, y: number): this;
+        bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): this;
+        quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): this;
+        rect(x: number, y: number, w: number, h: number): this;
+        roundedRect(x: number, y: number, w: number, h: number, r?: number): this;
+        ellipse(x: number, y: number, r1: number, r2?: number): this;
+        circle(x: number, y: number, raduis: number): this;
+        polygon(...points: number[][]): this;
+        path(path: string): this;
+        fill(color?: ColorValue, rule?: RuleValue): this;
+        fill(rule: RuleValue): this;
+        stroke(color?: ColorValue): this;
+        fillAndStroke(fillColor?: ColorValue, strokeColor?: ColorValue, rule?: RuleValue): this;
+        fillAndStroke(fillColor: ColorValue, rule?: RuleValue): this;
+        fillAndStroke(rule: RuleValue): this;
+        clip(rule?: RuleValue): this;
+        transform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): this;
+        translate(x: number, y: number): this;
+        rotate(angle: number, options?: { origin?: number[] }): this;
+        scale(xFactor: number, yFactor?: number, options?: { origin?: number[] }): this;
     }
 }
 
@@ -263,12 +263,12 @@ declare namespace PDFKit {
 
     interface PDFDocument
         extends NodeJS.ReadableStream,
-            Mixins.PDFAnnotation<PDFDocument>,
-            Mixins.PDFColor<PDFDocument>,
-            Mixins.PDFImage<PDFDocument>,
-            Mixins.PDFText<PDFDocument>,
-            Mixins.PDFVector<PDFDocument>,
-            Mixins.PDFFont<PDFDocument> {
+            Mixins.PDFAnnotation,
+            Mixins.PDFColor,
+            Mixins.PDFImage,
+            Mixins.PDFText,
+            Mixins.PDFVector,
+            Mixins.PDFFont {
         /**
          * PDF Version
          */
@@ -393,31 +393,31 @@ declare module 'pdfkit/js/reference' {
 }
 
 declare module 'pdfkit/js/mixins/annotations' {
-    var PDFKitAnnotation: PDFKit.Mixins.PDFAnnotation<void>;
+    var PDFKitAnnotation: PDFKit.Mixins.PDFAnnotation;
     export = PDFKitAnnotation;
 }
 
 declare module 'pdfkit/js/mixins/color' {
-    var PDFKitColor: PDFKit.Mixins.PDFColor<void>;
+    var PDFKitColor: PDFKit.Mixins.PDFColor;
     export = PDFKitColor;
 }
 
 declare module 'pdfkit/js/mixins/fonts' {
-    var PDFKitFont: PDFKit.Mixins.PDFFont<void>;
+    var PDFKitFont: PDFKit.Mixins.PDFFont;
     export = PDFKitFont;
 }
 
 declare module 'pdfkit/js/mixins/images' {
-    var PDFKitImage: PDFKit.Mixins.PDFImage<void>;
+    var PDFKitImage: PDFKit.Mixins.PDFImage;
     export = PDFKitImage;
 }
 
 declare module 'pdfkit/js/mixins/text' {
-    var PDFKitText: PDFKit.Mixins.PDFText<void>;
+    var PDFKitText: PDFKit.Mixins.PDFText;
     export = PDFKitText;
 }
 
 declare module 'pdfkit/js/mixins/vector' {
-    var PDFKitVector: PDFKit.Mixins.PDFVector<void>;
+    var PDFKitVector: PDFKit.Mixins.PDFVector;
     export = PDFKitVector;
 }

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -188,3 +188,33 @@ doc.image('path/to/image.png', {
     goTo: {},
     destination: 'lorem',
 });
+
+
+// Subclassing
+class SubPDFDocument extends PDFDocument {
+    constructor(options:PDFKit.PDFDocumentOptions) {
+        super(options);
+    }
+
+    // override
+    text(text: string | number, x?:number | PDFKit.Mixins.TextOptions, y?:number, options?:PDFKit.Mixins.TextOptions):this {
+        if (typeof text === "string") {
+            return super.text(text, options);
+        }
+        else {
+            return super.text(text + "", options);
+        }
+    }
+
+    // new method
+    segment(xa:number, ya:number, xb:number, yb:number):this {
+        this.moveTo(xa, ya);
+        this.lineTo(xb, yb);
+        return this;
+    }
+}
+
+var subDoc = new SubPDFDocument({});
+
+subDoc.moveTo(subDoc.page.width / 2, subDoc.page.height / 2).text(10);
+subDoc.lineWidth(3).segment(10, subDoc.page.width - 10, subDoc.page.height - 10, 10).stroke("#00FFFF");


### PR DESCRIPTION
This make the type definition work correctly on subclasses of `PDFDocument`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

As it was, this type definition shows some shortcomings when subclassing `PDFDocument`.

For example, I implemented a basic style declaration system, here is the relevant part of the code.

```javascript
class MyCustomPDFDocument extends PDFDocument {
    constructor(options) {
        super(options);
    }

    /**
     * My custom type definition, expanding on the original signature
     * @param  {string} text
     * @param  {number | PDFKit.Mixins.TextOptions | string=} x
     * @param  {number=} y
     * @param  {PDFKit.Mixins.TextOptions | string?=} options
     * @return {this}
     */
    text() {
        // some custom code to catch options being a string, and substituing it for a valid TextOptions
        super.text(text, x, y, options);
    }
}
```

I would then use my custom class this way :

```javascript
const doc = new MyCustomPDFDocument({});

doc.moveDown(5).text("FooBar", "styleName");
```

Here without my fix, typescript will infer that `moveDown` returns a `PDFDocument`, when in reality it returns a `MyCustomPDFDocument`, preventing typescript to pickup on my custom type definition for the subsequent call to `text`.