### PR TITLE
The callback of an AWS Lambda handler is optional

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1085,7 +1085,7 @@ export interface LexResult {
 export type Handler<TEvent = any, TResult = any> = (
     event: TEvent,
     context: Context,
-    callback: Callback<TResult>,
+    callback?: Callback<TResult>,
 ) => void | Promise<TResult>;
 
 /**


### PR DESCRIPTION
The documentation says that the callback is optional, and if you
provide a handler that only takes two arguments, the lambda runs just
fine.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aee73c479bd3f156b1468f3fd7e34811263f9e1a/types/aws-lambda/index.d.ts#L1082

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
