### PR TITLE
[react-virtualized] Add missing props for render ranges

### DIFF
--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -1,4 +1,4 @@
-import { Validator, Requireable, PureComponent } from 'react';
+import { Validator, Requireable, PureComponent, Component } from 'react';
 import { List } from './List';
 import { Table } from './Table';
 import { CellMeasurerCache, MeasuredCellParent } from './CellMeasurer';
@@ -20,7 +20,7 @@ export type GridCellProps = {
     isScrolling: boolean;
     isVisible: boolean;
     key: string;
-    parent: MeasuredCellParent;
+    parent: React.Component<GridCoreProps> & MeasuredCellParent;
     rowIndex: number;
     style: React.CSSProperties;
 };
@@ -133,6 +133,7 @@ export type GridCellRangeProps = {
     columnStartIndex: number;
     columnStopIndex: number;
     isScrolling: boolean;
+    isScrollingOptOut: boolean;
     rowSizeAndPositionManager: CellSizeAndPositionManager;
     rowStartIndex: number;
     rowStopIndex: number;
@@ -140,7 +141,7 @@ export type GridCellRangeProps = {
     scrollTop: number;
     deferredMeasurementCache: CellMeasurerCache;
     horizontalOffsetAdjustment: number;
-    parent: MeasuredCellParent;
+    parent: React.Component<GridCoreProps> & MeasuredCellParent;
     styleCache: Map<React.CSSProperties>;
     verticalOffsetAdjustment: number;
     visibleColumnIndices: VisibleCellRange;

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -8,6 +8,7 @@
 //                 Maciej Goszczycki <https://github.com/mgoszcz2>
 //                 Brandon Hall <https://github.com/brandonhall>
 //                 Sebastian Busch <https://github.com/sbusch>
+//                 Adam Zmenak <https://github.com/azmenak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Adds `isScrollingOptOut` and replaces the type for parent to more accurately  cover available properties

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md
    - Adding `isScrollingOptOut` as per docs
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
