### PR TITLE
[dom-mediacapture-record] Nullable event listeners for MediaRecorder

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -51,3 +51,10 @@ recorder.onpause = onEvent;
 recorder.onresume = onEvent;
 recorder.onstart = onEvent;
 recorder.onstop = onEvent;
+
+recorder.ondataavailable = null;
+recorder.onerror = null;
+recorder.onpause = null;
+recorder.onresume = null;
+recorder.onstart = null;
+recorder.onstop = null;

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -39,12 +39,12 @@ declare class MediaRecorder extends EventTarget {
     readonly videoBitsPerSecond: number;
     readonly audioBitsPerSecond: number;
 
-    ondataavailable: (event: BlobEvent) => void;
-    onerror: (event: MediaRecorderErrorEvent) => void;
-    onpause: EventListener;
-    onresume: EventListener;
-    onstart: EventListener;
-    onstop: EventListener;
+    ondataavailable: ((event: BlobEvent) => void) | null;
+    onerror: ((event: MediaRecorderErrorEvent) => void) | null;
+    onpause: EventListener | null;
+    onresume: EventListener | null;
+    onstart: EventListener | null;
+    onstop: EventListener | null;
 
     constructor(stream: MediaStream, options?: MediaRecorderOptions);
 


### PR DESCRIPTION
Allow setting event listeners to null when using strictNullChecks.
In lib.dom.d.ts (provided by TypeScript), all event handlers are marked as nullable so you can unset your event handler.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
