### PR TITLE
[react-scroll-rotate] Introduce type definitions

### DIFF
--- a/types/react-scroll-rotate/index.d.ts
+++ b/types/react-scroll-rotate/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for react-scroll-rotate 0.0
+// Project: https://github.com/giladk/react-scroll-rotate#readme
+// Definitions by: Alex Bukurov <https://github.com/abukurov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+
+export interface ScrollRotateProps {
+  target?: string;
+  throttle?: number;
+  from?: number;
+  to?: number;
+  method?: 'px' | 'prec';
+  loops?: number;
+  animationDuration?: number;
+  children: React.ReactNode;
+}
+
+export class ScrollRotate extends React.Component<ScrollRotateProps> {}

--- a/types/react-scroll-rotate/react-scroll-rotate-tests.tsx
+++ b/types/react-scroll-rotate/react-scroll-rotate-tests.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { ScrollRotate } from "react-scroll-rotate";
+
+const elements = [
+  <ScrollRotate>
+    <span>content</span>
+  </ScrollRotate>,
+  <ScrollRotate
+    target="target"
+    throttle={0.25}
+    from={0}
+    to={360}
+    method="prec"
+    loops={1}
+    animationDuration={0.25}
+  >
+    <span>content</span>
+  </ScrollRotate>
+];

--- a/types/react-scroll-rotate/tsconfig.json
+++ b/types/react-scroll-rotate/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "jsx": "react",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-scroll-rotate-tests.tsx"
+    ]
+}

--- a/types/react-scroll-rotate/tslint.json
+++ b/types/react-scroll-rotate/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.