### PR TITLE
mongoose: Update Model.syncIndexes definition to allow Promises to be returned

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -3015,8 +3015,8 @@ declare module "mongoose" {
      * @param callback optional callback
      * @return Returns `undefined` if callback is specified, returns a promise if no callback.
      */
-    syncIndexes(options: object, callback?: (err: any) => void): void;
-    syncIndexes(options: object): Promise<void>;
+    syncIndexes(options: object | null | undefined, callback: (err: any) => void): void;
+    syncIndexes(options?: object | null): Promise<void>;
 
     /**
      * Lists the indexes currently defined in MongoDB. This may or may not be

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -1721,8 +1721,13 @@ MongoModel.createCollection({ capped: true, max: 42 }, err => {});
 MongoModel.distinct('url', { clicks: {$gt: 100}}, function (err, result) {
 });
 MongoModel.distinct('url').exec(cb);
-MongoModel.syncIndexes({});
-MongoModel.syncIndexes({}, cb);
+MongoModel.syncIndexes().then(() => {});
+MongoModel.syncIndexes({}).then(() => {});
+MongoModel.syncIndexes(null).then(() => {});
+MongoModel.syncIndexes(undefined).then(() => {});
+MongoModel.syncIndexes({}, err => {});
+MongoModel.syncIndexes(null, err => {});
+MongoModel.syncIndexes(undefined, err => {});
 MongoModel.listIndexes();
 MongoModel.listIndexes(cb);
 MongoModel.ensureIndexes({}, cb);


### PR DESCRIPTION
The existing definitions for `Model.syncIndexes`

```
syncIndexes(options: object, callback?: (err: any) => void): void;
syncIndexes(options: object): Promise<void>;
```

does not allow for the possibility for a `Promise` to be returned because the first always takes precedence. I also added `null | undefined` to the types for `options` because `Model.ensureIndexes` allows it (see second link below).

Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/mongoose/blob/5.5/lib/model.js#L1255-L1322, https://github.com/Automattic/mongoose/blob/5.5/lib/model.js#L1396-L1414