### PR TITLE
[@types/node] add missing optional code argument to util.deprecate

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -127,8 +127,10 @@ import { readFile } from 'fs';
     const foo = () => {};
     // $ExpectType () => void
     util.deprecate(foo, 'foo() is deprecated, use bar() instead');
-    // $ExpectType <T extends Function>(fn: T, message: string) => T
+    // $ExpectType <T extends Function>(fn: T, message: string, code?: string | undefined) => T
     util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
+    // $ExpectType <T extends Function>(fn: T, message: string, code?: string | undefined) => T
+    util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead', 'DEP0001');
 
     // util.isDeepStrictEqual
     util.isDeepStrictEqual({foo: 'bar'}, {foo: 'bar'});

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -51,7 +51,7 @@ declare module "util" {
     function isSymbol(object: any): object is symbol;
     /** @deprecated since v4.0.0 - use `value === undefined` instead. */
     function isUndefined(object: any): object is undefined;
-    function deprecate<T extends Function>(fn: T, message: string): T;
+    function deprecate<T extends Function>(fn: T, message: string, code?: string): T;
     function isDeepStrictEqual(val1: any, val2: any): boolean;
 
     interface CustomPromisify<TCustom extends Function> extends Function {

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -946,8 +946,10 @@ function bufferTests() {
         const foo = () => {};
         // $ExpectType () => void
         util.deprecate(foo, 'foo() is deprecated, use bar() instead');
-        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
         util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead', 'DEP0001');
 
         // util.isDeepStrictEqual
         util.isDeepStrictEqual({foo: 'bar'}, {foo: 'bar'});

--- a/types/node/v10/util.d.ts
+++ b/types/node/v10/util.d.ts
@@ -55,7 +55,7 @@ declare module "util" {
     function isSymbol(object: any): object is symbol;
     /** @deprecated since v4.0.0 - use `value === undefined` instead. */
     function isUndefined(object: any): object is undefined;
-    function deprecate<T extends Function>(fn: T, message: string): T;
+    function deprecate<T extends Function>(fn: T, message: string, code?: string): T;
     function isDeepStrictEqual(val1: any, val2: any): boolean;
 
     interface CustomPromisify<TCustom extends Function> extends Function {

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -5658,7 +5658,7 @@ declare module "util" {
     export function isString(object: any): object is string;
     export function isSymbol(object: any): object is symbol;
     export function isUndefined(object: any): object is undefined;
-    export function deprecate<T extends Function>(fn: T, message: string): T;
+    export function deprecate<T extends Function>(fn: T, message: string, code?: string): T;
 
     export interface CustomPromisify<TCustom extends Function> extends Function {
         __promisify__: TCustom;

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -843,8 +843,10 @@ namespace util_tests {
         const foo = () => {};
         // $ExpectType () => void
         util.deprecate(foo, 'foo() is deprecated, use bar() instead');
-        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
         util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead', 'DEP0001');
 
         // util.TextDecoder()
         var td = new util.TextDecoder();

--- a/types/node/v8/ts3.2/node-tests.ts
+++ b/types/node/v8/ts3.2/node-tests.ts
@@ -843,8 +843,10 @@ namespace util_tests {
         const foo = () => {};
         // $ExpectType () => void
         util.deprecate(foo, 'foo() is deprecated, use bar() instead');
-        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
         util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string, code?: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead', 'DEP0001');
 
         // util.TextDecoder()
         var td = new util.TextDecoder();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/util.html#util_util_deprecate_fn_msg_code
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
