### PR TITLE
[node]: Add missing stream properties

### DIFF
--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1116,6 +1116,18 @@ import moduleModule = require('module');
     moduleModule.createRequireFromPath('./test')('test');
 }
 
+/////////////////////////////////////////////////////////
+/// stream tests : https://nodejs.org/api/stream.html ///
+/////////////////////////////////////////////////////////
+
+{
+    const writeStream = fs.createWriteStream('./index.d.ts');
+    const _wom = writeStream.writableObjectMode; // $ExpectType boolean
+
+    const readStream = fs.createReadStream('./index.d.ts');
+    const _rom = readStream.readableObjectMode; // $ExpectType boolean
+}
+
 ////////////////////////////////////////////////////
 /// Node.js ESNEXT Support
 ////////////////////////////////////////////////////

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -26,6 +26,7 @@ declare module "stream" {
             readable: boolean;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
+            readonly readableObjectMode: boolean;
             destroyed: boolean;
             constructor(opts?: ReadableOptions);
             _read(size: number): void;
@@ -120,6 +121,7 @@ declare module "stream" {
             readonly writableFinished: boolean;
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
+            readonly writableObjectMode: boolean;
             destroyed: boolean;
             constructor(opts?: WritableOptions);
             _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
@@ -220,6 +222,7 @@ declare module "stream" {
             readonly writableFinished: boolean;
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
+            readonly writableObjectMode: boolean;
             constructor(opts?: DuplexOptions);
             _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             _writev?(chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -72,6 +72,7 @@ declare namespace _Readable {
         readable: boolean;
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
+        readonly readableObjectMode: boolean;
         _readableState: ReadableState;
 
         _read(size?: number): void;

--- a/types/readable-stream/readable-stream-tests.ts
+++ b/types/readable-stream/readable-stream-tests.ts
@@ -89,6 +89,8 @@ function test() {
     assertType<boolean>(streamD.allowHalfOpen);
     assertType<boolean>(streamD.readable);
     assertType<boolean>(streamD.writable);
+    assertType<boolean>(streamD.readableObjectMode);
+    assertType<boolean>(streamD.writableObjectMode);
     streamD.pipe(streamW);
 
     rs.addListener("read", (...args: any[]) => console.log(args));


### PR DESCRIPTION
Fixes #38704 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://nodejs.org/api/stream.html#stream_writable_writableobjectmode
  - https://nodejs.org/api/stream.html#stream_readable_readableobjectmode
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
   - N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
  - N/A
