### PR TITLE
[@types/slate] Fix Data class definition

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -12,17 +12,18 @@
 //                 Benjamin Evenson <https://github.com/benjiro>
 //                 Han Jeon <https://github.com/hanstar17>
 //                 Kay Delaney <https://github.com/kaydelaney>
+//                 Yuichiro Tsuchiya <https://github.com/tuttieee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as Immutable from "immutable";
 import { SyntheticEvent } from "react";
 
-export class Data extends Immutable.Record({}) {
-    [key: string]: any;
+export interface Data extends Immutable.Map<any, any> {}
 
-    static create(properties: Immutable.Map<string, any> | { [key: string]: any }): Data;
-    static fromJSON(object: { [key: string]: any }): Data;
-    static fromJS(object: { [key: string]: any }): Data;
+export namespace Data {
+    function create(properties: Immutable.Map<string, any> | { [key: string]: any }): Data;
+    function fromJSON(object: { [key: string]: any }): Data;
+    function fromJS(object: { [key: string]: any }): Data;
 }
 
 export interface RulesByNodeType {

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -22,6 +22,13 @@ import {
 import { List } from "immutable";
 
 const data = Data.create({ foo: "bar " });
+
+// $ExpectType any
+data.get('hoge');
+
+// $ExpectError
+data['foo'];
+
 const value = Value.create({ data });
 
 const node: BlockJSON = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/data.js
`Data` is `Immutable.Map`, but not `Immutable.Record`.
Confusing this can make a problem especially when using slate with immutable@4, in which Record's type is more strictly defined.
