### PR TITLE
add types for mysql-import

### DIFF
--- a/types/mysql-import/index.d.ts
+++ b/types/mysql-import/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for mysql-import 2.0
+// Project: https://github.com/pamblam/mysql-import#readme
+// Definitions by: Ben Grynhaus <https://github.com/bengry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Settings {
+    /**
+     * The MySQL host to connect to.
+     */
+    host: string;
+    /**
+     * The MySQL port to connect to.
+     */
+    port?: number;
+    /**
+     * The MySQL user to connect with.
+     */
+    user: string;
+    /**
+     * The password for the user.
+     */
+    password: string;
+    /**
+     * The database to connect to.
+     */
+    database: string;
+    /**
+     * Function to handle errors. The function will receive the Error. If not provided the error will be thrown.
+     */
+    onerror?(error: any): void;
+}
+
+export interface Importer {
+    /**
+     * Import an .sql file to the database.
+     */
+    import(filename: string): Promise<void>;
+}
+
+export function config(settings: Settings): Importer;

--- a/types/mysql-import/mysql-import-tests.ts
+++ b/types/mysql-import/mysql-import-tests.ts
@@ -1,0 +1,17 @@
+import * as mysqlImport from 'mysql-import';
+
+mysqlImport.config(); // $ExpectError
+
+mysqlImport.config({}); // $ExpectError
+
+// $ExpectType Importer
+const importer = mysqlImport.config({
+    host: 'localhost',
+    port: 1234,
+    user: 'user',
+    password: 'test',
+    database: 'database',
+    onerror: err => {},
+});
+
+importer.import('sql-file-path'); // $ExpectType Promise<void>

--- a/types/mysql-import/tsconfig.json
+++ b/types/mysql-import/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mysql-import-tests.ts"
+    ]
+}

--- a/types/mysql-import/tslint.json
+++ b/types/mysql-import/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.