### PR TITLE
[i18n-js] Add missing getFullScope static method to types definition

### DIFF
--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -17,6 +17,8 @@ I18n.t("noun", { defaultValue: "I'm a {{noun}}", noun: "Mac" });
 I18n.t("some.missing.scope", { defaults: [{ scope: "some.existing.scope" }] });
 I18n.t("some.missing.scope", { defaults: [{ message: "Some message" }] });
 
+I18n.getFullScope("translation", { scope: "some.scoped" });
+
 I18n.fallbacks = true;
 I18n.locales.no = ["nb", "en"];
 I18n.locales.no = "nb";

--- a/types/i18n-js/index.d.ts
+++ b/types/i18n-js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for i18n-js 3.0
 // Project: https://github.com/fnando/i18n-js
 // Definitions by: Yuya Tanaka <https://github.com/ypresto>
+//                 Ely Alvarado <https://github.com/elyalvarado>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -46,6 +47,7 @@ declare namespace I18n {
     }
     function translate(scope: Scope, options?: TranslateOptions): string;
     function t(scope: Scope, options?: TranslateOptions): string;
+    function getFullScope(scope: Scope, options?: TranslateOptions): string;
 
     function localize(scope: "currency" | "number" | "percentage", value: number, options?: InterpolateOptions): string;
     function localize(scope: Scope, value: string | number | Date, options?: InterpolateOptions): string;


### PR DESCRIPTION
`getFullScope` static method was missing from the types definition

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fnando/i18n-js/blob/dc76dcb1b5d7c0e3e50099c1d94c63a5fc048c1d/app/assets/javascripts/i18n.js#L401
