### PR TITLE
Align SearchOptions with ldapjs v1.0.2 implementation

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -53,7 +53,7 @@ export interface ClientOptions {
 export interface SearchOptions {
 	scope?: string;
 	filter?: string | Filter;
-	attributes?: string[];
+	attributes?: string | string[];
 	sizeLimit?: number;
 	timeLimit?: number;
 	derefAliases?: number;


### PR DESCRIPTION
Align SearchOptions type definition with the implementation of [`Client.prototype.search`](https://github.com/ldapjs/node-ldapjs/blob/v1.0.2/lib/client/client.js#L783) as of ldapjs v1.0.2.
