### PR TITLE
[react-share] Update for latest version

### DIFF
--- a/types/react-share/index.d.ts
+++ b/types/react-share/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-share 3.0
 // Project: https://github.com/nygardk/react-share#readme
 // Definitions by: icopp <https://github.com/icopp>
+//                 Maxim Zasorin <https://github.com/maximzasorin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -51,17 +52,7 @@ export const FacebookShareButton: React.StatelessComponent<
         hashtag?: string;
     }
 >;
-export const GooglePlusShareButton: React.StatelessComponent<
-    CommonShareButtonProps
->;
-export const LinkedinShareButton: React.StatelessComponent<
-    CommonShareButtonProps & {
-        /** Title of the shared page */
-        title?: string;
-        /** Description of the shared page */
-        description?: string;
-    }
->;
+export const LinkedinShareButton: React.StatelessComponent<CommonShareButtonProps>;
 export const TwitterShareButton: React.StatelessComponent<
     CommonShareButtonProps & {
         /** Title of the shared page */
@@ -89,6 +80,7 @@ export const WhatsappShareButton: React.StatelessComponent<
 >;
 export const PinterestShareButton: React.StatelessComponent<
     CommonShareButtonProps & {
+        /** An absolute link to the image that will be pinned */
         media: string;
         /** Description of the shared page */
         description?: string;
@@ -110,6 +102,8 @@ export const OKShareButton: React.StatelessComponent<
         title?: string;
         /** Description of the shared page */
         description?: string;
+        /** An absolute link to the image that will be shared */
+        image?: string;
     }
 >;
 export const RedditShareButton: React.StatelessComponent<
@@ -128,9 +122,14 @@ export const TumblrShareButton: React.StatelessComponent<
     }
 >;
 export const LivejournalShareButton: React.StatelessComponent<
-    CommonShareButtonProps & { title?: string; description?: string }
+    CommonShareButtonProps & {
+        /** Title of the shared page */
+        title?: string;
+        /** Description of the shared page */
+        description?: string;
+    }
 >;
-export const MalruShareButton: React.StatelessComponent<
+export const MailruShareButton: React.StatelessComponent<
     CommonShareButtonProps & {
         /** Title of the shared page */
         title?: string;
@@ -140,17 +139,69 @@ export const MalruShareButton: React.StatelessComponent<
         image?: string;
     }
 >;
+export const ViberShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /** Title of the shared page */
+        title?: string;
+        /** Separates title from the url, default: ' ' */
+        separator?: string;
+    }
+>;
+export const WorkplaceShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /** A quote to be shared along with the link. */
+        quote?: string;
+        /**
+         * A hashtag specified by the developer to be added to the shared
+         * content. People will still have the opportunity to remove this
+         * hashtag in the dialog. The hashtag should include the hash symbol.
+         */
+        hashtag?: string;
+    }
+>;
+export const LineShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /** Title of the shared page */
+        title?: string;
+    }
+>;
+export const WeiboShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /** Title of the shared page */
+        title?: string;
+        /** An absolute link to the image that will be shared */
+        image?: string;
+    }
+>;
 export const EmailShareButton: React.StatelessComponent<
     CommonShareButtonProps & {
         /** Title of the shared page */
         subject?: string;
-        /** Body of the email, defaults to shared url. */
+        /** Body of the email, will be prepended to the url. */
         body?: string;
+        /** Separates body from the url, default: ' ' */
+        separator?: string;
+        /** Opens the mail client in a new window. Defaults to false */
+        openWindow?: boolean;
     }
 >;
-
-export const LineShareButton: React.StatelessComponent<
-    CommonShareButtonProps & { title?: string }
+export const PocketShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /**
+         * Title of the shared page. Note that if Pocket detects a title tag
+         * on the page being saved, this parameter will be ignored
+         * and the title tag of the saved page will be used instead.
+         */
+        title?: string;
+    }
+>;
+export const InstapaperShareButton: React.StatelessComponent<
+    CommonShareButtonProps & {
+        /** Title of the shared page */
+        title?: string;
+        /** Description of the shared page */
+        description?: string;
+    }
 >;
 
 // =============================================================================
@@ -167,8 +218,6 @@ export interface ShareCountComponentProps {
 }
 
 export const FacebookShareCount: React.StatelessComponent<ShareCountComponentProps>;
-export const GooglePlusShareCount: React.StatelessComponent<ShareCountComponentProps>;
-export const LinkedinShareCount: React.StatelessComponent<ShareCountComponentProps>;
 export const PinterestShareCount: React.StatelessComponent<ShareCountComponentProps>;
 export const VKShareCount: React.StatelessComponent<ShareCountComponentProps>;
 export const OKShareCount: React.StatelessComponent<ShareCountComponentProps>;
