### PR TITLE
feat(koa): Move custom properties into DefaultContext

### DIFF
--- a/types/koa-bouncer/koa-bouncer-tests.ts
+++ b/types/koa-bouncer/koa-bouncer-tests.ts
@@ -1,43 +1,35 @@
 import Koa = require("koa");
-import Router = require("koa-router");
 import bouncer = require("koa-bouncer");
 
 const app = new Koa();
 
 app.use(bouncer.middleware());
-const router = new Router()
 
-router.post('/users', async (ctx) => {
+app.use(async ctx => {
     ctx.validateBody('uname')
         .required('Username required')
         .isString()
-        .trim()
+        .trim();
 
     ctx.validateBody('email')
         .optional()
         .isString()
         .trim()
-        .isEmail('Invalid email format')
+        .isEmail('Invalid email format');
 
     ctx.validateBody('password1')
         .required('Password required')
         .isString()
-        .isLength(6, 100, 'Password must be 6-100 chars')
+        .isLength(6, 100, 'Password must be 6-100 chars');
 
     ctx.validateBody('password2')
         .required('Password confirmation required')
         .isString()
-        .eq(ctx.vals.password1, 'Passwords must match')
+        .eq(ctx.vals.password1, 'Passwords must match');
 
-    ctx.validateBody('age')
-        .gte(18, 'Must be 18 or older')
+    ctx.validateBody('age').gte(18, 'Must be 18 or older');
 
-    console.log(ctx.vals)
-})
-
-app
-    .use(router.routes())
-    .use(router.allowedMethods());
-    
+    ctx.body = ctx.vals;
+});
 
 app.listen(80);

--- a/types/koa-log/index.d.ts
+++ b/types/koa-log/index.d.ts
@@ -24,7 +24,7 @@ declare namespace koaLog {
 
         function status(ctx: Koa.BaseContext): number;
 
-        function token(name: string, fn: (ctx: Koa.BaseContext) => string): void;
+        function token(name: string, fn: (ctx: Koa.ParameterizedContext) => string): void;
 
         function url(ctx: Koa.BaseContext): string;
     }

--- a/types/koa-log/koa-log-tests.ts
+++ b/types/koa-log/koa-log-tests.ts
@@ -1,10 +1,8 @@
 import Koa = require('koa');
 import koaLogger = require('koa-log');
 
-koaLogger.morgan.token('request-body', (ctx: Koa.BaseContext) => JSON.stringify(ctx.request.body));
-koaLogger.morgan.token('response-body', (ctx: Koa.BaseContext) => JSON.stringify(ctx.body));
+koaLogger.morgan.token('request-ip', ctx => JSON.stringify(ctx.request.ip));
+koaLogger.morgan.token('response-body', ctx => JSON.stringify(ctx.body));
 
 const app = new Koa();
-app.use(
-    koaLogger(':status :method :url took :response-time ms :request-body :response-body')
-);
+app.use(koaLogger(':status :method :url took :response-time ms :request-ip :response-body'));

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -78,7 +78,7 @@ app.use(async (ctx: Koa.ParameterizedContext<MyState, MyContext>, next) => {
 
 const router3 = new Router();
 router3.get('/', (ctx) => {
-    ctx.foo = "bar";
+    ctx.state.foo = 'bar';
     console.log(ctx.router.params);
     ctx.body = "Hello World!";
 });

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -540,7 +540,12 @@ declare namespace Application {
     /**
      * This interface can be augmented by users to add types to Koa's default context
      */
-    interface DefaultContext extends DefaultContextExtends {}
+    interface DefaultContext extends DefaultContextExtends {
+        /**
+         * Custom properties.
+         */
+        [key: string]: any;
+    }
 
     type Middleware<
         StateT = DefaultState,
@@ -680,10 +685,6 @@ declare namespace Application {
          * Default error handling.
          */
         onerror(err: Error): void;
-        /**
-         * Custom properties.
-         */
-        [key: string]: any;
     }
 
     interface Request extends BaseRequest {

--- a/types/koa__router/koa__router-tests.ts
+++ b/types/koa__router/koa__router-tests.ts
@@ -75,7 +75,7 @@ app.use(async (ctx: Koa.ParameterizedContext<MyState, MyContext>, next) => {
 
 const router3 = new Router();
 router3.get('/', (ctx) => {
-    ctx.foo = "bar";
+    ctx.state.foo = 'bar';
     console.log(ctx.router.params);
     ctx.body = "Hello World!";
 });


### PR DESCRIPTION
This allows having a strict `Koa<{}, {}>` where an arbitrary `ctx.unknownProperty` will raise `"Property 'unknownProperty' does not exist on type"`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **no url**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **no change, change to allow stronger typing (might be breaking in some codebases)**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

```
const app = new Koa<{}, { x: number }>();

app.use((ctx, next) => {
    console.log(ctx.x);
    console.log(ctx.foo); // Error:(l, c) TS2339: Property 'foo' does not exist on type 'ParameterizedContext<{}, { x: number; }>'.
})
```

If no explicit types are used (`const app = new Koa();`) the `DefaultContext` is used (which has an index signature).