### PR TITLE
[paper] Fix topPath return type from Shape to Path

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -2440,7 +2440,7 @@ declare module paper {
          * Creates a new path item with same geometry as this shape item, and inherits all settings from it, similar to item.clone().
          * @param insert - specifies whether the new path should be inserted into the scene graph. When set to true, it is inserted above the shape item — optional, default: true
          */
-        toPath(insert?: boolean): Shape;
+        toPath(insert?: boolean): Path;
 
     }
     /**

--- a/types/paper/paper-tests.ts
+++ b/types/paper/paper-tests.ts
@@ -13082,6 +13082,11 @@ function APIReferenceExamples() {
         }
 
     }
+    function Shape66() {
+        
+        let shape = paper.Shape.Circle(new paper.Point(80, 50), 30);
+        let path: paper.Path = shape.toPath();
+    }
     function Style0() {
 
         let path = new paper.Path.Circle(new paper.Point(80, 50), 30);


### PR DESCRIPTION
Return type of "toPath()" in Shape returns a new Path object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://paperjs.org/reference/shape/#topath>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

