### PR TITLE
Add typing for Stripe request and response events

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -39,6 +39,28 @@
 
 import { Agent } from 'http';
 
+interface RequestEvent {
+  api_version: string;
+  account?: string;
+  idempotency_key?: string;
+  method: string;
+  path: string;
+  request_start_time: number;
+}
+
+interface ResponseEvent {
+  api_version: string;
+  account?: string;
+  idempotency_key?: string;
+  method: string;
+  path: string;
+  status: number;
+  request_id: string;
+  elapsed: number;
+  request_start_time: number;
+  request_end_time: number;
+}
+
 declare class Stripe {
   DEFAULT_HOST: string;
   DEFAULT_PORT: string;
@@ -126,6 +148,13 @@ declare class Stripe {
   getMaxNetworkRetries(): number;
   getTelemetryEnabled(): boolean;
   getClientUserAgent(response: (userAgent: string) => void): void;
+
+  on(event: 'request', handler: (event: RequestEvent) => void): void;
+  on(event: 'response', handler: (event: ResponseEvent) => void): void;
+  once(event: 'request', handler: (event: RequestEvent) => void): void;
+  once(event: 'response', handler: (event: ResponseEvent) => void): void;
+  off(event: 'request', handler: (event: RequestEvent) => void): void;
+  off(event: 'response', handler: (event: ResponseEvent) => void): void;
 }
 export = Stripe;
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -20,6 +20,13 @@ stripe.setAppInfo({
 stripe.setTelemetryEnabled(true); // $ExpectType void
 stripe.getTelemetryEnabled(); // $ExpectType boolean
 
+stripe.on('request', event => {});
+stripe.on('response', event => {});
+stripe.once('request', event => {});
+stripe.once('response', event => {});
+stripe.off('request', event => {});
+stripe.off('response', event => {});
+
 // generic list tests
 // ##################################################################################
 stripe.balance.listTransactions().then(items => {


### PR DESCRIPTION
Adding the Stripe event objects to the type definition.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x  ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/stripe-node#request-and-response-events
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
