### PR TITLE
Add all available properties to the MethodInvocation interface.

### DIFF
--- a/types/meteor/ddp.d.ts
+++ b/types/meteor/ddp.d.ts
@@ -28,12 +28,24 @@ declare module "meteor/ddp" {
     }
 
     module DDPCommon {
+        interface MethodInvocationOptions {
+            userId: string | null;
+            setUserId?: (newUserId: string) => void;
+            isSimulation: boolean;
+            connection: Meteor.Connection;
+            randomSeed: string;
+        }
+
         interface MethodInvocation {
-            new(options: {}): MethodInvocation;
+            new(options: MethodInvocationOptions): MethodInvocation;
 
             unblock(): void;
 
-            setUserId(userId: number): void;
+            setUserId(userId: string): void;
+
+            userId: string | null;
+            isSimulation: boolean;
+            connection: Meteor.Connection;
         }
     }
 }

--- a/types/meteor/globals/ddp.d.ts
+++ b/types/meteor/globals/ddp.d.ts
@@ -26,11 +26,23 @@ declare module DDP {
 }
 
 declare module DDPCommon {
+    interface MethodInvocationOptions {
+        userId: string | null;
+        setUserId?: (newUserId: string) => void;
+        isSimulation: boolean;
+        connection: Meteor.Connection;
+        randomSeed: string;
+    }
+
     interface MethodInvocation {
-        new(options: {}): MethodInvocation;
+        new(options: MethodInvocationOptions): MethodInvocation;
 
         unblock(): void;
 
-        setUserId(userId: number): void;
+        setUserId(userId: string): void;
+
+        userId: string | null;
+        isSimulation: boolean;
+        connection: Meteor.Connection;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/methods.html

The `DDPCommon` exposes the `userId`, `isSimulation`, `connection` properties, but they were not present in the current definition. The constructor options were also provided  for sake of completeness. The types are based on [ddp-common/method_invocation.js](https://github.com/meteor/meteor/blob/master/packages/ddp-common/method_invocation.js#L38).