### PR TITLE
[draft-js] RichTextEditorUtil nullable return types

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -944,8 +944,8 @@ declare namespace Draft {
                  * For collapsed selections at the start of styled blocks, backspace should
                  * just remove the existing style.
                  */
-                static onBackspace(editorState: EditorState): EditorState;
-                static onDelete(editorState: EditorState): EditorState;
+                static onBackspace(editorState: EditorState): EditorState | null;
+                static onDelete(editorState: EditorState): EditorState | null;
                 static onTab(event: SyntheticKeyboardEvent, editorState: EditorState, maxDepth: number): EditorState;
 
                 static toggleBlockType(editorState: EditorState, blockType: DraftBlockType): EditorState;
@@ -968,7 +968,7 @@ declare namespace Draft {
                  * certain key commands (newline, backspace) to simply change the
                  * style of the block instead of the default behavior.
                  */
-                static tryToRemoveBlockStyle(editorState: EditorState): ContentState;
+                static tryToRemoveBlockStyle(editorState: EditorState): ContentState | null;
             }
         }
     }

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -935,7 +935,7 @@ declare namespace Draft {
                 static getCurrentBlockType(editorState: EditorState): string;
                 static getDataObjectForLinkURL(uri: URI): Object;
 
-                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState;
+                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState | null;
                 static handleKeyCommand(editorState: EditorState, command: string): null;
 
                 static insertSoftNewline(editorState: EditorState): EditorState;


### PR DESCRIPTION
A few methods in `RichTextEditorUtil` should be nullable, because those methods may return `null` depending on their input.

- handleKeyCommand may return null, even for members of DraftEditorCommand; for example 'move-selection-to-start-of-block' would result in a `null` return based on the implementation
- `onBackspace`, `onDelete`, and `tryToRemoveBlockStyle` may return `null` if the selection state is not collapsed

Source: https://github.com/facebook/draft-js/blob/master/src/model/modifier/RichTextEditorUtil.js#L78
