### PR TITLE
sinon: correct fake timer interfaces

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Sinon 7.0
+// Type definitions for Sinon 7.5
 // Project: https://sinonjs.org
 // Definitions by: William Sears <https://github.com/mrbigdog2u>
 //                 Jonathan Little <https://github.com/rationull>
@@ -729,16 +729,25 @@ declare namespace Sinon {
 
     interface SinonFakeTimers {
         now: number;
+        loopLimit: number;
 
         setTimeout(callback: (...args: any[]) => void, timeout: number, ...args: any[]): SinonTimerId;
         clearTimeout(id: SinonTimerId): void;
+
         setInterval(callback: (...args: any[]) => void, timeout: number, ...args: any[]): SinonTimerId;
         clearInterval(id: SinonTimerId): void;
+
         setImmediate(callback: (...args: any[]) => void, ...args: any[]): SinonTimerId;
         clearImmediate(id: SinonTimerId): void;
-        requestAnimationFrame(callback: (...args: any[]) => void): number;
-        cancelAnimationFrame(id: number): void;
-        nextTick(callback: () => void): void;
+
+        requestAnimationFrame(callback: (time: number) => void): SinonTimerId;
+        cancelAnimationFrame(id: SinonTimerId): void;
+
+        nextTick(callback: (...args: any[]) => void, ...args: any[]): void;
+        queueMicrotask(callback: () => void): void;
+
+        requestIdleCallback(func: (...args: any[]) => void, timeout?: number, ...args: any[]): SinonTimerId;
+        cancelIdleCallback(timerId: SinonTimerId): void;
 
         /**
          * Tick the clock ahead time milliseconds.
@@ -748,20 +757,20 @@ declare namespace Sinon {
          * time may be negative, which causes the clock to change but won’t fire any callbacks.
          * @param ms
          */
-        tick(ms: number | string): void;
+        tick(ms: number | string): number;
         /**
          * Advances the clock to the the moment of the first scheduled timer, firing it.
          */
-        next(): void;
+        next(): number;
         /**
          * This runs all pending timers until there are none remaining. If new timers are added while it is executing they will be run as well.
          * This makes it easier to run asynchronous tests to completion without worrying about the number of timers they use, or the delays in those timers.
          */
-        runAll(): void;
-        runToLast(): void;
+        runAll(): number;
+        runToLast(): number;
         reset(): void;
         runMicrotasks(): void;
-        runToFrame(): void;
+        runToFrame(): number;
 
         Date(): Date;
         Date(year: number): Date;
@@ -791,6 +800,8 @@ declare namespace Sinon {
          * @param now The new 'now' as a JavaScript Date
          */
         setSystemTime(date: Date): void;
+
+        countTimers(): number;
     }
 
     interface SinonFakeTimersConfig {

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -757,27 +757,39 @@ declare namespace Sinon {
 
     interface SinonFakeTimers {
         now: number;
+        loopLimit: number;
 
-        setTimeout(
-            callback: (...args: any[]) => void,
+        setTimeout<TArgs extends any[] = any[]>(
+            callback: (...args: TArgs) => void,
             timeout: number,
-            ...args: any[]
+            ...args: TArgs
         ): SinonTimerId;
         clearTimeout(id: SinonTimerId): void;
-        setInterval(
-            callback: (...args: any[]) => void,
+
+        setInterval<TArgs extends any[] = any[]>(
+            callback: (...args: TArgs) => void,
             timeout: number,
-            ...args: any[]
+            ...args: TArgs
         ): SinonTimerId;
         clearInterval(id: SinonTimerId): void;
-        setImmediate(
-            callback: (...args: any[]) => void,
-            ...args: any[]
+
+        setImmediate<TArgs extends any[] = any[]>(
+            callback: (...args: TArgs) => void,
+            ...args: TArgs
         ): SinonTimerId;
         clearImmediate(id: SinonTimerId): void;
-        requestAnimationFrame(callback: (...args: any[]) => void): number;
-        cancelAnimationFrame(id: number): void;
-        nextTick(callback: () => void): void;
+
+        requestAnimationFrame(callback: (time: number) => void): SinonTimerId;
+        cancelAnimationFrame(id: SinonTimerId): void;
+
+        nextTick<TArgs extends any[] = any[]>(
+            callback: (...args: TArgs) => void,
+            ...args: TArgs): void;
+        queueMicrotask(callback: () => void): void;
+
+        requestIdleCallback<TArgs extends any[] = any[]>(func: (...args: TArgs) => void, timeout?: number, ...args:
+            TArgs): SinonTimerId;
+        cancelIdleCallback(timerId: SinonTimerId): void;
 
         /**
          * Tick the clock ahead time milliseconds.
@@ -787,20 +799,20 @@ declare namespace Sinon {
          * time may be negative, which causes the clock to change but won’t fire any callbacks.
          * @param ms
          */
-        tick(ms: number | string): void;
+        tick(ms: number | string): number;
         /**
          * Advances the clock to the the moment of the first scheduled timer, firing it.
          */
-        next(): void;
+        next(): number;
         /**
          * This runs all pending timers until there are none remaining. If new timers are added while it is executing they will be run as well.
          * This makes it easier to run asynchronous tests to completion without worrying about the number of timers they use, or the delays in those timers.
          */
-        runAll(): void;
-        runToLast(): void;
+        runAll(): number;
+        runToLast(): number;
         reset(): void;
         runMicrotasks(): void;
-        runToFrame(): void;
+        runToFrame(): number;
 
         Date(): Date;
         Date(year: number): Date;
@@ -851,6 +863,8 @@ declare namespace Sinon {
          * @param now The new 'now' as a JavaScript Date
          */
         setSystemTime(date: Date): void;
+
+        countTimers(): number;
     }
 
     interface SinonFakeTimersConfig {

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -134,18 +134,20 @@ function testClock() {
     let clock = sinon.clock.create(1000);
     clock = sinon.clock.create(new Date());
 
-    let now = 0;
+    let now: sinon.SinonTimerId = 0;
     now = clock.now;
 
     const fn = () => { };
+    const fnWithArgs = (a: number, b: string) => {};
 
     clock.setTimeout(fn, 0);
-    clock.setTimeout(fn, 0, 'a', 'b');
     clock.setInterval(fn, 0);
-    clock.setInterval(fn, 0, 'a', 'b');
     clock.setImmediate(fn);
-    clock.setImmediate(fn, 'a', 'b');
     clock.requestAnimationFrame(fn);
+
+    now = clock.setTimeout(fnWithArgs, 0, 1234, 'abc');
+    now = clock.setInterval(fnWithArgs, 0, 1234, 'abc');
+    now = clock.setImmediate(fnWithArgs, 1234, 'abc');
 
     let timer = clock.setTimeout(fn, 0);
     clock.clearTimeout(timer);


### PR DESCRIPTION
Fixes #38564

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/latest/fake-timers/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

### Breaking change

Clock callbacks now require the correct strongly typed arguments.

This means you can't incorrectly pass args for a callback which takes none:

```ts
function fn() {}

clock.setTimeout(fn, 0, 'foo'); // WONT WORK ANYMORE! fn doesn't take such an arg
```

However this is fine IMO as such cases should be rather uncommon (or incorrect anyway).