### PR TITLE
[@types/async] Fix async.constant return type

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -259,7 +259,7 @@ export function race<T, E = Error>(tasks: Array<AsyncFunction<T, E>>, callback: 
 export function memoize(fn: Function, hasher?: Function): Function;
 export function unmemoize(fn: Function): Function;
 export function ensureAsync(fn: (... argsAndCallback: any[]) => void): Function;
-export function constant(...values: any[]): Function;
+export function constant(...values: any[]): AsyncFunction<any>;
 export function asyncify(fn: Function): (...args: any[]) => any;
 export function wrapSync(fn: Function): Function;
 export function log(fn: Function, ...args: any[]): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/caolan/async/blob/v3.1.0/lib/constant.js#L13
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.