### PR TITLE
Updated Cavy types for 3.1

### DIFF
--- a/types/cavy/cavy-tests.tsx
+++ b/types/cavy/cavy-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextInput, View, Text } from 'react-native';
 
-import { hook, TestScope, WithTestHook, Tester, useCavy } from 'cavy';
+import { hook, TestScope, WithTestHook, Tester, TestHookStore, useCavy, TestReport } from 'cavy';
 
 type Props = WithTestHook<{
   foo: string;
@@ -50,11 +50,23 @@ function sampleSpec(spec: TestScope) {
       spec.pause(1000); // $ExpectType Promise<void>
       spec.exists('View.Sample'); // $ExpectType Promise<true>
       spec.notExists('View.MissingSample'); // $ExpectType Promise<true>
+      spec.containsText('Input.Sample', "hello"); // $ExpectType Promise<void>
     });
   });
 }
 
-<Tester specs={[sampleSpec]} waitTime={42}>
+function sampleReporter(_report: TestReport) {}
+
+const testHookStore = new TestHookStore();
+
+<Tester
+  specs={[sampleSpec]}
+  store={testHookStore}
+  waitTime={42}
+  startDelay={42}
+  clearAsyncStorage={true}
+  reporter={sampleReporter}
+>
   <HookedSampleComponent foo="test" />
   <SampleFunctionComponent/>
 </Tester>;

--- a/types/cavy/index.d.ts
+++ b/types/cavy/index.d.ts
@@ -29,7 +29,7 @@ export interface TesterProps {
     startDelay?: number;
     clearAsyncStorage?: boolean;
     reporter?: (report: TestReport) => void;
-    
+
     // Deprecated
     sendReport?: boolean;
 }
@@ -61,7 +61,7 @@ export interface TestResult {
 }
 
 export interface TestReport {
-    results: TestResult[];
+    results: ReadonlyArray<TestResult>;
     errorCount: number;
     duration: number;
 }

--- a/types/cavy/index.d.ts
+++ b/types/cavy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cavy 2.2
+// Type definitions for cavy 3.1
 // Project: https://github.com/pixielabs/cavy
 // Definitions by: Tyler Hoffman <https://github.com/tyler-hoffman>
 //                 Abigail McPhillips <https://github.com/AbigailMcP>
@@ -23,8 +23,14 @@ export function hook<T extends {}>(component: React.ComponentClass<WithTestHook<
 export function useCavy(): TestHookGenerator;
 
 export interface TesterProps {
+    store: TestHookStore;
     specs: Array<(spec: TestScope) => void>;
-    waitTime: number;
+    waitTime?: number;
+    startDelay?: number;
+    clearAsyncStorage?: boolean;
+    reporter?: (report: TestReport) => void;
+    
+    // Deprecated
     sendReport?: boolean;
 }
 
@@ -32,6 +38,8 @@ export class Tester extends React.Component<TesterProps> {
     reRender(): void;
     clearAsync(): Promise<void>;
 }
+
+export class TestHookStore {}
 
 export class TestScope {
     component: Tester;
@@ -44,4 +52,16 @@ export class TestScope {
     pause(time: number): Promise<void>;
     exists(identifier: string): Promise<true>;
     notExists(identifier: string): Promise<true>;
+    containsText(identifier: string, text: string): Promise<void>;
+}
+
+export interface TestResult {
+    message: string;
+    passed: boolean;
+}
+
+export interface TestReport {
+    results: TestResult[];
+    errorCount: number;
+    duration: number;
 }


### PR DESCRIPTION
Added Tester properties:
- store (and corresponding TestHookStore type)
- startDelay
- clearAsyncStorage
- reporter (and corresponding TestResult/TestReport types)

Made waitTime optional

Added containsTest to TestScope


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pixielabs/cavy/tree/master/src
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.