### PR TITLE
[@types/express-session] Fix incorrect type for Session.all(callback)

### DIFF
--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -95,7 +95,7 @@ declare namespace session {
     get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
     set: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
     destroy: (sid: string, callback?: (err?: any) => void) => void;
-    all: (callback: (err: any, obj?: { [sid: string]: Express.SessionData; } | null) => void) => void;
+    all: (callback: (err: any, obj?: Express.SessionData[] | null) => void) => void;
     length: (callback: (err: any, length?: number | null) => void) => void;
     clear: (callback?: (err?: any) => void) => void;
     touch: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -95,7 +95,7 @@ declare namespace session {
     get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
     set: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
     destroy: (sid: string, callback?: (err?: any) => void) => void;
-    all: (callback: (err: any, obj?: Express.SessionData[] | null) => void) => void;
+    all: (callback: (err: any, obj?: Express.SessionData[] | { [sid: string]: Express.SessionData; } | null) => void) => void;
     length: (callback: (err: any, length?: number | null) => void) => void;
     clear: (callback?: (err?: any) => void) => void;
     touch: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -95,9 +95,9 @@ declare namespace session {
     get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
     set: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
     destroy: (sid: string, callback?: (err?: any) => void) => void;
-    all: (callback: (err: any, obj?: Express.SessionData[] | { [sid: string]: Express.SessionData; } | null) => void) => void;
-    length: (callback: (err: any, length?: number | null) => void) => void;
-    clear: (callback?: (err?: any) => void) => void;
+    all?: (callback: (err: any, obj?: Express.SessionData[] | { [sid: string]: Express.SessionData; } | null) => void) => void;
+    length?: (callback: (err: any, length?: number | null) => void) => void;
+    clear?: (callback?: (err?: any) => void) => void;
     touch: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
   }
 }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/session/blob/master/README.md

According to https://github.com/expressjs/session/blob/master/README.md 

>`store.all(callback)`
>Optional
>
>This optional method is used to get all sessions in the store as an **array**. The callback should be called as `callback(error, sessions)`.