### PR TITLE
Add types for object-assign-deep

### DIFF
--- a/types/object-assign-deep/index.d.ts
+++ b/types/object-assign-deep/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for object-assign-deep 0.4
+// Project: https://github.com/saikojosh/Object-Assign-Deep#readme
+// Definitions by: Nick Clifford <https://github.com/nickbclifford>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare const objectAssignDeep: ObjectConstructor['assign'];
+
+interface Options {
+    arrayBehaviour: "replace" | "merge";
+}
+
+interface objectAssignDeep {
+    noMutate: ObjectConstructor['assign'];
+
+    withOptions<T, U>(target: T, objects: [U], options: Options): T & U;
+    withOptions<T, U, V>(target: T, objects: [U, V], options: Options): T & U & V;
+    withOptions<T, U, V, W>(target: T, objects: [U, V, W], options: Options): T & U & V & W;
+    withOptions(target: any, objects: any[], options: Options): any;
+}
+
+export = objectAssignDeep;

--- a/types/object-assign-deep/object-assign-deep-tests.ts
+++ b/types/object-assign-deep/object-assign-deep-tests.ts
@@ -1,0 +1,45 @@
+import objectAssignDeep = require('object-assign-deep');
+
+const objectA = {
+	prop1: `Hello`,
+	prop2: `World`,
+	nested: {
+		bool: true,
+		super: 123,
+		still: `here!`,
+	},
+	array1: [1, 2, 3],
+	array2: [4, 5, 6],
+};
+
+const objectB = {
+	prop2: `Universe`,
+	name: `Josh`,
+	nested: {
+		bool: false,
+	},
+	array1: null,
+};
+
+const objectC = {
+	location: `United Kingdom`,
+	name: `Bob`,
+	nested: {
+		super: 999,
+	},
+	array2: [100, 101, 102],
+};
+
+const result: {
+    array1: null,
+    array2: number[],
+    location: string,
+    name: string,
+    nested: {
+        bool: boolean,
+        still: string,
+        super: number
+    },
+    prop1: string,
+    prop2: string
+} = objectAssignDeep(objectA, objectB, objectC);

--- a/types/object-assign-deep/tsconfig.json
+++ b/types/object-assign-deep/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-assign-deep-tests.ts"
+    ]
+}

--- a/types/object-assign-deep/tslint.json
+++ b/types/object-assign-deep/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
