### PR TITLE
New definition for non npm package amap-js-api-map-type

### DIFF
--- a/types/amap-js-api-map-type/amap-js-api-map-type-tests.ts
+++ b/types/amap-js-api-map-type/amap-js-api-map-type-tests.ts
@@ -1,0 +1,32 @@
+declare const map: AMap.Map;
+
+// $ExpectType MapType
+new AMap.MapType();
+// $ExpectType MapType
+new AMap.MapType({});
+// $ExpectType MapType
+const mapType = new AMap.MapType({
+    defaultType: 1,
+    showTraffic: true,
+    showRoad: true
+});
+
+// $ExpectError
+new AMap.MapType({
+    defaultType: 2
+});
+
+// $ExpectType void
+mapType.show();
+
+// $ExpectType void
+mapType.hide();
+
+mapType.on('show', (event: AMap.MapType.EventMap['show']) => {
+    // $ExpectType "show"
+    event.type;
+});
+mapType.on('hide', (event: AMap.MapType.EventMap['hide']) => {
+    // $ExpectType "hide"
+    event.type;
+});

--- a/types/amap-js-api-map-type/index.d.ts
+++ b/types/amap-js-api-map-type/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for non-npm package amap-js-api-map-type 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/map-control#AMap.MapType
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace MapType {
+        interface EventMap {
+            hide: Event<'hide'>;
+            show: Event<'show'>;
+        }
+        interface Options {
+            /**
+             * 初始化默认图层类型，默认为0
+             * 取值为0：默认底图
+             * 取值为1：卫星图
+             */
+            defaultType?: 0 | 1;
+            /**
+             * 是否叠加实时交通图层，默认false
+             */
+            showTraffic?: boolean;
+            /**
+             * 是否叠加路网图层，默认false
+             */
+            showRoad?: boolean;
+        }
+    }
+
+    class MapType extends EventEmitter {
+        constructor(options?: MapType.Options);
+        show(): void;
+        hide(): void;
+    }
+}

--- a/types/amap-js-api-map-type/tsconfig.json
+++ b/types/amap-js-api-map-type/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-map-type-tests.ts"
+    ]
+}

--- a/types/amap-js-api-map-type/tslint.json
+++ b/types/amap-js-api-map-type/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
