### PR TITLE
Add types for accurate-interval package

### DIFF
--- a/types/accurate-interval/accurate-interval-tests.ts
+++ b/types/accurate-interval/accurate-interval-tests.ts
@@ -2,3 +2,12 @@ import accurateInterval = require('accurate-interval');
 
 const interval = accurateInterval(() => void(0), 100, { aligned: true, immediate: true });
 interval.clear();
+const scheduledTime = 1000;
+const intervalScheludel = accurateInterval((scheduledTime: number) => void 0, 100, { aligned: true, immediate: true });
+const intervalScheludelError = accurateInterval(
+    () => {
+        return void 0;
+    },
+    100,
+    { aligned: true, immediate: true },
+);

--- a/types/accurate-interval/accurate-interval-tests.ts
+++ b/types/accurate-interval/accurate-interval-tests.ts
@@ -1,0 +1,4 @@
+import accurateInterval = require('accurate-interval');
+
+const interval = accurateInterval(() => void(0), 100, { aligned: true, immediate: true });
+interval.clear();

--- a/types/accurate-interval/index.d.ts
+++ b/types/accurate-interval/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for accurate-interval 1.0
+// Project: https://github.com/klyngbaek/accurate-interval#readme
+// Definitions by: Artur Dziedziczak <https://github.com/grayrattus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function accurateInterval(func: () => void, interval: number, opts: accurateInterval.Opts): accurateInterval.AccurateInterval;
+export = accurateInterval;
+
+declare namespace accurateInterval {
+    interface Opts {
+        aligned: boolean;
+        immediate: boolean;
+    }
+
+    interface AccurateInterval {
+        clear: () => void;
+    }
+}

--- a/types/accurate-interval/index.d.ts
+++ b/types/accurate-interval/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Artur Dziedziczak <https://github.com/grayrattus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function accurateInterval(func: () => void, interval: number, opts: accurateInterval.Opts): accurateInterval.AccurateInterval;
+declare function accurateInterval(func: (scheduledTime: number) => void, interval: number, opts: accurateInterval.Opts): accurateInterval.AccurateInterval;
 export = accurateInterval;
 
 declare namespace accurateInterval {

--- a/types/accurate-interval/tsconfig.json
+++ b/types/accurate-interval/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "accurate-interval-tests.ts"
+    ]
+}

--- a/types/accurate-interval/tslint.json
+++ b/types/accurate-interval/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Add types for accurate-interval package.
- [x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.