### PR TITLE
added types for express-status-monitor

### DIFF
--- a/types/express-status-monitor/express-status-monitor-tests.ts
+++ b/types/express-status-monitor/express-status-monitor-tests.ts
@@ -1,0 +1,43 @@
+import express = require('express');
+import expressStatusMonitor = require('express-status-monitor');
+import socketIO = require('socket.io');
+
+const app = express();
+app.use(expressStatusMonitor());
+app.use(
+    expressStatusMonitor({
+        title: 'Type Test',
+        theme: 'default.css',
+        path: '/status',
+        socketPath: '/socket.io',
+        websocket: null,
+        chartVisibility: {
+            cpu: true,
+            mem: false,
+            load: true,
+        },
+        ignoreStartsWith: '/admin',
+        healthChecks: [],
+    }),
+);
+app.use(
+    expressStatusMonitor({
+        spans: [{ interval: 10000, retention: 60 * 1000 }],
+        healthChecks: [
+            {
+                protocol: 'http',
+                host: 'localhost',
+                path: '/healthcheck',
+                port: '4000',
+            },
+        ],
+    }),
+);
+
+const io = socketIO.listen(80);
+
+app.use(
+    expressStatusMonitor({
+        websocket: io,
+    }),
+);

--- a/types/express-status-monitor/index.d.ts
+++ b/types/express-status-monitor/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for express-status-monitor 1.2
+// Project: https://github.com/RafalWilinski/express-status-monitor#readme
+// Definitions by: Alex Anderson <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="socket.io" />
+
+import express = require('express');
+
+declare namespace e {
+    interface ExpressStatusMonitorConfig {
+        title?: string;
+        theme?: string;
+        path?: string;
+        socketPath?: string;
+        websocket?: SocketIO.Server | null; // References a socket.io instance
+        spans?: RetentionSpan[];
+        chartVisibility?: {
+            cpu?: boolean;
+            mem?: boolean;
+            load?: boolean;
+            responseTime?: boolean;
+            rps?: boolean;
+            statusCodes?: boolean;
+        };
+        healthChecks?: HealthCheck[];
+        ignoreStartsWith?: string;
+    }
+
+    interface RetentionSpan {
+        interval: number;
+        retention: number;
+    }
+    interface HealthCheck {
+        protocol: string;
+        host: string;
+        path: string;
+        port: string | number;
+    }
+}
+
+declare function e(config?: e.ExpressStatusMonitorConfig): express.RequestHandler;
+
+export = e;

--- a/types/express-status-monitor/tsconfig.json
+++ b/types/express-status-monitor/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-status-monitor-tests.ts"
+    ]
+}

--- a/types/express-status-monitor/tslint.json
+++ b/types/express-status-monitor/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
