### PR TITLE
[react-responsive] Update useMediaQuery parameter list

### DIFF
--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -92,7 +92,7 @@ export const Context: React.Context<Partial<MediaQueryAllQueryable>>;
 
 export function useMediaQuery(
     settings: Partial<MediaQueryAllQueryable & { query?: string }>,
-    device?: MediaQueryTypes,
+    device?: MediaQueryMatchers,
     callback?: (matches: boolean) => void
 ): boolean;
 


### PR DESCRIPTION
According to the documentation (https://www.npmjs.com/package/react-responsive#forcing-a-device-with-the-device-prop), the `device` object can have the following keys:

> orientation, scan, aspectRatio, deviceAspectRatio, height, deviceHeight, width, deviceWidth, color, colorIndex, monochrome, resolution and type


This list is matched by the `MediaQueryMatchers` interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-responsive#forcing-a-device-with-the-device-prop
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
