### PR TITLE
Add a missing property in types/datatables.net

### DIFF
--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1784,6 +1784,7 @@ declare namespace DataTables {
         infoEmpty?: string;
         infoFiltered?: string;
         infoPostFix?: string;
+        decimal?: string;
         thousands?: string;
         lengthMenu?: string;
         loadingRecords?: string;


### PR DESCRIPTION
I add a new property into the LanguageSettings interface. This property is called "decimal" and defines the character user to represents the decimal separator of numeric cells. The documentation about this parameter is here:
https://datatables.net/examples/basic_init/comma-decimal.html