### PR TITLE
fix passport-google-oauth20 additional options.

### DIFF
--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Yasunori Ohoka <https://github.com/yasupeke>
 //                 Eduard Zintz <https://github.com/ezintz>
 //                 Tan Nguyen <https://github.com/ngtan>
+//                 Gleb Varenov <https://github.com/acerbic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -17,7 +18,6 @@ export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
 >;
 
 export interface _StrategyOptionsBase extends OAuth2StrategyOptionsWithoutRequiredURLs {
-    accessType?: 'offline' | 'online';
     authorizationURL?: string;
     callbackURL?: string;
     clientID: string;
@@ -64,4 +64,25 @@ export class Strategy extends oauth2.Strategy {
             done: VerifyCallback
         ) => void
     );
+}
+
+// additional Google-specific options
+export interface AuthenticateOptionsGoogle extends passport.AuthenticateOptions {
+    accessType?: 'offline' | 'online';
+    prompt?: string;
+    loginHint?: string;
+    includeGrantedScopes?: boolean;
+    display?: string;
+    hostedDomain?: string;
+    hd?: string;
+    requestVisibleActions?: any;
+    openIDRealm?: any;
+}
+
+// allow Google-specific options when using "google" strategy
+declare module 'passport' {
+    interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet, AuthorizeOptions = AuthenticateOptions> {
+        authenticate(strategy: 'google', options: AuthenticateOptionsGoogle, callback?: (...args: any[]) => any): AuthenticateRet;
+        authorize(strategy: 'google', options: AuthenticateOptionsGoogle, callback?: (...args: any[]) => any): AuthorizeRet;
+    }
 }


### PR DESCRIPTION
Using TS module augmentation, allow google-specific authorization
options to be used with "authorize" and "authenticate" passport
calls, when "google" strategy is used.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

1. Removed "accessType" from strategy initialization options, as it is not being used by [actual constructor code](https://github.com/jaredhanson/passport-google-oauth2/blob/723e8f3e8e711275f89e0163e2c77cfebae33f25/lib/strategy.js#L47).
2. Added interface `AuthenticateOptionsGoogle` which extends basic authentication options interface from "passport" package with Google-specific fields that are being picked up by [strategy (code)](https://github.com/jaredhanson/passport-google-oauth2/blob/723e8f3e8e711275f89e0163e2c77cfebae33f25/lib/strategy.js#L138).
3. With TypeScript (module augmentation)[http://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation] added an override for functions `authenticate` and `authorize` when they are being used with this strategy directly.

Resulting change:
- additional options, like "accessType" could be used without explicit types assertions, when `authenticate` or `authorize` are called with "google" strategy.
- for other use cases (i.e. if `authenticate` is called with array of strategies names, instead of a single name), `AuthenticateOptionsGoogle` interface assertion could be used to provide additional options.