### PR TITLE
Fixing unreachable method overloads

### DIFF
--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -341,7 +341,6 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * the promise as snapshotted at the time of calling `.reflect()`.
    */
   reflect(): Bluebird<Bluebird.Inspection<R>>;
-  reflect(): Bluebird<Bluebird.Inspection<any>>;
 
   /**
    * This is a convenience method for doing:

--- a/types/bootstrap-switch/index.d.ts
+++ b/types/bootstrap-switch/index.d.ts
@@ -61,7 +61,6 @@ declare namespace BootstrapSwitch {
         animate(state: boolean): JQuery;
         disabled(): boolean;
         disabled(state: boolean): JQuery;
-        toggleDisabled(): JQuery;
         readonly(): boolean;
         readonly(state: boolean): JQuery;
         toggleReadOnly(): JQuery;

--- a/types/color/v1/index.d.ts
+++ b/types/color/v1/index.d.ts
@@ -92,7 +92,6 @@ declare namespace Color {
         opaquer(value: number): Color;
         rotate(value: number): Color;
         mix(color: Color, value?: number): Color;
-        hsl(): Color;
     }
 }
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -753,7 +753,6 @@ declare namespace Draft {
                 getKey(): string;
 
                 getType(): DraftBlockType;
-                getType(): string;
 
                 getText(): string;
                 getCharacterList(): Immutable.List<CharacterMetadata>;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -215,8 +215,6 @@ declare class Dropzone {
 
 	accept(file: Dropzone.DropzoneFile, done: (error?: string | Error) => void): void;
 
-	getActiveFiles(): Dropzone.DropzoneFile[];
-
 	getFilesWithStatus(status: string): Dropzone.DropzoneFile[];
 
 	enqueueFile(file: Dropzone.DropzoneFile): void;

--- a/types/famous/index.d.ts
+++ b/types/famous/index.d.ts
@@ -34,7 +34,6 @@ declare module "famous/core" {
 		removeChild(node: Node): boolean;
 		getParent(): Node;
 		
-		isMounted(): boolean;
 		mount(): void;
 		dismount(): void;
 		

--- a/types/fromjs/index.d.ts
+++ b/types/fromjs/index.d.ts
@@ -37,7 +37,6 @@ declare namespace FromJS {
         toArray(): Array<T>;
         concat(second: Array<T>): IQueryable<T>;
         sum(): T;
-        distinct(): IQueryable<T>;
         any(): boolean;
         any(predicate: (item: T) => boolean): boolean;
         all(predicate: (item: T) => boolean): boolean;

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1021,8 +1021,8 @@ declare namespace Highland {
 		 * @name Stream.flatten()
 		 * @api public
 		 */
-		flatten<U>(): Stream<U>;
 		flatten(): Stream<R>;
+		flatten<U>(): Stream<U>;
 
 		/**
 		 * Forks a stream, allowing you to add additional consumers with shared

--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -1896,7 +1896,6 @@ declare namespace kendo.ui {
         navigateToPast(): void;
         navigateUp(): void;
         selectDates(): void;
-        selectDates(): void;
         value(): Date;
         value(value: Date): void;
         value(value: string): void;
@@ -10646,7 +10645,6 @@ declare namespace kendo.dataviz.ui {
         svg(): void;
         imageDataURL(): string;
         value(): void;
-        value(): void;
 
     }
 
@@ -18376,8 +18374,6 @@ declare namespace kendo.dataviz {
 
 
         select(): any;
-        select(): void;
-
     }
 
     interface NavigatorOptions {

--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -984,32 +984,32 @@ declare module "../index" {
         /**
          * @see _.fromPairs
          */
-        fromPairs<T>(
-          this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
-        ): LoDashImplicitWrapper<Dictionary<T>>;
+        fromPairs(
+            this: LoDashImplicitWrapper<List<any[]> | null | undefined>
+        ): LoDashImplicitWrapper<Dictionary<any>>;
 
         /**
          @see _.fromPairs
          */
