### PR TITLE
New definition for non npm package amap-js-api-control-bar

### DIFF
--- a/types/amap-js-api-control-bar/amap-js-api-control-bar-tests.ts
+++ b/types/amap-js-api-control-bar/amap-js-api-control-bar-tests.ts
@@ -1,0 +1,23 @@
+declare const map: AMap.Map;
+
+// $ExpectType ControlBar
+new AMap.ControlBar();
+// $ExpectType ControlBar
+const controlBar = new AMap.ControlBar({
+    position: {
+        left: 'left',
+        right: 'right',
+        top: 'top',
+        bottom: 'bottom'
+    },
+    showZoomBar: true,
+    showControlButton: true
+});
+
+// $ExpectType void
+controlBar.show();
+
+// $ExpectType void
+controlBar.hide();
+
+map.addControl(controlBar);

--- a/types/amap-js-api-control-bar/index.d.ts
+++ b/types/amap-js-api-control-bar/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for non-npm package amap-js-api-control-bar 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/map-control#control-bar
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace ControlBar {
+        interface EventMap {
+            hide: Event<'hide'>;
+            show: Event<'show'>;
+        }
+        interface Position {
+            top?: string;
+            right?: string;
+            bottom?: string;
+            left?: string;
+        }
+        interface Options {
+            /**
+             * 显示位置
+             */
+            position?: Position;
+            /**
+             * 是否显示缩放按钮
+             */
+            showZoomBar?: boolean;
+            /**
+             * 是否显示倾斜、旋转按钮
+             */
+            showControlButton?: boolean;
+        }
+    }
+    class ControlBar extends EventEmitter {
+        /**
+         * 组合了旋转、倾斜、复位、缩放在内的地图控件
+         * @param options 选项
+         */
+        constructor(options?: ControlBar.Options);
+        // internal
+        show(): void;
+        hide(): void;
+    }
+}

--- a/types/amap-js-api-control-bar/tsconfig.json
+++ b/types/amap-js-api-control-bar/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-control-bar-tests.ts"
+    ]
+}

--- a/types/amap-js-api-control-bar/tslint.json
+++ b/types/amap-js-api-control-bar/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
