### PR TITLE
levelup: add missing type parameters to constructor

### DIFF
--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -88,23 +88,23 @@ export interface LevelUp<DB = AbstractLevelDOWN, Iterator = AbstractIterator<any
 }
 
 interface LevelUpConstructor {
-    <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+    <DB extends AbstractLevelDOWN = AbstractLevelDOWN, Iterator = AbstractIterator<any, any>>(
         db: DB,
         options: any,
-        cb?: ErrorCallback): LevelUp<DB>;
+        cb?: ErrorCallback): LevelUp<DB, Iterator>;
 
-    <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+    <DB extends AbstractLevelDOWN = AbstractLevelDOWN, Iterator = AbstractIterator<any, any>>(
         db: DB,
-        cb?: ErrorCallback): LevelUp<DB>;
+        cb?: ErrorCallback): LevelUp<DB, Iterator>;
 
-    new <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+    new <DB extends AbstractLevelDOWN = AbstractLevelDOWN, Iterator = AbstractIterator<any, any>>(
         db: DB,
         options: any,
-        cb?: ErrorCallback): LevelUp<DB>;
+        cb?: ErrorCallback): LevelUp<DB, Iterator>;
 
-    new <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+    new <DB extends AbstractLevelDOWN = AbstractLevelDOWN, Iterator = AbstractIterator<any, any>>(
         db: DB,
-        cb?: ErrorCallback): LevelUp<DB>;
+        cb?: ErrorCallback): LevelUp<DB, Iterator>;
 
     errors: /*typeof levelerrors*/ any; // ? level-errors is not in DT
 }


### PR DESCRIPTION
This change updates the constructor's type parameters to match the class/interface definition at types/levelup/index.d.ts#L48. This makes it possible to extend the LevelUp class using all its type parameters.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: types/levelup/index.d.ts#L48
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
