### PR TITLE
[leaflet] match event types with appropriate handler function types

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -630,7 +630,7 @@ declare module 'leaflet' {
     }
 
     namespace DrawEvents {
-        interface Created extends Event {
+        interface Created extends LeafletEvent {
             /**
              * Layer that was just created.
              */
@@ -642,7 +642,7 @@ declare module 'leaflet' {
             layerType: string;
         }
 
-        interface Edited extends Event {
+        interface Edited extends LeafletEvent {
             /**
              * List of all layers just edited on the map.
              */
@@ -652,56 +652,56 @@ declare module 'leaflet' {
         /**
          * Triggered when layers have been removed (and saved) from the FeatureGroup.
          */
-        interface Deleted extends Event {
+        interface Deleted extends LeafletEvent {
             /**
              * List of all layers just removed from the map.
              */
             layers: LayerGroup;
         }
 
-        interface DrawStart extends Event {
+        interface DrawStart extends LeafletEvent {
             /**
              * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker
              */
             layerType: string;
         }
 
-        interface DrawStop extends Event {
+        interface DrawStop extends LeafletEvent {
             /**
              * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker
              */
             layerType: string;
         }
 
-        interface DrawVertex extends Event {
+        interface DrawVertex extends LeafletEvent {
             /**
              * List of all layers just being added from the map.
              */
             layers: LayerGroup;
         }
 
-        interface EditStart extends Event {
+        interface EditStart extends LeafletEvent {
             /**
              * The type of edit this is. One of: edit
              */
             handler: string;
         }
 
-        interface EditMove extends Event {
+        interface EditMove extends LeafletEvent {
             /**
              * Layer that was just moved.
              */
             layer: Layer;
         }
 
-        interface EditResize extends Event {
+        interface EditResize extends LeafletEvent {
             /**
              * Layer that was just resized.
              */
             layer: Layer;
         }
 
-        interface EditVertex extends Event {
+        interface EditVertex extends LeafletEvent {
             /**
              * List of all layers just being edited from the map.
              */
@@ -710,30 +710,30 @@ declare module 'leaflet' {
             poly: Polyline | Polygon;
         }
 
-        interface EditStop extends Event {
+        interface EditStop extends LeafletEvent {
             /**
              * The type of edit this is. One of: edit
              */
             handler: string;
         }
 
-        interface DeleteStart extends Event {
+        interface DeleteStart extends LeafletEvent {
             /**
              * The type of edit this is. One of: remove
              */
             handler: string;
         }
 
-        interface DeleteStop extends Event {
+        interface DeleteStop extends LeafletEvent {
             /**
              * The type of edit this is. One of: remove
              */
             handler: string;
         }
 
-        type ToolbarOpened = Event;
-        type ToolbarClosed = Event;
-        type MarkerContext = Event;
+        type ToolbarOpened = LeafletEvent;
+        type ToolbarClosed = LeafletEvent;
+        type MarkerContext = LeafletEvent;
     }
 
     namespace GeometryUtil {

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -222,10 +222,103 @@ export function bounds(topLeft: PointExpression, bottomRight: PointExpression): 
 
 export function bounds(points: Point[] | BoundsLiteral): Bounds;
 
+// Event handler types
+
 export type LeafletEventHandlerFn = (event: LeafletEvent) => void;
 
+export type LayersControlEventHandlerFn = (event: LayersControlEvent) => void;
+
+export type LayerEventHandlerFn = (event: LayerEvent) => void;
+
+export type ResizeEventHandlerFn = (event: ResizeEvent) => void;
+
+export type PopupEventHandlerFn = (event: PopupEvent) => void;
+
+export type TooltipEventHandlerFn = (event: TooltipEvent) => void;
+
+export type ErrorEventHandlerFn = (event: ErrorEvent) => void;
+
+export type LocationEventHandlerFn = (event: LocationEvent) => void;
+
+export type LeafletMouseEventHandlerFn = (event: LeafletMouseEvent) => void;
+
+export type LeafletKeyboardEventHandlerFn = (event: LeafletKeyboardEvent) => void;
+
+export type ZoomAnimEventHandlerFn = (event: ZoomAnimEvent) => void;
+
+export type DragEndEventHandlerFn = (event: DragEndEvent) => void;
+
+export type TileEventHandlerFn = (event: TileEvent) => void;
+
+export type TileErrorEventHandlerFn = (event: TileErrorEvent) => void;
+
 export interface LeafletEventHandlerFnMap {
-    [type: string]: LeafletEventHandlerFn;
+    baselayerchange?: LayersControlEventHandlerFn;
+    overlayadd?: LayersControlEventHandlerFn;
+    overlayremove?: LayersControlEventHandlerFn;
+
+    layeradd?: LayerEventHandlerFn;
+    layerremove?: LayerEventHandlerFn;
+
+    zoomlevelschange?: LeafletEventHandlerFn;
+    unload?: LeafletEventHandlerFn;
+    viewreset?: LeafletEventHandlerFn;
+    load?: LeafletEventHandlerFn;
+    zoomstart?: LeafletEventHandlerFn;
+    movestart?: LeafletEventHandlerFn;
+    zoom?: LeafletEventHandlerFn;
+    move?: LeafletEventHandlerFn;
+    zoomend?: LeafletEventHandlerFn;
+    moveend?: LeafletEventHandlerFn;
+    autopanstart?: LeafletEventHandlerFn;
+    dragstart?: LeafletEventHandlerFn;
+    drag?: LeafletEventHandlerFn;
+    add?: LeafletEventHandlerFn;
+    remove?: LeafletEventHandlerFn;
+    loading?: LeafletEventHandlerFn;
+    error?: LeafletEventHandlerFn;
+    update?: LeafletEventHandlerFn;
+    down?: LeafletEventHandlerFn;
+    predrag?: LeafletEventHandlerFn;
+
+    resize?: ResizeEventHandlerFn;
+
+    popupopen?: PopupEventHandlerFn;
+    popupclose?: PopupEventHandlerFn;
+
+    tooltipopen?: TooltipEventHandlerFn;
+    tooltipclose?: TooltipEventHandlerFn;
+
+    locationerror?: ErrorEventHandlerFn;
+
+    locationfound?: LocationEventHandlerFn;
+
+    click?: LeafletMouseEventHandlerFn;
+    dblclick?: LeafletMouseEventHandlerFn;
+    mousedown?: LeafletMouseEventHandlerFn;
+    mouseup?: LeafletMouseEventHandlerFn;
+    mouseover?: LeafletMouseEventHandlerFn;
+    mouseout?: LeafletMouseEventHandlerFn;
+    mousemove?: LeafletMouseEventHandlerFn;
+    contextmenu?: LeafletMouseEventHandlerFn;
+    preclick?: LeafletMouseEventHandlerFn;
+
+    keypress?: LeafletKeyboardEventHandlerFn;
+    keydown?: LeafletKeyboardEventHandlerFn;
+    keyup?: LeafletKeyboardEventHandlerFn;
+
+    zoomanim?: ZoomAnimEventHandlerFn;
+
+    dragend?: DragEndEventHandlerFn;
+
+    tileunload?: TileEventHandlerFn;
+    tileloadstart?: TileEventHandlerFn;
+    tileload?: TileEventHandlerFn;
+
+    tileerror?: TileErrorEventHandlerFn;
+
+    // [name: string]: any;
+    // You are able add additional properties, but it makes this interface unchackable.
 }
 
 /**
@@ -241,12 +334,46 @@ export abstract class Evented extends Class {
      * keyword will point to). You can also pass several space-separated types
      * (e.g. 'click dblclick').
      */
+    // tslint:disable:unified-signatures
     on(type: string, fn: LeafletEventHandlerFn, context?: any): this;
+    on(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn: LayersControlEventHandlerFn, context?: any): this;
+    on(type: 'layeradd' | 'layerremove',
+        fn: LayerEventHandlerFn, context?: any): this;
+    on(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn: LeafletEventHandlerFn, context?: any): this;
+    on(type: 'resize',
+        fn: ResizeEventHandlerFn, context?: any): this;
+    on(type: 'popupopen' | 'popupclose',
+        fn: PopupEventHandlerFn, context?: any): this;
+    on(type: 'tooltipopen' | 'tooltipclose',
+        fn: TooltipEventHandlerFn, context?: any): this;
+    on(type: 'locationerror',
+        fn: ErrorEventHandlerFn, context?: any): this;
+    on(type: 'locationfound',
+        fn: LocationEventHandlerFn, context?: any): this;
+    on(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn: LeafletMouseEventHandlerFn, context?: any): this;
+    on(type: 'keypress' | 'keydown' | 'keyup',
+        fn: LeafletKeyboardEventHandlerFn, context?: any): this;
+    on(type: 'zoomanim',
+        fn: ZoomAnimEventHandlerFn, context?: any): this;
+    on(type: 'dragend',
+        fn: DragEndEventHandlerFn, context?: any): this;
+    on(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn: TileEventHandlerFn, context?: any): this;
+    on(type: 'tileerror',
+        fn: TileErrorEventHandlerFn, context?: any): this;
 
     /**
      * Adds a set of type/listener pairs, e.g. {click: onClick, mousemove: onMouseMove}
      */
     on(eventMap: LeafletEventHandlerFnMap): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Removes a previously added listener function. If no function is specified,
@@ -254,20 +381,52 @@ export abstract class Evented extends Class {
      * Note that if you passed a custom context to on, you must pass the same context
      * to off in order to remove the listener.
      */
-     // With an eventMap there are no additional arguments allowed
-    // tslint:disable-next-line:unified-signatures
+    // tslint:disable:unified-signatures
     off(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
+    off(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn?: LayersControlEventHandlerFn, context?: any): this;
+    off(type: 'layeradd' | 'layerremove',
+        fn?: LayerEventHandlerFn, context?: any): this;
+    off(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn?: LeafletEventHandlerFn, context?: any): this;
+    off(type: 'resize',
+        fn?: ResizeEventHandlerFn, context?: any): this;
+    off(type: 'popupopen' | 'popupclose',
+        fn?: PopupEventHandlerFn, context?: any): this;
+    off(type: 'tooltipopen' | 'tooltipclose',
+        fn?: TooltipEventHandlerFn, context?: any): this;
+    off(type: 'locationerror',
+        fn?: ErrorEventHandlerFn, context?: any): this;
+    off(type: 'locationfound',
+        fn?: LocationEventHandlerFn, context?: any): this;
+    off(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn?: LeafletMouseEventHandlerFn, context?: any): this;
+    off(type: 'keypress' | 'keydown' | 'keyup',
+        fn?: LeafletKeyboardEventHandlerFn, context?: any): this;
+    off(type: 'zoomanim',
+        fn?: ZoomAnimEventHandlerFn, context?: any): this;
+    off(type: 'dragend',
+        fn?: DragEndEventHandlerFn, context?: any): this;
+    off(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn?: TileEventHandlerFn, context?: any): this;
+    off(type: 'tileerror',
+        fn?: TileErrorEventHandlerFn, context?: any): this;
 
     /**
      * Removes a set of type/listener pairs.
      */
-     // With an eventMap there are no additional arguments allowed
-    // tslint:disable-next-line:unified-signatures
+    // With an eventMap there are no additional arguments allowed
     off(eventMap: LeafletEventHandlerFnMap): this;
+
     /**
      * Removes all listeners to all events on the object.
      */
     off(): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Fires an event of the specified type. You can optionally provide a data
@@ -284,12 +443,46 @@ export abstract class Evented extends Class {
     /**
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
+    // tslint:disable:unified-signatures
     once(type: string, fn: LeafletEventHandlerFn, context?: any): this;
+    once(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn: LayersControlEventHandlerFn, context?: any): this;
+    once(type: 'layeradd' | 'layerremove',
+        fn: LayerEventHandlerFn, context?: any): this;
+    once(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn: LeafletEventHandlerFn, context?: any): this;
+    once(type: 'resize',
+        fn: ResizeEventHandlerFn, context?: any): this;
+    once(type: 'popupopen' | 'popupclose',
+        fn: PopupEventHandlerFn, context?: any): this;
+    once(type: 'tooltipopen' | 'tooltipclose',
+        fn: TooltipEventHandlerFn, context?: any): this;
+    once(type: 'locationerror',
+        fn: ErrorEventHandlerFn, context?: any): this;
+    once(type: 'locationfound',
+        fn: LocationEventHandlerFn, context?: any): this;
+    once(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn: LeafletMouseEventHandlerFn, context?: any): this;
+    once(type: 'keypress' | 'keydown' | 'keyup',
+        fn: LeafletKeyboardEventHandlerFn, context?: any): this;
+    once(type: 'zoomanim',
+        fn: ZoomAnimEventHandlerFn, context?: any): this;
+    once(type: 'dragend',
+        fn: DragEndEventHandlerFn, context?: any): this;
+    once(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn: TileEventHandlerFn, context?: any): this;
+    once(type: 'tileerror',
+        fn: TileEventHandlerFn, context?: any): this;
 
     /**
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
     once(eventMap: LeafletEventHandlerFnMap): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Adds an event parent - an Evented that will receive propagated events
@@ -309,7 +502,40 @@ export abstract class Evented extends Class {
      * keyword will point to). You can also pass several space-separated types
      * (e.g. 'click dblclick').
      */
+    // tslint:disable:unified-signatures
     addEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
+    addEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn: LayersControlEventHandlerFn, context?: any): this;
+    addEventListener(type: 'layeradd' | 'layerremove',
+        fn: LayerEventHandlerFn, context?: any): this;
+    addEventListener(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn: LeafletEventHandlerFn, context?: any): this;
+    addEventListener(type: 'resize',
+        fn: ResizeEventHandlerFn, context?: any): this;
+    addEventListener(type: 'popupopen' | 'popupclose',
+        fn: PopupEventHandlerFn, context?: any): this;
+    addEventListener(type: 'tooltipopen' | 'tooltipclose',
+        fn: TooltipEventHandlerFn, context?: any): this;
+    addEventListener(type: 'locationerror',
+        fn: ErrorEventHandlerFn, context?: any): this;
+    addEventListener(type: 'locationfound',
+        fn: LocationEventHandlerFn, context?: any): this;
+    addEventListener(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn: LeafletMouseEventHandlerFn, context?: any): this;
+    addEventListener(type: 'keypress' | 'keydown' | 'keyup',
+        fn: LeafletKeyboardEventHandlerFn, context?: any): this;
+    addEventListener(type: 'zoomanim',
+        fn: ZoomAnimEventHandlerFn, context?: any): this;
+    addEventListener(type: 'dragend',
+        fn: DragEndEventHandlerFn, context?: any): this;
+    addEventListener(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn: TileEventHandlerFn, context?: any): this;
+    addEventListener(type: 'tileerror',
+        fn: TileErrorEventHandlerFn, context?: any): this;
 
     /**
      * Alias for on(...)
@@ -317,6 +543,7 @@ export abstract class Evented extends Class {
      * Adds a set of type/listener pairs, e.g. {click: onClick, mousemove: onMouseMove}
      */
     addEventListener(eventMap: LeafletEventHandlerFnMap): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Alias for off(...)
@@ -326,7 +553,40 @@ export abstract class Evented extends Class {
      * Note that if you passed a custom context to on, you must pass the same context
      * to off in order to remove the listener.
      */
+    // tslint:disable:unified-signatures
     removeEventListener(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn?: LayersControlEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'layeradd' | 'layerremove',
+        fn?: LayerEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn?: LeafletEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'resize',
+        fn?: ResizeEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'popupopen' | 'popupclose',
+        fn?: PopupEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'tooltipopen' | 'tooltipclose',
+        fn?: TooltipEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'locationerror',
+        fn?: ErrorEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'locationfound',
+        fn?: LocationEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn?: LeafletMouseEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'keypress' | 'keydown' | 'keyup',
+        fn?: LeafletKeyboardEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'zoomanim',
+        fn?: ZoomAnimEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'dragend',
+        fn?: DragEndEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn?: TileEventHandlerFn, context?: any): this;
+    removeEventListener(type: 'tileerror',
+        fn?: TileErrorEventHandlerFn, context?: any): this;
 
     /**
      * Alias for off(...)
@@ -334,6 +594,7 @@ export abstract class Evented extends Class {
      * Removes a set of type/listener pairs.
      */
     removeEventListener(eventMap: LeafletEventHandlerFnMap): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Alias for off()
@@ -347,7 +608,40 @@ export abstract class Evented extends Class {
      *
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
+    // tslint:disable:unified-signatures
     addOneTimeEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
+        fn: LayersControlEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'layeradd' | 'layerremove',
+        fn: LayerEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'zoomlevelschange' | 'unload' | 'viewreset' | 'load' | 'zoomstart' |
+        'movestart' | 'zoom' | 'move' | 'zoomend' | 'moveend' | 'autopanstart' |
+        'dragstart' | 'drag' | 'add' | 'remove' | 'loading' | 'error' | 'update' |
+        'down' | 'predrag',
+        fn: LeafletEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'resize',
+        fn: ResizeEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'popupopen' | 'popupclose',
+        fn: PopupEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'tooltipopen' | 'tooltipclose',
+        fn: TooltipEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'locationerror',
+        fn: ErrorEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'locationfound',
+        fn: LocationEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'click' | 'dblclick' | 'mousedown' | 'mouseup' | 'mouseover' |
+        'mouseout' | 'mousemove' | 'contextmenu' | 'preclick',
+        fn: LeafletMouseEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'keypress' | 'keydown' | 'keyup',
+        fn: LeafletKeyboardEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'zoomanim',
+        fn: ZoomAnimEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'dragend',
+        fn: DragEndEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'tileunload' | 'tileloadstart' | 'tileload',
+        fn: TileEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: 'tileerror',
+        fn: TileErrorEventHandlerFn, context?: any): this;
 
     /**
      * Alias for once(...)
@@ -355,6 +649,7 @@ export abstract class Evented extends Class {
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
     addOneTimeEventListener(eventMap: LeafletEventHandlerFnMap): this;
+    // tslint:enable:unified-signatures
 
     /**
      * Alias for fire(...)
@@ -428,7 +723,7 @@ export class Layer extends Evented {
     // Extension methods
     onAdd(map: Map): this;
     onRemove(map: Map): this;
-    getEvents?(): {[name: string]: (event: LeafletEvent) => void};
+    getEvents?(): {[name: string]: LeafletEventHandlerFn};
     getAttribution?(): string | null;
     beforeAdd?(map: Map): this;
 
@@ -1275,6 +1570,12 @@ export class Handler extends Class {
 export interface LeafletEvent {
     type: string;
     target: any;
+    sourceTarget: any;
+    propagatedFrom: any;
+    /**
+     * @deprecated The same as {@link LeafletEvent.propagatedFrom propagatedFrom}.
+     */
+    layer: any;
 }
 
 export interface LeafletMouseEvent extends LeafletEvent {

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -163,13 +163,20 @@ map = new L.Map(htmlElement, mapOptions);
 let doesItHaveLayer: boolean;
 doesItHaveLayer = map.hasLayer(L.tileLayer(''));
 
-map.off('moveend');
-map.off('moveend', () => {});
-map.off('moveend', () => {}, {});
+map.on('zoomanim', (_e: L.ZoomAnimEvent) => {});
 
-map.removeEventListener('moveend');
-map.removeEventListener('moveend', () => {});
-map.removeEventListener('moveend', () => {}, {});
+map.once({
+    dragend: (_e: L.DragEndEvent) => {},
+    locationfound: (_e: L.LocationEvent) => {},
+});
+
+map.off('moveend');
+map.off('resize', (_e: L.ResizeEvent) => {});
+map.off('baselayerchange', (_e: L.LayersControlEvent) => {}, {});
+
+map.removeEventListener('loading');
+map.removeEventListener('dblclick', (_e: L.LeafletMouseEvent) => {});
+map.removeEventListener('locationerror', (_e: L.ErrorEvent) => {}, {});
 
 map.panInside(latLng, { padding: [50, 50], paddingBottomRight: point, paddingTopLeft: [100, 100] });
 


### PR DESCRIPTION
I went over the leaflet documentation and matched event `type` parameters in `Evented` methods with the appropriate event handler type. The change is non-breaking for the overloads that take `type` and `fn` handler. The overloads that take a handler map, however, may break if an event type not defined in leaflet is used. The reason for that is the handler map is an interface and we can't add a `[event: string]: any` declaration without making it impossible to type check. There may be something we could do to prevent that. If someone has an idea, please reach out.
In addition, I had to change the `leaflet-draw` definition to make the events it declares implement `LeafletEvent`. Although it's not clear from the documentation or source that all events inherit from `LeafletEvent`, you can see that it's effectively what happens when Leaflet dispatches events in [`Events.js`](https://github.com/Leaflet/Leaflet/blob/19c8e077ceccf487006e2d84a8db4f13e3991418/src/core/Events.js#L174):

```typescript
var event = Util.extend({}, data, {
	type: type,
	target: this,
	sourceTarget: data && data.sourceTarget || this
});
```

Addresses one of the concerns in #38295 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.5.0.html#evented
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
