### PR TITLE
added typings for sparql-http-client

### DIFF
--- a/types/sparql-http-client/index.d.ts
+++ b/types/sparql-http-client/index.d.ts
@@ -21,7 +21,7 @@ export interface SparqlClientOptions extends SparqlHttpOptions {
 export interface QueryRequestInit extends SparqlHttpOptions, RequestInit {}
 
 export interface SelectBindings {
-    results: { bindings: Array<Record<string, Term>> };
+    results: { bindings: ReadonlyArray<Record<string, Term>> };
 }
 
 export interface AskResult {

--- a/types/sparql-http-client/index.d.ts
+++ b/types/sparql-http-client/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for sparql-http-client 1.1
+// Project: https://github.com/zazuko/sparql-http-client
+// Definitions by: Tomasz Pluskiewicz <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Term } from 'rdf-js';
+import fetch, { Response, RequestInit } from 'node-fetch';
+import { URL } from 'url';
+
+export interface SparqlHttpOptions {
+    endpointUrl?: string;
+    updateUrl?: string;
+}
+
+export interface SparqlClientOptions extends SparqlHttpOptions {
+    fetch: typeof fetch;
+    URL: typeof URL;
+}
+
+export interface QueryRequestInit extends SparqlHttpOptions, RequestInit {}
+
+export interface SelectBindings {
+    results: { bindings: Array<Record<string, Term>> };
+}
+
+export interface AskResult {
+    boolean: boolean;
+}
+
+export interface SelectResponse {
+    json(): Promise<SelectBindings & AskResult>;
+}
+
+export class SparqlHttp<TResponse extends Response = Response> {
+    constructor(options?: SparqlHttpOptions);
+    updateQuery(query: string, options?: QueryRequestInit): Promise<Response>;
+    selectQuery(query: string, options?: QueryRequestInit): Promise<SelectResponse & TResponse>;
+    constructQuery(query: string, options?: QueryRequestInit): Promise<TResponse>;
+}

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -1,0 +1,41 @@
+import { SparqlHttp } from 'sparql-http-client';
+
+const client = new SparqlHttp();
+
+async function selectQuery() {
+    const response = await client.selectQuery('...', {
+        endpointUrl: 'http://example.com/endpoint',
+    });
+
+    const json = await response.json();
+
+    json.results.bindings.forEach(binding => {
+        console.log(`${binding.name.value} (${binding.name.termType})`);
+    });
+}
+
+async function askQuery() {
+    const response = await client.selectQuery('...', {
+        endpointUrl: 'http://example.com/endpoint',
+    });
+
+    const json = await response.json();
+
+    console.log(`The answer was ${json.boolean ? 'YES' : 'NO'}`);
+}
+
+async function constructQuery() {
+    const response = await client.constructQuery('...');
+
+    const json = await response.json();
+
+    console.log(`The answer was ${json.boolean ? 'YES' : 'NO'}`);
+}
+
+async function updateQuery() {
+    const response = await client.constructQuery('...', {
+        updateUrl: 'http://example.com/endpoint',
+    });
+
+    console.log(`The update ${response.ok ? 'succeeded' : 'faield'}`);
+}

--- a/types/sparql-http-client/tsconfig.json
+++ b/types/sparql-http-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sparql-http-client-tests.ts"
+    ]
+}

--- a/types/sparql-http-client/tslint.json
+++ b/types/sparql-http-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
