### PR TITLE
[react-helmet] Revert removal of default export

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -81,3 +81,4 @@ export const peek: () => HelmetData;
 export const rewind: () => HelmetData;
 export const renderStatic: () => HelmetData;
 export const canUseDOM: boolean;
+export default Helmet;

--- a/types/react-helmet/react-helmet-tests.tsx
+++ b/types/react-helmet/react-helmet-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Helmet, HelmetData } from "react-helmet";
+import HelmetDefaultExport from "react-helmet";
 
 const Application = () =>
     <div className="application">
@@ -102,6 +103,10 @@ function HTML() {
         }
     `}</style>
 </Helmet>;
+
+<HelmetDefaultExport>
+    <html lang="en" />
+</HelmetDefaultExport>;
 
 // $ExpectError
 <Helmet link={[ invalidProp: 'foo' ]} />;


### PR DESCRIPTION
Reverts one of the changes in #38557

The default export is still present in versions 5.x:
https://github.com/nfl/react-helmet/blob/5.2.0/src/Helmet.js#L287

It has only been removed in 6.0.0-beta.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfl/react-helmet/wiki/Upgrade-from-5.x.x----6.x.x-beta