### PR TITLE
Fix for aria-label ToggleSmall of carbon-components-react 

### DIFF
--- a/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
+++ b/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
@@ -6,7 +6,7 @@ interface InheritedProps extends
     Omit<ReactInputAttr, ExcludedAttributes>,
     RequiresIdProps
 {
-    ["aria-Label"]: NonNullable<React.AriaAttributes["aria-label"]>,
+    ["aria-label"]: NonNullable<React.AriaAttributes["aria-label"]>,
 }
 
 export interface ToggleSmallProps extends InheritedProps {

--- a/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
+++ b/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
@@ -6,7 +6,7 @@ interface InheritedProps extends
     Omit<ReactInputAttr, ExcludedAttributes>,
     RequiresIdProps
 {
-    ariaLabel: NonNullable<React.AriaAttributes["aria-label"]>,
+    ["aria-Label"]: NonNullable<React.AriaAttributes["aria-label"]>,
 }
 
 export interface ToggleSmallProps extends InheritedProps {


### PR DESCRIPTION
Change aria-label of ToggleSmall of carbon-components-react to Kebab Case to be consistent with implementation https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/ToggleSmall/ToggleSmall.js#L121

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/ToggleSmall/ToggleSmall.js#L121
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
