### PR TITLE
[pdfmake] use const enums for PageSize and PageOrientation

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -24,7 +24,7 @@ declare module "pdfmake/build/pdfmake" {
         vfs?: any
     ): TCreatedPdf;
 
-    enum PageSize {
+    const enum PageSize {
         A0_x_4 = "4A0",
         A0_x_2 = "2A0",
         AO = "A0",
@@ -75,7 +75,7 @@ declare module "pdfmake/build/pdfmake" {
         TABLOID = "TABLOID"
     }
 
-    enum PageOrientation {
+    const enum PageOrientation {
         PORTRAIT = "PORTRAIT",
         LANDSCAPE = "LANDSCAPE"
     }


### PR DESCRIPTION
Hello! I updated pdfmake definitions for PageSize and PageOrientation enums by making them constant. This way values of these enums (for example `PageSize.A4`) can be accessed at runtime.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pdfmake.github.io/docs/document-definition-object/page/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
