### PR TITLE
Stripe fix HeaderOptions support in stripe.sessions.create()

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -9816,6 +9816,11 @@ declare namespace Stripe {
         class Sessions extends StripeResource {
             create(
                 data: checkouts.sessions.ICheckoutCreationOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<checkouts.sessions.ICheckoutSession>,
+            ): Promise<checkouts.sessions.ICheckoutSession>;
+            create(
+                data: checkouts.sessions.ICheckoutCreationOptions,
                 response?: IResponseFn<checkouts.sessions.ICheckoutSession>,
             ): Promise<checkouts.sessions.ICheckoutSession>;
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -314,7 +314,31 @@ stripe.checkout.sessions.retrieve('ch_test_123', { expand: ['payment_intent'] })
 
 //#region Checkout with connect tests
 // ##################################################################################
-// With destination
+// Direct charges
+stripe.checkout.sessions.create(
+    {
+        payment_method_types: ['card'],
+        line_items: [{
+            name: "Cucumber from Roger's Farm",
+            amount: 200,
+            currency: 'usd',
+            quantity: 10,
+        }],
+        payment_intent_data: {
+            application_fee_amount: 200,
+        },
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+    },
+    {
+        stripe_account: '{{CONNECTED_STRIPE_ACCOUNT_ID}}',
+    },
+    (err, session) => {
+        // asynchronously called
+    }
+);
+
+// Destination charges with destination
 stripe.checkout.sessions.create(
     {
         payment_method_types: ['card'],
@@ -340,7 +364,7 @@ stripe.checkout.sessions.create(
     },
 );
 
-// With on_behalf_of
+// Destination charges with on_behalf_of
 stripe.checkout.sessions.create(
     {
         payment_method_types: ['card'],
@@ -367,6 +391,26 @@ stripe.checkout.sessions.create(
     },
 );
 
+// Subscriptions
+stripe.checkout.sessions.create(
+    {
+        payment_method_types: ['card'],
+        subscription_data: {
+            items: [{
+                plan: 'plan_123',
+            }],
+            application_fee_percent: 10,
+        },
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+    },
+    {
+        stripe_account: '{{CONNECTED_STRIPE_ACCOUNT_ID}}',
+    },
+    (err, session) => {
+        // asynchronously called
+    }
+);
 //#endregion
 
 //#region CreditNotes tests


### PR DESCRIPTION
This is a fix for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38392 .  The added tests come directly from the documentation.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/payments/checkout/connect
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
