### PR TITLE
Add node-easy-cert typings

### DIFF
--- a/types/node-easy-cert/index.d.ts
+++ b/types/node-easy-cert/index.d.ts
@@ -1,0 +1,103 @@
+// Type definitions for node-easy-cert 1.3
+// Project: https://github.com/ottomao/node-easy-cert
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
+
+export = CertManager;
+
+declare function CertManager(options: CertManager.CertManagerOptions): CertManager;
+declare class CertManager {
+    constructor(options: CertManager.CertManagerOptions);
+
+    /**
+     * Get the Root CA file path.
+     * If the Root CA file does not exist, returns `""`;
+     */
+    getRootCAFilePath(): string;
+
+    /**
+     * Generates a new Root CA certificate.
+     *
+     * @param config Configuration for the new Root CA.
+     * @param callback Callback called when certificate is ready with key and cert paths.
+     */
+    generateRootCA(config: CertManager.GenerateConfig, callback?: CertManager.GenerateCallback): void;
+
+    /**
+     * Get or create a new Certificate for given hostname.
+     *
+     * @param hostname Hostname for the new certificate.
+     * @param callback Callback called with key and cert content.
+     */
+    getCertificate(hostname: string, callback?: CertManager.GetCertificateCallback): void;
+
+    /**
+     * Clear all certificates in Root directory.
+     *
+     * @param callback Optional callback called when all certificates are cleared.
+     */
+    clearCerts(callback?: () => any): void;
+
+    /** Get whether Root CA file exists. */
+    isRootCAFileExists(): boolean;
+
+    /** Get whether Root CA certificate is trusted on this OS. */
+    ifRootCATrusted(): boolean;
+
+    /**
+     * Get the Root directory path.
+     * Root directory is the path where certificates are stored.
+     */
+    getRootDirPath(): string;
+}
+
+declare namespace CertManager {
+    interface CertManagerOptions {
+        /**
+         * Path where certificates should be stored.
+         * @default "/{USER_HOME}/{.node_easy_certs}/"
+         */
+        rootDirPath?: string;
+
+        /** The default attributes of a generated cert, you can change it here */
+        defaultCertAttrs?: CertificateAttribute[];
+    }
+
+    interface GenerateConfig {
+        /** The Common Name for the new certificate. */
+        commonName: string;
+
+        /**
+         * Should overwrite any existing file.
+         * @default false
+         */
+        overwrite?: boolean;
+    }
+
+    type GenerateCallback = (err: Error | CertErrors | null, keyPath: string, certPath: string) => any;
+
+    type GetCertificateCallback = (err: Error | CertErrors | null, keyContent: string, certContent: string) => any;
+
+    type CertErrors =
+        /** Error thrown when Root CA has not been generated yet. */
+        "ROOT_CA_NOT_EXISTS" |
+
+        /** Error thrown when Root CA was existed, beware that it will be overwrited. */
+        "ROOT_CA_EXISTED" |
+
+        /** Error thrown when no commonName options is specified when generating Root CA. */
+        "ROOT_CA_COMMON_NAME_UNSPECIFIED";
+
+    type CertificateAttribute = CertificateAttributeName | CertificateAttributeShortName;
+
+    interface CertificateAttributeName {
+        name: string;
+        value: string;
+    }
+
+    interface CertificateAttributeShortName {
+        shortName: string;
+        value: string;
+    }
+}

--- a/types/node-easy-cert/node-easy-cert-tests.ts
+++ b/types/node-easy-cert/node-easy-cert-tests.ts
@@ -1,0 +1,82 @@
+import * as CertManager from 'node-easy-cert';
+
+const options = {
+    rootDirPath: '/the/full/path/of/the/dir',
+    defaultCertAttrs: [
+        { name: 'countryName', value: 'CN' },
+        { name: 'organizationName', value: 'CertManager' },
+        { shortName: 'ST', value: 'SH' },
+        { shortName: 'OU', value: 'CertManager SSL' },
+    ],
+};
+
+const crtMgr = new CertManager(options);
+
+/*
+ * generateRootCA
+ */
+
+const rootCaOptions = {
+    commonName: 'the-name-you-like',
+};
+
+crtMgr.generateRootCA(rootCaOptions, (err, keyPath, certPath) => {
+    if (err === 'ROOT_CA_EXISTED') {
+        // log that overwrite should be specified to force generation
+    }
+
+    if (err === 'ROOT_CA_COMMON_NAME_UNSPECIFIED') {
+        // can't append in typescript :)
+    }
+
+    // log keyPath and certPath to allow users to trust them
+});
+
+/*
+ * getCertificate
+ */
+
+crtMgr.getCertificate('localhost', (err, keyContent, crtContent) => {
+    if (err === 'ROOT_CA_NOT_EXISTS') {
+        // log that the user should call generateRootCA before trying to generate certificates.
+    }
+
+    // log keyContent, crtContent
+});
+
+/*
+ * getRootDirPath
+ */
+
+const rootPath = crtMgr.getRootDirPath();
+
+/*
+ * getRootCAFilePath
+ */
+
+const rootCAFile = crtMgr.getRootCAFilePath();
+
+/*
+ * isRootCAFileExists
+ */
+
+if (crtMgr.isRootCAFileExists()) {
+    // generate certs
+}
+
+/*
+ * ifRootCATrusted
+ */
+
+if (!crtMgr.ifRootCATrusted()) {
+    // ask user to trust CA certificate
+}
+
+/*
+ * clearCerts
+ */
+
+crtMgr.clearCerts();
+crtMgr.clearCerts(() => {
+    // all certificates cleared!
+});

--- a/types/node-easy-cert/node-easy-cert-tests.ts
+++ b/types/node-easy-cert/node-easy-cert-tests.ts
@@ -1,4 +1,4 @@
-import * as CertManager from 'node-easy-cert';
+import CertManager = require('node-easy-cert');
 
 const options = {
     rootDirPath: '/the/full/path/of/the/dir',

--- a/types/node-easy-cert/tsconfig.json
+++ b/types/node-easy-cert/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-easy-cert-tests.ts"
+    ]
+}

--- a/types/node-easy-cert/tslint.json
+++ b/types/node-easy-cert/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "strict-export-declare-modifiers": true
+}

--- a/types/node-easy-cert/tslint.json
+++ b/types/node-easy-cert/tslint.json
@@ -1,4 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "strict-export-declare-modifiers": true
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.