### PR TITLE
Made create-react-class S(tate) template optional

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -79,6 +79,12 @@ const ClassicComponentNoProps: React.ClassicComponentClass = createReactClass({
     }
 });
 
+const ClassicComponentNoState: React.ClassicComponentClass = createReactClass<{ text: string }>({
+    render() {
+        return DOM.div(this.props.text);
+    }
+});
+
 // React.createFactory
 const classicFactory: React.ClassicFactory<Props> =
     React.createFactory(ClassicComponent);

--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -79,7 +79,7 @@ const ClassicComponentNoProps: React.ClassicComponentClass = createReactClass({
     }
 });
 
-const ClassicComponentNoState: React.ClassicComponentClass = createReactClass<{ text: string }>({
+const ClassicComponentNoState: React.ClassicComponentClass<{ text: string }> = createReactClass<{ text: string }>({
     render() {
         return DOM.div(this.props.text);
     }

--- a/types/create-react-class/index.d.ts
+++ b/types/create-react-class/index.d.ts
@@ -7,7 +7,7 @@
 import { ComponentSpec, ClassicComponentClass } from "react";
 
 declare namespace createReactClass {}
-declare function createReactClass<P, S>(spec: ComponentSpec<P, S>): ClassicComponentClass<P>;
+declare function createReactClass<P, S = {}>(spec: ComponentSpec<P, S>): ClassicComponentClass<P>;
 
 export as namespace createReactClass;
 export = createReactClass;


### PR DESCRIPTION
It's irksome having to always provide a `{}`...

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- ~[ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
