### PR TITLE
[@types/ignore-walk] Fix return type of walk and walk.sync

### DIFF
--- a/types/ignore-walk/ignore-walk-tests.ts
+++ b/types/ignore-walk/ignore-walk-tests.ts
@@ -7,11 +7,13 @@ walk({
 });
 
 walk().then((results) => {
+  console.log(results[0]);
   console.log(results);
 });
 
 walk.sync({path: '/path/to/file'});
-walk.sync();
+const results = walk.sync();
+console.log(results[0]);
 
 const walker = new walk.WalkerSync();
 console.log((walker.start().result as string[]).filter(entry => entry.substring(0, 5) !== '.git/'));

--- a/types/ignore-walk/index.d.ts
+++ b/types/ignore-walk/index.d.ts
@@ -8,9 +8,9 @@
 import { EventEmitter } from 'events';
 import { Stats } from 'fs';
 
-declare function walk(options?: walk.WalkerOptions, callback?: (results: Set<string>) => void): Promise<Set<string>>;
+declare function walk(options?: walk.WalkerOptions, callback?: (results: string[]) => void): Promise<string[]>;
 declare namespace walk {
-    function sync(options?: WalkerOptions): WalkerSync;
+    function sync(options?: WalkerOptions): string[];
 
     interface WalkerOptions {
         path?: string;


### PR DESCRIPTION
Slight mistake from #39121 in the proper return types for walk and walk.sync in that they're an array of strings, not a set or class definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/ignore-walk/blob/67e6a0bade23187d970dc3334740e4c883448013/index.js#L255-L264
