### PR TITLE
fix(wordpress__data): improve generator return type

### DIFF
--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 import { BlockIconNormalized } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
 

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { Dashicon } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 export * from './primitives';
 

--- a/types/wordpress__core-data/index.d.ts
+++ b/types/wordpress__core-data/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/core-data/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { Schema } from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';

--- a/types/wordpress__data-controls/index.d.ts
+++ b/types/wordpress__data-controls/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data-controls/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { APIFetchOptions } from '@wordpress/api-fetch';
 import { Action } from '@wordpress/data';

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { ComponentType, Consumer, Provider, useContext } from '@wordpress/element';
 import { AnyAction as Action, combineReducers, Reducer } from 'redux';
@@ -34,7 +34,7 @@ export interface GenericStoreConfig {
 export interface StoreConfig<S> {
     reducer: Reducer<S>;
     actions?: {
-        [k: string]: (...args: readonly any[]) => Action | IterableIterator<any>;
+        [k: string]: (...args: readonly any[]) => Action | Generator<any>;
     };
     selectors?: {
         [k: string]: (state: S, ...args: readonly any[]) => any;

--- a/types/wordpress__edit-post/index.d.ts
+++ b/types/wordpress__edit-post/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/edit-post/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { dispatch, select } from '@wordpress/data';
 

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { dispatch, select } from '@wordpress/data';
 

--- a/types/wordpress__media-utils/index.d.ts
+++ b/types/wordpress__media-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/media-utils/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 export * from './components';
 export * from './utils';

--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/notices/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { dispatch, select } from '@wordpress/data';
 import { MouseEventHandler } from '@wordpress/element';

--- a/types/wordpress__nux/index.d.ts
+++ b/types/wordpress__nux/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/nux/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { dispatch, select } from '@wordpress/data';
 

--- a/types/wordpress__plugins/index.d.ts
+++ b/types/wordpress__plugins/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/plugins/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { Dashicon } from '@wordpress/components';
 import { ComponentType } from '@wordpress/element';

--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { ComponentType } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';

--- a/types/wordpress__viewport/index.d.ts
+++ b/types/wordpress__viewport/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/viewport/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.6
 
 import { dispatch, select } from '@wordpress/data';
 


### PR DESCRIPTION
This PR simply adjusts the return type of a single function to the new `Generator` generic type provided in TypeScript
3.6 (and bumps the required TypeScript version accordingly).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.