### PR TITLE
Add discord-rpc missing Presence typings

### DIFF
--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/discordjs/RPC#readme
 // Definitions by: Jason Bothell <https://github.com/jasonhaxstuff>
 //                 Jack Baron <https://github.com/lolPants>
+//                 Dylan Hackworth <https://github.com/dylhack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { EventEmitter } from 'events';
@@ -192,4 +193,10 @@ export interface Presence {
 	smallImageKey?: string;
 	smallImageText?: string;
 	instance?: boolean;
+    partySize?: number;
+    partyMax?: number;
+    matchSecret?: string;
+    spectateSecret?: string;
+    joinSecret?: string;
+    instance?: number;
 }

--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -193,10 +193,10 @@ export interface Presence {
 	smallImageKey?: string;
 	smallImageText?: string;
 	instance?: boolean;
-    partySize?: number;
-    partyMax?: number;
-    matchSecret?: string;
-    spectateSecret?: string;
-    joinSecret?: string;
-    instance?: number;
+	partySize?: number;
+	partyMax?: number;
+	matchSecret?: string;
+	spectateSecret?: string;
+	joinSecret?: string;
+	instance?: number;
 }

--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -198,5 +198,4 @@ export interface Presence {
 	matchSecret?: string;
 	spectateSecret?: string;
 	joinSecret?: string;
-	instance?: number;
 }


### PR DESCRIPTION
Some properties remained missing so here are the up-to-date ones. For reference [this](https://github.com/discordapp/discord-api-docs/blob/master/docs/rich_presence/How_To.md#update-presence-payload-fields) is where they're all defined.
Added:
 - partySize?: number;
 - partyMax?: number;
 - matchSecret?: string;
 - spectateSecret?: string;
 - joinSecret?: string;

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/discordapp/discord-api-docs/blob/master/docs/rich_presence/How_To.md#update-presence-payload-fields>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

