### PR TITLE
[hapi__hapi] Fix Boom type errors

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -511,7 +511,7 @@ export interface Request extends Podium {
      * override with a different response.
      * In case of an aborted request the status code will be set to `disconnectStatusCode`.
      */
-    response: ResponseObject | Boom;
+    response: ResponseObject | Boom.Boom;
 
     /**
      * Same as pre but represented as the response object created by the pre method.
@@ -4047,7 +4047,7 @@ export namespace Lifecycle {
     type ReturnValueTypes =
         (null | string | number | boolean) |
         (Buffer) |
-        (Error | Boom) |
+        (Error | Boom.Boom) |
         (stream.Stream) |
         (object | object[]) |
         symbol |


### PR DESCRIPTION
When building a hapi server with this package, these messages appear:

```
> tsc --build tsconfig.build.json

node_modules/@types/hapi__hapi/index.d.ts:514:32 - error TS2709: Cannot use namespace 'Boom' as a type.

514     response: ResponseObject | Boom;
                                   ~~~~

node_modules/@types/hapi__hapi/index.d.ts:4050:18 - error TS2709: Cannot use namespace 'Boom' as a type.

4050         (Error | Boom) |
                      ~~~~


Found 2 errors.
```

For an example, see this PR CI: https://circleci.com/gh/apollographql/apollo-server/51952?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This quick edit should fix these errors.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.