### PR TITLE
[@types/ignore-walk] add types definition for ignore-walk

### DIFF
--- a/types/ignore-walk/ignore-walk-tests.ts
+++ b/types/ignore-walk/ignore-walk-tests.ts
@@ -1,0 +1,17 @@
+import walk = require('ignore-walk');
+
+walk({
+  path: process.cwd(),
+  ignoreFiles: ['.gitignore'],
+  includeEmpty: true
+});
+
+walk().then((results) => {
+  console.log(results);
+});
+
+walk.sync({path: '/path/to/file'});
+walk.sync();
+
+const walker = new walk.WalkerSync();
+console.log((walker.start().result as string[]).filter(entry => entry.substring(0, 5) !== '.git/'));

--- a/types/ignore-walk/index.d.ts
+++ b/types/ignore-walk/index.d.ts
@@ -1,0 +1,79 @@
+// Type definitions for ignore-walk 3.0
+// Project: https://github.com/isaacs/ignore-walk#readme
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types='node' />
+
+import { EventEmitter } from 'events';
+import { Stats } from 'fs';
+
+declare function walk(options?: walk.WalkerOptions, callback?: (results: Set<string>) => void): Promise<Set<string>>;
+declare namespace walk {
+    function sync(options?: WalkerOptions): WalkerSync;
+
+    interface WalkerOptions {
+        path?: string;
+        ignoreFiles?: string[];
+        parent?: Walker | WalkerSync | null;
+        includeEmpty?: boolean;
+        follow?: boolean;
+    }
+
+    class Walker extends EventEmitter {
+        path: string;
+        basename: string;
+        ignoreFiles: string[];
+        ignoreRules: {[file: string]: string};
+        parent: Walker | WalkerSync | null;
+        includeEmpty: boolean;
+        root: string;
+        follow: boolean;
+        result: Set<string> | string[];
+        entries: string[];
+        sawError: boolean;
+
+        constructor(opts?: WalkerOptions);
+        sort(a: string, b: string): number;
+        emit(ev: string, data: any): boolean;
+        start(): this;
+        isIgnoreFile(e: string): boolean;
+        onReaddir(entries: string[]): void;
+        addIgnoreFiles(): void;
+        addIgnoreFile(file: string, then: () => void): void;
+        onReadIgnoreFile(file: string, data: string, then: () => void): void;
+        filterEntries(): void;
+        onstat(st: Stats, entry: string, file: boolean, dir: boolean, then: () => void): void;
+        stat(entry: string, file: boolean, dir: boolean, the: () => void): void;
+        walkerOpt(entry: string): {
+            path: string;
+            ignoreFiles: string[];
+            parent: Walker | WalkerSync;
+            includeEmpty: boolean;
+            follow: boolean;
+        };
+        walker(entry: string, then: () => void): void;
+        filterEntry(entry: string, partial: boolean): boolean;
+
+        addListener(event: 'error', listener: (err: Error) => void): this;
+        addListener(event: 'done', listener: (data: string[]) => void): this;
+        on(event: 'error', listener: (err: Error) => void): this;
+        on(event: 'done', listener: (data: string[]) => void): this;
+        once(event: 'error', listener: (err: Error) => void): this;
+        once(event: 'done', listener: (data: string[]) => void): this;
+        prependListener(event: 'error', listener: (err: Error) => void): this;
+        prependListener(event: 'done', listener: (data: string[]) => void): this;
+        prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+        prependOnceListener(event: 'done', listener: (data: string[]) => void): this;
+    }
+
+    class WalkerSync extends Walker {
+        constructor(opts?: WalkerOptions);
+        start(): this;
+        addIgnoreFile(file: string, then: () => void): void;
+        stat(entry: string, file: boolean, dir: boolean, then: () => void): void;
+        walker(entry: string, then: () => void): void;
+    }
+}
+
+export = walk;

--- a/types/ignore-walk/tsconfig.json
+++ b/types/ignore-walk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ignore-walk-tests.ts"
+    ]
+}

--- a/types/ignore-walk/tslint.json
+++ b/types/ignore-walk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds types for [ignore-walk](https://npmjs.com/package/ignore-walk).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.