### PR TITLE
selenium-webdriver: added setBrowserName and setBrowserVersion Capabilities methods

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -7,6 +7,7 @@
 //   Ben Dixon <https://github.com/bendxn>,
 //   Ziyu <https://github.com/oddui>
 //   Johann Wolf <https://github.com/beta-vulgaris>
+//   Aleksey Chemakin <https://github.com/Dzenly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -1391,6 +1392,22 @@ export class Capabilities {
    * @return {!Capabilities} A self reference.
    */
   set(key: string, value: any): Capabilities;
+
+  /**
+   * Sets the name of the target browser.
+   *
+   * @param {(Browser|string)} name the browser name.
+   * @return {!Capabilities} a self reference.
+   */
+  setBrowserName(name: string): Capabilities;
+
+  /**
+   * Sets the desired version of the target browser.
+   *
+   * @param {string} version the desired version.
+   * @return {!Capabilities} a self reference.
+   */
+  setBrowserVersion(version: string): Capabilities;
 
   /**
    * Sets the logging preferences. Preferences may be specified as a

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -112,6 +112,9 @@ function TestCapabilities() {
     capabilities = capabilities.setScrollBehavior(1);
     capabilities = capabilities.setAlertBehavior('accept');
     capabilities = capabilities.setAlertBehavior();
+    capabilities = capabilities.setBrowserName('myBrowserName');
+    capabilities = capabilities.setBrowserName(webdriver.Browser.ANDROID);
+    capabilities = capabilities.setBrowserVersion('10.3.4');
 
     anything = capabilities.toJSON();
 


### PR DESCRIPTION
Function descriptions are taken from here:

* https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/lib/capabilities.js

* https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_Capabilities.html