### PR TITLE
fix: enums for googlemaps

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -720,7 +720,7 @@ service.findPlaceFromQuery(
         fields: ['name'],
     },
     (results, status) => {
-        if (status === google.maps.places.PlacesServiceStatus.ERROR) {
+        if (status !== google.maps.places.PlacesServiceStatus.OK) {
             return;
         }
 
@@ -734,7 +734,7 @@ service.findPlaceFromPhoneNumber(
         fields: ['name'],
     },
     (results, status) => {
-        if (status === google.maps.places.PlacesServiceStatus.ERROR) {
+        if (status !== google.maps.places.PlacesServiceStatus.OK) {
             return;
         }
 

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Maps JavaScript API 3.37
+// Type definitions for Google Maps JavaScript API 3.38
 // Project: https://developers.google.com/maps/
 // Definitions by: Chris Wrench <https://github.com/cgwrench>,
 //                 Kiarash Ghiaseddin <https://github.com/Silver-Connection>,
@@ -12,6 +12,7 @@
 //                 Colin Doig <https://github.com/captain-igloo>
 //                 Dmitry Demensky <https://github.com/demensky>
 //                 Vladimir Dashukevich <https://github.com/life777>
+//                 Simon Haenisch <https://github.com/simonhaenisch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 2.7
@@ -286,9 +287,11 @@ declare namespace google.maps {
     }
 
     enum MapTypeControlStyle {
-        DEFAULT,
-        DROPDOWN_MENU,
-        HORIZONTAL_BAR,
+        DEFAULT = 0,
+        DROPDOWN_MENU = 1,
+        HORIZONTAL_BAR = 2,
+        INSET = 3,
+        INSET_LARGE = 4,
     }
 
     type GestureHandlingOptions = 'cooperative' | 'greedy' | 'none' | 'auto';
@@ -343,7 +346,7 @@ declare namespace google.maps {
     }
 
     enum ScaleControlStyle {
-        DEFAULT,
+        DEFAULT = 0,
     }
 
     /** Options for the rendering of the Street View pegman control on the map. */
@@ -370,9 +373,9 @@ declare namespace google.maps {
     }
 
     enum ZoomControlStyle {
-        DEFAULT,
-        LARGE,
-        SMALL,
+        DEFAULT = 0,
+        LARGE = 1,
+        SMALL = 2,
     }
 
     /**
@@ -381,45 +384,55 @@ declare namespace google.maps {
      * Controls that are added first are positioned closer to the edge of the map.
      */
     enum ControlPosition {
+        /** Same as `BOTTOM_CENTER`. */
+        BOTTOM = 11,
         /** Elements are positioned in the center of the bottom row. */
-        BOTTOM_CENTER,
+        BOTTOM_CENTER = 11,
         /**
          * Elements are positioned in the bottom left and flow towards the middle.
          * Elements are positioned to the right of the Google logo.
          */
-        BOTTOM_LEFT,
+        BOTTOM_LEFT = 10,
         /**
          * Elements are positioned in the bottom right and flow towards the middle.
          * Elements are positioned to the left of the copyrights.
          */
-        BOTTOM_RIGHT,
+        BOTTOM_RIGHT = 12,
+        /** Elements are positioned in the center. */
+        CENTER = 13,
+        /** Same as `LEFT_TOP`. */
+        LEFT = 5,
         /**
          * Elements are positioned on the left, above bottom-left elements, and flow
          * upwards.
          */
-        LEFT_BOTTOM,
+        LEFT_BOTTOM = 6,
         /** Elements are positioned in the center of the left side. */
-        LEFT_CENTER,
+        LEFT_CENTER = 4,
         /**
          * Elements are positioned on the left, below top-left elements, and flow
          * downwards.
          */
-        LEFT_TOP,
+        LEFT_TOP = 5,
+        /** Same as `RIGHT_TOP`. */
+        RIGHT = 7,
         /**
          * Elements are positioned on the right, above bottom-right elements, and
          * flow upwards.
          */
-        RIGHT_BOTTOM,
+        RIGHT_BOTTOM = 9,
         /** Elements are positioned in the center of the right side. */
-        RIGHT_CENTER,
+        RIGHT_CENTER = 8,
         /** Elements are positioned on the right, below top-right elements, and flow downwards. */
-        RIGHT_TOP,
-        /**    Elements are positioned in the center of the top row. */
-        TOP_CENTER,
-        /** Elements are positioned in the top left and flow towards the middle. */
-        TOP_LEFT,
+        RIGHT_TOP = 7,
+        /** Same as `TOP_CENTER`. */
+        TOP = 2,
+        /** Elements are positioned in the center of the top row. */
+        TOP_CENTER = 2,
         /** Elements are positioned in the top right and flow towards the middle. */
-        TOP_RIGHT,
+        TOP_LEFT = 1,
+        /** Elements are positioned in the top right and flow towards the middle. */
+        TOP_RIGHT = 3,
     }
 
     type DrawingMode = 'Point' | 'LineString' | 'Polygon';
@@ -1565,11 +1578,11 @@ declare namespace google.maps {
          * The stroke is centered on the polygon's path, with half the stroke inside
          * the polygon and half the stroke outside the polygon.
          */
-        CENTER,
+        CENTER = 0,
         /** The stroke lies inside the polygon. */
-        INSIDE,
+        INSIDE = 1,
         /** The stroke lies outside the polygon. */
-        OUTSIDE,
+        OUTSIDE = 2,
     }
 
     class GroundOverlay extends MVCObject {
@@ -1674,13 +1687,13 @@ declare namespace google.maps {
     }
 
     enum GeocoderStatus {
-        ERROR,
-        INVALID_REQUEST,
-        OK,
-        OVER_QUERY_LIMIT,
-        REQUEST_DENIED,
-        UNKNOWN_ERROR,
-        ZERO_RESULTS,
+        ERROR = 'ERROR',
+        INVALID_REQUEST = 'INVALID_REQUEST',
+        OK = 'OK',
+        OVER_QUERY_LIMIT = 'OVER_QUERY_LIMIT',
+        REQUEST_DENIED = 'REQUEST_DENIED',
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+        ZERO_RESULTS = 'ZERO_RESULTS',
     }
 
     interface GeocoderResult {
@@ -1707,10 +1720,10 @@ declare namespace google.maps {
     }
 
     enum GeocoderLocationType {
-        APPROXIMATE,
-        GEOMETRIC_CENTER,
-        RANGE_INTERPOLATED,
-        ROOFTOP,
+        APPROXIMATE = 'APPROXIMATE',
+        GEOMETRIC_CENTER = 'GEOMETRIC_CENTER',
+        RANGE_INTERPOLATED = 'RANGE_INTERPOLATED',
+        ROOFTOP = 'ROOFTOP',
     }
 
     class DirectionsRenderer extends MVCObject {
@@ -1816,15 +1829,16 @@ declare namespace google.maps {
     }
 
     enum TravelMode {
-        BICYCLING,
-        DRIVING,
-        TRANSIT,
-        WALKING,
+        BICYCLING = 'BICYCLING',
+        DRIVING = 'DRIVING',
+        TRANSIT = 'TRANSIT',
+        TWO_WHEELER = 'TWO_WHEELER',
+        WALKING = 'WALKING',
     }
 
     enum UnitSystem {
-        IMPERIAL,
-        METRIC,
+        METRIC = 0,
+        IMPERIAL = 1,
     }
 
     interface TransitOptions {
@@ -1835,16 +1849,16 @@ declare namespace google.maps {
     }
 
     enum TransitMode {
-        BUS,
-        RAIL,
-        SUBWAY,
-        TRAIN,
-        TRAM,
+        BUS = 'BUS',
+        RAIL = 'RAIL',
+        SUBWAY = 'SUBWAY',
+        TRAIN = 'TRAIN',
+        TRAM = 'TRAM',
     }
 
     enum TransitRoutePreference {
-        FEWER_TRANSFERS,
-        LESS_WALKING,
+        FEWER_TRANSFERS = 'FEWER_TRANSFERS',
+        LESS_WALKING = 'LESS_WALKING',
     }
 
     interface TransitFare {
@@ -1858,9 +1872,9 @@ declare namespace google.maps {
     }
 
     enum TrafficModel {
-        BEST_GUESS,
-        OPTIMISTIC,
-        PESSIMISTIC,
+        BEST_GUESS = 'bestguess',
+        OPTIMISTIC = 'optimistic',
+        PESSIMISTIC = 'pessimistic',
     }
 
     /**
@@ -1888,14 +1902,14 @@ declare namespace google.maps {
     }
 
     enum DirectionsStatus {
-        INVALID_REQUEST,
-        MAX_WAYPOINTS_EXCEEDED,
-        NOT_FOUND,
-        OK,
-        OVER_QUERY_LIMIT,
-        REQUEST_DENIED,
-        UNKNOWN_ERROR,
-        ZERO_RESULTS,
+        INVALID_REQUEST = 'INVALID_REQUEST',
+        MAX_WAYPOINTS_EXCEEDED = 'MAX_WAYPOINTS_EXCEEDED',
+        NOT_FOUND = 'NOT_FOUND',
+        OK = 'OK',
+        OVER_QUERY_LIMIT = 'OVER_QUERY_LIMIT',
+        REQUEST_DENIED = 'REQUEST_DENIED',
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+        ZERO_RESULTS = 'ZERO_RESULTS',
     }
 
     interface DirectionsResult {
@@ -2098,11 +2112,11 @@ declare namespace google.maps {
     }
 
     enum ElevationStatus {
-        INVALID_REQUEST,
-        OK,
-        OVER_QUERY_LIMIT,
-        REQUEST_DENIED,
-        UNKNOWN_ERROR,
+        INVALID_REQUEST = 'INVALID_REQUEST',
+        OK = 'OK',
+        OVER_QUERY_LIMIT = 'OVER_QUERY_LIMIT',
+        REQUEST_DENIED = 'REQUEST_DENIED',
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR',
     }
 
     class MaxZoomService {
@@ -2115,8 +2129,8 @@ declare namespace google.maps {
     }
 
     enum MaxZoomStatus {
-        ERROR,
-        OK,
+        ERROR = 'ERROR',
+        OK = 'OK',
     }
 
     class DistanceMatrixService {
@@ -2159,19 +2173,19 @@ declare namespace google.maps {
     }
 
     enum DistanceMatrixStatus {
-        INVALID_REQUEST,
-        MAX_DIMENSIONS_EXCEEDED,
-        MAX_ELEMENTS_EXCEEDED,
-        OK,
-        OVER_QUERY_LIMIT,
-        REQUEST_DENIED,
-        UNKNOWN_ERROR,
+        INVALID_REQUEST = 'INVALID_REQUEST',
+        MAX_DIMENSIONS_EXCEEDED = 'MAX_DIMENSIONS_EXCEEDED',
+        MAX_ELEMENTS_EXCEEDED = 'MAX_ELEMENTS_EXCEEDED',
+        OK = 'OK',
+        OVER_QUERY_LIMIT = 'OVER_QUERY_LIMIT',
+        REQUEST_DENIED = 'REQUEST_DENIED',
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR',
     }
 
     enum DistanceMatrixElementStatus {
-        NOT_FOUND,
-        OK,
-        ZERO_RESULTS,
+        NOT_FOUND = 'NOT_FOUND',
+        OK = 'OK',
+        ZERO_RESULTS = 'ZERO_RESULTS',
     }
 
     /***** Save to Google Maps *****/
@@ -2438,15 +2452,15 @@ declare namespace google.maps {
     }
 
     enum KmlLayerStatus {
-        DOCUMENT_NOT_FOUND,
-        DOCUMENT_TOO_LARGE,
-        FETCH_ERROR,
-        INVALID_DOCUMENT,
-        INVALID_REQUEST,
-        LIMITS_EXCEEDED,
-        OK,
-        TIMED_OUT,
-        UNKNOWN,
+        DOCUMENT_NOT_FOUND = 'DOCUMENT_NOT_FOUND',
+        DOCUMENT_TOO_LARGE = 'DOCUMENT_TOO_LARGE',
+        FETCH_ERROR = 'FETCH_ERROR',
+        INVALID_DOCUMENT = 'INVALID_DOCUMENT',
+        INVALID_REQUEST = 'INVALID_REQUEST',
+        LIMITS_EXCEEDED = 'LIMITS_EXCEEDED',
+        OK = 'OK',
+        TIMED_OUT = 'TIMED_OUT',
+        UNKNOWN = 'UNKNOWN',
     }
 
     interface KmlMouseEvent {
@@ -2588,13 +2602,13 @@ declare namespace google.maps {
     }
 
     enum StreetViewPreference {
-        BEST,
-        NEAREST,
+        BEST = 'best',
+        NEAREST = 'nearest',
     }
 
     enum StreetViewSource {
-        DEFAULT,
-        OUTDOOR,
+        DEFAULT = 'default',
+        OUTDOOR = 'outdoor',
     }
 
     interface StreetViewLocationRequest {
@@ -2625,9 +2639,9 @@ declare namespace google.maps {
     }
 
     enum StreetViewStatus {
-        OK,
-        UNKNOWN_ERROR,
-        ZERO_RESULTS,
+        OK = 'OK',
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+        ZERO_RESULTS = 'ZERO_RESULTS',
     }
 
     class StreetViewCoverageLayer extends MVCObject {
@@ -3088,24 +3102,24 @@ declare namespace google.maps {
         }
 
         enum AdFormat {
-            BANNER,
-            BUTTON,
-            HALF_BANNER,
-            LARGE_HORIZONTAL_LINK_UNIT,
-            LARGE_RECTANGLE,
-            LARGE_VERTICAL_LINK_UNIT,
-            LEADERBOARD,
-            MEDIUM_RECTANGLE,
-            MEDIUM_VERTICAL_LINK_UNIT,
-            SKYSCRAPER,
-            SMALL_HORIZONTAL_LINK_UNIT,
-            SMALL_RECTANGLE,
-            SMALL_SQUARE,
-            SMALL_VERTICAL_LINK_UNIT,
-            SQUARE,
-            VERTICAL_BANNER,
-            WIDE_SKYSCRAPER,
-            X_LARGE_VERTICAL_LINK_UNIT,
+            BANNER = '468x60_as',
+            BUTTON = '125x125_as',
+            HALF_BANNER = '234x60_as',
+            LARGE_HORIZONTAL_LINK_UNIT = '728x15_0ads_al',
+            LARGE_RECTANGLE = '336x280_as',
+            LARGE_VERTICAL_LINK_UNIT = '180x90_0ads_al',
+            LEADERBOARD = '728x90_as',
+            MEDIUM_RECTANGLE = '300x250_as',
+            MEDIUM_VERTICAL_LINK_UNIT = '160x90_0ads_al',
+            SKYSCRAPER = '120x600_as',
+            SMALL_HORIZONTAL_LINK_UNIT = '468x15_0ads_al',
+            SMALL_RECTANGLE = '180x150_as',
+            SMALL_SQUARE = '200x200_as',
+            SMALL_VERTICAL_LINK_UNIT = '120x90_0ads_al',
+            SQUARE = '250x250_as',
+            VERTICAL_BANNER = '120x240_as',
+            WIDE_SKYSCRAPER = '160x600_as',
+            X_LARGE_VERTICAL_LINK_UNIT = '200x90_0ads_al',
         }
     }
 
@@ -3337,14 +3351,13 @@ declare namespace google.maps {
         }
 
         enum PlacesServiceStatus {
-            ERROR,
-            INVALID_REQUEST,
-            OK,
-            OVER_QUERY_LIMIT,
-            NOT_FOUND,
-            REQUEST_DENIED,
-            UNKNOWN_ERROR,
-            ZERO_RESULTS,
+            INVALID_REQUEST = 'INVALID_REQUEST',
+            NOT_FOUND = 'NOT_FOUND',
+            OK = 'OK',
+            OVER_QUERY_LIMIT = 'OVER_QUERY_LIMIT',
+            REQUEST_DENIED = 'REQUEST_DENIED',
+            UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+            ZERO_RESULTS = 'ZERO_RESULTS',
         }
 
         interface QueryAutocompletePrediction {
@@ -3373,8 +3386,8 @@ declare namespace google.maps {
         }
 
         enum RankBy {
-            DISTANCE,
-            PROMINENCE,
+            DISTANCE = 1,
+            PROMINENCE = 0,
         }
 
         class SearchBox extends MVCObject {
@@ -3497,27 +3510,27 @@ declare namespace google.maps {
              * Specifies that the DrawingManager creates circles, and that the overlay
              * given in the overlaycomplete event is a circle.
              */
-            CIRCLE,
+            CIRCLE = 'circle',
             /**
              * Specifies that the DrawingManager creates markers, and that the overlay
              * given in the overlaycomplete event is a marker.
              */
-            MARKER,
+            MARKER = 'marker',
             /**
              * Specifies that the DrawingManager creates polygons, and that the
              * overlay given in the overlaycomplete event is a polygon.
              */
-            POLYGON,
+            POLYGON = 'polygon',
             /**
              * Specifies that the DrawingManager creates polylines, and that the
              * overlay given in the overlaycomplete event is a polyline.
              */
-            POLYLINE,
+            POLYLINE = 'polyline',
             /**
              * Specifies that the DrawingManager creates rectangles, and that the
              * overlay given in the overlaycomplete event is a rectangle.
              */
-            RECTANGLE,
+            RECTANGLE = 'rectangle',
         }
     }
 
@@ -3567,9 +3580,9 @@ declare namespace google.maps {
         }
 
         enum MapsEngineStatus {
-            INVALID_LAYER,
-            OK,
-            UNKNOWN_ERROR,
+            INVALID_LAYER = 'INVALID_LAYER',
+            OK = 'OK',
+            UNKNOWN_ERROR = 'UNKNOWN_ERROR',
         }
 
         class HeatmapLayer extends MVCObject {

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -384,8 +384,6 @@ declare namespace google.maps {
      * Controls that are added first are positioned closer to the edge of the map.
      */
     enum ControlPosition {
-        /** Same as `BOTTOM_CENTER`. */
-        BOTTOM = 11,
         /** Elements are positioned in the center of the bottom row. */
         BOTTOM_CENTER = 11,
         /**
@@ -398,10 +396,6 @@ declare namespace google.maps {
          * Elements are positioned to the left of the copyrights.
          */
         BOTTOM_RIGHT = 12,
-        /** Elements are positioned in the center. */
-        CENTER = 13,
-        /** Same as `LEFT_TOP`. */
-        LEFT = 5,
         /**
          * Elements are positioned on the left, above bottom-left elements, and flow
          * upwards.
@@ -414,8 +408,6 @@ declare namespace google.maps {
          * downwards.
          */
         LEFT_TOP = 5,
-        /** Same as `RIGHT_TOP`. */
-        RIGHT = 7,
         /**
          * Elements are positioned on the right, above bottom-right elements, and
          * flow upwards.
@@ -425,8 +417,6 @@ declare namespace google.maps {
         RIGHT_CENTER = 8,
         /** Elements are positioned on the right, below top-right elements, and flow downwards. */
         RIGHT_TOP = 7,
-        /** Same as `TOP_CENTER`. */
-        TOP = 2,
         /** Elements are positioned in the center of the top row. */
         TOP_CENTER = 2,
         /** Elements are positioned in the top right and flow towards the middle. */

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -288,8 +288,8 @@ declare namespace google.maps {
 
     enum MapTypeControlStyle {
         DEFAULT = 0,
-        DROPDOWN_MENU = 1,
-        HORIZONTAL_BAR = 2,
+        HORIZONTAL_BAR = 1,
+        DROPDOWN_MENU = 2,
         INSET = 3,
         INSET_LARGE = 4,
     }
@@ -374,8 +374,8 @@ declare namespace google.maps {
 
     enum ZoomControlStyle {
         DEFAULT = 0,
-        LARGE = 1,
-        SMALL = 2,
+        SMALL = 1,
+        LARGE = 2,
     }
 
     /**
@@ -3376,8 +3376,8 @@ declare namespace google.maps {
         }
 
         enum RankBy {
-            DISTANCE = 1,
             PROMINENCE = 0,
+            DISTANCE = 1,
         }
 
         class SearchBox extends MVCObject {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I've had some troubles with enum types, because a lot of them are actually strings but weren't typed as such.

To get all the values of the enums, I wrote a script that prints them to the console from the actual api code. See this fiddle: https://jsfiddle.net/9u8t4w01/.

```html
<script src="https://maps.googleapis.com/maps/api/js?libraries=places,drawing,geometry,visualization,adsense"></script>
```

```js
const getByPath = (object, path) => path.split('.').reduce((nestedObject, key) => nestedObject && nestedObject[key], object);

const enums = ['MapTypeControlStyle', 'ScaleControlStyle', 'ZoomControlStyle', 'ControlPosition', 'StrokePosition', 'GeocoderStatus', 'GeocoderLocationType', 'TravelMode', 'UnitSystem', 'TransitMode', 'TransitRoutePreference', 'TrafficModel', 'DirectionsStatus', 'ElevationStatus', 'MaxZoomStatus', 'DistanceMatrixStatus', 'DistanceMatrixElementStatus', 'KmlLayerStatus', 'StreetViewPreference', 'StreetViewSource', 'StreetViewStatus', 'adsense.AdFormat', 'places.PlacesServiceStatus', 'places.RankBy', 'drawing.OverlayType', 'visualization.MapsEngineStatus'];

enums.map(key => console.log(JSON.stringify({ [key]: getByPath(google.maps, key) }, null, 2)));
```

The `PlacesServiceStatus` enum had a field `ERROR` which doesn't actually exist as a type (also see https://developers.google.com/maps/documentation/javascript/reference/places-service#PlacesServiceStatus). Therefore I removed it, but I'm not sure: would this be considered a breaking change for the types?