### PR TITLE
fix(pino): fix `redact` options type

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -505,7 +505,7 @@ declare namespace P {
 
     interface redactOptions {
         paths: string[];
-        censor?: string;
+        censor?: string | ((v: any) => any);
         remove?: boolean;
     }
 }

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -30,6 +30,14 @@ pino({
 });
 
 pino({
+    redact: { paths: [], censor: 'SECRET' },
+});
+
+pino({
+    redact: { paths: [], censor: () => 'SECRET' },
+});
+
+pino({
     browser: {
         write(o) {
         }


### PR DESCRIPTION
Pino docs make clear that `censor` can be a string or function, see link below

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino/blob/master/docs/api.md#redact-array--object
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.