### PR TITLE
Add types for JSX extensions to ESTree AST

### DIFF
--- a/types/estree-jsx/estree-jsx-tests.ts
+++ b/types/estree-jsx/estree-jsx-tests.ts
@@ -1,0 +1,122 @@
+import * as ESTree from 'estree';
+
+import {
+    Node,
+    JSXIdentifier,
+    JSXNamespacedName,
+    JSXMemberExpression,
+    JSXEmptyExpression,
+    JSXExpressionContainer,
+    JSXSpreadChild,
+    JSXSpreadAttribute,
+    JSXAttribute,
+    JSXOpeningElement,
+    JSXOpeningFragment,
+    JSXClosingElement,
+    JSXClosingFragment,
+    JSXElement,
+    JSXFragment,
+    JSXText
+} from 'estree-jsx';
+
+declare let node: Node;
+declare let identifier: JSXIdentifier;
+declare let namespacedName: JSXNamespacedName;
+declare let memberExpression: JSXMemberExpression;
+declare let emptyExpression: JSXEmptyExpression;
+declare let expressionContainer: JSXExpressionContainer;
+declare let spreadChild: JSXSpreadChild;
+declare let spreadAttribute: JSXSpreadAttribute;
+declare let attribute: JSXAttribute;
+declare let openingElement: JSXOpeningElement;
+declare let openingFragment: JSXOpeningFragment;
+declare let closingElement: JSXClosingElement;
+declare let closingFragment: JSXClosingFragment;
+declare let element: JSXElement;
+declare let fragment: JSXFragment;
+declare let text: JSXText;
+
+declare let estreeNode: ESTree.Node;
+
+declare let children: Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>;
+
+declare let string: string;
+declare let boolean: boolean;
+
+// JSXExpressionContainer
+const expOrEmpty: ESTree.Expression | JSXEmptyExpression = expressionContainer.expression;
+
+// JSXSpreadChild
+const exp: ESTree.Expression = spreadChild.expression;
+
+// JSXAttribute
+const attributeName: JSXIdentifier | JSXNamespacedName = attribute.name;
+const attributeValue: ESTree.Literal | JSXExpressionContainer | JSXElement | JSXFragment | null = attribute.value;
+
+// JSXOpeningElement
+const attributes: Array<JSXAttribute | JSXSpreadAttribute> = openingElement.attributes;
+boolean = openingElement.selfClosing;
+
+// JSXElement
+openingElement = element.openingElement;
+children = element.children;
+const closingElementOrNull: JSXClosingElement | null = element.closingElement;
+
+// JSXFragment
+openingFragment = fragment.openingFragment;
+children = fragment.children;
+closingFragment = fragment.closingFragment;
+
+// JSXText
+string = text.value;
+string = text.raw;
+
+// Test narrowing
+
+switch (node.type) {
+  case 'JSXAttribute':
+    attribute = node;
+    break;
+  case 'JSXClosingElement':
+    closingElement = node;
+    break;
+  case 'JSXClosingFragment':
+    closingFragment = node;
+    break;
+  case 'JSXElement':
+    element = node;
+    break;
+  case 'JSXEmptyExpression':
+    emptyExpression = node;
+    break;
+  case 'JSXExpressionContainer':
+    expressionContainer = node;
+    break;
+  case 'JSXFragment':
+    fragment = node;
+    break;
+  case 'JSXIdentifier':
+    identifier = node;
+    break;
+  case 'JSXMemberExpression':
+    memberExpression = node;
+    break;
+  case 'JSXNamespacedName':
+    namespacedName = node;
+    break;
+  case 'JSXOpeningElement':
+    openingElement = node;
+    break;
+  case 'JSXOpeningFragment':
+    openingFragment = node;
+    break;
+  case 'JSXSpreadAttribute':
+    spreadAttribute = node;
+    break;
+  case 'JSXText':
+    text = node;
+    break;
+
+  default:
+    estreeNode = node;
+}

