### PR TITLE
[react-lazyload] Updated types

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-lazyload ver 2.6.2
+// Type definitions for react-lazyload ver 2.6
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 //                 svobik7 <https://github.com/svobik7>

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -20,6 +20,7 @@ export interface LazyLoadProps {
     placeholder?: ReactNode;
     unmountIfInvisible?: boolean;
     scrollContainer?: string | Element;
+    preventLoading?: boolean;
 }
 
 export default class LazyLoad extends Component<LazyLoadProps> {

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-lazyload ver 2.5
+// Type definitions for react-lazyload ver 2.6.2
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 //                 svobik7 <https://github.com/svobik7>
@@ -18,8 +18,8 @@ export interface LazyLoadProps {
     throttle?: number | boolean;
     debounce?: number | boolean;
     placeholder?: ReactNode;
-    unmountIfInvisible?: boolean;
     scrollContainer?: string | Element;
+    unmountIfInvisible?: boolean;
     preventLoading?: boolean;
 }
 


### PR DESCRIPTION
The prop `preventLoading` was introduced [here](https://github.com/twobin/react-lazyload/pull/243) and can be found back in `master` and the README of twobin/react-lazyload:
https://github.com/twobin/react-lazyload#preventloading

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twobin/react-lazyload#preventloading
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
