### PR TITLE
Added @type/current-git-branch to repo

### DIFF
--- a/types/current-git-branch/current-git-branch-tests.ts
+++ b/types/current-git-branch/current-git-branch-tests.ts
@@ -1,4 +1,4 @@
-import getBranchName, {CurrentGitBranchOptions} from 'current-git-branch';
+import getBranchName, { CurrentGitBranchOptions } from 'current-git-branch';
 
 // test data
 const emptyOptions: CurrentGitBranchOptions = {};

--- a/types/current-git-branch/current-git-branch-tests.ts
+++ b/types/current-git-branch/current-git-branch-tests.ts
@@ -1,7 +1,12 @@
-import getBranchName from 'current-git-branch';
+import getBranchName, {CurrentGitBranchOptions} from 'current-git-branch';
 
+// test data
+const emptyOptions: CurrentGitBranchOptions = {};
+const filledOptions: CurrentGitBranchOptions = {altPath: '', branchOptions: ''};
+
+// tests
 getBranchName();
-getBranchName({altPath: '', branchOptions: ''});
-getBranchName({});
+getBranchName(emptyOptions);
+getBranchName(filledOptions);
 getBranchName('');
 getBranchName(['']);

--- a/types/current-git-branch/current-git-branch-tests.ts
+++ b/types/current-git-branch/current-git-branch-tests.ts
@@ -1,0 +1,7 @@
+import getBranchName from 'current-git-branch';
+
+getBranchName();
+getBranchName({altPath: '', branchOptions: ''});
+getBranchName({});
+getBranchName('');
+getBranchName(['']);

--- a/types/current-git-branch/index.d.ts
+++ b/types/current-git-branch/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Vladimir Grenaderov <https://github.com/VladimirGrenaderov>,
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.7
 
 declare namespace CurrentGitBranch {
     type CurrentGitBranchOptions = CurrentGitBranchOptionsObject | string[] | string;

--- a/types/current-git-branch/index.d.ts
+++ b/types/current-git-branch/index.d.ts
@@ -15,6 +15,6 @@ declare namespace CurrentGitBranch {
     }
 }
 
-declare function current_git_branch(args?: CurrentGitBranch.CurrentGitBranchOptions): CurrentGitBranch.CurrentGitBranchResult;
+declare function CurrentGitBranch(args?: CurrentGitBranch.CurrentGitBranchOptions): CurrentGitBranch.CurrentGitBranchResult;
 
-export = current_git_branch;
+export = CurrentGitBranch;

--- a/types/current-git-branch/index.d.ts
+++ b/types/current-git-branch/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for current-git-branch 1.1
+// Project: https://www.npmjs.com/package/current-git-branch
+// Definitions by: Vladimir Grenaderov <https://github.com/VladimirGrenaderov>,
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare namespace CurrentGitBranch {
+    type CurrentGitBranchOptions = CurrentGitBranchOptionsObject | string[] | string;
+    type CurrentGitBranchResult = string | boolean;
+
+    interface CurrentGitBranchOptionsObject {
+        altPath?: string;
+        branchOptions?: string;
+    }
+}
+
+declare function current_git_branch(args?: CurrentGitBranch.CurrentGitBranchOptions): CurrentGitBranch.CurrentGitBranchResult;
+
+export = current_git_branch;

--- a/types/current-git-branch/tsconfig.json
+++ b/types/current-git-branch/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "esModuleInterop": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "current-git-branch-tests.ts"
+    ]
+}

--- a/types/current-git-branch/tslint.json
+++ b/types/current-git-branch/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
