### PR TITLE
New definition for non npm package amap-js-api-tool-bar

### DIFF
--- a/types/amap-js-api-tool-bar/amap-js-api-tool-bar-tests.ts
+++ b/types/amap-js-api-tool-bar/amap-js-api-tool-bar-tests.ts
@@ -1,0 +1,80 @@
+declare const map: AMap.Map;
+declare const pixel: AMap.Pixel;
+declare const marker: AMap.Marker;
+// $ExpectType ToolBar
+new AMap.ToolBar();
+// $ExpectType ToolBar
+new AMap.ToolBar({});
+// $ExpectType ToolBar
+const toolBar = new AMap.ToolBar({
+    offset: pixel,
+    position: 'LT',
+    ruler: true,
+    noIpLocate: true,
+    locate: true,
+    liteStyle: false,
+    direction: true,
+    autoPosition: true,
+    locationMarker: marker,
+    useNative: false
+});
+
+map.addControl(toolBar);
+map.removeControl(toolBar);
+
+// $ExpectType Pixel
+toolBar.getOffset();
+
+// $ExpectType void
+toolBar.setOffset(pixel);
+
+// $ExpectType void
+toolBar.hideRuler();
+
+// $ExpectType void
+toolBar.showRuler();
+
+// $ExpectType void
+toolBar.hideDirection();
+
+// $ExpectType void
+toolBar.showDirection();
+
+// $ExpectType void
+toolBar.hideLocation();
+
+// $ExpectType void
+toolBar.showLocation();
+
+// $ExpectType void
+toolBar.doLocation();
+
+// $ExpectType LngLat | null | undefined
+toolBar.getLocation();
+
+// $ExpectType void
+toolBar.hide();
+
+// $ExpectType void
+toolBar.show();
+
+toolBar.on('show', (event: AMap.ToolBar.EventMap['show']) => {
+    // $ExpectType "show"
+    event.type;
+});
+
+toolBar.on('hide', (event: AMap.ToolBar.EventMap['hide']) => {
+    // $ExpectType "hide"
+    event.type;
+});
+
+toolBar.on('location', (event: AMap.ToolBar.EventMap['location']) => {
+    // $ExpectType "location"
+    event.type;
+    // $ExpectType LngLat
+    event.lnglat;
+});
+
+toolBar.on('zoomchanged', (event: AMap.ToolBar.EventMap['zoomchanged']) => {
+    const type: 'zoomin' | 'zoomout' = event.type;
+});

--- a/types/amap-js-api-tool-bar/index.d.ts
+++ b/types/amap-js-api-tool-bar/index.d.ts
@@ -1,0 +1,123 @@
+// Type definitions for non-npm package amap-js-api-tool-bar 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/map-control#AMap.ToolBar
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace ToolBar {
+        interface EventMap {
+            hide: Event<'hide'>;
+            show: Event<'show'>;
+            location: Event<'location', {lnglat: LngLat}>;
+            zoomchanged: Event<'zoomin' | 'zoomout'>;
+            // internal
+            'location-success': Event<'location-success'>; // TODO geolocation.getCurrentPosition
+            'location-failed': Event<'location-failed'>; // TODO geolocation.getCurrentPosition
+        }
+        type Position = 'LT' | 'RT' | 'LB' | 'RB';
+        interface Options {
+            /**
+             * 相对于地图容器左上角的偏移量
+             */
+            offset?: Pixel;
+            /**
+             * 控件停靠位置
+             * LT:左上角;
+             * RT:右上角;
+             * LB:左下角;
+             * RB:右下角;
+             */
+            position?: Position;
+            /**
+             * 标尺键盘是否可见
+             */
+            ruler?: boolean;
+            /**
+             * 定位失败后，是否开启IP定位
+             */
+            noIpLocate?: boolean;
+            /**
+             * 是否显示定位按钮
+             */
+            locate?: boolean;
+            /**
+             * 是否使用精简模式
+             */
+            liteStyle?: boolean;
+            /**
+             * 方向键盘是否可见
+             */
+            direction?: boolean;
+            /**
+             * 是否自动定位，即地图初始化加载完成后，是否自动定位的用户所在地，仅在支持HTML5的浏览器中有效
+             */
+            autoPosition?: boolean;
+            /**
+             * 自定义定位图标，值为Marker对象
+             */
+            locationMarker?: Marker;
+            /**
+             * 是否使用高德定位sdk用来辅助优化定位效果
+             */
+            useNative?: boolean;
+            // internal
+            timeout?: number;
+        }
+    }
+
+    class ToolBar extends EventEmitter {
+        constructor(options?: ToolBar.Options);
+        /**
+         * 获取工具条相对于地图容器左上角的偏移量
+         */
+        getOffset(): Pixel;
+        /**
+         * 设置工具条相对于地图容器左上角的偏移量
+         * @param offset 偏移量
+         */
+        setOffset(offset: Pixel): void;
+        /**
+         * 隐藏缩放级别等级条
+         */
+        hideRuler(): void;
+        /**
+         * 显示缩放级别等级条
+         */
+        showRuler(): void;
+        /**
+         * 隐藏方向键盘
+         */
+        hideDirection(): void;
+        /**
+         * 显示方向键盘
+         */
+        showDirection(): void;
+        /**
+         * 隐藏定位小部件
+         */
+        hideLocation(): void;
+        /**
+         * 显示定位小部件
+         */
+        showLocation(): void;
+        /**
+         * 进行位置定位
+         */
+        doLocation(): void;
+        /**
+         * 获取上次定位的结果
+         */
+        getLocation(): LngLat | null | undefined;
+        /**
+         * 隐藏工具条
+         */
+        hide(): void;
+        /**
+         * 显示工具条
+         */
+        show(): void;
+    }
+}

--- a/types/amap-js-api-tool-bar/tsconfig.json
+++ b/types/amap-js-api-tool-bar/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-tool-bar-tests.ts"
+    ]
+}

--- a/types/amap-js-api-tool-bar/tslint.json
+++ b/types/amap-js-api-tool-bar/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