-        fromPairs(
-            this: LoDashImplicitWrapper<List<any[]> | null | undefined>
-        ): LoDashImplicitWrapper<Dictionary<any>>;
+        fromPairs<T>(
+            this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
+          ): LoDashImplicitWrapper<Dictionary<T>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.fromPairs
          */
-        fromPairs<T>(
-          this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
-        ): LoDashExplicitWrapper<Dictionary<T>>;
+        fromPairs(
+            this: LoDashExplicitWrapper<List<any[]> | null | undefined>
+        ): LoDashExplicitWrapper<Dictionary<any>>;
 
         /**
          @see _.fromPairs
          */
-        fromPairs(
-            this: LoDashExplicitWrapper<List<any[]> | null | undefined>
-        ): LoDashExplicitWrapper<Dictionary<any>>;
+        fromPairs<T>(
+            this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
+          ): LoDashExplicitWrapper<Dictionary<T>>;
     }
 
     // head

--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -984,32 +984,33 @@ declare module "../index" {
         /**
          * @see _.fromPairs
          */
-        fromPairs(
-            this: LoDashImplicitWrapper<List<any[]> | null | undefined>
-        ): LoDashImplicitWrapper<Dictionary<any>>;
+        fromPairs<T>(
+            this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
+          ): LoDashImplicitWrapper<Dictionary<T>>;
 
         /**
          @see _.fromPairs
          */
-        fromPairs<T>(
-            this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
-          ): LoDashImplicitWrapper<Dictionary<T>>;
+        fromPairs(
+            this: LoDashImplicitWrapper<List<any[]> | null | undefined>
+        ): LoDashImplicitWrapper<Dictionary<any>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.fromPairs
          */
-        fromPairs(
-            this: LoDashExplicitWrapper<List<any[]> | null | undefined>
-        ): LoDashExplicitWrapper<Dictionary<any>>;
+        fromPairs<T>(
+            this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
+        ): LoDashExplicitWrapper<Dictionary<T>>;
+        
 
         /**
          @see _.fromPairs
          */
-        fromPairs<T>(
-            this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
-          ): LoDashExplicitWrapper<Dictionary<T>>;
+        fromPairs(
+            this: LoDashExplicitWrapper<List<any[]> | null | undefined>
+        ): LoDashExplicitWrapper<Dictionary<any>>;
     }
 
     // head

--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -985,8 +985,8 @@ declare module "../index" {
          * @see _.fromPairs
          */
         fromPairs<T>(
-            this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
-          ): LoDashImplicitWrapper<Dictionary<T>>;
+          this: LoDashImplicitWrapper<List<[PropertyName, T]> | null | undefined>
+        ): LoDashImplicitWrapper<Dictionary<T>>;
 
         /**
          @see _.fromPairs
@@ -1001,9 +1001,8 @@ declare module "../index" {
          * @see _.fromPairs
          */
         fromPairs<T>(
-            this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
+          this: LoDashExplicitWrapper<List<[PropertyName, T]> | null | undefined>
         ): LoDashExplicitWrapper<Dictionary<T>>;
