### PR TITLE
Add missing fields for react-vertical-timeline-component

### DIFF
--- a/types/react-vertical-timeline-component/index.d.ts
+++ b/types/react-vertical-timeline-component/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-vertical-timeline-component 2.3
+// Type definitions for react-vertical-timeline-component 2.5
 // Project: https://github.com/stephane-monnot/react-vertical-timeline, https://stephane-monnot.github.io/react-vertical-timeline
 // Definitions by: Stéphane Monnot <https://github.com/stephane-monnot>
+//                 Lukas Elmer <https://github.com/lukaselmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -22,6 +23,8 @@ export interface VerticalTimelineElementProps {
     position?: string;
     style?: React.CSSProperties;
     visibilitySensorProps?: any;
+    contentStyle?: React.CSSProperties;
+    contentArrowStyle?: React.CSSProperties;
 }
 
 export class VerticalTimeline extends React.Component<VerticalTimelineProps> { }

--- a/types/react-vertical-timeline-component/react-vertical-timeline-component-tests.tsx
+++ b/types/react-vertical-timeline-component/react-vertical-timeline-component-tests.tsx
@@ -9,6 +9,8 @@ export default class ReactVerticalTimelineComponentTests extends React.Component
                     iconOnClick={() => console.info('icon has been clicked')}
                     className="vertical-timeline-element--work"
                     date="2012 - present"
+                    contentStyle={{ background: 'rgb(33, 150, 243)', color: '#fff' }}
+                    contentArrowStyle={{ borderRight: '7px solid  rgb(33, 150, 243)' }}
                 >
                     <h3 className="vertical-timeline-element-title">Creative Director</h3>
                     <h4 className="vertical-timeline-element-subtitle">Miami, FL</h4>


### PR DESCRIPTION
Add `contentStyle` and `contentArrowStyle`, see https://stephane-monnot.github.io/react-vertical-timeline/#/?a=verticaltimelineelement-props

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stephane-monnot.github.io/react-vertical-timeline/#/?a=verticaltimelineelement-props
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
