### PR TITLE
Add types for @testing-library/react-hooks

### DIFF
--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for @testing-library/react-hooks 2.0
+// Project: https://github.com/testing-library/react-hooks-testing-library
+// Definitions by: Michael Peyper <https://github.com/mpeyper>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { ComponentType } from 'react';
+export { act } from 'react-test-renderer';
+
+export interface RenderHookOptions<P> {
+    initialProps?: P;
+    wrapper?: React.ComponentType;
+}
+
+export interface HookResult<R> {
+    readonly current: R;
+    readonly error: Error;
+}
+
+export interface RenderHookResult<P, R> {
+    readonly result: HookResult<R>;
+    readonly waitForNextUpdate: () => Promise<void>;
+    readonly unmount: () => boolean;
+    readonly rerender: (newProps?: P) => void;
+}
+
+export function renderHook<P, R>(callback: (props: P) => R, options?: RenderHookOptions<P>): RenderHookResult<P, R>;

--- a/types/testing-library__react-hooks/testing-library__react-hooks-tests.ts
+++ b/types/testing-library__react-hooks/testing-library__react-hooks-tests.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+const useHook = (initialValue: number) => {
+    const [value, setValue] = useState(initialValue);
+    return { value, setValue };
+};
+
+function checkTypesWithNoInitialProps() {
+    const { result, unmount, rerender } = renderHook(() => useHook(0));
+
+    // check types
+    const _result: {
+        current: {
+            value: number;
+            setValue: (_: number) => void;
+        };
+    } = result;
+    const _unmount: () => boolean = unmount;
+    const _rerender: () => void = rerender;
+}
+
+function checkTypesWithInitialProps() {
+    const { result, unmount, rerender } = renderHook(({ value }) => useHook(value), {
+        initialProps: { value: 10 },
+    });
+
+    // check types
+    const _result: {
+        current: {
+            value: number;
+            setValue: (_: number) => void;
+        };
+    } = result;
+    const _unmount: () => boolean = unmount;
+    const _rerender: (_?: { value: number }) => void = rerender;
+}
+
+function checkTypesWhenHookReturnsUndefined() {
+    renderHook(() => {});
+}
+
+function checkTypesWithError() {
+    const { result } = renderHook(() => useHook(0));
+
+    // check types
+    const _result: {
+        error: Error;
+    } = result;
+}
+
+async function checkTypesForWaitForNextUpdate() {
+    const { waitForNextUpdate } = renderHook(() => {});
+
+    await waitForNextUpdate();
+
+    // check type
+    const _waitForNextUpdate: () => Promise<void> = waitForNextUpdate;
+}
+
+function checkTypesWithUndefinedResult() {
+    act(() => undefined);
+}
+
+function checkTypesWithVoidResult() {
+    act(() => {});
+}
+
+function checkTypesWithPromiseResult() {
+    act(() => Promise.resolve());
+}

--- a/types/testing-library__react-hooks/tsconfig.json
+++ b/types/testing-library__react-hooks/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "target": "es6",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@testing-library/react-hooks": ["testing-library__react-hooks"]
+        }
+    },
+    "files": ["index.d.ts", "testing-library__react-hooks-tests.ts"]
+}

--- a/types/testing-library__react-hooks/tslint.json
+++ b/types/testing-library__react-hooks/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