-        
 
         /**
          @see _.fromPairs

--- a/types/ol/ImageCanvas.d.ts
+++ b/types/ol/ImageCanvas.d.ts
@@ -5,6 +5,5 @@ export type Loader = (p0: (p0?: Error) => void) => void;
 export default class ImageCanvas extends ImageBase {
     constructor(extent: Extent, resolution: number, pixelRatio: number, canvas: HTMLCanvasElement, opt_loader?: Loader);
     getError(): Error;
-    getImage(): HTMLCanvasElement;
     getImage(): HTMLCanvasElement | HTMLImageElement | HTMLVideoElement;
 }

--- a/types/ol/layer/Image.d.ts
+++ b/types/ol/layer/Image.d.ts
@@ -23,7 +23,6 @@ export default class ImageLayer extends Layer {
     constructor(opt_options?: Options);
     protected type: LayerType;
     getSource(): ImageSource;
-    getSource(): Source;
     on(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => void): void;

--- a/types/ol/layer/Tile.d.ts
+++ b/types/ol/layer/Tile.d.ts
@@ -26,7 +26,6 @@ export default class TileLayer extends Layer {
     protected type: LayerType;
     getPreload(): number;
     getSource(): TileSource;
-    getSource(): Source;
     getUseInterimTilesOnError(): boolean;
     setPreload(preload: number): void;
     setUseInterimTilesOnError(useInterimTilesOnError: boolean): void;

--- a/types/ol/layer/Vector.d.ts
+++ b/types/ol/layer/Vector.d.ts
@@ -38,7 +38,6 @@ export default class VectorLayer extends Layer {
     getRenderMode(): VectorRenderType | string;
     getRenderOrder(): (p0: Feature, p1: Feature) => number | null | undefined;
     getSource(): VectorSource;
-    getSource(): Source;
     getStyle(): StyleLike | null | undefined;
     getStyleFunction(): StyleFunction | undefined;
     getUpdateWhileAnimating(): boolean;

--- a/types/ol/layer/VectorTile.d.ts
+++ b/types/ol/layer/VectorTile.d.ts
@@ -35,7 +35,6 @@ export default class VectorTileLayer extends VectorLayer {
     constructor(opt_options?: Options);
     protected type: LayerType;
     getPreload(): number;
-    getSource(): VectorTile;
     getSource(): VectorSource;
     getUseInterimTilesOnError(): boolean;
     setPreload(preload: number): void;

--- a/types/ol/renderer/canvas/TileLayer.d.ts
+++ b/types/ol/renderer/canvas/TileLayer.d.ts
@@ -22,7 +22,6 @@ export default class CanvasTileLayerRenderer extends IntermediateCanvasRenderer 
     handles(layer: Layer): boolean;
     drawTileImage(tile: Tile, frameState: FrameState, layerState: State, x: number, y: number, w: number, h: number, gutter: number, transition: boolean): void;
     getLayer(): TileLayer | VectorTileLayer;
-    getLayer(): Layer;
     getTile(z: number, x: number, y: number, pixelRatio: number, projection: Projection): Tile;
     on(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => void): EventsKey | EventsKey[];

--- a/types/ol/style/Icon.d.ts
+++ b/types/ol/style/Icon.d.ts
@@ -25,7 +25,6 @@ export interface Options {
 export default class Icon extends ImageStyle {
     constructor(opt_options?: Options);
     clone(): Icon;
-    clone(): ImageStyle;
     getColor(): Color;
     getSrc(): string | undefined;
     setAnchor(anchor: number[]): void;

--- a/types/ol/style/RegularShape.d.ts
+++ b/types/ol/style/RegularShape.d.ts
@@ -32,7 +32,6 @@ export default class RegularShape extends ImageStyle {
     protected radius_: number;
     protected render_(atlasManager: AtlasManager | undefined): void;
     clone(): RegularShape;
-    clone(): ImageStyle;
     getAngle(): number;
     getChecksum(): string;
     getFill(): Fill;

--- a/types/openui5/sap.ui.d.ts
+++ b/types/openui5/sap.ui.d.ts
@@ -1511,12 +1511,6 @@ declare namespace sap {
         constructor(extensionObject: any);
 
 
-
-        /**
-         * Calls the static emptyQueue function in the Opa namespace {@link sap.ui.test.Opa#.emptyQueue}
-        */
-        emptyQueue(): void;
-
         /**
          * Waits until all waitFor calls are done.
          * @returns If the waiting was successful, the promise will be resolved. If not it will be rejected
@@ -1542,14 +1536,6 @@ declare namespace sap {
          * @param options The values to be added to the existing config
         */
         extendConfig(options: any): void;
-
-        /**
-         * Gives access to a singleton object you can save values in.This object will only be created once and
-         * it will never be destroyed.That means you can use it to save values you need in multiple separated
-         * tests.
-         * @returns the context object
-        */
-        getContext(): any;
 
         /**
          * Gives access to a singleton object you can save values in.Same as {@link sap.ui.test.Opa#getContext}
@@ -1710,12 +1696,6 @@ declare namespace sap {
          * @returns A promise that gets resolved on success.
         */
         iStartMyUIComponent(oOptions: any): any;
