### PR TITLE
[jasminewd2, jasmine] Fix jasminewd2 compatibility with older versions

### DIFF
--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -617,9 +617,6 @@ declare namespace jasmine {
     type MatchableArgs<Fn> = Fn extends (...args: infer P) => any ? { [K in keyof P]: P[K] | AsymmetricMatcher<any> } : never;
 
     interface FunctionMatchers<Fn extends Func> extends Matchers<any> {
-        toHaveBeenCalled(): boolean;
-        toHaveBeenCalledBefore(expected: Func): boolean;
-        toHaveBeenCalledTimes(expected: number): boolean;
         toHaveBeenCalledWith(...params: MatchableArgs<Fn>): boolean;
 
         /**

--- a/types/jasminewd2/index.d.ts
+++ b/types/jasminewd2/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-/// <reference types="jasmine/v2" />
+/// <reference types="jasmine" />
 
 declare function it(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
 declare function fit(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
@@ -45,6 +45,14 @@ declare namespace jasmine {
     toEqual(expected: Expected<ArrayLike<T>>, expectationFailOutput?: any): Promise<void>;
     toContain(expected: T, expectationFailOutput?: any): Promise<void>;
     not: ArrayLikeMatchers<T>;
+  }
+
+  // Add definition to be compatible with latest jasmine v3 types.
+  // Even though library is not compatible with jasmine v3, there is no suitable way to configure that now here.
+  // See for more detail: https://github.com/microsoft/dtslint/issues/253
+  interface FunctionMatchers<Fn extends (...args: any[]) => any> extends Matchers<any> {
+    toHaveBeenCalledWith(...params: any[]): boolean;
+    toHaveBeenCalledWith(...params: any[]): Promise<void>;
   }
 
   function addMatchers(matchers: AsyncCustomMatcherFactories): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

Hotfix for #38656

Fix compatibility with older versions of jasminewd2 to fix horrible regression affecting people. 

The most correct fix should be following:
- update jasminewd2 to depend on jasmine v2 - blocked by https://github.com/microsoft/dtslint/issues/253
- use approach with [path mapping](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library), but it requires ES imports/exports, which is not how the types are currently written:
    > Also, /// &lt;reference types=".." /> will not work with path mapping, so dependencies must use import.

Current fix solves the issue, but must be revisited going forward.