### PR TITLE
adding leaflet-groupedlayercontrol types

### DIFF
--- a/types/leaflet-groupedlayercontrol/index.d.ts
+++ b/types/leaflet-groupedlayercontrol/index.d.ts
@@ -18,13 +18,13 @@ declare module 'leaflet' {
     }
 
     export interface GroupedLayersOptions extends L.ControlOptions {
-        /** true */
-        collapsed?: boolean,
-        /** true */
-        autoZIndex?: boolean,
-        exclusiveGroups?: string[],
-        /** false */
-        groupCheckboxes?: boolean
+        /** Default: true */
+        collapsed?: boolean;
+        /** Default: true */
+        autoZIndex?: boolean;
+        exclusiveGroups?: string[];
+        /** Default: false */
+        groupCheckboxes?: boolean;
     }
 
 }

--- a/types/leaflet-groupedlayercontrol/index.d.ts
+++ b/types/leaflet-groupedlayercontrol/index.d.ts
@@ -8,16 +8,16 @@ import * as L from 'leaflet';
 
 declare module 'leaflet' {
     namespace Control {
-        class GroupedLayers extends L.Control {
-            constructor(baseLayers: { [index: string]: L.Layer }, groupedOverlays: { [index: string]: { [index: string]: L.LayerGroup } }, options: GroupedLayersOptions);
+        class GroupedLayers extends Control {
+            constructor(baseLayers: { [index: string]: Layer }, groupedOverlays: { [index: string]: { [index: string]: LayerGroup } }, options: GroupedLayersOptions);
         }
     }
 
     namespace control {
-        function groupedLayers(baseLayers: { [index: string]: L.Layer }, groupedOverlays: { [index: string]: { [index: string]: L.LayerGroup } }, options: GroupedLayersOptions): L.Control
+        function groupedLayers(baseLayers: { [index: string]: Layer }, groupedOverlays: { [index: string]: { [index: string]: LayerGroup } }, options: GroupedLayersOptions): Control;
     }
 
-    export interface GroupedLayersOptions extends L.ControlOptions {
+    interface GroupedLayersOptions extends ControlOptions {
         /** Default: true */
         collapsed?: boolean;
         /** Default: true */
@@ -26,5 +26,4 @@ declare module 'leaflet' {
         /** Default: false */
         groupCheckboxes?: boolean;
     }
-
 }

--- a/types/leaflet-groupedlayercontrol/index.d.ts
+++ b/types/leaflet-groupedlayercontrol/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for leaflet-groupedlayercontrol 0.6
+// Project: https://github.com/ismyrnow/leaflet-groupedlayercontrol
+// Definitions by: Ryan Conklin <https://github.com/ryanc16>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+    namespace Control {
+        class GroupedLayers extends L.Control {
+            constructor(baseLayers: { [index: string]: L.Layer }, groupedOverlays: { [index: string]: { [index: string]: L.LayerGroup } }, options: GroupedLayersOptions);
+        }
+    }
+
+    namespace control {
+        function groupedLayers(baseLayers: { [index: string]: L.Layer }, groupedOverlays: { [index: string]: { [index: string]: L.LayerGroup } }, options: GroupedLayersOptions): L.Control
+    }
+
+    export interface GroupedLayersOptions extends L.ControlOptions {
+        /** true */
+        collapsed?: boolean,
+        /** true */
+        autoZIndex?: boolean,
+        exclusiveGroups?: string[],
+        /** false */
+        groupCheckboxes?: boolean
+    }
+
+}

--- a/types/leaflet-groupedlayercontrol/index.d.ts
+++ b/types/leaflet-groupedlayercontrol/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ismyrnow/leaflet-groupedlayercontrol
 // Definitions by: Ryan Conklin <https://github.com/ryanc16>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as L from 'leaflet';
 

--- a/types/leaflet-groupedlayercontrol/leaflet-groupedlayercontrol-tests.ts
+++ b/types/leaflet-groupedlayercontrol/leaflet-groupedlayercontrol-tests.ts
@@ -1,0 +1,26 @@
+import * as L from 'leaflet';
+import 'leaflet-groupedlayercontrol';
+
+const map: L.Map = L.map('#map');
+
+const baseLayers = {
+    street: L.tileLayer('...')
+};
+
+const groupedOverlays = {
+    overlayGroup1: {
+        overlay1: L.layerGroup(),
+        overlay2: L.layerGroup()
+    },
+    overlayGroup2: {
+        overlay3: L.layerGroup()
+    }
+};
+
+const groupedLayersOptions: L.GroupedLayersOptions = {
+    position: 'topleft',
+    exclusiveGroups: ['overlayGroup1', 'overlayGroup2'],
+    groupCheckboxes: false
+};
+
+L.control.groupedLayers(baseLayers, groupedOverlays, groupedLayersOptions).addTo(map);

--- a/types/leaflet-groupedlayercontrol/tsconfig.json
+++ b/types/leaflet-groupedlayercontrol/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/leaflet-groupedlayercontrol/tsconfig.json
+++ b/types/leaflet-groupedlayercontrol/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "leaflet-groupedlayercontrol-tests.ts"
+    ]
+}

--- a/types/leaflet-groupedlayercontrol/tslint.json
+++ b/types/leaflet-groupedlayercontrol/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
First time contributing to DefinitelyTyped. I tried following the readme on contributing, so if anything needs improvement, I'll try to fix.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.