@@ -184,6 +233,8 @@ export interface IconComponentProps {
     size?: number;
     /** Whether to show round or rect icons */
     round?: boolean;
+    /** Allow rounded corners if using rect icons */
+    borderRadius?: number;
     /** Customize background style, e.g. fill */
     iconBgStyle?: React.CSSProperties;
     /**
@@ -197,7 +248,6 @@ export const FacebookIcon: React.StatelessComponent<IconComponentProps>;
 export const TwitterIcon: React.StatelessComponent<IconComponentProps>;
 export const TelegramIcon: React.StatelessComponent<IconComponentProps>;
 export const WhatsappIcon: React.StatelessComponent<IconComponentProps>;
-export const GooglePlusIcon: React.StatelessComponent<IconComponentProps>;
 export const LinkedinIcon: React.StatelessComponent<IconComponentProps>;
 export const PinterestIcon: React.StatelessComponent<IconComponentProps>;
 export const VKIcon: React.StatelessComponent<IconComponentProps>;
@@ -206,5 +256,9 @@ export const RedditIcon: React.StatelessComponent<IconComponentProps>;
 export const TumblrIcon: React.StatelessComponent<IconComponentProps>;
 export const LivejournalIcon: React.StatelessComponent<IconComponentProps>;
 export const MailruIcon: React.StatelessComponent<IconComponentProps>;
-export const EmailIcon: React.StatelessComponent<IconComponentProps>;
+export const ViberIcon: React.StatelessComponent<IconComponentProps>;
+export const WorkplaceIcon: React.StatelessComponent<IconComponentProps>;
 export const LineIcon: React.StatelessComponent<IconComponentProps>;
+export const PocketIcon: React.StatelessComponent<IconComponentProps>;
+export const InstapaperIcon: React.StatelessComponent<IconComponentProps>;
+export const EmailIcon: React.StatelessComponent<IconComponentProps>;

--- a/types/react-share/react-share-tests.ts
+++ b/types/react-share/react-share-tests.ts
@@ -1,18 +1,14 @@
 import {
     FacebookShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
-    GooglePlusShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
-    LinkedinShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
     PinterestShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
     VKShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
     OKShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
     RedditShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
     TumblrShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps> || StatelessComponent<ShareCountComponentProps>
-
     FacebookIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     TwitterIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     TelegramIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     WhatsappIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
-    GooglePlusIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     LinkedinIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     PinterestIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     VKIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
@@ -21,6 +17,10 @@ import {
     TumblrIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     LivejournalIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     MailruIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
-    EmailIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
+    ViberIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
+    WorkplaceIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
     LineIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
+    PocketIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
+    InstapaperIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
+    EmailIcon, // $ExpectType FunctionComponent<IconComponentProps> || StatelessComponent<IconComponentProps>
 } from 'react-share';


### PR DESCRIPTION
# PR

## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nygardk/react-share/releases/tag/v3.0.0
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## Changes

Hi! I've updated the type definitions for the [react-share](https://github.com/nygardk/react-share) library. Most of the changes are related to upgrading to version 3.0.0 of the react-share library, but there are also changes that should have been made earlier, but they have not been made in the type definitions.

Here are the changes that apply to version 3.0.1 of the original library:
* Added `PocketShareButton`
* Added `InstapaperShareButton`
* Added `borderRadius` prop for icons
* Removed support for Google+
* Removed `title` and `description` from `LinkedInShareButton`
* Removed `LinkedInShareCount`

And here are the other changes, which for some reason were not here:
* Added `image` property to `OKShareButton`
* Added `title` and `description` properties to `LivejournalShareButton`
* Added `ViberShareButton`
* Added `WorkplaceShareButton`
* Added `WeiboShareButton`
* Added `separator` and `openWindow` to `EmailShareButton`

I also found a mistake:
* Fixed typo in `MailruShareButton`

## Questions

### Version

I haven't updated the version of the library because I don't fully understand which the version will be here. The latest version of react-share is now 3.0.1 and type definitions is 3.0. I have made significant changes to type definitions, so it is likely that the version will need to be upgraded to 4.0, but then the major version will not be the same as the original library. I would be glad if you could help me in determining the new version.

### Tests for share buttons

This question is not directly related to PR, but I would be interested to know this. How can we add tests for FacebookShareButton, LinkedinShareButton, etc.?  Now there are tests for *ShareCount and *Icon, but no tests for *ShareButton.