### PR TITLE
New definition for non npm package amap-js-api-scale

### DIFF
--- a/types/amap-js-api-scale/amap-js-api-scale-tests.ts
+++ b/types/amap-js-api-scale/amap-js-api-scale-tests.ts
@@ -1,0 +1,38 @@
+declare const map: AMap.Map;
+declare const pixel: AMap.Pixel;
+
+// $ExpectType Scale
+new AMap.Scale();
+// $ExpectType Scale
+new AMap.Scale({});
+// $ExpectType Scale
+const scale = new AMap.Scale({
+    position: 'LT',
+    visible: true,
+    offset: pixel
+});
+
+// $ExpectType Pixel
+scale.offset;
+
+// $ExpectType boolean
+scale.visible;
+
+// $ExpectType Position
+scale.position;
+
+// $ExpectType void
+scale.show();
+
+// $ExpectType void
+scale.hide();
+
+scale.on('show', (event: AMap.Scale.EventMap['show']) => {
+    // $ExpectType "show"
+    event.type;
+});
+
+scale.on('hide', (event: AMap.Scale.EventMap['hide']) => {
+    // $ExpectType "hide"
+    event.type;
+});

--- a/types/amap-js-api-scale/index.d.ts
+++ b/types/amap-js-api-scale/index.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for non-npm package amap-js-api-scale 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/map-control#AMap.Scale
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace Scale {
+        interface EventMap {
+            show: Event<'show'>;
+            hide: Event<'hide'>;
+        }
+        type Position = 'LT' | 'RT' | 'LB' | 'RB';
+        interface Options {
+            /**
+             * 控件停靠位置
+             * LT:左上角;
+             * RT:右上角;
+             * LB:左下角;
+             * RB:右下角;
+             * 默认位置：LB
+             */
+            position?: Position;
+            /**
+             * 是否可见
+             */
+            visible?: boolean;
+            /**
+             * 相对于地图容器左上角的偏移量
+             */
+            offset?: Pixel;
+        }
+    }
+
+    /**
+     * 比例尺插件
+     */
+    class Scale extends EventEmitter {
+        constructor(options?: Scale.Options);
+        /**
+         * 控件停靠位置
+         */
+        position: Position;
+        /**
+         * 相对于地图容器左上角的偏移量
+         */
+        offset: Pixel;
+        /**
+         * 是否可见
+         */
+        visible: boolean;
+        /**
+         * 显示比例尺
+         */
+        show(): void;
+        /**
+         * 隐藏比例尺
+         */
+        hide(): void;
+    }
+}

--- a/types/amap-js-api-scale/tsconfig.json
+++ b/types/amap-js-api-scale/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-scale-tests.ts"
+    ]
+}

--- a/types/amap-js-api-scale/tslint.json
+++ b/types/amap-js-api-scale/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
