### PR TITLE
Add types for parse-author

### DIFF
--- a/types/parse-author/index.d.ts
+++ b/types/parse-author/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for parse-author 2.0
+// Project: https://github.com/jonschlinkert/parse-author
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Parse a string into an object with `name`, `email` and `url` properties following npm conventions.
+ *
+ * Useful for the `authors` property in package.json or for parsing an AUTHORS file into an array of authors objects.
+ */
+declare function parse(author: string): parse.Author;
+
+export = parse;
+
+declare namespace parse {
+    interface Author {
+        name?: string;
+        email?: string;
+        url?: string;
+    }
+}

--- a/types/parse-author/parse-author-tests.ts
+++ b/types/parse-author/parse-author-tests.ts
@@ -1,0 +1,6 @@
+import * as parse from 'parse-author';
+
+const author = parse('Jon Schlinkert <jon.schlinkert@sellside.com> (https://github.com/jonschlinkert)');
+author.name === 'Jon Schlinkert';
+author.email === 'jon.schlinkert@sellside.com';
+author.url === 'https://github.com/jonschlinkert';

--- a/types/parse-author/tsconfig.json
+++ b/types/parse-author/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-author-tests.ts"
+    ]
+}

--- a/types/parse-author/tslint.json
+++ b/types/parse-author/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.