### PR TITLE
Update firefox-webext-browser to version 70

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package WebExtension Development in FireFox 67.0
+// Type definitions for non-npm package WebExtension Development in FireFox 70.0
 // Project: https://developer.mozilla.org/en-US/Add-ons/WebExtensions
 // Definitions by: Jasmin Bom <https://github.com/jsmnbom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -17,91 +17,12 @@ interface Window {
     browser: typeof browser;
 }
 
-/**
- * Permissions: `alarms`
- *
- * Not allowed in: Content scripts, Devtools pages
- */
-declare namespace browser.alarms {
-    /* alarms types */
-    interface Alarm {
-        /** Name of this alarm. */
-        name: string;
-        /** Time when the alarm is scheduled to fire, in milliseconds past the epoch. */
-        scheduledTime: number;
-        /** When present, signals that the alarm triggers periodically after so many minutes. */
-        periodInMinutes?: number;
-    }
-
-    /* alarms functions */
-    /**
-     * Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the
-     * same name (or no name if none is specified), it will be cancelled and replaced by this alarm.
-     * @param alarmInfo Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if
-     *     'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided
-     *     instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided).
-     *     Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the
-     *     alarm recurs repeatedly after that many minutes.
-     */
-    function create(alarmInfo: {
-        /** Time when the alarm is scheduled to first fire, in milliseconds past the epoch. */
-        when?: number;
-        /** Number of minutes from the current time after which the alarm should first fire. */
-        delayInMinutes?: number;
-        /** Number of minutes after which the alarm should recur repeatedly. */
-        periodInMinutes?: number;
-    }): void;
-    /**
-     * Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the
-     * same name (or no name if none is specified), it will be cancelled and replaced by this alarm.
-     * @param name Optional name to identify this alarm. Defaults to the empty string.
-     * @param alarmInfo Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if
-     *     'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided
-     *     instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided).
-     *     Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the
-     *     alarm recurs repeatedly after that many minutes.
-     */
-    function create(name: string, alarmInfo: {
-        /** Time when the alarm is scheduled to first fire, in milliseconds past the epoch. */
-        when?: number;
-        /** Number of minutes from the current time after which the alarm should first fire. */
-        delayInMinutes?: number;
-        /** Number of minutes after which the alarm should recur repeatedly. */
-        periodInMinutes?: number;
-    }): void;
-
-    /**
-     * Retrieves details about the specified alarm.
-     * @param [name] The name of the alarm to get. Defaults to the empty string.
-     */
-    function get(name?: string): Promise<Alarm>;
-
-    /** Gets an array of all the alarms. */
-    function getAll(): Promise<Alarm[]>;
-
-    /**
-     * Clears the alarm with the given name.
-     * @param [name] The name of the alarm to clear. Defaults to the empty string.
-     */
-    function clear(name?: string): Promise<boolean>;
-
-    /** Clears all alarms. */
-    function clearAll(): Promise<boolean>;
-
-    /* alarms events */
-    /**
-     * Fired when an alarm has expired. Useful for transient background pages.
-     * @param name The alarm that has expired.
-     */
-    const onAlarm: WebExtEvent<(name: Alarm) => void>;
-}
-
 /** Not allowed in: Content scripts, Devtools pages */
 declare namespace browser._manifest {
     /* _manifest types */
-    type OptionalPermission = _OptionalPermission;
-
     type Permission = string | OptionalPermission | _Permission;
+
+    type OptionalPermission = _OptionalPermission;
 
     /** Represents a WebExtension manifest.json file */
     interface WebExtensionManifest {
@@ -164,14 +85,19 @@ declare namespace browser._manifest {
                 instant_url?: string;
                 /** @deprecated Unsupported on Firefox at this time. */
                 image_url?: string;
+                /** GET parameters to the search_url as a query string. */
+                search_url_get_params?: string;
                 /** POST parameters to the search_url as a query string. */
                 search_url_post_params?: string;
+                /** GET parameters to the suggest_url as a query string. */
+                suggest_url_get_params?: string;
                 /** POST parameters to the suggest_url as a query string. */
                 suggest_url_post_params?: string;
                 /** @deprecated Unsupported on Firefox at this time. */
                 instant_url_post_params?: string;
                 /** @deprecated Unsupported on Firefox at this time. */
                 image_url_post_params?: string;
+                search_form?: string;
                 /** @deprecated Unsupported on Firefox at this time. */
                 alternate_urls?: string[];
                 /** @deprecated Unsupported on Firefox. */
@@ -248,6 +174,7 @@ declare namespace browser._manifest {
         };
         browser_specific_settings?: {
             gecko?: FirefoxSpecificProperties;
+            edge?: { [key: string]: any };
         };
         name: string;
         short_name?: string;
@@ -285,6 +212,7 @@ declare namespace browser._manifest {
         };
         browser_specific_settings?: {
             gecko?: FirefoxSpecificProperties;
+            edge?: { [key: string]: any };
         };
         name: string;
         short_name?: string;
@@ -320,6 +248,7 @@ declare namespace browser._manifest {
         };
         browser_specific_settings?: {
             gecko?: FirefoxSpecificProperties;
+            edge?: { [key: string]: any };
         };
         name: string;
         short_name?: string;
@@ -340,6 +269,7 @@ declare namespace browser._manifest {
         };
         browser_specific_settings?: {
             gecko?: FirefoxSpecificProperties;
+            edge?: { [key: string]: any };
         };
         name: string;
         short_name?: string;
@@ -459,17 +389,26 @@ declare namespace browser._manifest {
     interface ThemeType {
         images?: {
             additional_backgrounds?: ImageDataOrExtensionURL[];
-            /** @deprecated Please use _theme.images.theme_frame_, this alias will be removed in Firefox 69. */
+            /**
+             * @deprecated Unsupported images property, use 'theme.images.theme_frame', this alias is ignored in
+             *     Firefox >= 70.
+             */
             headerURL?: ImageDataOrExtensionURL;
             theme_frame?: ImageDataOrExtensionURL;
         };
         colors?: {
             tab_selected?: ThemeColor;
-            /** @deprecated Please use _theme.colors.frame_, this alias will be removed in Firefox 69. */
+            /**
+             * @deprecated Unsupported colors property, use 'theme.colors.frame', this alias is ignored in Firefox >=
+             *     70.
+             */
             accentcolor?: ThemeColor;
             frame?: ThemeColor;
             frame_inactive?: ThemeColor;
-            /** @deprecated Please use _theme.colors.tab_background_text_, this alias will be removed in Firefox 69. */
+            /**
+             * @deprecated Unsupported color property, use 'theme.colors.tab_background_text', this alias is ignored in
+             *     Firefox >= 70.
+             */
             textcolor?: ThemeColor;
             tab_background_text?: ThemeColor;
             tab_background_separator?: ThemeColor;
@@ -477,7 +416,7 @@ declare namespace browser._manifest {
             tab_text?: ThemeColor;
             tab_line?: ThemeColor;
             toolbar?: ThemeColor;
-            /** @deprecated Please use _theme.colors.bookmark_text_, this alias will be removed in Firefox 69. */
+            /** This color property is an alias of 'bookmark_text'. */
             toolbar_text?: ThemeColor;
             bookmark_text?: ThemeColor;
             toolbar_field?: ThemeColor;
@@ -509,88 +448,6 @@ declare namespace browser._manifest {
             toolbar_field_highlight?: ThemeColor;
             toolbar_field_highlight_text?: ThemeColor;
         };
-        icons?: {
-            back?: ExtensionURL;
-            forward?: ExtensionURL;
-            reload?: ExtensionURL;
-            stop?: ExtensionURL;
-            bookmark_star?: ExtensionURL;
-            bookmark_menu?: ExtensionURL;
-            downloads?: ExtensionURL;
-            home?: ExtensionURL;
-            app_menu?: ExtensionURL;
-            cut?: ExtensionURL;
-            copy?: ExtensionURL;
-            paste?: ExtensionURL;
-            new_window?: ExtensionURL;
-            new_private_window?: ExtensionURL;
-            save_page?: ExtensionURL;
-            print?: ExtensionURL;
-            history?: ExtensionURL;
-            full_screen?: ExtensionURL;
-            find?: ExtensionURL;
-            options?: ExtensionURL;
-            addons?: ExtensionURL;
-            developer?: ExtensionURL;
-            synced_tabs?: ExtensionURL;
-            open_file?: ExtensionURL;
-            sidebars?: ExtensionURL;
-            subscribe?: ExtensionURL;
-            text_encoding?: ExtensionURL;
-            email_link?: ExtensionURL;
-            forget?: ExtensionURL;
-            pocket?: ExtensionURL;
-            getmsg?: ExtensionURL;
-            newmsg?: ExtensionURL;
-            address?: ExtensionURL;
-            reply?: ExtensionURL;
-            replyall?: ExtensionURL;
-            replylist?: ExtensionURL;
-            forwarding?: ExtensionURL;
-            delete?: ExtensionURL;
-            junk?: ExtensionURL;
-            file?: ExtensionURL;
-            nextUnread?: ExtensionURL;
-            prevUnread?: ExtensionURL;
-            mark?: ExtensionURL;
-            tag?: ExtensionURL;
-            compact?: ExtensionURL;
-            archive?: ExtensionURL;
-            chat?: ExtensionURL;
-            nextMsg?: ExtensionURL;
-            prevMsg?: ExtensionURL;
-            QFB?: ExtensionURL;
-            conversation?: ExtensionURL;
-            newcard?: ExtensionURL;
-            newlist?: ExtensionURL;
-            editcard?: ExtensionURL;
-            newim?: ExtensionURL;
-            send?: ExtensionURL;
-            spelling?: ExtensionURL;
-            attach?: ExtensionURL;
-            security?: ExtensionURL;
-            save?: ExtensionURL;
-            quote?: ExtensionURL;
-            buddy?: ExtensionURL;
-            join_chat?: ExtensionURL;
-            chat_accounts?: ExtensionURL;
-            calendar?: ExtensionURL;
-            tasks?: ExtensionURL;
-            synchronize?: ExtensionURL;
-            newevent?: ExtensionURL;
-            newtask?: ExtensionURL;
-            editevent?: ExtensionURL;
-            today?: ExtensionURL;
-            category?: ExtensionURL;
-            complete?: ExtensionURL;
-            priority?: ExtensionURL;
-            saveandclose?: ExtensionURL;
-            attendees?: ExtensionURL;
-            privacy?: ExtensionURL;
-            status?: ExtensionURL;
-            freebusy?: ExtensionURL;
-            timezones?: ExtensionURL;
-        };
         properties?: {
             additional_backgrounds_alignment?: _ThemeTypeAdditionalBackgroundsAlignment[];
             additional_backgrounds_tiling?: _ThemeTypeAdditionalBackgroundsTiling[];
@@ -600,6 +457,7 @@ declare namespace browser._manifest {
     /** Contents of manifest.json for a static theme */
     interface ThemeManifest {
         theme: ThemeType;
+        dark_theme?: ThemeType;
         default_locale?: string;
         theme_experiment?: ThemeExperiment;
         icons?: {
@@ -608,6 +466,33 @@ declare namespace browser._manifest {
     }
 
     type KeyName = string;
+
+    type _Permission =
+        "activityLog"
+        | "captivePortal"
+        | "contextualIdentities"
+        | "dns"
+        | "geckoProfiler"
+        | "identity"
+        | "management"
+        | "alarms"
+        | "mozillaAddons"
+        | "storage"
+        | "unlimitedStorage"
+        | "networkStatus"
+        | "privacy"
+        | "proxy"
+        | "nativeMessaging"
+        | "telemetry"
+        | "theme"
+        | "browsingData"
+        | "devtools"
+        | "menus"
+        | "contextMenus"
+        | "normandyAddonStudy"
+        | "pkcs11"
+        | "sessions"
+        | "urlbar";
 
     type _OptionalPermission =
         "browserSettings"
@@ -619,7 +504,6 @@ declare namespace browser._manifest {
         | "geolocation"
         | "idle"
         | "notifications"
-        | "topSites"
         | "webNavigation"
         | "webRequest"
         | "webRequestBlocking"
@@ -630,29 +514,8 @@ declare namespace browser._manifest {
         | "search"
         | "activeTab"
         | "tabs"
-        | "tabHide";
-
-    type _Permission =
-        "contextualIdentities"
-        | "dns"
-        | "identity"
-        | "management"
-        | "alarms"
-        | "mozillaAddons"
-        | "storage"
-        | "unlimitedStorage"
-        | "privacy"
-        | "proxy"
-        | "nativeMessaging"
-        | "telemetry"
-        | "theme"
-        | "browsingData"
-        | "devtools"
-        | "geckoProfiler"
-        | "menus"
-        | "contextMenus"
-        | "pkcs11"
-        | "sessions";
+        | "tabHide"
+        | "topSites";
 
     type _WebExtensionManifestIncognito = "not_allowed" | "spanning";
 
@@ -727,6 +590,147 @@ declare namespace browser._manifest {
 }
 
 /**
+ * Monitor extension activity
+ *
+ * Permissions: `activityLog`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.activityLog {
+    /**
+     * The type of log entry. api_call is a function call made by the extension and api_event is an event callback to
+     * the extension. content_script is logged when a content script is injected.
+     */
+    type _UndefinedType =
+        "api_call"
+        | "api_event"
+        | "content_script"
+        | "user_script";
+
+    /** The type of view where the activity occurred. Content scripts will not have a viewType. */
+    type _UndefinedViewType =
+        "background"
+        | "popup"
+        | "sidebar"
+        | "tab"
+        | "devtools_page"
+        | "devtools_panel";
+
+    interface _ActivityLogOnExtensionActivityEvent<TCallback = (details: {
+        /** The date string when this call is triggered. */
+        timeStamp: extensionTypes.Date;
+        /**
+         * The type of log entry. api_call is a function call made by the extension and api_event is an event callback
+         * to the extension. content_script is logged when a content script is injected.
+         */
+        type: _UndefinedType;
+        /** The type of view where the activity occurred. Content scripts will not have a viewType. */
+        viewType?: _UndefinedViewType;
+        /** The name of the api call or event, or the script url if this is a content or user script event. */
+        name: string;
+        data: {
+            /** A list of arguments passed to the call. */
+            args?: any[];
+            /** The result of the call. */
+            result?: object;
+            /** The tab associated with this event if it is a tab or content script. */
+            tabId?: number;
+            /** If the type is content_script, this is the url of the script that was injected. */
+            url?: string;
+        };
+    }) => void> {
+        addListener(cb: TCallback, id: string): void;
+
+        removeListener(cb: TCallback): void;
+
+        hasListener(cb: TCallback): boolean;
+    }
+
+    /* activityLog events */
+    /** Receives an activityItem for each logging event. */
+    const onExtensionActivity: _ActivityLogOnExtensionActivityEvent;
+}
+
+/**
+ * Permissions: `alarms`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.alarms {
+    /* alarms types */
+    interface Alarm {
+        /** Name of this alarm. */
+        name: string;
+        /** Time when the alarm is scheduled to fire, in milliseconds past the epoch. */
+        scheduledTime: number;
+        /** When present, signals that the alarm triggers periodically after so many minutes. */
+        periodInMinutes?: number;
+    }
+
+    /* alarms functions */
+    /**
+     * Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the
+     * same name (or no name if none is specified), it will be cancelled and replaced by this alarm.
+     * @param alarmInfo Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if
+     *     'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided
+     *     instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided).
+     *     Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the
+     *     alarm recurs repeatedly after that many minutes.
+     */
+    function create(alarmInfo: {
+        /** Time when the alarm is scheduled to first fire, in milliseconds past the epoch. */
+        when?: number;
+        /** Number of minutes from the current time after which the alarm should first fire. */
+        delayInMinutes?: number;
+        /** Number of minutes after which the alarm should recur repeatedly. */
+        periodInMinutes?: number;
+    }): void;
+    /**
+     * Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the
+     * same name (or no name if none is specified), it will be cancelled and replaced by this alarm.
+     * @param name Optional name to identify this alarm. Defaults to the empty string.
+     * @param alarmInfo Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if
+     *     'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided
+     *     instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided).
+     *     Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the
+     *     alarm recurs repeatedly after that many minutes.
+     */
+    function create(name: string, alarmInfo: {
+        /** Time when the alarm is scheduled to first fire, in milliseconds past the epoch. */
+        when?: number;
+        /** Number of minutes from the current time after which the alarm should first fire. */
+        delayInMinutes?: number;
+        /** Number of minutes after which the alarm should recur repeatedly. */
+        periodInMinutes?: number;
+    }): void;
+
+    /**
+     * Retrieves details about the specified alarm.
+     * @param [name] The name of the alarm to get. Defaults to the empty string.
+     */
+    function get(name?: string): Promise<Alarm>;
+
+    /** Gets an array of all the alarms. */
+    function getAll(): Promise<Alarm[]>;
+
+    /**
+     * Clears the alarm with the given name.
+     * @param [name] The name of the alarm to clear. Defaults to the empty string.
+     */
+    function clear(name?: string): Promise<boolean>;
+
+    /** Clears all alarms. */
+    function clearAll(): Promise<boolean>;
+
+    /* alarms events */
+    /**
+     * Fired when an alarm has expired. Useful for transient background pages.
+     * @param name The alarm that has expired.
+     */
+    const onAlarm: WebExtEvent<(name: Alarm) => void>;
+}
+
+/**
  * Use the `browser.browserSettings` API to control global settings of the browser.
  *
  * Permissions: `browserSettings`
@@ -796,6 +800,47 @@ declare namespace browser.browserSettings {
 
     /** This setting controls whether the document's fonts are used. */
     const useDocumentFonts: types.Setting;
+}
+
+/**
+ * This API provides the ability detect the captive portal state of the users connection.
+ *
+ * Permissions: `captivePortal`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.captivePortal {
+    /** The current captive portal state. */
+    type _UndefinedState =
+        "unknown"
+        | "not_captive"
+        | "unlocked_portal"
+        | "locked_portal";
+
+    type _Status = "captive" | "clear";
+
+    /* captivePortal functions */
+    /**
+     * Returns the current portal state, one of `unknown`, `not_captive`, `unlocked_portal`, `locked_portal`.
+     */
+    function getState(): Promise<_UndefinedState>;
+
+    /** Returns the time difference between NOW and the last time a request was completed in milliseconds. */
+    function getLastChecked(): Promise<number>;
+
+    /* captivePortal events */
+    /** Fired when the captive portal state changes. */
+    const onStateChanged: WebExtEvent<(details: {
+        /** The current captive portal state. */
+        state: _UndefinedState;
+    }) => void>;
+
+    /**
+     * This notification will be emitted when the captive portal service has determined that we can connect to the
+     * internet. The service will pass either `captive` if there is an unlocked captive portal present, or `clear` if
+     * no captive portal was detected.
+     */
+    const onConnectivityAvailable: WebExtEvent<(status: _Status) => void>;
 }
 
 /**
@@ -1965,6 +2010,104 @@ declare namespace browser.extensionTypes {
 }
 
 /**
+ * Exposes the browser's profiler.
+ *
+ * Permissions: `geckoProfiler`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.geckoProfiler {
+    /* geckoProfiler types */
+    type ProfilerFeature =
+        "java"
+        | "js"
+        | "leaf"
+        | "mainthreadio"
+        | "privacy"
+        | "responsiveness"
+        | "screenshots"
+        | "seqstyle"
+        | "stackwalk"
+        | "tasktracer"
+        | "threads"
+        | "trackopts"
+        | "jstracer"
+        | "jsallocations"
+        | "preferencereads";
+
+    type Supports = "windowLength";
+
+    /* geckoProfiler functions */
+    /** Starts the profiler with the specified settings. */
+    function start(settings: {
+        /**
+         * The maximum size in bytes of the buffer used to store profiling data. A larger value allows capturing a
+         * profile that covers a greater amount of time.
+         */
+        bufferSize: number;
+        /**
+         * The length of the window of time that's kept in the buffer. Any collected samples are discarded as soon as
+         * they are older than the number of seconds specified in this setting. Zero means no duration restriction.
+         */
+        windowLength?: number;
+        /**
+         * Interval in milliseconds between samples of profiling data. A smaller value will increase the detail of the
+         * profiles captured.
+         */
+        interval: number;
+        /** A list of active features for the profiler. */
+        features: ProfilerFeature[];
+        /** A list of thread names for which to capture profiles. */
+        threads?: string[];
+    }): Promise<any>;
+
+    /** Stops the profiler and discards any captured profile data. */
+    function stop(): Promise<any>;
+
+    /** Pauses the profiler, keeping any profile data that is already written. */
+    function pause(): Promise<any>;
+
+    /** Resumes the profiler with the settings that were initially used to start it. */
+    function resume(): Promise<any>;
+
+    /**
+     * Gathers the profile data from the current profiling session, and writes it to disk. The returned promise
+     * resolves to a path that locates the created file.
+     * @param fileName The name of the file inside the profile/profiler directory
+     */
+    function dumpProfileToFile(fileName: string): Promise<any>;
+
+    /** Gathers the profile data from the current profiling session. */
+    function getProfile(): Promise<any>;
+
+    /**
+     * Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer
+     * that contains a JSON string.
+     */
+    function getProfileAsArrayBuffer(): Promise<any>;
+
+    /**
+     * Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer
+     * that contains a gzipped JSON string.
+     */
+    function getProfileAsGzippedArrayBuffer(): Promise<any>;
+
+    /**
+     * Gets the debug symbols for a particular library.
+     * @param debugName The name of the library's debug file. For example, 'xul.pdb
+     * @param breakpadId The Breakpad ID of the library
+     */
+    function getSymbols(debugName: string, breakpadId: string): Promise<any>;
+
+    /* geckoProfiler events */
+    /**
+     * Fires when the profiler starts/stops running.
+     * @param isRunning Whether the profiler is running or not. Pausing the profiler will not affect this value.
+     */
+    const onRunning: WebExtEvent<(isRunning: boolean) => void>;
+}
+
+/**
  * Use the `browser.i18n` infrastructure to implement internationalization across your whole app or extension.
  */
 declare namespace browser.i18n {
@@ -2265,6 +2408,51 @@ declare namespace browser.management {
 }
 
 /**
+ * This API provides the ability to determine the status of and detect changes in the network connection. This API can
+ * only be used in privileged extensions.
+ *
+ * Permissions: `networkStatus`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.networkStatus {
+    /* networkStatus types */
+    interface NetworkLinkInfo {
+        /** Status of the network link, if "unknown" then link is usually assumed to be "up" */
+        status: _NetworkLinkInfoStatus;
+        /** If known, the type of network connection that is avialable. */
+        type: _NetworkLinkInfoType;
+        /** If known, the network id or name. */
+        id?: string;
+    }
+
+    /** Status of the network link, if "unknown" then link is usually assumed to be "up" */
+    type _NetworkLinkInfoStatus =
+        "unknown"
+        | "up"
+        | "down";
+
+    /** If known, the type of network connection that is avialable. */
+    type _NetworkLinkInfoType =
+        "unknown"
+        | "ethernet"
+        | "usb"
+        | "wifi"
+        | "wimax"
+        | "2g"
+        | "3g"
+        | "4g";
+
+    /* networkStatus functions */
+    /** Returns the $(ref:NetworkLinkInfo} of the current network connection. */
+    function getLinkInfo(): Promise<NetworkLinkInfo>;
+
+    /* networkStatus events */
+    /** Fired when the network connection state changes. */
+    const onConnectionChanged: WebExtEvent<(details: NetworkLinkInfo) => void>;
+}
+
+/**
  * Permissions: `notifications`
  *
  * Not allowed in: Content scripts, Devtools pages
@@ -2509,7 +2697,8 @@ declare namespace browser.privacy.network {
         "default"
         | "default_public_and_private_interfaces"
         | "default_public_interface_only"
-        | "disable_non_proxied_udp";
+        | "disable_non_proxied_udp"
+        | "proxy_only";
 
     /* privacy.network properties */
     /**
@@ -2698,6 +2887,10 @@ declare namespace browser.proxy {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -2729,15 +2922,21 @@ declare namespace browser.proxy {
     const settings: types.Setting;
 
     /* proxy functions */
-    /** Registers the proxy script for the extension. */
+    /**
+     * Registers the proxy script for the extension.
+     * @deprecated proxy.register has been deprecated and will be removed in Firefox 71.
+     */
     function register(url: string): Promise<void>;
 
-    /** Unregisters the proxy script for the extension. */
+    /**
+     * Unregisters the proxy script for the extension.
+     * @deprecated proxy.unregister has been deprecated and will be removed in Firefox 71.
+     */
     function unregister(): Promise<void>;
 
     /**
-     * Registers the proxy script for the extension.
-     * @deprecated Please use `proxy.register`
+     * Registers the proxy script for the extension. This is an alias for proxy.register.
+     * @deprecated proxy.registerProxyScript has been deprecated and will be removed in Firefox 71.
      */
     function registerProxyScript(url: string): Promise<any>;
 
@@ -2745,10 +2944,13 @@ declare namespace browser.proxy {
     /** Fired when proxy data is needed for a request. */
     const onRequest: _ProxyOnRequestEvent;
 
-    /** Notifies about proxy script errors. */
+    /** Notifies about errors caused by the invalid use of the proxy API. */
     const onError: WebExtEvent<(error: Error) => void>;
 
-    /** Please use `proxy.onError`. */
+    /**
+     * Please use `proxy.onError`.
+     * @deprecated proxy.onProxyError has been deprecated and will be removed in Firefox 71\. Use proxy.onError instead.
+     */
     const onProxyError: WebExtEvent<(error: Error) => void>;
 }
 
@@ -2953,6 +3155,8 @@ declare namespace browser.runtime {
 
     /**
      * Connects to a native application in the host machine.
+     *
+     * Not allowed in: Devtools pages
      * @param application The name of the registered application to connect to.
      * @returns Port through which messages can be sent and received with the application
      */
@@ -3001,6 +3205,8 @@ declare namespace browser.runtime {
 
     /**
      * Send a single message to a native application.
+     *
+     * Not allowed in: Devtools pages
      * @param application The name of the native messaging host.
      * @param message The message that will be passed to the native messaging host.
      */
@@ -3206,7 +3412,7 @@ declare namespace browser.storage {
  * Use the `browser.telemetry` API to send telemetry data to the Mozilla Telemetry service. Restricted to Mozilla
  * privileged webextensions.
  *
- * Permissions: `telemetry`, `mozillaAddons`
+ * Permissions: `telemetry`
  *
  * Not allowed in: Content scripts, Devtools pages
  */
@@ -3301,7 +3507,7 @@ declare namespace browser.telemetry {
      * @param [value] An optional string value to record.
      * @param [extra] An optional object of the form (string -> string). It should only contain registered extra keys.
      */
-    function recordEvent(category: string, method: string, object: string, value?: number, extra?: { [key: string]: string }): Promise<any>;
+    function recordEvent(category: string, method: string, object: string, value?: string, extra?: { [key: string]: string }): Promise<any>;
 
     /**
      * Register new scalars to record them from addons. See nsITelemetry.idl for more details.
@@ -3374,41 +3580,6 @@ declare namespace browser.theme {
      * @param updateInfo Details of the theme update
      */
     const onUpdated: WebExtEvent<(updateInfo: ThemeUpdateInfo) => void>;
-}
-
-/**
- * Use the browser.topSites API to access the top sites that are displayed on the new tab page.
- *
- * Permissions: `topSites`
- *
- * Not allowed in: Content scripts, Devtools pages
- */
-declare namespace browser.topSites {
-    /* topSites types */
-    /** An object encapsulating a most visited URL, such as the URLs on the new tab page. */
-    interface MostVisitedURL {
-        /** The most visited URL. */
-        url: string;
-        /** The title of the page. */
-        title?: string;
-        /** Data URL for the favicon, if available. */
-        favicon?: string;
-    }
-
-    /* topSites functions */
-    /** Gets a list of top sites. */
-    function get(options?: {
-        /** @deprecated Please use the other options to tune the results received from topSites. */
-        providers?: string[];
-        /** The number of top sites to return, defaults to the value used by Firefox */
-        limit?: number;
-        /** Limit the result to a single top site link per domain */
-        onePerDomain?: boolean;
-        /** Include sites that the user has blocked from appearing on the Firefox new tab. */
-        includeBlocked?: boolean;
-        /** Include sites favicon if available. */
-        includeFavicon?: boolean;
-    }): Promise<MostVisitedURL[]>;
 }
 
 /**
@@ -4022,6 +4193,8 @@ declare namespace browser.webRequest {
         types?: ResourceType[];
         tabId?: number;
         windowId?: number;
+        /** If provided, requests that do not match the incognito state will be filtered out. */
+        incognito?: boolean;
     }
 
     /**
@@ -4160,6 +4333,31 @@ declare namespace browser.webRequest {
         file?: string;
     }
 
+    /** Tracking flags that match our internal tracking classification */
+    type UrlClassificationFlags =
+        "fingerprinting"
+        | "fingerprinting_content"
+        | "cryptomining"
+        | "cryptomining_content"
+        | "tracking"
+        | "tracking_ad"
+        | "tracking_analytics"
+        | "tracking_social"
+        | "tracking_content"
+        | "any_basic_tracking"
+        | "any_strict_tracking"
+        | "any_social_tracking";
+
+    /** If the request has been classified this is an array of `UrlClassificationFlags`. */
+    type UrlClassificationParty = UrlClassificationFlags[];
+
+    interface UrlClassification {
+        /** First party classification flags if the request has been classified. */
+        firstParty: UrlClassificationParty;
+        /** Third party classification flags if the request has been classified. */
+        thirdParty: UrlClassificationParty;
+    }
+
     type _SecurityInfoState =
         "insecure"
         | "weak"
@@ -4192,6 +4390,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4220,6 +4422,8 @@ declare namespace browser.webRequest {
         type: ResourceType;
         /** The time when this signal is triggered, in milliseconds since the epoch. */
         timeStamp: number;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => BlockingResponse | Promise<BlockingResponse> | void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnBeforeRequestOptions[]): void;
 
@@ -4246,6 +4450,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4258,6 +4466,8 @@ declare namespace browser.webRequest {
         timeStamp: number;
         /** The HTTP request headers that are going to be sent out with this request. */
         requestHeaders?: HttpHeaders;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => BlockingResponse | Promise<BlockingResponse> | void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnBeforeSendHeadersOptions[]): void;
 
@@ -4284,6 +4494,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4296,6 +4510,8 @@ declare namespace browser.webRequest {
         timeStamp: number;
         /** The HTTP request headers that have been sent out with this request. */
         requestHeaders?: HttpHeaders;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnSendHeadersOptions[]): void;
 
@@ -4322,6 +4538,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4341,6 +4561,8 @@ declare namespace browser.webRequest {
         responseHeaders?: HttpHeaders;
         /** Standard HTTP status code returned by the server. */
         statusCode: number;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => BlockingResponse | Promise<BlockingResponse> | void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnHeadersReceivedOptions[]): void;
 
@@ -4367,6 +4589,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4397,6 +4623,8 @@ declare namespace browser.webRequest {
         statusLine: string;
         /** Standard HTTP status code returned by the server. */
         statusCode: number;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => BlockingResponse | Promise<BlockingResponse> | void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnAuthRequiredOptions[]): void;
 
@@ -4423,6 +4651,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4448,6 +4680,8 @@ declare namespace browser.webRequest {
          * that lack a status line) or an empty string if there are no headers.
          */
         statusLine: string;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnResponseStartedOptions[]): void;
 
@@ -4474,6 +4708,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4501,6 +4739,8 @@ declare namespace browser.webRequest {
          * that lack a status line) or an empty string if there are no headers.
          */
         statusLine: string;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnBeforeRedirectOptions[]): void;
 
@@ -4527,6 +4767,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4552,6 +4796,8 @@ declare namespace browser.webRequest {
          * that lack a status line) or an empty string if there are no headers.
          */
         statusLine: string;
+        /** Tracking classification if the request has been classified. */
+        urlClassification: UrlClassification;
     }) => void> {
         addListener(cb: TCallback, filter: RequestFilter, extraInfoSpec?: OnCompletedOptions[]): void;
 
@@ -4578,6 +4824,10 @@ declare namespace browser.webRequest {
         frameId: number;
         /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
         parentFrameId: number;
+        /** True for private browsing requests. */
+        incognito?: boolean;
+        /** The cookie store ID of the contextual identity. */
+        cookieStoreId?: string;
         /** URL of the resource that triggered this request. */
         originUrl?: string;
         /** URL of the page into which the requested resource will be loaded. */
@@ -4599,6 +4849,8 @@ declare namespace browser.webRequest {
          * must not parse and act based upon its content.
          */
         error: string;
+        /** Tracking classification if the request has been classified. */
+        urlClassification?: UrlClassification;
     }) => void> {
         addListener(cb: TCallback, filter: RequestFilter): void;
 
@@ -5679,90 +5931,6 @@ declare namespace browser.find {
 }
 
 /**
- * Exposes the browser's profiler.
- *
- * Permissions: `geckoProfiler`
- *
- * Not allowed in: Content scripts, Devtools pages
- */
-declare namespace browser.geckoProfiler {
-    /* geckoProfiler types */
-    type ProfilerFeature =
-        "java"
-        | "js"
-        | "leaf"
-        | "mainthreadio"
-        | "memory"
-        | "privacy"
-        | "responsiveness"
-        | "screenshots"
-        | "seqstyle"
-        | "stackwalk"
-        | "tasktracer"
-        | "threads"
-        | "trackopts"
-        | "jstracer";
-
-    type Supports = "windowLength";
-
-    /* geckoProfiler functions */
-    /** Starts the profiler with the specified settings. */
-    function start(settings: {
-        /**
-         * The maximum size in bytes of the buffer used to store profiling data. A larger value allows capturing a
-         * profile that covers a greater amount of time.
-         */
-        bufferSize: number;
-        /**
-         * The length of the window of time that's kept in the buffer. Any collected samples are discarded as soon as
-         * they are older than the number of seconds specified in this setting. Zero means no duration restriction.
-         */
-        windowLength?: number;
-        /**
-         * Interval in milliseconds between samples of profiling data. A smaller value will increase the detail of the
-         * profiles captured.
-         */
-        interval: number;
-        /** A list of active features for the profiler. */
-        features: ProfilerFeature[];
-        /** A list of thread names for which to capture profiles. */
-        threads?: string[];
-    }): Promise<any>;
-
-    /** Stops the profiler and discards any captured profile data. */
-    function stop(): Promise<any>;
-
-    /** Pauses the profiler, keeping any profile data that is already written. */
-    function pause(): Promise<any>;
-
-    /** Resumes the profiler with the settings that were initially used to start it. */
-    function resume(): Promise<any>;
-
-    /** Gathers the profile data from the current profiling session. */
-    function getProfile(): Promise<any>;
-
-    /**
-     * Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer
-     * that contains a JSON string.
-     */
-    function getProfileAsArrayBuffer(): Promise<any>;
-
-    /**
-     * Gets the debug symbols for a particular library.
-     * @param debugName The name of the library's debug file. For example, 'xul.pdb
-     * @param breakpadId The Breakpad ID of the library
-     */
-    function getSymbols(debugName: string, breakpadId: string): Promise<any>;
-
-    /* geckoProfiler events */
-    /**
-     * Fires when the profiler starts/stops running.
-     * @param isRunning Whether the profiler is running or not. Pausing the profiler will not affect this value.
-     */
-    const onRunning: WebExtEvent<(isRunning: boolean) => void>;
-}
-
-/**
  * Use the `browser.history` API to interact with the browser's record of visited pages. You can add, remove, and query
  * for URLs in the browser's history. To override the history page with your own version, see Override Pages.
  *
@@ -6459,6 +6627,65 @@ declare namespace browser.menus {
 
     /** Fired when a menu is hidden. This event is only fired if onShown has fired before. */
     const onHidden: WebExtEvent<() => void>;
+}
+
+/**
+ * Normandy Study API
+ *
+ * Permissions: `normandyAddonStudy`
+ */
+declare namespace browser.normandyAddonStudy {
+    /* normandyAddonStudy types */
+    interface Study {
+        /** The ID of the recipe for the study. */
+        recipeId: number;
+        /** A slug to identify the study. */
+        slug: string;
+        /** The name presented on about:studies. */
+        userFacingName: string;
+        /** The description presented on about:studies. */
+        userFacingDescription: string;
+        /** The study branch in which the user is enrolled. */
+        branch: string;
+        /** The state of the study. */
+        active: boolean;
+        /** The ID of the extension installed by the study. */
+        addonId: string;
+        /** The URL of the XPI that was downloaded and installed by the study. */
+        addonUrl: string;
+        /** The version of the extension installed by the study. */
+        addonVersion: string;
+        /** The start date for the study. */
+        studyStartDate: extensionTypes.Date;
+        /** The end date for the study. */
+        studyEndDate: extensionTypes.Date;
+        /** The record ID for the extension in Normandy server's database. */
+        extensionApiId: number;
+        /** A hash of the extension XPI file. */
+        extensionHash: string;
+        /** The algorithm used to hash the extension XPI file. */
+        extensionHashAlgorithm: string;
+    }
+
+    /* normandyAddonStudy functions */
+    /** Returns a study object for the current study. */
+    function getStudy(): Promise<any>;
+
+    /**
+     * Marks the study as ended and then uninstalls the addon.
+     * @param reason The reason why the study is ending.
+     */
+    function endStudy(reason: string): Promise<any>;
+
+    /** Returns an object with metadata about the client which may be required for constructing survey URLs. */
+    function getClientMetadata(): Promise<any>;
+
+    /* normandyAddonStudy events */
+    /**
+     * Fired when a user unenrolls from a study but before the addon is uninstalled.
+     * @param reason The reason why the study is ending.
+     */
+    const onUnenroll: WebExtEvent<(reason: string) => void>;
 }
 
 /**
@@ -7807,6 +8034,225 @@ declare namespace browser.tabs {
         newZoomFactor: number;
         zoomSettings: ZoomSettings;
     }) => void>;
+}
+
+/**
+ * Use the browser.topSites API to access the top sites that are displayed on the new tab page.
+ *
+ * Permissions: `topSites`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.topSites {
+    /* topSites types */
+    /** An object encapsulating a most visited URL, such as the URLs on the new tab page. */
+    interface MostVisitedURL {
+        /** The most visited URL. */
+        url: string;
+        /** The title of the page. */
+        title?: string;
+        /** Data URL for the favicon, if available. */
+        favicon?: string;
+        /** The entry type, either `url` for a normal page link, or `search` for a search shortcut. */
+        type?: _MostVisitedURLType;
+    }
+
+    /** The entry type, either `url` for a normal page link, or `search` for a search shortcut. */
+    type _MostVisitedURLType = "url" | "search";
+
+    /* topSites functions */
+    /** Gets a list of top sites. */
+    function get(options?: {
+        /** @deprecated Please use the other options to tune the results received from topSites. */
+        providers?: string[];
+        /** The number of top sites to return, defaults to the value used by Firefox */
+        limit?: number;
+        /** Limit the result to a single top site link per domain */
+        onePerDomain?: boolean;
+        /** Include sites that the user has blocked from appearing on the Firefox new tab. */
+        includeBlocked?: boolean;
+        /** Include sites favicon if available. */
+        includeFavicon?: boolean;
+        /** Include sites that the user has pinned on the Firefox new tab. */
+        includePinned?: boolean;
+        /** Include search shortcuts appearing on the Firefox new tab. */
+        includeSearchShortcuts?: boolean;
+        /**
+         * Return the sites that exactly appear on the user's new-tab page. When true, all other options are ignored
+         * except limit and includeFavicon.
+         */
+        newtab?: boolean;
+    }): Promise<MostVisitedURL[]>;
+}
+
+/**
+ * Use the `browser.urlbar` API to experiment with new features in the URLBar. Restricted to Mozilla privileged
+ * WebExtensions.
+ *
+ * Permissions: `urlbar`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.urlbar {
+    /* urlbar types */
+    /** A query performed in the urlbar. */
+    interface Query {
+        /** Whether the query's browser context is private. */
+        isPrivate: boolean;
+        /** The maximum number of results shown to the user. */
+        maxResults: number;
+        /** The query's search string. */
+        searchString: string;
+        /** List of acceptable source types to return. */
+        acceptableSources: SourceType[];
+    }
+
+    /** A result of a query. Queries can have many results. Each result is created by a provider. */
+    interface Result {
+        /** An object with arbitrary properties depending on the result's type. */
+        payload: object;
+        /** The result's source. */
+        source: SourceType;
+        /** The result's type. */
+        type: ResultType;
+    }
+
+    /**
+     * Possible types of results. `remote_tab`: A synced tab from another device. `search`: A search suggestion from a
+     * search engine. `tab`: An open tab in the browser. `url`: A URL that's not one of the other types.
+     */
+    type ResultType =
+        "remote_tab"
+        | "search"
+        | "tab"
+        | "url";
+
+    /**
+     * Possible sources of results. `bookmarks`: The result comes from the user's bookmarks. `history`: The result
+     * comes from the user's history. `search`: The result comes from a search engine. `tabs`: The result is an open
+     * tab in the browser or a synced tab from another device.
+     */
+    type SourceType =
+        "bookmarks"
+        | "history"
+        | "search"
+        | "tabs"
+        | "local"
+        | "network";
+
+    interface _UrlbarOnBehaviorRequestedEvent<TCallback = (query: Query) => "active" | "inactive" | "restricting"> {
+        addListener(cb: TCallback, providerName: string): void;
+
+        removeListener(cb: TCallback): void;
+
+        hasListener(cb: TCallback): boolean;
+    }
+
+    interface _UrlbarOnQueryCanceledEvent<TCallback = (query: Query) => void> {
+        addListener(cb: TCallback, providerName: string): void;
+
+        removeListener(cb: TCallback): void;
+
+        hasListener(cb: TCallback): boolean;
+    }
+
+    interface _UrlbarOnResultsRequestedEvent<TCallback = (query: Query) => Result[]> {
+        addListener(cb: TCallback, providerName: string): void;
+
+        removeListener(cb: TCallback): void;
+
+        hasListener(cb: TCallback): boolean;
+    }
+
+    /* urlbar properties */
+    /** Enables or disables the open-view-on-focus mode. */
+    const openViewOnFocus: types.Setting;
+
+    /** Enables or disables the engagement telemetry. */
+    const engagementTelemetry: types.Setting;
+
+    /* urlbar events */
+    /**
+     * Before a query starts, this event is fired for the given provider. Its purpose is to request the provider's
+     * behavior for the query. The listener should return a behavior in response. By default, providers are inactive,
+     * so if your provider should always be inactive, you don't need to listen for this event.
+     * @param query The query for which the behavior is requested.
+     * @returns The behavior of the provider for the query.
+     */
+    const onBehaviorRequested: _UrlbarOnBehaviorRequestedEvent;
+
+    /**
+     * This event is fired for the given provider when a query is canceled. The listener should stop any ongoing fetch
+     * or creation of results and clean up its resources.
+     * @param query The query that was canceled.
+     */
+    const onQueryCanceled: _UrlbarOnQueryCanceledEvent;
+
+    /**
+     * When a query starts, this event is fired for the given provider if the provider is active for the query and
+     * there are no other providers that are restricting. Its purpose is to request the provider's results for the
+     * query. The listener should return a list of results in response.
+     * @param query The query for which results are requested.
+     * @returns The results that the provider fetched for the query.
+     */
+    const onResultsRequested: _UrlbarOnResultsRequestedEvent;
+}
+
+/**
+ * A contextual tip appears in the urlbar's view (its search results panel) and has an icon, text, optional button, and
+ * an optional link. Use the `browser.urlbar.contextualTip` API to experiment with the contextual tip. Restricted to
+ * Mozilla privileged WebExtensions.
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.urlbar.contextualTip {
+    /* urlbar.contextualTip types */
+    /**
+     * An object containing the path to an icon, the title, button title, and link title to set on the contextual tip.
+     */
+    interface ContextualTip {
+        /** Specifies the default icon and theme icons */
+        icon?: {
+            /** Specifies the default icon to use in the contextual tip. */
+            defaultIcon: string | _manifest.IconPath;
+            /**
+             * Specifies icons to use for dark and light themes. Each item in the array is for a specified icon size.
+             */
+            themeIcons?: _manifest.ThemeIcons[];
+        };
+        /** A string to be used as the contextual tip's title. */
+        title: string;
+        /** A string to be used as the contextual tip's button's title. */
+        buttonTitle?: string;
+        /** A string to be used as the contextual tip's link's title. */
+        linkTitle?: string;
+    }
+
+    /* urlbar.contextualTip functions */
+    /**
+     * Sets the contextual tip in the most recent browser winodw with the given icon, title, button title, and link
+     * title. If the urlbar's view is not already open, then it will be opened so the contextual tip will be visible.
+     * Note that when the urlbar's view is closed, the contextual tip is hidden and will not appear again.
+     * `browser.urlbar.contextualTip.set` must be called each time a contextual tip should appear.
+     * @param details Specifies the contextual tip's texts.
+     */
+    function set(details: ContextualTip): void;
+
+    /** Hides the contextual tip (it will still be in the DOM). */
+    function remove(): void;
+
+    /* urlbar.contextualTip events */
+    /**
+     * Fired when the user clicks the contextual tip's button.
+     * @param windowId The id of the window where the contextual tip's button was clicked.
+     */
+    const onButtonClicked: WebExtEvent<(windowId: number) => void>;
+
+    /**
+     * Fired when the user clicks the contextual tip's link.
+     * @param windowId The id of the window where the contextual tip's link was clicked.
+     */
+    const onLinkClicked: WebExtEvent<(windowId: number) => void>;
 }
 
 /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/jsmnbom/3c0a39c4675b3602f212c19304f19427
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Note that many new async functions just return Promise<any> for now, until i have time to manually go through and check the return type since those are not in the mozilla spec files. This should be better for now tho as it will immediately allow users to use the new APIs.