### PR TITLE
fix(testing-library__dom): Rename `logDom` to `logDOM` 

### DIFF
--- a/types/testing-library__dom/index.d.ts
+++ b/types/testing-library__dom/index.d.ts
@@ -4,6 +4,7 @@
 //                 Kent C Dodds <https://github.com/kentcdodds>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Weyert de Boer <https://github.com/weyert>
+//                 Ronald Rey <https://github.com/reyronald>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/testing-library__dom/pretty-dom.d.ts
+++ b/types/testing-library__dom/pretty-dom.d.ts
@@ -1,6 +1,4 @@
 import { OptionsReceived } from 'pretty-format';
 
-type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
-
 export function prettyDOM(dom?: Element | HTMLDocument, maxLength?: number, options?: OptionsReceived): string | false;
-export function logDOM(...args: Parameters<typeof prettyDOM>): void;
+export function logDOM(dom?: Element | HTMLDocument, maxLength?: number, options?: OptionsReceived): void;

--- a/types/testing-library__dom/pretty-dom.d.ts
+++ b/types/testing-library__dom/pretty-dom.d.ts
@@ -1,3 +1,6 @@
 import { OptionsReceived } from 'pretty-format';
 
+type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
+
 export function prettyDOM(dom?: Element | HTMLDocument, maxLength?: number, options?: OptionsReceived): string | false;
+export function logDOM(...args: Parameters<typeof prettyDOM>): void;

--- a/types/testing-library__dom/query-helpers.d.ts
+++ b/types/testing-library__dom/query-helpers.d.ts
@@ -20,7 +20,6 @@ export type AllByAttribute = (
 
 export const queryByAttribute: QueryByAttribute;
 export const queryAllByAttribute: AllByAttribute;
-export function logDom(htmlElement: HTMLElement): void;
 export function getElementError(message: string, container: HTMLElement): Error;
 
 /**


### PR DESCRIPTION
The correct name of this function is `logDOM` as you can see here: https://github.com/testing-library/dom-testing-library/blob/13543a9762dff7e8f0cad8d57c1c02dc66052df6/src/pretty-dom.js#L62

With the current definitions released it's not possible to import it without ignoring the TS error. I also updated the typings around the arguments to match `prettyDOM` and moved it to `./pretty-dom.d.ts`.

My first commit used `Parameters` utility type to mirror `prettyDOM`'s signature but it was failing for TS 3.0, so instead of updating the necessary version here and all other dependent packages I decided to just manually copy the arguments.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
