### PR TITLE
multer-s3 - extended req and file definition to work with @koa/multer types

### DIFF
--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -8,11 +8,12 @@
 // TypeScript Version: 2.3
 
 import * as AWS from "aws-sdk";
-import { IncomingMessage } from 'http';
+import { IncomingMessage } from "http";
 import { StorageEngine } from "multer";
+import { StorageEngine as KoaStorageEngine } from "koa-multer";
 
 type MulterRequest = Express.Request | IncomingMessage;
-type MulterFile = Express.Multer.File | File;
+type MulterFile = Express.Multer.File;
 
 interface Options {
     s3: AWS.S3;
@@ -45,7 +46,7 @@ declare global {
 }
 
 interface S3Storage {
-    (options?: Options): StorageEngine;
+    (options?: Options): StorageEngine & KoaStorageEngine;
 
     AUTO_CONTENT_TYPE(
         req: MulterRequest,

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -9,7 +9,6 @@
 
 import * as AWS from "aws-sdk";
 
-
 declare namespace MulterS3 {
     interface File {
         /** Field name specified in the form */
@@ -32,7 +31,7 @@ declare namespace MulterS3 {
         buffer: Buffer;
     }
 
-    export interface Options<R> {
+    interface Options<R> {
         s3: AWS.S3;
         bucket: ((req: R, file: File, callback: (error: any, bucket?: string) => void) => void) | string;
         key?(req: R, file: File, callback: (error: any, key?: string) => void): void;
@@ -43,14 +42,16 @@ declare namespace MulterS3 {
         serverSideEncryption?: ((req: R, file: File, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
     }
 
-    export interface S3Storage {
-        <E,R>(options?: Options<R>): E;
-
+    interface S3Storage {
+        // tslint:disable-next-line:no-unnecessary-generics
+        <E, R>(options?: Options<R>): E;
         AUTO_CONTENT_TYPE<R>(
+            // tslint:disable-next-line:no-unnecessary-generics
             req: R,
             file: File,
             callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
         DEFAULT_CONTENT_TYPE<R>(
+            // tslint:disable-next-line:no-unnecessary-generics
             req: R,
             file: File,
             callback: (error: any, mime?: string) => void): void;

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -7,17 +7,18 @@
 // TypeScript Version: 2.3
 
 import * as AWS from "aws-sdk";
+import { IncomingMessage } from 'http';
 import { StorageEngine } from "multer";
 
 interface Options {
     s3: AWS.S3;
-    bucket: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, bucket?: string) => void) => void) | string;
-    key?(req: Express.Request, file: Express.Multer.File, callback: (error: any, key?: string) => void): void;
-    acl?: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, acl?: string) => void) => void) | string;
-    contentType?(req: Express.Request, file: Express.Multer.File, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
-    metadata?(req: Express.Request, file: Express.Multer.File, callback: (error: any, metadata?: any) => void): void;
-    cacheControl?: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, cacheControl?: string) => void) => void) | string;
-    serverSideEncryption?: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
+    bucket: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, bucket?: string) => void) => void) | string;
+    key?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, key?: string) => void): void;
+    acl?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, acl?: string) => void) => void) | string;
+    contentType?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
+    metadata?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, metadata?: any) => void): void;
+    cacheControl?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, cacheControl?: string) => void) => void) | string;
+    serverSideEncryption?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
 }
 
 declare global {
@@ -43,12 +44,12 @@ interface S3Storage {
     (options?: Options): StorageEngine;
 
     AUTO_CONTENT_TYPE(
-        req: Express.Request,
-        file: Express.Multer.File,
+        req: Express.Request | IncomingMessage,
+        file: Express.Multer.File | File,
         callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
     DEFAULT_CONTENT_TYPE(
-        req: Express.Request,
-        file: Express.Multer.File,
+        req: Express.Request | IncomingMessage,
+        file: Express.Multer.File | File,
         callback: (error: any, mime?: string) => void): void;
 }
 

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -5,7 +5,7 @@
 //                 Matt Terski <https://github.com/terski>
 //                 Agata Belkius <https://github.com/abelkius>
 // Definitions: https://github.com/DefinitelyType/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as AWS from "aws-sdk";
 import { IncomingMessage } from "http";

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -9,49 +9,53 @@
 
 import * as AWS from "aws-sdk";
 
-type MulterFile = Express.Multer.File;
 
-interface Options<R> {
-    s3: AWS.S3;
-    bucket: ((req: R, file: MulterFile, callback: (error: any, bucket?: string) => void) => void) | string;
-    key?(req: R, file: MulterFile, callback: (error: any, key?: string) => void): void;
-    acl?: ((req: R, file: MulterFile, callback: (error: any, acl?: string) => void) => void) | string;
-    contentType?(req: R, file: MulterFile, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
-    metadata?(req: R, file: MulterFile, callback: (error: any, metadata?: any) => void): void;
-    cacheControl?: ((req: R, file: MulterFile, callback: (error: any, cacheControl?: string) => void) => void) | string;
-    serverSideEncryption?: ((req: R, file: MulterFile, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
-}
+declare namespace MulterS3 {
+    interface File {
+        /** Field name specified in the form */
+        fieldname: string;
+        /** Name of the file on the user's computer */
+        originalname: string;
+        /** Encoding type of the file */
+        encoding: string;
+        /** Mime type of the file */
+        mimetype: string;
+        /** Size of the file in bytes */
+        size: number;
+        /** The folder to which the file has been saved (DiskStorage) */
+        destination: string;
+        /** The name of the file within the destination (DiskStorage) */
+        filename: string;
+        /** Location of the uploaded file (DiskStorage) */
+        path: string;
+        /** A Buffer of the entire file (MemoryStorage) */
+        buffer: Buffer;
+    }
 
-declare global {
-    namespace Express {
-        namespace MulterS3 {
-            interface File extends Multer.File {
-                bucket: string;
-                key: string;
-                acl: string;
-                contentType: string;
-                contentDisposition: null;
-                storageClass: string;
-                serverSideEncryption: null;
-                metadata: any;
-                location: string;
-                etag: string;
-            }
-        }
+    export interface Options<R> {
+        s3: AWS.S3;
+        bucket: ((req: R, file: File, callback: (error: any, bucket?: string) => void) => void) | string;
+        key?(req: R, file: File, callback: (error: any, key?: string) => void): void;
+        acl?: ((req: R, file: File, callback: (error: any, acl?: string) => void) => void) | string;
+        contentType?(req: R, file: File, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
+        metadata?(req: R, file: File, callback: (error: any, metadata?: any) => void): void;
+        cacheControl?: ((req: R, file: File, callback: (error: any, cacheControl?: string) => void) => void) | string;
+        serverSideEncryption?: ((req: R, file: File, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
+    }
+
+    export interface S3Storage {
+        <E,R>(options?: Options<R>): E;
+
+        AUTO_CONTENT_TYPE<R>(
+            req: R,
+            file: File,
+            callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
+        DEFAULT_CONTENT_TYPE<R>(
+            req: R,
+            file: File,
+            callback: (error: any, mime?: string) => void): void;
     }
 }
 
-interface S3Storage<E,R> {
-    (options?: Options<R>): E;
-
-    AUTO_CONTENT_TYPE(
-        req: R,
-        file: MulterFile,
-        callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
-    DEFAULT_CONTENT_TYPE(
-        req: R,
-        file: MulterFile,
-        callback: (error: any, mime?: string) => void): void;
-}
-
-export = S3Storage;
+declare const s3Storage: MulterS3.S3Storage;
+export = s3Storage;

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -8,22 +8,18 @@
 // TypeScript Version: 2.6
 
 import * as AWS from "aws-sdk";
-import { IncomingMessage } from "http";
-import { StorageEngine } from "multer";
-import { StorageEngine as KoaStorageEngine } from "koa-multer";
 
-type MulterRequest = Express.Request | IncomingMessage;
 type MulterFile = Express.Multer.File;
 
-interface Options {
+interface Options<R> {
     s3: AWS.S3;
-    bucket: ((req: MulterRequest, file: MulterFile, callback: (error: any, bucket?: string) => void) => void) | string;
-    key?(req: MulterRequest, file: MulterFile, callback: (error: any, key?: string) => void): void;
-    acl?: ((req: MulterRequest, file: MulterFile, callback: (error: any, acl?: string) => void) => void) | string;
-    contentType?(req: MulterRequest, file: MulterFile, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
-    metadata?(req: MulterRequest, file: MulterFile, callback: (error: any, metadata?: any) => void): void;
-    cacheControl?: ((req: MulterRequest, file: MulterFile, callback: (error: any, cacheControl?: string) => void) => void) | string;
-    serverSideEncryption?: ((req: MulterRequest, file: MulterFile, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
+    bucket: ((req: R, file: MulterFile, callback: (error: any, bucket?: string) => void) => void) | string;
+    key?(req: R, file: MulterFile, callback: (error: any, key?: string) => void): void;
+    acl?: ((req: R, file: MulterFile, callback: (error: any, acl?: string) => void) => void) | string;
+    contentType?(req: R, file: MulterFile, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
+    metadata?(req: R, file: MulterFile, callback: (error: any, metadata?: any) => void): void;
+    cacheControl?: ((req: R, file: MulterFile, callback: (error: any, cacheControl?: string) => void) => void) | string;
+    serverSideEncryption?: ((req: R, file: MulterFile, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
 }
 
 declare global {
@@ -45,18 +41,17 @@ declare global {
     }
 }
 
-interface S3Storage {
-    (options?: Options): StorageEngine & KoaStorageEngine;
+interface S3Storage<E,R> {
+    (options?: Options<R>): E;
 
     AUTO_CONTENT_TYPE(
-        req: MulterRequest,
+        req: R,
         file: MulterFile,
         callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
     DEFAULT_CONTENT_TYPE(
-        req: MulterRequest,
+        req: R,
         file: MulterFile,
         callback: (error: any, mime?: string) => void): void;
 }
 
-declare const s3Storage: S3Storage;
-export = s3Storage;
+export = S3Storage;

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: KIM Jaesuck a.k.a. gim tcaesvk <https://github.com/tcaesvk>
 //                 Gal Talmor <https://github.com/galtalmor>
 //                 Matt Terski <https://github.com/terski>
+//                 Agata Belkius <https://github.com/abelkius>
 // Definitions: https://github.com/DefinitelyType/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -10,15 +11,18 @@ import * as AWS from "aws-sdk";
 import { IncomingMessage } from 'http';
 import { StorageEngine } from "multer";
 
+type MulterRequest = Express.Request | IncomingMessage;
+type MulterFile = Express.Multer.File | File;
+
 interface Options {
     s3: AWS.S3;
-    bucket: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, bucket?: string) => void) => void) | string;
-    key?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, key?: string) => void): void;
-    acl?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, acl?: string) => void) => void) | string;
-    contentType?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
-    metadata?(req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, metadata?: any) => void): void;
-    cacheControl?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, cacheControl?: string) => void) => void) | string;
-    serverSideEncryption?: ((req: Express.Request | IncomingMessage, file: Express.Multer.File | File, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
+    bucket: ((req: MulterRequest, file: MulterFile, callback: (error: any, bucket?: string) => void) => void) | string;
+    key?(req: MulterRequest, file: MulterFile, callback: (error: any, key?: string) => void): void;
+    acl?: ((req: MulterRequest, file: MulterFile, callback: (error: any, acl?: string) => void) => void) | string;
+    contentType?(req: MulterRequest, file: MulterFile, callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
+    metadata?(req: MulterRequest, file: MulterFile, callback: (error: any, metadata?: any) => void): void;
+    cacheControl?: ((req: MulterRequest, file: MulterFile, callback: (error: any, cacheControl?: string) => void) => void) | string;
+    serverSideEncryption?: ((req: MulterRequest, file: MulterFile, callback: (error: any, serverSideEncryption?: string) => void) => void) | string;
 }
 
 declare global {
@@ -44,12 +48,12 @@ interface S3Storage {
     (options?: Options): StorageEngine;
 
     AUTO_CONTENT_TYPE(
-        req: Express.Request | IncomingMessage,
-        file: Express.Multer.File | File,
+        req: MulterRequest,
+        file: MulterFile,
         callback: (error: any, mime?: string, stream?: NodeJS.ReadableStream) => void): void;
     DEFAULT_CONTENT_TYPE(
-        req: Express.Request | IncomingMessage,
-        file: Express.Multer.File | File,
+        req: MulterRequest,
+        file: MulterFile,
         callback: (error: any, mime?: string) => void): void;
 }
 


### PR DESCRIPTION
I extended types in this definition to also work with `koa-multer` package. The only difference is the type for `req` that is passed through and `S3Storage` type that also differs just because of the `req` that is passed through. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa-multer/index.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
