### PR TITLE
Add type declarations for @hig/button

### DIFF
--- a/types/hig__button/hig__button-tests.tsx
+++ b/types/hig__button/hig__button-tests.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Button, { targets, types, widths, AvailableTargets, AvailableTypes, AvailableWidths } from '@hig/button';
+
+/** Button */
+const emptyFunc = () => {};
+const disabled = true;
+const icon = <div />;
+const link = '';
+const onClick = emptyFunc;
+const onBlur = emptyFunc;
+const onFocus = emptyFunc;
+const onHover = emptyFunc;
+const onMouseDown = emptyFunc;
+const onMouseEnter = emptyFunc;
+const onMouseLeave = emptyFunc;
+const onMouseUp = emptyFunc;
+const stylesheet = emptyFunc;
+const target = targets.BLANK;
+const title = '';
+const type = types.FLAT;
+const width = widths.GROW;
+
+// Minimal props
+<Button title="button" />;
+
+// All props
+<Button
+    disabled={disabled}
+    icon={icon}
+    link={link}
+    onClick={onClick}
+    onBlur={onBlur}
+    onFocus={onFocus}
+    onHover={onHover}
+    onMouseDown={onMouseDown}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+    onMouseUp={onMouseUp}
+    stylesheet={stylesheet}
+    target={target}
+    title={title}
+    type={type}
+    width={width}
+/>;
+
+/** Targets */
+const target1: AvailableTargets = targets.BLANK;
+const target2: AvailableTargets = targets.PARENT;
+const target3: AvailableTargets = targets.SELF;
+const target4: AvailableTargets = targets.TOP;
+
+/** Types */
+const types1: AvailableTypes = types.FLAT;
+const types2: AvailableTypes = types.OUTLINE;
+const types3: AvailableTypes = types.PRIMARY;
+const types4: AvailableTypes = types.SECONDARY;
+const types5: AvailableTypes = types.SOLID;
+
+/** Widths */
+const widths1: AvailableWidths = widths.GROW;
+const widths2: AvailableWidths = widths.SHRINK;

--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -4,6 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+// Turn off automatic exporting
+export {};
+
 import * as React from 'react';
 
 type Callback = () => void;

--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for hig__button 1.4.3
+// Project: https://github.com/Autodesk/hig/tree/development/packages/button
+// Definitions by: Matthew Bryant <https://github.com/matthewbryant95>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+type Callback = () => void;
+
+export interface Targets {
+    SELF: '_self';
+    BLANK: '_blank';
+    PARENT: '_parent';
+    TOP: '_top';
+}
+export interface Types {
+    FLAT: 'flat';
+    OUTLINE: 'outline';
+    SOLID: 'solid';
+    /** @deprecated */
+    PRIMARY: 'primary';
+    /** @deprecated */
+    SECONDARY: 'secondary';
+}
+export interface Widths {
+    SHRINK: 'shrink';
+    GROW: 'grow';
+}
+export type AvailableTargets = Targets[keyof Targets];
+export type AvailableTypes = Types[keyof Types];
+export type AvailableWidths = Widths[keyof Widths];
+
+export interface Props {
+    /** Prevents user interaction with the button */
+    disabled?: boolean;
+    /** A @hig/icon element */
+    icon?: JSX.Element;
+    /** Sets the link of a button */
+    link?: string;
+    /** Triggers when you click the button */
+    onClick?: Callback;
+    /** Triggers blur when focus is moved away from icon */
+    onBlur?: Callback;
+    /** Triggers when focus is moved to button */
+    onFocus?: Callback;
+    /** Triggers when you hover over the button */
+    onHover?: Callback;
+    /** Triggers when the user's mouse is pressed over the button */
+    onMouseDown?: Callback;
+    /** Triggers when the user's mouse is over the button */
+    onMouseEnter?: Callback;
+    /** Triggers when the user's mouse is no longer over the button */
+    onMouseLeave?: Callback;
+    /** Triggers when the user's mouse is no longer pressed over the button */
+    onMouseUp?: Callback;
+    /** Adds custom/overriding styles */
+    stylesheet?: unknown;
+    /** Specifies where to display the linked URL */
+    target?: AvailableTargets;
+    /** Sets the title of a button */
+    title: string;
+    /** Specifies type of button */
+    type?: AvailableTypes;
+    /** Specifies width of button */
+    width?: AvailableWidths;
+}
+
+export const availableTargets: AvailableTargets;
+export const availableTypes: AvailableTypes;
+export const availableWidths: AvailableWidths;
+export const targets: Targets;
+export const types: Types;
+export const widths: Widths;
+
+export default class Button extends React.Component<Props> {}

--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Autodesk/hig/tree/development/packages/button
 // Definitions by: Matthew Bryant <https://github.com/matthewbryant95>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Autodesk/hig/tree/development/packages/button
 // Definitions by: Matthew Bryant <https://github.com/matthewbryant95>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import * as React from 'react';
 

--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hig__button 1.4.3
+// Type definitions for hig__button 1.4
 // Project: https://github.com/Autodesk/hig/tree/development/packages/button
 // Definitions by: Matthew Bryant <https://github.com/matthewbryant95>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/hig__button/tsconfig.json
+++ b/types/hig__button/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "jsx": "react",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@hig/button": ["hig__button"]
+        }
+    },
+    "files": ["index.d.ts", "hig__button-tests.tsx"]
+}

--- a/types/hig__button/tslint.json
+++ b/types/hig__button/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.