### PR TITLE
Add FrameContext types to @types/react-frame-component

### DIFF
--- a/types/react-frame-component/index.d.ts
+++ b/types/react-frame-component/index.d.ts
@@ -17,11 +17,13 @@ export interface FrameComponentProps extends React.IframeHTMLAttributes<HTMLIFra
 
 export default class FrameComponent extends React.Component<FrameComponentProps> {}
 
-export interface FrameContext {
+export interface FrameContextProps {
     document?: any;
     window?: any;
 }
 
-export const FrameContextProvider: React.Provider<FrameContext>;
+export const FrameContext: React.Context<FrameContextProps>;
 
-export const FrameContextConsumer: React.Consumer<FrameContext>;
+export const FrameContextProvider: React.Provider<FrameContextProps>;
+
+export const FrameContextConsumer: React.Consumer<FrameContextProps>;


### PR DESCRIPTION
For people who wants to use `hooks`  like
```javascript
import React, { useContext } from 'react'
const { window: frameWindow } = useContext(FrameContext)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
