### PR TITLE
Add types for appboy-web-sdk

### DIFF
--- a/types/appboy-web-sdk/appboy-web-sdk-tests.ts
+++ b/types/appboy-web-sdk/appboy-web-sdk-tests.ts
@@ -1,0 +1,6 @@
+import { ControlMessage } from 'appboy-web-sdk';
+
+const triggerId = '123';
+const controlMessage = new ControlMessage(triggerId);
+// $ExpectType string | undefined
+controlMessage.triggerId;

--- a/types/appboy-web-sdk/index.d.ts
+++ b/types/appboy-web-sdk/index.d.ts
@@ -1,0 +1,445 @@
+// Type definitions for appboy-web-sdk 2.4
+// Project: https://github.com/Appboy/appboy-web-sdk#readme
+// Definitions by: Jared Rolt <https://github.com/jaredrolt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+// export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+
+/*~ You can declare types that are available via importing the module */
+export interface DeviceProperties {
+    readonly BROWSER: string;
+    readonly BROWSER_VERSION: string;
+    readonly OS: string;
+    readonly RESOLUTION: string;
+    readonly LANGUAGE: string;
+    readonly TIME_ZONE: string;
+    readonly USER_AGENT: string;
+}
+
+export interface Card {
+    dismissCard(): void;
+    removeAllSubscriptions(): void;
+    removeSubscription(subscriptionGuid: string): void;
+    subscribeToClickedEvent(subscriber: () => void): string;
+    subscribeToDismissedEvent(subscriber: () => void): string;
+}
+
+export interface ClassicCard<Extras = {}> extends Card {
+    id: string;
+    viewed: boolean;
+    title: string;
+    imageUrl: string;
+    description: string;
+    created: Date;
+    updated: Date;
+    categories: string[];
+    expiresAt: Date;
+    url: string;
+    linkText: string;
+    aspectRatio: string;
+    extras: Extras;
+    pinned: boolean;
+    dismissible: boolean;
+    clicked: boolean;
+}
+
+export interface CaptionedImage<Extras = {}> extends Card {
+    id: string;
+    viewed: boolean;
+    title: string;
+    imageUrl: string;
+    description: string;
+    created: Date;
+    updated: Date;
+    categories: string[];
+    expiresAt: Date;
+    url: string;
+    linkText: string;
+    aspectRatio: string;
+    extras: Extras;
+    pinned: boolean;
+    dismissible: boolean;
+    clicked: boolean;
+}
+
+export interface Banner<Extras = {}> extends Card {
+    id: string;
+    viewed: boolean;
+    imageUrl: string;
+    created: Date;
+    updated: Date;
+    categories: string[];
+    expiresAt: Date;
+    url: string;
+    linkText: string;
+    aspectRatio: string;
+    extras: Extras;
+    pinned: boolean;
+    dismissible: boolean;
+    clicked: boolean;
+}
+
+export interface ContentCards<T = ClassicCard|CaptionedImage|Banner> {
+    cards: T[];
+    lastUpdated: Date|null;
+    getUnviewedCardCount(): number;
+}
+
+export interface Feed<T = ClassicCard|CaptionedImage|Banner> {
+    cards: T[];
+    lastUpdated: Date|null;
+    getUnreadCardCount(): number;
+}
+
+export interface ControlCard<Extras = {}> extends Card {
+    id: string;
+    viewed: boolean;
+    updated: Date;
+    expiresAt: Date;
+    extras: Extras;
+    pinned: boolean;
+}
+
+export enum ClickAction {
+    NEWS_FEED = 'NEWS_FEED',
+    URI = 'URI',
+    NONE = 'NONE'
+}
+
+export enum CropType {
+    CENTER_CROP = 'CENTER_CROP',
+    FIT_CENTER = 'FIT_CENTER'
+}
+
+export enum DismissType {
+    AUTO_DISMISS = 'AUTO_DISMISS',
+    MANUAL = 'MANUAL'
+}
+
+export enum ImageStyle {
+    TOP = 'TOP',
+    GRAPHIC = 'GRAPHIC'
+}
+
+export enum OpenTarget {
+    NONE = 'NONE',
+    BLANK = 'BLANK'
+}
+
+export enum Orientation {
+    PORTRAIT = 'PORTRAIT',
+    LANDSCAPE = 'LANDSCAPE'
+}
+
+export enum SlideFrom {
+    TOP = 'TOP',
+    BOTTOM = 'BOTTOM'
+}
+
+export enum TextAlignment {
+    START = 'START',
+    CENTER = 'CENTER',
+    END = 'END'
+}
+
+export class Button {
+    constructor(
+      text: string,
+      backgroundColor?: number,
+      textColor?: number,
+      borderColor?: number,
+      clickAction?: ClickAction,
+      uri?: string,
+      id?: number
+    );
+    removeAllSubscriptions(): void;
+    removeSubscription(subscriptionGuid: string): void;
+    subscribeToClickedEvent(subscriber: () => void): string;
+    subscribeToDismissedEvent(subscriber: () => void): string;
+}
+
+export class InAppMessage {
+    readonly ClickAction: ClickAction;
+    readonly CropType: CropType;
+    readonly DismissType: DismissType;
+    readonly ImageStyle: ImageStyle;
+    readonly OpenTarget: OpenTarget;
+    readonly Orientation: Orientation;
+    readonly SlideFrom: SlideFrom;
+    readonly TextAlignment: TextAlignment;
+    closeMessage(): void;
+    removeAllSubscriptions(): void;
+    removeSubscription(subscriptionGuid: string): void;
+    subscribeToClickedEvent(subscriber: () => void): string;
+    subscribeToDismissedEvent(subscriber: () => void): string;
+}
+
+export class FullScreenMessage extends InAppMessage {
+    constructor(
+      message: string,
+      messageAlignment?: TextAlignment,
+      extras?: string[],
+      campaignId?: string,
+      cardId?: string,
+      triggerId?: string,
+      clickAction?: ClickAction,
+      uri?: string,
+      openTarget?: OpenTarget,
+      dismissType?: DismissType,
+      duration?: number,
+      icon?: string,
+      imageUrl?: string,
+      imageStyle?: ImageStyle,
+      iconColor?: number,
+      iconBackgroundColor?: number,
+      backgroundColor?: number,
+      textColor?: number,
+      closeButtonColor?: number,
+      animateIn?: boolean,
+      animateOut?: boolean,
+      header?: string,
+      headerAlignment?: TextAlignment,
+      headerTextColor?: number,
+      frameColor?: number,
+      buttons?: Button[],
+      cropType?: CropType,
+      orientation?: Orientation,
+      htmlId?: string,
+      css?: string
+    );
+}
+
+export class ModalMessage extends InAppMessage {
+    constructor(
+      message: string,
+      messageAlignment?: TextAlignment,
+      extras?: string[],
+      campaignId?: string,
+      cardId?: string,
+      triggerId?: string,
+      clickAction?: ClickAction,
+      uri?: string,
+      openTarget?: OpenTarget,
+      dismissType?: DismissType,
+      duration?: number,
+      icon?: string,
+      imageUrl?: string,
+      imageStyle?: ImageStyle,
+      iconColor?: number,
+      iconBackgroundColor?: number,
+      backgroundColor?: number,
+      textColor?: number,
+      closeButtonColor?: number,
+      animateIn?: boolean,
+      animateOut?: boolean,
+      header?: string,
+      headerAlignment?: TextAlignment,
+      headerTextColor?: number,
+      frameColor?: number,
+      buttons?: Button[],
+      cropType?: CropType,
+      htmlId?: string,
+      css?: string
+    );
+}
+
+export class HtmlMessage extends InAppMessage {
+    constructor(
+      message: string,
+      extras?: string[],
+      campaignId?: string,
+      cardId?: string,
+      triggerId?: string,
+      dismissType?: DismissType,
+      duration?: number,
+      animateIn?: boolean,
+      animateOut?: boolean,
+      frameColor?: number,
+      htmlId?: string,
+      css?: string
+    );
+}
+
+export class ControlMessage {
+    constructor(triggerId?: string);
+    triggerId?: string;
+}
+
+export enum Genders {
+    MALE = 'm',
+    FEMALE = 'f',
+    OTHER = 'o',
+    UNKNOWN = 'u',
+    NOT_APPLICAPLE = 'n',
+    PREFER_NOT_TO_SAY = 'p'
+}
+
+export enum NotificationSubscriptionTypes {
+    OPTED_IN = 'opted_id',
+    SUBSCRIBED = 'subscribed',
+    UNSUBSCRIBED = 'unsubscribed',
+}
+
+export interface User {
+    addAlias(alias: string, label: string): boolean;
+    addToCustomAttributeArray(key: string, value: string): boolean;
+    getUserId(callback: (userId: string) => void): void;
+    incrementCustomUserAttribute(key: string, incrementValue?: number): boolean;
+    removeFromCustomAttributeArray(key: string, value: string): boolean;
+    setAvatarImageUrl(avatarImageUrl: string): boolean;
+    setCountry(country: string|null): boolean;
+    setCustomLocationAttribute(key: string, latitude: number, longitude: number): boolean;
+    setCustomUserAttribute(key: string, value: string|boolean|Date|string[]|null): boolean;
+    setDateOfBirth(year: number|null, month: number|null, day: number|null): boolean;
+    setEmail(email: string|null): boolean;
+    setEmailNotificationSubscriptionType(notificationSubscriptionType: NotificationSubscriptionTypes): boolean;
+    setFirstName(firstName: string|null): boolean;
+    setGender(gender: Genders|null): boolean;
+    setHomeCity(homeCity: string|null): boolean;
+    setLanguage(language: string|null): boolean;
+    setLastKnownLocation(latitude: number, longitude: number, accuracy?: number, altitude?: number, altitudeAccuracy?: number): boolean;
+    setLastName(lastName: string|null): boolean;
+    setPhoneNumber(phoneNumber: string|null): boolean;
+    setPushNotificationSubscriptionType(notificationSubscriptionType: NotificationSubscriptionTypes): boolean;
+}
+
+export interface Options {
+    allowCrawlerActivity: boolean;
+    allowUserSuppliedJavascript: boolean;
+    appVersion: string;
+    baseUrl: string;
+    contentSecurityNonce: string;
+    devicePropertyWhitelist: Partial<DeviceProperties>;
+    disablePushTokenMaintenance: boolean;
+    doNotLoadFontAwesome: boolean;
+    enableHtmlInAppMessages: boolean;
+    enableLogging: boolean;
+    localization: string;
+    manageServiceWorkerExternally: boolean;
+    minimumIntervalBetweenTriggerActionsInSeconds: number;
+    noCookies: boolean;
+    openInAppMessagesInNewTab: boolean;
+    openCardsInNewTab: boolean;
+    requireExplicitInAppMessageDismissal: boolean;
+    safariWebsitePushId: string;
+    serviceWorkerLocation: string;
+    sessionTimeoutInSeconds: number;
+}
+
+export interface AppBoy {
+    DeviceProperties: DeviceProperties;
+    changeUser(userId: string): void;
+    destroy(): void;
+    getCachedContentCards(): ContentCards;
+    getCachedFeed(): Feed;
+    getDeviceId(callback: (deviceId: string) => void): void;
+    getUser(): User;
+    initialize(apiKey: string, options?: Partial<Options>): boolean;
+    isPushBlocked(): boolean;
+    isPushGranted(yesCallback: () => void, noCallback: () => void): void; // DEPRECATED; use isPushPermissionGranted instead.
+    isPushPermissionGranted(): boolean;
+    isPushSupported(): boolean;
+    logCardClick(card: Card, forContentCards?: boolean): boolean;
+    logCardDismissal(card: Card): boolean;
+    logCardImpressions(contentCards: Card[], forContentCards?: boolean): boolean;
+    logContentCardsDisplayed(): void;
+    logCustomEvent(eventName: string, eventProperties?: object): boolean;
+    logFeedDisplayed(): void;
+    logInAppMessageButtonClick(button: Button, inAppMessage: InAppMessage): boolean;
+    logInAppMessageClick(inAppMessage: InAppMessage): boolean;
+    logInAppMessageHtmlClick(inAppMessage: HtmlMessage, buttonId?: string, url?: string): boolean;
+    logInAppMessageImpression(inAppMessage: InAppMessage|ControlMessage): boolean;
+    logPurchase(productId: string, price: number, currencyCode?: string, quantity?: number, purchaseProperties?: object): boolean;
+    openSession(): void;
+    registerAppboyPushMessages(successCallback?: (endpoint: string, publicKey: string, userAuth: string) => void, deniedCallback?: (isTemporary: boolean) => void): void;
+    removeAllSubscriptions(): void;
+    removeSubscription(subscriptionGuid: string): void;
+    requestContentCardsRefresh(): void;
+    requestFeedRefresh(): void;
+    requestImmediateDataFlush(): void;
+    resumeWebTracking(): void;
+    setLogger(loggerFunction: (message?: string) => void): void;
+    stopWebTracking(): void;
+    subscribeToContentCardsUpdates(subscriber: (contentCards: ContentCards) => void): string;
+    subscribeToFeedUpdates(subscriber: (feed: Feed) => void): string;
+    subscribeToInAppMessage(callback: (inAppMesssage: InAppMessage|ControlMessage) => void): string;
+    subscribeToNewInAppMessages(subscriber: (inAppMessages: Array<InAppMessage|ControlMessage>) => Array<InAppMessage|ControlMessage>): string; // DEPRECATED; use subscribeToInAppMessage instead.
+    toggleAppboyLogging(): void;
+    trackLocation(): void;
+    unregisterAppboyPushMessages(successCallback?: () => void, errorCallback?: () => void): void;
+    wipeData(): void;
+}
+
+export default AppBoy;
+
+/*~ You can declare properties of the module using const, let, or var */
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+// export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    // function foo(): void;
+// }
+
+// interface AppBoy {
+//     DeviceProperties: DeviceProperties;
+//     changeUser(userId: string): void;
+//     destroy(): void;
+//     getCachedContentCards<T>(): ContentCards<T>;
+//     getCachedFeed(): Feed;
+//     getDeviceId(callback: (deviceId: string) => void): void;
+//     getUser(): User;
+//     initialize(apiKey: string, options?: Partial<Options>): boolean;
+//     isPushBlocked(): boolean;
+//     isPushGranted(yesCallback: () => void, noCallback: () => void): void; // DEPRECATED; use isPushPermissionGranted instead.
+//     isPushPermissionGranted(): boolean;
+//     isPushSupported(): boolean;
+//     logCardClick(card: Card, forContentCards?: boolean): boolean;
+//     logCardDismissal(card: Card): boolean
+//     logCardImpressions(contentCards: Card[], forContentCards?: boolean): boolean;
+//     logContentCardsDisplayed(): void;
+//     logCustomEvent<T = {}>(eventName: string, eventProperties?: T): boolean;
+//     logFeedDisplayed(): void;
+//     logInAppMessageButtonClick(button: Button, inAppMessage: InAppMessage): boolean;
+//     logInAppMessageClick(inAppMessage: InAppMessage): boolean;
+//     logInAppMessageHtmlClick(inAppMessage: HtmlMessage, buttonId?: string, url?: string): boolean;
+//     logInAppMessageImpression(inAppMessage: InAppMessage|ControlMessage): boolean;
+//     logPurchase<T = {}>(productId: string, price: number, currencyCode?: string, quantity?: number, purchaseProperties?: T): boolean;
+//     openSession(): void;
+//     registerAppboyPushMessages(successCallback?: (endpoint: string, publicKey: string, userAuth: string) => void, deniedCallback: (isTemporary: boolean) => void): void;
+//     removeAllSubscriptions(): void;
+//     removeSubscription(subscriptionGuid: string): void;
+//     requestContentCardsRefresh(): void;
+//     requestFeedRefresh(): void;
+//     requestImmediateDataFlush(): void;
+//     resumeWebTracking(): void;
+//     setLogger(loggerFunction: (message?: string) => void): void;
+//     stopWebTracking(): void;
+//     subscribeToContentCardsUpdates<T>(subscriber: (contentCards: ContentCards<T>) => void): string;
+//     subscribeToFeedUpdates<T>(subscriber: (feed: Feed<T>) => void): string;
+//     subscribeToInAppMessage(callback: (inAppMesssage: InAppMessage|ControlMessage) => void): string;
+//     subscribeToNewInAppMessages(subscriber: (inAppMessages: Array<InAppMessage|ControlMessage>) => Array<InAppMessage|ControlMessage>): string; // DEPRECATED; use subscribeToInAppMessage instead.
+//     toggleAppboyLogging(): void;
+//     trackLocation(): void;
+//     unregisterAppboyPushMessages(successCallback?: () => void, errorCallback?: () => void): void;
+//     wipeData(): void;
+// }
+
+//   declare const appboy: AppBoy;
+
+//   export default appboy;

