### PR TITLE
Extend Quill Key.key type

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -22,7 +22,7 @@ export type DeltaOperation = { insert?: any, delete?: number, retain?: number } 
 export type Sources = "api" | "user" | "silent";
 
 export interface Key {
-    key: string;
+    key: string | number;
     shortKey?: boolean;
 }
 


### PR DESCRIPTION
It's common to use numeric keycode, especially when we need to access any element of `keyboard.bindings` directly.
Casting to string like:
```
enum KEYS = {
    UP: 38,
    DOWN: 40,
};

keyboard.addBinding({
  key: KEYS.UP.toString(),
  // ...
});
```
does *not* work, so `number` should be allowed as well.