### PR TITLE
[node]: use canonical type for stdin, stdout, stderr

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -737,31 +737,6 @@ declare namespace NodeJS {
         [key: string]: string | undefined;
     }
 
-    interface WriteStream extends Socket {
-        readonly writableFinished: boolean;
-        readonly writableHighWaterMark: number;
-        readonly writableLength: number;
-        columns?: number;
-        rows?: number;
-        _write(chunk: any, encoding: string, callback: (err?: null | Error) => void): void;
-        _destroy(err: Error | null, callback: (err?: null | Error) => void): void;
-        _final(callback: (err?: null | Error) => void): void;
-        setDefaultEncoding(encoding: string): this;
-        cork(): void;
-        uncork(): void;
-        destroy(error?: Error): void;
-    }
-    interface ReadStream extends Socket {
-        readonly readableHighWaterMark: number;
-        readonly readableLength: number;
-        isRaw?: boolean;
-        setRawMode?(mode: boolean): void;
-        _read(size: number): void;
-        _destroy(err: Error | null, callback: (err?: null | Error) => void): void;
-        push(chunk: any, encoding?: string): boolean;
-        destroy(error?: Error): void;
-    }
-
     interface HRTime {
         (time?: [number, number]): [number, number];
     }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1119,6 +1119,7 @@ import moduleModule = require('module');
 /////////////////////////////////////////////////////////
 /// stream tests : https://nodejs.org/api/stream.html ///
 /////////////////////////////////////////////////////////
+import stream = require('stream');
 
 {
     const writeStream = fs.createWriteStream('./index.d.ts');
@@ -1126,6 +1127,8 @@ import moduleModule = require('module');
 
     const readStream = fs.createReadStream('./index.d.ts');
     const _rom = readStream.readableObjectMode; // $ExpectType boolean
+
+    const x: stream.Readable = process.stdin;
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -62,4 +62,9 @@ declare module "tty" {
         rows: number;
         isTTY: boolean;
     }
+
+    global {
+        type WriteStream = import('tty').WriteStream;
+        type ReadStream = import('tty').ReadStream;
+    }
 }

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -64,7 +64,9 @@ declare module "tty" {
     }
 
     global {
-        type WriteStream = import('tty').WriteStream;
-        type ReadStream = import('tty').ReadStream;
+        namespace NodeJS {
+            type WriteStream = import('tty').WriteStream;
+            type ReadStream = import('tty').ReadStream;
+        }
     }
 }


### PR DESCRIPTION
Fixes #38788.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - N/A - I'm de-duping existing types. I can't actually find documentation that explicitly says stdin is a tty.ReadStream, but in both the existing types and inspecting the runtime properties, it is.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
  - N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. 
  - N/A
