### PR TITLE
Add typings for react-add-to-calendar package

### DIFF
--- a/types/react-add-to-calendar/index.d.ts
+++ b/types/react-add-to-calendar/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for react-add-to-calendar 0.1
+// Project: https://github.com/jasonsalzman/react-add-to-calendar
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+export interface AddToCalendarEvent {
+    title?: string;
+    description?: string;
+    location?: string;
+    startTime?: string | Date;
+    endTime?: string | Date;
+}
+
+export interface AddToCalendarProps {
+    buttonClassClosed?: string;
+    buttonClassOpen?: string;
+    buttonLabel?: string;
+    buttonTemplate?: any;
+    buttonIconClass?: string;
+    useFontAwesomeIcons?: boolean;
+    buttonWrapperClass?: string;
+    displayItemIcons?: boolean;
+    optionsOpen?: boolean;
+    dropdownClass?: string;
+    event: AddToCalendarEvent;
+    listItems?: any[];
+    rootClass?: string;
+}
+
+declare const ReactAddToCalendar: React.ComponentClass<AddToCalendarProps>;
+
+export default ReactAddToCalendar;

--- a/types/react-add-to-calendar/react-add-to-calendar-tests.tsx
+++ b/types/react-add-to-calendar/react-add-to-calendar-tests.tsx
@@ -1,0 +1,34 @@
+import AddToCalendar from "react-add-to-calendar";
+import * as React from "react";
+
+const sampleEvent = {
+    title: 'Sample Event',
+    description: 'This is the sample event provided as an example only',
+    location: 'Portland, OR',
+    startTime: '2016-09-16T20:15:00-04:00',
+    endTime: '2016-09-16T21:45:00-04:00'
+};
+
+const AddToCalendarRequiredOptions: JSX.Element = (
+    <AddToCalendar
+        event={sampleEvent}
+    />
+);
+
+const AddToCalendarAllOptions: JSX.Element = (
+    <AddToCalendar
+        event={sampleEvent}
+        buttonClassClosed="test"
+        buttonClassOpen="test"
+        buttonLabel="test"
+        buttonTemplate=""
+        buttonIconClass="test"
+        useFontAwesomeIcons={false}
+        buttonWrapperClass="test"
+        displayItemIcons={false}
+        optionsOpen={false}
+        dropdownClass="test"
+        listItems={[]}
+        rootClass="test"
+    />
+);

--- a/types/react-add-to-calendar/tsconfig.json
+++ b/types/react-add-to-calendar/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-add-to-calendar-tests.tsx"
+    ]
+}

--- a/types/react-add-to-calendar/tslint.json
+++ b/types/react-add-to-calendar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for react-add-to-calendar package (https://github.com/jasonsalzman/react-add-to-calendar)

The package does not already provide its own types, or cannot have its .d.ts files generated via --declaration.

