### PR TITLE
Update Victory to include LineSegment component and missing VictoryLabel prop

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -201,6 +201,7 @@ declare module 'victory' {
          * @default 1
          */
         lineHeight?: StringOrNumberOrCallback;
+        direction?: 'rtl' | 'ltr' | 'inherit';
         /**
          * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
          * **This prop should not be set manually.**
@@ -318,6 +319,10 @@ declare module 'victory' {
          * @default ""
          */
         desc?: string;
+        /**
+         * The direction prop determines which text direction to apply to the rendered text element
+         * @default "inherit"
+         */
     }
 
     export class VictoryContainer extends React.Component<VictoryContainerProps, any> {}
@@ -889,6 +894,42 @@ declare module 'victory' {
      * VictoryTooltip renders text as well as a configurable Flyout container.
      */
     export class VictoryTooltip extends React.Component<VictoryTooltipProps, any> {}
+
+    interface PrimitiveCommonProps {
+        active?: boolean;
+        className?: string;
+        clipPath?: string;
+        data?: any[];
+        desc?: StringOrNumberOrCallback;
+        events?: object;
+        id?: number | string;
+        index?: number | string;
+        origin?: { x: number; y: number };
+        polar?: boolean;
+        role?: string;
+        scale?:
+            | ScalePropType
+            | D3Scale
+            | {
+                  x?: ScalePropType | D3Scale;
+                  y?: ScalePropType | D3Scale;
+              };
+        shapeRendering?: string;
+        style?: object;
+        tabIndex?: StringOrNumberOrCallback;
+        transform?: string;
+    }
+
+    export interface LineSegmentProps extends PrimitiveCommonProps {
+        datum?: any;
+        lineComponent?: React.ReactElement;
+        x1?: number;
+        x2?: number;
+        y1?: number;
+        y2?: number;
+    }
+
+    export class LineSegment extends React.Component<LineSegmentProps, any> {}
 
     /**
      * Animate object used in components

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 import {
-    VictoryAnimation,
-    VictoryLabel,
     AnimationStyle,
+    createContainer,
+    LineSegment,
+    VictoryAnimation,
     VictoryArea,
     VictoryAxis,
-    VictoryStack,
     VictoryBar,
-    VictoryLine,
+    VictoryBoxPlot,
+    VictoryBrushContainerProps,
     VictoryChart,
-    VictoryScatter,
+    VictoryGroup,
+    VictoryLabel,
+    VictoryLegend,
+    VictoryLine,
     VictoryPie,
+    VictoryScatter,
+    VictoryStack,
     VictoryStyleInterface,
     VictoryTheme,
     VictoryThemeDefinition,
-    VictoryLegend,
-    VictoryBoxPlot,
-    VictoryGroup,
-    createContainer,
     VictoryZoomContainerProps,
-    VictoryBrushContainerProps,
 } from 'victory';
 
 const commonData1 = [
@@ -57,6 +58,7 @@ test = (
         events={{
             onClick: () => {},
         }}
+        direction="rtl"
         text="test"
         transform="scale(1.2)"
         dx={10}
@@ -519,6 +521,10 @@ test = (
 );
 
 test = <VictoryScatter data={commonData2} size={() => 5} />;
+
+test = <LineSegment datum={[1, 2, 3]} lineComponent={<line></line>} x1={0} x2={100} y1={0} y2={100} />;
+
+test = <LineSegment datum={[1, 2, 3]} x1={0} x2={100} y1={0} y2={100} />;
 
 // VictoryPie test
 test = (


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
See information on LineSegment component:
https://formidable.com/open-source/victory/docs/victory-primitives#linesegment

See information on VictoryLabel direction prop:
https://formidable.com/open-source/victory/docs/victory-label#direction
