### PR TITLE
Add support for node 12.2 module.createRequire(filename) method

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -1132,7 +1132,12 @@ declare namespace NodeJS {
     class Module {
         static runMain(): void;
         static wrap(code: string): string;
-        static createRequireFromPath(path: string): (path: string) => any;
+
+        /**
+         * @deprecated Deprecated since: v12.2.0. Please use createRequire() instead.
+         */
+        static createRequireFromPath(path: string): NodeRequireFunction;
+        static createRequire(path: string): NodeRequireFunction;
         static builtinModules: string[];
 
         static Module: typeof Module;

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -1137,7 +1137,7 @@ declare namespace NodeJS {
          * @deprecated Deprecated since: v12.2.0. Please use createRequire() instead.
          */
         static createRequireFromPath(path: string): NodeRequireFunction;
-        static createRequire(path: string): NodeRequireFunction;
+        static createRequire(path: string | URL): NodeRequireFunction;
         static builtinModules: string[];
 
         static Module: typeof Module;

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -1137,7 +1137,7 @@ declare namespace NodeJS {
          * @deprecated Deprecated since: v12.2.0. Please use createRequire() instead.
          */
         static createRequireFromPath(path: string): NodeRequireFunction;
-        static createRequire(path: string | URL): NodeRequireFunction;
+        static createRequire(path: string): NodeRequireFunction;
         static builtinModules: string[];
 
         static Module: typeof Module;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 12.2
+// Type definitions for non-npm package Node.js 12.11
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 12.11
+// Type definitions for non-npm package Node.js 12.2
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>


### PR DESCRIPTION
1. Add support for node 12.2 module.createRequire(filename) method
2. Deprecated module. createRequireFromPath(filename)
3. Update return type for createRequireFromPath (use NodeRequireFunction)

https://nodejs.org/api/modules.html#modules_module_createrequire_filename

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/modules.html#modules_module_createrequire_filename
- [ x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.