### PR TITLE
[node-openload] add type definitions

### DIFF
--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -161,38 +161,43 @@ export class Openload {
 
     constructor(config: OpenloadConfig);
 
+    // TypeScript Version: 3.6
     get config(): OpenloadConfig;
+
+    // TypeScript Version: 3.6
     set config(object: OpenloadConfig);
+
+    // TypeScript Version: 3.6
     get locationPrefix(): string;
 
-    public getAccountInfo(): Promise<AccountInfo>;
+    getAccountInfo(): Promise<AccountInfo>;
 
-    public getDownloadTicket(file: string): Promise<DownloadTicket>;
+    getDownloadTicket(file: string): Promise<DownloadTicket>;
 
-    public getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
+    getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
 
-    public getDownload(file: string): Promise<DownloadLink>;
+    getDownload(file: string): Promise<DownloadLink>;
 
-    public getFileInfo(file: string): Promise<FileInfo>;
+    getFileInfo(file: string): Promise<FileInfo>;
 
-    public deleteFile(file: string | string[]): Promise<[boolean]>;
+    deleteFile(file: string | string[]): Promise<[boolean]>;
 
-    public listFolder(folder: string): Promise<ListFolder>;
+    listFolder(folder: string): Promise<ListFolder>;
 
-    public getFolder(folder: string): Promise<ListFolder>;
+    getFolder(folder: string): Promise<ListFolder>;
 
-    public remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
+    remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
 
-    public remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
+    remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
 
-    public upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
+    upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
 
-    public getSplashImage(file: string): Promise<string>;
+    getSplashImage(file: string): Promise<string>;
 }
 
 /**
  * Exports a Singleton of the Openload class by default
- * @param config {OpenloadConfig} The base config containing the user credentials
- * @returns {Openload} An Openload singleton
+ * @param config The base config containing the user credentials
+ * @returns An Openload singleton
  */
-export default function openload(config: OpenloadConfig): Openload;
+export default function(config: OpenloadConfig): Openload;

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -165,104 +165,29 @@ declare class Openload {
     set config(object: IOpenloadConfig);
     get locationPrefix(): string;
 
-    public getAccountInfo(): Promise<{
-        status: number;
-        msg: string;
-        result: IAccountInfo;
-    }>;
+    public getAccountInfo(): Promise<IAccountInfo>;
 
-    public getDownloadTicket(
-        file: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IDownloadTicket;
-    }>;
+    public getDownloadTicket(file: string): Promise<IDownloadTicket>;
 
-    public getDownloadLink(
-        obj: IDownloadLinkParam,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IDownloadLink;
-    }>;
+    public getDownloadLink(obj: IDownloadLinkParam): Promise<IDownloadLink>;
 
-    public getDownload(
-        file: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IDownloadTicket;
-    }>;
+    public getDownload(file: string): Promise<IDownloadLink>;
 
-    public getFileInfo(
-        file: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IFileInfo;
-    }>;
+    public getFileInfo(file: string): Promise<IFileInfo>;
 
-    public deleteFile(
-        file: string | string[],
-    ): Promise<
-        [
-            {
-                status: number;
-                msg: string;
-                result: boolean;
-            },
-        ]
-    >;
+    public deleteFile(file: string | string[]): Promise<[boolean]>;
 
-    public listFolder(
-        folder: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IListFolder;
-    }>;
+    public listFolder(folder: string): Promise<IListFolder>;
 
-    public getFolder(
-        folder: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IListFolder;
-    }>;
+    public getFolder(folder: string): Promise<IListFolder>;
 
-    public remoteUpload(
-        obj: IRemoteUploadParam,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IRemoteUpload;
-    }>;
+    public remoteUpload(obj: IRemoteUploadParam): Promise<IRemoteUpload>;
 
-    public remoteUploadStatus(
-        obj: IRemoteUploadStatusParam,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IRemoteUploadStatus;
-    }>;
+    public remoteUploadStatus(obj: IRemoteUploadStatusParam): Promise<IRemoteUploadStatus>;
 
-    public upload(
-        obj: IUploadParam,
-        cb: (progress: IUploadProgress) => void,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: IUpload;
-    }>;
+    public upload(obj: IUploadParam, cb: (progress: IUploadProgress) => void): Promise<IUpload>;
 
-    public getSplashImage(
-        file: string,
-    ): Promise<{
-        status: number;
-        msg: string;
-        result: string;
-    }>;
+    public getSplashImage(file: string): Promise<string>;
 }
 
 /**

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -3,37 +3,271 @@
 // Definitions by: Sascha Zarhuber <https://github.com/saschazar21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
+/**
+ * The model for the base config object needed for the Openload constructor
  */
