### PR TITLE
webpack: Add type definitions for logging API

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -698,6 +698,26 @@ declare namespace webpack {
         }
     }
 
+    /**
+     * @see https://webpack.js.org/api/logging/
+     * @since 4.39.0
+     */
+    interface Logger {
+        error(message?: any, ...optionalParams: any[]): void;
+        warn(message?: any, ...optionalParams: any[]): void;
+        info(message?: any, ...optionalParams: any[]): void;
+        log(message?: any, ...optionalParams: any[]): void;
+        debug(message?: any, ...optionalParams: any[]): void;
+        trace(message?: any, ...optionalParams: any[]): void;
+        group(...label: any[]): void;
+        groupEnd(): void;
+        groupCollapsed(...label: any): void;
+        status(message?: any, ...optionalParams: any[]): void;
+        clear(): void;
+        profile(label?: string): void;
+        profileEnd(label?: string): void;
+    }
+
     namespace debug {
         interface ProfilingPluginOptions {
             /** A relative path to a custom output file (json) */
@@ -718,6 +738,8 @@ declare namespace webpack {
             constructor(options?: ProfilingPluginOptions);
         }
     }
+
+    
     namespace compilation {
         class Asset {
         }
@@ -1025,6 +1047,7 @@ declare namespace webpack {
              * @deprecated Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead
              */
             applyPlugins(name: string, ...args: any[]): void;
+            getLogger(pluginName: string): Logger;
         }
 
         interface CompilerHooks {
@@ -1142,6 +1165,7 @@ declare namespace webpack {
         contextTimestamps: Map<string, number>;
         run(handler: Compiler.Handler): void;
         watch(watchOptions: Compiler.WatchOptions, handler: Compiler.Handler): Compiler.Watching;
+        getInfrastructureLogger(name: string): Logger;
     }
 
     namespace Compiler {

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -711,7 +711,7 @@ declare namespace webpack {
         trace(message?: any, ...optionalParams: any[]): void;
         group(...label: any[]): void;
         groupEnd(): void;
-        groupCollapsed(...label: any): void;
+        groupCollapsed(...label: any[]): void;
         status(message?: any, ...optionalParams: any[]): void;
         clear(): void;
         profile(label?: string): void;
@@ -739,7 +739,6 @@ declare namespace webpack {
         }
     }
 
-    
     namespace compilation {
         class Asset {
         }

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -998,3 +998,40 @@ configuration = {
         },
     },
 };
+
+// https://webpack.js.org/api/logging/
+class LoggingPlugin extends webpack.Plugin {
+    apply(compiler: webpack.Compiler): void {
+        const infrastructureLogger: webpack.Logger = compiler.getInfrastructureLogger('LoggingPlugin');
+        infrastructureLogger.error("File not found");
+        infrastructureLogger.warn("Ignoring unknown configuration option");
+        infrastructureLogger.info("Maintaining flux");
+        infrastructureLogger.debug("Dynamic reloads are inside the frobnitz");
+        infrastructureLogger.trace("Something might have gone wrong here");
+        infrastructureLogger.group("Start of messages");
+        infrastructureLogger.groupEnd();
+        infrastructureLogger.groupCollapsed("Start of collapsed messages");
+        infrastructureLogger.groupEnd();
+        infrastructureLogger.status("50% complete");
+        infrastructureLogger.clear();
+        infrastructureLogger.profile("How long does this take");
+        infrastructureLogger.profileEnd();
+
+        compiler.hooks.emit.tap('LoggingPlugin', compilation => {
+            const logger = compilation.getLogger('LoggingPlugin');
+            logger.error("File not found");
+            logger.warn("Ignoring unknown configuration option");
+            logger.info("Maintaining flux");
+            logger.debug("Dynamic reloads are inside the frobnitz");
+            logger.trace("Something might have gone wrong here");
+            logger.group("Start of messages");
+            logger.groupEnd();
+            logger.groupCollapsed("Start of collapsed messages");
+            logger.groupEnd();
+            logger.status("50% complete");
+            logger.clear();
+            logger.profile("How long does this take");
+            logger.profileEnd();
+        });
+    }
+}


### PR DESCRIPTION
Adds type definitions for the Logging API introduced in Webpack 4.39.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/api/logging/ and https://webpack.js.org/api/plugins/#logging
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.