### PR TITLE
[@types/ember__routing] Add support for Route.render w/ default args

### DIFF
--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -125,8 +125,11 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * (indicated by an `{{outlet}}`). `render` is used both during the entry
      * phase of routing (via the `renderTemplate` hook) and later in response to
      * user interaction.
+     * Not all options need to be passed to render. Default values will be used
+     * based on the name of the route specified in the router or the Route's
+     * controllerName and templateName properties.
      */
-    render(name: string, options?: RenderOptions): void;
+    render(name?: string, options?: RenderOptions): void;
 
     /**
      * A hook you can use to render the template for the current route.

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -61,6 +61,14 @@ Route.extend({
 });
 
 Route.extend({
+    controllerName: 'photos',
+    templateName: 'anOutletName',
+    renderTemplate() {
+        this.render(); // Render using defaults
+    },
+});
+
+Route.extend({
     renderTemplate(controller: Controller, model: {}) {
         this.render('posts', {
             view: 'someView', // the template to render, referenced by name


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This fixes an issue about invalid number arguments when you need to call `Route.render` with no arguments for its default action. The current version header is `3.0.0` and this is in documentation from that version until the current as of writing this `3.1.13`. 

The documentation [1] for Router.render states:

> Not all options need to be passed to render. Default values will be used based on the name of the route specified in the router or the Route's `controllerName` and `templateName` properties.

[1] https://api.emberjs.com/ember/3.13/classes/Route/methods/render?anchor=render

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

