### PR TITLE
Added type for @svgr/rollup

### DIFF
--- a/types/svgr__rollup/index.d.ts
+++ b/types/svgr__rollup/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Nick <https://github.com/fobdy>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
+// TypeScript Version: 3.0
 
 /// <reference types='node' />
 

--- a/types/svgr__rollup/index.d.ts
+++ b/types/svgr__rollup/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Nick <https://github.com/fobdy>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7'
 
 import { Plugin } from 'rollup';
 

--- a/types/svgr__rollup/index.d.ts
+++ b/types/svgr__rollup/index.d.ts
@@ -5,6 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
+/// <reference types='node' />
+
 import { Plugin } from 'rollup';
 
 declare namespace svgrRollup {

--- a/types/svgr__rollup/index.d.ts
+++ b/types/svgr__rollup/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @svgr/rollup 4.3
+// Project: https://github.com/smooth-code/svgr/tree/master/packages/rollup
+// Definitions by: Nick <https://github.com/fobdy>
+//                 Max Boguslavskiy <https://github.com/maxbogus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'rollup';
+
+declare namespace svgrRollup {
+    interface Options {
+        include?: string;
+        exclude: string;
+        babel: boolean;
+    }
+}
+
+declare function svgrRollup(options?: svgrRollup.Options): Plugin;
+
+export = svgrRollup;

--- a/types/svgr__rollup/index.d.ts
+++ b/types/svgr__rollup/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Nick <https://github.com/fobdy>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7'
+// TypeScript Version: 2.7
 
 import { Plugin } from 'rollup';
 

--- a/types/svgr__rollup/package.json
+++ b/types/svgr__rollup/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": "^1.23.1"
+    }
+}

--- a/types/svgr__rollup/svgr__rollup-tests.ts
+++ b/types/svgr__rollup/svgr__rollup-tests.ts
@@ -1,8 +1,8 @@
 import svgr, { Options } from '@svgr/rollup';
 
 // test data
-const partialOptions: Options = {exclude: '', babel: true};
-const fullOptions: Options = {include: '', exclude: '', babel: true};
+const partialOptions: Options = { exclude: '', babel: true };
+const fullOptions: Options = { include: '', exclude: '', babel: true };
 
 // tests
 svgr();

--- a/types/svgr__rollup/svgr__rollup-tests.ts
+++ b/types/svgr__rollup/svgr__rollup-tests.ts
@@ -1,0 +1,10 @@
+import svgr, { Options } from '@svgr/rollup';
+
+// test data
+const partialOptions: Options = {exclude: '', babel: true};
+const fullOptions: Options = {include: '', exclude: '', babel: true};
+
+// tests
+svgr();
+svgr(partialOptions);
+svgr(fullOptions);

--- a/types/svgr__rollup/tsconfig.json
+++ b/types/svgr__rollup/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "paths": {
+            "@svgr/rollup": ["svgr__rollup"]
+        },
+        "noEmit": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svgr__rollup-tests.ts"
+    ]
+}

--- a/types/svgr__rollup/tslint.json
+++ b/types/svgr__rollup/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
