### PR TITLE
Add overload that returns promise

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -14,9 +14,9 @@ declare function which(cmd: string, options: which.AsyncOptions, cb: (err: Error
 /** Finds the first instance of a specified executable in the PATH environment variable */
 declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
 /** Finds the first instance of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll): Promise<string[]>
+declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll): Promise<string[]>;
 /** Finds the first instance of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options?: which.AsyncOptions & which.OptionsFirst): Promise<string>
+declare function which(cmd: string, options?: which.AsyncOptions & which.OptionsFirst): Promise<string>;
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */
     function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsNoThrow): Array<string> | null;

--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -13,6 +13,8 @@ declare function which(cmd: string, options: which.AsyncOptions & which.OptionsF
 declare function which(cmd: string, options: which.AsyncOptions, cb: (err: Error | null, path: string | Array<string> | undefined) => void): void;
 /** Finds the first instance of a specified executable in the PATH environment variable */
 declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
+/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(cmd: string): Promise<string>
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */
     function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsNoThrow): Array<string> | null;

--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -14,7 +14,9 @@ declare function which(cmd: string, options: which.AsyncOptions, cb: (err: Error
 /** Finds the first instance of a specified executable in the PATH environment variable */
 declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
 /** Finds the first instance of a specified executable in the PATH environment variable */
-declare function which(cmd: string): Promise<string>
+declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll): Promise<string[]>
+/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(cmd: string, options?: which.AsyncOptions & which.OptionsFirst): Promise<string>
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */
     function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsNoThrow): Array<string> | null;

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -18,6 +18,8 @@ which("cat", {all: true}, (err, paths) => {
 });
 
 var promise: Promise<string> = which("cat");
+var promise1: Promise<string> = which("cat", { all: false });
+var promise2: Promise<string[]> = which("cat", { all: true });
 
 var paths = which.sync("cat", {all: true});
 for(let path of paths) {

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -17,6 +17,8 @@ which("cat", {all: true}, (err, paths) => {
   }
 });
 
+var promise: Promise<string> = which("cat");
+
 var paths = which.sync("cat", {all: true});
 for(let path of paths) {
   console.log(path);


### PR DESCRIPTION
which@2.0.1 supports `Promise`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-which/issues/65
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