-
-        /**
-         * Removes the IFrame from the DOM and removes all the references to its objects
-         * @returns A promise that gets resolved on success
-        */
-        iTeardownMyAppFrame(): any;
 
         /**
          * Removes the IFrame from the DOM and removes all the references to its objects
@@ -2809,12 +2789,6 @@ declare namespace sap {
         /**
          * Returns the metadata for the class that this object belongs to.
          * @returns Metadata for the class of the object
-        */
-        getMetadata(): sap.ui.base.Metadata;
-
-        /**
-         * Returns the metadata for the ManagedObject class.
-         * @returns Metadata for the ManagedObject class.
         */
         getMetadata(): sap.ui.base.Metadata;
 
@@ -9512,11 +9486,6 @@ declare namespace sap {
         getLastZIndex(): Number;
 
         /**
-         * Returns the last z-index that has been handed out. does not increase the internal z-index counter.
-        */
-        getLastZIndex(): Number;
-
-        /**
          * Returns a metadata object for class sap.ui.core.Popup.
          * @returns Metadata object describing this class
         */
@@ -9526,13 +9495,6 @@ declare namespace sap {
          * Returns the value if a Popup is of modal type
         */
         getModal(): void;
-
-        /**
-         * Returns the next available z-index on top of the existing/previous popups. Each call increases the
-         * internal z-index counter and the returned z-index.
-         * @returns the next z-index on top of the Popup stack
-        */
-        getNextZIndex(): Number;
 
         /**
          * Returns the next available z-index on top of the existing/previous popups. Each call increases the
@@ -10340,13 +10302,6 @@ declare namespace sap {
          * Element.
         */
         getLayoutData(): sap.ui.core.LayoutData;
-
-        /**
-         * Returns the runtime metadata for this UI element.When using the defineClass method, this function is
-         * automatically created and returnsa runtime representation of the design time metadata.
-         * @returns runtime metadata
-        */
-        getMetadata(): any;
 
         /**
          * Returns a metadata object for class sap.ui.core.Element.
@@ -11413,12 +11368,6 @@ declare namespace sap {
         /**
          * Returns the metadata for the specific class of the current instance.
          * @returns Metadata for the specific class of the current instance.
-        */
-        getMetadata(): sap.ui.base.Metadata;
-
-        /**
-         * Returns the metadata for the Component class.
-         * @returns Metadata for the Component class.
         */
         getMetadata(): sap.ui.base.Metadata;
 

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="mongoose" />
 /// <reference types="passport-local" />
@@ -27,10 +27,14 @@ declare module 'mongoose' {
     resetAttempts(cb: (err: any, res: any) => void): void;
   }
 
+  interface AuthenticateMethod<T> {
+    (username: string, password: string): Promise<AuthenticationResult>;
+    (username: string, password: string, cb: (err: any, user: T | boolean, error: any) => void): void;
+  }
+
   // statics
   interface PassportLocalModel<T extends Document> extends Model<T> {
-    authenticate(): (username: string, password: string) => Promise<AuthenticationResult>;
-    authenticate(): (username: string, password: string, cb: (err: any, user: T | boolean, error: any) => void) => void;
+    authenticate(): AuthenticateMethod<T> 
     serializeUser(): (user: PassportLocalModel<T>, cb: (err: any, id?: any) => void) => void;
     deserializeUser(): (username: string, cb: (err: any, user?: any) => void) => void;
 

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="mongoose" />
 /// <reference types="passport-local" />

--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -193,8 +193,6 @@ declare global {
 
       createdCallback?():void;
 
-      attachedCallback?():void;
-
       detachedCallback?():void;
 
       attributeChangedCallback?(name: string):void;

--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -71,7 +71,6 @@ declare namespace TestUtils {
 
     export interface ShallowRenderer {
         getRenderOutput<E extends ReactElement>(): E;
-        getRenderOutput(): ReactElement;
         render(element: ReactElement, context?: any): void;
         unmount(): void;
     }

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -68,10 +68,6 @@ export interface ShallowRenderer {
      */
     getRenderOutput<E extends ReactElement>(): E;
     /**
-     * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
-     */
-    getRenderOutput(): ReactElement;
-    /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
     render(element: ReactElement, context?: any): void;

--- a/types/react-dom/v15/test-utils/index.d.ts
+++ b/types/react-dom/v15/test-utils/index.d.ts
@@ -68,10 +68,6 @@ export interface ShallowRenderer {
      */
     getRenderOutput<E extends ReactElement>(): E;
     /**
-     * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
-     */
-    getRenderOutput(): ReactElement;
-    /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
     render(element: ReactElement, context?: any): void;

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -10,10 +10,6 @@ export interface ShallowRenderer {
      */
     getRenderOutput<E extends ReactElement>(): E;
     /**
-     * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
-     */
-    getRenderOutput(): ReactElement;
-    /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
     render(element: ReactElement, context?: any): void;

--- a/types/react-test-renderer/v15/shallow/index.d.ts
+++ b/types/react-test-renderer/v15/shallow/index.d.ts
@@ -6,10 +6,6 @@ export interface ShallowRenderer {
      */
     getRenderOutput<E extends ReactElement>(): E;
     /**
-     * After `shallowRenderer.render()` has been called, returns shallowly rendered output.
-     */
-    getRenderOutput(): ReactElement;
-    /**
      * Similar to `ReactDOM.render` but it doesn't require DOM and only renders a single level deep.
      */
     render(element: ReactElement, context?: any): void;

--- a/types/slimerjs/index.d.ts
+++ b/types/slimerjs/index.d.ts
@@ -110,7 +110,6 @@ interface WebPage {
     childFramesCount(): number;  // DEPRECATED
     childFramesName(): string;  // DEPRECATED
     clearCookies(): void;
-    close(): Promise<void>;
     close(): void;
     currentFrameName(): string;  // DEPRECATED
     deleteCookie(cookieName: string): boolean;

--- a/types/vec2/index.d.ts
+++ b/types/vec2/index.d.ts
@@ -40,12 +40,6 @@ declare class Vec2 {
     zero(): Vec2;
 
     /**
-     * Returns a clone of this vector.
-     * _Note_: this does not clone observers
-     */
-    zero(): Vec2;
-
-    /**
      * Negate the `x` and `y` coords of this vector.  If `returnNew` is truthy, a new vector with the negated coordinates will be returned.
      */
     negate(returnNew?: boolean): Vec2;


### PR DESCRIPTION
Sometimes developers write method overloads that cannot be used.  
For example:

```TypeScript
class ContentBlock extends Record {
   ...
   getType(): DraftBlockType;
   getType(): string;
}
```

When a client invokes an overloaded method [the first matching overload will always be used](https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#4.15.1), and hence the following program will result in a type-error: 

```TypeScript
var foo: string = new ContentBlock().getType();
```

The second method overload is therefore unreachable, and the overload will cause nothing but confusion for developers writing a client or maintaining the library.

Often the mistake is caused by a simple duplicate method, which makes no difference, but can be confusing.
Other times the pattern is mistakenly used instead of having a union-type as the return. 
And a last reason is more tricky, consider the following: 

```TypeScript
interface ShallowRenderer {
    getRenderOutput<E extends ReactElement>(): E;
    getRenderOutput(): ReactElement;
} 
```

The first overload of the above program will always be used when writing a client using the library. This happens even if no type-parameters are used, as the TypeScript compiler will simply insert a default type parameter. 

This pull request attempts to fix all trivially discoverable instances of this mistake. 


Please fill in this template.

- [x] Use a meaningful title for the pull request. ~~Include the name of the package modified.~~
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

~~If changing an existing definition:~~
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~