### PR TITLE
Adds missing importance attribute in LinkHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2001,6 +2001,7 @@ declare namespace React {
         crossOrigin?: string;
         href?: string;
         hrefLang?: string;
+        importance?: string;             
         integrity?: string;
         media?: string;
         rel?: string;


### PR DESCRIPTION
## Changes
* Adds missing `importance` to LinkHTMLAttributes

## Screenshot
<img width="931" alt="Screen Shot 2019-10-04 at 2 14 58 AM" src="https://user-images.githubusercontent.com/31827190/66152794-d3fd3300-e64c-11e9-9886-5cf33c6f0596.png">

## References
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
* https://github.com/zeit/next.js/pull/8878
