### PR TITLE
Revert "fix: Use ListIterator for the remove predicate."

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -1858,7 +1858,7 @@ declare module "../index" {
          */
         remove<T>(
             array: List<T>,
-            predicate?: ListIterator<T, NotVoid>
+            predicate?: ListIteratee<T>
         ): T[];
     }
 
@@ -1868,7 +1868,7 @@ declare module "../index" {
          */
         remove<T>(
             this: LoDashImplicitWrapper<List<T>>,
-            predicate?: ListIterator<T, NotVoid>
+            predicate?: ListIteratee<T>
         ): LoDashImplicitWrapper<T[]>;
     }
 
@@ -1878,7 +1878,7 @@ declare module "../index" {
          */
         remove<T>(
             this: LoDashExplicitWrapper<List<T>>,
-            predicate?: ListIterator<T, NotVoid>
+            predicate?: ListIteratee<T>
         ): LoDashExplicitWrapper<T[]>;
     }
 

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -3740,12 +3740,12 @@ declare namespace _ {
     type LodashReject1x2<T> = (predicate: lodash.ValueIterateeCustom<T, boolean>) => T[];
     type LodashReject2x2<T> = (predicate: lodash.ValueIterateeCustom<T[keyof T], boolean>) => Array<T[keyof T]>;
     interface LodashRemove {
-        <T>(predicate: (value: T) => lodash.NotVoid): LodashRemove1x1<T>;
+        <T>(predicate: lodash.ValueIteratee<T>): LodashRemove1x1<T>;
         <T>(predicate: lodash.__, array: lodash.List<T>): LodashRemove1x2<T>;
-        <T>(predicate: (value: T) => lodash.NotVoid, array: lodash.List<T>): T[];
+        <T>(predicate: lodash.ValueIteratee<T>, array: lodash.List<T>): T[];
     }
     type LodashRemove1x1<T> = (array: lodash.List<T>) => T[];
-    type LodashRemove1x2<T> = (predicate: (value: T) => lodash.NotVoid) => T[];
+    type LodashRemove1x2<T> = (predicate: lodash.ValueIteratee<T>) => T[];
     interface LodashRepeat {
         (n: number): LodashRepeat1x1;
         (n: lodash.__, string: string): LodashRepeat1x2;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -1074,15 +1074,23 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 
     _.remove(list); // $ExpectType AbcObject[]
     _.remove(list, listIterator); // $ExpectType AbcObject[]
+    _.remove(list, ""); // $ExpectType AbcObject[]
+    _.remove(list, { a: 42 }); // $ExpectType AbcObject[]
 
     _(list).remove(); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
     _(list).remove(listIterator); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(list).remove(""); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(list).remove({ a: 42 }); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
 
     _.chain(list).remove(); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
     _.chain(list).remove(listIterator); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(list).remove(""); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(list).remove({ a: 42 }); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
 
     fp.remove(valueIterator, list); // $ExpectType AbcObject[]
     fp.remove(valueIterator)(list); // $ExpectType AbcObject[]
+    fp.remove("", list); // $ExpectType AbcObject[]
+    fp.remove({ a: 42 }, list); // $ExpectType AbcObject[]
 }
 
 // _.tail

--- a/types/lodash/ts3.1/common/array.d.ts
+++ b/types/lodash/ts3.1/common/array.d.ts
@@ -1115,19 +1115,19 @@ declare module "../index" {
          * @param predicate The function invoked per iteration.
          * @return Returns the new array of removed elements.
          */
-        remove<T>(array: List<T>, predicate?: ListIterator<T, NotVoid>): T[];
+        remove<T>(array: List<T>, predicate?: ListIteratee<T>): T[];
     }
     interface Collection<T> {
         /**
          * @see _.remove
          */
-        remove(predicate?: ListIterator<T, NotVoid>): Collection<T>;
+        remove(predicate?: ListIteratee<T>): Collection<T>;
     }
     interface CollectionChain<T> {
         /**
          * @see _.remove
          */
-        remove(predicate?: ListIterator<T, NotVoid>): CollectionChain<T>;
+        remove(predicate?: ListIteratee<T>): CollectionChain<T>;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -3723,12 +3723,12 @@ declare namespace _ {
     type LodashReject1x2<T> = (predicate: lodash.ValueIterateeCustom<T, boolean>) => T[];
     type LodashReject2x2<T> = (predicate: lodash.ValueIterateeCustom<T[keyof T], boolean>) => Array<T[keyof T]>;
     interface LodashRemove {
-        <T>(predicate: (value: T) => lodash.NotVoid): LodashRemove1x1<T>;
+        <T>(predicate: lodash.ValueIteratee<T>): LodashRemove1x1<T>;
         <T>(predicate: lodash.__, array: lodash.List<T>): LodashRemove1x2<T>;
-        <T>(predicate: (value: T) => lodash.NotVoid, array: lodash.List<T>): T[];
+        <T>(predicate: lodash.ValueIteratee<T>, array: lodash.List<T>): T[];
     }
     type LodashRemove1x1<T> = (array: lodash.List<T>) => T[];
-    type LodashRemove1x2<T> = (predicate: (value: T) => lodash.NotVoid) => T[];
+    type LodashRemove1x2<T> = (predicate: lodash.ValueIteratee<T>) => T[];
     interface LodashRepeat {
         (n: number): LodashRepeat1x1;
         (n: lodash.__, string: string): LodashRepeat1x2;

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -1082,15 +1082,23 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
     _.remove(list); // $ExpectType AbcObject[]
     _.remove(list, listIterator); // $ExpectType AbcObject[]
+    _.remove(list, ""); // $ExpectType AbcObject[]
+    _.remove(list, { a: 42 }); // $ExpectType AbcObject[]
 
     _(list).remove(); // $ExpectType Collection<AbcObject>
     _(list).remove(listIterator); // $ExpectType Collection<AbcObject>
+    _(list).remove(""); // $ExpectType Collection<AbcObject>
+    _(list).remove({ a: 42 }); // $ExpectType Collection<AbcObject>
 
     _.chain(list).remove(); // $ExpectType CollectionChain<AbcObject>
     _.chain(list).remove(listIterator); // $ExpectType CollectionChain<AbcObject>
+    _.chain(list).remove(""); // $ExpectType CollectionChain<AbcObject>
+    _.chain(list).remove({ a: 42 }); // $ExpectType CollectionChain<AbcObject>
 
     fp.remove(valueIterator, list); // $ExpectType AbcObject[]
     fp.remove(valueIterator)(list); // $ExpectType AbcObject[]
+    fp.remove("", list); // $ExpectType AbcObject[]
+    fp.remove({ a: 42 }, list); // $ExpectType AbcObject[]
 }
 
 // _.tail


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#38897

I manged to delude myself into believing a bug in my production code was due to passing an iteratee shorthand to `remove`. My delusion was validated by the lodash documentation and apparent source here:
https://github.com/lodash/lodash/blob/master/remove.js

But, taking a look at the _actual_ source distributed via npm:
https://github.com/lodash/lodash/blob/4.17.15-npm/remove.js#L41

We can see that iteratee shorthands are absolutely supported.