### PR TITLE
[react] support new lazy-loading <img> attribute

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1928,6 +1928,7 @@ declare namespace React {
         crossOrigin?: "anonymous" | "use-credentials" | "";
         decoding?: "async" | "auto" | "sync";
         height?: number | string;
+        loading?: "eager" | "lazy" | "auto";
         sizes?: string;
         src?: string;
         srcSet?: string;


### PR DESCRIPTION
I'm not sure what the policy for including draft HTML attributes is, but since it's supported by Chrome 77+ and someone opened an issue requesting it, I don't see a good reason why we shouldn't include it in the typings.

Closes #38755.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.chromestatus.com/feature/5645767347798016> is the Chrome documentation which links to the Editor's Draft W3C spec (whatwg/html#3752)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
