### PR TITLE
Upgrade types for remotedev-serialize for immutable@4

### DIFF
--- a/types/remotedev-serialize/v3/index.d.ts
+++ b/types/remotedev-serialize/v3/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for remotedev-serialize 1.0
+// Project: https://github.com/zalmoxisus/remotedev-serialize/
+// Definitions by: Julian Hundeloh <https://github.com/jaulz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// TypeScript Version: 2.1
+
+import * as Immutable from 'immutable';
+
+export type Options = Record<string, boolean>;
+
+export type Refs = Record<string, any>;
+
+export type DefaultReplacer = (key: string, value: any) => any;
+
+export type Replacer = (
+  key: string,
+  value: any,
+  replacer: DefaultReplacer
+) => any;
+
+export type DefaultReviver = (key: string, value: any) => any;
+
+export type Reviver = (key: string, value: any, reviver: DefaultReviver) => any;
+
+export function immutable(
+  immutable: typeof Immutable,
+  refs?: Refs,
+  customReplacer?: Replacer,
+  customReviver?: Reviver
+): {
+  stringify: (input: any) => string;
+  parse: (input: string) => any;
+  serialize: (
+    immutable: typeof Immutable,
+    refs?: Refs,
+    customReplacer?: Replacer,
+    customReviver?: Reviver
+  ) => {
+    replacer: Replacer;
+    reviver: Reviver;
+    options: Options;
+  };
+};

--- a/types/remotedev-serialize/v3/package.json
+++ b/types/remotedev-serialize/v3/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "immutable": "^4.0.0-rc.12"
+        "immutable": "^3.8.1"
     }
 }

--- a/types/remotedev-serialize/v3/remotedev-serialize-tests.ts
+++ b/types/remotedev-serialize/v3/remotedev-serialize-tests.ts
@@ -1,0 +1,8 @@
+import * as Immutable from 'immutable';
+import * as Serialize from 'remotedev-serialize';
+
+const { stringify, parse } = Serialize.immutable(Immutable);
+
+const data = Immutable.fromJS({ foo: 'bar', baz: { qux: 42 } });
+const serialized = stringify(data);
+const parsed = parse(serialized);

--- a/types/remotedev-serialize/v3/tsconfig.json
+++ b/types/remotedev-serialize/v3/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "remotedev-serialize-tests.ts"
+    ]
+}

--- a/types/remotedev-serialize/v3/tslint.json
+++ b/types/remotedev-serialize/v3/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
