### PR TITLE
[HOLD] [relay-runtime] Update fragment reference definitions

### DIFF
--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -2,7 +2,15 @@
 // tslint:disable:use-default-type-parameter
 
 import * as React from 'react';
-import { Environment, Network, RecordSource, Store, ConnectionHandler } from 'relay-runtime';
+import {
+    Environment,
+    Network,
+    RecordSource,
+    Store,
+    ConnectionHandler,
+    _FragmentRefs,
+    FragmentRefs,
+} from 'relay-runtime';
 
 import {
     commitMutation,
@@ -100,13 +108,11 @@ const MyEmptyQueryRenderer = () => (
 type StoryLike = (storyID: string) => void;
 
 // Artifact produced by relay-compiler-language-typescript
-declare const _Story_story$ref: unique symbol;
-type Story_story$ref = typeof _Story_story$ref;
 type Story_story = {
     readonly id: string;
     readonly text: string;
     readonly isPublished: boolean;
-    readonly ' $refType': Story_story$ref;
+    readonly ' $refType': 'Story_story';
 };
 
 const Story = (() => {
@@ -176,20 +182,20 @@ const Story = (() => {
 
     function requiresTheRightProps() {
         const onLike = (id: string) => console.log(`Liked story #${id}`);
-        const story: { ' $fragmentRefs': Story_story$ref } = {} as any;
+        const story: _FragmentRefs<'Story_story'> = {} as any;
         <StoryRefetchContainer story={story} onLike={onLike} />;
     }
 
     function requiresTheCorrectFragmentRef() {
         const onLike = (id: string) => console.log(`Liked story #${id}`);
-        const feed: { ' $fragmentRefs': FeedStories_feed$ref } = {} as any;
+        const feed: _FragmentRefs<'FeedStories_feed'> = {} as any;
         // $ExpectError
         <StoryRefetchContainer story={feed} onLike={onLike} />;
     }
 
     function doesNotRequireRelayPropToBeProvidedByParent() {
         const onLike = (id: string) => console.log(`Liked story #${id}`);
-        const story: { ' $fragmentRefs': Story_story$ref } = {} as any;
+        const story: _FragmentRefs<'Story_story'> = {} as any;
         const relayProp: RelayRefetchProp = {} as any;
         // $ExpectError
         <StoryRefetchContainer story={story} onLike={onLike} relay={relayProp} />;
@@ -222,7 +228,7 @@ const Story = (() => {
 
     function canTakeComponentRef() {
         const onLike = (id: string) => console.log(`Liked story #${id}`);
-        const story: { ' $fragmentRefs': Story_story$ref } = {} as any;
+        const story: _FragmentRefs<'Story_story'> = {} as any;
         <StoryRefetchContainer story={story} onLike={onLike} componentRef={ref => console.log(ref)} />;
     }
 
@@ -234,23 +240,19 @@ const Story = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
-declare const _FeedStories_feed$ref: unique symbol;
-type FeedStories_feed$ref = typeof _FeedStories_feed$ref;
-declare const _FeedStory_edges$ref: unique symbol;
-type FeedStory_edges$ref = typeof _FeedStory_edges$ref;
 type FeedStories_feed = {
     readonly edges: ReadonlyArray<{
         readonly node: {
             readonly id: string;
-            readonly ' $fragmentRefs': Story_story$ref & FeedStories_feed$ref;
+            readonly ' $fragmentRefs': FragmentRefs<'Story_story' | 'FeedStories_feed'>;
         };
-        readonly ' $fragmentRefs': FeedStory_edges$ref;
+        readonly ' $fragmentRefs': FragmentRefs<'FeedStory_edges'>;
     }>;
-    readonly ' $refType': FeedStories_feed$ref;
+    readonly ' $refType': 'FeedStories_feed';
 };
 type FeedStory_edges = ReadonlyArray<{
     readonly publishedAt: string;
-    readonly ' $refType': FeedStory_edges$ref;
+    readonly ' $refType': 'FeedStory_edges';
 }>;
 
 const Feed = (() => {
@@ -304,20 +306,20 @@ const Feed = (() => {
 
     function requiresTheRightProps() {
         const onStoryLike = (id: string) => console.log(`Liked story #${id}`);
-        const feed: { ' $fragmentRefs': FeedStories_feed$ref } = {} as any;
+        const feed: _FragmentRefs<'FeedStories_feed'> = {} as any;
         <FeedFragmentContainer feed={feed} onStoryLike={onStoryLike} />;
     }
 
     function requiresTheCorrectFragmentRef() {
         const onStoryLike = (id: string) => console.log(`Liked story #${id}`);
-        const story: { ' $fragmentRefs': Story_story$ref } = {} as any;
+        const story: _FragmentRefs<'Story_story'> = {} as any;
         // $ExpectError
         <FeedFragmentContainer feed={story} onStoryLike={onStoryLike} />;
     }
 
     function doesNotRequireRelayPropToBeProvidedByParent() {
         const onStoryLike = (id: string) => console.log(`Liked story #${id}`);
-        const feed: { ' $fragmentRefs': FeedStories_feed$ref } = {} as any;
+        const feed: _FragmentRefs<'FeedStories_feed'> = {} as any;
         const relayProp: RelayProp = {} as any;
         // $ExpectError
         <FeedFragmentContainer feed={feed} onStoryLike={onStoryLike} relay={relayProp} />;
@@ -343,7 +345,7 @@ const Feed = (() => {
 
     function canTakeComponentRef() {
         const onStoryLike = (id: string) => console.log(`Liked story #${id}`);
-        const feed: { ' $fragmentRefs': FeedStories_feed$ref } = {} as any;
+        const feed: _FragmentRefs<'FeedStories_feed'> = {} as any;
         <FeedFragmentContainer feed={feed} onStoryLike={onStoryLike} componentRef={ref => console.log(ref)} />;
     }
 
@@ -355,17 +357,15 @@ const Feed = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
-declare const _UserFeed_user$ref: unique symbol;
-type UserFeed_user$ref = typeof _UserFeed_user$ref;
 type UserFeed_user = {
     readonly feed: {
         readonly pageInfo: {
             readonly endCursor?: string | null;
             readonly hasNextPage: boolean;
         };
-        readonly ' $fragmentRefs': FeedStories_feed$ref;
+        readonly ' $fragmentRefs': FragmentRefs<'FeedStories_feed'>;
     };
-    readonly ' $refType': UserFeed_user$ref;
+    readonly ' $refType': 'UserFeed_user';
 };
 () => {
     interface Props {
@@ -451,18 +451,18 @@ type UserFeed_user = {
     );
 
     function requiresTheRightProps() {
-        const user: { ' $fragmentRefs': UserFeed_user$ref } = {} as any;
+        const user: _FragmentRefs<'UserFeed_user'> = {} as any;
         <UserFeedPaginationContainer loadMoreTitle="Load More" user={user} />;
     }
 
     function requiresTheCorrectFragmentRef() {
-        const story: { ' $fragmentRefs': Story_story$ref } = {} as any;
+        const story: _FragmentRefs<'Story_story'> = {} as any;
         // $ExpectError
         <UserFeedPaginationContainer loadMoreTitle="Load More" user={story} />;
     }
 
     function doesNotRequireRelayPropToBeProvidedByParent() {
-        const user: { ' $fragmentRefs': UserFeed_user$ref } = {} as any;
+        const user: _FragmentRefs<'UserFeed_user'> = {} as any;
         const relayProp: RelayPaginationProp = {} as any;
         // $ExpectError
         <UserFeedPaginationContainer loadMoreTitle="Load More" user={user} relay={relayProp} />;
@@ -494,7 +494,7 @@ type UserFeed_user = {
     }
 
     function canTakeComponentRef() {
-        const user: { ' $fragmentRefs': UserFeed_user$ref } = {} as any;
+        const user: _FragmentRefs<'UserFeed_user'> = {} as any;
         <UserFeedPaginationContainer loadMoreTitle="Load More" user={user} componentRef={ref => console.log(ref)} />;
     }
 };
@@ -613,7 +613,8 @@ function functionWithInline(storyRef: FragmentRef<Story_story>): Story_story {
     return readInlineData<Story_story>(storyFragment, storyRef);
 }
 
-functionWithInline({ ' $fragmentRefs': _Story_story$ref });
+const inlineData: _FragmentRefs<'Story_story'> = {} as any;
+functionWithInline(inlineData).isPublished;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern Subscriptions

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -192,13 +192,28 @@ export { RelayNetworkLoggerTransaction } from './lib/network/RelayNetworkLoggerT
 export { createRelayNetworkLogger } from './lib/network/createRelayNetworkLogger';
 export { deepFreeze } from './lib/util/deepFreeze';
 
-// These match the output of relay-compiler-language-typescript.
-export interface _RefType<T> {
-    ' $refType': T;
-}
-export interface _FragmentRefs<T> {
-    ' $fragmentRefs': T;
+/**
+ * relay-compiler-language-typescript support for fragment references
+ */
+
+/**
+ * @private
+ */
+export interface _RefType<Ref extends string> {
+    ' $refType': Ref;
 }
 
+/**
+ * @private
+ */
+export interface _FragmentRefs<Refs extends string> {
+    ' $fragmentRefs': FragmentRefs<Refs>;
+}
+
+// This is used in the actual artifacts to define the various fragment references a container holds.
+export type FragmentRefs<Refs extends string> = {
+    [ref in Refs]: true;
+};
+
 // This is a utility type for converting from a data type to a fragment reference that will resolve to that data type.
-export type FragmentRef<T> = T extends _RefType<infer U> ? _FragmentRefs<U> : never;
+export type FragmentRef<Fragment> = Fragment extends _RefType<infer U> ? _FragmentRefs<U> : never;

--- a/types/relay-runtime/tslint.json
+++ b/types/relay-runtime/tslint.json
@@ -1,4 +1,7 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        // We have some internal types that are helpfully tagged with @private
+        "no-redundant-jsdoc-2": false
+    }
 }


### PR DESCRIPTION
⚠️ This is a breaking change, but alas there’s no other way around it.

As of TS 3.6 an intersection of multiple unique symbols results in
`never`, which means our fragment reference checking is now unsafe.

Depends on https://github.com/relay-tools/relay-compiler-language-typescript/pull/139