### PR TITLE
[react-material-ui-form-validator] Fix #38102, fix type of event argument in onSubmit

### DIFF
--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -10,7 +10,7 @@ import { TextFieldProps } from "material-ui";
 
 export interface ValidatorFormProps {
     className?: string;
-    onSubmit: (event: React.FormEventHandler) => void;
+    onSubmit: (event: React.FormEvent) => void;
     instantValidate?: boolean;
     onError?: (errors: any[]) => void;
     debounceTime?: number;

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -6,7 +6,9 @@ import {
 } from 'react-material-ui-form-validator';
 
 class Test extends React.Component {
-    onSubmitted = (event: React.FormEventHandler) => {};
+    onSubmitted = (event: React.FormEvent) => {
+        alert(event.target);
+    }
     onError = (errors: any[]) => {};
     onValidate = (isValid: boolean) => {};
 

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -7,7 +7,7 @@ import {
 
 class Test extends React.Component {
     onSubmitted = (event: React.FormEvent) => {
-        alert(event.target);
+        event.preventDefault(); // Actually preventDefault() is called by ValidatorForm
     }
     onError = (errors: any[]) => {};
     onValidate = (isValid: boolean) => {};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/NewOldMax/react-form-validator-core/blob/0.6.4/src/ValidatorForm.jsx#L64
  - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38102
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