--- a/types/estree-jsx/index.d.ts
+++ b/types/estree-jsx/index.d.ts
@@ -1,0 +1,103 @@
+// Type definitions for JSX extensions to ESTree AST specification
+// Project: https://github.com/facebook/jsx
+// Definitions by: Tony Ross <https://github.com/antross>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Based on https://github.com/facebook/jsx/blob/master/AST.md.
+// Extends existing types for ESTree AST from `@types/estree`.
+
+import {
+    BaseExpression,
+    BaseNode,
+    Expression,
+    Literal,
+    Node as ESTreeNode
+} from 'estree';
+
+export * from 'estree';
+
+export type Node =
+    ESTreeNode | JSXIdentifier | JSXNamespacedName | JSXMemberExpression |
+    JSXEmptyExpression | JSXExpressionContainer | JSXSpreadAttribute |
+    JSXAttribute | JSXOpeningElement | JSXOpeningFragment | JSXClosingElement |
+    JSXClosingFragment | JSXElement | JSXFragment | JSXText;
+
+export interface JSXIdentifier extends BaseNode {
+    type: 'JSXIdentifier';
+    name: string;
+}
+
+export interface JSXMemberExpression extends BaseExpression {
+    type: 'JSXMemberExpression';
+}
+
+export interface JSXNamespacedName extends BaseExpression {
+    type: 'JSXNamespacedName';
+}
+
+export interface JSXEmptyExpression extends BaseNode {
+    type: 'JSXEmptyExpression';
+}
+
+export interface JSXExpressionContainer extends BaseNode {
+    type: 'JSXExpressionContainer';
+    expression: Expression | JSXEmptyExpression;
+}
+
+export interface JSXSpreadChild extends BaseNode {
+    type: 'JSXSpreadChild';
+    expression: Expression;
+}
+
+interface JSXBoundaryElement extends BaseNode {
+    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+}
+
+export interface JSXOpeningElement extends JSXBoundaryElement {
+    type: 'JSXOpeningElement';
+    attributes: Array<JSXAttribute | JSXSpreadAttribute>;
+    selfClosing: boolean;
+}
+
+export interface JSXClosingElement extends JSXBoundaryElement {
+    type: 'JSXClosingElement';
+}
+
+export interface JSXAttribute extends BaseNode {
+    type: 'JSXAttribute';
+    name: JSXIdentifier | JSXNamespacedName;
+    value: Literal | JSXExpressionContainer | JSXElement | JSXFragment | null;
+}
+
+export interface JSXSpreadAttribute extends BaseNode {
+    type: 'JSXSpreadAttribute';
+    argument: Expression;
+}
+
+export interface JSXText extends BaseNode {
+    type: 'JSXText';
+    value: string;
+    raw: string;
+}
+
+export interface JSXElement extends BaseExpression {
+    type: 'JSXElement';
+    openingElement: JSXOpeningElement;
+    children: Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>;
+    closingElement: JSXClosingElement | null;
+}
+
+export interface JSXFragment extends BaseExpression {
+    type: 'JSXFragment';
+    openingFragment: JSXOpeningFragment;
+    children: Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>;
+    closingFragment: JSXClosingFragment;
+}
+
+export interface JSXOpeningFragment extends BaseNode {
+    type: 'JSXOpeningFragment';
+}
+
+export interface JSXClosingFragment extends BaseNode {
+    type: 'JSXClosingFragment';
+}

--- a/types/estree-jsx/tsconfig.json
+++ b/types/estree-jsx/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "estree-jsx-tests.ts"
+    ]
+}

--- a/types/estree-jsx/tslint.json
+++ b/types/estree-jsx/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false,
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Declare JSX types and export a modified `Node` type containing
the union of `Node` from `@types/estree` plus JSX node types.

Like `@types/estree` this is a types-only package to aid consuming
ASTs created by various JavaScript parsers used in tooling.

A couple questions:
1. This imports types from `@types/estree`. Do I need to do anything special to ensure this is referenced in the final NPM package or is that handled automatically based on the `import`?
2. Since this is a types-only package I had to disable the `dt-header` and `npm-naming` rules in `tslint.json`. I was not able to figure out how to do this using a disable comment. Is there a better approach for headers in types-only packages to pass linting?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
