### PR TITLE
Create types for react-native-rss-parser

### DIFF
--- a/types/react-native-rss-parser/index.d.ts
+++ b/types/react-native-rss-parser/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for react-native-rss-parser 1.4
+// Project: https://github.com/jameslawler/react-native-rss-parser
+// Definitions by: Emiliano Leite <https://github.com/emilianoLeite>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.3
+
+export { };
+
+type Maybe<T> = T | undefined;
+
+export interface FeedItem {
+    id: string;
+    title: string;
+    links: Array<{
+        url: string;
+        rel: string;
+    }>;
+    description: string;
+    content: string;
+    authors: Array<Maybe<{ name: string; }>>;
+    categories: Array<Maybe<{ name: string; }>>;
+    published: string;
+    enclosures: Array<{
+        url: string;
+        length: string;
+        mimeType: string;
+    }>;
+    itunes: any;
+}
+
+export interface Feed {
+    type: string;
+    title: string;
+    links: Array<{
+        url: string;
+        rel: string;
+    }>;
+    description: string;
+    language: string;
+    copyright: Maybe<string>;
+    authors: Array<Maybe<{ name: string; }>>;
+    lastUpdated: string;
+    lastPublished: string;
+    categories: Array<Maybe<{ name: string; }>>;
+    image: {
+        title: string;
+        description: Maybe<string>;
+        url: string;
+        height: Maybe<string>;
+        width: Maybe<string>;
+    };
+    itunes: any;
+    items: FeedItem[];
+}
+
+export function parse(feedUrl: string): Promise<Feed>;

--- a/types/react-native-rss-parser/index.d.ts
+++ b/types/react-native-rss-parser/index.d.ts
@@ -17,15 +17,25 @@ export interface FeedItem {
     }>;
     description: string;
     content: string;
-    authors: Array<Maybe<{ name: string; }>>;
-    categories: Array<Maybe<{ name: string; }>>;
+    authors: Array<Maybe<{ name: string }>>;
+    categories: Array<Maybe<{ name: string }>>;
     published: string;
     enclosures: Array<{
         url: string;
         length: string;
         mimeType: string;
     }>;
-    itunes: any;
+    itunes: {
+        authors: Maybe<Array<{ name: string }>>;
+        block: Maybe<string>;
+        duration: string;
+        explicit: string;
+        image: Maybe<string>;
+        isClosedCaptioned: Maybe<string>;
+        order: Maybe<string>;
+        subtitle: string;
+        summary: Maybe<string>;
+    };
 }
 
 export interface Feed {
@@ -38,10 +48,10 @@ export interface Feed {
     description: string;
     language: string;
     copyright: Maybe<string>;
-    authors: Array<Maybe<{ name: string; }>>;
+    authors: Array<Maybe<{ name: string }>>;
     lastUpdated: string;
     lastPublished: string;
-    categories: Array<Maybe<{ name: string; }>>;
+    categories: Array<Maybe<{ name: string }>>;
     image: {
         title: string;
         description: Maybe<string>;
@@ -49,7 +59,24 @@ export interface Feed {
         height: Maybe<string>;
         width: Maybe<string>;
     };
-    itunes: any;
+    itunes: {
+        authors: Array<{ name: string }>;
+        block: Maybe<string>;
+        categories: Array<{
+            name: string;
+            subCategories: Array<Maybe<{ name: string }>>;
+        }>;
+        complete: Maybe<string>;
+        explicit: string;
+        image: string;
+        newFeedUrl: Maybe<string>;
+        owner: {
+            name: string;
+            email: string;
+        };
+        subtitle: Maybe<string>;
+        summary: string;
+    };
     items: FeedItem[];
 }
 

--- a/types/react-native-rss-parser/react-native-rss-parser-tests.ts
+++ b/types/react-native-rss-parser/react-native-rss-parser-tests.ts
@@ -1,0 +1,18 @@
+import { parse } from 'react-native-rss-parser';
+
+// -- Globals --
+declare const fetch: (url: string) => Promise<any>;
+declare const console: any;
+
+fetch('http://rss-url.com')
+    .then(response => response.text())
+    .then(parse)
+    .then(feed => {
+        feed.authors[0].name; // $ExpectError
+        feed.image.title.toUpperCase(); // $ExpectType string
+        feed.image.height.toUpperCase(); // $ExpectError
+
+        feed.items[0].id; // $ExpectType string
+        feed.items[0].authors.name; // $ExpectError
+    })
+    .catch(console.error);

--- a/types/react-native-rss-parser/tsconfig.json
+++ b/types/react-native-rss-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-rss-parser-tests.ts"
+    ]
+}

--- a/types/react-native-rss-parser/tslint.json
+++ b/types/react-native-rss-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
