### PR TITLE
[forge-viewer] Update clientToWorld return type

### DIFF
--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -779,7 +779,9 @@ declare namespace Autodesk {
             leaveLiveReview(): void;
             setModelUnits(modelUnits: any): void;
             worldToClient(pt: THREE.Vector3): THREE.Vector3;
-            clientToWorld(clientX: number, clientY: number, ignoreTransparent: boolean): object;
+            clientToWorld(clientX: number, clientY: number, ignoreTransparent: boolean):
+              | null
+              | (Partial<Private.HitTestResult> & { point: THREE.Vector3, model: Model });
             modelHasTopology(): boolean;
             setSelectionColor(col: THREE.Color, selectionType: number): void;
             set2dSelectionColor(col: THREE.Color, opacity: number): void;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -780,8 +780,8 @@ declare namespace Autodesk {
             setModelUnits(modelUnits: any): void;
             worldToClient(pt: THREE.Vector3): THREE.Vector3;
             clientToWorld(clientX: number, clientY: number, ignoreTransparent: boolean):
-              | null
-              | (Partial<Private.HitTestResult> & { point: THREE.Vector3, model: Model });
+                | null
+                | (Partial<Private.HitTestResult> & { point: THREE.Vector3, model: Model });
             modelHasTopology(): boolean;
             setSelectionColor(col: THREE.Color, selectionType: number): void;
             set2dSelectionColor(col: THREE.Color, opacity: number): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.api.autodesk.com/modelderivative/v2/viewers/7.3/viewer3D.js

The client to world function appears to return:

1. null if nothing was hit
2. point and model on a 2D collision
3. point, model and a hitTestResult on a 3D collision

I have tried to update the types to reflect the possible options.
