### PR TITLE
Make passport-http-bearer options optional

### DIFF
--- a/types/passport-http-bearer/index.d.ts
+++ b/types/passport-http-bearer/index.d.ts
@@ -11,9 +11,9 @@ import passport = require("passport");
 import express = require("express");
 
 interface IStrategyOptions {
-    scope: string | Array<string>;
-    realm: string;
-    passReqToCallback: boolean;
+    scope?: string | Array<string>;
+    realm?: string;
+    passReqToCallback?: boolean;
 }
 interface IVerifyOptions {
     message: string;

--- a/types/passport-http-bearer/passport-http-bearer-tests.ts
+++ b/types/passport-http-bearer/passport-http-bearer-tests.ts
@@ -52,6 +52,12 @@ passport.use(new httpBearer.Strategy({
     });
 }));
 
+passport.use(
+    new httpBearer.Strategy({}, (token, done) => {
+        done(null, false);
+    }),
+);
+
 let app = express();
 app.post("/login", passport.authenticate("bearer", { failureRedirect: "/login" }), function(req, res) {
     res.redirect("/");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-http-bearer/blob/43cd6a065836d02a6337539300b23ca89253cfa5/lib/strategy.js#L67
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.