### PR TITLE
[@hapi/joi] fix the joi.assert() and joi.attempt() types

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -961,13 +961,22 @@ schema = Joi.compile(schemaMap);
 
 Joi.assert(obj, schema);
 Joi.assert(obj, schema, str);
+Joi.assert(obj, schema, str, validOpts);
 Joi.assert(obj, schema, err);
+Joi.assert(obj, schema, err, validOpts);
+Joi.assert(obj, schema, validOpts);
 Joi.assert(obj, schemaLike);
 
-Joi.attempt(obj, schema);
-Joi.attempt(obj, schema, str);
-Joi.attempt(obj, schema, err);
-Joi.attempt(obj, schemaLike);
+{
+    let value = { username: 'example', password: 'example' };
+    value = Joi.attempt(obj, schema);
+    value = Joi.attempt(obj, schema, str);
+    value = Joi.attempt(obj, schema, str, validOpts);
+    value = Joi.attempt(obj, schema, err);
+    value = Joi.attempt(obj, schema, err, validOpts);
+    value = Joi.attempt(obj, schema, validOpts);
+    value = Joi.attempt(obj, schemaLike);
+}
 
 ref = Joi.ref(str, refOpts);
 ref = Joi.ref(str);

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -1961,16 +1961,18 @@ declare namespace Joi {
          * @param schema - the schema object.
          * @param message - optional message string prefix added in front of the error message. may also be an Error object.
          */
+        assert(value: any, schema: SchemaLike, options?: ValidationOptions): void;
         assert(value: any, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): void;
 
         /**
-         * Validates a value against a schema and throws if validation fails.
+         * Validates a value against a schema, returns valid object, and throws if validation fails.
          *
          * @param value - the value to validate.
          * @param schema - the schema object.
          * @param message - optional message string prefix added in front of the error message. may also be an Error object.
          */
-        attempt(value: any, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): void;
+        attempt(value: any, schema: SchemaLike, options?: ValidationOptions): any;
+        attempt(value: any, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): any;
 
         cache: CacheConfiguration;
 

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -1962,7 +1962,7 @@ declare namespace Joi {
          * @param message - optional message string prefix added in front of the error message. may also be an Error object.
          */
         assert(value: any, schema: SchemaLike, options?: ValidationOptions): void;
-        assert(value: any, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): void;
+        assert(value: any, schema: SchemaLike, message: string | Error, options?: ValidationOptions): void;
 
         /**
          * Validates a value against a schema, returns valid object, and throws if validation fails.
@@ -1972,7 +1972,7 @@ declare namespace Joi {
          * @param message - optional message string prefix added in front of the error message. may also be an Error object.
          */
         attempt(value: any, schema: SchemaLike, options?: ValidationOptions): any;
-        attempt(value: any, schema: SchemaLike, message?: string | Error, options?: ValidationOptions): any;
+        attempt(value: any, schema: SchemaLike, message: string | Error, options?: ValidationOptions): any;
 
         cache: CacheConfiguration;
 


### PR DESCRIPTION
Adds support for the `(value, schema, options)` call signature to the `joi.assert()` and `joi.attempt()` types and fixes the `joi.attempt()` type's return signature and documentation.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapi.dev/family/joi/?v=16.1.7#attemptvalue-schema-message-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

cc @RecuencoJones