### PR TITLE
Add types for @styled-system/should-forward-prop

### DIFF
--- a/types/styled-system__should-forward-prop/index.d.ts
+++ b/types/styled-system__should-forward-prop/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for @styled-system/should-forward-prop 5.1
+// Project: https://github.com/styled-system/styled-system/tree/master/packages/should-forward-prop
+// Definitions by: Tom Picton <https://github.com/tpict>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type genericShouldForwardProp = (prop: string) => boolean;
+
+export function createShouldForwardProp(props: string[]): genericShouldForwardProp;
+declare const shouldForwardProp: genericShouldForwardProp;
+export default shouldForwardProp;

--- a/types/styled-system__should-forward-prop/styled-system__should-forward-prop-tests.ts
+++ b/types/styled-system__should-forward-prop/styled-system__should-forward-prop-tests.ts
@@ -1,0 +1,10 @@
+import shouldForwardProp, {
+  createShouldForwardProp
+} from "@styled-system/should-forward-prop";
+
+shouldForwardProp("onClick");  // True
+shouldForwardProp("variant");  // False
+
+const customShouldForwardProp = createShouldForwardProp(["magic"]);
+customShouldForwardProp("magic");  // True
+customShouldForwardProp("you know");  // False

--- a/types/styled-system__should-forward-prop/tsconfig.json
+++ b/types/styled-system__should-forward-prop/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@styled-system/should-forward-prop": [
+              "styled-system__should-forward-prop"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "styled-system__should-forward-prop-tests.ts"
+    ]
+}

--- a/types/styled-system__should-forward-prop/tslint.json
+++ b/types/styled-system__should-forward-prop/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type definitions for https://github.com/styled-system/styled-system/tree/master/packages/should-forward-prop.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.