### PR TITLE
Update react-dnd-multi-backend to version 4.0

### DIFF
--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -54,6 +54,10 @@ export interface BackendDeclaration {
      */
     backend: BackendFactory;
     /**
+     * Parameters to the backend
+     */
+    options?: object;
+    /**
      * Flag to indicate that this backend needs to have a custom preview generated. This is mainly
      * used for backends such as the react-dnd-touch-backend, where there is no default preview
      * available.

--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-dnd-multi-backend 3.0
+// Type definitions for react-dnd-multi-backend 4.0
 // Project: https://github.com/LouisBrunner/react-dnd-multi-backend, https://louisbrunner.github.io/dnd-multi-backend/packages/react-dnd-multi-backend
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 Adam Haglund <https://github.com/beeequeue>

--- a/types/react-dnd-multi-backend/package.json
+++ b/types/react-dnd-multi-backend/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "dnd-core": "^4.0.5"
+        "dnd-core": "^9.3.1"
     }
 }

--- a/types/react-dnd-multi-backend/package.json
+++ b/types/react-dnd-multi-backend/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "dnd-core": "^9.3.1"
+        "dnd-core": "^9.3.1",
+        "react-dnd-touch-backend": "^9.3.1"
     }
 }

--- a/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
+++ b/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
@@ -9,7 +9,7 @@ const context = {};
 /**
  * Most common use case - using the default HTML5 with Touch as a fallback.
  */
-const multiDndComponent = createDragDropManager(MultiBackend(HTML5ToTouch), context);
+const multiDndComponent = createDragDropManager(MultiBackend(HTML5ToTouch), context, {});
 
 /**
  * Creating a custom list of backends, including creating a touch transition.
@@ -17,18 +17,19 @@ const multiDndComponent = createDragDropManager(MultiBackend(HTML5ToTouch), cont
 const CustomBackends: Backends = {
     backends: [
     {
-        backend: TouchBackend({ enableMouseEvents: false }),
+        backend: TouchBackend,
+        options: { enableMouseEvents: false },
         preview: true,
         transition: createTransition('touchstart', (event: TouchEvent) => {
             return event.touches != null;
         })
     },
     {
-        backend: TouchBackend({}),
+        backend: TouchBackend,
         transition: TouchTransition
     }]
 };
-const multiCustomBackendsComponent = createDragDropManager(MultiBackend(CustomBackends), context);
+const multiCustomBackendsComponent = createDragDropManager(MultiBackend(CustomBackends), context, {});
 
 /**
  * Testing the Preview component.


### PR DESCRIPTION
Update react-dnd-multi-backend to 4.0

The types haven't changed much since 3.x, and this updates to the version, 9.3.1, of dnd-core that is fixed for use with Typescript 3.7.

The only problem is that it isn't officially available yet, but I don't think 3.x is going to get any more updates since dnd-core 9.x has been out for a while and react-dnd-multi-backend 3.x only supports versions earlier than 9.x. You can find the discussion here: https://github.com/LouisBrunner/dnd-multi-backend/issues/31