--- a/types/appboy-web-sdk/index.d.ts
+++ b/types/appboy-web-sdk/index.d.ts
@@ -4,16 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-// export as namespace myLib;
-
-/*~ If this module has methods, declare them as functions like so.
- */
-
-/*~ You can declare types that are available via importing the module */
 export interface DeviceProperties {
     readonly BROWSER: string;
     readonly BROWSER_VERSION: string;
@@ -379,67 +369,3 @@ export interface AppBoy {
 }
 
 export default AppBoy;
-
-/*~ You can declare properties of the module using const, let, or var */
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-// export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    // function foo(): void;
-// }
-
-// interface AppBoy {
-//     DeviceProperties: DeviceProperties;
-//     changeUser(userId: string): void;
-//     destroy(): void;
-//     getCachedContentCards<T>(): ContentCards<T>;
-//     getCachedFeed(): Feed;
-//     getDeviceId(callback: (deviceId: string) => void): void;
-//     getUser(): User;
-//     initialize(apiKey: string, options?: Partial<Options>): boolean;
-//     isPushBlocked(): boolean;
-//     isPushGranted(yesCallback: () => void, noCallback: () => void): void; // DEPRECATED; use isPushPermissionGranted instead.
-//     isPushPermissionGranted(): boolean;
-//     isPushSupported(): boolean;
-//     logCardClick(card: Card, forContentCards?: boolean): boolean;
-//     logCardDismissal(card: Card): boolean
-//     logCardImpressions(contentCards: Card[], forContentCards?: boolean): boolean;
-//     logContentCardsDisplayed(): void;
-//     logCustomEvent<T = {}>(eventName: string, eventProperties?: T): boolean;
-//     logFeedDisplayed(): void;
-//     logInAppMessageButtonClick(button: Button, inAppMessage: InAppMessage): boolean;
-//     logInAppMessageClick(inAppMessage: InAppMessage): boolean;
-//     logInAppMessageHtmlClick(inAppMessage: HtmlMessage, buttonId?: string, url?: string): boolean;
-//     logInAppMessageImpression(inAppMessage: InAppMessage|ControlMessage): boolean;
-//     logPurchase<T = {}>(productId: string, price: number, currencyCode?: string, quantity?: number, purchaseProperties?: T): boolean;
-//     openSession(): void;
-//     registerAppboyPushMessages(successCallback?: (endpoint: string, publicKey: string, userAuth: string) => void, deniedCallback: (isTemporary: boolean) => void): void;
-//     removeAllSubscriptions(): void;
-//     removeSubscription(subscriptionGuid: string): void;
-//     requestContentCardsRefresh(): void;
-//     requestFeedRefresh(): void;
-//     requestImmediateDataFlush(): void;
-//     resumeWebTracking(): void;
-//     setLogger(loggerFunction: (message?: string) => void): void;
-//     stopWebTracking(): void;
-//     subscribeToContentCardsUpdates<T>(subscriber: (contentCards: ContentCards<T>) => void): string;
-//     subscribeToFeedUpdates<T>(subscriber: (feed: Feed<T>) => void): string;
-//     subscribeToInAppMessage(callback: (inAppMesssage: InAppMessage|ControlMessage) => void): string;
-//     subscribeToNewInAppMessages(subscriber: (inAppMessages: Array<InAppMessage|ControlMessage>) => Array<InAppMessage|ControlMessage>): string; // DEPRECATED; use subscribeToInAppMessage instead.
-//     toggleAppboyLogging(): void;
-//     trackLocation(): void;
-//     unregisterAppboyPushMessages(successCallback?: () => void, errorCallback?: () => void): void;
-//     wipeData(): void;
-// }
-
-//   declare const appboy: AppBoy;
-
-//   export default appboy;

--- a/types/appboy-web-sdk/tsconfig.json
+++ b/types/appboy-web-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "appboy-web-sdk-tests.ts"
+    ]
+}

--- a/types/appboy-web-sdk/tslint.json
+++ b/types/appboy-web-sdk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
