### PR TITLE
[react-router] add string[] to matchPath and useRouteMatch arg types

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -127,7 +127,7 @@ export interface match<Params extends { [K in keyof Params]?: string } = {}> {
 // Omit taken from https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238
 export type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
-export function matchPath<Params extends { [K in keyof Params]?: string }>(pathname: string, props: string | RouteProps, parent?: match<Params> | null): match<Params> | null;
+export function matchPath<Params extends { [K in keyof Params]?: string }>(pathname: string, props: string | string[] | RouteProps, parent?: match<Params> | null): match<Params> | null;
 
 export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean | undefined }): string;
 
@@ -156,5 +156,5 @@ export function useLocation<S = H.LocationState>(): H.Location<S>;
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: string };
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(
-    path?: string | RouteProps,
+    path?: string | string[] | RouteProps,
 ): match<Params> | null;

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -15,7 +15,8 @@ const HooksTest: React.FC = () => {
     const { id } = useParams();
     const params = useParams<Params>();
     const match1 = useRouteMatch<Params>('/:id');
-    const match2 = useRouteMatch<Params>({ path: '/:id', exact: true });
+    const match2 = useRouteMatch<Params>(['/one/:id', '/two/:id']);
+    const match3 = useRouteMatch<Params>({ path: '/:id', exact: true });
 
     history.location.state.s;
     location.state.s;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reacttraining.com/react-router/web/api/matchPath/props>