### PR TITLE
[react] Allow both "class" and "className" component attributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1638,6 +1638,7 @@ declare namespace React {
 
         // Standard HTML Attributes
         accessKey?: string;
+        class?: string;
         className?: string;
         contentEditable?: boolean;
         contextMenu?: string;
@@ -2210,6 +2211,7 @@ declare namespace React {
     interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
+        class?: string;
         className?: string;
         color?: string;
         height?: number | string;


### PR DESCRIPTION
Starting in React 16, unknown props are still attached to the rendered HTML element in the DOM:
https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html

Since React has no special treatment for the "class" property for a component, it now simply forwards it along and renders it. So now

`<div class="foobar">` and `<div className="foobar">` both produce the same outcome in the DOM.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html>