### PR TITLE
Add types for esquery

### DIFF
--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -1,0 +1,34 @@
+import * as esprima from 'esprima';
+import * as esquery from 'esquery';
+
+const AST = esprima.parseScript(`const x = 2;
+const f = n => {
+    const y = 4;
+    if (n > 4) return true;
+    return false;
+}`);
+
+const s = 'FunctionDeclaration !VariableDeclaration > VariableDeclarator[init.value>3]';
+
+// $ExpectType Selector | undefined
+const selector = esquery.parse(s);
+
+// $ExpectError
+esquery.parse(3);
+
+if (selector) {
+    // $ExpectType Node[]
+    esquery.match(AST, selector);
+
+    // $ExpectError
+    esquery.match(AST, 'VariableDeclarator');
+}
+
+// $ExpectError
+esquery.match(3, selector);
+
+// $ExpectType Node[]
+esquery(AST, s);
+
+// $ExpectType Node[]
+esquery.query(AST, s)

--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -2,16 +2,22 @@ import * as esprima from 'esprima';
 import * as esquery from 'esquery';
 
 const AST = esprima.parseScript(`const x = 2;
-const f = n => {
+function f (n) {
     const y = 4;
-    if (n > 4) return true;
+    if (n > y) return true;
     return false;
 }`);
 
-const s = 'FunctionDeclaration !VariableDeclaration > VariableDeclarator[init.value>3]';
+const s = 'FunctionDeclaration !VariableDeclaration > VariableDeclarator[init.value > 3]';
 
 // $ExpectType Selector | undefined
 const selector = esquery.parse(s);
+
+// $ExpectType Node[]
+const nodes = esquery.query(AST, s);
+
+// $ExpectType Node[]
+esquery(AST, s);
 
 // $ExpectError
 esquery.parse(3);
@@ -22,13 +28,10 @@ if (selector) {
 
     // $ExpectError
     esquery.match(AST, 'VariableDeclarator');
+
+    // $ExpectType boolean
+    esquery.matches(nodes[0], selector, esquery(AST, 'FunctionDeclaration'));
 }
 
 // $ExpectError
 esquery.match(3, selector);
-
-// $ExpectType Node[]
-esquery(AST, s);
-
-// $ExpectType Node[]
-esquery.query(AST, s)

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for esquery 1.0
+// Project: https://github.com/jrfeenst/esquery
+// Definitions by: cherryblossom000 <https://github.com/cherryblossom000>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Node } from 'estree';
+
+export as namespace esquery;
+
+export = query;
+
+interface Atom { type: string; }
+
+interface Literal extends Atom {
+    type: 'literal';
+    value: string | number;
+}
+interface StringLiteral extends Literal { value: string; }
+interface NumericLiteral extends Literal { value: number; }
+interface RegExpSelector extends Atom {
+    type: 'regexp';
+    value: RegExp;
+}
+
+interface Nth extends query.Selector { index: NumericLiteral; }
+interface BinarySelector extends query.Selector {
+    type: 'child' | 'sibling' | 'adjacent' | 'descendant';
+    left: query.Selector;
+    right: query.Selector;
+}
+interface MultiSelector extends query.Selector {
+    selectors: query.Selector[];
+}
+
+/** Query the code AST using the selector string. */
+declare function query(ast: Node, selector: string): Node[];
+
+declare namespace query {
+    /** Parse a selector and return its AST. */
+    function parse(selector: string): Selector | undefined;
+    /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
+    function match(ast: Node, selector: Selector): Node[];
+    /** Given a `node` and its ancestors, determine if `node` is matched by `selector`. */
+    function matches(node: Node, selector: Selector, ancestry: Node[]): boolean;
+    /** Query the code AST using the selector string. */
+    function query(ast: Node, selector: string): Node[];
+
+    interface Selector extends Atom { subject?: boolean; }
+
+    interface Field extends Atom {
+        type: 'field';
+        name: string;
+    }
+    interface Type extends Atom {
+        type: 'type';
+        value: string;
+    }
+    interface Sequence extends MultiSelector { type: 'compound'; }
+    interface Identifier extends Selector {
+        type: 'identifier';
+        value: string;
+    }
+    interface Wildcard extends Selector {
+        type: 'wildcard';
+        value: '*';
+    }
+    interface Attribute extends Selector {
+        type: 'attribute';
+        name: string;
+        operator?: '=' | '!=' | '>' | '<' | '>=' | '<=';
+        value?: Literal | RegExpSelector | Type;
+    }
+    interface NthChild extends Nth { type: 'nth-child'; }
+    interface NthLastChild extends Nth { type: 'nth-last-child'; }
+    interface Descendant extends BinarySelector { type: 'descendant'; }
+    interface Child extends BinarySelector { type: 'child'; }
+    interface Sibling extends BinarySelector { type: 'sibling'; }
+    interface Adjacent extends BinarySelector { type: 'adjacent'; }
+    interface Negation extends MultiSelector { type: 'not'; }
+    interface Matches extends MultiSelector { type: 'matches'; }
+    interface Has extends MultiSelector { type: 'has'; }
+    interface Class extends Atom {
+        type: 'class';
+        name: 'declaration' | 'expression' | 'function' | 'pattern' | 'statement';
+    }
+}

--- a/types/esquery/tsconfig.json
+++ b/types/esquery/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "esquery-tests.ts"
+    ]
+}

--- a/types/esquery/tslint.json
+++ b/types/esquery/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types for [esquery](https://www.npmjs.com/package/esquery).
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)

The only thing that is inaccurate is the fact that there is a circular reference to `query` from `query` in the package, which I'm not sure how to type:

```js
function esqueryModule() {
    function parse(selector) {...}
    function match(ast, selector) {...}
    function matches(node, selector, ancestry) {...}
    function query(ast, selector) {...}

    query.parse = parse;
    query.match = match;
    query.maches = matches;
    return query.query = query;
}

if (typeof define === "function" && define.amd) {
    define(esqueryModule());
} else if (typeof module !== "undefined" && module.exports) { 
    module.exports = esqueryModule();
} else {
    this.moduleName = esqueryModule();
}
```

- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.