### PR TITLE
[@types/wav] adds typings for wav

### DIFF
--- a/types/wav/index.d.ts
+++ b/types/wav/index.d.ts
@@ -1,16 +1,74 @@
 // Type definitions for wav 1.0
 // Project: https://github.com/TooTallNate/node-wav#readme
-// Definitions by: Matthew Peveler <https://github.com/me>
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export class Reader {
+/// <reference types="node" />
 
+import { Transform, TransformOptions } from "stream";
+import { WriteStream } from 'fs';
+
+export interface Format {
+  audioFormat: number;
+  endianness: 'LE' | 'BE';
+  channels: number;
+  sampleRate: number;
+  byteRate: number;
+  blockAlign: number;
+  bitDepth: number;
+  signed: boolean;
 }
 
-export class Writer {
-
+export interface UnknownChunk {
+  id: string;
+  data: any;
 }
 
-export class FileWriter {
+export class Reader extends Transform {
+    constructor(opts?: TransformOptions);
 
+    addListener(event: "format", listener: (format: Format) => void): this;
+    addListener(event: "chunk", listener: (unknownChunk: UnknownChunk) => void): this;
+    addListener(event: string, listener: (...args: any[]) => void): this;
+
+    on(event: "format", listener: (format: Format) => void): this;
+    on(event: "chunk", listener: (unknownChunk: UnknownChunk) => void): this;
+    on(event: string, listener: (...args: any[]) => void): this;
+}
+
+export interface WriterOptions extends TransformOptions {
+  format?: number;
+  channels?: number;
+  sampleRate?: number;
+  bitDepth?: number;
+}
+
+export class Writer extends Transform {
+  endianness: 'LE';
+  format: number;
+  channels: number;
+  sampleRate: number;
+  bitDepth: number;
+  bytesProcessed: number;
+
+  constructor(opts?: WriterOptions);
+
+  addListener(event: "header", listener: (header: Buffer) => void): this;
+  addListener(event: string, listener: (...args: any[]) => void): this;
+
+  on(event: "header", listener: (header: Buffer) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
+export class FileWriter extends Writer {
+  path: string;
+  file: WriteStream;
+
+  constructor(path: string, opts?: WriterOptions);
+
+  addListener(event: "done", listener: () => void): this;
+  addListener(event: string, listener: (...args: any[]) => void): this;
+
+  on(event: "done", listener: () => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
 }

--- a/types/wav/index.d.ts
+++ b/types/wav/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for wav 1.0
+// Project: https://github.com/TooTallNate/node-wav#readme
+// Definitions by: Matthew Peveler <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class Reader {
+
+}
+
+export class Writer {
+
+}
+
+export class FileWriter {
+
+}

--- a/types/wav/tsconfig.json
+++ b/types/wav/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wav-tests.ts"
+    ]
+}

--- a/types/wav/tslint.json
+++ b/types/wav/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wav/wav-tests.ts
+++ b/types/wav/wav-tests.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import wav from 'wav';
+import Speaker from 'speaker';
+
+var file = fs.createReadStream('track01.wav');
+var reader = new wav.Reader();
+
+// the "format" event gets emitted at the end of the WAVE header
+reader.on('format', (format) => {
+
+  // the WAVE header is stripped from the output of the reader
+  reader.pipe(new Speaker(format));
+});
+
+// pipe the WAVE file to the Reader instance
+file.pipe(reader);

--- a/types/wav/wav-tests.ts
+++ b/types/wav/wav-tests.ts
@@ -1,16 +1,28 @@
-import fs from 'fs';
-import wav from 'wav';
-import Speaker from 'speaker';
+import { createReadStream } from 'fs';
+import { Reader, Writer, FileWriter } from 'wav';
 
-var file = fs.createReadStream('track01.wav');
-var reader = new wav.Reader();
+const file = createReadStream('track01.wav');
+const reader = new Reader();
+const reader2 = new Reader();
 
-// the "format" event gets emitted at the end of the WAVE header
-reader.on('format', (format) => {
-
-  // the WAVE header is stripped from the output of the reader
-  reader.pipe(new Speaker(format));
+const writer = new Writer({
+  sampleRate: 16000,
+  channels: 1
 });
 
-// pipe the WAVE file to the Reader instance
+const fileWriter = new FileWriter('./test.wav', {
+  sampleRate: 16000,
+  channels: 1
+});
+
+reader.on('format', (format) => {
+  console.log(format);
+  reader.pipe(writer);
+});
+
+reader2.on('format', (format) => {
+  console.log(format);
+  reader2.pipe(fileWriter);
+});
+
 file.pipe(reader);


### PR DESCRIPTION
Typings for https://npmjs.com/package/wav

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
