### PR TITLE
Adds two private methods used when building custom adapters

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1482,6 +1482,10 @@ export namespace DS {
          * Determines the pathname for a given type.
          */
         pathForType<K extends keyof ModelRegistry>(modelName: K): string;
+
+        private parseErrorResponse(responseTest: string): any;
+
+        private normalizeErrorResponse(status: number, headers: any, payload: any): any[];
     }
     /**
      * ## Using Embedded Records


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/data/blob/master/packages/adapter/addon/rest.js#L1142-L1179

This change adds two private methods that may be overridden by folks building custom adapters.

Feels a bit off to have their return types be `any` and `any[]`, but this seems accurate based on the implementation.