### PR TITLE
[workbox] Fixed onSync argument type

### DIFF
--- a/types/workbox-sw/index.d.ts
+++ b/types/workbox-sw/index.d.ts
@@ -822,7 +822,7 @@ interface QueueOptions {
 	 * Note: if the replay fails after a sync event, make sure you throw an
 	 * error, so the browser knows to retry the sync event later.
 	 */
-	onSync: (queue: Queue) => void;
+	onSync: (queue: { queue: Queue }) => void;
 
 	/**
 	 * The amount of time (in minutes) a request may be retried. After this amount of time has

--- a/types/workbox-sw/workbox-sw-tests.ts
+++ b/types/workbox-sw/workbox-sw-tests.ts
@@ -9,8 +9,8 @@ WorkboxSW.precaching.precacheAndRoute(/foo/);
 
 WorkboxSW.precaching.precacheAndRoute(["some-resource.js"], {directoryIndex: "/"}); // $ExpectType void
 
-new WorkboxSW.backgroundSync.Queue("queue-name", { // $ExpectType Queue
-  onSync: ({ queue }) => {
-    queue; // $ExpectType Queue
-  }
+new WorkboxSW.backgroundSync.Queue('queue-name', {
+    onSync: ({ queue }) => {
+        queue; // $ExpectType Queue
+    },
 });

--- a/types/workbox-sw/workbox-sw-tests.ts
+++ b/types/workbox-sw/workbox-sw-tests.ts
@@ -8,3 +8,9 @@ WorkboxSW.routing.registerRoute("/", WorkboxSW.strategies.networkFirst()); // $E
 WorkboxSW.precaching.precacheAndRoute(/foo/);
 
 WorkboxSW.precaching.precacheAndRoute(["some-resource.js"], {directoryIndex: "/"}); // $ExpectType void
+
+new WorkboxSW.backgroundSync.Queue("queue-name", { // $ExpectType Queue
+  onSync: ({ queue }) => {
+    queue; // $ExpectType Queue
+  }
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/workbox/blob/master/packages/workbox-background-sync/src/Queue.ts#L356
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
