### PR TITLE
Fix incorrect import/export clashes.

### DIFF
--- a/types/actions-on-google/assistant-app.d.ts
+++ b/types/actions-on-google/assistant-app.d.ts
@@ -3,7 +3,7 @@ import * as express from 'express';
 import { BasicCard, BrowseCarousel, BrowseItem, Carousel, ImageDisplays, List, MediaObject,
          MediaResponse, MediaValues, OptionItem, RichResponse, SimpleResponse } from './response-builder';
 import { ActionPaymentTransactionConfig, Cart, GooglePaymentTransactionConfig, LineItem,
-         Location, Order, OrderUpdate, TransactionDecision, TransactionValues } from './transactions';
+         Order, OrderUpdate, TransactionDecision, TransactionValues } from './transactions';
 
 //
 // Note: These enums are exported due to limitations with Typescript and this

--- a/types/azure-sb/lib/models/acstokenresult.d.ts
+++ b/types/azure-sb/lib/models/acstokenresult.d.ts
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
+import { Azure as Az } from 'azure-sb';
+import Dictionary = Az.ServiceBus.Dictionary;
 
 export namespace Azure.ServiceBus.Results {
     export interface AcsTokenResponse extends Dictionary<string | Dictionary<string>> {

--- a/types/azure-sb/lib/models/notificationhubresult.d.ts
+++ b/types/azure-sb/lib/models/notificationhubresult.d.ts
@@ -14,12 +14,11 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
+import { Azure as Az } from 'azure-sb';
 
 export namespace Azure.ServiceBus.Results {
     export interface NotificationHubResult {
-        serialize(resource: Azure.ServiceBus.CreateNotificationHubOptions): string;
+        serialize(resource: Az.ServiceBus.CreateNotificationHubOptions): string;
 
         parse(xml: object): object | object[];
     }

--- a/types/azure-sb/lib/models/queuemessageresult.d.ts
+++ b/types/azure-sb/lib/models/queuemessageresult.d.ts
@@ -15,8 +15,8 @@
 //
 
 // Module dependencies.
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
+import { Azure as Az } from 'azure-sb';
+import Dictionary = Az.ServiceBus.Dictionary;
 
 export namespace Azure.ServiceBus.Results {
     export interface QueueResponse {
@@ -26,7 +26,7 @@ export namespace Azure.ServiceBus.Results {
 
     export interface QueueMessageResponse {
         body: any;
-        brokerProperties?: Azure.ServiceBus.BrokerProperties;
+        brokerProperties?: Az.ServiceBus.BrokerProperties;
         customProperties?: Dictionary<any>;
         contentType?: string;
         location?: string;

--- a/types/azure-sb/lib/models/queueresult.d.ts
+++ b/types/azure-sb/lib/models/queueresult.d.ts
@@ -14,9 +14,6 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
-
 export namespace Azure.ServiceBus.Results {
     export interface QueueProperties {
         DeadLetteringOnMessageExpiration: string;

--- a/types/azure-sb/lib/models/registrationresult.d.ts
+++ b/types/azure-sb/lib/models/registrationresult.d.ts
@@ -14,9 +14,6 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
-
 export namespace Azure.ServiceBus.Results {
     export interface RegistrationResult {
         serialize(type: string, resource: object, properties: string[]): string;

--- a/types/azure-sb/lib/models/resourceresult.d.ts
+++ b/types/azure-sb/lib/models/resourceresult.d.ts
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-import Dictionary = Azure.ServiceBus.Dictionary;
+import { Azure as Az } from 'azure-sb';
+import Dictionary = Az.ServiceBus.Dictionary;
 
 export namespace Azure.ServiceBus.Results {
     export interface ResourceResult {

--- a/types/azure-sb/lib/models/ruleresult.d.ts
+++ b/types/azure-sb/lib/models/ruleresult.d.ts
@@ -15,11 +15,11 @@
 //
 
 // Module dependencies.
-import { Azure } from 'azure-sb';
+import { Azure as Az } from 'azure-sb';
 
 export namespace Azure.ServiceBus.Results {
     export interface RuleResult {
-        serialize(rule: Azure.ServiceBus.CreateRuleOptions): string;
+        serialize(rule: Az.ServiceBus.CreateRuleOptions): string;
 
         parse(xml: object): object | object[];
     }

--- a/types/azure-sb/lib/models/subscriptionresult.d.ts
+++ b/types/azure-sb/lib/models/subscriptionresult.d.ts
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-import { Azure } from 'azure-sb';
-
 export namespace Azure.ServiceBus.Results {
     export interface SubscriptionProperties {
         LockDuration: string;

--- a/types/lingui__react/withI18n.d.ts
+++ b/types/lingui__react/withI18n.d.ts
@@ -1,6 +1,5 @@
 import { ComponentClass, StatelessComponent } from 'react';
 import { I18n } from '@lingui/core';
-import { withI18nProps } from './withI18n';
 
 export type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
 

--- a/types/microrouter/index.d.ts
+++ b/types/microrouter/index.d.ts
@@ -6,9 +6,9 @@
 
 /// <reference types="node"/>
 
-import { IncomingMessage, ServerResponse, Server } from 'http';
+import { IncomingMessage, ServerResponse as HttpServerResponse, Server } from 'http';
 import { RequestHandler } from 'micro';
-export type ServerResponse = ServerResponse;
+export type ServerResponse = HttpServerResponse;
 export type ServerRequest = IncomingMessage & {
     params: { [key: string]: string },
     query: { [key: string]: string }

--- a/types/passport-linkedin-oauth2/index.d.ts
+++ b/types/passport-linkedin-oauth2/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Profile as passportProfile, AuthenticateOptions, Strategy as passportStrategy } from 'passport';
+import { Profile as passportProfile, AuthenticateOptions as PassportAuthenticateOptions, Strategy as passportStrategy } from 'passport';
 import { Request } from 'express';
 
 export interface Profile extends passportProfile {
@@ -20,7 +20,7 @@ export interface Profile extends passportProfile {
     _json: any;
 }
 
-export interface AuthenticateOptions extends AuthenticateOptions {
+export interface AuthenticateOptions extends PassportAuthenticateOptions {
     authType?: string;
 }
 

--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "ts-toolbelt": "^4.5.0"
+        "ts-toolbelt": "^4.7.7"
     }
 }

--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -6,7 +6,7 @@ import {
   TouchableHighlightProps,
   TouchableNativeFeedbackProps,
   TabBarIOSItemProps,
-  ToolbarAndroidProps
+  ToolbarAndroidProps as ReactNativeToolbarAndroidProps
 } from 'react-native';
 
 export interface IconProps extends TextProps {
@@ -74,7 +74,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
 
 export type ImageSource = any;
 
-export interface ToolbarAndroidProps extends ToolbarAndroidProps {
+export interface ToolbarAndroidProps extends ReactNativeToolbarAndroidProps {
   /**
    * Name of the navigation logo icon
    * (similar to ToolbarAndroid logo)

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -6,7 +6,6 @@
 
 import * as React from 'react';
 import { Observable } from 'rxjs/Observable';
-import { Action } from 'redux';
 import { Epic } from 'redux-observable';
 
 export interface Action {

--- a/types/react-router-navigation-core/index.d.ts
+++ b/types/react-router-navigation-core/index.d.ts
@@ -9,7 +9,7 @@
 import { PureComponent, ReactNode, ComponentClass, ReactElement } from "react";
 import { BackHandler, StyleProp, ViewStyle } from "react-native";
 import { History, Location } from "history";
-import { RouterProps, RouteProps, match } from "react-router";
+import { RouterProps, match } from "react-router";
 
 export type Route<T = {}> = {
     key: string;

--- a/types/redux-form/lib/Form.d.ts
+++ b/types/redux-form/lib/Form.d.ts
@@ -1,5 +1,5 @@
 import { Component, FormHTMLAttributes, FormEvent, FormEventHandler } from "react";
-import { FormProps, FormErrors, FormSubmitHandler, Omit } from "../index";
+import { FormErrors, FormSubmitHandler, Omit } from "../index";
 
 interface FormSubmitProp<FormData = {}, P = {}, ErrorType = string> {
     onSubmit?: FormSubmitHandler<FormData, P, ErrorType>;

--- a/types/redux-form/v7/lib/Form.d.ts
+++ b/types/redux-form/v7/lib/Form.d.ts
@@ -1,5 +1,5 @@
 import { Component, FormHTMLAttributes, FormEvent, FormEventHandler } from "react";
-import { FormProps, FormErrors, FormSubmitHandler, Omit } from "../index";
+import { FormErrors, FormSubmitHandler, Omit } from "../index";
 
 interface FormSubmitProp<FormData = {}, P = {}, ErrorType = string> {
     onSubmit?: FormSubmitHandler<FormData, P, ErrorType>;

--- a/types/redux-orm/db/Table.d.ts
+++ b/types/redux-orm/db/Table.d.ts
@@ -1,5 +1,5 @@
 import Model, { AnyModel, FieldSpecKeys, IdType, Ref } from '../Model';
-import { ForeignKey, OneToOne, TableOpts } from '../index';
+import { ForeignKey, OneToOne } from '../index';
 import { Field } from '../fields';
 
 /**

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -8,7 +8,7 @@ import {
     NormalizationScalarField,
     NormalizationLinkedField,
 } from '../util/NormalizationNode';
-import { Environment, RecordState, GraphQLResponse, StoreUpdater, SelectorStoreUpdater } from '../..';
+import { RecordState, GraphQLResponse } from '../..';
 import {
     ConnectionReference,
     ConnectionResolver,


### PR DESCRIPTION
A new error in Typescript 3.7 forbids name clashes like this:

```ts
import { X } from 'y'
export interface X { }
```

Previously they were incorrectly allowed. Typescript 3.7 will have a
beta version in the next day or two. In the meantime you can try
typescript@next -- the nightly build -- to see these errors.

There were generally two fixes

1. Remove the import -- it was unused.
2. Rename the import -- it conflicts but is still used.

I also updated one dependency: ts-toolbelt, which recently shipped a fix for this error.
There are 3 dependencies that are still broken: react-dnd, protractor and three. I'll look at those next and send a PR to those projects if necessary.