-export as namespace myLib;
+interface IOpenloadConfig {
+    /* the api_key, available directly from the WebUI after successful login */
+    api_key: string;
+    /* the api_login, a string available from the WebUI, NOT the user's e-mail */
+    api_login: string;
+    /* the api_version to target, needed for forming the URL, by default 1 */
+    api_version?: number;
+}
 
-/*~ If this module has methods, declare them as functions like so.
+/**
+ * The account info response
  */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+interface IAccountInfo {
+    extid: string;
+    email: string;
+    signup_at: string;
+    storage_left: number;
+    storage_used: string;
+    traffic: {
+        left: number;
+        used_24h: number;
+    };
+    balance: number;
+}
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
+interface IDownloadTicket {
+    ticket: string;
+    captcha_url: string;
+    captcha_w: number;
+    captcha_h: number;
+    wait_time: number;
+    valid_until: string;
+}
+
+interface IDownloadLink {
     name: string;
-    length: number;
-    extras?: string[];
+    size: number;
+    sha1: string;
+    content_type: string;
+    upload_at: string;
+    url: string;
+    token: string;
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
+interface IDownloadLinkParam {
+    file: string;
+    ticket: string;
+    captcha_response: string;
+}
 
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
+interface IFileInfo {
+    [key: string]: {
+        id: string;
+        status: number;
+        name: string;
+        size: number;
+        sha1: string;
+        content_type: string;
+    };
+}
+
+interface IUpload {
+    url: string;
+    valid_until: string;
+}
+
+interface IUploadParam {
+    file: string | ArrayBuffer;
+    folder?: string;
+    filename?: string;
+    contentType?: string;
+}
+
+interface IRemoteUpload {
+    id: string;
+    folderid: string;
+}
+
+interface IRemoteUploadParam {
+    url: string;
+    folder?: string;
+    headers?: string;
+}
+
+interface IRemoteUploadStatus {
+    [key: number]: {
+        id: number;
+        remoteurl: string;
+        status: string;
+        bytes_loaded: string;
+        bytes_total: string;
+        folderid: string;
+        added: string;
+        last_update: string;
+        extid: string | boolean;
+        url: string | boolean;
+    };
+}
+
+interface IRemoteUploadStatusParam {
+    limit?: number;
+    id?: string;
+}
+
+interface IListFolder {
+    folders: [
+        {
+            id: string;
+            name: string;
+        },
+    ];
+    files: [
+        {
+            name: string;
+            sha1: string;
+            folderid: string;
+            upload_at: string;
+            status: string;
+            size: string;
+            content_type: string;
+            download_count: string;
+            cstatus: string;
+            link: string;
+            linkextid: string;
+        },
+    ];
+}
+
+interface IRunningFileConverts {
+    name: string;
+    id: string;
+    status: string;
+    last_update: string;
+    progress: number;
+    retries: string;
+    link: string;
+    linkextid: string;
+}
+
+interface IUploadProgress {
+    percent: number;
+    transferred: number;
+    total: number;
+}
+
+/**
+ * The Openload base class, contains all the supported endpoints as member functions
  */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
+declare class Openload {
+    private _version: number;
+    private _locationPrefix: string;
+    private _config: IOpenloadConfig;
+
+    constructor(config: IOpenloadConfig);
+
+    get config(): IOpenloadConfig;
+    set config(object: IOpenloadConfig);
+    get locationPrefix(): string;
+
+    public getAccountInfo(): Promise<{
+        status: number;
+        msg: string;
+        result: IAccountInfo;
+    }>;
+
+    public getDownloadTicket(
+        file: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IDownloadTicket;
+    }>;
+
+    public getDownloadLink(
+        obj: IDownloadLinkParam,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IDownloadLink;
+    }>;
+
+    public getDownload(
+        file: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IDownloadTicket;
+    }>;
+
+    public getFileInfo(
+        file: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IFileInfo;
+    }>;
+
+    public deleteFile(
+        file: string | string[],
+    ): Promise<
+        [
+            {
+                status: number;
+                msg: string;
+                result: boolean;
+            },
+        ]
+    >;
+
+    public listFolder(
+        folder: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IListFolder;
+    }>;
+
+    public getFolder(
+        folder: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IListFolder;
+    }>;
+
+    public remoteUpload(
+        obj: IRemoteUploadParam,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IRemoteUpload;
+    }>;
+
+    public remoteUploadStatus(
+        obj: IRemoteUploadStatusParam,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IRemoteUploadStatus;
+    }>;
+
+    public upload(
+        obj: IUploadParam,
+        cb: (progress: IUploadProgress) => void,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: IUpload;
+    }>;
+
+    public getSplashImage(
+        file: string,
+    ): Promise<{
+        status: number;
+        msg: string;
+        result: string;
+    }>;
 }
+
+/**
+ * Exports a Singleton of the Openload class by default
+ * @param config {OpenloadConfig} The base config containing the user credentials
+ * @returns {Openload} An Openload singleton
+ */
+export default function openload(config: IOpenloadConfig): Openload;

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -3,196 +3,199 @@
 // Definitions by: Sascha Zarhuber <https://github.com/saschazar21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * The model for the base config object needed for the Openload constructor
- */
-export interface OpenloadConfig {
-    /* the api_key, available directly from the WebUI after successful login */
-    api_key: string;
-    /* the api_login, a string available from the WebUI, NOT the user's e-mail */
-    api_login: string;
-    /* the api_version to target, needed for forming the URL, by default 1 */
-    api_version?: number;
-}
+declare namespace Openload {
+    /**
+     * The model for the base config object needed for the Openload constructor
+     */
+    interface OpenloadConfig {
+        /* the api_key, available directly from the WebUI after successful login */
+        api_key: string;
+        /* the api_login, a string available from the WebUI, NOT the user's e-mail */
+        api_login: string;
+        /* the api_version to target, needed for forming the URL, by default 1 */
+        api_version?: number;
+    }
 
-/**
- * The account info response
- */
-export interface AccountInfo {
-    extid: string;
-    email: string;
-    signup_at: string;
-    storage_left: number;
-    storage_used: string;
-    traffic: {
-        left: number;
-        used_24h: number;
-    };
-    balance: number;
-}
+    /**
+     * The account info response
+     */
+    interface AccountInfo {
+        extid: string;
+        email: string;
+        signup_at: string;
+        storage_left: number;
+        storage_used: string;
+        traffic: {
+            left: number;
+            used_24h: number;
+        };
+        balance: number;
+    }
 
-export interface DownloadTicket {
-    ticket: string;
-    captcha_url: string;
-    captcha_w: number;
-    captcha_h: number;
-    wait_time: number;
-    valid_until: string;
-}
+    interface DownloadTicket {
+        ticket: string;
+        captcha_url: string;
+        captcha_w: number;
+        captcha_h: number;
+        wait_time: number;
+        valid_until: string;
+    }
 
-export interface DownloadLink {
-    name: string;
-    size: number;
-    sha1: string;
-    content_type: string;
-    upload_at: string;
-    url: string;
-    token: string;
-}
-
-export interface DownloadLinkParam {
-    file: string;
-    ticket: string;
-    captcha_response: string;
-}
-
-export interface FileInfo {
-    [key: string]: {
-        id: string;
-        status: number;
+    interface DownloadLink {
         name: string;
         size: number;
         sha1: string;
         content_type: string;
-    };
-}
+        upload_at: string;
+        url: string;
+        token: string;
+    }
 
-export interface Upload {
-    url: string;
-    valid_until: string;
-}
+    interface DownloadLinkParam {
+        file: string;
+        ticket: string;
+        captcha_response: string;
+    }
 
-export interface UploadParam {
-    file: string | ArrayBuffer;
-    folder?: string;
-    filename?: string;
-    contentType?: string;
-}
-
-export interface RemoteUpload {
-    id: string;
-    folderid: string;
-}
-
-export interface RemoteUploadParam {
-    url: string;
-    folder?: string;
-    headers?: string;
-}
-
-export interface RemoteUploadStatus {
-    [key: number]: {
-        id: number;
-        remoteurl: string;
-        status: string;
-        bytes_loaded: string;
-        bytes_total: string;
-        folderid: string;
-        added: string;
-        last_update: string;
-        extid: string | boolean;
-        url: string | boolean;
-    };
-}
-
-export interface RemoteUploadStatusParam {
-    limit?: number;
-    id?: string;
-}
-
-export interface ListFolder {
-    folders: [
-        {
+    interface FileInfo {
+        [key: string]: {
             id: string;
+            status: number;
             name: string;
-        },
-    ];
-    files: [
-        {
-            name: string;
+            size: number;
             sha1: string;
-            folderid: string;
-            upload_at: string;
-            status: string;
-            size: string;
             content_type: string;
-            download_count: string;
-            cstatus: string;
-            link: string;
-            linkextid: string;
-        },
-    ];
-}
+        };
+    }
 
-export interface RunningFileConverts {
-    name: string;
-    id: string;
-    status: string;
-    last_update: string;
-    progress: number;
-    retries: string;
-    link: string;
-    linkextid: string;
-}
+    interface Upload {
+        url: string;
+        valid_until: string;
+    }
 
-export interface UploadProgress {
-    percent: number;
-    transferred: number;
-    total: number;
-}
+    interface UploadParam {
+        file: string | ArrayBuffer;
+        folder?: string;
+        filename?: string;
+        contentType?: string;
+    }
 
-/**
- * The Openload base class, contains all the supported endpoints as member functions
- */
-export class Openload {
-    private _version: number;
-    private _locationPrefix: string;
-    private _config: OpenloadConfig;
+    interface RemoteUpload {
+        id: string;
+        folderid: string;
+    }
 
-    constructor(config: OpenloadConfig);
+    interface RemoteUploadParam {
+        url: string;
+        folder?: string;
+        headers?: string;
+    }
 
-    // TypeScript Version: 3.6
-    get config(): OpenloadConfig;
+    interface RemoteUploadStatus {
+        [key: number]: {
+            id: number;
+            remoteurl: string;
+            status: string;
+            bytes_loaded: string;
+            bytes_total: string;
+            folderid: string;
+            added: string;
+            last_update: string;
+            extid: string | boolean;
+            url: string | boolean;
+        };
+    }
 
-    // TypeScript Version: 3.6
-    set config(object: OpenloadConfig);
+    interface RemoteUploadStatusParam {
+        limit?: number;
+        id?: string;
+    }
 
-    // TypeScript Version: 3.6
-    get locationPrefix(): string;
+    interface ListFolder {
+        folders: [
+            {
+                id: string;
+                name: string;
+            },
+        ];
+        files: [
+            {
+                name: string;
+                sha1: string;
+                folderid: string;
+                upload_at: string;
+                status: string;
+                size: string;
+                content_type: string;
+                download_count: string;
+                cstatus: string;
+                link: string;
+                linkextid: string;
+            },
+        ];
+    }
 
-    getAccountInfo(): Promise<AccountInfo>;
+    interface RunningFileConverts {
+        name: string;
+        id: string;
+        status: string;
+        last_update: string;
+        progress: number;
+        retries: string;
+        link: string;
+        linkextid: string;
+    }
 
-    getDownloadTicket(file: string): Promise<DownloadTicket>;
+    interface UploadProgress {
+        percent: number;
+        transferred: number;
+        total: number;
+    }
 
-    getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
+    /**
+     * The Openload base class, contains all the supported endpoints as member functions
+     */
+    class Openload {
+        private _version: number;
+        private _locationPrefix: string;
+        private _config: OpenloadConfig;
 
-    getDownload(file: string): Promise<DownloadLink>;
+        constructor(config: OpenloadConfig);
 
-    getFileInfo(file: string): Promise<FileInfo>;
+        // TypeScript Version: 3.6
+        get config(): OpenloadConfig;
 
-    deleteFile(file: string | string[]): Promise<[boolean]>;
+        // TypeScript Version: 3.6
+        set config(object: OpenloadConfig);
 
-    listFolder(folder: string): Promise<ListFolder>;
+        // TypeScript Version: 3.6
+        get locationPrefix(): string;
 
-    getFolder(folder: string): Promise<ListFolder>;
+        getAccountInfo(): Promise<AccountInfo>;
 
-    remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
+        getDownloadTicket(file: string): Promise<DownloadTicket>;
 
-    remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
+        getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
 
-    upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
+        getDownload(file: string): Promise<DownloadLink>;
 
-    getSplashImage(file: string): Promise<string>;
+        getFileInfo(file: string): Promise<FileInfo>;
+
+        deleteFile(file: string | string[]): Promise<[boolean]>;
+
+        listFolder(folder: string): Promise<ListFolder>;
+
+        getFolder(folder: string): Promise<ListFolder>;
+
+        remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
+
+        remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
+
+        upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
+
+        getSplashImage(file: string): Promise<string>;
+    }
+    export function openload(config: OpenloadConfig): Openload;
 }
 
 /**
@@ -200,4 +203,4 @@ export class Openload {
  * @param config The base config containing the user credentials
  * @returns An Openload singleton
  */
-export function openload(config: OpenloadConfig): Openload;
+export = Openload;

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -200,4 +200,4 @@ export class Openload {
  * @param config The base config containing the user credentials
  * @returns An Openload singleton
  */
-export default function(config: OpenloadConfig): Openload;
+export function openload(config: OpenloadConfig): Openload;

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for node-openload 2.2
+// Project: https://github.com/saschazar21/node-openload#readme
+// Definitions by: Sascha Zarhuber <https://github.com/saschazar21>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -3,199 +3,196 @@
 // Definitions by: Sascha Zarhuber <https://github.com/saschazar21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Openload {
-    /**
-     * The model for the base config object needed for the Openload constructor
-     */
-    interface OpenloadConfig {
-        /* the api_key, available directly from the WebUI after successful login */
-        api_key: string;
-        /* the api_login, a string available from the WebUI, NOT the user's e-mail */
-        api_login: string;
-        /* the api_version to target, needed for forming the URL, by default 1 */
-        api_version?: number;
-    }
+/**
+ * The model for the base config object needed for the Openload constructor
+ */
+interface OpenloadConfig {
+    /* the api_key, available directly from the WebUI after successful login */
+    api_key: string;
+    /* the api_login, a string available from the WebUI, NOT the user's e-mail */
+    api_login: string;
+    /* the api_version to target, needed for forming the URL, by default 1 */
+    api_version?: number;
+}
 
-    /**
-     * The account info response
-     */
-    interface AccountInfo {
-        extid: string;
-        email: string;
-        signup_at: string;
-        storage_left: number;
-        storage_used: string;
-        traffic: {
-            left: number;
-            used_24h: number;
-        };
-        balance: number;
-    }
+/**
+ * The account info response
+ */
+interface AccountInfo {
+    extid: string;
+    email: string;
+    signup_at: string;
+    storage_left: number;
+    storage_used: string;
+    traffic: {
+        left: number;
+        used_24h: number;
+    };
+    balance: number;
+}
 
-    interface DownloadTicket {
-        ticket: string;
-        captcha_url: string;
-        captcha_w: number;
-        captcha_h: number;
-        wait_time: number;
-        valid_until: string;
-    }
+interface DownloadTicket {
+    ticket: string;
+    captcha_url: string;
+    captcha_w: number;
+    captcha_h: number;
+    wait_time: number;
+    valid_until: string;
+}
 
-    interface DownloadLink {
+interface DownloadLink {
+    name: string;
+    size: number;
+    sha1: string;
+    content_type: string;
+    upload_at: string;
+    url: string;
+    token: string;
+}
+
+interface DownloadLinkParam {
+    file: string;
+    ticket: string;
+    captcha_response: string;
+}
+
+interface FileInfo {
+    [key: string]: {
+        id: string;
+        status: number;
         name: string;
         size: number;
         sha1: string;
         content_type: string;
-        upload_at: string;
-        url: string;
-        token: string;
-    }
+    };
+}
 
-    interface DownloadLinkParam {
-        file: string;
-        ticket: string;
-        captcha_response: string;
-    }
+interface Upload {
+    url: string;
+    valid_until: string;
+}
 
-    interface FileInfo {
-        [key: string]: {
-            id: string;
-            status: number;
-            name: string;
-            size: number;
-            sha1: string;
-            content_type: string;
-        };
-    }
+interface UploadParam {
+    file: string | ArrayBuffer;
+    folder?: string;
+    filename?: string;
+    contentType?: string;
+}
 
-    interface Upload {
-        url: string;
-        valid_until: string;
-    }
+interface RemoteUpload {
+    id: string;
+    folderid: string;
+}
 
-    interface UploadParam {
-        file: string | ArrayBuffer;
-        folder?: string;
-        filename?: string;
-        contentType?: string;
-    }
+interface RemoteUploadParam {
+    url: string;
+    folder?: string;
+    headers?: string;
+}
 
-    interface RemoteUpload {
-        id: string;
-        folderid: string;
-    }
-
-    interface RemoteUploadParam {
-        url: string;
-        folder?: string;
-        headers?: string;
-    }
-
-    interface RemoteUploadStatus {
-        [key: number]: {
-            id: number;
-            remoteurl: string;
-            status: string;
-            bytes_loaded: string;
-            bytes_total: string;
-            folderid: string;
-            added: string;
-            last_update: string;
-            extid: string | boolean;
-            url: string | boolean;
-        };
-    }
-
-    interface RemoteUploadStatusParam {
-        limit?: number;
-        id?: string;
-    }
-
-    interface ListFolder {
-        folders: [
-            {
-                id: string;
-                name: string;
-            },
-        ];
-        files: [
-            {
-                name: string;
-                sha1: string;
-                folderid: string;
-                upload_at: string;
-                status: string;
-                size: string;
-                content_type: string;
-                download_count: string;
-                cstatus: string;
-                link: string;
-                linkextid: string;
-            },
-        ];
-    }
-
-    interface RunningFileConverts {
-        name: string;
-        id: string;
+interface RemoteUploadStatus {
+    [key: number]: {
+        id: number;
+        remoteurl: string;
         status: string;
+        bytes_loaded: string;
+        bytes_total: string;
+        folderid: string;
+        added: string;
         last_update: string;
-        progress: number;
-        retries: string;
-        link: string;
-        linkextid: string;
-    }
+        extid: string | boolean;
+        url: string | boolean;
+    };
+}
 
-    interface UploadProgress {
-        percent: number;
-        transferred: number;
-        total: number;
-    }
+interface RemoteUploadStatusParam {
+    limit?: number;
+    id?: string;
+}
 
-    /**
-     * The Openload base class, contains all the supported endpoints as member functions
-     */
-    class Openload {
-        private _version: number;
-        private _locationPrefix: string;
-        private _config: OpenloadConfig;
+interface ListFolder {
+    folders: [
+        {
+            id: string;
+            name: string;
+        },
+    ];
+    files: [
+        {
+            name: string;
+            sha1: string;
+            folderid: string;
+            upload_at: string;
+            status: string;
+            size: string;
+            content_type: string;
+            download_count: string;
+            cstatus: string;
+            link: string;
+            linkextid: string;
+        },
+    ];
+}
 
-        constructor(config: OpenloadConfig);
+interface RunningFileConverts {
+    name: string;
+    id: string;
+    status: string;
+    last_update: string;
+    progress: number;
+    retries: string;
+    link: string;
+    linkextid: string;
+}
 
-        // TypeScript Version: 3.6
-        get config(): OpenloadConfig;
+interface UploadProgress {
+    percent: number;
+    transferred: number;
+    total: number;
+}
 
-        // TypeScript Version: 3.6
-        set config(object: OpenloadConfig);
+/**
+ * The Openload base class, contains all the supported endpoints as member functions
+ */
+declare class Openload {
+    private _version: number;
+    private _locationPrefix: string;
+    private _config: OpenloadConfig;
 
-        // TypeScript Version: 3.6
-        get locationPrefix(): string;
+    constructor(config: OpenloadConfig);
 
-        getAccountInfo(): Promise<AccountInfo>;
+    // TypeScript Version: 3.6
+    get config(): OpenloadConfig;
 
-        getDownloadTicket(file: string): Promise<DownloadTicket>;
+    // TypeScript Version: 3.6
+    set config(object: OpenloadConfig);
 
-        getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
+    // TypeScript Version: 3.6
+    get locationPrefix(): string;
 
-        getDownload(file: string): Promise<DownloadLink>;
+    getAccountInfo(): Promise<AccountInfo>;
 
-        getFileInfo(file: string): Promise<FileInfo>;
+    getDownloadTicket(file: string): Promise<DownloadTicket>;
 
-        deleteFile(file: string | string[]): Promise<[boolean]>;
+    getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
 
-        listFolder(folder: string): Promise<ListFolder>;
+    getDownload(file: string): Promise<DownloadLink>;
 
-        getFolder(folder: string): Promise<ListFolder>;
+    getFileInfo(file: string): Promise<FileInfo>;
 
-        remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
+    deleteFile(file: string | string[]): Promise<[boolean]>;
 
-        remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
+    listFolder(folder: string): Promise<ListFolder>;
 
-        upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
+    getFolder(folder: string): Promise<ListFolder>;
 
-        getSplashImage(file: string): Promise<string>;
-    }
-    export function openload(config: OpenloadConfig): Openload;
+    remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
+
+    remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
+
+    upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
+
+    getSplashImage(file: string): Promise<string>;
 }
 
 /**
@@ -203,4 +200,5 @@ declare namespace Openload {
  * @param config The base config containing the user credentials
  * @returns An Openload singleton
  */
-export = Openload;
+declare function openload(config: OpenloadConfig): Openload;
+export = openload;

--- a/types/node-openload/index.d.ts
+++ b/types/node-openload/index.d.ts
@@ -6,7 +6,7 @@
 /**
  * The model for the base config object needed for the Openload constructor
  */
-interface IOpenloadConfig {
+export interface OpenloadConfig {
     /* the api_key, available directly from the WebUI after successful login */
     api_key: string;
     /* the api_login, a string available from the WebUI, NOT the user's e-mail */
@@ -18,7 +18,7 @@ interface IOpenloadConfig {
 /**
  * The account info response
  */
-interface IAccountInfo {
+export interface AccountInfo {
     extid: string;
     email: string;
     signup_at: string;
@@ -31,7 +31,7 @@ interface IAccountInfo {
     balance: number;
 }
 
-interface IDownloadTicket {
+export interface DownloadTicket {
     ticket: string;
     captcha_url: string;
     captcha_w: number;
@@ -40,7 +40,7 @@ interface IDownloadTicket {
     valid_until: string;
 }
 
-interface IDownloadLink {
+export interface DownloadLink {
     name: string;
     size: number;
     sha1: string;
@@ -50,13 +50,13 @@ interface IDownloadLink {
     token: string;
 }
 
-interface IDownloadLinkParam {
+export interface DownloadLinkParam {
     file: string;
     ticket: string;
     captcha_response: string;
 }
 
-interface IFileInfo {
+export interface FileInfo {
     [key: string]: {
         id: string;
         status: number;
@@ -67,30 +67,30 @@ interface IFileInfo {
     };
 }
 
-interface IUpload {
+export interface Upload {
     url: string;
     valid_until: string;
 }
 
-interface IUploadParam {
+export interface UploadParam {
     file: string | ArrayBuffer;
     folder?: string;
     filename?: string;
     contentType?: string;
 }
 
-interface IRemoteUpload {
+export interface RemoteUpload {
     id: string;
     folderid: string;
 }
 
-interface IRemoteUploadParam {
+export interface RemoteUploadParam {
     url: string;
     folder?: string;
     headers?: string;
 }
 
-interface IRemoteUploadStatus {
+export interface RemoteUploadStatus {
     [key: number]: {
         id: number;
         remoteurl: string;
@@ -105,12 +105,12 @@ interface IRemoteUploadStatus {
     };
 }
 
-interface IRemoteUploadStatusParam {
+export interface RemoteUploadStatusParam {
     limit?: number;
     id?: string;
 }
 
-interface IListFolder {
+export interface ListFolder {
     folders: [
         {
             id: string;
@@ -134,7 +134,7 @@ interface IListFolder {
     ];
 }
 
-interface IRunningFileConverts {
+export interface RunningFileConverts {
     name: string;
     id: string;
     status: string;
@@ -145,7 +145,7 @@ interface IRunningFileConverts {
     linkextid: string;
 }
 
-interface IUploadProgress {
+export interface UploadProgress {
     percent: number;
     transferred: number;
     total: number;
@@ -154,38 +154,38 @@ interface IUploadProgress {
 /**
  * The Openload base class, contains all the supported endpoints as member functions
  */
-declare class Openload {
+export class Openload {
     private _version: number;
     private _locationPrefix: string;
-    private _config: IOpenloadConfig;
+    private _config: OpenloadConfig;
 
-    constructor(config: IOpenloadConfig);
+    constructor(config: OpenloadConfig);
 
-    get config(): IOpenloadConfig;
-    set config(object: IOpenloadConfig);
+    get config(): OpenloadConfig;
+    set config(object: OpenloadConfig);
     get locationPrefix(): string;
 
-    public getAccountInfo(): Promise<IAccountInfo>;
+    public getAccountInfo(): Promise<AccountInfo>;
 
-    public getDownloadTicket(file: string): Promise<IDownloadTicket>;
+    public getDownloadTicket(file: string): Promise<DownloadTicket>;
 
-    public getDownloadLink(obj: IDownloadLinkParam): Promise<IDownloadLink>;
+    public getDownloadLink(obj: DownloadLinkParam): Promise<DownloadLink>;
 
-    public getDownload(file: string): Promise<IDownloadLink>;
+    public getDownload(file: string): Promise<DownloadLink>;
 
-    public getFileInfo(file: string): Promise<IFileInfo>;
+    public getFileInfo(file: string): Promise<FileInfo>;
 
     public deleteFile(file: string | string[]): Promise<[boolean]>;
 
-    public listFolder(folder: string): Promise<IListFolder>;
+    public listFolder(folder: string): Promise<ListFolder>;
 
-    public getFolder(folder: string): Promise<IListFolder>;
+    public getFolder(folder: string): Promise<ListFolder>;
 
-    public remoteUpload(obj: IRemoteUploadParam): Promise<IRemoteUpload>;
+    public remoteUpload(obj: RemoteUploadParam): Promise<RemoteUpload>;
 
-    public remoteUploadStatus(obj: IRemoteUploadStatusParam): Promise<IRemoteUploadStatus>;
+    public remoteUploadStatus(obj: RemoteUploadStatusParam): Promise<RemoteUploadStatus>;
 
-    public upload(obj: IUploadParam, cb: (progress: IUploadProgress) => void): Promise<IUpload>;
+    public upload(obj: UploadParam, cb: (progress: UploadProgress) => void): Promise<Upload>;
 
     public getSplashImage(file: string): Promise<string>;
 }
@@ -195,4 +195,4 @@ declare class Openload {
  * @param config {OpenloadConfig} The base config containing the user credentials
  * @returns {Openload} An Openload singleton
  */
-export default function openload(config: IOpenloadConfig): Openload;
+export default function openload(config: OpenloadConfig): Openload;

--- a/types/node-openload/node-openload-tests.ts
+++ b/types/node-openload/node-openload-tests.ts
@@ -1,0 +1,56 @@
+import openload, { IUploadProgress } from 'node-openload';
+
+const config = {
+    api_key: 'test-1234',
+    api_login: 'testlogin',
+};
+
+const ol = openload(config);
+
+ol.config;
+ol.config = config;
+ol.locationPrefix;
+
+ol.getAccountInfo().then(info => info.email);
+ol.getDownloadTicket('testfile-id')
+    .then(result => {
+        const { ticket } = result;
+
+        return ol.getDownloadLink({
+            captcha_response: 'arbitrary captcha response',
+            file: 'testfile-id',
+            ticket,
+        });
+    })
+    .then(result => result.url);
+
+ol.getDownload('testfile-id').then(result => result.url);
+
+ol.getFileInfo('testfile-id').then(result => result.content_type);
+
+ol.deleteFile('testfile-id, testfile_id2').then(result => result.length);
+
+ol.listFolder('testfolder').then(result => result.files);
+
+ol.getFolder('testfolder').then(result => result.folders);
+
+// Needed because remoteUploadStatus returns an object with integer keys
+// https://stackoverflow.com/a/52856805
+declare global {
+    interface ObjectConstructor {
+        numberKeys<T>(o: T): Array<keyof T>;
+    }
+}
+Object.numberKeys = Object.keys as any;
+ol.remoteUpload({ url: 'https://someurl.com/to/image.jpg' })
+    .then(result => {
+        const { id } = result;
+
+        return ol.remoteUploadStatus({ id });
+    })
+    .then(result => Object.numberKeys(result).map(key => result[key].remoteurl));
+
+const cb = (progress: IUploadProgress) => progress.percent;
+ol.upload({ file: './file.txt/' }, cb).then(result => result.url);
+
+ol.getSplashImage('testfile-id').then(imgUrl => imgUrl);

--- a/types/node-openload/node-openload-tests.ts
+++ b/types/node-openload/node-openload-tests.ts
@@ -1,4 +1,4 @@
-import { openload, UploadProgress } from 'node-openload';
+import openload = require('node-openload');
 
 const config = {
     api_key: 'test-1234',
@@ -50,7 +50,7 @@ ol.remoteUpload({ url: 'https://someurl.com/to/image.jpg' })
     })
     .then(result => Object.numberKeys(result).map(key => result[key].remoteurl));
 
-const cb = (progress: UploadProgress) => progress.percent;
+const cb = (progress: { percent: number; transferred: number; total: number }) => progress.percent;
 ol.upload({ file: './file.txt/' }, cb).then(result => result.url);
 
 ol.getSplashImage('testfile-id').then(imgUrl => imgUrl);

--- a/types/node-openload/node-openload-tests.ts
+++ b/types/node-openload/node-openload-tests.ts
@@ -1,4 +1,4 @@
-import openload, { UploadProgress } from 'node-openload';
+import { openload, UploadProgress } from 'node-openload';
 
 const config = {
     api_key: 'test-1234',

--- a/types/node-openload/node-openload-tests.ts
+++ b/types/node-openload/node-openload-tests.ts
@@ -1,4 +1,4 @@
-import openload, { IUploadProgress } from 'node-openload';
+import openload, { UploadProgress } from 'node-openload';
 
 const config = {
     api_key: 'test-1234',
@@ -50,7 +50,7 @@ ol.remoteUpload({ url: 'https://someurl.com/to/image.jpg' })
     })
     .then(result => Object.numberKeys(result).map(key => result[key].remoteurl));
 
-const cb = (progress: IUploadProgress) => progress.percent;
+const cb = (progress: UploadProgress) => progress.percent;
 ol.upload({ file: './file.txt/' }, cb).then(result => result.url);
 
 ol.getSplashImage('testfile-id').then(imgUrl => imgUrl);

--- a/types/node-openload/tsconfig.json
+++ b/types/node-openload/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-openload-tests.ts"
+    ]
+}

--- a/types/node-openload/tslint.json
+++ b/types/node-openload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
