### PR TITLE
[@types/consul] Add missing Watch options to node-consul

### DIFF
--- a/types/consul/index.d.ts
+++ b/types/consul/index.d.ts
@@ -961,9 +961,9 @@ declare namespace Consul {
         interface Options {
             method: Function;
             options?: CommonOptions & WatchOptions;
-            backoffFactor: number;
-            backoffMax: number;
-            maxAttempts: number;
+            backoffFactor?: number;
+            backoffMax?: number;
+            maxAttempts?: number;
         }
     }
 

--- a/types/consul/index.d.ts
+++ b/types/consul/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Consul v0.23.0
 // Project: https://github.com/silas/node-consul
 // Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+//                 Vadym Vakhovskiy <https://github.com/vadim-v>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -960,6 +961,9 @@ declare namespace Consul {
         interface Options {
             method: Function;
             options?: CommonOptions & WatchOptions;
+            backoffFactor: number;
+            backoffMax: number;
+            maxAttempts: number;
         }
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/silas/node-consul/tree/0.36.0#watch
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.