### PR TITLE
Fix incorrect Stripe package types

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3741,7 +3741,7 @@ declare namespace Stripe {
             /**
              * The subscription that this invoice was prepared for, if any.
              */
-            subscription: string | subscriptions.ISubscription;
+            subscription: string | subscriptions.ISubscription | null;
 
             /**
              * Only set for upcoming invoices that preview prorations. The time used to calculate prorations.
@@ -4413,7 +4413,7 @@ declare namespace Stripe {
 
             amount: number;
             currency: string;
-            customer: string;
+            customer: string | customers.ICustomer;
             date: number;
             description: string;
 


### PR DESCRIPTION
I have two types fixes for in incorrect types.

First the subscription value in the invoice object can be null. You can see that in the docs [here](https://stripe.com/docs/api/invoices/object#invoice_object-subscription).

Second, the customer value in the InvoiceItem object is expandable so I am updating the type to follow the pattern for the other expandable item. Typing for it is in the Stripe docs [here](https://stripe.com/docs/api/invoiceitems/object#invoiceitem_object-customer).

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/invoices/object#invoice_object-subscription and https://stripe.com/docs/api/invoiceitems/object#invoiceitem_object-customer
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
