### PR TITLE
[@types/node] Add new function overload in 12.10 to fs.rmdir

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -684,6 +684,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException | null) => void): void;
+    function rmdir(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }, callback: (err: NodeJS.ErrnoException | null) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace rmdir {
@@ -692,6 +693,7 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
         function __promisify__(path: PathLike): Promise<void>;
+        function __promisify__(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }): Promise<void>;
     }
 
     /**
@@ -699,6 +701,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdirSync(path: PathLike): void;
+    function rmdirSync(path: PathLike, options: { recursive?: boolean; }): void;
 
     export interface MakeDirectoryOptions {
         /**
@@ -2031,6 +2034,7 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
         function rmdir(path: PathLike): Promise<void>;
+        function rmdir(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }): Promise<void>;
 
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -679,12 +679,18 @@ declare module "fs" {
      */
     function unlinkSync(path: PathLike): void;
 
+    interface RmdirOptions {
+        emfileWait?: number;
+        maxBusyTries?: number;
+        recursive?: boolean;
+    }
+
     /**
      * Asynchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException | null) => void): void;
-    function rmdir(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }, callback: (err: NodeJS.ErrnoException | null) => void): void;
+    function rmdir(path: PathLike, options: RmdirOptions, callback: (err: NodeJS.ErrnoException | null) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace rmdir {
@@ -692,16 +698,14 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike): Promise<void>;
-        function __promisify__(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }): Promise<void>;
+        function __promisify__(path: PathLike, options?: RmdirOptions): Promise<void>;
     }
 
     /**
      * Synchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function rmdirSync(path: PathLike): void;
-    function rmdirSync(path: PathLike, options: { recursive?: boolean; }): void;
+    function rmdirSync(path: PathLike, options?: { recursive?: boolean; }): void;
 
     export interface MakeDirectoryOptions {
         /**
@@ -2033,8 +2037,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function rmdir(path: PathLike): Promise<void>;
-        function rmdir(path: PathLike, options: { emfileWait?: number; maxBusyTries?: number; recursive?: boolean; }): Promise<void>;
+        function rmdir(path: PathLike, options?: RmdirOptions): Promise<void>;
 
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -679,10 +679,27 @@ declare module "fs" {
      */
     function unlinkSync(path: PathLike): void;
 
-    interface RmdirOptions {
-        emfileWait?: number;
-        maxBusyTries?: number;
+    export interface RmdirSyncOptions {
+        /**
+         * If true, perform a recursive directory removal. In recursive mode, errors are not reported if path does not
+         * exist, and operations are retried on failure. Default: false.
+         */
         recursive?: boolean;
+    }
+
+    export interface RmdirOptions extends RmdirSyncOptions {
+        /**
+         * If an EMFILE error is encountered, Node.js will retry the operation with a linear backoff of 1ms longer on
+         * each try until the timeout duration passes this limit. This option is ignored if the recursive option is not
+         * true. Default: 1000.
+         */
+        emfileWait?: number;
+        /**
+         * If an EBUSY, ENOTEMPTY, or EPERM error is encountered, Node.js will retry the operation with a linear backoff
+         * wait of 100ms longer on each try. This option represents the number of retries. This option is ignored if the
+         * recursive option is not true. Default: 3.
+         */
+        maxBusyTries?: number;
     }
 
     /**
@@ -690,6 +707,12 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException | null) => void): void;
+
+    /**
+     * Asynchronous rmdir(2) - delete a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options An object optionally specifying the retry behavior and whether to recursively delete subdirectories.
+     */
     function rmdir(path: PathLike, options: RmdirOptions, callback: (err: NodeJS.ErrnoException | null) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -697,6 +720,7 @@ declare module "fs" {
         /**
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param options An object optionally specifying the retry behavior and whether to recursively delete subdirectories.
          */
         function __promisify__(path: PathLike, options?: RmdirOptions): Promise<void>;
     }
@@ -704,8 +728,9 @@ declare module "fs" {
     /**
      * Synchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options An object optionally specifying whether to recursively delete subdirectories.
      */
-    function rmdirSync(path: PathLike, options?: { recursive?: boolean; }): void;
+    function rmdirSync(path: PathLike, options?: RmdirSyncOptions): void;
 
     export interface MakeDirectoryOptions {
         /**
@@ -2036,6 +2061,7 @@ declare module "fs" {
         /**
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param options An object optionally specifying the retry behavior and whether to recursively delete subdirectories.
          */
         function rmdir(path: PathLike, options?: RmdirOptions): Promise<void>;
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -38,6 +38,7 @@
 //                 Marcin Kopacz <https://github.com/chyzwar>
 //                 Trivikram Kamat <https://github.com/trivikr>
 //                 Minh Son Nguyen <https://github.com/nguymin4>
+//                 Hannes Leutloff <https://github.com/yeldiRium>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.


### PR DESCRIPTION
Resolves #39103.

In Node.JS 12.10.0 new options were added for [fs.rmdir](https://nodejs.org/api/fs.html#fs_fs_rmdir_path_options_callback), [fs.rmdirSync](https://nodejs.org/api/fs.html#fs_fs_rmdirsync_path_options) and [fs.promises.rmdir](https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html (Also individually linked above)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.