### PR TITLE
[plotly.js] add hiddenlabels to Layout

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -280,6 +280,7 @@ export interface Layout {
 	bargap: number;
 	bargroupgap: number;
 	selectdirection: 'h' | 'v' | 'd' | 'any';
+	hiddenlabels: string[];
 }
 
 export interface Legend extends Label {


### PR DESCRIPTION
`hiddenlabels` is used to hide slices on funnelareas & pie charts. See documentation link below.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://plot.ly/javascript/reference/#layout-hiddenlabels>>