### PR TITLE
fix(react-native): Alert.prompt signature

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6697,7 +6697,7 @@ export interface AccessibilityInfoStatic {
  */
 export interface AlertButton {
     text?: string;
-    onPress?: () => void;
+    onPress?: (value?: string) => void;
     style?: 'default' | 'cancel' | 'destructive';
 }
 
@@ -6748,7 +6748,7 @@ interface AlertOptions {
  */
 export interface AlertStatic {
     alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions) => void;
-    prompt: (title: string, message?: string, callbackOrButtons?: (text: string) => void | AlertButton[], type?: AlertType, defaultValue?: string, keyboardType?: string) => void;
+    prompt: (title: string, message?: string, callbackOrButtons?: ((text: string) => void) | AlertButton[], type?: AlertType, defaultValue?: string, keyboardType?: string) => void;
 }
 
 export type AlertType = 'default' | 'plain-text' | 'secure-text' | 'login-password';

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -525,6 +525,32 @@ class AlertTest extends React.Component {
     }
 }
 
+Alert.prompt(
+    'Enter password',
+    'Enter your password to claim your $1.5B in lottery winnings',
+    text => {
+        console.log(text);
+    },
+    'secure-text',
+);
+
+Alert.prompt(
+    'Enter password',
+    'Enter your password to claim your $1.5B in lottery winnings',
+    [
+        {
+            text: 'Cancel',
+            onPress: () => console.log('Cancel Pressed'),
+            style: 'cancel',
+        },
+        {
+            text: 'OK',
+            onPress: password => console.log('OK Pressed, password: ' + password),
+        },
+    ],
+    'secure-text',
+);
+
 class MaskedViewTest extends React.Component {
     render() {
         return (


### PR DESCRIPTION
The signature of callbackOrButtons allows either:
1. function that returns void
2. array of AlertButton

Instead, the current signature does:
1. function that returns void or an array of AlertButton

This fixes the signature to be correct, patching the change made in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38602

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://facebook.github.io/react-native/docs/alertios#alert>>
