### PR TITLE
Add missing limit option to ncp definition

### DIFF
--- a/types/ncp/index.d.ts
+++ b/types/ncp/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ncp v2.0.0
 // Project: https://github.com/AvianFlu/ncp
 // Definitions by: Bart van der Schoor <https://github.com/bartvds>
+//                 Benoit Lemaire <https://github.com/belemaire>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -15,4 +16,5 @@ interface Options {
     dereference?: boolean;
     stopOnErr?: boolean;
     errs?: NodeJS.WritableStream;
+    limit?: number;
 }

--- a/types/ncp/ncp-tests.ts
+++ b/types/ncp/ncp-tests.ts
@@ -26,6 +26,9 @@ opts = {
 opts = {
 	errs: new stream.Writable()
 };
+opts = {
+	limit: 512
+};
 
 ncp.ncp('foo', 'bar', (err: Error) => {
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes

Add missing `limit` option to [ncp] package type definition.
This option is missing from the README of [ncp], but is actually part of the parsed options in the source code [here](https://github.com/AvianFlu/ncp/blob/v2.0.0/lib/ncp.js#L28).

[ncp]: https://github.com/AvianFlu/ncp