### PR TITLE
[openpgp] Fix return type of write()

### DIFF
--- a/types/openpgp/index.d.ts
+++ b/types/openpgp/index.d.ts
@@ -6,6 +6,7 @@
 //                 Carlos Villavicencio <https://github.com/po5i>
 //                 Eric Camellini <https://github.com/ecamellini>
 //                 SardineFish <https://github.com/SardineFish>
+//                 Ryo Ota <https://github.com/nwtgck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 import BN = require("bn.js");
@@ -2898,7 +2899,7 @@ export namespace packet {
          * class instance.
          * @returns A Uint8Array containing valid openpgp packets.
          */
-        write(): Uint8Array;
+        write(): Uint8Array | ReadableStream<Uint8Array>;
 
         /**
          * Adds a packet to the list. This is the only supported method of doing so;

--- a/types/openpgp/ts3.2/index.d.ts
+++ b/types/openpgp/ts3.2/index.d.ts
@@ -6,6 +6,7 @@
 //                 Carlos Villavicencio <https://github.com/po5i>
 //                 Eric Camellini <https://github.com/ecamellini>
 //                 SardineFish <https://github.com/SardineFish>
+//                 Ryo Ota <https://github.com/nwtgck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import BN = require("bn.js")
@@ -2967,7 +2968,7 @@ export namespace packet {
          * class instance.
          * @returns A Uint8Array containing valid openpgp packets.
          */
-        write(): Uint8Array;
+        write(): Uint8Array | ReadableStream<Uint8Array>;
 
         /**
          * Adds a packet to the list. This is the only supported method of doing so;


### PR DESCRIPTION
Hi developers! I'm very new to update `@types/openpgp`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  - In [Official README](https://github.com/openpgpjs/openpgpjs/tree/1e37b27673dce595e9c88530aad80faded86055f#streaming-encrypt-uint8array-data-with-a-password),  you can find `const encrypted = ciphertext.message.packets.write(); // get raw encrypted packets as ReadableStream<Uint8Array>`.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I changed only [types/openpgp/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/openpgp/index.d.ts). Should I update [types/openpgp/ts3.2/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/openpgp/ts3.2/index.d.ts) too and the openpgp version number in the header?