### PR TITLE
Add `events.once` type definitions

### DIFF
--- a/types/events.once/events.once-tests.ts
+++ b/types/events.once/events.once-tests.ts
@@ -1,5 +1,27 @@
 // Copied from https://github.com/davidmarkclements/events.once/blob/master/readme.md
 
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 David Mark Clements
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import once from 'events.once';
 import { EventEmitter } from 'events';
 

--- a/types/events.once/events.once-tests.ts
+++ b/types/events.once/events.once-tests.ts
@@ -1,0 +1,27 @@
+// Taken from https://github.com/davidmarkclements/events.once/blob/master/readme.md
+
+import once from 'events.once';
+import { EventEmitter } from 'events';
+
+async function run() {
+    const ee = new EventEmitter();
+    process.nextTick(() => {
+        ee.emit('myevent', 42);
+    });
+
+    const [value] = await once(ee, 'myevent');
+    console.log(value);
+
+    const err = new Error('kaboom');
+    process.nextTick(() => {
+        ee.emit('error', err);
+    });
+
+    try {
+        await once(ee, 'myevent');
+    } catch (err) {
+        console.log('error happened', err);
+    }
+}
+
+run();

--- a/types/events.once/events.once-tests.ts
+++ b/types/events.once/events.once-tests.ts
@@ -1,4 +1,4 @@
-// Taken from https://github.com/davidmarkclements/events.once/blob/master/readme.md
+// Copied from https://github.com/davidmarkclements/events.once/blob/master/readme.md
 
 import once from 'events.once';
 import { EventEmitter } from 'events';

--- a/types/events.once/index.d.ts
+++ b/types/events.once/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for events.once 2.0
-// Project: https://github.com/davidmarkclements/events.once#readme
+// Project: https://github.com/davidmarkclements/events.once
 // Definitions by: John Meyer <https://github.com/0x326>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7

--- a/types/events.once/index.d.ts
+++ b/types/events.once/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for events.once 2.0
+// Project: https://github.com/davidmarkclements/events.once#readme
+// Definitions by: John Meyer <https://github.com/0x326>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+/// <reference types="node" />
+
+import { once } from 'events';
+
+/*~ This declaration specifies that the function
+ *~ is the exported object from the file
+ */
+export = once;

--- a/types/events.once/tsconfig.json
+++ b/types/events.once/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "events.once-tests.ts"
+    ]
+}

--- a/types/events.once/tslint.json
+++ b/types/events.once/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
