### PR TITLE
[@types/cytoscape] Fix return type of eles.boundingBox. Closes #39080

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -634,3 +634,20 @@ cy.elements(':grabbable').dfs({ roots: '#1' });
 // TODO: traversing (need to actively check the nodes/edges distinction)
 // TODO: algorithms
 // TODO: compound nodes (there aren't any in current test case)
+
+// Check eles.boundingBox return type: https://js.cytoscape.org/#eles.boundingBox
+const box1 = eles.boundingBox({});
+box1.x1;
+box1.x2;
+box1.y1;
+box1.y2;
+box1.w;
+box1.h;
+// Check eles.renderedBoundingBox return type: https://js.cytoscape.org/#eles.renderedBoundingBox
+const box2 = eles.renderedBoundingBox({});
+box2.x1;
+box2.x2;
+box2.y1;
+box2.y2;
+box2.w;
+box2.h;

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1812,14 +1812,14 @@ declare namespace cytoscape {
          * @param options An object containing options for the function.
          * http://js.cytoscape.org/#eles.boundingBox
          */
-        boundingBox(options: BoundingBoxOptions): BoundingBox12 | BoundingBoxWH;
-        boundingbox(options: BoundingBoxOptions): BoundingBox12 | BoundingBoxWH;
+        boundingBox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        boundingbox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         /**
          * Get the bounding box of the elements in rendered coordinates.
          * @param options An object containing options for the function.
          */
-        renderedBoundingBox(options: BoundingBoxOptions): BoundingBox12 | BoundingBoxWH;
-        renderedBoundingbox(options: BoundingBoxOptions): BoundingBox12 | BoundingBoxWH;
+        renderedBoundingBox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        renderedBoundingbox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://js.cytoscape.org/#eles.boundingBox
