### PR TITLE
[react-native] Adds StyleSheet.compose definition

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -25,6 +25,7 @@
 //                 Eli White <https://github.com/TheSavior>
 //                 Romain Faust <https://github.com/romain-faust>
 //                 Be Birchall <https://github.com/bebebebebe>
+//                 Felix Haus <https://github.com/ofhouse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -5091,6 +5092,14 @@ export namespace StyleSheet {
      * the alternative use.
      */
     export function flatten<T>(style?: StyleProp<T>): T;
+
+    /**
+     * Combines two styles such that style2 will override any styles in style1.
+     * If either style is falsy, the other one is returned without allocating
+     * an array, saving allocations and maintaining reference equality for
+     * PureComponent checks.
+     */
+    export function compose<T>(style1?: StyleProp<T>, style2?: StyleProp<T>): T;
 
     /**
      * WARNING: EXPERIMENTAL. Breaking changes will probably happen a lot and will

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -193,6 +193,31 @@ const s = StyleSheet.create({
 });
 const f1: TextStyle = s.shouldWork;
 
+// StyleSheet.compose
+// It create a new style object by composing two existing styles
+const composeTextStyle1: StyleProp<TextStyle> = {
+    color: '#000000',
+    fontSize: 20,
+};
+
+const composeTextStyle2: StyleProp<TextStyle> = {
+    fontSize: 12,
+};
+
+const composeImageStyle: StyleProp<ImageStyle> = {
+    resizeMode: 'contain',
+};
+
+// It should only possible to combine styles from the same type,
+// so the following code is invalid:
+// const noCombinedStyle2 = StyleSheet.compose(composeImageStyle, composeTextStyle2);
+
+// Composing two styles from the same type is fine
+const combinedStyle2 = StyleSheet.compose(
+    composeTextStyle1,
+    composeTextStyle2,
+);
+
 const testNativeSyntheticEvent = <T extends {}>(e: NativeSyntheticEvent<T>): void => {
     e.isDefaultPrevented();
     e.preventDefault();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/stylesheet#compose
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR adds the definition for static method `Stylesheet.compose` which is documented [here].(https://facebook.github.io/react-native/docs/stylesheet#compose)
