### PR TITLE
[readable-stream] refer to node v10 type definitions

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -4,12 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="node" />
+/// <reference types="node/v10" />
 
 import * as events from "events";
 import * as stream from "stream";
 import * as SafeBuffer from "safe-buffer";
-import { StringDecoder } from "string_decoder";
+import { NodeStringDecoder } from "string_decoder";
 
 declare class _Readable extends stream.Readable {
     // static ReadableState: _Readable.ReadableState;
@@ -61,18 +61,12 @@ declare namespace _Readable {
     };
 
     class Duplex extends Writable implements /*extends*/_Readable, stream.Duplex {
-        /**
-         * This is a dummy function required to retain type compatibility to node.
-         * @deprecated DO NOT USE
-         */
-        static from(source: any): any;
         allowHalfOpen: boolean;
         destroyed: boolean;
         // Readable
         readable: boolean;
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
-        readonly readableObjectMode: boolean;
         _readableState: ReadableState;
 
         _read(size?: number): void;
@@ -135,7 +129,7 @@ declare namespace _Readable {
         awaitDrain: number;
         defaultEncoding: string;
         readingMore: boolean;
-        decoder: StringDecoder | null;
+        decoder: NodeStringDecoder | null;
         encoding: string | null;
 
         // new (options: ReadableStateOptions, stream: _Readable): ReadableState;

--- a/types/readable-stream/readable-stream-tests.ts
+++ b/types/readable-stream/readable-stream-tests.ts
@@ -89,8 +89,6 @@ function test() {
     assertType<boolean>(streamD.allowHalfOpen);
     assertType<boolean>(streamD.readable);
     assertType<boolean>(streamD.writable);
-    assertType<boolean>(streamD.readableObjectMode);
-    assertType<boolean>(streamD.writableObjectMode);
     streamD.pipe(streamW);
 
     rs.addListener("read", (...args: any[]) => console.log(args));


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/readable-stream
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

readable-stream is based on streams of node.js 10 therefore it should refer to these type definitions also to avoid that changes in actual node.js versions require wrong changes in readable-stream.

Not sure if such binding to an older version results in conflicts for projects refering to @types/readable-stream and @types/node@12.x - I did a fast local test and it seems it's fine.

Refs: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38907#issuecomment-538799991

fyi @SimonSchick
