### PR TITLE
fix: Use ListIterator for the remove predicate.

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -1858,7 +1858,7 @@ declare module "../index" {
          */
         remove<T>(
             array: List<T>,
-            predicate?: ListIteratee<T>
+            predicate?: ListIterator<T, NotVoid>
         ): T[];
     }
 
@@ -1868,7 +1868,7 @@ declare module "../index" {
          */
         remove<T>(
             this: LoDashImplicitWrapper<List<T>>,
-            predicate?: ListIteratee<T>
+            predicate?: ListIterator<T, NotVoid>
         ): LoDashImplicitWrapper<T[]>;
     }
 
@@ -1878,7 +1878,7 @@ declare module "../index" {
          */
         remove<T>(
             this: LoDashExplicitWrapper<List<T>>,
-            predicate?: ListIteratee<T>
+            predicate?: ListIterator<T, NotVoid>
         ): LoDashExplicitWrapper<T[]>;
     }
 

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -3740,12 +3740,12 @@ declare namespace _ {
     type LodashReject1x2<T> = (predicate: lodash.ValueIterateeCustom<T, boolean>) => T[];
     type LodashReject2x2<T> = (predicate: lodash.ValueIterateeCustom<T[keyof T], boolean>) => Array<T[keyof T]>;
     interface LodashRemove {
-        <T>(predicate: lodash.ValueIteratee<T>): LodashRemove1x1<T>;
+        <T>(predicate: (value: T) => lodash.NotVoid): LodashRemove1x1<T>;
         <T>(predicate: lodash.__, array: lodash.List<T>): LodashRemove1x2<T>;
-        <T>(predicate: lodash.ValueIteratee<T>, array: lodash.List<T>): T[];
+        <T>(predicate: (value: T) => lodash.NotVoid, array: lodash.List<T>): T[];
     }
     type LodashRemove1x1<T> = (array: lodash.List<T>) => T[];
-    type LodashRemove1x2<T> = (predicate: lodash.ValueIteratee<T>) => T[];
+    type LodashRemove1x2<T> = (predicate: (value: T) => lodash.NotVoid) => T[];
     interface LodashRepeat {
         (n: number): LodashRepeat1x1;
         (n: lodash.__, string: string): LodashRepeat1x2;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -1074,23 +1074,15 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 
     _.remove(list); // $ExpectType AbcObject[]
     _.remove(list, listIterator); // $ExpectType AbcObject[]
-    _.remove(list, ""); // $ExpectType AbcObject[]
-    _.remove(list, { a: 42 }); // $ExpectType AbcObject[]
 
     _(list).remove(); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
     _(list).remove(listIterator); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
-    _(list).remove(""); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
-    _(list).remove({ a: 42 }); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
 
     _.chain(list).remove(); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
     _.chain(list).remove(listIterator); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
-    _.chain(list).remove(""); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
-    _.chain(list).remove({ a: 42 }); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
 
     fp.remove(valueIterator, list); // $ExpectType AbcObject[]
     fp.remove(valueIterator)(list); // $ExpectType AbcObject[]
-    fp.remove("", list); // $ExpectType AbcObject[]
-    fp.remove({ a: 42 }, list); // $ExpectType AbcObject[]
 }
 
 // _.tail

--- a/types/lodash/ts3.1/common/array.d.ts
+++ b/types/lodash/ts3.1/common/array.d.ts
@@ -1115,19 +1115,19 @@ declare module "../index" {
          * @param predicate The function invoked per iteration.
          * @return Returns the new array of removed elements.
          */
-        remove<T>(array: List<T>, predicate?: ListIteratee<T>): T[];
+        remove<T>(array: List<T>, predicate?: ListIterator<T, NotVoid>): T[];
     }
     interface Collection<T> {
         /**
          * @see _.remove
          */
-        remove(predicate?: ListIteratee<T>): Collection<T>;
+        remove(predicate?: ListIterator<T, NotVoid>): Collection<T>;
     }
     interface CollectionChain<T> {
         /**
          * @see _.remove
          */
-        remove(predicate?: ListIteratee<T>): CollectionChain<T>;
+        remove(predicate?: ListIterator<T, NotVoid>): CollectionChain<T>;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -3723,12 +3723,12 @@ declare namespace _ {
     type LodashReject1x2<T> = (predicate: lodash.ValueIterateeCustom<T, boolean>) => T[];
     type LodashReject2x2<T> = (predicate: lodash.ValueIterateeCustom<T[keyof T], boolean>) => Array<T[keyof T]>;
     interface LodashRemove {
-        <T>(predicate: lodash.ValueIteratee<T>): LodashRemove1x1<T>;
+        <T>(predicate: (value: T) => lodash.NotVoid): LodashRemove1x1<T>;
         <T>(predicate: lodash.__, array: lodash.List<T>): LodashRemove1x2<T>;
-        <T>(predicate: lodash.ValueIteratee<T>, array: lodash.List<T>): T[];
+        <T>(predicate: (value: T) => lodash.NotVoid, array: lodash.List<T>): T[];
     }
     type LodashRemove1x1<T> = (array: lodash.List<T>) => T[];
-    type LodashRemove1x2<T> = (predicate: lodash.ValueIteratee<T>) => T[];
+    type LodashRemove1x2<T> = (predicate: (value: T) => lodash.NotVoid) => T[];
     interface LodashRepeat {
         (n: number): LodashRepeat1x1;
         (n: lodash.__, string: string): LodashRepeat1x2;

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -1082,23 +1082,15 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
     _.remove(list); // $ExpectType AbcObject[]
     _.remove(list, listIterator); // $ExpectType AbcObject[]
-    _.remove(list, ""); // $ExpectType AbcObject[]
-    _.remove(list, { a: 42 }); // $ExpectType AbcObject[]
 
     _(list).remove(); // $ExpectType Collection<AbcObject>
     _(list).remove(listIterator); // $ExpectType Collection<AbcObject>
-    _(list).remove(""); // $ExpectType Collection<AbcObject>
-    _(list).remove({ a: 42 }); // $ExpectType Collection<AbcObject>
 
     _.chain(list).remove(); // $ExpectType CollectionChain<AbcObject>
     _.chain(list).remove(listIterator); // $ExpectType CollectionChain<AbcObject>
-    _.chain(list).remove(""); // $ExpectType CollectionChain<AbcObject>
-    _.chain(list).remove({ a: 42 }); // $ExpectType CollectionChain<AbcObject>
 
     fp.remove(valueIterator, list); // $ExpectType AbcObject[]
     fp.remove(valueIterator)(list); // $ExpectType AbcObject[]
-    fp.remove("", list); // $ExpectType AbcObject[]
-    fp.remove({ a: 42 }, list); // $ExpectType AbcObject[]
 }
 
 // _.tail


### PR DESCRIPTION
Unlike many lodash functions, `remove` does not accept an iteratee shorthand, according to the [documentation](https://lodash.com/docs/4.17.15#remove) and the [source](https://github.com/lodash/lodash/blob/c89637e4db06592b319d3ca53c854fbfb8545349/remove.js#L39).

`ListIterator<T, NotVoid>` is drawn from the existing `ListIteratee<T> type`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.