### PR TITLE
Update type definitions for react-svg-pan-zoom v3

### DIFF
--- a/types/react-svg-pan-zoom/index.d.ts
+++ b/types/react-svg-pan-zoom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-svg-pan-zoom 2.5
+// Type definitions for react-svg-pan-zoom 3.3
 // Project: https://github.com/chrvadala/react-svg-pan-zoom#readme, https://chrvadala.github.io/react-svg-pan-zoom
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -23,6 +23,12 @@ export const POSITION_RIGHT = 'right';
 export const POSITION_BOTTOM = 'bottom';
 export const POSITION_LEFT = 'left';
 
+export const ALIGN_CENTER = 'center';
+export const ALIGN_LEFT = 'left';
+export const ALIGN_RIGHT = 'right';
+export const ALIGN_TOP = 'top';
+export const ALIGN_BOTTOM = 'bottom';
+
 export type Mode = typeof MODE_IDLE | typeof MODE_PANNING | typeof MODE_ZOOMING;
 
 export interface Value {
@@ -43,6 +49,7 @@ export interface Value {
 	startY?: number | null;
 	endX?: number | null;
 	endY?: number | null;
+	miniatureOpen: boolean;
 }
 
 export type Tool = typeof TOOL_AUTO | typeof TOOL_NONE | typeof TOOL_PAN |
@@ -57,9 +64,6 @@ export interface OptionalProps {
 	// background of the svg
 	SVGBackground: string;
 
-	// value of the viewer (current point of view)
-	value: Value | null;
-
 	// CSS style of the Viewer
 	style: object;
 
@@ -72,14 +76,21 @@ export interface OptionalProps {
 	// perform PAN if the mouse is on viewer border
 	detectAutoPan: boolean;
 
-	// toolbar position
-	toolbarPosition: ToolbarPosition;
+	detectPinchGesture: boolean;
 
-	// handler something changed
-	onChangeValue(value: Value): void;
+	toolbarProps: {
+		position?: ToolbarPosition;
+		SVGAlignX?: typeof ALIGN_CENTER | typeof ALIGN_LEFT | typeof ALIGN_RIGHT;
+		SVGAlignY?: typeof ALIGN_CENTER | typeof ALIGN_TOP | typeof ALIGN_BOTTOM;
+	};
 
-	// handler tool changed
-	onChangeTool(tool: Tool): void;
+	customMiniature: React.ReactElement | React.ComponentType;
+	miniatureProps: {
+		position: typeof POSITION_NONE | typeof POSITION_RIGHT | typeof POSITION_LEFT;
+		background: string;
+		width: number;
+		height: number;
+	};
 
 	// Note: The `T` type parameter is the type of the `target` of the event:
 	// handler click
@@ -97,17 +108,32 @@ export interface OptionalProps {
 	// handler mousedown
 	onMouseDown<T>(event: ViewerMouseEvent<T>): void;
 
+	// handler zoom level changed
+	onZoom<T>(event: ViewerMouseEvent<T>): void;
+
+	// handler pan action performed
+	onPan<T>(event: ViewerMouseEvent<T>): void;
+
 	// if disabled the user can move the image outside the viewer
 	preventPanOutside: boolean;
 
 	// how much scale in or out
 	scaleFactor: number;
 
-	// current active tool (TOOL_NONE, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT)
-	tool: Tool;
+	// how much scale in or out on mouse wheel (requires detectWheel enabled)
+	scaleFactorOnWheel: number;
+
+	// maximum amount of scale a user can zoom in to
+  scaleFactorMax: number;
+
+  // minimum amount of a scale a user can zoom out of
+	scaleFactorMin: number;
 
 	// modifier keys //https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState
 	modifierKeys: string[];
+
+	// Turn off zoom on double click
+	disableDoubleClickZoomWithToolAuto: boolean;
 
 	// override default toolbar component
 	// TODO: specify function type more clearly
@@ -121,6 +147,14 @@ export interface RequiredProps {
 	width: number;
 	// height of the viewer displayed on screen
 	height: number;
+	// current active tool (TOOL_NONE, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT)
+	tool: Tool;
+	// value of the viewer (current point of view)
+	value: Value | null;
+	// handler tool changed
+	onChangeTool(tool: Tool): void;
+	// handler something changed
+	onChangeValue(value: Value): void;
 
 	// accept only one node SVG
 	// TODO: Figure out how to constrain `children` or maybe just leave it commented out
@@ -128,9 +162,43 @@ export interface RequiredProps {
 	// children: () => any;
 }
 
+export interface UncontrolledExtraOptionalProps {
+	// current active tool (TOOL_NONE, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT)
+	tool: Tool;
+	// value of the viewer (current point of view)
+	value: Value | null;
+	// handler tool changed
+	onChangeTool(tool: Tool): void;
+	// handler something changed
+	onChangeValue(value: Value): void;
+}
+
+export interface UncontrolledRequiredProps {
+	// width of the viewer displayed on screen
+	width: number;
+	// height of the viewer displayed on screen
+	height: number;
+}
+
 export type Props = RequiredProps & Partial<OptionalProps>;
 
 export class ReactSVGPanZoom extends React.Component<Props> {
+	pan(SVGDeltaX: number, SVGDeltaY: number): void;
+	zoom(SVGPointX: number, SVGPointY: number, scaleFactor: number): void;
+	fitSelection(selectionSVGPointX: number, selectionSVGPointY: number, selectionWidth: number, selectionHeight: number): void;
+	fitToViewer(): void;
+	setPointOnViewerCenter(SVGPointX: number, SVGPointY: number, zoomLevel: number): void;
+	reset(): void;
+	zoomOnViewerCenter(scaleFactor: number): void;
+	getValue(): Value;
+	setValue(value: Value): void;
+	getTool(): Tool;
+	setTool(tool: Tool): void;
+}
+
+export type UncontrolledProps = UncontrolledRequiredProps & Partial<OptionalProps> & Partial<UncontrolledExtraOptionalProps>;
+
+export class UncontrolledReactSVGPanZoom extends React.Component<UncontrolledProps> {
 	pan(SVGDeltaX: number, SVGDeltaY: number): void;
 	zoom(SVGPointX: number, SVGPointY: number, scaleFactor: number): void;
 	fitSelection(selectionSVGPointX: number, selectionSVGPointY: number, selectionWidth: number, selectionHeight: number): void;

--- a/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
+++ b/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
@@ -4,14 +4,47 @@ import {
   ReactSVGPanZoom,
   Props,
   fitToViewer,
-  ViewerMouseEvent
+  ViewerMouseEvent,
+  Value,
+  Tool,
+  MODE_PANNING,
+  TOOL_NONE,
+  UncontrolledReactSVGPanZoom
 } from 'react-svg-pan-zoom';
 
-class Example1 extends React.Component {
+interface State {
+  value: Value;
+  tool: Tool;
+}
+
+class Example1 extends React.Component<{}, State> {
   Viewer: ReactSVGPanZoom | null;
 
   constructor(props: Props) {
     super(props);
+    this.state = {
+      value: {
+        version: 2,
+        mode: MODE_PANNING,
+        focus: true,
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        viewerWidth: 500,
+        viewerHeight: 500,
+        SVGWidth: 500,
+        SVGHeight: 500,
+        startX: null,
+        startY: null,
+        endX: null,
+        endY: null,
+        miniatureOpen: true
+      },
+      tool: TOOL_NONE
+    };
   }
 
   componentDidMount() {
@@ -21,6 +54,17 @@ class Example1 extends React.Component {
   }
 
   render() {
+    const miniatureProps = {
+      position: 'left' as 'left',
+      background: '#fff',
+      width: 100,
+      height: 80
+    };
+
+    const toolbarProps = {
+      position: 'right' as 'right'
+    };
+
     return (
       <div>
         <button onClick={event => { if (this.Viewer) this.Viewer.zoomOnViewerCenter(1.1); }}>
@@ -36,7 +80,13 @@ class Example1 extends React.Component {
         <hr/>
 
         <ReactSVGPanZoom
+          toolbarProps={toolbarProps}
+          miniatureProps={miniatureProps}
           style={{border: "1px solid black"}}
+          tool={this.state.tool}
+          value={this.state.value}
+          onChangeTool={(tool: Tool) => this.setState({tool})}
+          onChangeValue={(value: Value) => this.setState({value})}
           width={500} height={500} ref={Viewer => this.Viewer = Viewer}
           onClick={(event: ViewerMouseEvent<any>)  => console.log('click', event.x, event.y, event.originalEvent)}
           onMouseUp={(event: ViewerMouseEvent<any>) => console.log('up', event.x, event.y)}
@@ -55,6 +105,16 @@ class Example1 extends React.Component {
           </svg>
         </ReactSVGPanZoom>
       </div>
+    );
+  }
+}
+class MyViewer extends React.Component {
+  render() {
+    return (
+      <UncontrolledReactSVGPanZoom
+        width={200} height={400}
+      >
+      </UncontrolledReactSVGPanZoom>
     );
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/chrvadala/react-svg-pan-zoom/blob/master/docs/migrate-from-v2-to-v3.md>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.