### PR TITLE
Added type for rollup-plugin-peer-deps-external package

### DIFF
--- a/types/rollup-plugin-peer-deps-external/index.d.ts
+++ b/types/rollup-plugin-peer-deps-external/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for rollup-plugin-peer-deps-external 2.2
+// Project: https://github.com/Updater/rollup-plugin-peer-deps-external
+// Definitions by: Nick <https://github.com/fobdy>,
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="node" />
+
+import { Plugin } from 'rollup';
+
+declare namespace PeerDepsExternalPlugin {
+    interface PluginPeerDepsExternalOptions {
+        packageJsonPath?: string;
+        includeDependencies?: boolean;
+    }
+}
+
+declare function PeerDepsExternalPlugin(
+    options?: PeerDepsExternalPlugin.PluginPeerDepsExternalOptions
+): Plugin;
+
+export = PeerDepsExternalPlugin;

--- a/types/rollup-plugin-peer-deps-external/package.json
+++ b/types/rollup-plugin-peer-deps-external/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "rollup": "^0.63.4",
-        "rollup-plugin-peer-deps-external": "^2.2.0"
+        "rollup": "^0.63.4"
     }
 }

--- a/types/rollup-plugin-peer-deps-external/package.json
+++ b/types/rollup-plugin-peer-deps-external/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^0.63.4",
+        "rollup-plugin-peer-deps-external": "^2.2.0"
+    }
+}

--- a/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
+++ b/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
@@ -2,4 +2,4 @@ import external from 'rollup-plugin-peer-deps-external';
 
 external();
 external({});
-external({ includeDependencies: true, packageJsonPath: '' });
+external({includeDependencies: true, packageJsonPath: ''});

--- a/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
+++ b/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
@@ -1,0 +1,7 @@
+import external from 'rollup-plugin-peer-deps-external';
+
+const module = external();
+
+module();
+module({});
+external({includeDependencies: true, packageJsonPath: ''});

--- a/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
+++ b/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
@@ -2,4 +2,4 @@ import external from 'rollup-plugin-peer-deps-external';
 
 external();
 external({});
-external({includeDependencies: true, packageJsonPath: ''});
+external({ includeDependencies: true, packageJsonPath: '' });

--- a/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
+++ b/types/rollup-plugin-peer-deps-external/rollup-plugin-peer-deps-external-tests.ts
@@ -1,7 +1,5 @@
 import external from 'rollup-plugin-peer-deps-external';
 
-const module = external();
-
-module();
-module({});
-external({includeDependencies: true, packageJsonPath: ''});
+external();
+external({});
+external({ includeDependencies: true, packageJsonPath: '' });

--- a/types/rollup-plugin-peer-deps-external/tsconfig.json
+++ b/types/rollup-plugin-peer-deps-external/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-peer-deps-external-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-peer-deps-external/tslint.json
+++ b/types/rollup-plugin-peer-deps-external/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
