### PR TITLE
Add type definitions for array.prototype.flat

### DIFF
--- a/types/array.prototype.flat/array.prototype.flat-tests.ts
+++ b/types/array.prototype.flat/array.prototype.flat-tests.ts
@@ -1,0 +1,75 @@
+import flat = require('array.prototype.flat');
+import 'array.prototype.flat/auto';
+import flatImpl = require('array.prototype.flat/implementation');
+import getPolyfill = require('array.prototype.flat/polyfill');
+import shim = require('array.prototype.flat/shim');
+
+// Infers nesting-level of the output array from
+// the depth argument up to a depth of 4.
+flat(['foo'], 0); // $ExpectType string[]
+flat([['foo']], 1); // $ExpectType string[]
+flat([['foo']], 0); // $ExpectType string[][]
+flat([[['foo']]], 2); // $ExpectType string[]
+flat([[['foo']]], 1); // $ExpectType string[][]
+flat([[['foo']]], 0); // $ExpectType string[][][]
+flat([[[['foo']]]], 3); // $ExpectType string[]
+flat([[[['foo']]]], 2); // $ExpectType string[][]
+flat([[[['foo']]]], 1); // $ExpectType string[][][]
+flat([[[['foo']]]], 0); // $ExpectType string[][][][]
+flat([[[[['foo']]]]], 4); // $ExpectType string[]
+flat([[[[['foo']]]]], 3); // $ExpectType string[][]
+flat([[[[['foo']]]]], 2); // $ExpectType string[][][]
+flat([[[[['foo']]]]], 1); // $ExpectType string[][][][]
+flat([[[[['foo']]]]], 0); // $ExpectType string[][][][][]
+
+flatImpl(['foo'], 0); // $ExpectType string[]
+flatImpl([['foo']], 1); // $ExpectType string[]
+flatImpl([['foo']], 0); // $ExpectType string[][]
+flatImpl([[['foo']]], 2); // $ExpectType string[]
+flatImpl([[['foo']]], 1); // $ExpectType string[][]
+flatImpl([[['foo']]], 0); // $ExpectType string[][][]
+flatImpl([[[['foo']]]], 3); // $ExpectType string[]
+flatImpl([[[['foo']]]], 2); // $ExpectType string[][]
+flatImpl([[[['foo']]]], 1); // $ExpectType string[][][]
+flatImpl([[[['foo']]]], 0); // $ExpectType string[][][][]
+flatImpl([[[[['foo']]]]], 4); // $ExpectType string[]
+flatImpl([[[[['foo']]]]], 3); // $ExpectType string[][]
+flatImpl([[[[['foo']]]]], 2); // $ExpectType string[][][]
+flatImpl([[[[['foo']]]]], 1); // $ExpectType string[][][][]
+flatImpl([[[[['foo']]]]], 0); // $ExpectType string[][][][][]
+
+['foo'].flat(0); // $ExpectType string[]
+[['foo']].flat(1); // $ExpectType string[]
+[['foo']].flat(0); // $ExpectType string[][]
+[[['foo']]].flat(2); // $ExpectType string[]
+[[['foo']]].flat(1); // $ExpectType string[][]
+[[['foo']]].flat(0); // $ExpectType string[][][]
+[[[['foo']]]].flat(3); // $ExpectType string[]
+[[[['foo']]]].flat(2); // $ExpectType string[][]
+[[[['foo']]]].flat(1); // $ExpectType string[][][]
+[[[['foo']]]].flat(0); // $ExpectType string[][][][]
+[[[[['foo']]]]].flat(4); // $ExpectType string[]
+[[[[['foo']]]]].flat(3); // $ExpectType string[][]
+[[[[['foo']]]]].flat(2); // $ExpectType string[][][]
+[[[[['foo']]]]].flat(1); // $ExpectType string[][][][]
+[[[[['foo']]]]].flat(0); // $ExpectType string[][][][][]
+
+// Supports `ReadonlyArray` up to a depth of 4.
+const readOnly: ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<string>>>>> = [[[[['foo']]]]];
+flat(readOnly, 4); // $ExpectType string[]
+
+// Supports `Array` up to a depth of 7.
+const mutable: string[][][][][][][][] = [[[[[[[['string']]]]]]]];
+flat(mutable, 7); // $ExpectType string[]
+mutable.flat(7); // $ExpectType string[]
+
+// `getPolyfill` returns a flat implementation
+getPolyfill()([['foo']], 1); // $ExpectType string[]
+
+// `shim` installs a flat implementation in `Array` prototype and returns it
+shim()([['foo']], 1); // $ExpectType string[]
+
+//  `getPolyfill`, `implementation`, and `shim` are properties of the `flat` function.
+const _getPolyfill: typeof getPolyfill = flat.getPolyfill;
+const _implementation: typeof flatImpl = flat.implementation;
+const _shim: typeof shim = flat.shim;

