### PR TITLE
[office-js, office-js-preview]Clarifying Worksheet.copy behavior

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -20615,22 +20615,24 @@ declare namespace Excel {
         calculate(markAllDirty: boolean): void;
         /**
          *
-         * Copy a worksheet and place it at the specified position. Return the copied worksheet.
-         *
+         * Copies a worksheet and places it at the specified position. 
+         * 
          * [Api set: ExcelApi 1.7]
          *
-         * @param positionType Optional.
-         * @param relativeTo Optional.
+         * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
+         * @param relativeTo The existing worksheet which determines the newly created worksheet's position. This is only needed if `positionType` is "Before" or "After".
+         * @returns The newly created worksheet.
          */
         copy(positionType?: Excel.WorksheetPositionType, relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**
          *
-         * Copy a worksheet and place it at the specified position. Return the copied worksheet.
-         *
+         * Copies a worksheet and places it at the specified position. 
+         * 
          * [Api set: ExcelApi 1.7]
          *
-         * @param positionType Optional.
-         * @param relativeTo Optional.
+         * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
+         * @param relativeTo The existing worksheet which determines the newly created worksheet's position. This is only needed if `positionType` is "Before" or "After".
+         * @returns The newly created worksheet.
          */
         copy(positionType?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -17997,22 +17997,24 @@ declare namespace Excel {
         calculate(markAllDirty: boolean): void;
         /**
          *
-         * Copy a worksheet and place it at the specified position. Return the copied worksheet.
-         *
+         * Copies a worksheet and places it at the specified position. 
+         * 
          * [Api set: ExcelApi 1.7]
          *
-         * @param positionType Optional.
-         * @param relativeTo Optional.
+         * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
+         * @param relativeTo The existing worksheet which determines the newly created worksheet's position. This is only needed if `positionType` is "Before" or "After".
+         * @returns The newly created worksheet.
          */
         copy(positionType?: Excel.WorksheetPositionType, relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**
          *
-         * Copy a worksheet and place it at the specified position. Return the copied worksheet.
-         *
+         * Copies a worksheet and places it at the specified position. 
+         * 
          * [Api set: ExcelApi 1.7]
          *
-         * @param positionType Optional.
-         * @param relativeTo Optional.
+         * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
+         * @param relativeTo The existing worksheet which determines the newly created worksheet's position. This is only needed if `positionType` is "Before" or "After".
+         * @returns The newly created worksheet.
          */
         copy(positionType?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js-docs-pr/issues/1365#issuecomment-542063018
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

