### PR TITLE
[slonik] update types to support sql.join

### DIFF
--- a/types/slonik/slonik-tests.ts
+++ b/types/slonik/slonik-tests.ts
@@ -22,11 +22,11 @@ import {
   UniqueIntegrityConstraintViolationError,
   SqlTaggedTemplateType
 } from 'slonik';
-import { ArrayTokenSymbol, TupleListTokenSymbol } from 'slonik/symbols';
+import { ArrayTokenSymbol, BinaryTokenSymbol } from 'slonik/symbols';
 
 // make sure symbols are unique
 // $ExpectError
-const badSymbolAssignment: typeof ArrayTokenSymbol = TupleListTokenSymbol;
+const badSymbolAssignment: typeof ArrayTokenSymbol = BinaryTokenSymbol;
 
 const VALUE = 'foo';
 
@@ -267,6 +267,23 @@ createTimestampWithTimeZoneTypeParser();
   const query0 = sql`SELECT ${'foo'} FROM bar`;
   // ExpectType SqlSqlTokenType
   const query1 = sql`SELECT ${'baz'} FROM (${query0})`;
+
+  await connection.query(sql`
+    SELECT ${sql.identifier(['foo', 'a'])}
+    FROM (
+      VALUES
+      (
+        ${sql.join(
+          [
+            sql.join(['a1', 'b1', 'c1'], sql`, `),
+            sql.join(['a2', 'b2', 'c2'], sql`, `)
+          ],
+          sql`), (`
+        )}
+      )
+    ) foo(a, b, c)
+    WHERE foo.b IN (${sql.join(['c1', 'a2'], sql`, `)})
+  `);
 
   await connection.query(sql`
       SELECT (${sql.json([1, 2, { test: 12, other: 'test' }])})

--- a/types/slonik/symbols.d.ts
+++ b/types/slonik/symbols.d.ts
@@ -1,13 +1,7 @@
 export const ArrayTokenSymbol: unique symbol;
-export const AssignmentListTokenSymbol: unique symbol;
-export const BooleanExpressionTokenSymbol: unique symbol;
-export const ComparisonPredicateTokenSymbol: unique symbol;
-export const IdentifierListTokenSymbol: unique symbol;
+export const BinaryTokenSymbol: unique symbol;
 export const IdentifierTokenSymbol: unique symbol;
 export const JsonTokenSymbol: unique symbol;
-export const RawSqlTokenSymbol: unique symbol;
+export const ListTokenSymbol: unique symbol;
 export const SqlTokenSymbol: unique symbol;
-export const ValueListTokenSymbol: unique symbol;
-export const TupleTokenSymbol: unique symbol;
-export const TupleListTokenSymbol: unique symbol;
 export const UnnestTokenSymbol: unique symbol;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/slonik/commit/910177db4e8bdb8f2d2b4a9e82bd017044a6801d#diff-196906dac4d96fa06e8bde4437b30d65

As mentioned in the [#38524](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38524#issuecomment-537039019) support for `sql.join` was still missing from the Slonik v19 types.