### PR TITLE
ramda#2883: Remove references to R.isNaN

### DIFF
--- a/types/ramda/es/isNaN.d.ts
+++ b/types/ramda/es/isNaN.d.ts
@@ -1,2 +1,0 @@
-import { isNaN } from '../index';
-export default isNaN;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ramda 0.26
 // Project: https://github.com/donnut/typescript-ramda, https://ramdajs.com
-// Definitions by: Erwin Poeze <https://github.com/donnut>
+// Definitions by: Scott O'Malley <https://github.com/TheHandsomeCoder>
+//                 Erwin Poeze <https://github.com/donnut>
 //                 Matt DeKrey <https://github.com/mdekrey>
 //                 Matt Dziuban <https://github.com/mrdziuban>
 //                 Stephen King <https://github.com/sbking>
@@ -130,7 +131,6 @@
 /// <reference path="./es/isArrayLike.d.ts" />
 /// <reference path="./es/is.d.ts" />
 /// <reference path="./es/isEmpty.d.ts" />
-/// <reference path="./es/isNaN.d.ts" />
 /// <reference path="./es/isNil.d.ts" />
 /// <reference path="./es/join.d.ts" />
 /// <reference path="./es/juxt.d.ts" />
@@ -386,7 +386,6 @@
 /// <reference path="./src/isArrayLike.d.ts" />
 /// <reference path="./src/is.d.ts" />
 /// <reference path="./src/isEmpty.d.ts" />
-/// <reference path="./src/isNaN.d.ts" />
 /// <reference path="./src/isNil.d.ts" />
 /// <reference path="./src/join.d.ts" />
 /// <reference path="./src/juxt.d.ts" />
@@ -1638,11 +1637,6 @@ declare namespace R {
          * Reports whether the list has zero elements.
          */
         isEmpty(value: any): boolean;
-
-        /**
-         * Returns true if the input value is NaN.
-         */
-        isNaN(x: any): boolean;
 
         /**
          * Checks if the input value is null or undefined.

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -500,7 +500,7 @@ interface Obj {
     R.none(Number.isNaN, [1, 2, 3]); // => true
     R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
     R.none(Number.isNaN)([1, 2, 3, NaN]); // => false
-};;
+};
 
 () => {
 >>>>>>> ramda#2883: Remove references to R.isNaN

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -478,8 +478,6 @@ interface Obj {
 };
 
 () => {
-<<<<<<< HEAD
-=======
     const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
 
     R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
@@ -499,11 +497,10 @@ interface Obj {
 () => {
     R.none(Number.isNaN, [1, 2, 3]); // => true
     R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
-    R.none(Number.isNaN)([1, 2, 3, NaN]); // => false
+    R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
 };
 
 () => {
->>>>>>> ramda#2883: Remove references to R.isNaN
     const list = ["foo", "bar", "baz", "quux"];
     R.nth(1, list); // => 'bar'
     R.nth(-1, list); // => 'quux'

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -499,8 +499,8 @@ interface Obj {
 () => {
     R.none(Number.isNaN, [1, 2, 3]); // => true
     R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
-    R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
-};
+    R.none(Number.isNaN)([1, 2, 3, NaN]); // => false
+};;
 
 () => {
 >>>>>>> ramda#2883: Remove references to R.isNaN

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -478,6 +478,32 @@ interface Obj {
 };
 
 () => {
+<<<<<<< HEAD
+=======
+    const sampleList = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+    R.move<string>(0, 2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+    R.move<string>(-1, 0, sampleList); // => ['f', 'a', 'b', 'c', 'd', 'e'] list rotation
+
+    const moveCurried1 = R.move(0, 2);
+    moveCurried1<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried2 = R.move(0);
+    moveCurried2<string>(2, sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+
+    const moveCurried3 = R.move(0);
+    const moveCurried4 = moveCurried3(2);
+    moveCurried4<string>(sampleList); // => ['b', 'c', 'a', 'd', 'e', 'f']
+};
+
+() => {
+    R.none(Number.isNaN, [1, 2, 3]); // => true
+    R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
+    R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
+};
+
+() => {
+>>>>>>> ramda#2883: Remove references to R.isNaN
     const list = ["foo", "bar", "baz", "quux"];
     R.nth(1, list); // => 'bar'
     R.nth(-1, list); // => 'quux'

--- a/types/ramda/src/isNaN.d.ts
+++ b/types/ramda/src/isNaN.d.ts
@@ -1,2 +1,0 @@
-import { isNaN } from '../index';
-export default isNaN;

--- a/types/ramda/test/isNaN-tests.ts
+++ b/types/ramda/test/isNaN-tests.ts
@@ -1,7 +1,0 @@
-import * as R from 'ramda';
-
-() => {
-  R.isNaN(NaN); // => true
-  R.isNaN(undefined); // => false
-  R.isNaN({}); // => false
-};

--- a/types/ramda/test/none-tests.ts
+++ b/types/ramda/test/none-tests.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 
 () => {
-  R.none(R.isNaN, [1, 2, 3]); // => true
-  R.none(R.isNaN, [1, 2, 3, NaN]); // => false
-  R.none(R.isNaN)([1, 2, 3, NaN]); // => false
+  R.none(Number.isNaN, [1, 2, 3]); // => true
+  R.none(Number.isNaN, [1, 2, 3, NaN]); // => false
+  R.none(Number.isNaN)([1, 2, 3, NaN]); // => false
 };

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -112,7 +112,6 @@
         "test/is-tests.ts",
         "test/isArrayLike-tests.ts",
         "test/isEmpty-tests.ts",
-        "test/isNaN-tests.ts",
         "test/join-tests.ts",
         "test/juxt-tests.ts",
         "test/keys-tests.ts",


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ramda/ramda/issues/2883>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Closes ramda/ramda#2883
