### PR TITLE
Add types for redux-cablecar

### DIFF
--- a/types/redux-cablecar/index.d.ts
+++ b/types/redux-cablecar/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for redux-cablecar 3.0
+// Project: https://github.com/ndhays/redux-cablecar#readme
+// Definitions by: Christoph Flick <https://github.com/ChFlick>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Action, Middleware, Store } from 'redux';
+
+export interface Options {
+    connected?: () => void;
+    disconnected?: () => void;
+    params?: object;
+    prefix?: string;
+    optimisticOnFail?: boolean;
+}
+
+export interface CableCar {
+    changeChannel: (channel: string, options?: Options) => void;
+    getChannel: () => string;
+    getParams: () => object;
+    perform: (method: string, payload: any) => void;
+    send: (action: string) => void;
+}
+
+declare var middleware: Middleware & {
+    connect: (store: Store, channel: string, options?: Options) => CableCar;
+    setProvider: (actionCableProvider: string) => void;
+};
+
+export default middleware;

--- a/types/redux-cablecar/index.d.ts
+++ b/types/redux-cablecar/index.d.ts
@@ -18,7 +18,7 @@ export interface CableCar {
     changeChannel: (channel: string, options?: Options) => void;
     getChannel: () => string;
     getParams: () => object;
-    perform: (method: string, payload: any) => void;
+    perform: (method: string, payload?: any) => void;
     send: (action: string) => void;
 }
 

--- a/types/redux-cablecar/package.json
+++ b/types/redux-cablecar/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "redux": "^4.0.4"
+    }
+}

--- a/types/redux-cablecar/redux-cablecar-tests.ts
+++ b/types/redux-cablecar/redux-cablecar-tests.ts
@@ -1,0 +1,18 @@
+import cablecar, { Options } from 'redux-cablecar';
+import { applyMiddleware, createStore } from 'redux';
+
+const store = createStore(() => null, applyMiddleware(cablecar));
+
+cablecar.setProvider('testProvider');
+
+const car = cablecar.connect(store, 'testChannel');
+
+const options: Options = {
+    connected: () => { },
+    prefix: 'ASDF'
+};
+
+const anotherCar = cablecar.connect(store, 'secondeTestChannel', options);
+
+car.perform('activate', { data: 'something' });
+anotherCar.send('noice_action');

--- a/types/redux-cablecar/tsconfig.json
+++ b/types/redux-cablecar/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "redux-cablecar-tests.ts"
+    ]
+}

--- a/types/redux-cablecar/tslint.json
+++ b/types/redux-cablecar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
