### PR TITLE
New definition for non npm package amap-js-api-overview

### DIFF
--- a/types/amap-js-api-overview/amap-js-api-overview-tests.ts
+++ b/types/amap-js-api-overview/amap-js-api-overview-tests.ts
@@ -1,0 +1,52 @@
+declare const map: AMap.Map;
+
+declare const tileLayer: AMap.TileLayer;
+
+// $ExpectType OverView<TileLayer>
+new AMap.OverView();
+// $ExpectType OverView<TileLayer>
+new AMap.OverView({});
+// $ExpectType OverView<TileLayer>
+const overview = new AMap.OverView({
+    tileLayer,
+    isOpen: true,
+    visible: true
+});
+
+// $ExpectType void
+overview.show();
+
+// $ExpectType void
+overview.hide();
+
+// $ExpectType void
+overview.open();
+
+// $ExpectType void
+overview.close();
+
+// $ExpectType void
+overview.setTileLayer(tileLayer);
+
+// $ExpectType TileLayer
+overview.getTileLayer();
+
+overview.on('show', (event: AMap.OverView.EventMap['show']) => {
+    // $ExpectType "show"
+    event.type;
+});
+
+overview.on('hide', (event: AMap.OverView.EventMap['hide']) => {
+    // $ExpectType "hide"
+    event.type;
+});
+
+overview.on('open', (event: AMap.OverView.EventMap['open']) => {
+    // $ExpectType "open"
+    event.type;
+});
+
+overview.on('close', (event: AMap.OverView.EventMap['close']) => {
+    // $ExpectType "close"
+    event.type;
+});

--- a/types/amap-js-api-overview/index.d.ts
+++ b/types/amap-js-api-overview/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for non-npm package amap-js-api-overview 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/map-control#AMap.OverView
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+
+declare namespace AMap {
+    namespace OverView {
+        interface EventMap {
+            show: Event<'show'>;
+            hide: Event<'hide'>;
+            open: Event<'open'>;
+            close: Event<'close'>;
+        }
+        interface Options<L extends TileLayer = TileLayer> {
+            /**
+             * 鹰眼窗体中需显示的切片图层
+             */
+            tileLayer?: L;
+            /**
+             * 鹰眼是否展开，默认为false
+             */
+            isOpen?: boolean;
+            /**
+             * 鹰眼是否显示，默认为true
+             */
+            visible?: boolean;
+        }
+    }
+
+    /**
+     * 地图鹰眼插件
+     */
+    class OverView<L extends TileLayer = TileLayer> extends EventEmitter {
+        constructor(options?: OverView.Options<L>);
+        /**
+         * 显示鹰眼窗体
+         */
+        show(): void;
+        /**
+         * 隐藏鹰眼窗体
+         */
+        hide(): void;
+        /**
+         * 展开鹰眼窗口
+         */
+        open(): void;
+        /***
+         * 折叠鹰眼窗口
+         */
+        close(): void;
+        /**
+         * 设置鹰眼中需显示的切片图层
+         * @param tileLayer 切片图层
+         */
+        setTileLayer(tileLayer: L): void;
+        /**
+         * 获取窗体中显示的切片图层
+         */
+        getTileLayer(): L;
+    }
+}

--- a/types/amap-js-api-overview/tsconfig.json
+++ b/types/amap-js-api-overview/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-overview-tests.ts"
+    ]
+}

--- a/types/amap-js-api-overview/tslint.json
+++ b/types/amap-js-api-overview/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
