### PR TITLE
[@types/prompts]: Change Choice's value to be any instead of a string

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -50,7 +50,7 @@ declare namespace prompts {
 
     interface Choice {
         title: string;
-        value: string;
+        value: any;
         disable?: boolean;
     }
 

--- a/types/prompts/prompts-tests.ts
+++ b/types/prompts/prompts-tests.ts
@@ -29,6 +29,20 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
             },
             name: 'confirmation',
             message: "Have you tried TypeScript?"
+        },
+        {
+            type: 'select',
+            name: 'so-many-options',
+            choices: [
+                {
+                    title: 'A',
+                    value: 'A'
+                },
+                {
+                    title: 'A',
+                    value: {foo: 'bar'}
+                },
+            ]
         }
     ]);
 })();


### PR DESCRIPTION
The following code should work but is not supported by our types, judging by testing it without types and by looking at the source code because the lack of documentation for the `value` property):

```javascript
prompts([
  {
    type: 'select',
    name: 'templateDefinition',
    message: 'Choose project type',
    choices: [
      {
        title: 'A',
        value: { foo: 'bar' },
      },
      {
        title: 'B',
        value: { bar: 'baz' },
      }
    ],
  }
])
```
This fixes that.

I think it's convenient sometimes to use literally anything as a choice value, so you don't have to manually match an identifier somewhere else in your code.
There doesn't seem to be any strict documentation about the `value` property, yet the production code supports `any`thing.


### ☑️ Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/terkelg/prompts/blob/master/lib/elements/select.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.