### PR TITLE
mongodb: make `query` parameter to `distinct` optional

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -928,8 +928,9 @@ export interface Collection<TSchema = Default> {
     deleteOne(filter: FilterQuery<TSchema>, options?: CommonOptions & { bypassDocumentValidation?: boolean }): Promise<DeleteWriteOpResultObject>;
     deleteOne(filter: FilterQuery<TSchema>, options: CommonOptions & { bypassDocumentValidation?: boolean }, callback: MongoCallback<DeleteWriteOpResultObject>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#distinct */
+    distinct(key: string, callback: MongoCallback<any>): void;
     distinct(key: string, query: FilterQuery<TSchema>, callback: MongoCallback<any>): void;
-    distinct(key: string, query: FilterQuery<TSchema>, options?: { readPreference?: ReadPreference | string, maxTimeMS?: number, session?: ClientSession }): Promise<any>;
+    distinct(key: string, query?: FilterQuery<TSchema>, options?: { readPreference?: ReadPreference | string, maxTimeMS?: number, session?: ClientSession }): Promise<any>;
     distinct(key: string, query: FilterQuery<TSchema>, options: { readPreference?: ReadPreference | string, maxTimeMS?: number, session?: ClientSession }, callback: MongoCallback<any>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#drop */
     drop(options?: { session: ClientSession }): Promise<any>;

--- a/types/mongodb/test/collection/distinct.ts
+++ b/types/mongodb/test/collection/distinct.ts
@@ -1,0 +1,16 @@
+import { connectionString } from '../index';
+import { connect, MongoError } from 'mongodb';
+
+// test collection.distinct functions
+async function run() {
+  const client = await connect(connectionString);
+  const collection = client.db('test').collection('test.distinct');
+
+  collection.distinct('test', (err: MongoError, fields: any) => {});
+  collection.distinct('test', { foo: 1 }, (err: MongoError, fields: any) => {});
+  collection.distinct('test', { foo: 1 }, { maxTimeMS: 400 }, (err: MongoError, fields: any) => {});
+
+  collection.distinct('test'); // $ExpectType Promise<any>
+  collection.distinct('test', { foo: 1 }); // $ExpectType Promise<any>
+  collection.distinct('test', { foo: 1 }, { maxTimeMS: 400 }); // $ExpectType Promise<any>
+}

--- a/types/mongodb/tsconfig.json
+++ b/types/mongodb/tsconfig.json
@@ -29,6 +29,7 @@
         "test/collection/updateX.ts",
         "test/collection/mapReduce.ts",
         "test/collection/aggregate.ts",
-        "test/collection/count.ts"
+        "test/collection/count.ts",
+        "test/collection/distinct.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/mongodb/node-mongodb-native/blob/0463f7838dbfc0740f6fa52174b96241eb0c3980/lib/collection.js#L1516
  - https://github.com/mongodb/node-mongodb-native/pull/2162
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.