### PR TITLE
[office-js] [office-js-preview] (Outlook) Item id not a getCallbackTo…

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -13936,10 +13936,15 @@ declare namespace Office {
         /**
          * Gets a string that contains a token used to call REST APIs or Exchange Web Services.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The `getCallbackTokenAsync` method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
          * The lifetime of the callback token is 5 minutes.
          *
          * The token is returned as a string in the `asyncResult.value` property.
+         *
+         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
+         * 
+         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
+         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
          *
          * *REST Tokens*
          *
@@ -13957,6 +13962,13 @@ declare namespace Office {
          * The token will be limited in scope to accessing the current item.
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
+         *
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
+         * bearer authorization token to call the Exchange Web Services (EWS)
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
+         * attachment or item. For example, you can create a remote service to
+         * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
          * **Note**: It is recommended that add-ins use the REST APIs instead of Exchange Web Services whenever possible.
          *
@@ -13987,21 +13999,24 @@ declare namespace Office {
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The `getCallbackTokenAsync` method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
          * The lifetime of the callback token is 5 minutes.
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
-         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
-         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
+         * bearer authorization token to call the Exchange Web Services (EWS)
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} or
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
+         * attachment or item. For example, you can create a remote service to
+         * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
-         * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
+         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
-         * Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
+         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
          *
-         * [Api set: Mailbox 1.0]
+         * [Api set: Mailbox 1.0 for Read mode support; 1.3 for Compose mode support]
          *
          * @remarks
          *

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -13941,10 +13941,10 @@ declare namespace Office {
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
-         * 
-         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
-         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
+         * Calling the `getCallbackTokenAsync` method in read mode requires a minimum permission level of **ReadItem**.
+         *
+         * Calling the `getCallbackTokenAsync` method in compose mode requires you to have saved the item.
+         * The `saveAsync` method requires a minimum permission level of **ReadWriteItem**.
          *
          * *REST Tokens*
          *
@@ -13963,8 +13963,8 @@ declare namespace Office {
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
-         * bearer authorization token to call the Exchange Web Services (EWS)
+         * You can pass both the token and either an attachment identifier or item identifier to a third-party system. The third-party system uses
+         * the token as a bearer authorization token to call the Exchange Web Services (EWS)
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
          * attachment or item. For example, you can create a remote service to
@@ -14004,17 +14004,17 @@ declare namespace Office {
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
-         * bearer authorization token to call the Exchange Web Services (EWS)
+         * You can pass both the token and either an attachment identifier or item identifier to a third-party system. The third-party system uses
+         * the token as a bearer authorization token to call the Exchange Web Services (EWS)
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} or
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
          * attachment or item. For example, you can create a remote service to
          * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
-         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
+         * Calling the `getCallbackTokenAsync` method in read mode requires a minimum permission level of **ReadItem**.
          *
-         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
-         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
+         * Calling the `getCallbackTokenAsync` method in compose mode requires you to have saved the item.
+         * The `saveAsync` method requires a minimum permission level of **ReadWriteItem**.
          *
          * [Api set: Mailbox 1.0 for Read mode support; 1.3 for Compose mode support]
          *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -12248,10 +12248,10 @@ declare namespace Office {
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
-         * 
-         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
-         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
+         * Calling the `getCallbackTokenAsync` method in read mode requires a minimum permission level of **ReadItem**.
+         *
+         * Calling the `getCallbackTokenAsync` method in compose mode requires you to have saved the item.
+         * The `saveAsync` method requires a minimum permission level of **ReadWriteItem**.
          *
          * *REST Tokens*
          *
@@ -12270,8 +12270,8 @@ declare namespace Office {
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
-         * bearer authorization token to call the Exchange Web Services (EWS)
+         * You can pass both the token and either an attachment identifier or item identifier to a third-party system. The third-party system uses
+         * the token as a bearer authorization token to call the Exchange Web Services (EWS)
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
          * attachment or item. For example, you can create a remote service to
@@ -12311,17 +12311,17 @@ declare namespace Office {
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
-         * bearer authorization token to call the Exchange Web Services (EWS)
+         * You can pass both the token and either an attachment identifier or item identifier to a third-party system. The third-party system uses
+         * the token as a bearer authorization token to call the Exchange Web Services (EWS)
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
          * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
          * attachment or item. For example, you can create a remote service to
          * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
-         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
+         * Calling the `getCallbackTokenAsync` method in read mode requires a minimum permission level of **ReadItem**.
          *
-         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
-         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
+         * Calling the `getCallbackTokenAsync` method in compose mode requires you to have saved the item.
+         * The `saveAsync` method requires a minimum permission level of **ReadWriteItem**.
          *
          * [Api set: Mailbox 1.0 for Read mode support; 1.3 for Compose mode support]
          *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -12243,10 +12243,15 @@ declare namespace Office {
         /**
          * Gets a string that contains a token used to call REST APIs or Exchange Web Services.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The `getCallbackTokenAsync` method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
          * The lifetime of the callback token is 5 minutes.
          *
          * The token is returned as a string in the `asyncResult.value` property.
+         *
+         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
+         * 
+         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
+         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
          *
          * *REST Tokens*
          *
@@ -12264,6 +12269,13 @@ declare namespace Office {
          * The token will be limited in scope to accessing the current item.
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
+         *
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
+         * bearer authorization token to call the Exchange Web Services (EWS)
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
+         * attachment or item. For example, you can create a remote service to
+         * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
          * **Note**: It is recommended that add-ins use the REST APIs instead of Exchange Web Services whenever possible.
          *
@@ -12294,21 +12306,24 @@ declare namespace Office {
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The `getCallbackTokenAsync` method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
          * The lifetime of the callback token is 5 minutes.
          *
          * The token is returned as a string in the `asyncResult.value` property.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
-         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
-         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a
+         * bearer authorization token to call the Exchange Web Services (EWS)
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getattachment-operation | GetAttachment} operation or
+         * {@link https://docs.microsoft.com/exchange/client-developer/web-service-reference/getitem-operation | GetItem} operation to return an
+         * attachment or item. For example, you can create a remote service to
+         * {@link https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item | get attachments from the selected item}.
          *
-         * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
+         * To call the `getCallbackTokenAsync` method in read mode, **ReadItem** is the minimum permission level your app can specify in its manifest.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
-         * Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * If the item has not yet been saved in compose mode, you must call the `saveAsync` method before calling the `getCallbackTokenAsync` method.
+         * To call the `saveAsync` method, **ReadWriteItem** is the minimum permission level your app can specify.
          *
-         * [Api set: Mailbox 1.0]
+         * [Api set: Mailbox 1.0 for Read mode support; 1.3 for Compose mode support]
          *
          * @remarks
          *


### PR DESCRIPTION
…kenAsync param

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js-docs-pr/pull/1370/files
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.