### PR TITLE
[@types/react-modal] Allow `null` in bodyOpenClassName, htmlOpenClassName & role

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-modal 3.8
+// Type definitions for react-modal 3.10
 // Project: https://github.com/reactjs/react-modal
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>,
 //                 Drew Noakes <https://github.com/drewnoakes>,
@@ -50,11 +50,11 @@ declare namespace ReactModal {
         /* String className to be applied to the portal. Defaults to "ReactModalPortal". */
         portalClassName?: string;
 
-        /* String className to be applied to the document.body. */
-        bodyOpenClassName?: string;
+        /* String className to be applied to the document.body (must be a constant string). When set to null it doesn't add any class to document.body. */
+        bodyOpenClassName?: string | null;
 
-        /* String className to be applied to the document.html. */
-        htmlOpenClassName?: string;
+        /* String className to be applied to the document.html (must be a constant string). Defaults to null. */
+        htmlOpenClassName?: string | null;
 
         /* String or object className to be applied to the modal content. */
         className?: string | Classes;
@@ -101,8 +101,8 @@ declare namespace ReactModal {
         /* Additional data attributes to be applied to to the modal content in the form of "data-*" */
         data?: any;
 
-        /* String indicating the role of the modal, allowing the 'dialog' role to be applied if desired. */
-        role?: string;
+        /* String indicating the role of the modal, allowing the 'dialog' role to be applied if desired. Defaults to "dialog". */
+        role?: string | null;
 
         /* String indicating how the content container should be announced to screenreaders. */
         contentLabel?: string;


### PR DESCRIPTION
As per the [docs](https://github.com/reactjs/react-modal/blob/2ae092aecb376170b72ec3d7e069670cbaff275c/docs/styles/classes.md#for-the-documentbody-and-html-tag) and [tests](https://github.com/reactjs/react-modal/blob/c747c247ae22bf09dd4188719a3bfa7ce1c644c0/specs/Modal.spec.js) the following props can be `null`:

* `bodyOpenClassName`
* `htmlOpenClassName`
* `role`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docs](https://github.com/reactjs/react-modal/blob/2ae092aecb376170b72ec3d7e069670cbaff275c/docs/styles/classes.md#for-the-documentbody-and-html-tag) and [tests](https://github.com/reactjs/react-modal/blob/c747c247ae22bf09dd4188719a3bfa7ce1c644c0/specs/Modal.spec.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
