### PR TITLE
Less: add missing option and fix render callback type inaccuracy

### DIFF
--- a/types/less/index.d.ts
+++ b/types/less/index.d.ts
@@ -156,8 +156,8 @@ interface LessStatic {
 
     refreshStyles(): void;
 
-    render(input: string, callback: (error: Less.RenderError, output: Less.RenderOutput) => void): void;
-    render(input: string, options: Less.Options, callback: (error: Less.RenderError, output: Less.RenderOutput) => void): void;
+    render(input: string, callback: (error: Less.RenderError, output: Less.RenderOutput | undefined) => void): void;
+    render(input: string, options: Less.Options, callback: (error: Less.RenderError, output: Less.RenderOutput | undefined) => void): void;
 
     render(input: string): Promise<Less.RenderOutput>;
     render(input: string, options: Less.Options): Promise<Less.RenderOutput>;

--- a/types/less/index.d.ts
+++ b/types/less/index.d.ts
@@ -118,6 +118,8 @@ declare namespace Less {
         modifyVars?: {
           [key: string] : string,
         };
+        /** Read files synchronously in Node.js */
+        syncImport?: boolean;
     }
 
     interface RenderError {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `syncImport` option: [usage in less][1], [usage in less dependent][2]
  - callback parameter type: [no second argument passed sometimes][3]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

[1]: https://github.com/less/less.js/blob/0fac98e24c7c2c8eee47edac95bf3731869110aa/lib/less-node/file-manager.js#L42
[2]: https://github.com/mrmckeb/typescript-plugin-css-modules/blob/c9f17cfd7509724ee82fe5dd06bf3e7b616ec4a7/src/helpers/DtsSnapshotCreator.ts#L48
[3]: https://github.com/less/less.js/blob/bd76d6558240b68c0080e74b3e86bc9330d50095/lib/less/render.js#L34