### PR TITLE
Added image-thumbnail types

### DIFF
--- a/types/image-thumbnail/image-thumbnail-tests.ts
+++ b/types/image-thumbnail/image-thumbnail-tests.ts
@@ -1,0 +1,14 @@
+import { createReadStream } from 'fs';
+import imageThumbnail = require('image-thumbnail');
+
+imageThumbnail({ uri: '' }); // $ExpectType Promise<Buffer>
+imageThumbnail({ uri: '' }, { responseType: 'base64' }); // $ExpectType Promise<string>
+
+imageThumbnail(''); // $ExpectType Promise<Buffer>
+imageThumbnail('', { responseType: 'base64' }); // $ExpectType Promise<string>
+
+imageThumbnail(Buffer.from([])); // $ExpectType Promise<Buffer>
+imageThumbnail(Buffer.from([]), { responseType: 'base64' }); // $ExpectType Promise<string>
+
+imageThumbnail(createReadStream('')); // $ExpectType Promise<Buffer>
+imageThumbnail(createReadStream(''), { responseType: 'base64' }); // $ExpectType Promise<string>

--- a/types/image-thumbnail/index.d.ts
+++ b/types/image-thumbnail/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for image-thumbnail 1.0
+// Project: https://github.com/onildoaguiar/image-thumbnail
+// Definitions by: Noam Alffasy <https://github.com/noamalffasy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { ReadStream } from 'fs';
+
+declare namespace ImageThumbnail {
+    interface Options {
+        percentage?: number;
+        width?: number;
+        height?: number;
+        responseType?: string;
+    }
+
+    interface Init {
+        (src: { uri: string } | string | Buffer | ReadStream, options?: { responseType: 'buffer' } & Options): Promise<
+            Buffer
+        >;
+        (src: { uri: string } | string | Buffer | ReadStream, options?: { responseType: 'base64' } & Options): Promise<
+            string
+        >;
+    }
+}
+
+declare const imageThumbnail: ImageThumbnail.Init;
+
+export = imageThumbnail;
+export as namespace imageThumbnail;

--- a/types/image-thumbnail/index.d.ts
+++ b/types/image-thumbnail/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for image-thumbnail 1.0
-// Project: https://github.com/onildoaguiar/image-thumbnail
+// Project: https://github.com/onildoaguiar/image-thumbnail#readme
 // Definitions by: Noam Alffasy <https://github.com/noamalffasy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -7,25 +7,22 @@
 
 import { ReadStream } from 'fs';
 
-declare namespace ImageThumbnail {
+export = imageFunction;
+
+declare function imageFunction(
+    src: { uri: string } | string | Buffer | ReadStream,
+    options?: { responseType: 'buffer' } & imageFunction.Options,
+): Promise<Buffer>;
+declare function imageFunction(
+    src: { uri: string } | string | Buffer | ReadStream,
+    options?: { responseType: 'base64' } & imageFunction.Options,
+): Promise<string>;
+
+declare namespace imageFunction {
     interface Options {
         percentage?: number;
         width?: number;
         height?: number;
         responseType?: string;
     }
-
-    interface Init {
-        (src: { uri: string } | string | Buffer | ReadStream, options?: { responseType: 'buffer' } & Options): Promise<
-            Buffer
-        >;
-        (src: { uri: string } | string | Buffer | ReadStream, options?: { responseType: 'base64' } & Options): Promise<
-            string
-        >;
-    }
 }
-
-declare const imageThumbnail: ImageThumbnail.Init;
-
-export = imageThumbnail;
-export as namespace imageThumbnail;

--- a/types/image-thumbnail/tsconfig.json
+++ b/types/image-thumbnail/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/image-thumbnail/tsconfig.json
+++ b/types/image-thumbnail/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "image-thumbnail-tests.ts"
+    ]
+}

--- a/types/image-thumbnail/tslint.json
+++ b/types/image-thumbnail/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/image-thumbnail/tslint.json
+++ b/types/image-thumbnail/tslint.json
@@ -1,3 +1,1 @@
-{
-    "extends": "dtslint/dt.json"
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.