### PR TITLE
bookshelf: fix return type of Models extend method

### DIFF
--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -92,7 +92,7 @@ declare namespace Bookshelf {
 		static collection<T extends Model<any>>(models?: T[], options?: CollectionOptions<T>): Collection<T>;
 		static count(column?: string, options?: SyncOptions): BlueBird<number | string>;
 		/** @deprecated use Typescript classes */
-		static extend<T extends Model<any>>(prototypeProperties?: any, classProperties?: any): Function; // should return a type
+		static extend<T extends Model<any>>(prototypeProperties?: any, classProperties?: any): T;
 		static fetchAll<T extends Model<any>>(): BlueBird<Collection<T>>;
 		/** @deprecated should use `new` objects instead. */
 		static forge<T>(attributes?: any, options?: ModelOptions): T;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bookshelf/bookshelf/blob/master/lib/extend.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
