### PR TITLE
feat(semver): Update to v6.2

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for semver 6.0
+// Type definitions for semver 6.2
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>
 //                 Klaus Meinhardt <https://github.com/ajafff>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/semver
 
 export const SEMVER_SPEC_VERSION: "2.0.0";
@@ -15,43 +16,66 @@ export interface Options {
     includePrerelease?: boolean;
 }
 
+export interface CoerceOptions extends Options {
+    /**
+     * Used by `coerce()` to coerce from right to left.
+     *
+     * @default false
+     *
+     * @example
+     * coerce('1.2.3.4', { rtl: true });
+     * // => SemVer { version: '2.3.4', ... }
+     *
+     * @since 6.2.0
+     */
+    rtl?: boolean;
+}
+
 /**
  * Return the parsed version as a SemVer object, or null if it's not valid.
  */
-export function parse(v: string | SemVer, optionsOrLoose?: boolean | Options): SemVer | null;
+export function parse(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): SemVer | null;
+
 /**
- * Return the parsed version, or null if it's not valid.
+ * Return the parsed version as a string, or null if it's not valid.
  */
-export function valid(v: string | SemVer, optionsOrLoose?: boolean | Options): string | null;
+export function valid(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): string | null;
+
+/**
+ * Coerces a string to SemVer if possible
+ */
+export function coerce(version: string | number | SemVer | null | undefined, options?: CoerceOptions): SemVer | null;
+
 /**
  * Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
  */
 export function clean(version: string, optionsOrLoose?: boolean | Options): string | null;
+
 /**
  * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
  */
