### PR TITLE
[promise.allsettled] Update typing to handle iterables and tuples with elements that may or may not be Promises.

### DIFF
--- a/types/promise.allsettled/implementation.d.ts
+++ b/types/promise.allsettled/implementation.d.ts
@@ -1,10 +1,10 @@
 import { PromiseRejection, PromiseResolution, PromiseResult } from './types';
 
-type PromiseTuple<T extends [unknown, ...unknown[]]> = {[P in keyof T]: Promise<T[P]>};
+type PromiseTuple<T extends [unknown, ...unknown[]]> = {[P in keyof T]: Promise<T[P]> | T[P]};
 type PromiseResultTuple<T extends [unknown, ...unknown[]]> = {[P in keyof T]: PromiseResult<T[P]>};
 
 declare function allSettled(): Promise<[]>;
 declare function allSettled<T extends [unknown, ...unknown[]]>(iterable: PromiseTuple<T>): Promise<PromiseResultTuple<T>>;
-declare function allSettled<T>(iterable: Iterable<T>): Promise<Array<PromiseResult<T>>>;
+declare function allSettled<T>(iterable: Iterable<Promise<T> | T>): Promise<Array<PromiseResult<T>>>;
 
 export = allSettled;

--- a/types/promise.allsettled/index.d.ts
+++ b/types/promise.allsettled/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for promise.allsettled 1.0
 // Project: https://github.com/ljharb/promise.allsettled#readme
 // Definitions by: Martin Jurča <https://github.com/jurca>
+//                 Elizabeth Lorenz <https://github.com/kisaraofpern>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/promise.allsettled/promise.allsettled-tests.ts
+++ b/types/promise.allsettled/promise.allsettled-tests.ts
@@ -8,5 +8,12 @@ allSettled(); // $ExpectType Promise<[]>
 const r0: Result<[number]> = allSettled([Promise.resolve(0)]);
 const r1: Result<[number, string]> = allSettled([Promise.resolve(1), Promise.resolve('a')]);
 const r2: Result<[never, boolean]> = allSettled([Promise.reject<never>(null), Promise.resolve(true)]); // tslint:disable-line use-default-type-parameter
-const input = [0, 1, 2, 3, 4];
+const input = [
+  Promise.resolve(0),
+  Promise.resolve(1),
+  Promise.resolve(2),
+  3,
+  4
+];
 const r3: ArrayResult<number> = allSettled(input);
+const r4: Result<[number, string]> = allSettled([0, Promise.resolve("foo")]);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This change handles a subtly different case that is implied by package code: [npmjs documentation](https://www.npmjs.com/package/promise.allsettled)