### PR TITLE
[webpack-env] Add overload for require.ensure that omits the errorCb

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -34,6 +34,7 @@ declare namespace __WebpackModuleApi {
          *
          * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
          */
+        ensure(paths: string[], callback: (require: NodeRequire) => void, chunkName?: string): void;
         ensure(paths: string[], callback: (require: NodeRequire) => void, errorCallback?: (error: any) => void, chunkName?: string): void;
         context(path: string, deep?: boolean, filter?: RegExp, mode?: "sync" | "eager" | "weak" | "lazy" | "lazy-once"): RequireContext;
         /**

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -84,5 +84,14 @@ if (module.hot) {
     module.hot.removeStatusHandler(statusHandler);
 }
 
+require.ensure([], (require) => {
+    require("some/module");
+});
 
+require.ensure([], (require) => {
+    require("some/module");
+}, (e) => {}, 'chunkWithErrorHandling')
 
+require.ensure([], (require) => {
+    require("some/module");
+}, 'chunkWithoutErrorHandling');


### PR DESCRIPTION
The current typings allow both the `errorCallback` and the chunk name to be omitted; however they don't allow for the `errorCallback` to be omitted, but for the chunk name to be provided.  This adds an overload for that case.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
