### PR TITLE
Bump xmpp__jid to 1.3

### DIFF
--- a/types/xmpp__jid/index.d.ts
+++ b/types/xmpp__jid/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @xmpp/jid 0.6
+// Type definitions for @xmpp/jid 1.3
 // Project: https://github.com/xmppjs/xmpp.js/tree/master/packages/jid
 // Definitions by: PJakcson <https://github.com/PJakcson>
 //                 BendingBender <https://github.com/BendingBender>

--- a/types/xmpp__jid/tslint.json
+++ b/types/xmpp__jid/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
This makes the version not match the source package's, but it skips it past the incorrectly deprecated version.

The DT publishing infrastructure is not designed to let people publish older versions once a newer version has been published.