### PR TITLE
[office-js, office-js-preview] Adding note about SVG support

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3910,7 +3910,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60kB size limitation for SVG insertions.</td>
+         *     <td>There is a 60KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -4109,7 +4109,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60kB size limitation for SVG insertions.</td>
+         *     <td>There is a 60KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3910,7 +3910,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *     <td>There is a 60kB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -4109,7 +4109,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *     <td>There is a 60kB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3910,7 +3910,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60KB size limitation for SVG insertions.</td>
+         *     <td>There is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -4109,7 +4109,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60KB size limitation for SVG insertions.</td>
+         *     <td>There is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3905,6 +3905,17 @@ declare namespace Office {
          *   </tr>
          * </table>
          * 
+         * **Type-specific behaviors**
+         * 
+         * <table>
+         *   <tr>
+         *     <td>`Office.CoercionType.XmlSvg`</td>
+         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *   </tr>
+         * </table>
+         * 
+         * **Hosts**
+         * 
          * The possible values for the {@link Office.CoercionType} parameter vary by the host. 
          * 
          * <table>
@@ -4091,6 +4102,18 @@ declare namespace Office {
          *     <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td>
          *   </tr>
          * </table>
+         * 
+         * 
+         * **Type-specific behaviors**
+         * 
+         * <table>
+         *   <tr>
+         *     <td>`Office.CoercionType.XmlSvg`</td>
+         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *   </tr>
+         * </table>
+         * 
+         * **Hosts**
          * 
          * The possible values for the {@link Office.CoercionType} parameter vary by the host. 
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3795,7 +3795,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60KB size limitation for SVG insertions.</td>
+         *     <td>There is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -3993,7 +3993,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60KB size limitation for SVG insertions.</td>
+         *     <td>There is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3795,7 +3795,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *     <td>There is a 60kB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -3993,7 +3993,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *     <td>There is a 60kB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3795,7 +3795,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60kB size limitation for SVG insertions.</td>
+         *     <td>There is a 60KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -3993,7 +3993,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 60kB size limitation for SVG insertions.</td>
+         *     <td>There is a 60KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3790,6 +3790,17 @@ declare namespace Office {
          *   </tr>
          * </table>
          * 
+         * **Type-specific behaviors**
+         * 
+         * <table>
+         *   <tr>
+         *     <td>`Office.CoercionType.XmlSvg`</td>
+         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *   </tr>
+         * </table>
+         * 
+         * **Hosts**
+         * 
          * The possible values for the {@link Office.CoercionType} parameter vary by the host. 
          * 
          * <table>
@@ -3976,6 +3987,17 @@ declare namespace Office {
          *     <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td>
          *   </tr>
          * </table>
+         * 
+         * **Type-specific behaviors**
+         * 
+         * <table>
+         *   <tr>
+         *     <td>`Office.CoercionType.XmlSvg`</td>
+         *     <td>There is a 60k size limitation for SVG insertions.</td>
+         *   </tr>
+         * </table>
+         * 
+         * **Hosts**
          * 
          * The possible values for the {@link Office.CoercionType} parameter vary by the host. 
          * 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js/issues/744
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
