### PR TITLE
change export declaration to avoid esModuleInterop

### DIFF
--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -581,4 +581,4 @@ declare class RedBN extends BN {
     redPow(b: BN): RedBN;
 }
 
-export = BN;
+export default BN;


### PR DESCRIPTION
Change declaration of export to avoid use of esModuleInterop in tsconfig of a project using bn.js