### PR TITLE
[redux-immutable] Fix typing for combineReducers()

### DIFF
--- a/types/redux-immutable/index.d.ts
+++ b/types/redux-immutable/index.d.ts
@@ -8,8 +8,8 @@
 // TypeScript Version: 2.3
 
 import { ReducersMapObject, Reducer, Action } from 'redux';
-import { Collection } from 'immutable';
+import { Collection, Map } from 'immutable';
 
-export declare function combineReducers<S, A extends Action, T>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Keyed<T, S>): Reducer<S, A>;
+export declare function combineReducers<S, A extends Action, T>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Keyed<T, S>): Reducer<Map<keyof S, any>, A>;
 export declare function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S, A>;
 export declare function combineReducers<S>(reducers: ReducersMapObject<S, any>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S>;

--- a/types/redux-immutable/index.d.ts
+++ b/types/redux-immutable/index.d.ts
@@ -11,5 +11,5 @@ import { ReducersMapObject, Reducer, Action } from 'redux';
 import { Collection, Map } from 'immutable';
 
 export declare function combineReducers<S, A extends Action, T>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Keyed<T, S>): Reducer<Map<keyof S, any>, A>;
-export declare function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S, A>;
-export declare function combineReducers<S>(reducers: ReducersMapObject<S, any>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S>;
+export declare function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Indexed<S>): Reducer<Map<keyof S, any>, A>;
+export declare function combineReducers<S>(reducers: ReducersMapObject<S, any>, getDefaultState?: () => Collection.Indexed<S>): Reducer<Map<keyof S, any>>;


### PR DESCRIPTION
The `combineReducers()` function was typed wrong so it did not work with `createStore()` from redux at all.

Here's a simple version of the definitions that helps explain the mistake:

```typescript
// redux.d.ts
function createStore<S>(reducer: Reducer<S>): Store<S>;

interface Store<S> {
  getState(): S;
}


// redux-immutable.d.ts
function combineReducers(...args): Reducer<S>; // wrongly typed
```

When using `redux-immutable` like, 

```typescript
const store = createStore(
  combineReducers({
    module1: reducer1,
    module2: reducer2
  })
);

// expected: values from module1
// actual: TS2339 Property 'get' does not exist on type '{ module1: unknown; module2: unknown; }'.
store.getState().get('module1');
```

the `store.getState()` call is supposed to return an `Immutable.Map` instance. But because `getState()` returns the same type as `combineReducers()`, it turned out to be a plain object after all.

According to [`redux-immutable` source code](https://github.com/gajus/redux-immutable/blob/8593b891f955148be650292fadb65c90348ad4db/src/combineReducers.js#L11), `combineReducers(reducers)` returns a `Immutable.Map` object instead of the original reducers object passed as its 1st argument.

----

CI failed due to errors from inside of `redux` definition ([details](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/596106688#L324)).

