### PR TITLE
[dojo] Use gender-neutral pronouns

### DIFF
--- a/types/dojo/dojox.css3.d.ts
+++ b/types/dojo/dojox.css3.d.ts
@@ -187,8 +187,8 @@ declare namespace dojox {
              */
             expand(args: Object): any;
             /**
-             * Returns an animation that flips an element around his y axis.
-             * Flips an element around his y axis. The default is a 360deg flip
+             * Returns an animation that flips an element around its y axis.
+             * Flips an element around its y axis. The default is a 360deg flip
              * but it is possible to run a partial flip using args.whichAnims.
              *
              * @param args

--- a/types/dojo/dojox.fx.d.ts
+++ b/types/dojo/dojox.fx.d.ts
@@ -937,9 +937,9 @@ declare namespace dojox {
              * "both" (default) : both
              *
              * axis: String
-             * "center" (default)      : the node is flipped around his center
-             * "shortside"             : the node is flipped around his "short" (in perspective) side
-             * "longside"              : the node is flipped around his "long" (in perspective) side
+             * "center" (default)      : the node is flipped around its center
+             * "shortside"             : the node is flipped around its "short" (in perspective) side
+             * "longside"              : the node is flipped around its "long" (in perspective) side
              * "cube"                  : the node flips around the central axis of the cube
              *
              * shift: Integer:
@@ -1156,9 +1156,9 @@ declare namespace dojox {
              * "both" (default) : both
              *
              * axis: String
-             * "center" (default)      : the node is flipped around his center
-             * "shortside"             : the node is flipped around his "short" (in perspective) side
-             * "longside"              : the node is flipped around his "long" (in perspective) side
+             * "center" (default)      : the node is flipped around its center
+             * "shortside"             : the node is flipped around its "short" (in perspective) side
+             * "longside"              : the node is flipped around its "long" (in perspective) side
              * "cube"                  : the node flips around the central axis of the cube
              *
              * shift: Integer:
@@ -1413,9 +1413,9 @@ declare namespace dojox {
              * "both" (default) : both
              *
              * axis: String
-             * "center" (default)      : the node is flipped around his center
-             * "shortside"             : the node is flipped around his "short" (in perspective) side
-             * "longside"              : the node is flipped around his "long" (in perspective) side
+             * "center" (default)      : the node is flipped around its center
+             * "shortside"             : the node is flipped around its "short" (in perspective) side
+             * "longside"              : the node is flipped around its "long" (in perspective) side
              * "cube"                  : the node flips around the central axis of the cube
              *
              * shift: Integer:
@@ -1654,9 +1654,9 @@ declare namespace dojox {
              * "both" (default) : both
              *
              * axis: String
-             * "center" (default)      : the node is flipped around his center
-             * "shortside"             : the node is flipped around his "short" (in perspective) side
-             * "longside"              : the node is flipped around his "long" (in perspective) side
+             * "center" (default)      : the node is flipped around its center
+             * "shortside"             : the node is flipped around its "short" (in perspective) side
+             * "longside"              : the node is flipped around its "long" (in perspective) side
              * "cube"                  : the node flips around the central axis of the cube
              *
              * shift: Integer:

--- a/types/dojo/dojox.mdnd.d.ts
+++ b/types/dojo/dojox.mdnd.d.ts
@@ -267,7 +267,7 @@ declare namespace dojox {
             constructor(params: Object, node: HTMLElement);
             /**
              * The user clicks on the handle, but the drag action will really begin
-             * if he tracks the main node to more than 3 pixels.
+             * if they track the main node to more than 3 pixels.
              *
              */
             "dragDistance": number;
@@ -795,7 +795,7 @@ declare namespace dojox {
                  * return for:
                  *
                  * X point : the middle
-                 * Y point : search if the user goes up or goes down with his mouse.
+                 * Y point : search if the user goes up or goes down with their mouse.
                  * Up : top of the draggable item
                  * Down : bottom of the draggable item
                  *
@@ -940,7 +940,7 @@ declare namespace dojox {
                  * return for:
                  *
                  * X point : the middle
-                 * Y point : search if the user goes up or goes down with his mouse.
+                 * Y point : search if the user goes up or goes down with their mouse.
                  * Up : top of the draggable item
                  * Down : bottom of the draggable item
                  *


### PR DESCRIPTION
Continuation of #39053 since Dojo types were large enough to make CI run out of memory. This commit fixes up that single remaining package.