### PR TITLE
ramda: improve mapObjIndexed typing

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1773,18 +1773,19 @@ declare namespace R {
         /**
          * Like mapObj, but but passes additional arguments to the predicate function.
          */
-        mapObjIndexed<T, TResult>(
-            fn: (value: T, key: string, obj?: {
-                [key: string]: T
-            }) => TResult,
-            obj: {
-                [key: string]: T
-            }
+        mapObjIndexed<T extends object, V>(
+            fn: (value: T[keyof T], key: keyof T, obj: T) => V,
+            obj: T,
         ): {
-            [key: string]: TResult
+            [K in keyof T]: V;
         };
-        mapObjIndexed<T, TResult>(fn: (value: T, key: string, obj?: any) => TResult, obj: any): { [index: string]: TResult };
-        mapObjIndexed<T, TResult>(fn: (value: T, key: string, obj?: any) => TResult): (obj: any) => { [index: string]: TResult };
+        mapObjIndexed<T extends object = any , V = any>(
+            fn: (value: T[keyof T], key: keyof T, obj: T) => V,
+        ): (
+            obj: T,
+        ) => {
+            [K in keyof T]: V;
+        };
 
         /**
          * Tests a regular expression agains a String

--- a/types/ramda/test/mapObjIndexed-tests.ts
+++ b/types/ramda/test/mapObjIndexed-tests.ts
@@ -22,3 +22,23 @@ import * as R from 'ramda';
   }, testObject);
   console.log(errorMessages);
 };
+
+() => {
+    interface Student {
+        name: string;
+        teacherName: string;
+    }
+
+    const s: Student = {
+        name: 'sn',
+        teacherName: 'tn',
+    };
+
+    const ns: Student = R.mapObjIndexed((value, key) => value, s);
+
+    const ns1: Student = R.mapObjIndexed<Student, string>((value, key) => value)(s);
+
+    const ns2: {
+        [index: string]: any;
+    } = R.mapObjIndexed((value, key) => value)(s);
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

provider narrower typing of mapObjIndexed, see:
```typescript
    interface Student {
        name: string;
        teacherName: string;
    }

    const s: Student = {
        name: 'sn',
        teacherName: 'tn',
    };

    const ns: Student = R.mapObjIndexed((value, key) => value, s);

    const ns1: Student = R.mapObjIndexed<Student, string>((value, key) => value)(s);

    const ns2: {
        [index: string]: any;
    } = R.mapObjIndexed((value, key) => value)(s);
```
Before this commit, the `ns` ,`ns1`, `ns2` will be infer as `{ [index:string]: string}`