### PR TITLE
react-loadable fix webpack/node.js compatibility

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -66,7 +66,7 @@ declare namespace LoadableExport {
          * });
          * ```
          */
-        webpack?: () => (string | number)[];
+        webpack?: () => Array<string | number>;
     }
 
     interface OptionsWithoutRender<Props> extends CommonOptions {

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -66,7 +66,7 @@ declare namespace LoadableExport {
          * });
          * ```
          */
-        webpack?: () => number[];
+        webpack?: () => (string | number)[];
     }
 
     interface OptionsWithoutRender<Props> extends CommonOptions {


### PR DESCRIPTION
According to  webpack types
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f58986ca20210f8e6612942db077b9228740a315/types/webpack-env/index.d.ts#L44

`resolve` returns array of strings in node.js and array of numbers in webpack, therefore `CommonOptions.webpack` must accept both and not only `number[]`.


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see snippet above
