### PR TITLE
[@types/react-redux] add types for hook factories

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -13,6 +13,7 @@
 //                 Boris Sergeyev <https://github.com/surgeboris>
 //                 Søren Bruus Frank <https://github.com/soerenbf>
 //                 Jonathan Ziller <https://github.com/mrwolfz>
+//                 Dylan Vann <https://github.com/dylanvann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -577,5 +578,29 @@ export interface TypedUseSelectorHook<TState> {
  * }
  */
 export function useStore<S = any, A extends Action = AnyAction>(): Store<S, A>;
+
+/**
+ * Hook factory, which creates a `useSelector` hook bound to a given context.
+ *
+ * @param Context passed to your `<Provider>`.
+ * @returns A `useSelector` hook bound to the specified context.
+ */
+export function createSelectorHook(context?: Context<ReactReduxContextValue>): typeof useSelector;
+
+/**
+ * Hook factory, which creates a `useStore` hook bound to a given context.
+ *
+ * @param Context passed to your `<Provider>`.
+ * @returns A `useStore` hook bound to the specified context.
+ */
+export function createStoreHook(context?: Context<ReactReduxContextValue>): typeof useStore;
+
+/**
+ * Hook factory, which creates a `useDispatch` hook bound to a given context.
+ *
+ * @param Context passed to your `<Provider>`.
+ * @returns A `useDispatch` hook bound to the specified context.
+ */
+export function createDispatchHook(context?: Context<ReactReduxContextValue>): typeof useDispatch;
 
 // tslint:enable:no-unnecessary-generics

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1402,6 +1402,11 @@ function testCreateHookFunctions() {
     createDispatchHook();
     // $ExpectType <TState, TSelected>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
     createSelectorHook();
+    interface RootState {
+        property: string;
+    }
+    // Should be able to create a version typed for a specific root state.
+    const useTypedSelector: TypedUseSelectorHook<RootState> = createSelectorHook();
     // $ExpectType <S = any, A extends Action<any> = AnyAction>() => Store<S, A>
     createStoreHook();
 }

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -26,6 +26,9 @@ import {
     useDispatch,
     useSelector,
     useStore,
+    createDispatchHook,
+    createSelectorHook,
+    createStoreHook,
     TypedUseSelectorHook,
 } from 'react-redux';
 import objectAssign = require('object-assign');
@@ -1391,6 +1394,16 @@ function testUseStore() {
     const typedState = typedStore.getState();
     typedState.counter;
     typedState.things.stuff; // $ExpectError
+}
+
+// These should match the types of the hooks.
+function testCreateHookFunctions() {
+    // $ExpectType { <TDispatch = Dispatch<any>>(): TDispatch; <A extends Action<any> = AnyAction>(): Dispatch<A>; }
+    createDispatchHook();
+    // $ExpectType <TState, TSelected>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
+    createSelectorHook();
+    // $ExpectType <S = any, A extends Action<any> = AnyAction>() => Store<S, A>
+    createStoreHook();
 }
 
 function testConnectedProps() {


### PR DESCRIPTION
Updates type definitions for changes in [this PR](https://github.com/reduxjs/react-redux/pull/1309) to `react-redux`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reduxjs/react-redux/pull/1309
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.