### PR TITLE
fix(newrelic): make noticeError customAttributes signature wider

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -67,14 +67,14 @@ export function setControllerName(name: string, action: string): void;
  *
  * Most recently set value wins.
  */
-export function addCustomAttribute(key: string, value: string | number): void;
+export function addCustomAttribute(key: string, value: string | number | boolean): void;
 
 /**
  * Adds all custom attributes in an object to the current transaction.
  *
  * See documentation for `addCustomAttribute` for more information on setting custom attributes.
  */
-export function addCustomAttributes(atts: { [key: string]: string | number }): void;
+export function addCustomAttributes(atts: { [key: string]: string | number | boolean }): void;
 
 /**
  * Tell the tracer whether to ignore the current transaction.

--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Matt R. Wilson <https://github.com/mastermatt>
 //                 Brooks Patton <https://github.com/brookspatton>
 //                 Michael Bond <https://github.com/MichaelRBond>
+//                 Kyle Scully <https://github.com/zieka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api
@@ -66,14 +67,14 @@ export function setControllerName(name: string, action: string): void;
  *
  * Most recently set value wins.
  */
-export function addCustomAttribute(key: string, value: string|number): void;
+export function addCustomAttribute(key: string, value: string | number): void;
 
 /**
  * Adds all custom attributes in an object to the current transaction.
  *
  * See documentation for `addCustomAttribute` for more information on setting custom attributes.
  */
-export function addCustomAttributes(atts: { [key: string]: string|number }): void;
+export function addCustomAttributes(atts: { [key: string]: string | number }): void;
 
 /**
  * Tell the tracer whether to ignore the current transaction.
@@ -93,7 +94,7 @@ export function setIgnoreTransaction(ignored: boolean): void;
  *
  *  Optional. Any custom attributes to be displayed in the New Relic UI.
  */
-export function noticeError(error: Error, customAttributes?: { [key: string]: string }): void;
+export function noticeError(error: Error, customAttributes?: { [key: string]: string | number | boolean }): void;
 
 /**
  * If the URL for a transaction matches the provided pattern, name the
@@ -163,7 +164,12 @@ export function getBrowserTimingHeader(): string;
  * If a promise is returned from the handler, the segment's ending will be tied to that promise resolving or rejecting.
  */
 export function startSegment<T extends PromiseLike<any>>(name: string, record: boolean, handler: T): T;
-export function startSegment<T, C extends (...args: any[]) => any>(name: string, record: boolean, handler: (cb?: C) => T, callback?: C): T;
+export function startSegment<T, C extends (...args: any[]) => any>(
+    name: string,
+    record: boolean,
+    handler: (cb?: C) => T,
+    callback?: C,
+): T;
 
 /**
  * Instrument a particular callback to improve visibility into a transaction.
@@ -322,7 +328,10 @@ export const instrumentMessages: Instrument;
  * before shutting down. Defaults to `false`.
  */
 export function shutdown(cb?: (error?: Error) => void): void;
-export function shutdown(options?: { collectPendingData?: boolean, timeout?: number }, cb?: (error?: Error) => void): void;
+export function shutdown(
+    options?: { collectPendingData?: boolean; timeout?: number },
+    cb?: (error?: Error) => void,
+): void;
 
 /**
  * Wraps an AWS Lambda function with NewRelic instrumentation and returns the value of the handler
@@ -333,7 +342,7 @@ export function shutdown(options?: { collectPendingData?: boolean, timeout?: num
 export function setLambdaHandler<T>(handler: (...args: any[]) => T): T;
 
 export interface Instrument {
-    (opts: { moduleName: string, onRequire: () => void, onError?: (err: Error) => void }): void;
+    (opts: { moduleName: string; onRequire: () => void; onError?: (err: Error) => void }): void;
     (moduleName: string, onRequire: () => void, onError?: (err: Error) => void): void;
 }
 

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -1,43 +1,45 @@
 /// <reference types="node" />
-import * as newrelic from "newrelic";
+import * as newrelic from 'newrelic';
 
-newrelic.setTransactionName("foo"); // $ExpectType void
+newrelic.setTransactionName('foo'); // $ExpectType void
 
 const trans = newrelic.getTransaction();
 trans.ignore(); // $ExpectType void
 trans.end(); // $ExpectType void
-trans.end(() => { }); // $ExpectType void
+trans.end(() => {}); // $ExpectType void
 
-newrelic.setDispatcher("foo"); // $ExpectType void
-newrelic.setDispatcher("foo", "42"); // $ExpectType void
+newrelic.setDispatcher('foo'); // $ExpectType void
+newrelic.setDispatcher('foo', '42'); // $ExpectType void
 
-newrelic.setControllerName("foo", "GET"); // $ExpectType void
+newrelic.setControllerName('foo', 'GET'); // $ExpectType void
 
-newrelic.addCustomAttribute("foo", "bar"); // $ExpectType void
-newrelic.addCustomAttribute("foo", 42); // $ExpectType void
-newrelic.addCustomAttributes({ foo: "bar", baz: "bang" }); // $ExpectType void
-newrelic.addCustomAttributes({ foo: "bar", baz: 42 }); // $ExpectType void
+newrelic.addCustomAttribute('foo', 'bar'); // $ExpectType void
+newrelic.addCustomAttribute('foo', 42); // $ExpectType void
+newrelic.addCustomAttributes({ foo: 'bar', baz: 'bang' }); // $ExpectType void
+newrelic.addCustomAttributes({ foo: 'bar', baz: 42 }); // $ExpectType void
 
 newrelic.setIgnoreTransaction(true); // $ExpectType void
 
-newrelic.noticeError(Error("Oh no!")); // $ExpectType void
-newrelic.noticeError(Error("Oh no!"), { foo: "bar" }); // $ExpectType void
+newrelic.noticeError(Error('Oh no!')); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: 'bar' }); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: 42 }); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: true }); // $ExpectType void
 
-newrelic.addNamingRule("/user/customers/all/.*", "/user/customers/all"); // $ExpectType void
-newrelic.addNamingRule(/\/user\/customers\/.*/, "/user/customers/:customer"); // $ExpectType void
+newrelic.addNamingRule('/user/customers/all/.*', '/user/customers/all'); // $ExpectType void
+newrelic.addNamingRule(/\/user\/customers\/.*/, '/user/customers/:customer'); // $ExpectType void
 
