### PR TITLE
feat: Add `define‑properties`

### DIFF
--- a/types/define-properties/.editorconfig
+++ b/types/define-properties/.editorconfig
@@ -1,0 +1,3 @@
+# This package uses tabs
+[*]
+indent_style = tab

--- a/types/define-properties/define-properties-tests.ts
+++ b/types/define-properties/define-properties-tests.ts
@@ -1,0 +1,47 @@
+import define = require('define-properties');
+
+declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: WeakMap<T, V>): V;
+
+const object: object = undefined!;
+const object_foo = new WeakMap<object, string>();
+
+// $ExpectType boolean
+define.supportsDescriptors;
+
+// $ExpectType typeof defineProperties
+define;
+
+// $ExpectError
+define(object);
+
+// $ExpectError
+define(null, {});
+
+define(object, {
+	getFoo() {
+		this; // $ExpectType any
+
+		return __classPrivateFieldGet(this, object_foo);
+	}
+});
+
+define(object, {
+	foo: 'any'
+}, {
+	foo: () => (object as any).foo !== 'any'
+});
+
+// $ExpectError
+define(object, {
+	foo: 'any'
+}, {
+	foo: () => (object as any).foo !== 'any',
+	bar: () => { throw new Error(); },
+});
+
+define(object, {
+	foo: 'any',
+	bar: 'valid'
+}, {
+	foo: () => (object as any).foo !== 'any',
+});

--- a/types/define-properties/index.d.ts
+++ b/types/define-properties/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for define-properties 1.1
 // Project: https://github.com/ljharb/define-properties#readme
-// Definitions by: ExE Boss <https://github.com/me>
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/define-properties/index.d.ts
+++ b/types/define-properties/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for define-properties 1.1
+// Project: https://github.com/ljharb/define-properties#readme
+// Definitions by: ExE Boss <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+declare namespace defineProperties {
+	/**
+	 * Whether the current environment correctly supports property descriptors.
+	 */
+	const supportsDescriptors: boolean;
+}
+
+/**
+ * Defines new properties in `map` as non-enumerable if they don't already
+ * exist on `object`.
+ *
+ * @param object The object to define non-enumerable properties on.
+ * @param map The map of newly defined properties.
+ * @param predicates The optional predicates map, return `true` to override existing properties on `object`.
+ */
+declare function defineProperties<K extends keyof any>(
+	object: object,
+	map: Record<K, any> & ThisType<any>,
+	predicates?: Partial<Record<K, () => boolean>>,
+): void;
+export = defineProperties;

--- a/types/define-properties/tsconfig.json
+++ b/types/define-properties/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": ["index.d.ts", "define-properties-tests.ts"]
+}

--- a/types/define-properties/tslint.json
+++ b/types/define-properties/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@ljharb, @andrewbranch)