### PR TITLE
Add more permissive interface for RelationshipMeta options

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -35,11 +35,18 @@ interface AttributeMeta<Model extends DS.Model> {
     parentType: Model;
     isAttribute: true;
 }
+
+interface RelationshipMetaOptions {
+    async?: boolean;
+    inverse?: string;
+    polymorphic?: boolean;
+    [k: string]: any;
+}
 interface RelationshipMeta<Model extends DS.Model> {
     key: RelationshipsFor<Model>;
     kind: 'belongsTo' | 'hasMany';
     type: keyof ModelRegistry;
-    options: object;
+    options: RelationshipMetaOptions;
     name: string;
     parentType: Model;
     isRelationship: true;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Unfortunately  there's no simple link  to provide for this

Currently `RelationshipMeta` options  are  types as `object`.  This is incorrect in  practice.

Generally this  is only of interest to folks  creating custom adapters  and serializers, so not a huge deal, but when working on libraries (such as active-model-adapter), this is more troublesome.

This PR makes the options more permissive, documenting know options keys and providing an 'any' option for keys that are as yet unknown.