### PR TITLE
[@types/websocket] fix header argument for w3cwebsocket constructor

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -694,7 +694,7 @@ declare class w3cwebsocket {
     onclose: () => void;
     onmessage: (message: any) => void;
 
-    constructor(url: string, protocols?: string | string[], origin?: string, headers?: any[], requestOptions?: object, clientConfig?: IClientConfig);
+    constructor(url: string, protocols?: string | string[], origin?: string, headers?: http.OutgoingHttpHeaders, requestOptions?: object, clientConfig?: IClientConfig);
 
     send(data: Buffer): void;
     send(data: IStringified): void;

--- a/types/websocket/websocket-tests.ts
+++ b/types/websocket/websocket-tests.ts
@@ -160,7 +160,7 @@ function serverTest2() {
 
 function clientTest2() {
     var ipArray = getLocalIpArray();
-    
+
     var client = new websocket.client();
     client.on("connect", (conn) => {
         console.log(`on connect`);
@@ -177,7 +177,24 @@ function clientTest2() {
     client.connect(`ws://${ipArray[0]}:8888`, undefined, undefined, undefined, {
         localAddress: ipArray[0]
     });
-    
+
+}
+
+function clientTest3() {
+    let ipArray = getLocalIpArray();
+
+    let client = new websocket.w3cwebsocket(`${ipArray[0]}:8888`, null, null, {'foo': 'bar', 'set-cookie': ['foo=bar', 'bar=baz']});
+    client.onopen = () => {
+        console.log('opened');
+    }
+
+    client.onmessage = (msg) => {
+        console.log(msg);
+    }
+
+    client.onclose = () => {
+        console.log('closed');
+    }
 }
 
 function testClientAbortApi() {
@@ -193,5 +210,6 @@ function testClientAbortApi() {
     console.log(`websocket test start.`);
     serverTest2();
     clientTest2();
+    clientTest3();
     testClientAbortApi();
 }


### PR DESCRIPTION
This fixes the `header` arg of the `w3cwebsocket` constructor for the `@types/websocket` library. 

Internally, it takes the header arg, passes it to a constructed `WebSocketClient` [here](https://github.com/theturtle32/WebSocket-Node/blob/master/lib/W3CWebSocket.js#L62), which then combines it with another object [here](https://github.com/theturtle32/WebSocket-Node/blob/master/lib/WebSocketClient.js#L187-L190) before it all gets passed down to the `[http | https].request` method [here](https://github.com/theturtle32/WebSocket-Node/blob/master/lib/WebSocketClient.js#L254), which in turn expects the headers to be of type `http.OutgoingHttpHeaders`.

Fixes #30534

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/theturtle32/WebSocket-Node/blob/master/lib/WebSocketClient.js#L254
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (I am unsure of what else might be out of date with this definition so I did not add/change version in the header).
