### PR TITLE
[requestidlecallback] export "request" instead

### DIFF
--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for requestidlecallback 0.1
+// Type definitions for requestidlecallback 0.3
 // Project: https://w3c.github.io/requestidlecallback/, https://github.com/afarkas/requestidlecallback
-// Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>, Teramoto Daiki <https://github.com/teramotodaiki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function requestIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
-export function cancelIdleCallback(handle: IdleCallbackHandle): void;
+export function request(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
+export function cancel(handle: IdleCallbackHandle): void;
 
 export type DOMHighResTimeStamp = number;
 export type IdleCallbackHandle = number;

--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for requestidlecallback 0.3
 // Project: https://w3c.github.io/requestidlecallback/, https://github.com/afarkas/requestidlecallback
-// Definitions by: 贺师俊 <https://github.com/hax>, Vladimir Grenaderov <https://github.com/VladimirGrenaderov>, Max Boguslavskiy <https://github.com/maxbogus>, Teramoto Daiki <https://github.com/teramotodaiki>
+// Definitions by: 贺师俊 <https://github.com/hax>
+//                 Vladimir Grenaderov <https://github.com/VladimirGrenaderov>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+//                 Teramoto Daiki <https://github.com/teramotodaiki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function request(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;

--- a/types/requestidlecallback/index.d.ts
+++ b/types/requestidlecallback/index.d.ts
@@ -12,15 +12,15 @@ export type IdleCallbackHandle = number;
 export type IdleRequestCallback = (deadline: IdleDeadline) => void;
 
 export interface IdleDeadline {
-	timeRemaining(): DOMHighResTimeStamp;
-	readonly didTimeout: boolean;
+    timeRemaining(): DOMHighResTimeStamp;
+    readonly didTimeout: boolean;
 }
 
 export interface IdleRequestOptions {
-	timeout: number;
+    timeout: number;
 }
 
 export interface Window {
-  requestIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
-  cancelIdleCallback(handle: number): void;
+    requestIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): IdleCallbackHandle;
+    cancelIdleCallback(handle: number): void;
 }

--- a/types/requestidlecallback/requestidlecallback-tests.ts
+++ b/types/requestidlecallback/requestidlecallback-tests.ts
@@ -1,8 +1,8 @@
 import {
-  requestIdleCallback,
-  cancelIdleCallback,
-  IdleRequestOptions,
-  IdleCallbackHandle,
+    request as requestIdleCallback,
+    cancel as cancelIdleCallback,
+    IdleRequestOptions,
+    IdleCallbackHandle,
 } from 'requestidlecallback';
 
 // Test requestIdleCallback with default param


### PR DESCRIPTION
aFarkas's requestIdleCallback polyfill does not export as "requestIdleCallback". It's "request" and "cancel".

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/aFarkas/requestIdleCallback/blob/18e7d0036d970204e32451e6c4190003161176c0/index.js#L209-L212
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
