### PR TITLE
[@types/hapi-pino] fix/improve types, improve tests

### DIFF
--- a/types/hapi-pino/hapi-pino-tests.ts
+++ b/types/hapi-pino/hapi-pino-tests.ts
@@ -1,4 +1,4 @@
-import { Server } from '@hapi/hapi';
+import { Request, Server } from '@hapi/hapi';
 import * as pino from 'pino';
 import * as HapiPino from 'hapi-pino';
 
@@ -6,39 +6,78 @@ const pinoLogger = pino();
 
 const server = new Server();
 
-server.register({
-    plugin: HapiPino,
-    options: {
-        logPayload: false,
-        logRouteTags: false,
-        stream: process.stdout,
-        prettyPrint: process.env.NODE_ENV !== 'PRODUCTION',
-        levelTags: {
-            trace: 'trace',
-            debug: 'debug',
-            info: 'info',
-            warn: 'warn',
-            error: 'error'
+function example1() {
+    server
+        .register({
+            plugin: HapiPino,
+            options: {
+                logPayload: false,
+                logRouteTags: false,
+                stream: process.stdout,
+                prettyPrint: process.env.NODE_ENV !== 'PRODUCTION',
+
+                tags: {
+                    trace: 'trace',
+                    debug: 'debug',
+                    info: 'info',
+                    warn: 'warn',
+                    error: 'error',
+                    fatal: 'fatal',
+                },
+                allTags: 'info',
+                serializers: {
+                    req: (req: any) => console.log(req),
+                },
+                instance: pinoLogger,
+                logEvents: false,
+                mergeHapiLogData: false,
+                ignorePaths: ['/testRoute'],
+                level: 'debug',
+                redact: ['test.property'],
+            },
+        })
+        .then(() => {
+            server.logger().debug('using logger object directly');
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: (request, h) => {
+                    request.logger.debug('using logger directly');
+                },
+            });
+        });
+}
+
+function example2() {
+    server.register({
+        plugin: HapiPino,
+        options: {
+            redact: {
+                paths: ['test.property', 'another.property'],
+                remove: true,
+            },
+            prettyPrint: {
+                levelFirst: true,
+                colorize: true,
+                translateTime: 'SYS:yyyy-mm-dd HH:MM:ss.l',
+                ignore: 'hostname,pid',
+            },
+            getChildBindings: (req: Request) => ({
+                'x-request-id': req.headers['x-request-id'],
+            }),
         },
-        allTags: 'info',
-        serializers: {
-            req: (req: any) => console.log(req)
-        },
-        instance: pinoLogger,
-        logEvents: false,
-        mergeHapiLogData: false,
+    });
+}
+
+function example3() {
+    HapiPino.register(server, {
         ignorePaths: ['/testRoute'],
         level: 'debug',
-        redact: ['test.property']
-    }
-}).then(() => {
-    server.logger().debug('using logger object directly');
-
-    server.route({
-        method: 'GET',
-        path: '/',
-        handler: (request, h) => {
-            request.logger.debug('using logger directly');
-        }
+        tags: {
+            trace: 'trace',
+            debug: 'debug',
+        },
+        redact: ['test.property'],
     });
-});
+}

--- a/types/hapi-pino/hapi-pino-tests.ts
+++ b/types/hapi-pino/hapi-pino-tests.ts
@@ -57,6 +57,7 @@ function example2() {
                 paths: ['test.property', 'another.property'],
                 remove: true,
             },
+            logRequestStart: true,
             prettyPrint: {
                 levelFirst: true,
                 colorize: true,

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi-pino 6.2
+// Type definitions for hapi-pino 6.3
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
@@ -23,19 +23,24 @@ declare module '@hapi/hapi' {
 }
 
 declare namespace HapiPino {
+    interface Serializers {
+        [key: string]: pino.SerializerFn;
+    }
+
     interface Options {
         logPayload?: boolean;
         logRouteTags?: boolean;
+        logRequestStart?: boolean;
         stream?: NodeJS.WriteStream;
         prettyPrint?: boolean | pino.PrettyOptions;
         tags?: { [key in pino.Level]?: string };
         allTags?: pino.Level;
-        serializers?: { [key: string]: pino.SerializerFn };
+        serializers?: Serializers;
         getChildBindings?: (
             req: Request,
         ) => {
             level?: pino.Level | string;
-            serializers?: Options['serializers'];
+            serializers?: Serializers;
             [key: string]: any;
         };
         instance?: pino.Logger;

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for hapi-pino 6.0
+// Type definitions for hapi-pino 6.2
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
+//                 Matt Jeanes <https://github.com/BlooJeans>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -9,7 +10,7 @@
 
 import * as pino from 'pino';
 
-import { Plugin } from '@hapi/hapi';
+import { Plugin, Request } from '@hapi/hapi';
 
 declare module '@hapi/hapi' {
     interface Server {
@@ -22,22 +23,27 @@ declare module '@hapi/hapi' {
 }
 
 declare namespace HapiPino {
-    type LogLevels = 'trace' | 'debug' | 'info' | 'warn' | 'error';
-
     interface Options {
         logPayload?: boolean;
         logRouteTags?: boolean;
         stream?: NodeJS.WriteStream;
-        prettyPrint?: boolean;
-        levelTags?: { [key in LogLevels]: string };
-        allTags?: LogLevels;
-        serializers?: { [key: string]: (param: any) => void};
+        prettyPrint?: boolean | pino.PrettyOptions;
+        tags?: { [key in pino.Level]?: string };
+        allTags?: pino.Level;
+        serializers?: { [key: string]: pino.SerializerFn };
+        getChildBindings?: (
+            req: Request,
+        ) => {
+            level?: pino.Level | string;
+            serializers?: Options['serializers'];
+            [key: string]: any;
+        };
         instance?: pino.Logger;
         logEvents?: string[] | false | null;
         mergeHapiLogData?: boolean;
         ignorePaths?: string[];
-        level?: LogLevels;
-        redact?: string[];
+        level?: pino.Level;
+        redact?: string[] | pino.redactOptions;
     }
 }
 


### PR DESCRIPTION
Summary:
- fix: `levelTags` -> `tags`
- fix: `tags` to allow for optional keys (before it required that you specified all keys)
- improve: add missing "fatal" from LogLevels (copied-directly from `@types/hapi`, since it's not exported from there)
- improve: updated `prettyPrint` and `redact` to include their advanced config options
- improve: add typedefs for `getChildBindings()` (new in 6.2.0)
- improve: more test coverage

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/hapi-pino#options

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
