### PR TITLE
Unused files webpack plugin fix

### DIFF
--- a/types/unused-files-webpack-plugin/index.d.ts
+++ b/types/unused-files-webpack-plugin/index.d.ts
@@ -7,7 +7,7 @@
 
 import { Plugin } from 'webpack';
 
-interface Options {
+export interface Options {
     patterns?: string[];
     failOnUnused: boolean;
     globOptions?: {
@@ -17,8 +17,6 @@ interface Options {
     cwd?: string;
 }
 
-declare class UnusedFilesWebpackPlugin extends Plugin {
+export class UnusedFilesWebpackPlugin extends Plugin {
     constructor(options: Options);
 }
-
-export = UnusedFilesWebpackPlugin;

--- a/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
+++ b/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
@@ -1,5 +1,5 @@
 import * as webpack from 'webpack';
-import { UnusedFilesWebpackPlugin} from 'unused-files-webpack-plugin';
+import { UnusedFilesWebpackPlugin } from 'unused-files-webpack-plugin';
 
 const ignoredFiles = [''];
 const config: webpack.Configuration = {

--- a/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
+++ b/types/unused-files-webpack-plugin/unused-files-webpack-plugin-tests.ts
@@ -1,5 +1,5 @@
 import * as webpack from 'webpack';
-import UnusedFilesWebpackPlugin = require('unused-files-webpack-plugin');
+import { UnusedFilesWebpackPlugin} from 'unused-files-webpack-plugin';
 
 const ignoredFiles = [''];
 const config: webpack.Configuration = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
