### PR TITLE
Rebass: Add tx prop to BoxKnownProps

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -57,7 +57,7 @@ interface BoxKnownProps
         StyledSystem.AlignSelfProps,
         SxProps {
     variant?: StyledSystem.ResponsiveValue<string>;
-    tx?: number | string;
+    tx?: string;
 }
 export interface BoxProps
     extends BoxKnownProps,

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -57,6 +57,7 @@ interface BoxKnownProps
         StyledSystem.AlignSelfProps,
         SxProps {
     variant?: StyledSystem.ResponsiveValue<string>;
+    tx?: number | string;
 }
 export interface BoxProps
     extends BoxKnownProps,

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -25,6 +25,8 @@ const boxCss = css`
 
 const CssBox = () => <Box css={boxCss} />;
 
+const VariantBox = () => <Box tx="specialBoxes" />;
+
 export default () => (
     <Box width={1} css={{ height: "100vh" }} py={[1, 2, 3]} ml="1em" display="block">
         <Flex width={1} alignItems="center" justifyContent="center">
@@ -77,6 +79,8 @@ export default () => (
             </Box>
 
             <CssBox />
+
+            <VariantBox />
         </Flex>
     </Box>
 );


### PR DESCRIPTION
The `tx` prop is used to modify the lookup on the theme object when a `variant` is specified. Handy if you want to write an extension of a Rebass component with its own variants.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rebassjs/rebass/blob/c8aaa05e7207f2304897e4f4a78071827dd085fe/packages/reflexbox/src/index.js#L16-L25
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.