### PR TITLE
react: Remove deprecation warning for `context`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -416,6 +416,7 @@ declare namespace React {
         /**
          * If using the new style context, re-declare this in your class to be the
          * `React.ContextType` of your `static contextType`.
+         * Should be used with type annotation or static contextType.
          *
          * ```ts
          * static contextType = MyContext
@@ -425,8 +426,7 @@ declare namespace React {
          * declare context: React.ContextType<typeof MyContext>
          * ```
          *
-         * @deprecated if used without a type annotation, or without static contextType
-         * @see https://reactjs.org/docs/legacy-context.html
+         * @see https://reactjs.org/docs/context.html
          */
         // TODO (TypeScript 3.0): unknown
         context: any;


### PR DESCRIPTION
Context for the suggested change: https://github.com/facebook/react/issues/16250#issuecomment-521634029.

`context` is now marked with the `@deprecated` JSDoc tag. 
In the TypeScript code, it's true only in some cases. In the JavaScript code, `this.context` can be a modern API.

Editors like WebStorm and VS Code use type definitions for code assistance (completion, docs, etc) in JavaScript files.

Since `context` is marked as deprecated, WebStorm shows a warning in the JavaScript code. Both in VS Code and WebStorm, there's a deprecation warning in the doc popup.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/issues/16250#issuecomment-521634029.
