### PR TITLE
feat(mui-datatables): update typings to v2.12 of lib

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 2.10
+// Type definitions for mui-datatables 2.12
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
@@ -127,9 +127,22 @@ export interface MUIDataTableColumnOptions {
     viewColumns?: boolean;
 }
 
+export interface MUIDataTableIsRowCheck {
+    lookup: {
+        dataIndex: number;
+    };
+    data: [
+        {
+            index: number;
+            dataIndex: number;
+        }
+    ];
+}
+
 export interface MUIDataTableOptions {
     caseSensitive?: boolean;
     count?: number;
+    customFilterDialogFooter?: (filterList: any[]) => React.ReactNode;
     customFooter?: (
         rowCount: number,
         page: number,
@@ -138,9 +151,13 @@ export interface MUIDataTableOptions {
         changePage: number
     ) => React.ReactNode;
     customRowRender?: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
-
     customSearch?: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
-    customSearchRender?: (searchText: string, handleSearch: any, hideSearch: any, options: any) => React.Component | JSX.Element;
+    customSearchRender?: (
+        searchText: string,
+        handleSearch: any,
+        hideSearch: any,
+        options: any
+    ) => React.Component | JSX.Element;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     customToolbar?: () => React.ReactNode;
     customToolbarSelect?: (
@@ -159,7 +176,8 @@ export interface MUIDataTableOptions {
     filter?: boolean;
     filterType?: 'dropdown' | 'checkbox' | 'multiselect' | 'textField';
     fixedHeader?: boolean;
-    isRowSelectable?: (dataIndex: number) => boolean;
+    isRowExpandable?: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
+    isRowSelectable?: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     onCellClick?: (
         colData: any,
         cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent }
@@ -175,11 +193,15 @@ export interface MUIDataTableOptions {
         data: any
     ) => BlobPart;
     onFilterChange?: (changedColumn: string, filterList: any[]) => void;
+    onFilterDialogOpen?: () => void;
+    onFilterDialogClose?: () => void;
     onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
     onRowsDelete?: (rowsDeleted: any[]) => void;
+    onRowsExpand?: (currentRowsExpanded: any[], allRowsExpanded: any[]) => void;
     onRowsSelect?: (currentRowsSelected: any[], rowsSelected: any[]) => void;
     onSearchChange?: (searchText: string) => void;
     onSearchOpen?: () => void;
+    onSearchClose?: () => void;
     onTableChange?: (action: string, tableState: MUIDataTableState) => void;
     onTableInit?: (action: string, tableState: MUIDataTableState) => void;
     page?: number;
@@ -194,11 +216,14 @@ export interface MUIDataTableOptions {
     rowsExpanded?: any[];
     rowsSelected?: any[];
     search?: boolean;
+    searchOpen?: boolean;
     searchPlaceholder?: string;
     searchText?: string;
     selectableRows?: SelectableRows;
+    selectableRowsHeader?: boolean;
     selectableRowsOnClick?: boolean;
     serverSide?: boolean;
+    serverSideFilterList?: any[];
     setRowProps?: (row: any[], rowIndex: number) => object;
     sort?: boolean;
     sortFilterList?: boolean;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,4 @@
-import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels, SelectableRows } from 'mui-datatables';
+import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels } from 'mui-datatables';
 import * as React from 'react';
 
 interface Props extends MUIDataTableOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Issue that brought it to my attention: https://github.com/gregnb/mui-datatables/issues/978
  - Tag that introduced the changes: https://github.com/gregnb/mui-datatables/releases/tag/2.12.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.