### PR TITLE
Add typings for proper-url-join

### DIFF
--- a/types/proper-url-join/index.d.ts
+++ b/types/proper-url-join/index.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for proper-url-join 2.0
+// Project: https://github.com/moxystudio/js-proper-url-join
+// Definitions by: Jules Sam. Randolph <https://github.com/jsamr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { StringifyOptions } from 'query-string';
+
+export interface Options {
+    /**
+     * Add a leading slash.
+     *
+     * **Default**: `true`
+     */
+    leadingSlash?: boolean;
+    /**
+     * Add a trailing slash.
+     *
+     * **Default**: `false`
+     */
+    trailingSlash?: boolean;
+    /**
+     * Protocol relative URLs.
+     *
+     * **Default**: `false`
+     */
+    protocolRelative?: boolean;
+    /**
+     * Query string object that will be properly stringified and appended to the url.
+     * It will be merged with the query string in the url, if it exists.
+     */
+    query?: {
+        [k: string]: string|number|ReadonlyArray<string|number>;
+    };
+    /**
+     * [query-string](https://github.com/sindresorhus/query-string#stringifyobject-options) singify method options to be considered when stringifying the query.
+     */
+    queryOptions?: StringifyOptions;
+}
+
+export type PathArg = string|null|undefined|number;
+
+interface urlJoin {
+    (p1: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, p7: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, p7: PathArg, p8: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, p7: PathArg, p8: PathArg, p9: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, p7: PathArg, p8: PathArg, p9: PathArg, p10: PathArg, options?: Options): string;
+    (p1: PathArg, p2: PathArg, p3: PathArg, p4: PathArg, p5: PathArg, p6: PathArg, p7: PathArg, p8: PathArg, p9: PathArg, p10: PathArg, p11: PathArg, ...args: Array<PathArg|Options>): string;
+}
+
+declare const urlJoin: urlJoin;
+
+export default urlJoin;

--- a/types/proper-url-join/package.json
+++ b/types/proper-url-join/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "query-string": "^6.3.0"
+    }
+}

--- a/types/proper-url-join/proper-url-join-tests.ts
+++ b/types/proper-url-join/proper-url-join-tests.ts
@@ -1,0 +1,31 @@
+import urlJoin from 'proper-url-join';
+
+urlJoin('foo', 'bar'); // /foo/bar
+urlJoin('/foo/', '/bar/'); // /foo/bar
+urlJoin('foo', '', 'bar'); // /foo/bar
+urlJoin('foo', undefined, 'bar'); // /foo/bar
+urlJoin('foo', null, 'bar'); // /foo/bar
+
+// With leading & trailing slash options
+urlJoin('foo', 'bar', { leadingSlash: false }); // foo/bar
+urlJoin('foo', 'bar', { trailingSlash: true }); // /foo/bar/
+urlJoin('foo', 'bar', { leadingSlash: false, trailingSlash: true }); // foo/bar/
+
+// Absolute URLs
+urlJoin('http://google.com', 'foo'); // http://google.com/foo
+
+// Protocol relative URLs
+urlJoin('//google.com', 'foo', { protocolRelative: true }); // //google.com/foo
+
+// With query string as an url part
+urlJoin('foo', 'bar?queryString'); // /foo/bar?queryString
+urlJoin('foo', 'bar?queryString', { trailingSlash: true }); // /foo/bar/?queryString
+
+// With query string as an object
+urlJoin('foo', { query: { biz: 'buz', foo: 'bar' } }); // /foo?biz=buz&foo=bar
+
+// With both query string as an url part and an object
+urlJoin('foo', 'bar?queryString', { query: { biz: 'buz', foo: 'bar' } });
+
+// $ExpectError
+urlJoin('foo', 'bar?queryString', { query: { biz: 'buz', foo: 'bar' } }, 'wrong');

--- a/types/proper-url-join/tsconfig.json
+++ b/types/proper-url-join/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "proper-url-join-tests.ts"
+    ]
+}

--- a/types/proper-url-join/tslint.json
+++ b/types/proper-url-join/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.