-export function inc(v: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
-export function inc(
-  v: string | SemVer,
-  release: ReleaseType,
-  identifier?: string,
-): string | null;
+export function inc(version: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
+export function inc(version: string | SemVer, release: ReleaseType, identifier?: string): string | null;
+
 /**
  * Return the major version number.
  */
-export function major(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
+export function major(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
 /**
  * Return the minor version number.
  */
-export function minor(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
+export function minor(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
 /**
  * Return the patch version number.
  */
-export function patch(v: string | SemVer, optionsOrLoose?: boolean | Options): number;
+export function patch(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
 /**
  * Returns an array of prerelease components, or null if none exist.
  */
-export function prerelease(v: string | SemVer, optionsOrLoose?: boolean | Options): ReadonlyArray<string> | null;
+export function prerelease(version: string | SemVer, optionsOrLoose?: boolean | Options): ReadonlyArray<string> | null;
 
 // Comparison
 /**
@@ -88,29 +112,56 @@ export function cmp(v1: string | SemVer, operator: Operator, v2: string | SemVer
 export type Operator = '===' | '!==' | '' | '=' | '==' | '!=' | '>' | '>=' | '<' | '<=';
 
 /**
- * Return 0 if v1 == v2, or 1 if v1 is greater, or -1 if v2 is greater. Sorts in ascending order if passed to Array.sort().
+ * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
  */
 export function compare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
 /**
- * The reverse of compare. Sorts an array of versions in descending order when passed to Array.sort().
+ * The reverse of compare.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
  */
 export function rcompare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
 
 /**
- * Compares two identifiers, must be numeric strings or truthy/falsy values. Sorts in ascending order if passed to Array.sort().
+ * Compares two identifiers, must be numeric strings or truthy/falsy values.
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
  */
-export function compareIdentifiers(a: string | null, b: string | null): 1 | 0 | -1;
+export function compareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
 /**
- * The reverse of compareIdentifiers. Sorts in descending order when passed to Array.sort().
+ * The reverse of compareIdentifiers.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
  */
-export function rcompareIdentifiers(a: string | null, b: string | null): 1 | 0 | -1;
+export function rcompareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
 
 /**
- * Sorts an array of semver entries in ascending order.
+ * Compares two versions including build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
+ *
+ * @since 6.1.0
+ */
+export function compareBuild(a: string | SemVer, b: string | SemVer): 1 | 0 | -1;
+
+/**
+ * Sorts an array of semver entries in ascending order using `compareBuild()`.
  */
 export function sort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
 /**
- * Sorts an array of semver entries in descending order.
+ * Sorts an array of semver entries in descending order using `compareBuild()`.
  */
 export function rsort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
 
@@ -123,7 +174,7 @@ export function diff(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: 
 /**
  * Return the valid range or null if it's not valid
  */
-export function validRange(range: string | Range, optionsOrLoose?: boolean | Options): string;
+export function validRange(range: string | Range | null | undefined, optionsOrLoose?: boolean | Options): string;
 /**
  * Return true if the version satisfies the range.
  */
@@ -158,12 +209,6 @@ export function outside(version: string | SemVer, range: string | Range, hilo: '
  */
 export function intersects(range1: string | Range, range2: string | Range, optionsOrLoose?: boolean | Options): boolean;
 
-// Coercion
-/**
- * Coerces a string to semver if possible
- */
-export function coerce(version: string | SemVer): SemVer | null;
-
 export class SemVer {
     constructor(version: string | SemVer, optionsOrLoose?: boolean | Options);
 
@@ -180,9 +225,46 @@ export class SemVer {
     build: ReadonlyArray<string>;
     prerelease: ReadonlyArray<string | number>;
 
+    /**
+     * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
     compare(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the release portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
     compareMain(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the prerelease portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
     comparePre(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the build identifier of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compareBuild(other: string | SemVer): 1 | 0 | -1;
+
     inc(release: ReleaseType, identifier?: string): SemVer;
 }
 

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -3,7 +3,8 @@ import * as semver from "semver";
 let bool: boolean;
 let num: number;
 let str = '';
-let strn: string | null = '';
+// $ExpectType string | null
+let strn: string | null = Math.random() < 0.5 ? null : String(Math.random());
 let diff: semver.ReleaseType | null;
 const op: semver.Operator = '';
 declare const arr: any[];
@@ -19,10 +20,14 @@ const v2 = '';
 const version = '';
 const versions: string[] = [];
 const loose = true;
-let sem: semver.SemVer | null = new semver.SemVer(str, {});
+// $ExpectType SemVer | null
+let sem: semver.SemVer | null = Math.random() < 0.5 ? new semver.SemVer(str, {}) : null;
 
-sem = new semver.SemVer(str, {includePrerelease: false});
-sem = new semver.SemVer(str, {loose: true});
+// $ExpectType string | SemVer | null | undefined
+const anyVersion = Math.random() < 0.5 ? undefined : Math.random() < 0.5 ? strn : sem;
+
+sem = new semver.SemVer(str, { includePrerelease: false });
+sem = new semver.SemVer(str, { loose: true });
 
 sem = semver.parse(str);
 strn = semver.valid(str);
@@ -73,6 +78,25 @@ sem = semver.minVersion(str, loose);
 
 // Coercion
 sem = semver.coerce(str);
+
+sem = semver.coerce(strn);
+sem = semver.coerce(strn, { rtl: false });
+sem = semver.coerce(strn, { rtl: true });
+
+sem = semver.coerce(sem);
+sem = semver.coerce(sem, { rtl: false });
+sem = semver.coerce(sem, { rtl: true });
+
+sem = semver.coerce(1);
+sem = semver.coerce(2, { rtl: false });
+sem = semver.coerce(3, { rtl: true });
+
+sem = semver.coerce(anyVersion);
+sem = semver.coerce(anyVersion, { rtl: false });
+sem = semver.coerce(anyVersion, { rtl: true });
+
+sem = semver.coerce(false); // $ExpectError
+sem = semver.coerce(anyVersion, true); // $ExpectError
 
 let ver = new semver.SemVer(str, bool);
 str = ver.raw;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -2,9 +2,10 @@ import * as semver from "semver";
 
 let bool: boolean;
 let num: number;
-let str = '';
+// $ExpectType string
+let str = String(Math.random());
 // $ExpectType string | null
-let strn: string | null = Math.random() < 0.5 ? null : String(Math.random());
+let strn: string | null = Math.random() < 0.5 ? null : str;
 let diff: semver.ReleaseType | null;
 const op: semver.Operator = '';
 declare const arr: any[];
@@ -94,9 +95,6 @@ sem = semver.coerce(3, { rtl: true });
 sem = semver.coerce(anyVersion);
 sem = semver.coerce(anyVersion, { rtl: false });
 sem = semver.coerce(anyVersion, { rtl: true });
-
-sem = semver.coerce(false); // $ExpectError
-sem = semver.coerce(anyVersion, true); // $ExpectError
 
 let ver = new semver.SemVer(str, bool);
 str = ver.raw;

--- a/types/semver/tsconfig.json
+++ b/types/semver/tsconfig.json
@@ -1,17 +1,13 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es5"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
I&nbsp;decided to&nbsp;update to&nbsp;v6.2 instead of&nbsp;v6.3, since&nbsp;the&nbsp;only&nbsp;v6.3 change is&nbsp;exporting the&nbsp;`tokens`&nbsp;enum, which&nbsp;I&nbsp;have no&nbsp;idea how&nbsp;I&nbsp;should go&nbsp;about&nbsp;exposing (since&nbsp;the&nbsp;numeric values of&nbsp;its&nbsp;entries are&nbsp;dynamically&nbsp;allocated, and might therefore change between versions, like&nbsp;when the&nbsp;`rtl` option was&nbsp;introduced to&nbsp;`coerce(…)`, which&nbsp;changed the&nbsp;order of&nbsp;the&nbsp;`re`&nbsp;and&nbsp;`src`&nbsp;arrays).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/npm/node-semver/blob/9f5f615165b3a0b906467f1edeebb0f5de379a9e/CHANGELOG.md#620>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

review?(@weswigham)