### PR TITLE
[jsonwebtoken] Fix verify with encrypted key

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -161,7 +161,7 @@ export function sign(
  */
 export function verify(
     token: string,
-    secretOrPublicKey: string | Buffer,
+    secretOrPublicKey: Secret,
     options?: VerifyOptions,
 ): object | string;
 
@@ -176,12 +176,12 @@ export function verify(
  */
 export function verify(
     token: string,
-    secretOrPublicKey: string | Buffer | GetPublicKeyOrSecret,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     callback?: VerifyCallback,
 ): void;
 export function verify(
     token: string,
-    secretOrPublicKey: string | Buffer | GetPublicKeyOrSecret,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     options?: VerifyOptions,
     callback?: VerifyCallback,
 ): void;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -159,11 +159,7 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(
-    token: string,
-    secretOrPublicKey: Secret,
-    options?: VerifyOptions,
-): object | string;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): object | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -76,6 +76,13 @@ jwt.verify(token, "wrong-secret", (err, decoded) => {
     // decoded undefined
 });
 
+// verify with encrypted RSA SHA256 private key
+jwt.verify(token, secret, (err, decoded) => {
+    const result = decoded as TestObject;
+
+    console.log(result.foo); // bar
+});
+
 // verify a token asymmetric
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
