### PR TITLE
add type definitions for @ledgerhq/hw-transport-webusb

### DIFF
--- a/types/ledgerhq__hw-transport-webusb/index.d.ts
+++ b/types/ledgerhq__hw-transport-webusb/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for @ledgerhq/hw-transport-webusb 4.70
+// Project: https://github.com/LedgerHQ/ledgerjs/tree/master/packages/hw-transport-webusb, https://github.com/ledgerhq/ledgerjs
+// Definitions by: Joshua <https://github.com/questofiranon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+import Transport, { DescriptorEvent, Observer, Subscription } from '@ledgerhq/hw-transport';
+
+declare class TransportWebUSB extends Transport {
+    constructor(device: string);
+
+    static listen(observer: Observer<DescriptorEvent<string>>): Subscription;
+
+    static request(): Promise<TransportWebUSB>;
+    static openConnection(): Promise<TransportWebUSB>;
+
+    static open(device: string): Promise<TransportWebUSB>;
+}
+
+export default TransportWebUSB;

--- a/types/ledgerhq__hw-transport-webusb/ledgerhq__hw-transport-webusb-tests.ts
+++ b/types/ledgerhq__hw-transport-webusb/ledgerhq__hw-transport-webusb-tests.ts
@@ -1,0 +1,23 @@
+import TransportWebUSB from '@ledgerhq/hw-transport-webusb';
+
+// $ExpectType Promise<boolean>
+TransportWebUSB.isSupported();
+// $ExpectType Promise<ReadonlyArray<string>>
+TransportWebUSB.list();
+// $ExpectType Promise<TransportWebUSB>
+TransportWebUSB.request();
+// $ExpectType Promise<TransportWebUSB>
+TransportWebUSB.open('test');
+// $ExpectType Promise<TransportWebUSB>
+TransportWebUSB.openConnection();
+
+const test = TransportWebUSB.open('test').then(transport => {
+    // $ExpectType void
+    transport.setScrambleKey('BTC');
+
+    // $ExpectType Promise<Buffer>
+    transport.exchange(Buffer.from('test', 'hex'));
+
+    // $ExpectType Promise<void>
+    transport.close();
+});

--- a/types/ledgerhq__hw-transport-webusb/tsconfig.json
+++ b/types/ledgerhq__hw-transport-webusb/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ledgerhq/hw-transport": ["ledgerhq__hw-transport"],
+            "@ledgerhq/hw-transport-webusb": ["ledgerhq__hw-transport-webusb"]
+        }
+    },
+    "files": ["index.d.ts", "ledgerhq__hw-transport-webusb-tests.ts"]
+}

--- a/types/ledgerhq__hw-transport-webusb/tslint.json
+++ b/types/ledgerhq__hw-transport-webusb/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.