### PR TITLE
react-autosuggest: restrict input props

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -68,7 +68,6 @@ declare namespace Autosuggest {
         onChange(event: React.FormEvent<any>, params: ChangeEvent): void;
         onBlur?(event: React.FocusEvent<any>, params?: BlurEvent<TSuggestion>): void;
         value: string;
-        [key: string]: any;
     }
 
     interface SuggestionSelectedEventData<TSuggestion> {

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -558,3 +558,9 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
 
 ReactDOM.render(
    <ReactAutosuggestCustomTest/>, document.getElementById('app'));
+
+const test: Autosuggest.InputProps<{ foo: string }> = {
+    onChange: () => {},
+    value: 'foo',
+    anything: false // $ExpectError
+};


### PR DESCRIPTION
This brings `InputProps` inline with React's types for `input`. That is, the following errors in React:

```tsx
<input anything={false} />
```

This also means that `keyof InputProps<T>` returns a union of literals instead of `string`. This is helpful because it means that keys will be validated in operations such as `Pick<InputProps<T>, 'autoFocus'>`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
