### PR TITLE
Add types for nodemon

### DIFF
--- a/types/nodemon/index.d.ts
+++ b/types/nodemon/index.d.ts
@@ -1,0 +1,163 @@
+// Type definitions for nodemon 1.19
+// Project: http://nodemon.io
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export = nodemon;
+
+declare function nodemon(options: nodemon.Settings | string): typeof nodemon;
+
+declare namespace nodemon {
+    function restart(): void;
+
+    function addListener(event: string | symbol, listener: (...args: any[]) => void): typeof nodemon;
+    function addListener(
+        event: 'start' | 'exit' | 'crash' | 'config:update' | 'readable',
+        listener: () => void,
+    ): typeof nodemon;
+    function addListener(event: 'restart', listener: (files?: string[]) => void): typeof nodemon;
+    function addListener(event: 'quit', listener: (code?: number) => void): typeof nodemon;
+    function addListener(event: 'watching', listener: (file: string) => void): typeof nodemon;
+    function addListener(event: 'log', listener: (msg: LogMessage) => void): typeof nodemon;
+    function addListener(event: 'stdout' | 'stderr', listener: (data: Buffer) => void): typeof nodemon;
+
+    function on(event: string | symbol, listener: (...args: any[]) => void): typeof nodemon;
+    function on(event: 'start' | 'exit' | 'crash' | 'config:update' | 'readable', listener: () => void): typeof nodemon;
+    function on(event: 'restart', listener: (files?: string[]) => void): typeof nodemon;
+    function on(event: 'quit', listener: (code?: number) => void): typeof nodemon;
+    function on(event: 'watching', listener: (file: string) => void): typeof nodemon;
+    function on(event: 'log', listener: (msg: LogMessage) => void): typeof nodemon;
+    function on(event: 'stdout' | 'stderr', listener: (data: Buffer) => void): typeof nodemon;
+
+    function once(event: string | symbol, listener: (...args: any[]) => void): typeof nodemon;
+    function once(
+        event: 'start' | 'exit' | 'crash' | 'config:update' | 'readable',
+        listener: () => void,
+    ): typeof nodemon;
+    function once(event: 'quit', listener: (code?: number) => void): typeof nodemon;
+    function once(event: 'restart', listener: (files?: string[]) => void): typeof nodemon;
+    function once(event: 'watching', listener: (file: string) => void): typeof nodemon;
+    function once(event: 'log', listener: (msg: LogMessage) => void): typeof nodemon;
+    function once(event: 'stdout' | 'stderr', listener: (data: Buffer) => void): typeof nodemon;
+
+    function removeAllListeners(event?: string | symbol): typeof nodemon;
+
+    function emit(event: string | symbol, ...args: any[]): boolean;
+    function emit(event: 'start' | 'exit' | 'crash' | 'config:update' | 'readable'): boolean;
+    function emit(event: 'quit', code?: number): boolean;
+    function emit(event: 'restart', files?: string[]): boolean;
+    function emit(event: 'watching', listener: (file: string) => void): boolean;
+    function emit(event: 'log', msg: LogMessage): boolean;
+    function emit(event: 'stdout' | 'stderr', data: Buffer): boolean;
+
+    function reset(done?: () => void): void;
+
+    interface Settings {
+        env?: { [key: string]: string | boolean | number };
+        script?: string;
+        /**
+         * Extensions to look for, ie. js,jade,hbs.
+         */
+        ext?: string;
+        /**
+         * Execute script with "app", ie. -x "python -v". May use variables.
+         */
+        exec?: string;
+        /**
+         * Watch directory or file.  One entry per watched value.  Wildcards are allowed.
+         */
+        watch?: ReadonlyArray<string | { re: string }>;
+        /**
+         * Ignore specific files or directories.  One entry per ignored value.  Wildcards are allowed.
+         */
+        ignore?: ReadonlyArray<string | { re: string }>;
+        /**
+         * Minimise nodemon messages to start/stop only.
+         */
+        quiet?: boolean;
+        /**
+         * Show detail on what is causing restarts.
+         */
+        verbose?: boolean;
+        /**
+         * Try to read from stdin. Set to false to have nodemon pass stdin directly to child process
+         */
+        stdin?: boolean;
+        stdout?: boolean;
+        /**
+         * Execute script on change only, not startup
+         */
+        runOnChangeOnly?: boolean;
+        /**
+         * Debounce restart in seconds.
+         */
+        delay?: number;
+        /**
+         * Forces node to use the most compatible version for watching file changes.
+         *
+         * Use polling to watch for changes (typically needed when watching over a network/Docker)
+         */
+        legacyWatch?: boolean;
+        /**
+         * Exit on crash, allows use of nodemon with daemon tools like forever.js.
+         */
+        exitcrash?: boolean;
+        /**
+         * The global config file is useful for setting up default executables
+         */
+        execMap?: {
+            [k: string]: any;
+        };
+        events?: { [key: string]: string };
+        restartable?: string;
+        args?: ReadonlyArray<string>;
+        /**
+         * Arguments to pass to node if exec is "node"
+         */
+        nodeArgs?: ReadonlyArray<string>;
+        scriptPosition?: number;
+        /**
+         * Set to false to disable color output
+         */
+        colours?: boolean;
+        /**
+         * Change into <dir> before running the script
+         */
+        cwd?: string;
+        /**
+         * Print full debug configuration
+         */
+        dump?: boolean;
+        /**
+         * Root paths to ignore
+         */
+        ignoreRoot?: string[];
+        /**
+         * Opt-out of update version check
+         */
+        noUpdateNotifier?: boolean;
+        /**
+         * Combined with legacyWatch, milliseconds to poll for (default 100)
+         */
+        pollingInterval?: number;
+        /**
+         * Use specified kill signal instead of default (ex. SIGTERM)
+         */
+        signal?: {
+            [k: string]: any;
+        };
+        /**
+         * Force nodemon to use spawn (over fork) [node only]
+         */
+        spawn?: boolean;
+        [k: string]: any;
+    }
+
+    interface LogMessage {
+        type: string;
+        message: string;
+        colour: string;
+    }
+}

--- a/types/nodemon/nodemon-tests.ts
+++ b/types/nodemon/nodemon-tests.ts
@@ -1,0 +1,17 @@
+import nodemon = require('nodemon');
+
+nodemon({
+  script: 'app.js',
+  ext: 'js json'
+});
+
+nodemon.on('start', () => {
+  console.log('App has started');
+}).on('quit', () => {
+  console.log('App has quit');
+  process.exit();
+}).on('restart', (files) => {
+    // $ExpectType string[] | undefined
+    files;
+    console.log('App restarted due to: ', files);
+});

--- a/types/nodemon/tsconfig.json
+++ b/types/nodemon/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "nodemon-tests.ts"
+    ]
+}

--- a/types/nodemon/tslint.json
+++ b/types/nodemon/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
