### PR TITLE
Updates the way the trustedTypes policy factory is exposed.

### DIFF
--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -15,23 +15,23 @@ declare global {
     }
 
     class TrustedHTML {
-        private constructor(); // to prevent instantiting with 'new'.
-        private _brand: true; // To prevent structural typing.
+        private constructor(); // To prevent instantiting with 'new'.
+        private brand: true; // To prevent structural typing.
     }
 
     class TrustedScript {
-        private constructor(); // to prevent instantiting with 'new'.
-        private _brand: true; // To prevent structural typing.
+        private constructor(); // To prevent instantiting with 'new'.
+        private brand: true; // To prevent structural typing.
     }
 
     class TrustedScriptURL {
-        private constructor(); // to prevent instantiting with 'new'.
-        private _brand: true; // To prevent structural typing.
+        private constructor(); // To prevent instantiting with 'new'.
+        private brand: true; // To prevent structural typing.
     }
 
     class TrustedURL {
-        private constructor(); // to prevent instantiting with 'new'.
-        private _brand: true; // To prevent structural typing.
+        private constructor(); // To prevent instantiting with 'new'.
+        private brand: true; // To prevent structural typing.
     }
 
     interface TrustedTypePolicy {
@@ -47,7 +47,7 @@ declare global {
             name: string,
             policyOptions: Pick<TrustedTypePolicyOptions, Keys>,
             expose?: boolean,
-            ): Pick<TrustedTypePolicy, 'name'|Keys>;
+        ): Pick<TrustedTypePolicy, 'name' | Keys>;
         getPolicyNames(): string[];
         isHTML(value: any): value is TrustedHTML;
         isScript(value: any): value is TrustedScript;
@@ -60,7 +60,13 @@ declare global {
     }
 
     interface Window {
-        trustedTypes: TrustedTypePolicyFactory;
+        // NOTE: This is needed while the implementation in Chrome still relies
+        // on the old uppercase name, either of the values below could be
+        // undefined.
+        // See https://github.com/w3c/webappsec-trusted-types/issues/177
+        trustedTypes?: TrustedTypePolicyFactory;
+        /** @deprecated Prefer the lowercase version. */
+        TrustedTypes?: TrustedTypePolicyFactory;
         TrustedHTML: TrustedHTML;
         TrustedScript: TrustedScript;
         TrustedScriptURL: TrustedScriptURL;
@@ -70,7 +76,8 @@ declare global {
     }
 }
 
-// this is not available in global scope. It's only used for the export.
+// This is not available in global scope. It's only used for the export. This is
+// necessary to be able to use these types from nodejs (for SSR).
 declare const trustedTypes: TrustedTypePolicyFactory;
 
 export default trustedTypes;

--- a/types/trusted-types/trusted-types-tests.ts
+++ b/types/trusted-types/trusted-types-tests.ts
@@ -6,6 +6,12 @@ TT;
 // $ExpectError
 trustedTypes;
 
+// $ExpectType TrustedTypePolicyFactory | undefined
+window.trustedTypes;
+
+// $ExpectType TrustedTypePolicyFactory | undefined
+window.TrustedTypes;
+
 const rules = {
     createHTML: (s: string) => s,
     createScript: (s: string) => s,
@@ -14,10 +20,10 @@ const rules = {
 };
 
 // $ExpectType string[]
-window.trustedTypes.getPolicyNames();
-window.trustedTypes.createPolicy('default', rules, true);
+TT.getPolicyNames();
+TT.createPolicy('default', rules, true);
 
-const policy = window.trustedTypes.createPolicy('test', rules);
+const policy = TT.createPolicy('test', rules);
 
 // $ExpectType string
 policy.name;
@@ -30,7 +36,7 @@ policy.createScriptURL('');
 // $ExpectType TrustedURL
 policy.createURL('');
 
-const htmlOnlyPolicy = window.trustedTypes.createPolicy('htmlOnly', {
+const htmlOnlyPolicy = TT.createPolicy('htmlOnly', {
     createHTML: (html: string) => {
         return html;
     },
@@ -44,16 +50,16 @@ const html = htmlOnlyPolicy.createHTML('');
 htmlOnlyPolicy.createScript('');
 
 // $ExpectType boolean
-window.trustedTypes.isHTML(html);
+TT.isHTML(html);
 // $ExpectType boolean
-window.trustedTypes.isScript(html);
+TT.isScript(html);
 // $ExpectType boolean
-window.trustedTypes.isScriptURL(html);
+TT.isScriptURL(html);
 // $ExpectType boolean
-window.trustedTypes.isURL(html);
+TT.isURL(html);
 
-// test that types are globaly available
-const trustedHTML: TrustedHTML = null as any;
+// Ensure the types are globaly available
+let trustedHTML: TrustedHTML = null as any;
 const trustedScript: TrustedScript = null as any;
 
 // $ExpectError


### PR DESCRIPTION
Since Chrome is still shipping the API using `TrustedTypes` (capitalized),
we need to keep it exposed.

We expose both `window.trustedTypes` & `window.TrustedTypes` as optionals
since either of them could be undefined.

Also cleans up formatting & comments.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/w3c/webappsec-trusted-types/issues/177
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.