### PR TITLE
Update react-virtualized-select index.d.ts for `optionHeight` prop

### DIFF
--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -24,7 +24,7 @@ export interface VirtualizedOptionRenderOptions<T> {
 
 export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
-    optionHeight?: number | (({ option: any }) => number);
+    optionHeight?: number | ((option) => number);
     optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -24,7 +24,7 @@ export interface VirtualizedOptionRenderOptions<T> {
 
 export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
-    optionHeight?: number | ((option) => number);
+    optionHeight?: number | ((option: TValue) => number);
     optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -24,7 +24,7 @@ export interface VirtualizedOptionRenderOptions<T> {
 
 export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
-    optionHeight?: number;
+    optionHeight?: number | (({ option: any }) => number);
     optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -24,7 +24,7 @@ export interface VirtualizedOptionRenderOptions<T> {
 
 export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
-    optionHeight?: number | (({ option: TValue }) => number);
+    optionHeight?: number | ((options: { option: TValue }) => number);
     optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -24,7 +24,7 @@ export interface VirtualizedOptionRenderOptions<T> {
 
 export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
-    optionHeight?: number | ((option: TValue) => number);
+    optionHeight?: number | (({ option: TValue }) => number);
     optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }


### PR DESCRIPTION
`optionHeight` can take a number or a function that returns a number, so I've updated the type for that prop

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized-select#react-virtualized-select-props
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.