### PR TITLE
fix(pino): DestinationStream can be any object with write()`

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -171,7 +171,10 @@ declare namespace P {
         labels: { [level: number]: string; };
     }
     type TimeFn = () => string;
-    type DestinationStream = stream.Writable | stream.Duplex | stream.Transform | NodeJS.WritableStream | SonicBoom;
+
+    interface DestinationStream {
+        write(msg: string): void;
+    }
 
     interface LoggerOptions {
         /**

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -26,6 +26,10 @@ const log2: pino.Logger = pino({
 });
 
 pino({
+    write(o) {},
+});
+
+pino({
     browser: {
         write(o) {
         }


### PR DESCRIPTION
This is per the [pino docs](https://github.com/pinojs/pino/blob/master/docs/api.md#destination-sonicboom--writablestream--string):

> The destination parameter, at a minimum must be an object with a write method. 

Inspecting the source confirms that only a write method (with no particular return type) is required for basic usage: https://github.com/pinojs/pino/blob/master/lib/proto.js#L153. Calls to other potential methods (flush, flushSync, etc) are always guarded with an existence check, as they're not required.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino/blob/master/docs/api.md#destination-sonicboom--writablestream--string
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.