### PR TITLE
[filesize-parser] Add types for filesize-parser

### DIFF
--- a/types/filesize-parser/filesize-parser-tests.ts
+++ b/types/filesize-parser/filesize-parser-tests.ts
@@ -1,0 +1,10 @@
+import filesizeParser = require('filesize-parser');
+
+// Without options
+filesizeParser('200kb');
+
+// With empty options
+filesizeParser('200kb', {});
+
+// With `base` option
+filesizeParser('200kb', { base: 10 });

--- a/types/filesize-parser/filesize-parser-tests.ts
+++ b/types/filesize-parser/filesize-parser-tests.ts
@@ -8,6 +8,3 @@ filesizeParser('200kb', {});
 
 // With `base` option
 filesizeParser('200kb', { base: 10 });
-
-// Not included in the package's docs, but any input with a toString() method is valid
-filesizeParser(200, { base: 10 });

--- a/types/filesize-parser/filesize-parser-tests.ts
+++ b/types/filesize-parser/filesize-parser-tests.ts
@@ -8,3 +8,6 @@ filesizeParser('200kb', {});
 
 // With `base` option
 filesizeParser('200kb', { base: 10 });
+
+// Not included in the package's docs, but any input with a toString() method is valid
+filesizeParser(200, { base: 10 });

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface FilesizeParserOptions {
-    base?: number;
+    base?: 2 | 10;
 }
 
 interface StringLike {

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -7,6 +7,8 @@ interface FilesizeParserOptions {
     base?: number;
 }
 
-declare function filesizeParser(input: string, options?: FilesizeParserOptions): number;
+type StringLike = { toString(): string };
+
+declare function filesizeParser(input: StringLike, options?: FilesizeParserOptions): number;
 
 export = filesizeParser;

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -7,7 +7,9 @@ interface FilesizeParserOptions {
     base?: number;
 }
 
-type StringLike = { toString(): string };
+interface StringLike {
+    toString(): string;
+}
 
 declare function filesizeParser(input: StringLike, options?: FilesizeParserOptions): number;
 

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for filesize-parser 1.5
+// Project: https://github.com/patrickkettner/filesize-parser
+// Definitions by: Florian Reuschel <https://github.com/loilo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface FilesizeParserOptions {
+    base?: number;
+}
+
+declare function filesizeParser(input: string, options?: FilesizeParserOptions): number;
+
+export = filesizeParser;

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -7,10 +7,6 @@ interface FilesizeParserOptions {
     base?: 2 | 10;
 }
 
-interface StringLike {
-    toString(): string;
-}
-
-declare function filesizeParser(input: StringLike, options?: FilesizeParserOptions): number;
+declare function filesizeParser(input: string, options?: FilesizeParserOptions): number;
 
 export = filesizeParser;

--- a/types/filesize-parser/tsconfig.json
+++ b/types/filesize-parser/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/filesize-parser/tsconfig.json
+++ b/types/filesize-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "filesize-parser-tests.ts"
+    ]
+}

--- a/types/filesize-parser/tslint.json
+++ b/types/filesize-parser/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.