### PR TITLE
[tus-js-client] Align definitions with v1.7

### DIFF
--- a/types/tus-js-client/index.d.ts
+++ b/types/tus-js-client/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for tus-js-client 1.5
+// Type definitions for tus-js-client 1.7
 // Project: https://github.com/tus/tus-js-client/
 // Definitions by: Kevin Somers-Higgins <https://github.com/kevhiggins>
 //                 Marius Kleidl <https://github.com/Acconut>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
 
 export interface UploadOptions {
     endpoint: string;
@@ -21,12 +22,13 @@ export interface UploadOptions {
     overridePatchMethod?: boolean;
     retryDelays?: number[];
     removeFingerprintOnSuccess?: boolean;
+    uploadLengthDeferred?: boolean;
 }
 
 export class Upload {
-    constructor(file: File | Blob, options: UploadOptions);
+    constructor(file: File | Blob | Pick<ReadableStreamDefaultReader, "read">, options: UploadOptions);
 
-    file: File | Blob;
+    file: File | Blob | Pick<ReadableStreamDefaultReader, "read">;
     options: UploadOptions;
     url: string | null;
 

--- a/types/tus-js-client/tus-js-client-tests.ts
+++ b/types/tus-js-client/tus-js-client-tests.ts
@@ -43,3 +43,11 @@ upload.abort();
 const upload2 = new Tus.Upload(file, {
 	endpoint: ""
 });
+
+const reader = {
+    read: () => Promise.resolve({ done: true, value: '' }),
+};
+const upload3 = new Tus.Upload(reader, {
+    endpoint: '',
+    uploadLengthDeferred: true,
+});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tus/tus-js-client/pull/126
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
