### PR TITLE
Added rollup-plugin-visualizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
         "prettier": "^1.17.1",
         "types-publisher": "github:Microsoft/types-publisher#production"
     },
-    "dependencies": {
-        "rollup": "^1.21.4",
-        "rollup-plugin-visualizer": "^2.6.0"
-    },
+    "dependencies": {},
     "husky": {
         "hooks": {
             "pre-commit": "precise-commits"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
         "prettier": "^1.17.1",
         "types-publisher": "github:Microsoft/types-publisher#production"
     },
-    "dependencies": {},
+    "dependencies": {
+        "rollup": "^1.21.4",
+        "rollup-plugin-visualizer": "^2.6.0"
+    },
     "husky": {
         "hooks": {
             "pre-commit": "precise-commits"

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="node" />
 import { Plugin } from 'rollup';
 
-interface PluginVisualizerOptions {
+export interface PluginVisualizerOptions {
     filename?: string;
     title?: string;
     sourcemap?: boolean;
@@ -17,6 +17,4 @@ interface PluginVisualizerOptions {
     bundlesRelative?: boolean;
 }
 
-declare function visualizer(options?: PluginVisualizerOptions): Plugin;
-
-export = visualizer;
+export default function visualizer(options?: PluginVisualizerOptions): Plugin;

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -1,19 +1,24 @@
 // Type definitions for rollup-plugin-visualizer 2.6
 // Project: https://www.npmjs.com/package/rollup-plugin-visualizer
-// Definitions by: Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions by: Nick <https://github.com/fobdy>,
+//                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
 /// <reference types="node" />
 import { Plugin } from 'rollup';
 
-export interface PluginVisualizerOptions {
-    filename?: string;
-    title?: string;
-    sourcemap?: boolean;
-    open?: boolean;
-    template?: string;
-    bundlesRelative?: boolean;
+declare namespace visualizer {
+    interface PluginVisualizerOptions {
+        filename?: string;
+        title?: string;
+        sourcemap?: boolean;
+        open?: boolean;
+        template?: string;
+        bundlesRelative?: boolean;
+    }
 }
 
-export default function visualizer(options?: PluginVisualizerOptions): Plugin;
+declare function visualizer(options?: visualizer.PluginVisualizerOptions): Plugin;
+
+export = visualizer;

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for rollup-plugin-visualizer 2.6
 // Project: https://www.npmjs.com/package/rollup-plugin-visualizer
-// Definitions by: Nikolai Tsapkin <https://github.com/>
-//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions by: Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: Nikolai Tsapkin <https://github.com/>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
-// import { Plugin } from 'rollup';
+import { Plugin } from 'rollup';
 
 export interface PluginVisualizerOptions {
     filename?: string;
@@ -17,4 +17,4 @@ export interface PluginVisualizerOptions {
     bundlesRelative?: boolean;
 }
 
-export default function visualizer(options?: PluginVisualizerOptions): any;
+export default function visualizer(options?: PluginVisualizerOptions): Plugin;

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -6,7 +6,7 @@
 // TypeScript Version: 2.3
 
 /// <reference types="node" />
-import { Plugin } from 'rollup';
+// import { Plugin } from 'rollup';
 
 export interface PluginVisualizerOptions {
     filename?: string;
@@ -17,4 +17,4 @@ export interface PluginVisualizerOptions {
     bundlesRelative?: boolean;
 }
 
-export default function visualizer(options?: PluginVisualizerOptions): Plugin;
+export default function visualizer(options?: PluginVisualizerOptions): any;

--- a/types/rollup-plugin-visualizer/index.d.ts
+++ b/types/rollup-plugin-visualizer/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for rollup-plugin-visualizer 2.6
+// Project: https://www.npmjs.com/package/rollup-plugin-visualizer
+// Definitions by: Nikolai Tsapkin <https://github.com/>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+import { Plugin } from 'rollup';
+
+interface PluginVisualizerOptions {
+    filename?: string;
+    title?: string;
+    sourcemap?: boolean;
+    open?: boolean;
+    template?: string;
+    bundlesRelative?: boolean;
+}
+
+declare function visualizer(options?: PluginVisualizerOptions): Plugin;
+
+export = visualizer;

--- a/types/rollup-plugin-visualizer/package.json
+++ b/types/rollup-plugin-visualizer/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4"
+    }
+}

--- a/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
+++ b/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
@@ -7,7 +7,7 @@ const fullOptions = {
     sourcemap: true,
     open: true,
     template: '',
-    bundlesRelative: true
+    bundlesRelative: true,
 };
 visualizer({});
 visualizer(fullOptions);

--- a/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
+++ b/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
@@ -1,0 +1,13 @@
+import visualizer from 'rollup-plugin-visualizer';
+
+visualizer(); // $ExpectType Plugin
+const fullOptions = {
+    filename: 'filename',
+    title: 'title',
+    sourcemap: true,
+    open: true,
+    template: '',
+    bundlesRelative: true
+};
+visualizer({});
+visualizer(fullOptions);

--- a/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
+++ b/types/rollup-plugin-visualizer/rollup-plugin-visualizer-tests.ts
@@ -1,7 +1,7 @@
-import visualizer from 'rollup-plugin-visualizer';
+import visualizer, { PluginVisualizerOptions } from 'rollup-plugin-visualizer';
 
 visualizer(); // $ExpectType Plugin
-const fullOptions = {
+const fullOptions: PluginVisualizerOptions = {
     filename: 'filename',
     title: 'title',
     sourcemap: true,

--- a/types/rollup-plugin-visualizer/tsconfig.json
+++ b/types/rollup-plugin-visualizer/tsconfig.json
@@ -9,6 +9,7 @@
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
+        "esModuleInterop": true,
         "typeRoots": [
             "../"
         ],

--- a/types/rollup-plugin-visualizer/tsconfig.json
+++ b/types/rollup-plugin-visualizer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-visualizer-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-visualizer/tslint.json
+++ b/types/rollup-plugin-visualizer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
