### PR TITLE
vuelidate: Add function call signature to ValidationRule

### DIFF
--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -14,7 +14,7 @@ export interface ValidationParams {
 
 // const ValidationRule
 export interface ValidationRule {
-    (...params: unknown[]): boolean
+    (...params: any[]): boolean
     $params(): ValidationParams
     $pending(): boolean
 }

--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -14,6 +14,7 @@ export interface ValidationParams {
 
 // const ValidationRule
 export interface ValidationRule {
+    (...params: unknown[]): boolean
     $params(): ValidationParams
     $pending(): boolean
 }

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -19,7 +19,7 @@ const contains = (param: string): CustomRule =>
 
 const mustBeCool3 = helpers.withParams(
     { type: 'mustBeCool3' },
-    (value) => !helpers.req(value) || value.indexOf('cool') >= 0
+    (value: any) => !helpers.req(value) || value.indexOf('cool') >= 0
 )
 
 const mustBeCool3Result: boolean = mustBeCool3(50)

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -22,6 +22,8 @@ const mustBeCool3 = helpers.withParams(
     (value) => !helpers.req(value) || value.indexOf('cool') >= 0
 )
 
+const mustBeCool3Result: boolean = mustBeCool3(50)
+
 const mustBeCool4 = helpers.regex('mustBeCool4', /^.*cool.*$/)
 
 const mustBeSame = (reference: string) => helpers.withParams(


### PR DESCRIPTION
`ValidationRule` is a function object that, when called, takes in parameters and then applies them to the inner validator function. The call signature for `ValidationRule` to behave as a function is currently missing. This PR simply adds that call signature to `ValidationRule`. 

We ran into this while writing tests for built-in validator-composed functions, like so:

```typescript
export const greaterThanZero: ValidationRule = and(
  minValue(0),
  not((value: UserInput) => value == 0)
);
export const greaterThanOrEqualToZero: ValidationRule = minValue(0);
```

For example, `greaterThanOrEqualToZero` could written as a `CustomRule` like so:

```typescript
const greaterThanOrEqualToZero = (value: UserInput) => !helpers.req(value) || value! >= 0
```

But it can also just be composed from the existing `ValidationRule`, `minValue`:

```typescript
const greaterThanOrEqualToZero: ValidationRule = minValue(0);
```

These behave identically in a validation form context, but we were unable to correctly unit test them without this type fix. Simply adding this call signature allowed our tests to pass. We also tested thoroughly through the `validations` option and various form setups before submitting this PR.

Vuelidate `withParams` reference that demonstrates `ValidationRule` behaves as a function: https://github.com/vuelidate/vuelidate/blob/bb23f01ab4f14a813a25cff8defb7788cd8859ac/src/params.js#L36-L55

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Vuelidate function return reference for a ValidationRule](https://github.com/vuelidate/vuelidate/blob/bb23f01ab4f14a813a25cff8defb7788cd8859ac/src/params.js#L36-L55)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
