### PR TITLE
[stripe] Add missing properties on StripeError

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stripe 6.32
+// Type definitions for stripe 7.10
 // Project: https://github.com/stripe/stripe-node/
 // Definitions by: William Johnston <https://github.com/wjohnsto>
 //                 Peter Harris <https://github.com/codeanimal>

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -13900,7 +13900,6 @@ declare namespace Stripe {
             };
             readonly requestId: string;
             readonly detail?: any;
-            readonly: number;
             readonly params?: string;
             readonly type: string;
         }

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -13902,6 +13902,14 @@ declare namespace Stripe {
             readonly detail?: any;
             readonly params?: string;
             readonly type: string;
+            readonly statusCode?: number;
+
+            readonly charge?: string;
+            readonly decline_code?: string;
+            readonly payment_intent?: paymentIntents.IPaymentIntent;
+            readonly payment_method?: paymentMethods.IPaymentMethod;
+            readonly setup_intent?: setupIntents.ISetupIntent;
+            readonly source?: sources.ISource;
         }
         class StripeCardError extends StripeError {
             readonly type: 'StripeCardError';

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -2065,6 +2065,30 @@ stripe.charges
         if (err instanceof Stripe.errors.StripeCardError) {
             const type = err.type;
         }
+
+        if (err instanceof Stripe.errors.StripeError) {
+            if (err.charge) {
+                const charge: string = err.charge;
+            }
+            if (err.payment_intent) {
+                const payment_intent: Stripe.paymentIntents.IPaymentIntent = err.payment_intent;
+            }
+            if (err.payment_method) {
+                const payment_method: Stripe.paymentMethods.IPaymentMethod = err.payment_method;
+            }
+            if (err.setup_intent) {
+                const setup_intent: Stripe.setupIntents.ISetupIntent = err.setup_intent;
+            }
+            if (err.source) {
+                const source: Stripe.sources.ISource = err.source;
+            }
+            if (err.decline_code) {
+                const decline_code: string = err.decline_code;
+            }
+            if (err.statusCode) {
+                const statusCode: number = err.statusCode;
+            }
+        }
     });
 
 //#endregion Errors


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/stripe-node/pull/699
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This reflect the following change made in Stripe 7.10.0: https://github.com/stripe/stripe-node/pull/699
I also removed a property that was most likely added by mistake (`readonly: number`), and added an older missing property.
