### PR TITLE
[@types/enzyme] Add component display name selector generic overloads

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -128,6 +128,7 @@ function ShallowWrapperTest() {
     let elementWrapper: ShallowWrapper<HTMLAttributes<{}>>;
     let anotherStatelessWrapper: ShallowWrapper<AnotherStatelessProps, never>;
     let anotherComponentWrapper: ShallowWrapper<AnotherComponentProps, any>;
+    let displayNameWrapper: ShallowWrapper<AnotherComponentProps, any>;
 
     // testStatePropsInstanceFn(shallow<MyComponent>(<MyComponent stringProp="value" numberProp={1}/>));
     function testStatePropsInstance() {
@@ -179,6 +180,7 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.find(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.find({ prop: 'value' });
         elementWrapper = shallowWrapper.find('.selector');
+        displayNameWrapper = shallowWrapper.find<AnotherComponentProps>('AnotherComponent');
         // Since AnotherComponent does not have a constructor, it cannot match the
         // previous selector overload of ComponentClass { new(props?, contenxt? ) }
         const s1: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
@@ -287,6 +289,7 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.children(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.children({ prop: 'value' });
         elementWrapper = shallowWrapper.children('.selector');
+        displayNameWrapper = shallowWrapper.children<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_childAt() {
@@ -309,6 +312,7 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.parents(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.parents({ prop: 'myprop' });
         elementWrapper = shallowWrapper.parents('.selector');
+        displayNameWrapper = shallowWrapper.parents<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_parent() {
@@ -320,6 +324,7 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.closest(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.closest({ prop: 'myprop' });
         elementWrapper = shallowWrapper.closest('.selector');
+        displayNameWrapper = shallowWrapper.closest<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_shallow() {
@@ -402,6 +407,12 @@ function ShallowWrapperTest() {
         const props2: AnotherComponentProps = shallowWrapper.find(AnotherComponent).props();
         const props3: AnotherStatelessProps = shallowWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = shallowWrapper.find('.selector').props();
+        const props5: AnotherComponentProps = shallowWrapper.find<AnotherComponentProps>('AnotherComponent').props();
+    }
+
+    function test_props_component_display_name_selector() {
+        shallowWrapper.find<AnotherComponentProps>('AnotherComponent').props().anotherStringProp; // $ExpectType string | undefined
+        shallowWrapper.find('AnotherComponent').props().anotherStringProp; // $ExpectError
     }
 
     function test_prop() {
@@ -570,6 +581,7 @@ function ReactWrapperTest() {
     let elementWrapper: ReactWrapper<HTMLAttributes<{}>>;
     let anotherStatelessWrapper: ReactWrapper<AnotherStatelessProps, never>;
     let anotherComponentWrapper: ReactWrapper<AnotherComponentProps, any>;
+    let displayNameWrapper: ReactWrapper<AnotherComponentProps, any>;
 
     function testStatePropsInstance() {
         const wrapper = mount<MyComponent>(<MyComponent stringProp="value" numberProp={1}/>);
@@ -643,10 +655,11 @@ function ReactWrapperTest() {
     }
 
     function test_find() {
-        elementWrapper = reactWrapper.find('.selector');
         anotherComponentWrapper = reactWrapper.find(AnotherComponent);
         anotherStatelessWrapper = reactWrapper.find(AnotherStatelessComponent);
         reactWrapper = reactWrapper.find({ prop: 'myprop' });
+        elementWrapper = reactWrapper.find('.selector');
+        displayNameWrapper = reactWrapper.find<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_findWhere() {
@@ -731,6 +744,7 @@ function ReactWrapperTest() {
         anotherStatelessWrapper = reactWrapper.children(AnotherStatelessComponent);
         reactWrapper = reactWrapper.children({ prop: 'myprop' });
         elementWrapper = reactWrapper.children('.selector');
+        displayNameWrapper = reactWrapper.children<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_childAt() {
@@ -753,6 +767,7 @@ function ReactWrapperTest() {
         anotherStatelessWrapper = reactWrapper.parents(AnotherStatelessComponent);
         reactWrapper = reactWrapper.parents({ prop: 'myprop' });
         elementWrapper = reactWrapper.parents('.selector');
+        displayNameWrapper = reactWrapper.parents<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_parent() {
@@ -764,6 +779,7 @@ function ReactWrapperTest() {
         anotherStatelessWrapper = reactWrapper.closest(AnotherStatelessComponent);
         reactWrapper = reactWrapper.closest({ prop: 'myprop' });
         elementWrapper = reactWrapper.closest('.selector');
+        displayNameWrapper = reactWrapper.closest<AnotherComponentProps>('AnotherComponent');
     }
 
     function test_text() {
@@ -838,6 +854,12 @@ function ReactWrapperTest() {
         const props2: AnotherComponentProps = reactWrapper.find(AnotherComponent).props();
         const props3: AnotherStatelessProps = reactWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = reactWrapper.find('.selector').props();
+        const props5: AnotherComponentProps = reactWrapper.find<AnotherComponentProps>('AnotherComponent').props();
+    }
+
+    function test_props_component_display_name_selector() {
+        reactWrapper.find<AnotherComponentProps>('AnotherComponent').props().anotherStringProp; // $ExpectType string | undefined
+        reactWrapper.find('AnotherComponent').props().anotherStringProp; // $ExpectError
     }
 
     function test_prop() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -410,6 +410,7 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
     find<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    find<P2>(displayName: string): ShallowWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Removes nodes in the current wrapper that do not match the provided selector.
@@ -430,8 +431,9 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      */
     children<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     children<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
-    children(selector: string): ShallowWrapper<HTMLAttributes, any>;
     children(props?: EnzymePropSelector): ShallowWrapper<any, any>;
+    children(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    children<P2>(displayName: string): ShallowWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a new wrapper with child at the specified index.
@@ -465,8 +467,9 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      */
     parents<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     parents<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
-    parents(selector: string): ShallowWrapper<HTMLAttributes, any>;
     parents(props?: EnzymePropSelector): ShallowWrapper<any, any>;
+    parents(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    parents<P2>(displayName: string): ShallowWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a wrapper of the first element that matches the selector by traversing up through the current node's
@@ -478,6 +481,7 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
     closest<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     closest(props: EnzymePropSelector): ShallowWrapper<any, any>;
     closest(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    closest<P2>(displayName: string): ShallowWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a wrapper with the direct parent of the node in the current wrapper.
@@ -543,6 +547,7 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
     find<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
+    find<P2>(displayName: string): ReactWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.
@@ -563,8 +568,9 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      */
     children<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     children<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
-    children(selector: string): ReactWrapper<HTMLAttributes, any>;
     children(props?: EnzymePropSelector): ReactWrapper<any, any>;
+    children(selector: string): ReactWrapper<HTMLAttributes, any>;
+    children<P2>(displayName: string): ReactWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a new wrapper with child at the specified index.
@@ -580,8 +586,9 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      */
     parents<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     parents<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
-    parents(selector: string): ReactWrapper<HTMLAttributes, any>;
     parents(props?: EnzymePropSelector): ReactWrapper<any, any>;
+    parents(selector: string): ReactWrapper<HTMLAttributes, any>;
+    parents<P2>(displayName: string): ReactWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a wrapper of the first element that matches the selector by traversing up through the current node's
@@ -593,6 +600,7 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
     closest<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     closest(props: EnzymePropSelector): ReactWrapper<any, any>;
     closest(selector: string): ReactWrapper<HTMLAttributes, any>;
+    closest<P2>(displayName: string): ReactWrapper<P2, any>; // tslint:disable-line unified-signatures
 
     /**
      * Returns a wrapper with the direct parent of the node in the current wrapper.


### PR DESCRIPTION
This adds generic overloads for the selector functions when using a **component display name** instead of the component constructor (or any other valid selector type).

**Before:** 
```ts
shallowWrapper.find('AnotherComponent').props().anotherStringProp; // Error: Property 'anotherStringProp' does not exist on type 'HTMLAttributes'.ts(2339)
(shallowWrapper.find('AnotherComponent').props() as AnotherComponentProps).anotherStringProp; // OK
```

**~After:~**
```ts
shallowWrapper.find<AnotherComponentProps>('AnotherComponent').props().anotherStringProp; // OK
```

I have added the `// tslint:disable-line unified-signatures` flags to the newly added overloads because this way it's more explicit if you want to get typed props with a `displayName` selector. Otherwise, the linter suggests merging 3 of them together which ends up in not so clear signatures anymore.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://airbnb.io/enzyme/docs/api/selector.html#3-a-react-components-displayname
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.