### PR TITLE
node: correct deprecations/exerimentals

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -20,13 +20,9 @@ declare module "assert" {
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
         function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
         function ok(value: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use notStrictEqual() instead. */
         function notEqual(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use deepStrictEqual() instead. */
         function deepEqual(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use notDeepStrictEqual() instead. */
         function notDeepEqual(actual: any, expected: any, message?: string | Error): void;
         function strictEqual(actual: any, expected: any, message?: string | Error): void;
         function notStrictEqual(actual: any, expected: any, message?: string | Error): void;

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -185,9 +185,6 @@ declare namespace setImmediate {
 }
 declare function clearImmediate(immediateId: NodeJS.Immediate): void;
 
-/**
- * @experimental
- */
 declare function queueMicrotask(callback: () => void): void;
 
 // TODO: change to `type NodeRequireFunction = (id: string) => any;` in next mayor version.


### PR DESCRIPTION
undeprecate non strict asserts.
queueMicrotask() is not experimental anymore.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://nodejs.org/dist/latest-v12.x/docs/api/globals.html#globals_queuemicrotask_callback
https://nodejs.org/dist/latest-v12.x/docs/api/assert.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
