### PR TITLE
pdfjs-dist: Update some definitions to match implementation in v2.1.266

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -241,8 +241,15 @@ interface PDFProgressData {
 }
 
 interface PDFDocumentStats {
-    streamTypes: object; // Used stream types in the document (an item is set to true if specific stream ID was used in the document).
-    fontTypes: object; // Used font types in the document (an item is set to true if specific font ID was used in the document).
+    /**
+     * Used stream types in the document (an item is set to true if specific stream ID was used in the document).
+     */
+    streamTypes: object;
+
+    /**
+     * Used font types in the document (an item is set to true if specific font ID was used in the document).
+     */
+    fontTypes: object;
 }
 
 /**
@@ -274,24 +281,21 @@ interface PDFDocumentProxy {
     getPageIndex(ref: {num: number, gen: number}): Promise<number>;
 
     /**
-     * TODO: return type of Promise<???>
-     *  A promise that is resolved with a lookup table for mapping named destinations to reference numbers.
+     * A promise that is resolved with a lookup table for mapping named destinations to reference numbers.
      **/
-    getDestinations(): Promise<any[]>;
+    getDestinations(): Promise<any[]>; // TODO: return type of Promise<???>
 
     /**
-     * TODO: return type of Promise<???>
      * @param id The named destination to get.
      * @return A promise that is resolved with all information of the given named destination.
      */
-    getDestination(id: string): Promise<any>;
+    getDestination(id: string): Promise<any>; // TODO: return type of Promise<???>
 
     /**
-     * TODO: return type of Promise<???>
      * @return A promise that is resolved with an Array containing the page labels that
      *   correspond to the page indexes, or `null` when no page labels are present in the PDF file.
      */
-    getPageLabels(): Promise<any[] | null>;
+    getPageLabels(): Promise<any[] | null>; // TODO: return type of Promise<???>
 
     /**
      * @return A promise that is resolved with a string containing the page layout name.
@@ -309,17 +313,15 @@ interface PDFDocumentProxy {
     getViewerPreferences(): Promise<object>;
 
     /**
-     * TODO: return type of Promise<???>
      * @return A promise that is resolved with an Array containing the
      *   destination, or `null` when no open action is present in the PDF file.
      */
-    getOpenActionDestination(): Promise<any[] | null>;
+    getOpenActionDestination(): Promise<any[] | null>; // TODO: return type of Promise<???>
 
     /**
-     * TODO: return type of ???
      * @return A promise that is resolved with a lookup table for mapping named attachments to their content.
      */
-    getAttachments(): any;
+    getAttachments(): any; // TODO: return type of ???
 
     /**
      *  A promise that is resolved with an array of all the JavaScript strings in the name tree.
@@ -332,12 +334,11 @@ interface PDFDocumentProxy {
     getOutline(): Promise<PDFTreeNode[]>;
 
     /**
-     * TODO: return type of Promise<???>
      * @return A promise that is resolved with an Array that contains
      *   the permission flags for the PDF document, or `null` when
      *   no permissions are present in the PDF file.
      */
-    getPermissions(): Promise<any[] | null>;
+    getPermissions(): Promise<any[] | null>; // TODO: return type of Promise<???>
 
     /**
      * A promise that is resolved with the info and metadata of the PDF.
@@ -421,8 +422,15 @@ interface ViewportParameters {
  * Page getTextContent parameters.
  */
 interface GetTextContentParameters {
-    normalizeWhitespace: boolean; // Replaces all occurrences of whitespace with standard spaces (0x20). The default value is `false`.
-    disabledCombineTextItems: boolean; // Do not attempt to combine same line TextItem's. The default value is `false`.
+    /**
+     * Replaces all occurrences of whitespace with standard spaces (0x20). The default value is `false`.
+     */
+    normalizeWhitespace: boolean;
+
+    /**
+     * Do not attempt to combine same line TextItem's. The default value is `false`.
+     */
+    disabledCombineTextItems: boolean;
 }
 
 interface PDFAnnotationData {
@@ -485,8 +493,15 @@ interface PDFRenderTask extends PDFLoadingTask<PDFPageProxy> {
  * PDF page operator list.
  */
 interface PDFOperatorList {
-    fnArray: any[]; // Array containing the operator functions.  TODO: Type of Array<???>
-    argsArray: any[]; // Array containing the arguments of the functions.
+    /**
+     * Array containing the operator functions.
+     */
+    fnArray: any[]; // TODO: Type of Array<???>
+
+    /**
+     * Array containing the arguments of the functions.
+     */
+    argsArray: any[];
 }
 
 /**

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -14,14 +14,6 @@ interface GlobalWorkerOptions {
   workerSrc: string;
 }
 
-interface PDFPromise<T> {
-    isResolved(): boolean;
-    isRejected(): boolean;
-    resolve(value: T): void;
-    reject(reason: string): void;
-    then<U>(onResolve: (promise: T) => U, onReject?: (reason: string) => void): PDFPromise<U>;
-}
-
 interface PDFTreeNode {
     title: string;
     bold: boolean;
@@ -448,8 +440,8 @@ interface PDFAnnotations {
     getHtmlElement(commonOjbs: any): HTMLElement; // throw new NotImplementedException()
     getEmptyContainer(tagName: string, rect: number[]): HTMLElement; // deprecated
     isViewable(): boolean;
-    loadResources(keys: any): PDFPromise<any>;
-    getOperatorList(evaluator: any): PDFPromise<any>;
+    loadResources(keys: any): Promise<any>;
+    getOperatorList(evaluator: any): Promise<any>;
     // ... todo
 }
 
@@ -755,7 +747,7 @@ interface PDFJSStatic {
 }
 
 interface PDFLoadingTask<T> {
-    promise: PDFPromise<T>;
+    promise: Promise<T>;
 }
 
 declare const Util: PDFJSUtilStatic;

--- a/types/pdfjs-dist/pdfjs-dist-tests.ts
+++ b/types/pdfjs-dist/pdfjs-dist-tests.ts
@@ -1,4 +1,4 @@
-import { getDocument, PDFDocumentProxy, PDFPromise, Util } from 'pdfjs-dist';
+import { getDocument, PDFDocumentProxy, Util } from 'pdfjs-dist';
 
 //
 // Fetch the PDF document from the URL using promises
@@ -53,10 +53,3 @@ function goNext() {
         renderPage(pageNum);
     }
 }
-
-//
-// Test PDFPromise allows return value mutation
-//
-var promise: PDFPromise<string> = getDocument('helloworld.pdf').promise.then(pdf => {
-	return "arbitrary string";
-});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mozilla/pdf.js/blob/v2.1.266/src/display/api.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

