### PR TITLE
3 more fixes for TS 3.7

### DIFF
--- a/types/lyricist/lyricist-tests.ts
+++ b/types/lyricist/lyricist-tests.ts
@@ -16,14 +16,14 @@ Promise
         lyricist.search('any_song'),
         lyricist.song(1, { fetchLyrics: true, textFormat: LyricistTextFormat.PLAIN }),
         lyricist.songsByArtist(1, { page: 1, perPage: 10, sort: 'asc' }),
-    ] as const)
+    ])
     .then((results) => {
         const album: Album = results[0];
         const artist: Artist = results[1];
         const artistByName: Artist = results[2];
         const searchResult: SearchResult[] = results[3];
         const song: Song = results[4];
-        const songsByArtist: SongByArtist[] = results[5];
+        const songsByArtist: SongByArtist[] = results[5] as SongByArtist[];
 
         console.log('album', album.name);
         console.log('artist', artist.name);

--- a/types/lyricist/lyricist-tests.ts
+++ b/types/lyricist/lyricist-tests.ts
@@ -16,7 +16,7 @@ Promise
         lyricist.search('any_song'),
         lyricist.song(1, { fetchLyrics: true, textFormat: LyricistTextFormat.PLAIN }),
         lyricist.songsByArtist(1, { page: 1, perPage: 10, sort: 'asc' }),
-    ])
+    ] as const)
     .then((results) => {
         const album: Album = results[0];
         const artist: Artist = results[1];

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -647,7 +647,7 @@ requestSubscription(
             const notification = !!rootField ? rootField.getLinkedRecord('notification') : null;
             // Add it to a connection
             const viewer = store.getRoot().getLinkedRecord('viewer');
-            const notifications = ConnectionHandler.getConnection(viewer!, 'notifications');
+            const notifications = ConnectionHandler.getConnection(viewer, 'notifications');
             const edge = ConnectionHandler.createEdge(
                 store,
                 notifications!,

--- a/types/react-sortable-tree/package.json
+++ b/types/react-sortable-tree/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "react-dnd": "5 || 6 || 7"
+    "react-dnd": "^9.3.1"
   }
 }


### PR DESCRIPTION
1. lyricist: patch tests until TS fixes Promise.all
2. react-relay: fix lint
3. react-sortable-tree: upgrade react-dnd dependency

The change to lyricist is just a workaround for now.

React-sortable-tree's upgrade is the same as other dependents of react-dnd that I did yesterday.