### PR TITLE
[mui-datatables] Change MUIDataTableOptions.onDownload return type from string to BlobPart

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -173,7 +173,7 @@ export interface MUIDataTableOptions {
         buildBody: (data: any) => string,
         columns: any,
         data: any
-    ) => string;
+    ) => BlobPart;
     onFilterChange?: (changedColumn: string, filterList: any[]) => void;
     onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
     onRowsDelete?: (rowsDeleted: any[]) => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/20712442a657f16de79f01b42aaaf0cf4863e0ba/src/utils.js#L65...L73
  - First arguments of the `new Blob()` expect `BlobPart[]`.
    - https://github.com/microsoft/TypeScript/blob/3c794e9f9ba4f6777f7ea4e7e666f23714d46068/lib/lib.dom.d.ts#L2527
  - And `BlobPart` includes string.
    - https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L19973
