### PR TITLE
Remove @xmpp/jid from removed packages list

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -3991,12 +3991,6 @@
             "asOfVersion": "11.0.1"
         },
         {
-            "libraryName": "@xmpp/jid",
-            "typingsPackageName": "xmpp__jid",
-            "sourceRepoURL": "github.com/node-xmpp/node-xmpp/",
-            "asOfVersion": "1.2.1"
-        },
-        {
             "libraryName": "xterm.js",
             "typingsPackageName": "xterm",
             "sourceRepoURL": "https://github.com/sourcelair/xterm.js/",


### PR DESCRIPTION
It's not actually removed and the source package doesn't ship types.

Also the "asOfVersion" currently quoted doesn't exist and the package URL is not formatted like the rest of the entries.