### PR TITLE
Add types for mock-req-res

### DIFF
--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -4,9 +4,6 @@
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="express" />
-/// <reference types="sinon" />
-
 import { Request, Response } from "express";
 import { SinonStub, SinonSpy } from "sinon";
 

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Request, Response } from "express";
-import { SinonStub, SinonSpy } from "sinon";
+import express = require('express');
+import sinon = require('sinon');
 
 declare namespace mockReqRes {
 	interface Dictionary<T> {
@@ -16,30 +16,30 @@ declare namespace mockReqRes {
 
 	type ResponsePayload = Dictionary<any>;
 
-	interface RequestOutput extends Request {
-		get: SinonStub;
+	interface RequestOutput extends express.Request {
+		get: sinon.SinonStub;
 	}
 
-	interface ResponseOutput extends Response {
-		cookie: SinonSpy;
-		clearCookie: SinonSpy;
-		download: SinonSpy;
-		format: SinonSpy;
-		getHeader: SinonSpy;
-		json: SinonSpy;
-		jsonp: SinonSpy;
-		send: SinonSpy;
-		sendFile: SinonSpy;
-		sendStatus: SinonSpy;
-		setHeader: SinonSpy;
-		redirect: SinonSpy;
-		render: SinonSpy;
-		end: SinonSpy;
-		set: SinonSpy;
-		type: SinonSpy;
-		get: SinonStub;
-		status: SinonStub;
-		vary: SinonStub;
+	interface ResponseOutput extends express.Response {
+		cookie: sinon.SinonSpy;
+		clearCookie: sinon.SinonSpy;
+		download: sinon.SinonSpy;
+		format: sinon.SinonSpy;
+		getHeader: sinon.SinonSpy;
+		json: sinon.SinonSpy;
+		jsonp: sinon.SinonSpy;
+		send: sinon.SinonSpy;
+		sendFile: sinon.SinonSpy;
+		sendStatus: sinon.SinonSpy;
+		setHeader: sinon.SinonSpy;
+		redirect: sinon.SinonSpy;
+		render: sinon.SinonSpy;
+		end: sinon.SinonSpy;
+		set: sinon.SinonSpy;
+		type: sinon.SinonSpy;
+		get: sinon.SinonStub;
+		status: sinon.SinonStub;
+		vary: sinon.SinonStub;
 	}
 
 	function mockRequest(options?: RequestPayload): RequestOutput;

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for mock-req-res 1.1
 // Project: https://github.com/davesag/mock-req-res#readme
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped // TypeScript Version: 3.1
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped // TypeScript Version: 3.6
 
 import { Request, Response } from 'express';
 import { SinonStub, SinonSpy } from 'sinon';

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for mock-req-res 1.1
 // Project: https://github.com/davesag/mock-req-res#readme
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped // TypeScript Version: 3.6
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 import { Request, Response } from 'express';
 import { SinonStub, SinonSpy } from 'sinon';

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -1,0 +1,53 @@
+
+// Type definitions for mock-req-res 1.1
+// Project: https://github.com/davesag/mock-req-res#readme
+// Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="express" />
+/// <reference types="sinon" />
+
+import { Request, Response } from "express";
+import { SinonStub, SinonSpy } from "sinon";
+
+declare namespace mockReqRes {
+	interface Dictionary<T> {
+		[key: string]: T;
+	}
+
+	type RequestPayload = Dictionary<any>;
+
+	type ResponsePayload = Dictionary<any>;
+
+	interface RequestOutput extends Request {
+		get: SinonStub;
+	}
+
+	interface ResponseOutput extends Response {
+		cookie: SinonSpy;
+		clearCookie: SinonSpy;
+		download: SinonSpy;
+		format: SinonSpy;
+		getHeader: SinonSpy;
+		json: SinonSpy;
+		jsonp: SinonSpy;
+		send: SinonSpy;
+		sendFile: SinonSpy;
+		sendStatus: SinonSpy;
+		setHeader: SinonSpy;
+		redirect: SinonSpy;
+		render: SinonSpy;
+		end: SinonSpy;
+		set: SinonSpy;
+		type: SinonSpy;
+		get: SinonStub;
+		status: SinonStub;
+		vary: SinonStub;
+	}
+
+	function mockRequest(options?: RequestPayload): RequestOutput;
+
+	function mockResponse(options?: ResponsePayload): ResponseOutput;
+}
+
+export = mockReqRes;

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -1,11 +1,10 @@
-
 // Type definitions for mock-req-res 1.1
 // Project: https://github.com/davesag/mock-req-res#readme
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped // TypeScript Version: 3.1
 
-import express = require('express');
-import sinon = require('sinon');
+import { Request, Response } from "express";
+import { SinonStub, SinonSpy } from "sinon";
 
 declare namespace mockReqRes {
 	interface Dictionary<T> {
@@ -16,35 +15,43 @@ declare namespace mockReqRes {
 
 	type ResponsePayload = Dictionary<any>;
 
-	interface RequestOutput extends express.Request {
-		get: sinon.SinonStub;
+	interface RequestOutput extends Request {
+		get: SinonStub;
 	}
 
-	interface ResponseOutput extends express.Response {
-		cookie: sinon.SinonSpy;
-		clearCookie: sinon.SinonSpy;
-		download: sinon.SinonSpy;
-		format: sinon.SinonSpy;
-		getHeader: sinon.SinonSpy;
-		json: sinon.SinonSpy;
-		jsonp: sinon.SinonSpy;
-		send: sinon.SinonSpy;
-		sendFile: sinon.SinonSpy;
-		sendStatus: sinon.SinonSpy;
-		setHeader: sinon.SinonSpy;
-		redirect: sinon.SinonSpy;
-		render: sinon.SinonSpy;
-		end: sinon.SinonSpy;
-		set: sinon.SinonSpy;
-		type: sinon.SinonSpy;
-		get: sinon.SinonStub;
-		status: sinon.SinonStub;
-		vary: sinon.SinonStub;
+	interface ResponseOutput extends Response {
+		cookie: SinonSpy;
+		clearCookie: SinonSpy;
+		download: SinonSpy;
+		format: SinonSpy;
+		getHeader: SinonSpy;
+		json: SinonSpy;
+		jsonp: SinonSpy;
+		send: SinonSpy;
+		sendFile: SinonSpy;
+		sendStatus: SinonSpy;
+		setHeader: SinonSpy;
+		redirect: SinonSpy;
+		render: SinonSpy;
+		end: SinonSpy;
+		set: SinonSpy;
+		type: SinonSpy;
+		get: SinonStub;
+		status: SinonStub;
+		vary: SinonStub;
 	}
 
 	function mockRequest(options?: RequestPayload): RequestOutput;
 
 	function mockResponse(options?: ResponsePayload): ResponseOutput;
+
+	interface Mock {
+		mockRequest(options?: RequestPayload): RequestOutput;
+
+		mockResponse(options?: ResponsePayload): ResponseOutput;
+	  }
 }
+
+declare function mockReqRes(): mockReqRes.Mock;
 
 export = mockReqRes;

--- a/types/mock-req-res/index.d.ts
+++ b/types/mock-req-res/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Sandor Turanszky <https://github.com/sandorTuranszky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped // TypeScript Version: 3.1
 
-import { Request, Response } from "express";
-import { SinonStub, SinonSpy } from "sinon";
+import { Request, Response } from 'express';
+import { SinonStub, SinonSpy } from 'sinon';
 
 declare namespace mockReqRes {
 	interface Dictionary<T> {

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -1,4 +1,4 @@
-import { Request, Response, RequestHandler } from "express";
+import { Request, Response, RequestHandler } from 'express';
 import { mockRequest, mockResponse } from "mock-req-res";
 
 const handler: RequestHandler = (req: Request, res: Response) => {

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -1,0 +1,24 @@
+import { RequestHandler, Request, Response } from "express";
+import { mockRequest, mockResponse } from "mock-req-res";
+
+const handler: RequestHandler = (req: Request, res: Response) => {
+	return res
+		.status(200)
+		.json(
+			`Hello from handler with an originalUrl value of '${req.originalUrl}'`,
+		);
+};
+
+const req = mockRequest({ originalUrl: "/" });
+const res = mockResponse();
+const next = () => {};
+
+handler(req, res, next); // OK
+
+// Argument of type '{}' is not assignable to parameter of type 'Request<Dictionary<string>>'. 
+// Type '{}' is missing the following properties from type 'Request<Dictionary<string>>': get, header, accepts, acceptsCharsets, and 72 more.t
+handler({}, res, next); // Error
+
+// Argument of type '{}' is not assignable to parameter of type 'Response'. 
+// Type '{}' is missing the following properties from type 'Response': status, sendStatus, links, send, and 74 more.
+handler(req, {}, next); // Error

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -2,11 +2,7 @@ import express = require('express');
 import { mockRequest, mockResponse } from "mock-req-res";
 
 const handler: express.RequestHandler = (req: express.Request, res: express.Response) => {
-	return res
-		.status(200)
-		.json(
-			`Hello from handler with an originalUrl value of '${req.originalUrl}'`,
-		);
+    return res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
 };
 
 const req = mockRequest({ originalUrl: "/" });

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -1,7 +1,7 @@
-import { RequestHandler, Request, Response } from "express";
+import express = require('express');
 import { mockRequest, mockResponse } from "mock-req-res";
 
-const handler: RequestHandler = (req: Request, res: Response) => {
+const handler: express.RequestHandler = (req: express.Request, res: express.Response) => {
 	return res
 		.status(200)
 		.json(
@@ -17,8 +17,8 @@ handler(req, res, next); // OK
 
 // Argument of type '{}' is not assignable to parameter of type 'Request<Dictionary<string>>'. 
 // Type '{}' is missing the following properties from type 'Request<Dictionary<string>>': get, header, accepts, acceptsCharsets, and 72 more.t
-handler({}, res, next); // Error
+// handler({}, res, next); // Error
 
 // Argument of type '{}' is not assignable to parameter of type 'Response'. 
 // Type '{}' is missing the following properties from type 'Response': status, sendStatus, links, send, and 74 more.
-handler(req, {}, next); // Error
+// handler(req, {}, next); // Error

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -1,7 +1,7 @@
-import express = require('express');
+import { Request, Response, RequestHandler } from "express";
 import { mockRequest, mockResponse } from "mock-req-res";
 
-const handler: express.RequestHandler = (req: express.Request, res: express.Response) => {
+const handler: RequestHandler = (req: Request, res: Response) => {
     return res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
 };
 
@@ -11,10 +11,10 @@ const next = () => {};
 
 handler(req, res, next); // OK
 
-// Argument of type '{}' is not assignable to parameter of type 'Request<Dictionary<string>>'. 
+// Argument of type '{}' is not assignable to parameter of type 'Request<Dictionary<string>>'.
 // Type '{}' is missing the following properties from type 'Request<Dictionary<string>>': get, header, accepts, acceptsCharsets, and 72 more.t
 // handler({}, res, next); // Error
 
-// Argument of type '{}' is not assignable to parameter of type 'Response'. 
+// Argument of type '{}' is not assignable to parameter of type 'Response'.
 // Type '{}' is missing the following properties from type 'Response': status, sendStatus, links, send, and 74 more.
 // handler(req, {}, next); // Error

--- a/types/mock-req-res/tsconfig.json
+++ b/types/mock-req-res/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mock-req-res-tests.ts"
+    ]
+}

--- a/types/mock-req-res/tslint.json
+++ b/types/mock-req-res/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