-newrelic.addIgnoringRule("^/items/[0-9]+$"); // $ExpectType void
+newrelic.addIgnoringRule('^/items/[0-9]+$'); // $ExpectType void
 newrelic.addIgnoringRule(/^[0-9]+$/); // $ExpectType void
 
 newrelic.getBrowserTimingHeader(); // $ExpectType string
 
-newrelic.startSegment('foo', false, () => "bar"); // $ExpectType string
-newrelic.startSegment('foo', false, () => "bar", () => "baz"); // $ExpectType string
+newrelic.startSegment('foo', false, () => 'bar'); // $ExpectType string
+newrelic.startSegment('foo', false, () => 'bar', () => 'baz'); // $ExpectType string
 newrelic.startSegment('foo', false, Promise.all([5, 7])).then(([a, b]: [number, number]) => {
     console.log(a, b);
 });
 
-const wrappedFn = newrelic.createTracer("foo", (x: number) => {
+const wrappedFn = newrelic.createTracer('foo', (x: number) => {
     return x * x;
 });
 const wrappedResult: number = wrappedFn(42);
@@ -52,7 +54,7 @@ newrelic.startWebTransaction('/some/url/path', () => {
 
 newrelic.startWebTransaction('/some/url/path', Promise.resolve(7)); // $ExpectType Promise<number>
 
-newrelic.startBackgroundTransaction('Red October', (foo) => foo); // $ExpectType any
+newrelic.startBackgroundTransaction('Red October', foo => foo); // $ExpectType any
 newrelic.startBackgroundTransaction('Red October', () => 7); // $ExpectType number
 newrelic.startBackgroundTransaction('Red October', Promise.resolve(7)); // $ExpectType Promise<number>
 newrelic.startBackgroundTransaction('Red October', 'Subs', () => {
@@ -65,8 +67,8 @@ newrelic.startBackgroundTransaction('Red October', 'Subs', () => {
 
 newrelic.endTransaction(); // $ExpectType void
 
-newrelic.recordMetric("foo", 42); // $ExpectType void
-newrelic.recordMetric("foo", {
+newrelic.recordMetric('foo', 42); // $ExpectType void
+newrelic.recordMetric('foo', {
     count: 10,
     total: 42,
     min: 1,
@@ -74,37 +76,37 @@ newrelic.recordMetric("foo", {
     sumOfSquares: 60,
 });
 
-newrelic.incrementMetric("foo"); // $ExpectType void
-newrelic.incrementMetric("foo", 42); // $ExpectType void
+newrelic.incrementMetric('foo'); // $ExpectType void
+newrelic.incrementMetric('foo', 42); // $ExpectType void
 
-newrelic.recordCustomEvent("my_event", {
+newrelic.recordCustomEvent('my_event', {
     foo: true,
     bar: 42,
     baz: "don't panic",
 });
 
-newrelic.instrument("foo", () => { }); // $ExpectType void
-newrelic.instrumentDatastore("foo", () => { }, (err: Error) => { });
+newrelic.instrument('foo', () => {}); // $ExpectType void
+newrelic.instrumentDatastore('foo', () => {}, (err: Error) => {});
 newrelic.instrumentWebframework({
-    moduleName: "foo",
-    onRequire: () => { },
+    moduleName: 'foo',
+    onRequire: () => {},
 });
 newrelic.instrumentMessages({
-    moduleName: "foo",
-    onRequire: () => { },
-    onError: (err) => {
+    moduleName: 'foo',
+    onRequire: () => {},
+    onError: err => {
         const error: Error = err;
-     },
+    },
 });
 
 newrelic.shutdown(); // $ExpectType void
 newrelic.shutdown({ collectPendingData: true });
 newrelic.shutdown({ timeout: 3000 });
 newrelic.shutdown({ collectPendingData: true, timeout: 3000 });
-newrelic.shutdown({ collectPendingData: true, timeout: 3000 }, (err) => {
+newrelic.shutdown({ collectPendingData: true, timeout: 3000 }, err => {
     const error: Error | undefined = err;
 });
-newrelic.shutdown((err) => {
+newrelic.shutdown(err => {
     const error: Error | undefined = err;
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
     - https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
        ```js
        try {
          // code that throws an error
        } catch (err) {
          newrelic.noticeError(err, { attribute1: 'value1', attribute2: 2 });
        }
        ```
     - https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute
        > Custom attribute values cannot be complex objects, only simple types such as Strings and Integers.