### PR TITLE
[pino-http, express-pino-logger] Add `id` to http.IncomingMessage

### DIFF
--- a/types/express-pino-logger/express-pino-logger-tests.ts
+++ b/types/express-pino-logger/express-pino-logger-tests.ts
@@ -31,11 +31,24 @@ server.use(middleware);
 // existing logger
 
 const logger = pino();
-const optionsWithLogger = { logger };
+const optionsWithLogger: expressPinoLogger.Options = { logger };
 middleware = expressPinoLogger(optionsWithLogger);
 server.use(middleware);
 
 server.use((req, res, next) => {
     req.log.info('');
+    next();
+});
+
+// additional options
+const optionsWithGenReqId: expressPinoLogger.Options = {
+    logger,
+    genReqId: (req) => 'foo',
+};
+middleware = expressPinoLogger(optionsWithGenReqId);
+server.use(middleware);
+
+server.use((req, res, next) => {
+    req.log.info('%s', req.id);
     next();
 });

--- a/types/express-pino-logger/index.d.ts
+++ b/types/express-pino-logger/index.d.ts
@@ -1,22 +1,10 @@
 // Type definitions for express-pino-logger 4.0
 // Project: https://github.com/pinojs/express-pino-logger#readme
 // Definitions by: Oleg Repin <https://github.com/iamolegga>
+//                 Griffin Yourick <https://github.com/tough-griff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
-import { Handler } from 'express';
-import { DestinationStream, LoggerOptions, Logger } from 'pino';
+import PinoHttp = require("pino-http");
 
-declare function expressPinoLogger(optionsOrStream?: LoggerOptions | DestinationStream | { logger: Logger }): Handler;
-
-declare function expressPinoLogger(options: LoggerOptions, stream: DestinationStream): Handler;
-
-export = expressPinoLogger;
-
-declare global {
-    namespace Express {
-        interface Request {
-            log: Logger;
-        }
-    }
-}
+export = PinoHttp;

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
+//                 Griffin Yourick <https://github.com/tough-griff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -15,6 +16,7 @@ declare function PinoHttp(stream?: DestinationStream): PinoHttp.HttpLogger;
 
 declare namespace PinoHttp {
     type HttpLogger = (req: IncomingMessage, res: ServerResponse) => void;
+    type ReqId = number | string | object;
 
     /**
      * Options for pino-http
@@ -31,12 +33,13 @@ declare namespace PinoHttp {
     }
 
     interface GenReqId {
-        (req: IncomingMessage): number | string | object;
+        (req: IncomingMessage): ReqId;
     }
 }
 
 declare module 'http' {
     interface IncomingMessage {
+        id: PinoHttp.ReqId;
         log: Logger;
     }
     interface ServerResponse {

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -8,7 +8,7 @@ const httpLogger = pinoHttp();
 
 function handle(req: http.IncomingMessage, res: http.ServerResponse) {
   httpLogger(req, res);
-  req.log.info('something else');
+  req.log.info('something else: %s', req.id);
   const err: Error | undefined = res.err;
 }
 


### PR DESCRIPTION
[`pino-http`](https://github.com/pinojs/pino-http/blob/master/logger.js#L64), and thus by extension `express-pino-logger`, attaches an `id` property to each request object. 

Since [`express-pino-logger`](https://github.com/pinojs/express-pino-logger/blob/master/logger.js#L2) simply exports the `pino-http` logger, I also updated the `express-pino-logger` type definitions to simply export the `pino-http` types, since there's no sense in maintaining the same defs in two places.

Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/pinojs/express-pino-logger/blob/master/logger.js#L2 
  - https://github.com/pinojs/pino-http/blob/master/logger.js#L64
