### PR TITLE
Xrm: Implemented missing members Xrm.Controls.QuickFormControl

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -2509,6 +2509,28 @@ declare namespace Xrm {
         }
 
         /**
+         * Interface for UI elements which can have the disabled value read.
+         */
+        interface UiCanGetDisabledElement {
+            /**
+             * Gets a boolean value, indicating whether the control is disabled.
+             * @returns true if it is disabled, otherwise false.
+             */
+            getDisabled(): boolean;
+        }
+
+        /**
+         * Interface for UI elements which can have the disabled value updated.
+         */
+        interface UiCanSetDisabledElement {
+            /**
+             * Sets the state of the control to either enabled, or disabled.
+             * @param disabled true to disable, false to enable.
+             */
+            setDisabled(disabled: boolean): void;
+        }
+
+        /**
          * Interface for UI elements which can have the visibility value read.
          */
         interface UiCanGetVisibleElement {
@@ -2717,7 +2739,7 @@ declare namespace Xrm {
          * Interface for a standard control.
          * @see {@link Control}
          */
-        interface StandardControl extends Control, UiStandardElement, UiFocusable {
+        interface StandardControl extends Control, UiStandardElement, UiFocusable, UiCanGetDisabledElement, UiCanSetDisabledElement {
             /**
              * Clears the notification identified by uniqueId.
              * @param uniqueId (Optional) Unique identifier.
@@ -2725,18 +2747,6 @@ declare namespace Xrm {
              * @remarks If the uniqueId parameter is not used, the current notification shown will be removed.
              */
             clearNotification(uniqueId?: string): boolean;
-
-            /**
-             * Gets a boolean value, indicating whether the control is disabled.
-             * @returns true if it is disabled, otherwise false.
-             */
-            getDisabled(): boolean;
-
-            /**
-             * Sets the state of the control to either enabled, or disabled.
-             * @param disabled true to disable, false to enable.
-             */
-            setDisabled(disabled: boolean): void;
 
             /**
              * Sets a control-local notification message.
@@ -3162,7 +3172,7 @@ declare namespace Xrm {
          * Interface for a quick view control instance on a form.
          * @see {@link https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/formcontext-ui-quickforms External Link: formContext.ui.quickForms (Client API reference)}
          */
-        interface QuickFormControl extends Control, UiLabelElement, UiCanGetVisibleElement {
+        interface QuickFormControl extends Control, UiLabelElement, UiFocusable, UiCanGetDisabledElement, UiCanSetDisabledElement, UiCanGetVisibleElement, UiCanSetVisibleElement {
             /**
              * Gets the constituent controls in a quick view control.
              * @returns An array of controls.
@@ -3209,6 +3219,12 @@ declare namespace Xrm {
              * @returns Returns a string value ("quickform") that categorizes quick view controls.
              */
             getControlType(): ControlQuickFormType;
+
+            /**
+             * Gets a reference to the Section parent of the control.
+             * @returns The parent Section.
+             */
+            getParent(): Section;
 
             /**
              * Returns whether the data binding for the constituent controls in a quick view control is complete.


### PR DESCRIPTION
Introduced Xrm.Controls.UiCanGetDisabledElement and Xrm.Controls.SetDisabledElement on QuickForm and StandardAttribute interface
Implemented missing Xrm.Controls.QuickFormControl members

- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/formcontext-ui-quickforms
