### PR TITLE
Added missing emitParticle and d3ReheatSimulation methods to force-graph

### DIFF
--- a/types/force-graph/force-graph-tests.ts
+++ b/types/force-graph/force-graph-tests.ts
@@ -3,6 +3,10 @@ import ForceGraph from 'force-graph';
 const graph = ForceGraph();
 graph(new HTMLElement());
 
+const node1: ForceGraph.GraphNode = {id: '1', name: 'node1', val: 123};
+const node2: ForceGraph.GraphNode = {id: '2', name: 'node2', val: 321};
+const link: ForceGraph.GraphLinkObject = {source: node1, target: node2, type: 'test', id: '3'};
+
 graph
     .graphData({nodes: [], links: []})
     .nodeId('testNode')
@@ -28,6 +32,8 @@ graph
     .linkVisibility((link) => true)
     .linkColor('color')
     .linkColor((link) => link.type)
+    .emitParticle(link)
+    .d3ReheatSimulation()
     .linkAutoColorBy('type')
     .linkAutoColorBy((link) => link.type)
     .linkWidth(1)

--- a/types/force-graph/index.d.ts
+++ b/types/force-graph/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for force-graph 1.15
+// Type definitions for force-graph 1.21
 // Project: https://github.com/vasturiano/force-graph
 // Definitions by: Peter Kimberley <https://github.com/p-kimberley>
+//                 Noah Santschi-Cooney <https://github.com/Strum355>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function ForceGraph(): ForceGraph.ForceGraphInstance;

--- a/types/force-graph/index.d.ts
+++ b/types/force-graph/index.d.ts
@@ -116,6 +116,7 @@ declare namespace ForceGraph {
         linkDirectionalParticleSpeed(speed?: number | string | LinkAccessorFn<number>): ForceGraphInstance & (number | string | LinkAccessorFn<number>);
         linkDirectionalParticleWidth(width?: number | string | LinkAccessorFn<number>): ForceGraphInstance & (number | string | LinkAccessorFn<number>);
         linkDirectionalParticleColor(color?: string | LinkAccessorFn<string>): ForceGraphInstance & (string | LinkAccessorFn<string>);
+        emitParticle(link: GraphLinkObject): ForceGraphInstance & (string | LinkAccessorFn<string>);
 
         // Render control
         pauseAnimation(): ForceGraphInstance;
@@ -131,6 +132,7 @@ declare namespace ForceGraph {
         d3AlphaDecay(decay?: number): ForceGraphInstance & number;
         d3VelocityDecay(decay?: number): ForceGraphInstance & number;
         d3Force(force: 'link' | 'charge' | 'center' | string, forceFn?: ForceFn): ForceGraphInstance & ForceFn;
+        d3ReheatSimulation(): ForceGraphInstance;
         warmupTicks(ticks?: number): ForceGraphInstance & number;
         cooldownTicks(ticks?: number): ForceGraphInstance & number;
         cooldownTime(milliseconds?: number): ForceGraphInstance & number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
(https://github.com/vasturiano/force-graph#force-engine-d3-force-configuration)[https://github.com/vasturiano/force-graph#force-engine-d3-force-configuration]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.