### PR TITLE
Fixing confusion with the new and constructor keywords.

### DIFF
--- a/types/ember/v1/index.d.ts
+++ b/types/ember/v1/index.d.ts
@@ -192,7 +192,6 @@ interface String {
 }
 
 interface Array<T> {
-    constructor(arr: any[]): void;
     activate(): void;
     addArrayObserver(target: any, opts?: EnumerableConfigurationOptions): any[];
     addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): any[];

--- a/types/forge-di/index.d.ts
+++ b/types/forge-di/index.d.ts
@@ -12,7 +12,7 @@ declare class Forge {
      * Creates a new instance
      * @returns {Forge} a new instance.
      */
-    new(): Forge;
+    constructor();
 
     /**
      * The bindings mapped to this forge instance.

--- a/types/google-drive-realtime-api/index.d.ts
+++ b/types/google-drive-realtime-api/index.d.ts
@@ -52,8 +52,8 @@ declare namespace gapi.drive.realtime {
 		// use the permissionId property.
 		userId : string;
 
-		new (sessionId:string, userId:string, displayName:string, color:string, isMe:boolean, isAnonymous:boolean,
-		     photoUrl:string, permissionId:string) : Collaborator;
+		constructor (sessionId:string, userId:string, displayName:string, color:string, isMe:boolean, isAnonymous:boolean,
+		     photoUrl:string, permissionId:string);
 	}
 
 	// Complete

--- a/types/knockback/index.d.ts
+++ b/types/knockback/index.d.ts
@@ -76,8 +76,8 @@ declare namespace Knockback {
         constructor (format: KnockoutObservable<any>, args: any[]);
     }
 
-    interface LocalizedObservable {
-        constructor (value: any, options: any, vm: any);
+    class LocalizedObservable {
+        constructor(value: any, options: any, vm: any);
         destroy();
         resetToCurrent();
         observedValue(value: any);

--- a/types/microsoft-ajax/index.d.ts
+++ b/types/microsoft-ajax/index.d.ts
@@ -627,7 +627,7 @@ declare namespace Sys {
 
         //#region Constructors
 
-        constructor(): void;
+        new(): void;
 
         //#endregion
 

--- a/types/microsoft-ajax/index.d.ts
+++ b/types/microsoft-ajax/index.d.ts
@@ -2505,7 +2505,6 @@ declare namespace Sys {
         * @see {@link http://msdn.microsoft.com/en-us/library/bb383800(v=vs.100).aspx}
         */
         class ProfileService {
-
             constructor();
 
             //#region Fields
@@ -2525,24 +2524,29 @@ declare namespace Sys {
             //#region Methods
 
             /**
-            * Loads the specified profile properties.
-            *
-            * If propertyNames is not supplied, all profile properties enabled for read access are loaded from the server.
-            * The loaded profile can then be accessed directly from the properties field.
-            * This enables your application to access the profile properties by using simple field syntax, as shown in the following example:
-            * @example
-            *      Sys.Services.ProfileService.load(null, LoadCompletedCallback, ProfileFailedCallback, null);
-            *
-            * @param propertyName
-            *      A string array that contains the profile properties to load.
-            * @param loadCompletedCallback
-            *      The function that is called when loading has completed. The default is null.
-            * @param failedCallback
-            *      The function that is called when loading has failed. The default is null.
-            * @param userContext
-            *      User context information passed to the callback functions.
-            */
-            static load(propertyNames: string[], loadCompletedCallback: Function, failedCallback: Function, userContext: any): void;
+             * Loads the specified profile properties.
+             *
+             * If propertyNames is not supplied, all profile properties enabled for read access are loaded from the server.
+             * The loaded profile can then be accessed directly from the properties field.
+             * This enables your application to access the profile properties by using simple field syntax, as shown in the following example:
+             * @example
+             *      Sys.Services.ProfileService.load(null, LoadCompletedCallback, ProfileFailedCallback, null);
+             *
+             * @param propertyName
+             *      A string array that contains the profile properties to load.
+             * @param loadCompletedCallback
+             *      The function that is called when loading has completed. The default is null.
+             * @param failedCallback
+             *      The function that is called when loading has failed. The default is null.
+             * @param userContext
+             *      User context information passed to the callback functions.
+             */
+            static load(
+                propertyNames: string[],
+                loadCompletedCallback: Function,
+                failedCallback: Function,
+                userContext: any,
+            ): void;
             /**
              * @param propertyNames
              *          A string array that contains the profile properties to save.
@@ -2553,7 +2557,12 @@ declare namespace Sys {
              * @param userContext
              *      User context information passed to the callback functions.
              */
-            static save(propertyNames: string[], saveCompletedCallback: Function, failedCallback: Function, userContext: any): void;
+            static save(
+                propertyNames: string[],
+                saveCompletedCallback: Function,
+                failedCallback: Function,
+                userContext: any,
+            ): void;
 
             //#endregion
 

--- a/types/microsoft-ajax/index.d.ts
+++ b/types/microsoft-ajax/index.d.ts
@@ -2506,7 +2506,7 @@ declare namespace Sys {
         */
         class ProfileService {
 
-            new(): ProfileService;
+            constructor();
 
             //#region Fields
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -619,7 +619,7 @@ declare module "mongoose" {
    * QueryCursor can only be accessed by query#cursor(), we only
    *   expose its interface to enable type-checking.
    */
-  interface QueryCursor<T extends Document> extends stream.Readable {
+  class QueryCursor<T extends Document> extends stream.Readable {
     /**
      * A QueryCursor is a concurrency primitive for processing query results
      * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
@@ -633,7 +633,7 @@ declare module "mongoose" {
      * @event data Emitted when the stream is flowing and the next doc is ready
      * @event end Emitted when the stream is exhausted
      */
-    constructor(query: Query<T>, options: any): QueryCursor<T>;
+    constructor(query: Query<T>, options: any);
 
     /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
     close(callback?: (error: any, result: any) => void): Promise<any>;

--- a/types/mongoose/v3/index.d.ts
+++ b/types/mongoose/v3/index.d.ts
@@ -45,8 +45,8 @@ declare module "mongoose" {
     Promise: any;
   }
 
-  export interface Connection extends NodeJS.EventEmitter {
-    constructor(base: Mongoose): Connection;
+  export class Connection extends NodeJS.EventEmitter {
+    constructor(base: Mongoose);
 
     close(callback?: (err: any) => void): Connection;
     collection(name: string, options?: Object): Collection;

--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -215,7 +215,7 @@ declare module "mongoose" {
    * QueryStream can only be accessed using query#stream(), we only
    *   expose its interface here.
    */
-  interface QueryStream extends stream.Stream {
+  class QueryStream extends stream.Stream {
     /**
      * Provides a Node.js 0.8 style ReadStream interface for Queries.
      * @event data emits a single Mongoose document
@@ -230,7 +230,7 @@ declare module "mongoose" {
        */
       transform?: Function;
       [other: string]: any;
-    }): QueryStream;
+    });
 
     /**
      * Destroys the stream, closing the underlying cursor, which emits the close event.
@@ -550,7 +550,7 @@ declare module "mongoose" {
    * QueryCursor can only be accessed by query#cursor(), we only
    *   expose its interface to enable type-checking.
    */
-  interface QueryCursor<T extends Document> extends stream.Readable {
+  class QueryCursor<T extends Document> extends stream.Readable {
     /**
      * A QueryCursor is a concurrency primitive for processing query results
      * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
@@ -564,7 +564,7 @@ declare module "mongoose" {
      * @event data Emitted when the stream is flowing and the next doc is ready
      * @event end Emitted when the stream is exhausted
      */
-    constructor(query: Query<T>, options: any): QueryCursor<T>;
+    constructor(query: Query<T>, options: any);
 
     /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
     close(callback?: (error: any, result: any) => void): Promise<any>;

--- a/types/oja/index.d.ts
+++ b/types/oja/index.d.ts
@@ -29,7 +29,7 @@ export type AddableFunction = (runtime: Flow) => void;
 export type AddableToAction = Action | AddableFunction;
 
 export class EventContext {
-    new(context: EventContext | object): this;
+    constructor(context: EventContext | object);
     stageContext(topics: string | ReadonlyArray<string>): StageContext;
     state(): State;
     repub(type: string, handler: (event: any) => void): void;
@@ -44,7 +44,7 @@ export class StageContext extends EventContext {
 }
 
 export class ReadableStream extends Readable {
-    new(topic: string, emitter: EventEmitter): this;
+    constructor(topic: string, emitter: EventEmitter);
     push(data: any): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -89,8 +89,8 @@ interface EventSubscription {
  * EventSubscriptionVendor stores a set of EventSubscriptions that are
  * subscribed to a particular event type.
  */
-interface EventSubscriptionVendor {
-    constructor(): EventSubscriptionVendor;
+declare class EventSubscriptionVendor {
+    constructor();
 
     /**
      * Adds a subscription keyed by an event type.

--- a/types/routie/index.d.ts
+++ b/types/routie/index.d.ts
@@ -4,15 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace routie {
-    interface Route {
-        constructor(path: string, name: string): Route;
-        addHandler(fn: Function): void;
-        removeHandler(fn: Function): void;
-        run(params: any): void;
-        match(path: string, params: any): boolean;
-        toURL(params: any): string;
-    }
-
     interface Routie extends RoutieStatic {
         (path: string): void;
         (path: string, fn: Function): void;

--- a/types/rx-angular/index.d.ts
+++ b/types/rx-angular/index.d.ts
@@ -13,9 +13,7 @@ declare namespace Rx {
         safeApply($scope: ng.IScope, callback: (data: T) => void): Rx.Observable<T>;
     }
 
-    export interface ScopeScheduler extends IScheduler {
-        constructor(scope: ng.IScope) : ScopeScheduler;
-    }
+    export interface ScopeScheduler extends IScheduler {}
 
     export interface ScopeSchedulerStatic extends SchedulerStatic {
         new ($scope: angular.IScope): ScopeScheduler;

--- a/types/stacktrace-js/index.d.ts
+++ b/types/stacktrace-js/index.d.ts
@@ -22,8 +22,8 @@ declare namespace StackTrace {
     offline?:     boolean;
   }
 
-  export interface StackFrame {
-    constructor(functionName: string, args: any, fileName: string, lineNumber: number, columnNumber: number): StackFrame;
+  export class StackFrame {
+    constructor(functionName: string, args: any, fileName: string, lineNumber: number, columnNumber: number);
 
     functionName: string;
     args:         any;

--- a/types/stream-meter/index.d.ts
+++ b/types/stream-meter/index.d.ts
@@ -10,8 +10,8 @@ import { Transform } from 'stream';
 declare function m(maxBytes?: number): m.StreamMeter;
 
 declare namespace m {
-    export interface StreamMeter extends Transform {
-        constructor(maxBytes?: number): StreamMeter;
+    export class StreamMeter extends Transform {
+        constructor(maxBytes?: number);
         bytes: number;
         maxBytes: number;
     }


### PR DESCRIPTION
It sometimes happens that developers confuse the `new` and `constructor` keywords. 
Consider the following example:

```TypeScript
interface Foo {
    constructor(): Bar;
}
```

With the `Foo` interface the developer meant to create an interface with a constructor, but instead created a interface that contains a method named `constructor`, which is not actually a constructor.

The developer might have meant to write:

```TypeScript
interface Foo {
    new(): Bar;
}
```

The same thing can happen when the  `new` keyword is accidentally used instead of the `constructor` keyword in a class definition. 

This pull request attempts to fix most instances of this mistake across DefinitelyTyped.  

The fix is either done by swapping the `new` and `constructor` keywords, or by replacing an `interface` with a `class`. 

The different instances of the mistake was found using a query written in [QL](https://semmle.com/ql). 
The results of which were manually vetted by me (as there [are](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/material-design-lite/index.d.ts#L121) [reasons](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/di-lite/index.d.ts#L57) for using the "wrong" keyword).

Please fill in this template.

- [x] Use a meaningful title for the pull request. ~~Include the name of the package modified.~~
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

~~If changing an existing definition:~~
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