--- a/types/array.prototype.flat/auto.d.ts
+++ b/types/array.prototype.flat/auto.d.ts
@@ -1,0 +1,162 @@
+// Adapted from https://github.com/microsoft/TypeScript/blob/master/lib/lib.es2019.array.d.ts
+
+interface ReadonlyArray<T> {
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(
+        this:
+            | ReadonlyArray<U[][][][]>
+            | ReadonlyArray<ReadonlyArray<U[][][]>>
+            | ReadonlyArray<Array<ReadonlyArray<U[][]>>>
+            | ReadonlyArray<Array<Array<ReadonlyArray<U[]>>>>
+            | ReadonlyArray<Array<Array<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<U[][]>>>
+            | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U[]>>>>
+            | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U[]>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>>
+            | ReadonlyArray<Array<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>>,
+        depth: 4,
+    ): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(
+        this:
+            | ReadonlyArray<U[][][]>
+            | ReadonlyArray<Array<Array<ReadonlyArray<U>>>>
+            | ReadonlyArray<Array<ReadonlyArray<U[]>>>
+            | ReadonlyArray<ReadonlyArray<U[][]>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>
+            | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>
+            | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>,
+        depth: 3,
+    ): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(
+        this:
+            | ReadonlyArray<U[][]>
+            | ReadonlyArray<ReadonlyArray<U[]>>
+            | ReadonlyArray<Array<ReadonlyArray<U>>>
+            | ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>,
+        depth: 2,
+    ): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: ReadonlyArray<U[]> | ReadonlyArray<ReadonlyArray<U>>, depth?: 1): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: ReadonlyArray<U>, depth: 0): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth. If no depth is provided, flat method defaults to the depth of 1.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat(depth?: number): any[];
+}
+
+interface Array<T> {
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][][][][][][], depth: 7): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][][][][][], depth: 6): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][][][][], depth: 5): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][][][], depth: 4): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][][], depth: 3): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][][], depth: 2): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[][], depth?: 1): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<U>(this: U[], depth: 0): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth. If no depth is provided, flat method defaults to the depth of 1.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat(depth?: number): any[];
+}

--- a/types/array.prototype.flat/implementation.d.ts
+++ b/types/array.prototype.flat/implementation.d.ts
@@ -1,0 +1,112 @@
+// Adapted from https://github.com/microsoft/TypeScript/blob/master/lib/lib.es2019.array.d.ts
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(receiver: U[][][][][][][][], depth: 7): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(receiver: U[][][][][][][], depth: 6): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(receiver: U[][][][][][], depth: 5): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(
+    receiver:
+        | ReadonlyArray<U[][][][]>
+        | ReadonlyArray<ReadonlyArray<U[][][]>>
+        | ReadonlyArray<Array<ReadonlyArray<U[][]>>>
+        | ReadonlyArray<Array<Array<ReadonlyArray<U[]>>>>
+        | ReadonlyArray<Array<Array<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<U[][]>>>
+        | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<Array<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U[]>>>>
+        | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U[]>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>>
+        | ReadonlyArray<Array<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>>,
+    depth: 4,
+): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(
+    receiver:
+        | ReadonlyArray<U[][][]>
+        | ReadonlyArray<Array<Array<ReadonlyArray<U>>>>
+        | ReadonlyArray<Array<ReadonlyArray<U[]>>>
+        | ReadonlyArray<ReadonlyArray<U[][]>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>
+        | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>
+        | ReadonlyArray<ReadonlyArray<Array<ReadonlyArray<U>>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>,
+    depth: 3,
+): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(
+    receiver:
+        | ReadonlyArray<U[][]>
+        | ReadonlyArray<ReadonlyArray<U[]>>
+        | ReadonlyArray<Array<ReadonlyArray<U>>>
+        | ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>,
+    depth: 2,
+): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(receiver: ReadonlyArray<U[]> | ReadonlyArray<ReadonlyArray<U>>, depth?: 1): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat<U>(receiver: ReadonlyArray<U>, depth: 0): U[];
+
+/**
+ * Returns a new array with all sub-array elements concatenated into it recursively up to the
+ * specified depth. If no depth is provided, flat method defaults to the depth of 1.
+ *
+ * @param depth The maximum recursion depth
+ */
+declare function flat(receiver: ReadonlyArray<any>, depth?: number): any[];
+
+export = flat;

--- a/types/array.prototype.flat/index.d.ts
+++ b/types/array.prototype.flat/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for array.prototype.flat 1.2
+// Project: https://github.com/es-shims/Array.prototype.flat#readme
+// Definitions by: Kyle Lin <https://github.com/kylejlin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import flatImpl = require('./implementation');
+
+type FlatImpl = typeof flatImpl;
+
+interface Flat extends FlatImpl {
+    getPolyfill(): FlatImpl;
+    implementation: FlatImpl;
+    shim(): FlatImpl;
+}
+
+declare const flat: Flat;
+export = flat;

--- a/types/array.prototype.flat/polyfill.d.ts
+++ b/types/array.prototype.flat/polyfill.d.ts
@@ -1,0 +1,4 @@
+import flat = require('./implementation');
+
+declare function getPolyfill(): typeof flat;
+export = getPolyfill;

--- a/types/array.prototype.flat/shim.d.ts
+++ b/types/array.prototype.flat/shim.d.ts
@@ -1,0 +1,4 @@
+import flat = require('./implementation');
+
+declare function shim(): typeof flat;
+export = shim;

--- a/types/array.prototype.flat/tsconfig.json
+++ b/types/array.prototype.flat/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "array.prototype.flat-tests.ts",
+        "auto.d.ts",
+        "implementation.d.ts",
+        "index.d.ts",
+        "polyfill.d.ts",
+        "shim.d.ts"
+    ]
+}

--- a/types/array.prototype.flat/tslint.json
+++ b/types/array.prototype.flat/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
