### PR TITLE
Lowercase js-cookie same site cookie values

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -39,7 +39,7 @@ declare namespace Cookies {
          * providing some protection against cross-site request forgery
          * attacks (CSRF)
          */
-        sameSite?: 'Strict' | 'Lax' | 'None';
+        sameSite?: 'strict' | 'lax' | 'none';
 
         /**
          * An attribute which will be serialized, conformably to RFC 6265

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -9,7 +9,7 @@ Cookies.set('name', 'value', { expires: 7, path: '', domain: '', secure: true })
 Cookies.set('name', 'value', { secure: true });
 Cookies.set('name', 'value', { domain: '' });
 Cookies.set('name', 'value', { path: '' });
-Cookies.set('name', 'value', { sameSite: 'Strict' });
+Cookies.set('name', 'value', { sameSite: 'strict' });
 Cookies.set('name', 'value', { custom: 'property' });
 
 // $ExpectType string | undefined


### PR DESCRIPTION
This matches the documented usage at https://github.com/js-cookie/js-cookie/#samesite, and also is more consistent with other attribute values typically entered in lowercase (e.g. domain names and boolean values).