### PR TITLE
fix: Parse.File save method enable option for progress callback

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -259,7 +259,7 @@ declare namespace Parse {
         constructor(name: string, data: any, type?: string);
         name(): string;
         url(): string;
-        save(options?: SuccessFailureOptions): Promise<File>;
+        save(options?: FullOptions): Promise<File>;
 
     }
 


### PR DESCRIPTION
according to official specs (link below), there are those options:
Valid options are:
useMasterKey: In Cloud Code and Node only, causes the Master Key to be used for this request.
progress: In Browser only, callback for upload progress
<<https://parseplatform.org/Parse-SDK-JS/api/master/Parse.File.html>>