### PR TITLE
Add types for camunda-external-task-client-js

### DIFF
--- a/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
+++ b/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
@@ -1,0 +1,5 @@
+import { Client, Variables } from 'camunda-external-task-client-js';
+
+new Client({ baseUrl: '' }); // $ExpectType Client
+new Variables(); // $ExpectType Variables
+new Variables().set('a', 42).getAllTyped(); // $ExpectType TypedValue[]

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -4,8 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-export class Client {
-    constructor(config: {
+declare namespace CamundaExternalTaskClient {
+    class Client {
+        constructor(config: ClientConfig);
+        start(): void;
+        stop(): void;
+        subscribe(topic: string, options: SubscribeOptions, handler: Handler): TopicSubscription;
+        subscribe(topic: string, handler: Handler): TopicSubscription;
+    }
+
+    interface ClientConfig {
         baseUrl: string;
         workerId?: string;
         maxTasks?: number;
@@ -16,134 +24,99 @@ export class Client {
         asyncResponseTimeout?: number;
         interceptors?: Interceptor | Interceptor[];
         use?: Middleware | Middleware[];
-    });
+    }
 
-    start(): void;
+    class Variables {
+        get(variableName: string): Value;
+        getTyped(variableName: string): TypedValue;
+        getAll(): Value[];
+        getAllTyped(): TypedValue[];
+        set(variableName: string, value: Value): Variables;
+        setTyped(variableName: string, typedValue: TypedValue): Variables;
+        setAll(values: { [key: string]: Value }): Variables;
+        setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
+    }
 
-    stop(): void;
+    type Handler = (args: HandlerArgs) => void;
 
-    subscribe(
-        topic: string,
-        options: SubscribeOptions,
-        handler: Handler,
-    ): TopicSubscription;
+    interface HandlerArgs {
+        task: Task;
+        taskService: TaskService;
+    }
 
-    subscribe(
-        topic: string,
-        handler: Handler,
-    ): TopicSubscription;
+    interface Task {
+        variables: Variables;
+
+        // These are not guaranteed by package documentation, but are returned according to REST API docs
+        activityId?: string;
+        activityInstanceId?: string;
+        businessKey?: string;
+        errorDetails?: string;
+        errorMessage?: string;
+        executionId?: string;
+        id?: string;
+        lockExpirationTime?: string;
+        priority?: number;
+        processDefinitionId?: string;
+        processDefinitionKey?: string;
+        processInstanceId?: string;
+        retries?: number;
+        tenantId?: string;
+        topicName?: string;
+        workerId?: string;
+    }
+
+    type Value = any;
+
+    interface TypedValue {
+        value: Value;
+        type: string;
+        valueInfo: object;
+    }
+
+    interface TaskService {
+        complete(task: Task, processVariables?: Variables, localVariables?: Variables): void;
+        handleFailure(task: Task, options?: HandleFailureOptions): void;
+        handleBpmnError(task: Task, errorCode: string, errorMessage?: string, variables?: Variables): void;
+        extendLock(task: Task, newDuration: number): void;
+        unlock(task: Task): void;
+    }
+
+    interface HandleFailureOptions {
+        errorMessage?: string;
+        errorDetails?: string;
+        retires?: number;
+        retryTimeout?: number;
+    }
+
+    interface SubscribeOptions {
+        lockDuration?: number;
+        variables?: any[];
+        businessKey?: string;
+        processDefinitionId?: string;
+        processDefinitionIdIn?: string;
+        processDefinitionKey?: string;
+        processDefinitionKeyIn?: string;
+        processDefinitionVersionTag?: string;
+        withoutTenantId?: boolean;
+        tenantIdIn?: string[];
+    }
+
+    interface TopicSubscription {
+        unsubscribe: () => void;
+    }
+
+    type Interceptor = <T = any>(config: T) => T;
+
+    type Middleware = (client: Client) => void;
+
+    type Logger = Middleware & {
+        success(text: string): void;
+        error(text: string): void;
+    };
+
+    const logger: Logger;
 }
 
-export class Variables {
-    get(variableName: string): Value;
-
-    getTyped(variableName: string): TypedValue;
-
-    getAll(): Value[];
-
-    getAllTyped(): TypedValue[];
-
-    set(variableName: string, value: Value): Variables;
-
-    setTyped(variableName: string, typedValue: TypedValue): Variables;
-
-    setAll(values: { [key: string]: Value }): Variables;
-
-    setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
-}
-
-type Handler = (args: HandlerArgs) => void;
-
-interface HandlerArgs {
-    task: Task;
-    taskService: TaskService;
-}
-
-interface Task {
-    variables: Variables;
-
-    // These are not guaranteed by package documentation, but are returned according to REST API docs
-    activityId?: string;
-    activityInstanceId?: string;
-    businessKey?: string;
-    errorDetails?: string;
-    errorMessage?: string;
-    executionId?: string;
-    id?: string;
-    lockExpirationTime?: string;
-    priority?: number;
-    processDefinitionId?: string;
-    processDefinitionKey?: string;
-    processInstanceId?: string;
-    retries?: number;
-    tenantId?: string;
-    topicName?: string;
-    workerId?: string;
-}
-
-type Value = any;
-
-interface TypedValue {
-    value: Value;
-    type: string;
-    valueInfo: object;
-}
-
-interface TaskService {
-    complete(
-        task: Task,
-        processVariables?: Variables,
-        localVariables?: Variables,
-    ): void;
-
-    handleFailure(task: Task, options?: HandleFailureOptions): void;
-
-    handleBpmnError(
-        task: Task,
-        errorCode: string,
-        errorMessage?: string,
-        variables?: Variables,
-    ): void;
-
-    extendLock(task: Task, newDuration: number): void;
-
-    unlock(task: Task): void;
-}
-
-interface HandleFailureOptions {
-    errorMessage?: string;
-    errorDetails?: string;
-    retires?: number;
-    retryTimeout?: number;
-}
-
-interface SubscribeOptions {
-    lockDuration?: number;
-    variables?: any[];
-    businessKey?: string;
-    processDefinitionId?: string;
-    processDefinitionIdIn?: string;
-    processDefinitionKey?: string;
-    processDefinitionKeyIn?: string;
-    processDefinitionVersionTag?: string;
-    withoutTenantId?: boolean;
-    tenantIdIn?: string[];
-}
-
-interface TopicSubscription {
-    unsubscribe: () => void;
-}
-
-type Interceptor = <T = any>(config: T) => T;
-
-type Middleware = (client: Client) => void;
-
-type Logger = Middleware & {
-    success(text: string): void;
-
-    error(text: string): void;
-};
-
-export const logger: Logger;
-
-export {};
+/* tslint:disable-next-line export-just-namespace */
+export = CamundaExternalTaskClient;

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -1,0 +1,149 @@
+// Type definitions for camunda-external-task-client-js 1.2
+// Project: https://github.com/camunda/camunda-external-task-client-js#readme
+// Definitions by: MacRusher <https://github.com/MacRusher>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+export class Client {
+    constructor(config: {
+        baseUrl: string;
+        workerId?: string;
+        maxTasks?: number;
+        maxParallelExecutions?: number;
+        interval?: number;
+        lockDuration?: number;
+        autoPoll?: boolean;
+        asyncResponseTimeout?: number;
+        interceptors?: Interceptor | Interceptor[];
+        use?: Middleware | Middleware[];
+    });
+
+    start(): void;
+
+    stop(): void;
+
+    subscribe(
+        topic: string,
+        options: SubscribeOptions,
+        handler: Handler,
+    ): TopicSubscription;
+
+    subscribe(
+        topic: string,
+        handler: Handler,
+    ): TopicSubscription;
+}
+
+export class Variables {
+    get(variableName: string): Value;
+
+    getTyped(variableName: string): TypedValue;
+
+    getAll(): Value[];
+
+    getAllTyped(): TypedValue[];
+
+    set(variableName: string, value: Value): Variables;
+
+    setTyped(variableName: string, typedValue: TypedValue): Variables;
+
+    setAll(values: { [key: string]: Value }): Variables;
+
+    setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
+}
+
+type Handler = (args: HandlerArgs) => void;
+
+interface HandlerArgs {
+    task: Task;
+    taskService: TaskService;
+}
+
+interface Task {
+    variables: Variables;
+
+    // These are not guaranteed by package documentation, but are returned according to REST API docs
+    activityId?: string;
+    activityInstanceId?: string;
+    businessKey?: string;
+    errorDetails?: string;
+    errorMessage?: string;
+    executionId?: string;
+    id?: string;
+    lockExpirationTime?: string;
+    priority?: number;
+    processDefinitionId?: string;
+    processDefinitionKey?: string;
+    processInstanceId?: string;
+    retries?: number;
+    tenantId?: string;
+    topicName?: string;
+    workerId?: string;
+}
+
+type Value = any;
+
+interface TypedValue {
+    value: Value;
+    type: string;
+    valueInfo: object;
+}
+
+interface TaskService {
+    complete(
+        task: Task,
+        processVariables?: Variables,
+        localVariables?: Variables,
+    ): void;
+
+    handleFailure(task: Task, options?: HandleFailureOptions): void;
+
+    handleBpmnError(
+        task: Task,
+        errorCode: string,
+        errorMessage?: string,
+        variables?: Variables,
+    ): void;
+
+    extendLock(task: Task, newDuration: number): void;
+
+    unlock(task: Task): void;
+}
+
+interface HandleFailureOptions {
+    errorMessage?: string;
+    errorDetails?: string;
+    retires?: number;
+    retryTimeout?: number;
+}
+
+interface SubscribeOptions {
+    lockDuration?: number;
+    variables?: any[];
+    businessKey?: string;
+    processDefinitionId?: string;
+    processDefinitionIdIn?: string;
+    processDefinitionKey?: string;
+    processDefinitionKeyIn?: string;
+    processDefinitionVersionTag?: string;
+    withoutTenantId?: boolean;
+    tenantIdIn?: string[];
+}
+
+interface TopicSubscription {
+    unsubscribe: () => void;
+}
+
+type Interceptor = <T = any>(config: T) => T;
+
+type Middleware = (client: Client) => void;
+
+type Logger = Middleware & {
+    success(text: string): void;
+
+    error(text: string): void;
+};
+
+export const logger: Logger;
+
+export {};

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -4,119 +4,114 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-declare namespace CamundaExternalTaskClient {
-    class Client {
-        constructor(config: ClientConfig);
-        start(): void;
-        stop(): void;
-        subscribe(topic: string, options: SubscribeOptions, handler: Handler): TopicSubscription;
-        subscribe(topic: string, handler: Handler): TopicSubscription;
-    }
-
-    interface ClientConfig {
-        baseUrl: string;
-        workerId?: string;
-        maxTasks?: number;
-        maxParallelExecutions?: number;
-        interval?: number;
-        lockDuration?: number;
-        autoPoll?: boolean;
-        asyncResponseTimeout?: number;
-        interceptors?: Interceptor | Interceptor[];
-        use?: Middleware | Middleware[];
-    }
-
-    class Variables {
-        get(variableName: string): Value;
-        getTyped(variableName: string): TypedValue;
-        getAll(): Value[];
-        getAllTyped(): TypedValue[];
-        set(variableName: string, value: Value): Variables;
-        setTyped(variableName: string, typedValue: TypedValue): Variables;
-        setAll(values: { [key: string]: Value }): Variables;
-        setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
-    }
-
-    type Handler = (args: HandlerArgs) => void;
-
-    interface HandlerArgs {
-        task: Task;
-        taskService: TaskService;
-    }
-
-    interface Task {
-        variables: Variables;
-
-        // These are not guaranteed by package documentation, but are returned according to REST API docs
-        activityId?: string;
-        activityInstanceId?: string;
-        businessKey?: string;
-        errorDetails?: string;
-        errorMessage?: string;
-        executionId?: string;
-        id?: string;
-        lockExpirationTime?: string;
-        priority?: number;
-        processDefinitionId?: string;
-        processDefinitionKey?: string;
-        processInstanceId?: string;
-        retries?: number;
-        tenantId?: string;
-        topicName?: string;
-        workerId?: string;
-    }
-
-    type Value = any;
-
-    interface TypedValue {
-        value: Value;
-        type: string;
-        valueInfo: object;
-    }
-
-    interface TaskService {
-        complete(task: Task, processVariables?: Variables, localVariables?: Variables): void;
-        handleFailure(task: Task, options?: HandleFailureOptions): void;
-        handleBpmnError(task: Task, errorCode: string, errorMessage?: string, variables?: Variables): void;
-        extendLock(task: Task, newDuration: number): void;
-        unlock(task: Task): void;
-    }
-
-    interface HandleFailureOptions {
-        errorMessage?: string;
-        errorDetails?: string;
-        retires?: number;
-        retryTimeout?: number;
-    }
-
-    interface SubscribeOptions {
-        lockDuration?: number;
-        variables?: any[];
-        businessKey?: string;
-        processDefinitionId?: string;
-        processDefinitionIdIn?: string;
-        processDefinitionKey?: string;
-        processDefinitionKeyIn?: string;
-        processDefinitionVersionTag?: string;
-        withoutTenantId?: boolean;
-        tenantIdIn?: string[];
-    }
-
-    interface TopicSubscription {
-        unsubscribe: () => void;
-    }
-
-    type Interceptor = <T = any>(config: T) => T;
-
-    type Middleware = (client: Client) => void;
-
-    type Logger = Middleware & {
-        success(text: string): void;
-        error(text: string): void;
-    };
-
-    const logger: Logger;
+export class Client {
+    constructor(config: ClientConfig);
+    start(): void;
+    stop(): void;
+    subscribe(topic: string, options: SubscribeOptions, handler: Handler): TopicSubscription;
+    subscribe(topic: string, handler: Handler): TopicSubscription;
 }
 
-/* tslint:disable-next-line export-just-namespace */
-export = CamundaExternalTaskClient;
+export interface ClientConfig {
+    baseUrl: string;
+    workerId?: string;
+    maxTasks?: number;
+    maxParallelExecutions?: number;
+    interval?: number;
+    lockDuration?: number;
+    autoPoll?: boolean;
+    asyncResponseTimeout?: number;
+    interceptors?: Interceptor | Interceptor[];
+    use?: Middleware | Middleware[];
+}
+
+export class Variables {
+    get(variableName: string): Value;
+    getTyped(variableName: string): TypedValue;
+    getAll(): Value[];
+    getAllTyped(): TypedValue[];
+    set(variableName: string, value: Value): Variables;
+    setTyped(variableName: string, typedValue: TypedValue): Variables;
+    setAll(values: { [key: string]: Value }): Variables;
+    setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
+}
+
+export type Handler = (args: HandlerArgs) => void;
+
+export interface HandlerArgs {
+    task: Task;
+    taskService: TaskService;
+}
+
+export interface Task {
+    variables: Variables;
+
+    // These are not guaranteed by package documentation, but are returned according to REST API docs
+    activityId?: string;
+    activityInstanceId?: string;
+    businessKey?: string;
+    errorDetails?: string;
+    errorMessage?: string;
+    executionId?: string;
+    id?: string;
+    lockExpirationTime?: string;
+    priority?: number;
+    processDefinitionId?: string;
+    processDefinitionKey?: string;
+    processInstanceId?: string;
+    retries?: number;
+    tenantId?: string;
+    topicName?: string;
+    workerId?: string;
+}
+
+export type Value = any;
+
+export interface TypedValue {
+    value: Value;
+    type: string;
+    valueInfo: object;
+}
+
+export interface TaskService {
+    complete(task: Task, processVariables?: Variables, localVariables?: Variables): void;
+    handleFailure(task: Task, options?: HandleFailureOptions): void;
+    handleBpmnError(task: Task, errorCode: string, errorMessage?: string, variables?: Variables): void;
+    extendLock(task: Task, newDuration: number): void;
+    unlock(task: Task): void;
+}
+
+export interface HandleFailureOptions {
+    errorMessage?: string;
+    errorDetails?: string;
+    retires?: number;
+    retryTimeout?: number;
+}
+
+export interface SubscribeOptions {
+    lockDuration?: number;
+    variables?: any[];
+    businessKey?: string;
+    processDefinitionId?: string;
+    processDefinitionIdIn?: string;
+    processDefinitionKey?: string;
+    processDefinitionKeyIn?: string;
+    processDefinitionVersionTag?: string;
+    withoutTenantId?: boolean;
+    tenantIdIn?: string[];
+}
+
+export interface TopicSubscription {
+    unsubscribe: () => void;
+}
+
+export type Interceptor = <T = any>(config: T) => T;
+
+export type Middleware = (client: Client) => void;
+
+export type Logger = Middleware & {
+    success(text: string): void;
+    error(text: string): void;
+};
+
+export const logger: Logger;

--- a/types/camunda-external-task-client-js/tsconfig.json
+++ b/types/camunda-external-task-client-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "camunda-external-task-client-js-tests.ts"
+    ]
+}

--- a/types/camunda-external-task-client-js/tslint.json
+++ b/types/camunda-external-task-client-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Typings for https://github.com/camunda/camunda-external-task-client-js/
Maintainers decided that they will not maintain type definitions themselves: https://github.com/camunda/camunda-external-task-client-js/issues/20#issuecomment-513653355

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

