### PR TITLE
[js-cookie] Update CookieAttributes definition to accept SameSite and freeform attributes

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -4,6 +4,7 @@
 //                 BendingBender <https://github.com/BendingBender>
 //                 Antoine Lépée <https://github.com/alepee>
 //                 Yuto Doi <https://github.com/yutod>
+//                 Nicolas Reynis <https://github.com/nreynis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -32,6 +33,18 @@ declare namespace Cookies {
          * secure protocol (https). Defaults to false.
          */
         secure?: boolean;
+
+        /**
+         * Define the first party cookie policy.
+         * @see: https://tools.ietf.org/html/draft-west-first-party-cookies-07
+         */
+        samesite?: 'Strict' | 'Lax';
+
+        /**
+         * An attribute which will be serialized, conformably to RFC 6265
+         * section 5.2.
+         */
+        [property: string]: any;
     }
 
     interface CookiesStatic<T extends object = object> {

--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -35,10 +35,11 @@ declare namespace Cookies {
         secure?: boolean;
 
         /**
-         * Define the first party cookie policy.
-         * @see: https://tools.ietf.org/html/draft-west-first-party-cookies-07
+         * Asserts that a cookie must not be sent with cross-origin requests,
+         * providing some protection against cross-site request forgery
+         * attacks (CSRF)
          */
-        samesite?: 'Strict' | 'Lax';
+        sameSite?: 'Strict' | 'Lax' | 'None';
 
         /**
          * An attribute which will be serialized, conformably to RFC 6265

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -9,6 +9,8 @@ Cookies.set('name', 'value', { expires: 7, path: '', domain: '', secure: true })
 Cookies.set('name', 'value', { secure: true });
 Cookies.set('name', 'value', { domain: '' });
 Cookies.set('name', 'value', { path: '' });
+Cookies.set('name', 'value', { samesite: 'Strict' });
+Cookies.set('name', 'value', { custom: 'property' });
 
 // $ExpectType string | undefined
 Cookies.get('name');

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -9,7 +9,7 @@ Cookies.set('name', 'value', { expires: 7, path: '', domain: '', secure: true })
 Cookies.set('name', 'value', { secure: true });
 Cookies.set('name', 'value', { domain: '' });
 Cookies.set('name', 'value', { path: '' });
-Cookies.set('name', 'value', { samesite: 'Strict' });
+Cookies.set('name', 'value', { sameSite: 'Strict' });
 Cookies.set('name', 'value', { custom: 'property' });
 
 // $ExpectType string | undefined


### PR DESCRIPTION
Fix #38798 
`CookieAttributes` definition should be kept open. The underlying code isn't restricted to known attributes, it will serialize any attribute to the best of it's capacity:
https://github.com/js-cookie/js-cookie/blob/master/src/js.cookie.mjs#L51

I also added definitions for the `SameSite` attribute:
https://tools.ietf.org/html/draft-west-first-party-cookies-07
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies
https://web.dev/samesite-cookies-explained
https://caniuse.com/#feat=same-site-cookie-attribute