### PR TITLE
Add typings for jest-matcher-one-of

### DIFF
--- a/types/jest-matcher-one-of/index.d.ts
+++ b/types/jest-matcher-one-of/index.d.ts
@@ -2,10 +2,9 @@
 // Project: https://github.com/d4nyll/jest-matcher-one-of#readme
 // Definitions by: Joe Mitchard <https://github.com/joemitchard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
-declare module 'jest-matcher-one-of';
-
 declare namespace jest {
     interface Matchers<R> {
         toBeOneOf(expected: any[]): R;

--- a/types/jest-matcher-one-of/index.d.ts
+++ b/types/jest-matcher-one-of/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for jest-matcher-one-of 1.0
+// Project: https://github.com/d4nyll/jest-matcher-one-of#readme
+// Definitions by: Joe Mitchard <https://github.com/joemitchard>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="jest" />
+declare module 'jest-matcher-one-of';
+
+declare namespace jest {
+    interface Matchers<R> {
+        toBeOneOf(expected: any[]): R;
+    }
+}

--- a/types/jest-matcher-one-of/jest-matcher-one-of-tests.ts
+++ b/types/jest-matcher-one-of/jest-matcher-one-of-tests.ts
@@ -1,0 +1,1 @@
+expect('x').toBeOneOf(['x', 'y']);

--- a/types/jest-matcher-one-of/tsconfig.json
+++ b/types/jest-matcher-one-of/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jest-matcher-one-of-tests.ts"
+    ]
+}

--- a/types/jest-matcher-one-of/tslint.json
+++ b/types/jest-matcher-one-of/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
